### PR TITLE
Fix bug #65269: SplFileObject::__construct() throws LogicException as well

### DIFF
--- a/reference/spl/splfileobject/construct.xml
+++ b/reference/spl/splfileobject/construct.xml
@@ -74,6 +74,9 @@
   <para>
    Throws a <classname>RuntimeException</classname> if the <parameter>filename</parameter> cannot be opened.
   </para>
+  <para>
+   Throws a <classname>LogicException</classname> if the <parameter>filename</parameter> is a directory.
+  </para>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Fix for [bug 65269](https://bugs.php.net/bug.php?id=65269).