### PR TITLE
Fix generator xrange() example

### DIFF
--- a/language/generators.xml
+++ b/language/generators.xml
@@ -49,7 +49,7 @@
 <![CDATA[
 <?php
 function xrange($start, $limit, $step = 1) {
-    if ($start < $limit) {
+    if ($start <= $limit) {
         if ($step <= 0) {
             throw new LogicException('Step must be +ve');
         }

--- a/language/generators.xml
+++ b/language/generators.xml
@@ -62,7 +62,7 @@ function xrange($start, $limit, $step = 1) {
             throw new LogicException('Step must be -ve');
         }
 
-        for ($i = $start; $i >= $limit; $i -= $step) {
+        for ($i = $start; $i >= $limit; $i += $step) {
             yield $i;
         }
     }

--- a/language/generators.xml
+++ b/language/generators.xml
@@ -51,7 +51,7 @@
 function xrange($start, $limit, $step = 1) {
     if ($start <= $limit) {
         if ($step <= 0) {
-            throw new LogicException('Step must be +ve');
+            throw new LogicException('Step must be positive');
         }
 
         for ($i = $start; $i <= $limit; $i += $step) {
@@ -59,7 +59,7 @@ function xrange($start, $limit, $step = 1) {
         }
     } else {
         if ($step >= 0) {
-            throw new LogicException('Step must be -ve');
+            throw new LogicException('Step must be negative');
         }
 
         for ($i = $start; $i >= $limit; $i += $step) {


### PR DESCRIPTION
First, the increment part in the `else` branch's loop must be `+=`, not `-=`, because `$step` is negative there.
Second, `$start == $limit` is OK for `range()`, the resulting sequence will simply contain only one value.

Also, I've noticed some deviation from how `range()` behaves: it ignores `$step`'s sign, and derives it from which of `$start` and `$limit` is greater. It also emits a warning if `$start != $limit && abs($step) > abs($limit - $start)` , and returns `false` (as well as if `$step == 0`).

If `xrange()` is thought of as an equivalent of `range()`, this should be addressed. Though, personally, I more like `xrange()` the way it is (except for the two errors initially mentioned), as it looks more consistent.

To check for [dis]similarities between `range()` and `xrange()`, I've used
<details><summary>the following code</summary>

```php
define('MAX_ITERATIONS', 20);

function testFunction($func, $args) {
    list($from, $to, $step) = $args;
    $counter = 0;
    try {
        foreach ($func($from, $to, $step) as $number) {
            echo " $number";
            $counter++;
            if ($counter > MAX_ITERATIONS) {
                echo ' INT' . PHP_EOL;
                break;
            }
        }
    } catch (Throwable $e) {
        echo " EXP: {$e->getMessage()}";
    }
    echo PHP_EOL;
}

$cases = [
    [2, 11, 2],
    [2, 11, -2],
    [2, 11, 0],
    [2, 2, 0],
    [11, 2, 2],
    [11, 2, -2],
    [2, 2, 2],
    [2, -2, -2],
    [2, 4, 10]
];

foreach ($cases as $case) {

    $caseAsString = implode(', ', $case);

    echo "Testing [$caseAsString]:" . PHP_EOL;
    echo 'range(): ';
    testFunction('range', $case);
    echo 'xrange():';
    testFunction('xrange', $case);
    echo PHP_EOL;

}
```
</details>