### PR TITLE
Fix title for proc_open entry.

### DIFF
--- a/appendices/migration74/new-features.xml
+++ b/appendices/migration74/new-features.xml
@@ -336,7 +336,7 @@ public function __unserialize(array $data): void;
   </sect3>
 
   <sect3 xml:id="migration74.new-features.standard.proc-open">
-   <title>Array merge functions without arguments</title>
+   <title>proc_open</title>
    <para>
     <function>proc_open</function> now accepts an array instead of a
     string for the command. In this case the process will be opened


### PR DESCRIPTION
Currently the "proc_open" section in new-features duplicates the title for the "Array merge functions without arguments" section.