### PR TITLE
Change FTP_IMAGE to FTP_BINARY

### DIFF
--- a/reference/ftp/functions/ftp-append.xml
+++ b/reference/ftp/functions/ftp-append.xml
@@ -14,7 +14,7 @@
    <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>remote_file</parameter></methodparam>
    <methodparam><type>string</type><parameter>local_file</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_IMAGE</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_BINARY</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
 

--- a/reference/ftp/functions/ftp-fget.xml
+++ b/reference/ftp/functions/ftp-fget.xml
@@ -12,7 +12,7 @@
    <methodparam><type>resource</type><parameter>ftp_stream</parameter></methodparam>
    <methodparam><type>resource</type><parameter>handle</parameter></methodparam>
    <methodparam><type>string</type><parameter>remote_file</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_IMAGE</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_BINARY</constant></initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>resumepos</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/ftp/functions/ftp-fput.xml
+++ b/reference/ftp/functions/ftp-fput.xml
@@ -12,7 +12,7 @@
    <methodparam><type>resource</type><parameter>ftp_stream</parameter></methodparam>
    <methodparam><type>string</type><parameter>remote_file</parameter></methodparam>
    <methodparam><type>resource</type><parameter>handle</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_IMAGE</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_BINARY</constant></initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>startpos</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/ftp/functions/ftp-nb-fget.xml
+++ b/reference/ftp/functions/ftp-nb-fget.xml
@@ -12,7 +12,7 @@
    <methodparam><type>resource</type><parameter>ftp_stream</parameter></methodparam>
    <methodparam><type>resource</type><parameter>handle</parameter></methodparam>
    <methodparam><type>string</type><parameter>remote_file</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_IMAGE</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_BINARY</constant></initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>resumepos</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/ftp/functions/ftp-nb-fput.xml
+++ b/reference/ftp/functions/ftp-nb-fput.xml
@@ -12,7 +12,7 @@
    <methodparam><type>resource</type><parameter>ftp_stream</parameter></methodparam>
    <methodparam><type>string</type><parameter>remote_file</parameter></methodparam>
    <methodparam><type>resource</type><parameter>handle</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_IMAGE</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_BINARY</constant></initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>startpos</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/ftp/functions/ftp-nb-get.xml
+++ b/reference/ftp/functions/ftp-nb-get.xml
@@ -12,7 +12,7 @@
    <methodparam><type>resource</type><parameter>ftp_stream</parameter></methodparam>
    <methodparam><type>string</type><parameter>local_file</parameter></methodparam>
    <methodparam><type>string</type><parameter>remote_file</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_IMAGE</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_BINARY</constant></initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>resumepos</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/ftp/functions/ftp-nb-put.xml
+++ b/reference/ftp/functions/ftp-nb-put.xml
@@ -12,7 +12,7 @@
    <methodparam><type>resource</type><parameter>ftp_stream</parameter></methodparam>
    <methodparam><type>string</type><parameter>remote_file</parameter></methodparam>
    <methodparam><type>string</type><parameter>local_file</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_IMAGE</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_BINARY</constant></initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>startpos</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/ftp/functions/ftp-put.xml
+++ b/reference/ftp/functions/ftp-put.xml
@@ -12,7 +12,7 @@
    <methodparam><type>resource</type><parameter>ftp_stream</parameter></methodparam>
    <methodparam><type>string</type><parameter>remote_file</parameter></methodparam>
    <methodparam><type>string</type><parameter>local_file</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_IMAGE</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_BINARY</constant></initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>startpos</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>


### PR DESCRIPTION
`FTP_IMAGE` is an alias of `FTP_BINARY`.
This makes the doc for this page consistent with others using `FTP_BINARY`