### PR TITLE
Add missing MB_CASE_UPPER_SIMPLE constant

### DIFF
--- a/reference/mbstring/constants.xml
+++ b/reference/mbstring/constants.xml
@@ -92,6 +92,17 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.mb-case-upper-simple">
+   <term>
+    <constant>MB_CASE_UPPER_SIMPLE</constant> 
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.mb-case-title-simple">
    <term>
     <constant>MB_CASE_TITLE_SIMPLE</constant> 


### PR DESCRIPTION
This constant appears in the [7.3 migration page](https://www.php.net/manual/en/migration73.constants.php#migration73.constants.mbstring), but for some reason was forgotten here.