### PR TITLE
Fix mysqli_get_client_info() parameter list

### DIFF
--- a/reference/mysqli/mysqli/get-client-info.xml
+++ b/reference/mysqli/mysqli/get-client-info.xml
@@ -19,7 +19,7 @@
   <para>&style.procedural;</para>
   <methodsynopsis>
    <type>string</type><methodname>mysqli_get_client_info</methodname>
-   <methodparam><type>mysqli</type><parameter>link</parameter></methodparam>
+   <methodparam><type>mysqli</type><parameter>link</parameter><initializer>NULL</initializer></methodparam>
   </methodsynopsis>
   <para>
    Returns a string that represents the MySQL client library version.


### PR DESCRIPTION
Based on the discussion at https://github.com/php/php-src/pull/4878#pullrequestreview-309797488, the signature of `mysqli_get_client_info()` should be fixed in the documentation.