### PR TITLE
Fix: Remove $serverctrls parameter from ldap_bind()

### DIFF
--- a/reference/ldap/functions/ldap-bind.xml
+++ b/reference/ldap/functions/ldap-bind.xml
@@ -13,7 +13,6 @@
    <methodparam><type>resource</type><parameter>link_identifier</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>bind_rdn</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>bind_password</parameter><initializer>&null;</initializer></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>serverctrls</parameter><initializer>array()</initializer></methodparam>
   </methodsynopsis>
   <para>
    Binds to the LDAP directory with specified RDN and password.
@@ -43,14 +42,6 @@
      <term><parameter>bind_password</parameter></term>
      <listitem>
       <para>
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>serverctrls</parameter></term>
-     <listitem>
-      <para>
-       Array of <link linkend="ldap.controls">LDAP Controls</link> to send with the request.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
This PR

* [x] removes the non-existent `$serverctrls` parameter from the documentation for `ldap_bind()`

💁‍♂ When looking at (for example)

* https://github.com/php/php-src/blob/php-7.3.11/ext/ldap/ldap.c#L1142-L1194
* https://github.com/php/php-src/blob/php-7.4.1/ext/ldap/ldap.c#L1117-L1169

it's not apparent that `ldap_bind()` accepts 4 arguments. It does not have a `$serverctrls` parameter.
