### PR TITLE
Cross-link FFI::load and FFI::scope

### DIFF
--- a/reference/ffi/ffi/load.xml
+++ b/reference/ffi/ffi/load.xml
@@ -46,6 +46,15 @@
   </para>
  </refsect1>
 
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>FFI::scope</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/ffi/ffi/load.xml
+++ b/reference/ffi/ffi/load.xml
@@ -50,7 +50,7 @@
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>FFI::scope</function></member>
+    <member><methodname>FFI::scope</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/ffi/ffi/scope.xml
+++ b/reference/ffi/ffi/scope.xml
@@ -39,6 +39,15 @@
   </para>
  </refsect1>
 
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>FFI::load</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/ffi/ffi/scope.xml
+++ b/reference/ffi/ffi/scope.xml
@@ -43,7 +43,7 @@
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>FFI::load</function></member>
+    <member><methodname>FFI::load</methodname></member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
These two methods are by design used in tandem, so they should cross-link to each other.