### PR TITLE
Fix #79133 - Replace <literal> with <code>

### DIFF
--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -249,7 +249,7 @@ class MyException extends Exception
    </para>
    <para>
     In PHP 7.1 and later, a &catch; block may specify multiple exceptions
-    using the pipe (<literal>|</literal>) character. This is useful for when
+    using the pipe (<code>|</code>) character. This is useful for when
     different exceptions from different class hierarchies are handled the
     same.
    </para>


### PR DESCRIPTION
For output reasons - a single literal pipe will be printed italic - looking like a `/`