### PR TITLE
Document missing curl constants added in 7.3.x

### DIFF
--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -1894,6 +1894,39 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curl-version-asynchdns">
+   <term>
+    <constant>CURL_VERSION_ASYNCHDNS</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.10.7
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-brotli">
+   <term>
+    <constant>CURL_VERSION_BROTLI</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.57.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-conv">
+   <term>
+    <constant>CURL_VERSION_CONV</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.15.4
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curl-version-curldebug">
    <term>
     <constant>CURL_VERSION_CURLDEBUG</constant>
@@ -1902,6 +1935,83 @@
    <listitem>
     <simpara>
      Available since PHP 7.3.6 and cURL 7.19.6
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-debug">
+   <term>
+    <constant>CURL_VERSION_DEBUG</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.10.6
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-gssapi">
+   <term>
+    <constant>CURL_VERSION_GSSAPI</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.38.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-gssnegotiate">
+   <term>
+    <constant>CURL_VERSION_GSSNEGOTIATE</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.10.6 (deprecated since 7.38.0)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-idn">
+   <term>
+    <constant>CURL_VERSION_IDN</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.12.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-multi-ssl">
+   <term>
+    <constant>CURL_VERSION_MULTI_SSL</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.56.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-ntlm">
+   <term>
+    <constant>CURL_VERSION_NTLM</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.10.6
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-ntlm-wb">
+   <term>
+    <constant>CURL_VERSION_NTLM_WB</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.22.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -1960,6 +2070,28 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curl-version-spnego">
+   <term>
+    <constant>CURL_VERSION_SPNEGO</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.10.8
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-sspi">
+   <term>
+    <constant>CURL_VERSION_SSPI</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.13.2
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curl-version-ssl">
    <term>
     <constant>CURL_VERSION_SSL</constant>
@@ -1968,6 +2100,17 @@
    <listitem>
     <simpara>
      
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-tlsauth-srp">
+   <term>
+    <constant>CURL_VERSION_TLSAUTH_SRP</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.21.4
     </simpara>
    </listitem>
   </varlistentry>
@@ -4181,6 +4324,226 @@
    <listitem>
     <simpara>
      Available since PHP 7.3.0 and cURL 7.52.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlauth-bearer">
+   <term>
+    <constant>CURLAUTH_BEARER</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.61.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlinfo-appconnect-time-t">
+   <term>
+    <constant>CURLINFO_APPCONNECT_TIME_T</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.61.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlinfo-connect-time-t">
+   <term>
+    <constant>CURLINFO_CONNECT_TIME_T</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.61.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlinfo-filetime-t">
+   <term>
+    <constant>CURLINFO_FILETIME_T</constant>
+   (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.59.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlinfo-namelookup-time-t">
+   <term>
+    <constant>CURLINFO_NAMELOOKUP_TIME_T</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.61.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlinfo-pretransfer-time-t">
+   <term>
+    <constant>CURLINFO_PRETRANSFER_TIME_T</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.61.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlinfo-redirect-time-t">
+   <term>
+    <constant>CURLINFO_REDIRECT_TIME_T</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.61.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlinfo-starttransfer-time-t">
+   <term>
+    <constant>CURLINFO_STARTTRANSFER_TIME_T</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.61.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlinfo-total-time-t">
+   <term>
+    <constant>CURLINFO_TOTAL_TIME_T</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.61.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlinfo-lock-data-connect">
+   <term>
+    <constant>CURL_LOCK_DATA_CONNECT</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.10.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlinfo-lock-data-psl">
+   <term>
+    <constant>CURL_LOCK_DATA_PSL</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.61.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-disallow-username-in-url">
+   <term>
+    <constant>CURLOPT_DISALLOW_USERNAME_IN_URL</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.61.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-dns-shuffle-addresses">
+   <term>
+    <constant>CURLOPT_DNS_SHUFFLE_ADDRESSES</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.60.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-happy-eyeballs-timeout-ms">
+   <term>
+    <constant>CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.59.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-haproxyprotocol">
+   <term>
+    <constant>CURLOPT_HAPROXYPROTOCOL</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.60.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-tls13-ciphers">
+   <term>
+    <constant>CURLOPT_PROXY_TLS13_CIPHERS</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.61.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssh-compression">
+   <term>
+    <constant>CURLOPT_SSH_COMPRESSION</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.56.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-timevalue-large">
+   <term>
+    <constant>CURLOPT_TIMEVALUE_LARGE</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.59.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tls13-ciphers">
+   <term>
+    <constant>CURLOPT_TLS13_CIPHERS</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.61.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlssh-auth-gssapi">
+   <term>
+    <constant>CURLSSH_AUTH_GSSAPI</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0 and cURL 7.58.0
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -260,12 +260,12 @@
         </listitem>
         <listitem>
          <simpara>
-          <constant>CURLINFO_HTTP_VERSION</constant> - The version used in the last HTTP connection. The return value will be one of the defined CURL_HTTP_VERSION_* or 0 if the version can't be determined
+          <constant>CURLINFO_HTTP_VERSION</constant> - The version used in the last HTTP connection. The return value will be one of the defined <constant>CURL_HTTP_VERSION_*</constant> constants or 0 if the version can't be determined
          </simpara>
         </listitem>
         <listitem>
          <simpara>
-          <constant>CURLINFO_PROTOCOL</constant> - The protocol used in the last HTTP connection. The returned value will be exactly one of the CURLPROTO_* values
+          <constant>CURLINFO_PROTOCOL</constant> - The protocol used in the last HTTP connection. The returned value will be exactly one of the <constant>CURLPROTO_*</constant> values
          </simpara>
         </listitem>
         <listitem>
@@ -280,12 +280,12 @@
         </listitem>
         <listitem>
          <simpara>
-          <constant>CURLINFO_SIZE_DOWNLOAD_T</constant> - Total amount of bytes that were downloaded. The amount is only for the latest transfer and will be reset again for each new transfer
+          <constant>CURLINFO_SIZE_DOWNLOAD_T</constant> - Total number of bytes that were downloaded. The number is only for the latest transfer and will be reset again for each new transfer
          </simpara>
         </listitem>
         <listitem>
          <simpara>
-          <constant>CURLINFO_SIZE_UPLOAD_T</constant> - Total amount of bytes that were uploaded
+          <constant>CURLINFO_SIZE_UPLOAD_T</constant> - Total number of bytes that were uploaded
          </simpara>
         </listitem>
         <listitem>

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -248,6 +248,96 @@
           <constant>CURLINFO_RTSP_SESSION_ID</constant> - RTSP session ID
          </simpara>
         </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant> - The content-length of the download. This is the value read from the <literal>Content-Type:</literal> field. -1 if the size isn't known
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant> - The specified size of the upload. -1 if the size isn't known
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_HTTP_VERSION</constant> - The version used in the last HTTP connection. The return value will be one of the defined CURL_HTTP_VERSION_* or 0 if the version can't be determined
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_PROTOCOL</constant> - The protocol used in the last HTTP connection. The returned value will be exactly one of the CURLPROTO_* values
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_PROXY_SSL_VERIFYRESULT</constant> - The result of the certificate verification that was requested (using the <constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant> option). Only used for HTTPS proxies
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_SCHEME</constant> - The URL scheme used for the most recent connection
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_SIZE_DOWNLOAD_T</constant> - Total amount of bytes that were downloaded. The amount is only for the latest transfer and will be reset again for each new transfer
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_SIZE_UPLOAD_T</constant> - Total amount of bytes that were uploaded
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_SPEED_DOWNLOAD_T</constant> - The average download speed in bytes/second that curl measured for the complete download
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_SPEED_UPLOAD_T</constant> - The average upload speed in bytes/second that curl measured for the complete upload 
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_APPCONNECT_TIME_T</constant> - Time, in microseconds, it took from the start until the SSL/SSH connect/handshake to the remote host was completed
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_CONNECT_TIME_T</constant> - Total time taken, in microseconds, from the start until the connection to the remote host (or proxy) was completed
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_FILETIME_T</constant> - Remote time of the retrieved document (as Unix timestamp), an alternative to <constant>CURLINFO_FILETIME</constant> to allow systems with 32 bit long variables to extract dates outside of the 32bit timestamp range
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_NAMELOOKUP_TIME_T</constant> - Time in microseconds from the start until the name resolving was completed
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_PRETRANSFER_TIME_T</constant> - Time taken from the start until the file transfer is just about to begin, in microseconds
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_REDIRECT_TIME_T</constant> - Total time, in microseconds, it took for all redirection steps include name lookup, connect, pretransfer and transfer before final transaction was started
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_STARTTRANSFER_TIME_T</constant> - Time, in microseconds, it took from the start until the first byte is received
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_TOTAL_TIME_T</constant> - Total time in microseconds for the previous transfer, including name resolving, TCP connect etc.
+         </simpara>
+        </listitem>
        </itemizedlist>
       </para>
      </listitem>
@@ -467,6 +557,29 @@
        <entry>5.1.3</entry>
        <entry>
         Introduced <constant>CURLINFO_HEADER_OUT</constant>.
+       </entry>
+      </row>
+      <row>
+       <entry>7.3.0</entry>
+       <entry>
+        Introduced <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant>,
+        <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant>, 
+        <constant>CURLINFO_HTTP_VERSION</constant>,
+        <constant>CURLINFO_PROTOCOL</constant>,
+        <constant>CURLINFO_PROXY_SSL_VERIFYRESULT</constant>,
+        <constant>CURLINFO_SCHEME</constant>,
+        <constant>CURLINFO_SIZE_DOWNLOAD_T</constant>,
+        <constant>CURLINFO_SIZE_UPLOAD_T</constant>,
+        <constant>CURLINFO_SPEED_DOWNLOAD_T</constant>,
+        <constant>CURLINFO_SPEED_UPLOAD_T</constant>,
+        <constant>CURLINFO_APPCONNECT_TIME_T</constant>,
+        <constant>CURLINFO_CONNECT_TIME_T</constant>,
+        <constant>CURLINFO_FILETIME_T</constant>,
+        <constant>CURLINFO_NAMELOOKUP_TIME_T</constant>,
+        <constant>CURLINFO_PRETRANSFER_TIME_T</constant>,
+        <constant>CURLINFO_REDIRECT_TIME_T</constant>,
+        <constant>CURLINFO_STARTTRANSFER_TIME_T</constant>,
+        <constant>CURLINFO_TOTAL_TIME_T</constant>.
        </entry>
       </row>
      </tbody>

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -119,6 +119,46 @@
            </entry>
           </row>
           <row>
+           <entry valign="top"><constant>CURLOPT_DISALLOW_USERNAME_IN_URL</constant></entry>
+           <entry valign="top">
+            &true; to not allow URLs that include a username. Usernames are allowed by default (0).
+           </entry>
+           <entry valign="top">
+            Added in cURL 7.61.0. Available since PHP 7.3.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_DNS_SHUFFLE_ADDRESSES</constant></entry>
+           <entry valign="top">
+            &true; to shuffle the order of all returned addresses so that they will be used 
+            in a random order, when a name is resolved and more than one IP address is returned.
+            This may cause IPv4 to be used before IPv6 or vice versa.
+           </entry>
+           <entry valign="top">
+            Added in cURL 7.60.0. Available since PHP 7.3.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_HAPROXYPROTOCOL</constant></entry>
+           <entry valign="top">
+            &true; to send an HAProxy PROXY protocol v1 header at beginning of the connection.
+            The default action is not to send this header.
+           </entry>
+           <entry valign="top">
+            Added in cURL 7.60.0. Available since PHP 7.3.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_SSH_COMPRESSION</constant></entry>
+           <entry valign="top">
+            &true; to enable built-in SSH compression. This is a request, not an order; 
+            the server may or may not do it.
+           </entry>
+           <entry valign="top">
+            Added in cURL 7.56.0. Available since PHP 7.3.0.
+           </entry>
+          </row>
+          <row>
            <entry valign="top"><constant>CURLOPT_DNS_USE_GLOBAL_CACHE</constant></entry>
            <entry valign="top">
             &true; to use a global DNS cache. This option is not thread-safe.
@@ -311,6 +351,18 @@
            </entry>
           </row>
           <row>
+           <entry valign="top"><constant>CURLOPT_KEEP_SENDING_ON_ERROR</constant></entry>
+           <entry valign="top">
+            &true; to keep sending the request body if the HTTP code returned is 
+            equal to or larger than 300. The default action would be to stop sending
+            and close the stream or connection. Suitable for manual NTLM authentication.
+            Most applications do not need this option.
+           </entry>
+           <entry valign="top">
+            Available as of PHP 7.3.0 if built against libcurl >= 7.51.0.
+           </entry>
+          </row>
+          <row>
            <entry valign="top"><constant>CURLOPT_MUTE</constant></entry>
            <entry valign="top">
             &true; to be completely silent with regards to
@@ -483,6 +535,31 @@
            </entry>
           </row>
           <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant></entry>
+           <entry valign="top">
+            &false; to stop cURL from verifying the peer's certificate.
+            Alternate certificates to verify against can be
+            specified with the <constant>CURLOPT_CAINFO</constant> option
+            or a certificate directory can be specified with the
+            <constant>CURLOPT_CAPATH</constant> option.
+            When set to false, the peer certificate verification succeeds regardless.
+           </entry>
+           <entry valign="top">
+            &true; by default. Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_SUPPRESS_CONNECT_HEADERS</constant></entry>
+           <entry valign="top">
+            &true; to suppress proxy CONNECT response headers from the user callback functions 
+            <constant>CURLOPT_HEADERFUNCTION</constant> and <constant>CURLOPT_WRITEFUNCTION</constant>,
+            when <constant>CURLOPT_HTTPPROXYTUNNEL</constant> is used and a CONNECT request is made.
+           </entry>
+           <entry valign="top">
+            Added in cURL 7.54.0. Available since PHP 7.3.0.
+           </entry>
+          </row>
+          <row>
            <entry valign="top"><constant>CURLOPT_TCP_FASTOPEN</constant></entry>
            <entry valign="top">
             &true; to enable TCP Fast Open.
@@ -622,6 +699,18 @@
            </entry>
            <entry valign="top">
             Added in cURL 7.36.0. Available since PHP 7.0.7.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS</constant></entry>
+           <entry valign="top">
+            Head start for ipv6 for happy eyeballs, an algorithm that attempts 
+            to connect to both IPv4 and IPv6 addresses for dual-stack hosts, 
+            preferring IPv6 first for timeout milliseconds.
+            Defaults to CURL_HET_DEFAULT, which is currently 200 milliseconds.
+           </entry>
+           <entry valign="top">
+            Added in cURL 7.59.0. Available since PHP 7.3.0.
            </entry>
           </row>
           <row>
@@ -869,6 +958,38 @@
            </entry>
           </row>
           <row>
+           <entry valign="top"><constant>CURLOPT_SOCKS5_AUTH</constant></entry>
+           <entry valign="top">
+            <para>
+             The SOCKS5 authentication method(s) to use. The options are:
+             <parameter>CURLAUTH_BASIC</parameter>,
+             <parameter>CURLAUTH_GSSAPI</parameter>,
+             <parameter>CURLAUTH_NONE</parameter>.
+            </para>
+            <para>
+             The bitwise <literal>|</literal> (or) operator can be used to combine
+             more than one method. If this is done, cURL will poll the server to see
+             what methods it supports and pick the best one.
+            </para>
+            <para>
+             <parameter>CURLAUTH_BASIC</parameter> allows username/password authentication.
+            </para>
+            <para>
+             <parameter>CURLAUTH_GSSAPI</parameter> allows GSS-API authentication.
+            </para>
+            <para>
+             <parameter>CURLAUTH_NONE</parameter> allows no authentication.
+            </para>
+           </entry>
+           <entry valign="top">
+            Defaults to <literal>CURLAUTH_BASIC|CURLAUTH_GSSAPI</literal>.
+            Set the actual username and password with the <constant>CURLOPT_PROXYUSERPWD</constant> option.
+           </entry>
+           <entry valign="top">
+            Available as of 7.3.0 and curl >= 7.55.0.
+           </entry>
+          </row>
+          <row>
            <entry valign="top"><constant>CURLOPT_SSL_OPTIONS</constant></entry>
            <entry valign="top">
             Set SSL behavior options, which is a bitmask of any of the following constants:
@@ -918,6 +1039,69 @@
             </note>
            </entry>
            <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_SSL_OPTIONS</constant></entry>
+           <entry valign="top">
+            Set proxy SSL behavior options, which is a bitmask of any of the following constants:
+            <simpara>
+             <constant>CURLSSLOPT_ALLOW_BEAST</constant>: do not attempt to use
+             any workarounds for a security flaw in the SSL3 and TLS1.0 protocols.
+            </simpara>
+            <simpara>
+             <constant>CURLSSLOPT_NO_REVOKE</constant>: disable certificate
+             revocation checks for those SSL backends where such behavior is
+             present. (curl >= 7.44.0)
+            </simpara>
+            <simpara>
+             <constant>CURLSSLOPT_NO_PARTIALCHAIN</constant>: do not accept "partial" 
+             certificate chains, which it otherwise does by default. (curl >= 7.68.0)
+            </simpara>
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_SSL_VERIFYHOST</constant></entry>
+           <entry valign="top">
+            Set to <literal>2</literal> to verify in the HTTPS proxy's certificate name fields against the proxy name. 
+            When set to <literal>0</literal> the connection succeeds regardless of the names used in the certificate. 
+            Use that ability with caution! 
+            <literal>1</literal> treated as a debug option in curl 7.28.0 and earlier. 
+            From curl 7.28.1 to 7.65.3 <constant>CURLE_BAD_FUNCTION_ARGUMENT</constant> is returned.
+            From curl 7.66.0 onwards <literal>1</literal> and <literal>2</literal> is treated as the same value.
+            In production environments the value of this option should be kept at <literal>2</literal> (default value).
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_SSLVERSION</constant></entry>
+           <entry valign="top">
+            One of <constant>CURL_SSLVERSION_DEFAULT</constant>,
+            <constant>CURL_SSLVERSION_TLSv1</constant>,
+            <constant>CURL_SSLVERSION_TLSv1_0</constant>,
+            <constant>CURL_SSLVERSION_TLSv1_1</constant>,
+            <constant>CURL_SSLVERSION_TLSv1_2</constant>,
+            <constant>CURL_SSLVERSION_TLSv1_3</constant>,
+            <constant>CURL_SSLVERSION_MAX_DEFAULT</constant>,
+            <constant>CURL_SSLVERSION_MAX_TLSv1_0</constant>,
+            <constant>CURL_SSLVERSION_MAX_TLSv1_2</constant>,
+            <constant>CURL_SSLVERSION_MAX_TLSv1_2</constant>,
+            <constant>CURL_SSLVERSION_MAX_TLSv1_3</constant> or
+            <constant>CURL_SSLVERSION_SSLv3</constant>.
+            <note>
+             <para>
+              Your best bet is to not set this and let it use the default <constant>CURL_SSLVERSION_DEFAULT</constant>
+              which will attempt to figure out the remote SSL protocol version.
+             </para>
+            </note>
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -975,6 +1159,19 @@
             <parameter>CURL_TIMECOND_IFMODSINCE</parameter> is used.
            </entry>
            <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_TIMEVALUE_LARGE</constant></entry>
+           <entry valign="top">
+            The time in seconds since January 1st, 1970. The time will be used
+            by <constant>CURLOPT_TIMECONDITION</constant>. Defaults to zero.
+            The difference between this option and <constant>CURLOPT_TIMEVALUE</constant>
+            is the type of the argument. On systems where 'long' is only 32 bit wide, 
+            this option has to be used to set dates beyond the year 2038.
+           </entry>
+           <entry valign="top">
+            Added in cURL 7.59.0. Available since PHP 7.3.0.
            </entry>
           </row>
           <row>
@@ -1059,6 +1256,20 @@
           </row>
          </thead>
          <tbody>
+          <row>
+           <entry valign="top"><constant>CURLOPT_ABSTRACT_UNIX_SOCKET</constant></entry>
+           <entry valign="top">
+            Enables the use of an abstract Unix domain socket instead of 
+            establishing a TCP connection to a host and sets the path to
+            the given <type>string</type>. This option shares the same semantics
+            as <constant>CURLOPT_UNIX_SOCKET_PATH</constant>. These two options
+            share the same storage and therefore only one of them can be set
+            per handle. 
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and cURL 7.53.0
+           </entry>
+          </row>
           <row>
            <entry valign="top"><constant>CURLOPT_CAINFO</constant></entry>
            <entry valign="top">
@@ -1313,6 +1524,26 @@
            </entry>
           </row>
           <row>
+           <entry valign="top"><constant>CURLOPT_PRE_PROXY</constant></entry>
+           <entry valign="top">
+            Set a <type>string</type> holding the host name or dotted numerical 
+            IP address to be used as the preproxy that curl connects to before 
+            it connects to the HTTP(S) proxy specified in the 
+            <constant>CURLOPT_PROXY</constant> option for the upcoming request.
+            The preproxy can only be a SOCKS proxy and it should be prefixed with
+            <literal>[scheme]://</literal> to specify which kind of socks is used.
+            A numerical IPv6 address must be written within [brackets].
+            Setting the preproxy to an empty string explicitly disables the use of a preproxy. 
+            To specify port number in this string, append <literal>:[port]</literal>
+            to the end of the host name. The proxy's port number may optionally be 
+            specified with the separate option <constant>CURLOPT_PROXYPORT</constant>. 
+            Defaults to using port 1080 for proxies if a port is not specified.
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+           </entry>
+          </row>
+          <row>
            <entry valign="top"><constant>CURLOPT_PROXY</constant></entry>
            <entry valign="top">
             The HTTP proxy to tunnel requests through.
@@ -1327,6 +1558,178 @@
            </entry>
            <entry valign="top">
             Added in cURL 7.34.0. Available since PHP 7.0.7.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_CAINFO</constant></entry>
+           <entry valign="top">
+            The path to proxy Certificate Authority (CA) bundle. Set the path as a 
+            <type>string</type> naming a file holding one or more certificates to 
+            verify the HTTPS proxy with.
+            This option is for connecting to an HTTPS proxy, not an HTTPS server.
+            Defaults set to the system path where libcurl's cacert bundle is assumed 
+            to be stored.
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_CAPATH</constant></entry>
+           <entry valign="top">
+            The directory holding multiple CA certificates to verify the HTTPS proxy with.
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_CRLFILE</constant></entry>
+           <entry valign="top">
+            Set the file name with the concatenation of CRL (Certificate Revocation List) 
+            in PEM format to use in the certificate validation that occurs during 
+            the SSL exchange.
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_KEYPASSWD</constant></entry>
+           <entry valign="top">
+            Set the string be used as the password required to use the 
+            <constant>CURLOPT_PROXY_SSLKEY</constant> private key. You never needed a 
+            passphrase to load a certificate but you need one to load your private key.
+            This option is for connecting to an HTTPS proxy, not an HTTPS server.
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_PINNEDPUBLICKEY</constant></entry>
+           <entry valign="top">
+            Set the pinned public key for HTTPS proxy. The string can be the file name 
+            of your pinned public key. The file format expected is "PEM" or "DER". 
+            The string can also be any number of base64 encoded sha256 hashes preceded by 
+            "sha256//" and separated by ";"
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_SSLCERT</constant></entry>
+           <entry valign="top">
+            The file name of your client certificate used to connect to the HTTPS proxy. 
+            The default format is "P12" on Secure Transport and "PEM" on other engines, 
+            and can be changed with <constant>CURLOPT_PROXY_SSLCERTTYPE</constant>.
+            With NSS or Secure Transport, this can also be the nickname of the certificate 
+            you wish to authenticate with as it is named in the security database. 
+            If you want to use a file from the current directory, please precede it with 
+            "./" prefix, in order to avoid confusion with a nickname.
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_SSLCERTTYPE</constant></entry>
+           <entry valign="top">
+            The format of your client certificate used when connecting to an HTTPS proxy.
+            Supported formats are "PEM" and "DER", except with Secure Transport. 
+            OpenSSL (versions 0.9.3 and later) and Secure Transport 
+            (on iOS 5 or later, or OS X 10.7 or later) also support "P12" for 
+            PKCS#12-encoded files. Defaults to "PEM".
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_SSL_CIPHER_LIST</constant></entry>
+           <entry valign="top">
+            The list of ciphers to use for the connection to the HTTPS proxy. 
+            The list must be syntactically correct, it consists of one or more cipher 
+            strings separated by colons. Commas or spaces are also acceptable separators 
+            but colons are normally used, !, - and + can be used as operators.
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_TLS13_CIPHERS</constant></entry>
+           <entry valign="top">
+            The list of cipher suites to use for the TLS 1.3 connection to a proxy.
+            The list must be syntactically correct, it consists of one or more 
+            cipher suite strings separated by colons. This option is currently used 
+            only when curl is built to use OpenSSL 1.1.1 or later. 
+            If you are using a different SSL backend you can try setting 
+            TLS 1.3 cipher suites by using the <constant>CURLOPT_PROXY_SSL_CIPHER_LIST</constant> option.
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.61.0. Available when built with OpenSSL >= 1.1.1.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_SSLKEY</constant></entry>
+           <entry valign="top">
+            The file name of your private key used for connecting to the HTTPS proxy. 
+            The default format is "PEM" and can be changed with 
+            <constant>CURLOPT_PROXY_SSLKEYTYPE</constant>. 
+            (iOS and Mac OS X only) This option is ignored if curl was built against Secure Transport.
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0. Available if built TLS enabled.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_SSLKEYTYPE</constant></entry>
+           <entry valign="top">
+            The format of your private key. Supported formats are "PEM", "DER" and "ENG".
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_TLSAUTH_PASSWORD</constant></entry>
+           <entry valign="top">
+            The password to use for the TLS authentication method specified with the 
+            <constant>CURLOPT_PROXY_TLSAUTH_TYPE</constant> option. Requires that the 
+            <constant>CURLOPT_PROXY_TLSAUTH_USERNAME</constant> option to also be set.
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_TLSAUTH_TYPE</constant></entry>
+           <entry valign="top">
+            The method of the TLS authentication used for the HTTPS connection. Supported method is "SRP".
+            <note>
+             <para>
+              Secure Remote Password (SRP) authentication for TLS provides mutual authentication 
+              if both sides have a shared secret. To use TLS-SRP, you must also set the 
+              <constant>CURLOPT_PROXY_TLSAUTH_USERNAME</constant> and 
+              <constant>CURLOPT_PROXY_TLSAUTH_PASSWORD</constant> options.
+             </para>
+            </note>
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_TLSAUTH_USERNAME</constant></entry>
+           <entry valign="top">
+            Tusername to use for the HTTPS proxy TLS authentication method specified with the 
+            <constant>CURLOPT_PROXY_TLSAUTH_TYPE</constant> option. Requires that the
+            <constant>CURLOPT_PROXY_TLSAUTH_PASSWORD</constant> option to also be set.
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -1500,6 +1903,19 @@
             and <literal>"ENG"</literal>.
            </entry>
            <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_TLS13_CIPHERS</constant></entry>
+           <entry valign="top">
+            The list of cipher suites to use for the TLS 1.3 connection. The list must be 
+            syntactically correct, it consists of one or more cipher suite strings separated by colons. 
+            This option is currently used only when curl is built to use OpenSSL 1.1.1 or later. 
+            If you are using a different SSL backend you can try setting 
+            TLS 1.3 cipher suites by using the <constant>CURLOPT_SSL_CIPHER_LIST</constant> option.
+           </entry>
+           <entry valign="top">
+            Available since PHP 7.3.0 and libcurl >= cURL 7.61.0. Available when built with OpenSSL >= 1.1.1.
            </entry>
           </row>
           <row>
@@ -1828,6 +2244,26 @@
        <entry>7.3.15, 7.4.3</entry>
        <entry>
         Introduced <constant>CURLOPT_HTTP09_ALLOWED </constant>.
+       </entry>
+      </row>
+      <row>
+       <entry>7.3.0</entry>
+       <entry>
+        Introduced <constant>CURLOPT_ABSTRACT_UNIX_SOCKET</constant>, <constant>CURLOPT_KEEP_SENDING_ON_ERROR</constant>,
+        <constant>CURLOPT_PRE_PROXY</constant>, <constant>CURLOPT_PROXY_CAINFO</constant>,
+        <constant>CURLOPT_PROXY_CAPATH</constant>, <constant>CURLOPT_PROXY_CRLFILE</constant>,
+        <constant>CURLOPT_PROXY_KEYPASSWD</constant>, <constant>CURLOPT_PROXY_PINNEDPUBLICKEY</constant>,
+        <constant>CURLOPT_PROXY_SSLCERT</constant>, <constant>CURLOPT_PROXY_SSLCERTTYPE</constant>,
+        <constant>CURLOPT_PROXY_SSL_CIPHER_LIST</constant>, <constant>CURLOPT_PROXY_SSLKEY</constant>,
+        <constant>CURLOPT_PROXY_SSLKEYTYPE</constant>, <constant>CURLOPT_PROXY_SSL_OPTIONS</constant>,
+        <constant>CURLOPT_PROXY_SSL_VERIFYHOST</constant>, <constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant>,
+        <constant>CURLOPT_PROXY_SSLVERSION</constant>, <constant>CURLOPT_PROXY_TLSAUTH_PASSWORD</constant>,
+        <constant>CURLOPT_PROXY_TLSAUTH_TYPE</constant>, <constant>CURLOPT_PROXY_TLSAUTH_USERNAME</constant>,
+        <constant>CURLOPT_SOCKS5_AUTH</constant>, <constant>CURLOPT_SUPPRESS_CONNECT_HEADERS</constant>,
+        <constant>CURLOPT_DISALLOW_USERNAME_IN_URL</constant>, <constant>CURLOPT_DNS_SHUFFLE_ADDRESSES</constant>,
+        <constant>CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS</constant>, <constant>CURLOPT_HAPROXYPROTOCOL</constant>,
+        <constant>CURLOPT_PROXY_TLS13_CIPHERS</constant>, <constant>CURLOPT_SSH_COMPRESSION</constant>,
+        <constant>CURLOPT_TIMEVALUE_LARGE</constant> and <constant>CURLOPT_TLS13_CIPHERS</constant>.
        </entry>
       </row>
       <row>

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -141,7 +141,7 @@
           <row>
            <entry valign="top"><constant>CURLOPT_HAPROXYPROTOCOL</constant></entry>
            <entry valign="top">
-            &true; to send an HAProxy PROXY protocol v1 header at beginning of the connection.
+            &true; to send an HAProxy PROXY protocol v1 header at the start of the connection.
             The default action is not to send this header.
            </entry>
            <entry valign="top">
@@ -704,7 +704,7 @@
           <row>
            <entry valign="top"><constant>CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS</constant></entry>
            <entry valign="top">
-            Head start for ipv6 for happy eyeballs, an algorithm that attempts 
+            Head start for ipv6 for the happy eyeballs algorithm. Happy eyeballs attempts
             to connect to both IPv4 and IPv6 addresses for dual-stack hosts, 
             preferring IPv6 first for timeout milliseconds.
             Defaults to CURL_HET_DEFAULT, which is currently 200 milliseconds.


### PR DESCRIPTION
FYI, I was looking at the following blame and curl's symbol versions reference for these changes:
[blame](https://github.com/php/php-src/blame/494615fcb8c1fb5984e0e7d666e51a2dfc6bee55/UPGRADING#L570)
[symbols in versions](https://github.com/curl/curl/blob/master/docs/libcurl/symbols-in-versions)

There are two commits of interest from the blame:
[Add constants from curl 7.50 to 7.55](https://github.com/php/php-src/commit/02b2dbb7242cba4324ceebe27fe8ad1e5eedc818) - merged into 7.3.0RC3
[Add constants from curl 7.56 to 7.61](https://github.com/php/php-src/commit/64881a1e64b47cb612d358f2ebf234defe314e90) - merged into 7.3.0RC3