### PR TITLE
Add missed `deprecated` attributes in versions.xml of info/ and image/

### DIFF
--- a/reference/image/versions.xml
+++ b/reference/image/versions.xml
@@ -90,14 +90,14 @@
  <function name="imagepalettetotruecolor" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
  <function name="imagepng" from="PHP 4, PHP 5, PHP 7"/>
  <function name="imagepolygon" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagepsbbox" from="PHP 4, PHP 5"/>
- <function name="imagepscopyfont" from="PHP 5"/>
- <function name="imagepsencodefont" from="PHP 4, PHP 5"/>
- <function name="imagepsextendfont" from="PHP 4, PHP 5"/>
- <function name="imagepsfreefont" from="PHP 4, PHP 5"/>
- <function name="imagepsloadfont" from="PHP 4, PHP 5"/>
- <function name="imagepsslantfont" from="PHP 4, PHP 5"/>
- <function name="imagepstext" from="PHP 4, PHP 5"/>
+ <function name="imagepsbbox" from="PHP 4, PHP 5" deprecated="PHP 7"/>
+ <function name="imagepscopyfont" from="PHP 5" deprecated="PHP 7"/>
+ <function name="imagepsencodefont" from="PHP 4, PHP 5" deprecated="PHP 7"/>
+ <function name="imagepsextendfont" from="PHP 4, PHP 5" deprecated="PHP 7"/>
+ <function name="imagepsfreefont" from="PHP 4, PHP 5" deprecated="PHP 7"/>
+ <function name="imagepsloadfont" from="PHP 4, PHP 5" deprecated="PHP 7"/>
+ <function name="imagepsslantfont" from="PHP 4, PHP 5" deprecated="PHP 7"/>
+ <function name="imagepstext" from="PHP 4, PHP 5" deprecated="PHP 7"/>
  <function name="imagerectangle" from="PHP 4, PHP 5, PHP 7"/>
  <function name="imageresolution" from="PHP 7 &gt;= 7.2.0"/>
  <function name="imagerotate" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>

--- a/reference/info/versions.xml
+++ b/reference/info/versions.xml
@@ -48,8 +48,8 @@
  <function name='php_egg_logo_guid' from='PHP 4 &gt;= 4.0.3, PHP 5 &lt; 5.5.0, PHP 7'/>
  <function name='php_ini_loaded_file' from='PHP 5 &gt;= 5.2.4, PHP 7'/>
  <function name='php_ini_scanned_files' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='php_logo_guid' from='PHP 4, PHP 5 &lt; 5.5.0'/>
- <function name='php_real_logo_guid' from='PHP 5 &lt; 5.5.0'/>
+ <function name='php_logo_guid' from='PHP 4, PHP 5 &lt; 5.5.0' deprecated='PHP 5.5.0' />
+ <function name='php_real_logo_guid' from='PHP 5 &lt; 5.5.0' deprecated='PHP 5.5.0' />
  <function name='php_sapi_name' from='PHP 4 &gt;= 4.0.1, PHP 5, PHP 7'/>
  <function name='php_uname' from='PHP 4 &gt;= 4.0.2, PHP 5, PHP 7'/>
  <function name='phpcredits' from='PHP 4, PHP 5, PHP 7'/>
@@ -62,7 +62,7 @@
  <function name='set_time_limit' from='PHP 4, PHP 5, PHP 7'/>
  <function name='sys_get_temp_dir' from='PHP 5 &gt;= 5.2.1, PHP 7'/>
  <function name='version_compare' from='PHP 4 &gt;= 4.1.0, PHP 5, PHP 7'/>
- <function name='zend_logo_guid' from='PHP 4, PHP &lt; 5.5.0'/>
+ <function name='zend_logo_guid' from='PHP 4, PHP &lt; 5.5.0' deprecated='PHP 5.5.0'/>
  <function name='zend_thread_id' from='PHP 5, PHP 7'/>
  <function name='zend_version' from='PHP 4, PHP 5, PHP 7'/>
 </versions>


### PR DESCRIPTION
Added `deprecated` tags to some functions, because they should be placed in a '**Deprecated**' section of menu.
![image](https://user-images.githubusercontent.com/695546/73822245-b7455780-4806-11ea-9a11-aec87f819660.png)
