### PR TITLE
Remove hint to security purpose of disable_functions

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -353,8 +353,7 @@
       </term>
       <listitem>
        <para>
-        This directive allows you to disable certain functions for 
-        <link linkend="security">security</link> reasons. It takes 
+        This directive allows you to disable certain functions. It takes 
         on a comma-delimited list of function names. disable_functions
         is not affected by <link linkend="ini.safe-mode">Safe Mode</link>.
        </para>

--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -354,8 +354,7 @@
       <listitem>
        <para>
         This directive allows you to disable certain functions. It takes 
-        on a comma-delimited list of function names. disable_functions
-        is not affected by <link linkend="ini.safe-mode">Safe Mode</link>.
+        on a comma-delimited list of function names.
        </para>
        <para>
         Only <link linkend="functions.internal">internal functions</link> can
@@ -377,8 +376,7 @@
       <listitem>
        <simpara>
         This directive allows you to disable certain classes. It takes
-        on a comma-delimited list of class names. disable_classes
-        is not affected by <link linkend="ini.safe-mode">Safe Mode</link>.
+        on a comma-delimited list of class names.
        </simpara>
        <simpara>
         This directive must be set in &php.ini;  For example, you

--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -376,9 +376,8 @@
       </term>
       <listitem>
        <simpara>
-        This directive allows you to disable certain classes for
-        <link linkend="security">security</link> reasons.  It takes
-        on a comma-delimited list of class names.  disable_classes
+        This directive allows you to disable certain classes. It takes
+        on a comma-delimited list of class names. disable_classes
         is not affected by <link linkend="ini.safe-mode">Safe Mode</link>.
        </simpara>
        <simpara>


### PR DESCRIPTION
Because this feature shouldnt be used for security purposes (its zero percent effective) this hint is misleading.