### PR TITLE
Fix typo on Runtime Configuration page

### DIFF
--- a/reference/info/ini.xml
+++ b/reference/info/ini.xml
@@ -5,7 +5,7 @@
  &extension.runtime;
  <para>
   <table>
-   <title>PHP Options/Inf Configuration Options</title>
+   <title>PHP Options/Info Configuration Options</title>
    <tgroup cols="4">
     <thead>
      <row>


### PR DESCRIPTION
https://www.php.net/manual/en/info.configuration.php