### PR TITLE
Remove the incorrect pattern "..." in glob()

### DIFF
--- a/reference/filesystem/functions/glob.xml
+++ b/reference/filesystem/functions/glob.xml
@@ -53,11 +53,6 @@
         </listitem>
         <listitem>
          <simpara>
-          <literal>...</literal> - Matches all the subdirectories, recursively.
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
           <literal>\</literal> - Escapes the following character,
           except when the <constant>GLOB_NOESCAPE</constant> flag is used.
          </simpara>


### PR DESCRIPTION
According to the linked answer on Stack Overflow, and to my actual experience, the ... special character does nothing, returning anything but a recursive list of sub-directories. Looks like it should be removed.
https://stackoverflow.com/questions/58852914/glob-pattern-does-not-match-anything