### PR TITLE
Clarification of return values descriptions for mysqi fetch functions

### DIFF
--- a/reference/mysqli/mysqli_result/fetch-assoc.xml
+++ b/reference/mysqli/mysqli_result/fetch-assoc.xml
@@ -39,7 +39,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an associative array of strings representing the fetched row in the result
+   Returns an associative array representing the fetched row in the result
    set, where each key in the array represents the name of one of the result
    set's columns or &null; if there are no more rows in resultset.
   </para>
@@ -47,7 +47,7 @@
    If two or more columns of the result have the same field names, the last
    column will take precedence. To access the other column(s) of the same
    name, you either need to access the result with numeric indices by using
-   <function>mysqli_fetch_row</function> or add alias names.
+   <function>mysqli_fetch_row</function> or add alias names to the SQL query.
   </para>
  </refsect1>
 

--- a/reference/mysqli/mysqli_result/fetch-object.xml
+++ b/reference/mysqli/mysqli_result/fetch-object.xml
@@ -63,9 +63,17 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an object with string properties that corresponds to the fetched
-   row or &null; if there are no more rows in resultset.
+   Returns an object representing the fetched row, where each property
+   represents the name of one of the result set's columns or &null;
+   if there are no more rows in resultset.
   </para>
+  <para>
+   If two or more columns of the result have the same field names, the last
+   column will take precedence. To access the other column(s) of the same
+   name, you either need to access the result with numeric indices by using
+   <function>mysqli_fetch_row</function> or add alias names to the SQL query.
+  </para>
+
   &database.field-case;
   &database.fetch-null;
  </refsect1>

--- a/reference/mysqli/mysqli_result/fetch-row.xml
+++ b/reference/mysqli/mysqli_result/fetch-row.xml
@@ -39,7 +39,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <function>mysqli_fetch_row</function> returns an array of strings that corresponds to the fetched row
+   <function>mysqli_fetch_row</function> returns an enumerated array representing the fetched row
    or &null; if there are no more rows in result set.
   </para>
   &database.fetch-null;


### PR DESCRIPTION
The first intention was to remove "of strings" as factually incorrect. In mysqli, a null, int or float value can be returned in the resulting array or object depends on the configuration. 

Besides, "string" being sort of a synonym for "row", made an ambiguity which resulted in the disastrous  Russian translation where it now says "returns an array of rows".

Then some minor unification and clarification followed. 