### PR TITLE
Link to hash_algos() from hash() and hash_file()

### DIFF
--- a/reference/hash/functions/hash-file.xml
+++ b/reference/hash/functions/hash-file.xml
@@ -24,7 +24,7 @@
      <term><parameter>algo</parameter></term>
      <listitem>
       <para>
-       Name of selected hashing algorithm (i.e. "md5", "sha256", "haval160,4", etc..)
+       Name of selected hashing algorithm (i.e. "md5", "sha256", "haval160,4", etc..). For a list of supported algorithms see <function>hash_algos</function>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/hash/functions/hash.xml
+++ b/reference/hash/functions/hash.xml
@@ -23,7 +23,7 @@
      <term><parameter>algo</parameter></term>
      <listitem>
       <para>
-       Name of selected hashing algorithm (e.g. "md5", "sha256", "haval160,4", etc..)
+       Name of selected hashing algorithm (i.e. "md5", "sha256", "haval160,4", etc..). For a list of supported algorithms see <function>hash_algos</function>.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
`hash_hkdf()`, `hash_hmac()`, `hash_hmac_file()`, and `hash_pbkdf2()` all link to `hash_algos()`, but this hasn't been copied across to the "main" hash functions `hash()` and `hash_file()`. This PR brings these functions in line.

(Because it annoys me every time I see `etc..`)