### PR TITLE
Fix #79245: Document DateTime::RFC7231

### DIFF
--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -78,6 +78,12 @@
      <initializer>"D, d M Y H:i:s O"</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
+      <modifier>const</modifier>
+      <type>string</type>
+      <varname linkend="datetime.constants.rfc7231">DateTimeInterface::RFC7231</varname>
+      <initializer>"D, d M Y H:i:s \G\M\T"</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
      <modifier>const</modifier>
      <type>string</type>
      <varname linkend="datetime.constants.rfc2822">DateTimeInterface::RFC2822</varname>
@@ -107,7 +113,7 @@
      <varname linkend="datetime.constants.w3c">DateTimeInterface::W3C</varname>
      <initializer>"Y-m-d\TH:i:sP"</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTimeInterface'])" />
    </classsynopsis>
@@ -195,6 +201,16 @@
        RFC 1123 (example: Mon, 15 Aug 2005 15:52:01 +0000)
       </simpara>
      </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="datetime.constants.rfc7231">
+      <term><constant>DateTimeInterface::RFC7231</constant></term>
+      <term><constant>DATE_RFC7231</constant></term>
+      <listitem>
+       <simpara>
+        RFC 7231 (since PHP 7.0.19 and 7.1.5) (example: Sat, 30 Apr 2016 17:52:13 GMT)
+       </simpara>
+      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="datetime.constants.rfc2822">


### PR DESCRIPTION
This constant was introduced via php/php-src#2450 by @duncan3dc but it was never documented.