### PR TITLE
Fix #79256: Generator::next not behaving as documented

### DIFF
--- a/language/predefined/generator/next.xml
+++ b/language/predefined/generator/next.xml
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Calling <methodname>Generator::next</methodname> is equivalent to calling
+   Calling <methodname>Generator::next</methodname> has the same effect as calling
    <methodname>Generator::send</methodname> with &null; as argument.
   </para>
  </refsect1>


### PR DESCRIPTION
Attempting to use the return value of a void function will evaluate to NULL, hence calling next() has the same effect as send(null) https://3v4l.org/PsDrI9 so that sentence is valid.

This change is just to not say 'it is equivalent', as they aren't fully the same.