### PR TITLE
Fix #79168: Missing `__construct` method documentation in SPL Exceptions

### DIFF
--- a/reference/spl/badfunctioncallexception.xml
+++ b/reference/spl/badfunctioncallexception.xml
@@ -49,6 +49,7 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.badfunctioncallexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 -->
    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[1])"><xi:fallback /></xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/spl/badfunctioncallexception.xml
+++ b/reference/spl/badfunctioncallexception.xml
@@ -8,9 +8,9 @@
  xmlns="http://docbook.org/ns/docbook">
  <title>The BadFunctionCallException class</title>
  <titleabbrev>BadFunctionCallException</titleabbrev>
- 
+
  <partintro>
- 
+
 <!-- {{{ BadFunctionCallException intro -->
   <section xml:id="badfunctioncallexception.intro">
    &reftitle.intro;
@@ -20,27 +20,27 @@
    </para>
   </section>
 <!-- }}} -->
- 
+
   <section xml:id="badfunctioncallexception.synopsis">
    &reftitle.classsynopsis;
- 
+
 <!-- {{{ Synopsis -->
    <classsynopsis>
     <ooclass><classname>BadFunctionCallException</classname></ooclass>
- 
+
 <!-- {{{ Exception synopsis -->
     <classsynopsisinfo>
      <ooclass>
       <classname>BadFunctionCallException</classname>
      </ooclass>
- 
+
     <ooclass>
       <modifier>extends</modifier>
       <classname>LogicException</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)" />
 
@@ -53,17 +53,17 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->
- 
+
   </section>
- 
+
  </partintro>
- 
+
  <!-- If the exception has any methods you'd like to document use this
  &reference.extname.entities.classname;
  -->
- 
+
 </phpdoc:exceptionref>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/spl/badmethodcallexception.xml
+++ b/reference/spl/badmethodcallexception.xml
@@ -49,6 +49,7 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.badmethodcallexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 -->
    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[1])"><xi:fallback /></xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/spl/badmethodcallexception.xml
+++ b/reference/spl/badmethodcallexception.xml
@@ -8,9 +8,9 @@
  xmlns="http://docbook.org/ns/docbook">
  <title>The BadMethodCallException class</title>
  <titleabbrev>BadMethodCallException</titleabbrev>
- 
+
  <partintro>
- 
+
 <!-- {{{ BadMethodCallException intro -->
   <section xml:id="badmethodcallexception.intro">
    &reftitle.intro;
@@ -20,27 +20,27 @@
    </para>
   </section>
 <!-- }}} -->
- 
+
   <section xml:id="badmethodcallexception.synopsis">
    &reftitle.classsynopsis;
- 
+
 <!-- {{{ Synopsis -->
    <classsynopsis>
     <ooclass><classname>BadMethodCallException</classname></ooclass>
- 
+
 <!-- {{{ Exception synopsis -->
     <classsynopsisinfo>
      <ooclass>
       <classname>BadMethodCallException</classname>
      </ooclass>
- 
+
     <ooclass>
       <modifier>extends</modifier>
       <classname>BadFunctionCallException</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)" />
 
@@ -53,17 +53,17 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->
- 
+
   </section>
- 
+
  </partintro>
- 
+
  <!-- If the exception has any methods you'd like to document use this
  &reference.extname.entities.classname;
  -->
- 
+
 </phpdoc:exceptionref>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/spl/domainexception.xml
+++ b/reference/spl/domainexception.xml
@@ -48,6 +48,7 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domainexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 -->
    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[1])"><xi:fallback /></xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/spl/domainexception.xml
+++ b/reference/spl/domainexception.xml
@@ -8,9 +8,9 @@
  xmlns="http://docbook.org/ns/docbook">
  <title>The DomainException class</title>
  <titleabbrev>DomainException</titleabbrev>
- 
+
  <partintro>
- 
+
 <!-- {{{ DomainException intro -->
   <section xml:id="domainexception.intro">
    &reftitle.intro;
@@ -19,27 +19,27 @@
    </para>
   </section>
 <!-- }}} -->
- 
+
   <section xml:id="domainexception.synopsis">
    &reftitle.classsynopsis;
- 
+
 <!-- {{{ Synopsis -->
    <classsynopsis>
     <ooclass><classname>DomainException</classname></ooclass>
- 
+
 <!-- {{{ Exception synopsis -->
     <classsynopsisinfo>
      <ooclass>
       <classname>DomainException</classname>
      </ooclass>
- 
+
     <ooclass>
       <modifier>extends</modifier>
       <classname>LogicException</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)" />
 
@@ -52,17 +52,17 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->
- 
+
   </section>
- 
+
  </partintro>
- 
+
  <!-- If the exception has any methods you'd like to document use this
  &reference.extname.entities.classname;
  -->
- 
+
 </phpdoc:exceptionref>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/spl/invalidargumentexception.xml
+++ b/reference/spl/invalidargumentexception.xml
@@ -48,6 +48,7 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.invalidargumentexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 -->
    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[1])"><xi:fallback /></xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/spl/invalidargumentexception.xml
+++ b/reference/spl/invalidargumentexception.xml
@@ -8,9 +8,9 @@
  xmlns="http://docbook.org/ns/docbook">
  <title>The InvalidArgumentException class</title>
  <titleabbrev>InvalidArgumentException</titleabbrev>
- 
+
  <partintro>
- 
+
 <!-- {{{ InvalidArgumentException intro -->
   <section xml:id="invalidargumentexception.intro">
    &reftitle.intro;
@@ -19,27 +19,27 @@
    </para>
   </section>
 <!-- }}} -->
- 
+
   <section xml:id="invalidargumentexception.synopsis">
    &reftitle.classsynopsis;
- 
+
 <!-- {{{ Synopsis -->
    <classsynopsis>
     <ooclass><classname>InvalidArgumentException</classname></ooclass>
- 
+
 <!-- {{{ Exception synopsis -->
     <classsynopsisinfo>
      <ooclass>
       <classname>InvalidArgumentException</classname>
      </ooclass>
- 
+
     <ooclass>
       <modifier>extends</modifier>
       <classname>LogicException</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)" />
 
@@ -52,16 +52,16 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->
- 
+
   </section>
  </partintro>
- 
+
  <!-- If the exception has any methods you'd like to document use this
  &reference.extname.entities.classname;
  -->
- 
+
 </phpdoc:exceptionref>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/spl/lengthexception.xml
+++ b/reference/spl/lengthexception.xml
@@ -48,6 +48,7 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.lengthexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 -->
    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[1])"><xi:fallback /></xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/spl/lengthexception.xml
+++ b/reference/spl/lengthexception.xml
@@ -8,9 +8,9 @@
  xmlns="http://docbook.org/ns/docbook">
  <title>The LengthException class</title>
  <titleabbrev>LengthException</titleabbrev>
- 
+
  <partintro>
- 
+
 <!-- {{{ LengthException intro -->
   <section xml:id="lengthexception.intro">
    &reftitle.intro;
@@ -19,27 +19,27 @@
    </para>
   </section>
 <!-- }}} -->
- 
+
   <section xml:id="lengthexception.synopsis">
    &reftitle.classsynopsis;
- 
+
 <!-- {{{ Synopsis -->
    <classsynopsis>
     <ooclass><classname>LengthException</classname></ooclass>
- 
+
 <!-- {{{ Exception synopsis -->
     <classsynopsisinfo>
      <ooclass>
       <classname>LengthException</classname>
      </ooclass>
- 
+
     <ooclass>
       <modifier>extends</modifier>
       <classname>LogicException</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)" />
 
@@ -52,17 +52,17 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->
- 
+
   </section>
- 
+
  </partintro>
- 
+
  <!-- If the exception has any methods you'd like to document use this
  &reference.extname.entities.classname;
  -->
- 
+
 </phpdoc:exceptionref>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/spl/logicexception.xml
+++ b/reference/spl/logicexception.xml
@@ -49,6 +49,7 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.logicexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 -->
    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[1])"><xi:fallback /></xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/spl/logicexception.xml
+++ b/reference/spl/logicexception.xml
@@ -8,9 +8,9 @@
  xmlns="http://docbook.org/ns/docbook">
  <title>The LogicException class</title>
  <titleabbrev>LogicException</titleabbrev>
- 
+
  <partintro>
- 
+
 <!-- {{{ LogicException intro -->
   <section xml:id="logicexception.intro">
    &reftitle.intro;
@@ -20,27 +20,27 @@
    </para>
   </section>
 <!-- }}} -->
- 
+
   <section xml:id="logicexception.synopsis">
    &reftitle.classsynopsis;
- 
+
 <!-- {{{ Synopsis -->
    <classsynopsis>
     <ooclass><classname>LogicException</classname></ooclass>
- 
+
 <!-- {{{ Exception synopsis -->
     <classsynopsisinfo>
      <ooclass>
       <classname>LogicException</classname>
      </ooclass>
- 
+
     <ooclass>
       <modifier>extends</modifier>
       <classname>Exception</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)" />
 
@@ -53,17 +53,17 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->
- 
+
   </section>
- 
+
  </partintro>
- 
+
  <!-- If the exception has any methods you'd like to document use this
  &reference.extname.entities.classname;
  -->
- 
+
 </phpdoc:exceptionref>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/spl/outofboundsexception.xml
+++ b/reference/spl/outofboundsexception.xml
@@ -49,6 +49,7 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.outofboundsexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 -->
    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[1])"><xi:fallback /></xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/spl/outofboundsexception.xml
+++ b/reference/spl/outofboundsexception.xml
@@ -8,9 +8,9 @@
  xmlns="http://docbook.org/ns/docbook">
  <title>The OutOfBoundsException class</title>
  <titleabbrev>OutOfBoundsException</titleabbrev>
- 
+
  <partintro>
- 
+
 <!-- {{{ OutOfBoundsException intro -->
   <section xml:id="outofboundsexception.intro">
    &reftitle.intro;
@@ -20,27 +20,27 @@
    </para>
   </section>
 <!-- }}} -->
- 
+
   <section xml:id="outofboundsexception.synopsis">
    &reftitle.classsynopsis;
- 
+
 <!-- {{{ Synopsis -->
    <classsynopsis>
     <ooclass><classname>OutOfBoundsException</classname></ooclass>
- 
+
 <!-- {{{ Exception synopsis -->
     <classsynopsisinfo>
      <ooclass>
       <classname>OutOfBoundsException</classname>
      </ooclass>
- 
+
     <ooclass>
       <modifier>extends</modifier>
       <classname>RuntimeException</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)" />
 
@@ -53,17 +53,17 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->
- 
+
   </section>
- 
+
  </partintro>
- 
+
  <!-- If the exception has any methods you'd like to document use this
  &reference.extname.entities.classname;
  -->
- 
+
 </phpdoc:exceptionref>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/spl/outofrangeexception.xml
+++ b/reference/spl/outofrangeexception.xml
@@ -49,6 +49,7 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.outofrangeexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 -->
    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[1])"><xi:fallback /></xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/spl/outofrangeexception.xml
+++ b/reference/spl/outofrangeexception.xml
@@ -8,9 +8,9 @@
  xmlns="http://docbook.org/ns/docbook">
  <title>The OutOfRangeException class</title>
  <titleabbrev>OutOfRangeException</titleabbrev>
- 
+
  <partintro>
- 
+
 <!-- {{{ OutOfRangeException intro -->
   <section xml:id="outofrangeexception.intro">
    &reftitle.intro;
@@ -20,27 +20,27 @@
    </para>
   </section>
 <!-- }}} -->
- 
+
   <section xml:id="outofrangeexception.synopsis">
    &reftitle.classsynopsis;
- 
+
 <!-- {{{ Synopsis -->
    <classsynopsis>
     <ooclass><classname>OutOfRangeException</classname></ooclass>
- 
+
 <!-- {{{ Exception synopsis -->
     <classsynopsisinfo>
      <ooclass>
       <classname>OutOfRangeException</classname>
      </ooclass>
- 
+
     <ooclass>
       <modifier>extends</modifier>
       <classname>LogicException</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)" />
 
@@ -53,17 +53,17 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->
- 
+
   </section>
- 
+
  </partintro>
- 
+
  <!-- If the exception has any methods you'd like to document use this
  &reference.extname.entities.classname;
  -->
- 
+
 </phpdoc:exceptionref>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/spl/overflowexception.xml
+++ b/reference/spl/overflowexception.xml
@@ -48,6 +48,7 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.overflowexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 -->
    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[1])"><xi:fallback /></xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/spl/overflowexception.xml
+++ b/reference/spl/overflowexception.xml
@@ -8,9 +8,9 @@
  xmlns="http://docbook.org/ns/docbook">
  <title>The OverflowException class</title>
  <titleabbrev>OverflowException</titleabbrev>
- 
+
  <partintro>
- 
+
 <!-- {{{ OverflowException intro -->
   <section xml:id="overflowexception.intro">
    &reftitle.intro;
@@ -19,27 +19,27 @@
    </para>
   </section>
 <!-- }}} -->
- 
+
   <section xml:id="overflowexception.synopsis">
    &reftitle.classsynopsis;
- 
+
 <!-- {{{ Synopsis -->
    <classsynopsis>
     <ooclass><classname>OverflowException</classname></ooclass>
- 
+
 <!-- {{{ Exception synopsis -->
     <classsynopsisinfo>
      <ooclass>
       <classname>OverflowException</classname>
      </ooclass>
- 
+
     <ooclass>
       <modifier>extends</modifier>
       <classname>RuntimeException</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)" />
 
@@ -52,17 +52,17 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->
- 
+
   </section>
- 
+
  </partintro>
- 
+
  <!-- If the exception has any methods you'd like to document use this
  &reference.extname.entities.classname;
  -->
- 
+
 </phpdoc:exceptionref>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/spl/rangeexception.xml
+++ b/reference/spl/rangeexception.xml
@@ -51,6 +51,7 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rangeexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 -->
    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[1])"><xi:fallback /></xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/spl/rangeexception.xml
+++ b/reference/spl/rangeexception.xml
@@ -8,9 +8,9 @@
  xmlns="http://docbook.org/ns/docbook">
  <title>The RangeException class</title>
  <titleabbrev>RangeException</titleabbrev>
- 
+
  <partintro>
- 
+
 <!-- {{{ RangeException intro -->
   <section xml:id="rangeexception.intro">
    &reftitle.intro;
@@ -22,27 +22,27 @@
    </para>
   </section>
 <!-- }}} -->
- 
+
   <section xml:id="rangeexception.synopsis">
    &reftitle.classsynopsis;
- 
+
 <!-- {{{ Synopsis -->
    <classsynopsis>
     <ooclass><classname>RangeException</classname></ooclass>
- 
+
 <!-- {{{ Exception synopsis -->
     <classsynopsisinfo>
      <ooclass>
       <classname>RangeException</classname>
      </ooclass>
- 
+
     <ooclass>
       <modifier>extends</modifier>
       <classname>RuntimeException</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)" />
 
@@ -55,17 +55,17 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->
- 
+
   </section>
- 
+
  </partintro>
- 
+
  <!-- If the exception has any methods you'd like to document use this
  &reference.extname.entities.classname;
  -->
- 
+
 </phpdoc:exceptionref>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/spl/runtimeexception.xml
+++ b/reference/spl/runtimeexception.xml
@@ -48,6 +48,7 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.runtimeexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 -->
    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[1])"><xi:fallback /></xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/spl/runtimeexception.xml
+++ b/reference/spl/runtimeexception.xml
@@ -8,9 +8,9 @@
  xmlns="http://docbook.org/ns/docbook">
  <title>The RuntimeException class</title>
  <titleabbrev>RuntimeException</titleabbrev>
- 
+
  <partintro>
- 
+
 <!-- {{{ RuntimeException intro -->
   <section xml:id="runtimeexception.intro">
    &reftitle.intro;
@@ -19,27 +19,27 @@
    </para>
   </section>
 <!-- }}} -->
- 
+
   <section xml:id="runtimeexception.synopsis">
    &reftitle.classsynopsis;
- 
+
 <!-- {{{ Synopsis -->
    <classsynopsis>
     <ooclass><classname>RuntimeException</classname></ooclass>
- 
+
 <!-- {{{ Exception synopsis -->
     <classsynopsisinfo>
      <ooclass>
       <classname>RuntimeException</classname>
      </ooclass>
- 
+
     <ooclass>
       <modifier>extends</modifier>
       <classname>Exception</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)" />
 
@@ -52,17 +52,17 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->
- 
+
   </section>
- 
+
  </partintro>
- 
+
  <!-- If the exception has any methods you'd like to document use this
  &reference.extname.entities.classname;
  -->
- 
+
 </phpdoc:exceptionref>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/spl/underflowexception.xml
+++ b/reference/spl/underflowexception.xml
@@ -49,6 +49,7 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.underflowexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 -->
    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[1])"><xi:fallback /></xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/spl/underflowexception.xml
+++ b/reference/spl/underflowexception.xml
@@ -8,9 +8,9 @@
  xmlns="http://docbook.org/ns/docbook">
  <title>The UnderflowException class</title>
  <titleabbrev>UnderflowException</titleabbrev>
- 
+
  <partintro>
- 
+
 <!-- {{{ UnderflowException intro -->
   <section xml:id="underflowexception.intro">
    &reftitle.intro;
@@ -20,27 +20,27 @@
    </para>
   </section>
 <!-- }}} -->
- 
+
   <section xml:id="underflowexception.synopsis">
    &reftitle.classsynopsis;
- 
+
 <!-- {{{ Synopsis -->
    <classsynopsis>
     <ooclass><classname>UnderflowException</classname></ooclass>
- 
+
 <!-- {{{ Exception synopsis -->
     <classsynopsisinfo>
      <ooclass>
       <classname>UnderflowException</classname>
      </ooclass>
- 
+
     <ooclass>
       <modifier>extends</modifier>
       <classname>RuntimeException</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)" />
 
@@ -53,17 +53,17 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->
- 
+
   </section>
- 
+
  </partintro>
- 
+
  <!-- If the exception has any methods you'd like to document use this
  &reference.extname.entities.classname;
  -->
- 
+
 </phpdoc:exceptionref>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/spl/unexpectedvalueexception.xml
+++ b/reference/spl/unexpectedvalueexception.xml
@@ -51,6 +51,7 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.unexpectedvalueexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 -->
    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[1])"><xi:fallback /></xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/spl/unexpectedvalueexception.xml
+++ b/reference/spl/unexpectedvalueexception.xml
@@ -8,9 +8,9 @@
  xmlns="http://docbook.org/ns/docbook">
  <title>The UnexpectedValueException class</title>
  <titleabbrev>UnexpectedValueException</titleabbrev>
- 
+
  <partintro>
- 
+
 <!-- {{{ UnexpectedValueException intro -->
   <section xml:id="unexpectedvalueexception.intro">
    &reftitle.intro;
@@ -22,27 +22,27 @@
    </para>
   </section>
 <!-- }}} -->
- 
+
   <section xml:id="unexpectedvalueexception.synopsis">
    &reftitle.classsynopsis;
- 
+
 <!-- {{{ Synopsis -->
    <classsynopsis>
     <ooclass><classname>UnexpectedValueException</classname></ooclass>
- 
+
 <!-- {{{ Exception synopsis -->
     <classsynopsisinfo>
      <ooclass>
       <classname>UnexpectedValueException</classname>
      </ooclass>
- 
+
     <ooclass>
       <modifier>extends</modifier>
       <classname>RuntimeException</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)" />
 
@@ -55,17 +55,17 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->
- 
+
   </section>
- 
+
  </partintro>
- 
+
  <!-- If the exception has any methods you'd like to document use this
  &reference.extname.entities.classname;
  -->
- 
+
 </phpdoc:exceptionref>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
Generalizing the `Exception::__construct` documentation to `methodsynopsis`
instead of `constructorsynopsis` will include it in SPL Exception queries.