### PR TITLE
Fix #78540: Add missing properties during DateInterval dump

### DIFF
--- a/reference/datetime/dateinterval/construct.xml
+++ b/reference/datetime/dateinterval/construct.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="dateinterval.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="dateinterval.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>DateInterval::__construct</refname>
   <refpurpose>Creates a new DateInterval object</refpurpose>
@@ -130,10 +130,62 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title><classname>DateInterval</classname> example</title>
-    <programlisting role="php">
+  <example>
+   <title><classname>DateInterval</classname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$interval = new DateInterval('P2Y4DT6H8M');
+
+var_dump($interval);
+?>
+]]>
+   </programlisting>
+   <para>
+    The above example will output for PHP 5.3.27 and PHP 5.4.17 versions and above:
+   </para>
+   <screen role="php">
+<![CDATA[
+object(DateInterval)#1 (16) {
+  ["y"]=>
+  int(2)
+  ["m"]=>
+  int(0)
+  ["d"]=>
+  int(4)
+  ["h"]=>
+  int(6)
+  ["i"]=>
+  int(8)
+  ["s"]=>
+  int(0)
+  ["f"]=>
+  float(0)
+  ["weekday"]=>
+  int(0)
+  ["weekday_behavior"]=>
+  int(0)
+  ["first_last_day_of"]=>
+  int(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  bool(false)
+  ["special_type"]=>
+  int(0)
+  ["special_amount"]=>
+  int(0)
+  ["have_weekday_relative"]=>
+  int(0)
+  ["have_special_relative"]=>
+  int(0)
+}
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>Old <classname>DateInternal</classname> example</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 
@@ -143,7 +195,9 @@ var_dump($interval);
 ?>
 ]]>
     </programlisting>
-    &example.outputs;
+    <para>
+     The above example will output for PHP 5.3.26 and PHP 5.4.16 versions and bellow:
+    </para>
     <screen role="php">
 <![CDATA[
 object(DateInterval)#1 (8) {
@@ -165,9 +219,8 @@ object(DateInterval)#1 (8) {
   bool(false)
 }
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
See https://3v4l.org/Kmt9V for the different outputs across multiple PHP versions.

They were added via php/php-src@0ee71557ffd and php/php-src@55626549d81d.