### PR TITLE
Fix #78130: Add SplPriorityQueue::isCorrupted version

### DIFF
--- a/reference/spl/versions.xml
+++ b/reference/spl/versions.xml
@@ -942,6 +942,7 @@
  <function name="splpriorityqueue::top" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
  <function name="splpriorityqueue::extract" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
  <function name="splpriorityqueue::count" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="splpriorityqueue::iscorrupted" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
  <function name="splpriorityqueue::isempty" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
  <function name="splpriorityqueue::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
  <function name="splpriorityqueue::current" from="PHP 5 &gt;= 5.3.0, PHP 7"/>


### PR DESCRIPTION
Introduced via php/php-src@c54045a1f949, documented via php/doc-en@5f6c0c7994f3 but it was never added to `versions.xml`.

Thanks to @nikic to point how to fix this one 👍 