### PR TITLE
Add preg_last_error_msg documentation

### DIFF
--- a/reference/pcre/functions/preg-last-error-msg.xml
+++ b/reference/pcre/functions/preg-last-error-msg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="function.preg-last-error-msg" xmlns="https://docbook.org/ns/docbook">
+<refentry xml:id="function.preg-last-error-msg" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>preg_last_error_msg</refname>
   <refpurpose>Returns the error message of the last PCRE regex execution</refpurpose>

--- a/reference/pcre/functions/preg-last-error-msg.xml
+++ b/reference/pcre/functions/preg-last-error-msg.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.preg-last-error-msg" xmlns="https://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>preg_last_error_msg</refname>
+  <refpurpose>Returns the error message of the last PCRE regex execution</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>preg_last_error_msg</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Returns the error message of the last PCRE regex execution.
+  </para>
+  <para>
+   <example>
+    <title><function>preg_last_error_msg</function> example</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+preg_match('/(?:\D+|<\d+>)*[!?]/', 'foobar foobar foobar');
+
+if (preg_last_error() !== PREG_NO_ERROR) {
+    echo preg_last_error_msg();
+}
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Backtrack limit exhausted
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the error message on success, <literal>"No error"</literal> if no
+   error has occurred.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>preg_last_error</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcre/functions/preg-last-error-msg.xml
+++ b/reference/pcre/functions/preg-last-error-msg.xml
@@ -15,6 +15,23 @@
   <para>
    Returns the error message of the last PCRE regex execution.
   </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the error message on success, or <literal>"No error"</literal> if no
+   error has occurred.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
   <para>
    <example>
     <title><function>preg_last_error_msg</function> example</title>
@@ -38,14 +55,6 @@ Backtrack limit exhausted
 ]]>
     </screen>
    </example>
-  </para>
- </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns the error message on success, <literal>"No error"</literal> if no
-   error has occurred.
   </para>
  </refsect1>
 

--- a/reference/pcre/functions/preg-last-error.xml
+++ b/reference/pcre/functions/preg-last-error.xml
@@ -25,7 +25,7 @@
 preg_match('/(?:\D+|<\d+>)*[!?]/', 'foobar foobar foobar');
 
 if (preg_last_error() == PREG_BACKTRACK_LIMIT_ERROR) {
-    print 'Backtrack limit was exhausted!';
+    echo 'Backtrack limit was exhausted!';
 }
 
 ?>
@@ -56,6 +56,15 @@ Backtrack limit was exhausted!
     <member><constant>PREG_BAD_UTF8_ERROR</constant></member>
     <member><constant>PREG_BAD_UTF8_OFFSET_ERROR</constant> (since PHP 5.3.0)</member>
     <member><constant>PREG_JIT_STACKLIMIT_ERROR</constant> (since PHP 7.0.0)</member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>preg_last_error_msg</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -422,6 +422,7 @@ Array
     <member><function>preg_replace</function></member>
     <member><function>preg_split</function></member>
     <member><function>preg_last_error</function></member>
+    <member><function>preg_last_error_msg</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/pcre/versions.xml
+++ b/reference/pcre/versions.xml
@@ -7,6 +7,7 @@
  <function name='preg_filter' from='PHP 5 &gt;= 5.3.0, PHP 7'/>
  <function name='preg_grep' from='PHP 4, PHP 5, PHP 7'/>
  <function name='preg_last_error' from='PHP 5 &gt;= 5.2.0, PHP 7'/>
+ <function name='preg_last_error_msg' from='PHP 8'/>
  <function name='preg_match' from='PHP 4, PHP 5, PHP 7'/>
  <function name='preg_match_all' from='PHP 4, PHP 5, PHP 7'/>
  <function name='preg_quote' from='PHP 4, PHP 5, PHP 7'/>


### PR DESCRIPTION
This PR adds the documentation for `preg_last_error_msg`, added in [php-src/pull/5185](https://github.com/php/php-src/pull/5185)

Here's a rendered version of the manual page
![Screenshot](https://user-images.githubusercontent.com/205852/75263625-8b5a3800-57ee-11ea-950e-7bdc06d684c0.png)

