### PR TITLE
Allow only bool|float|int|string for sprintf $args

### DIFF
--- a/reference/strings/functions/sprintf.xml
+++ b/reference/strings/functions/sprintf.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>string</type><methodname>sprintf</methodname>
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam choice="opt"><type>bool|float|int|string</type><parameter>...</parameter></methodparam>
   </methodsynopsis>
   <para>
    Returns a string produced according to the formatting string


### PR DESCRIPTION
Other types for $args than `bool|float|int|string` won't work with `sprintf()`.