### PR TITLE
Fix #79341: XmlWriter docs does not say $uri is nullable

### DIFF
--- a/reference/xmlwriter/functions/xmlwriter-start-attribute-ns.xml
+++ b/reference/xmlwriter/functions/xmlwriter-start-attribute-ns.xml
@@ -54,6 +54,8 @@
      <listitem>
       <para>
        The namespace URI.
+       If <parameter>uri</parameter> is &null;, the namespace declaration will be
+       omitted.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/xmlwriter/functions/xmlwriter-start-attribute-ns.xml
+++ b/reference/xmlwriter/functions/xmlwriter-start-attribute-ns.xml
@@ -14,7 +14,7 @@
    <type>bool</type><methodname>XMLWriter::startAttributeNs</methodname>
    <methodparam><type>string</type><parameter>prefix</parameter></methodparam>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam><type>?string</type><parameter>uri</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>
   <methodsynopsis>

--- a/reference/xmlwriter/functions/xmlwriter-start-attribute-ns.xml
+++ b/reference/xmlwriter/functions/xmlwriter-start-attribute-ns.xml
@@ -22,7 +22,7 @@
    <methodparam><type>resource</type><parameter>xmlwriter</parameter></methodparam>
    <methodparam><type>string</type><parameter>prefix</parameter></methodparam>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam><type>?string</type><parameter>uri</parameter></methodparam>
   </methodsynopsis>
   <para>
    Starts a namespaced attribute.

--- a/reference/xmlwriter/functions/xmlwriter-start-element-ns.xml
+++ b/reference/xmlwriter/functions/xmlwriter-start-element-ns.xml
@@ -38,6 +38,7 @@
      <listitem>
       <para>
        The namespace prefix.
+       If <parameter>prefix</parameter> is &null;, the namespace will be omitted.
       </para>
      </listitem>
     </varlistentry>
@@ -54,6 +55,8 @@
      <listitem>
       <para>
        The namespace URI.
+       If <parameter>uri</parameter> is &null;, the namespace declaration will be
+       omitted.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/xmlwriter/functions/xmlwriter-start-element-ns.xml
+++ b/reference/xmlwriter/functions/xmlwriter-start-element-ns.xml
@@ -20,9 +20,9 @@
   <methodsynopsis>
    <type>bool</type><methodname>xmlwriter_start_element_ns</methodname>
    <methodparam><type>resource</type><parameter>xmlwriter</parameter></methodparam>
-   <methodparam><type>string</type><parameter>prefix</parameter></methodparam>
+   <methodparam><type>?string</type><parameter>prefix</parameter></methodparam>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam><type>?string</type><parameter>uri</parameter></methodparam>
   </methodsynopsis>
   <para>
    Starts a namespaced element.

--- a/reference/xmlwriter/functions/xmlwriter-start-element-ns.xml
+++ b/reference/xmlwriter/functions/xmlwriter-start-element-ns.xml
@@ -12,9 +12,9 @@
   <para>&style.oop;</para>
   <methodsynopsis>
    <type>bool</type><methodname>XMLWriter::startElementNs</methodname>
-   <methodparam><type>string</type><parameter>prefix</parameter></methodparam>
+   <methodparam><type>?string</type><parameter>prefix</parameter></methodparam>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam><type>?string</type><parameter>uri</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>
   <methodsynopsis>

--- a/reference/xmlwriter/functions/xmlwriter-write-attribute-ns.xml
+++ b/reference/xmlwriter/functions/xmlwriter-write-attribute-ns.xml
@@ -21,9 +21,9 @@
   <methodsynopsis>
    <type>bool</type><methodname>xmlwriter_write_attribute_ns</methodname>
    <methodparam><type>resource</type><parameter>xmlwriter</parameter></methodparam>
-   <methodparam><type>string</type><parameter>prefix</parameter></methodparam>
+   <methodparam><type>?string</type><parameter>prefix</parameter></methodparam>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam><type>?string</type><parameter>uri</parameter></methodparam>
    <methodparam><type>string</type><parameter>content</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/xmlwriter/functions/xmlwriter-write-attribute-ns.xml
+++ b/reference/xmlwriter/functions/xmlwriter-write-attribute-ns.xml
@@ -12,9 +12,9 @@
   <para>&style.oop;</para>
   <methodsynopsis>
    <type>bool</type><methodname>XMLWriter::writeAttributeNs</methodname>
-   <methodparam><type>string</type><parameter>prefix</parameter></methodparam>
+   <methodparam><type>?string</type><parameter>prefix</parameter></methodparam>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam><type>?string</type><parameter>uri</parameter></methodparam>
    <methodparam><type>string</type><parameter>content</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/xmlwriter/functions/xmlwriter-write-attribute-ns.xml
+++ b/reference/xmlwriter/functions/xmlwriter-write-attribute-ns.xml
@@ -40,6 +40,7 @@
      <listitem>
       <para>
        The namespace prefix.
+       If <parameter>prefix</parameter> is &null;, the namespace will be omitted.
       </para>
      </listitem>
     </varlistentry>
@@ -56,6 +57,8 @@
      <listitem>
       <para>
        The namespace URI.
+       If <parameter>uri</parameter> is &null;, the namespace declaration will be
+       omitted.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/xmlwriter/functions/xmlwriter-write-element-ns.xml
+++ b/reference/xmlwriter/functions/xmlwriter-write-element-ns.xml
@@ -12,10 +12,10 @@
   <para>&style.oop;</para>
   <methodsynopsis>
    <type>bool</type><methodname>XMLWriter::writeElementNs</methodname>
-   <methodparam><type>string</type><parameter>prefix</parameter></methodparam>
+   <methodparam><type>?string</type><parameter>prefix</parameter></methodparam>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>content</parameter></methodparam>
+   <methodparam><type>?string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>content</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>
   <methodsynopsis>

--- a/reference/xmlwriter/functions/xmlwriter-write-element-ns.xml
+++ b/reference/xmlwriter/functions/xmlwriter-write-element-ns.xml
@@ -40,6 +40,7 @@
      <listitem>
       <para>
        The namespace prefix.
+       If <parameter>prefix</parameter> is &null;, the namespace will be omitted.
       </para>
      </listitem>
     </varlistentry>
@@ -56,6 +57,8 @@
      <listitem>
       <para>
        The namespace URI.
+       If <parameter>uri</parameter> is &null;, the namespace declaration will be
+       omitted.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/xmlwriter/functions/xmlwriter-write-element-ns.xml
+++ b/reference/xmlwriter/functions/xmlwriter-write-element-ns.xml
@@ -21,10 +21,10 @@
   <methodsynopsis>
    <type>bool</type><methodname>xmlwriter_write_element_ns</methodname>
    <methodparam><type>resource</type><parameter>xmlwriter</parameter></methodparam>
-   <methodparam><type>string</type><parameter>prefix</parameter></methodparam>
+   <methodparam><type>?string</type><parameter>prefix</parameter></methodparam>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>content</parameter></methodparam>
+   <methodparam><type>?string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>content</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Writes a full namespaced element tag.


### PR DESCRIPTION
@salathe, is it okay to use nullable type markers (`?`)? Should that be clarified in https://www.php.net/manual/en/about.prototypes.php?