### PR TITLE
Change definition for varargs

### DIFF
--- a/reference/strings/functions/sprintf.xml
+++ b/reference/strings/functions/sprintf.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>string</type><methodname>sprintf</methodname>
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter role="vararglist">args</parameter></methodparam>
   </methodsynopsis>
   <para>
    Returns a string produced according to the formatting string
@@ -25,7 +25,7 @@
    <variablelist>
     &strings.parameter.format;
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>...args</parameter></term>
      <listitem>
       <para>
       </para>


### PR DESCRIPTION
This would allow to properly render all arguments definitions

- arguments
- arguments by reference
- varible-length argument lists
- varible-length argument lists passed by reference

See https://github.com/php/phd/pull/24 and https://github.com/salathe/phpdoc-base/pull/2

_This is an example of what would have been needed to be done_

![image](https://user-images.githubusercontent.com/327717/76146546-e532eb80-6093-11ea-916e-26dfe2bb7f47.png)
