### PR TITLE
Added changelog documentation to mb_convert_case()

### DIFF
--- a/reference/mbstring/functions/mb-convert-case.xml
+++ b/reference/mbstring/functions/mb-convert-case.xml
@@ -41,8 +41,8 @@
        <constant>MB_CASE_LOWER</constant>, 
        <constant>MB_CASE_TITLE</constant>,
        <constant>MB_CASE_FOLD</constant>,
-       <constant>MB_CASE_LOWER_SIMPLE</constant>,
        <constant>MB_CASE_UPPER_SIMPLE</constant>,
+       <constant>MB_CASE_LOWER_SIMPLE</constant>,
        <constant>MB_CASE_TITLE_SIMPLE</constant>,
        <constant>MB_CASE_FOLD_SIMPLE</constant>.
       </para>
@@ -97,12 +97,13 @@
       <row>
        <entry>7.3.0</entry>
        <entry>
+        Added support for
         <constant>MB_CASE_FOLD</constant>,
         <constant>MB_CASE_UPPER_SIMPLE</constant>,
         <constant>MB_CASE_LOWER_SIMPLE</constant>,
         <constant>MB_CASE_TITLE_SIMPLE</constant>, and
-        <constant>MB_CASE_FOLD_SIMPLE</constant>,
-        <parameter>mode</parameter> were added.
+        <constant>MB_CASE_FOLD_SIMPLE</constant>
+        as <parameter>mode</parameter>.
        </entry>
       </row>
      </tbody>

--- a/reference/mbstring/functions/mb-convert-case.xml
+++ b/reference/mbstring/functions/mb-convert-case.xml
@@ -82,6 +82,35 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>7.3.0</entry>
+       <entry>
+        <constant>MB_CASE_FOLD</constant>,
+        <constant>MB_CASE_UPPER_SIMPLE</constant>,
+        <constant>MB_CASE_LOWER_SIMPLE</constant>,
+        <constant>MB_CASE_TITLE_SIMPLE</constant>, and
+        <constant>MB_CASE_FOLD_SIMPLE</constant>,
+        <parameter>mode</parameter> were added.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>


### PR DESCRIPTION
Since I stumbled upon this problem, I think it's worth to mention in the changelog that 7.3.0 added the constants MB_CASE_FOLD and MB_CASE_*_SIMPLE
