### PR TITLE
Operator Precedence - Add `print`, fix associativity of `instanceof` and unary operators

### DIFF
--- a/language/operators.xml
+++ b/language/operators.xml
@@ -266,6 +266,11 @@
         </entry>
        </row>
        <row>
+        <entry>right</entry>
+        <entry><literal>print</literal></entry>
+        <entry><function>print</function></entry>
+       </row>
+       <row>
         <entry>left</entry>
         <entry><literal>and</literal></entry>
         <entry>

--- a/language/operators.xml
+++ b/language/operators.xml
@@ -78,7 +78,7 @@
       </thead>
       <tbody>
        <row>
-        <entry>non-associative</entry>
+        <entry>(n/a)</entry>
         <entry>
          <literal>clone</literal>
          <literal>new</literal>
@@ -91,7 +91,7 @@
         <entry><link linkend="language.operators.arithmetic">arithmetic</link></entry>
        </row>
        <row>
-        <entry>right</entry>
+        <entry>(n/a)</entry>
         <entry>
          <literal>++</literal> 
          <literal>--</literal> 
@@ -109,14 +109,14 @@
         </entry>
        </row>
        <row>
-        <entry>non-associative</entry>
+        <entry>left</entry>
         <entry><literal>instanceof</literal></entry>
         <entry>
          <link linkend="language.types">types</link>
         </entry>
        </row>
        <row>
-        <entry>right</entry>
+        <entry>(n/a)</entry>
         <entry><literal>!</literal></entry>
         <entry>
          <link linkend="language.operators.logical">logical</link>
@@ -252,21 +252,21 @@
         </entry>
        </row>
        <row>
-        <entry>right</entry>
+        <entry>(n/a)</entry>
         <entry><literal>yield from</literal></entry>
         <entry>
          <link linkend="control-structures.yield.from">yield from</link>
         </entry>
        </row>
        <row>
-        <entry>right</entry>
+        <entry>(n/a)</entry>
         <entry><literal>yield</literal></entry>
         <entry>
          <link linkend="control-structures.yield">yield</link>
         </entry>
        </row>
        <row>
-        <entry>right</entry>
+        <entry>(n/a)</entry>
         <entry><literal>print</literal></entry>
         <entry><function>print</function></entry>
        </row>


### PR DESCRIPTION
See:
- https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4893#discussion_r398776216
- https://github.com/php/php-src/commit/2a04efe0e42c9d7ac150bc918e16edb96cf4f219 (part of)