### PR TITLE
Fix the return value of \zip_open()

### DIFF
--- a/reference/zip/functions/zip-open.xml
+++ b/reference/zip/functions/zip-open.xml
@@ -36,8 +36,8 @@
   <para>
    Returns a resource handle for later use with
    <function>zip_read</function> and <function>zip_close</function>
-   or returns the number of error if <parameter>filename</parameter> does not
-   exist or in case of other error.
+   or returns either &false; or the number of error if <parameter>filename</parameter>
+   does not exist or in case of other error.
   </para>
  </refsect1>
  <refsect1 role="seealso">


### PR DESCRIPTION
\zip_open() can also return false [0].

[0] https://github.com/php/php-src/blob/php-7.4.4/ext/zip/php_zip.c#L1160