### PR TITLE
Adding documentation for mb_str_split

### DIFF
--- a/reference/mbstring/functions/mb-str-split.xml
+++ b/reference/mbstring/functions/mb-str-split.xml
@@ -65,7 +65,7 @@
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>str-split</function></member>
+    <member><function>str_split</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/mbstring/functions/mb-str-split.xml
+++ b/reference/mbstring/functions/mb-str-split.xml
@@ -57,7 +57,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <function>mb_str_split</function> returns an array of strings. In case of an error, returns False.
+   <function>mb_str_split</function> returns an array of strings, &return.falseforfailure;.
   </para>
  </refsect1>
 

--- a/reference/mbstring/functions/mb-str-split.xml
+++ b/reference/mbstring/functions/mb-str-split.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>array</type><methodname>mb_str_split</methodname>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>split_length</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>split_length</parameter><initializer>1</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>encoding</parameter><initializer>mb_internal_encoding()</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/mbstring/functions/mb-str-split.xml
+++ b/reference/mbstring/functions/mb-str-split.xml
@@ -16,8 +16,8 @@
   </methodsynopsis>
   <para>
    This function will return an array of strings, it's a version of <function>str_split</function> with support for encodings of variable character size as well as fixed-size encodings of 1,2 or 4 byte characters.
-   If the <parameter>split_length</parameter> is specified, the string is broken down into chunks of the specified length in characters, not bytes.
-   The <parameter>encoding</parameter> can be optionally specified and it is good practice to do so.
+   If the <parameter>split_length</parameter> parameter is specified, the string is broken down into chunks of the specified length in characters (not bytes).
+   The <parameter>encoding</parameter> parameter can be optionally specified and it is good practice to do so.
   </para>
  </refsect1>
 
@@ -46,7 +46,7 @@
      <listitem>
       &mbstring.encoding.parameter;
       <para>
-        A string specifying one of the supported encodings
+        A string specifying one of the supported encodings.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mbstring/functions/mb-str-split.xml
+++ b/reference/mbstring/functions/mb-str-split.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
    This function will return an array of strings, it's a version of <function>str_split</function> with support for encodings of variable character size as well as fixed-size encodings of 1,2 or 4 byte characters.
-   If <parameter>split_length</parameter> is specified, the string is broken down into chunks of the specified length in characters, not bytes.
+   If the <parameter>split_length</parameter> is specified, the string is broken down into chunks of the specified length in characters, not bytes.
    The <parameter>encoding</parameter> can be optionally specified and it is good practice to do so.
   </para>
  </refsect1>
@@ -29,7 +29,7 @@
      <term><parameter>string</parameter></term>
      <listitem>
       <para>
-       The <type>string</type> to stplit into characters or chunks.
+       The <type>string</type> to split into characters or chunks.
       </para>
      </listitem>
     </varlistentry>
@@ -57,7 +57,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <function>mb_str_split</function> returns an array of strings. In case of error, returns False.
+   <function>mb_str_split</function> returns an array of strings. In case of an error, returns False.
   </para>
  </refsect1>
 

--- a/reference/mbstring/functions/mb-str-split.xml
+++ b/reference/mbstring/functions/mb-str-split.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.mb-str-split" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>mb_str_split</refname>
+  <refpurpose>Given a multibyte string, return an array of its characters.</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>array</type><methodname>mb_str_split</methodname>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>split_length</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>encoding</parameter><initializer>mb_internal_encoding()</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   This function will return an array of strings, it's a version of <function>str_split</function> with support for encodings of variable character size as well as fixed-size encodings of 1,2 or 4 byte characters.
+   If <parameter>split_length</parameter> is specified, the string is broken down into chunks of the specified length in characters, not bytes.
+   The <parameter>encoding</parameter> can be optionally specified and it is good practice to do so.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>string</parameter></term>
+     <listitem>
+      <para>
+       The <type>string</type> to stplit into characters or chunks.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>split_length</parameter></term>
+     <listitem>
+      <para>
+        If specified, each element of the returned array will be composed of multiple characters instead of a single character.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>encoding</parameter></term>
+     <listitem>
+      &mbstring.encoding.parameter;
+      <para>
+        A string specifying one of the supported encodings
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <function>mb_str_split</function> returns an array of strings. In case of error, returns False.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>str-split</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mbstring/versions.xml
+++ b/reference/mbstring/versions.xml
@@ -64,6 +64,7 @@
  <function name="mb_substitute_character" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
  <function name="mb_substr" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
  <function name="mb_substr_count" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
+ <function name="mb_str_split" from="PHP 7 &gt;= 7.4.0"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
According to [this item](https://bugs.php.net/bug.php?id=79425) in the issue tracker, I looked into the new function and drafted a corresponding doc page. It's a pretty straightforward function.


Notes:

1. I couldn't test this due to configure.php followed by php .manual.xml yielding a parse error :/
```

php .manual.xml 
PHP Parse error:  syntax error, unexpected ']', expecting end of file in /home/tomas/p/php/doc-base/.manual.xml on line 9262

```

2.  I tried to add a couple of \<link linkend="reference.mbstring.supported-encodings"\> but I received errors on these, so I removed them. A link to the book and supported encodings on the See Also section would be nice.