### PR TITLE
Use consistent modifiers order "public" before "readonly"

### DIFF
--- a/reference/dom/domcharacterdata.xml
+++ b/reference/dom/domcharacterdata.xml
@@ -46,8 +46,8 @@
      <varname linkend="domcharacterdata.props.data">data</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>int</type>
      <varname linkend="domcharacterdata.props.length">length</varname>
     </fieldsynopsis>

--- a/reference/dom/domdocument.xml
+++ b/reference/dom/domdocument.xml
@@ -41,26 +41,26 @@
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 <!-- If the property is documented below (xml:id=domdocument.props) use this -->
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>string</type>
      <varname linkend="domdocument.props.actualencoding">actualEncoding</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>DOMConfiguration</type>
      <varname linkend="domdocument.props.config">config</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>DOMDocumentType</type>
      <varname linkend="domdocument.props.doctype">doctype</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>DOMElement</type>
      <varname linkend="domdocument.props.documentelement">documentElement</varname>
     </fieldsynopsis>
@@ -80,8 +80,8 @@
      <varname linkend="domdocument.props.formatoutput">formatOutput</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>DOMImplementation</type>
      <varname linkend="domdocument.props.implementation">implementation</varname>
     </fieldsynopsis>
@@ -129,8 +129,8 @@
      <varname linkend="domdocument.props.version">version</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>string</type>
      <varname linkend="domdocument.props.xmlencoding">xmlEncoding</varname>
     </fieldsynopsis>

--- a/reference/dom/domdocumenttype.xml
+++ b/reference/dom/domdocumenttype.xml
@@ -41,38 +41,38 @@
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 <!-- If the property is documented below (xml:id=domdocumenttype.props) use this -->
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>string</type>
      <varname linkend="domdocumenttype.props.publicid">publicId</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>string</type>
      <varname linkend="domdocumenttype.props.systemid">systemId</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>string</type>
      <varname linkend="domdocumenttype.props.name">name</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>DOMNamedNodeMap</type>
      <varname linkend="domdocumenttype.props.entities">entities</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>DOMNamedNodeMap</type>
      <varname linkend="domdocumenttype.props.notations">notations</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>string</type>
      <varname linkend="domdocumenttype.props.internalsubset">internalSubset</varname>
     </fieldsynopsis>

--- a/reference/dom/domelement.xml
+++ b/reference/dom/domelement.xml
@@ -42,14 +42,14 @@
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 <!-- If the property is documented below (xml:id=domelement.props) use this -->
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>bool</type>
      <varname linkend="domelement.props.schematypeinfo">schemaTypeInfo</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>string</type>
      <varname linkend="domelement.props.tagname">tagName</varname>
     </fieldsynopsis>

--- a/reference/dom/domentity.xml
+++ b/reference/dom/domentity.xml
@@ -40,20 +40,20 @@
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 <!-- If the property is documented below (xml:id=domentity.props) use this -->
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>string</type>
      <varname linkend="domentity.props.publicid">publicId</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>string</type>
      <varname linkend="domentity.props.systemid">systemId</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>string</type>
      <varname linkend="domentity.props.notationname">notationName</varname>
     </fieldsynopsis>
@@ -63,14 +63,14 @@
      <varname linkend="domentity.props.actualencoding">actualEncoding</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>string</type>
      <varname linkend="domentity.props.encoding">encoding</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>string</type>
      <varname linkend="domentity.props.version">version</varname>
     </fieldsynopsis>

--- a/reference/dom/domexception.xml
+++ b/reference/dom/domexception.xml
@@ -56,8 +56,8 @@ FIXME: Remove me once you perform substitutions
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 <!-- If the property is documented below (xml:id=domexception.props) use this -->
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>int</type>
      <varname linkend="domexception.props.code">code</varname>
     </fieldsynopsis>

--- a/reference/dom/domnamednodemap.xml
+++ b/reference/dom/domnamednodemap.xml
@@ -48,8 +48,8 @@ Remove me once you perform substitutions
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 <!-- If the property is documented below (xml:id=domnamednodemap.props) use this -->
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>int</type>
      <varname linkend="domnamednodemap.props.length">length</varname>
     </fieldsynopsis>

--- a/reference/dom/domnodelist.xml
+++ b/reference/dom/domnodelist.xml
@@ -48,8 +48,8 @@ Remove me once you perform substitutions
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 <!-- If the property is documented below (xml:id=domnodelist.props) use this -->
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>int</type>
      <varname linkend="domnodelist.props.length">length</varname>
     </fieldsynopsis>

--- a/reference/dom/domnotation.xml
+++ b/reference/dom/domnotation.xml
@@ -51,14 +51,14 @@ Remove me once you perform substitutions
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 <!-- If the property is documented below (xml:id=domnotation.props) use this -->
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>string</type>
      <varname linkend="domnotation.props.publicid">publicId</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>string</type>
      <varname linkend="domnotation.props.systemid">systemId</varname>
     </fieldsynopsis>

--- a/reference/dom/domprocessinginstruction.xml
+++ b/reference/dom/domprocessinginstruction.xml
@@ -42,8 +42,8 @@
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 <!-- If the property is documented below (xml:id=domprocessinginstruction.props) use this -->
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>string</type>
      <varname linkend="domprocessinginstruction.props.target">target</varname>
     </fieldsynopsis>

--- a/reference/dom/domtext.xml
+++ b/reference/dom/domtext.xml
@@ -43,8 +43,8 @@
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 <!-- If the property is documented below (xml:id=domtext.props) use this -->
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>string</type>
      <varname linkend="domtext.props.wholetext">wholeText</varname>
     </fieldsynopsis>

--- a/reference/solr/solrdocumentfield.xml
+++ b/reference/solr/solrdocumentfield.xml
@@ -34,20 +34,20 @@
 <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>string</type>
      <varname linkend="solrdocumentfield.props.name">name</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>float</type>
      <varname linkend="solrdocumentfield.props.boost">boost</varname>
     </fieldsynopsis>
     <fieldsynopsis>
-     <modifier>readonly</modifier>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>array</type>
      <varname linkend="solrdocumentfield.props.values">values</varname>
     </fieldsynopsis>


### PR DESCRIPTION
Before this change:
 - public/readonly: 50 cases
 - readonly/public: 30 cases (mostly in DOM)

Reordered to be always public/readonly, in this order.
