### PR TITLE
Fix other typos outside of php module docs

### DIFF
--- a/appendices/migration53.xml
+++ b/appendices/migration53.xml
@@ -2246,7 +2246,7 @@ try {
    <listitem>
     <simpara>
      The standard &php.ini; files have been re-organized and renamed. 
-     <literal>php.ini-development</literal> contains settings recommded
+     <literal>php.ini-development</literal> contains settings recommended
      for use in development environments. <literal>php.ini-production</literal>
      contains settings recommended for use in production environments.
     </simpara>

--- a/appendices/migration54.xml
+++ b/appendices/migration54.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- Based on UPGRADING version 322438. Work in progess !-->
+<!-- Based on UPGRADING version 322438. Work in progress !-->
 
 <appendix xml:id="migration54" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Migrating from PHP 5.3.x to PHP 5.4.x</title>

--- a/appendices/migration55.xml
+++ b/appendices/migration55.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- Based on UPGRADING version 322438. Work in progess !-->
+<!-- Based on UPGRADING version 322438. Work in progress !-->
 
 <appendix xml:id="migration55" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Migrating from PHP 5.4.x to PHP 5.5.x</title>

--- a/appendices/migration73/incompatible.xml
+++ b/appendices/migration73/incompatible.xml
@@ -74,7 +74,7 @@ while ($foo) {
     <literal>$obj->offsetGet("123")</literal> will be called instead of
     <literal>$obj->offsetGet(123)</literal>. This matches existing behavior for
     non-literals. The behavior of arrays is not affected in any way, they
-    continue to implicitly convert integeral string keys to integers.
+    continue to implicitly convert integral string keys to integers.
    </para>
   </sect3>
 

--- a/appendices/reserved.constants.xml
+++ b/appendices/reserved.constants.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 
  <!--
-   This file shold only be present in the English doc tree. If you
+   This file should only be present in the English doc tree. If you
    copy it over to your translation tree you will be hunted down
    relentlessly! You have been warned! :)
  -->

--- a/chmonly/search.xml
+++ b/chmonly/search.xml
@@ -247,7 +247,7 @@
    <para>
     The manual content and the user notes are separated to
     <filename>php_manual_LANG.chm</filename> and
-    <filename>php_manual_notes.chm</filename>. There were several resons
+    <filename>php_manual_notes.chm</filename>. There were several reasons
     to do this, including:
     <itemizedlist>
      <listitem>

--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -139,7 +139,7 @@
           <entry>&false;</entry>
           <entry>
            Defaults to &false;, as it can be quite hard to read error messages
-           in the shell enviroment when they are cluttered up with uninterpreted
+           in the shell environment when they are cluttered up with uninterpreted
            <acronym>HTML</acronym> tags.
           </entry>
          </row>
@@ -660,7 +660,7 @@ array(370) {
           experienced - if appropriate, a bug report should be opened at
           <link xlink:href="&url.php.bugs;">&url.php.bugs;</link>.
           It is still easy to run into trouble when trying to use variables
-          (shell or PHP) in commnad-line code, or using backslashes for
+          (shell or PHP) in command-line code, or using backslashes for
           escaping, so take great care when doing so. You have been warned!
          </para>
         </note>

--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -758,7 +758,7 @@ php_admin_value[memory_limit] = 32M
     </para>
     <para>
      Settings defined with <literal>php_admin_value</literal> and <literal>php_admin_flag</literal>
-     cannot be overriden with <function>ini_set</function>.
+     cannot be overridden with <function>ini_set</function>.
     </para>
     <para>
      As of 5.3.3, PHP settings are also possible to be set in webserver.

--- a/install/unix/index.xml
+++ b/install/unix/index.xml
@@ -128,7 +128,7 @@
     explanations running <command>./configure --help</command>.
     Our manual documents the different options separately. You will
     find the <link linkend="configure.about">core options in the appendix</link>,
-    while the different extension specific options are descibed on the
+    while the different extension specific options are described on the
     reference pages.
    </para>
     

--- a/install/unix/nginx.xml
+++ b/install/unix/nginx.xml
@@ -33,7 +33,7 @@
  <orderedlist>
   <listitem>
    <para>
-    It is recomended that you visit the Nginx Wiki
+    It is recommended that you visit the Nginx Wiki
     <link xlink:href="&url.nginx.wiki.install;">install</link> page 
     in order to obtain and install Nginx on your system.
    </para>

--- a/install/windows/legacy/sambar.xml
+++ b/install/windows/legacy/sambar.xml
@@ -60,7 +60,7 @@
       account used by the Sambar Server Service. The default account used for
       the Sambar Server Service is LocalSystem which will not have access to
       remote resources. The account can be amended by using the Services
-      option from within the Windows Control Panel Administation Tools.
+      option from within the Windows Control Panel Administration Tools.
      </para>
     </note>
    </sect2>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -658,7 +658,7 @@ font_index</parameter></term><listitem><para>A font resource, returned by <funct
        <programlisting role='php'>
 <![CDATA[
 <?php
-// Set the enviroment variable for GD
+// Set the environment variable for GD
 putenv('GDFONTPATH=' . realpath('.'));
 
 // Name the font to be used (note the lack of the .ttf extension)

--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -268,7 +268,7 @@ class MyException extends Exception
     If a &return; statement is encountered inside either the &try; or the &catch; blocks,
     the &finally; block will still be executed. Moreover, the &return; statement is
     evaluated when encountered, but the result will be returned after the &finally; block
-    is executed. Additionaly, if the &finally; block also contains a &return; statement,
+    is executed. Additionally, if the &finally; block also contains a &return; statement,
     the value from the &finally; block is returned.
    </para>
   </simplesect>


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Integral