### PR TITLE
fix return values documentation on linkinfo() function

### DIFF
--- a/reference/filesystem/functions/linkinfo.xml
+++ b/reference/filesystem/functions/linkinfo.xml
@@ -43,7 +43,7 @@
   <para>
    <function>linkinfo</function> returns the <literal>st_dev</literal> field
    of the Unix C stat structure returned by the <literal>lstat</literal>
-   system call. Returns 0 or &false; in case of error.
+   system call. Returns 0 or a positive integer on success or -1 in case of error.
   </para>
  </refsect1>
 
@@ -64,6 +64,14 @@
        <entry>
         This function is now available on Windows platforms  (Vista, Server 
         2008 or greater).
+       </entry>
+      </row>
+      <row>
+       <entry>2020-04-29</entry>
+       <entry>
+        The documentation incorrectly stated before this date that the function 
+        "Returns 0 or FALSE in case of error.", when it in fact returns 0 or a 
+        positive integer on success or -1 in case of error.
        </entry>
       </row>
      </tbody>

--- a/reference/filesystem/functions/linkinfo.xml
+++ b/reference/filesystem/functions/linkinfo.xml
@@ -43,7 +43,8 @@
   <para>
    <function>linkinfo</function> returns the <literal>st_dev</literal> field
    of the Unix C stat structure returned by the <literal>lstat</literal>
-   system call. Returns 0 or a positive integer on success or -1 in case of error.
+   system call. Returns a non-negative integer on success, -1 in case the link was not found, 
+   or &false; if an &open.base_dir; violation occurs.
   </para>
  </refsect1>
 
@@ -64,14 +65,6 @@
        <entry>
         This function is now available on Windows platforms  (Vista, Server 
         2008 or greater).
-       </entry>
-      </row>
-      <row>
-       <entry>2020-04-29</entry>
-       <entry>
-        The documentation incorrectly stated before this date that the function 
-        "Returns 0 or FALSE in case of error.", when it in fact returns 0 or a 
-        positive integer on success or -1 in case of error.
        </entry>
       </row>
      </tbody>

--- a/reference/filesystem/functions/linkinfo.xml
+++ b/reference/filesystem/functions/linkinfo.xml
@@ -44,7 +44,7 @@
    <function>linkinfo</function> returns the <literal>st_dev</literal> field
    of the Unix C stat structure returned by the <literal>lstat</literal>
    system call. Returns a non-negative integer on success, -1 in case the link was not found, 
-   or &false; if an &open.base_dir; violation occurs.
+   or &false; if an open.base_dir violation occurs.
   </para>
  </refsect1>
 


### PR DESCRIPTION
The return values on this page are not correctly documented. I have updated them to more closely explain what the function returns.
Proof: https://3v4l.org/O8IbZ