### PR TITLE
Document other primes for `opcache.max_accelerated_files`

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -325,7 +325,7 @@
       The maximum number of keys (and therefore scripts) in the OPcache hash
       table. The actual value used will be the first number in the set of
       prime numbers
-      <literal>{ 223, 463, 983, 1979, 3907, 7963, 16229, 32531, 65407, 130987 }</literal>
+      <literal>{ 223, 463, 983, 1979, 3907, 7963, 16229, 32531, 65407, 130987, 262237, 524521, 1048793 }</literal>
       that is greater than or equal to the configured value. The minimum value is 200. The maximum
       value is 100000 in PHP &lt; 5.5.6, and 1000000 in later versions.
      </para>


### PR DESCRIPTION
See https://github.com/php/php-src/blob/master/ext/opcache/zend_accelerator_hash.c