### PR TITLE
Remove unnecessary "Sometimes"

### DIFF
--- a/language/control-structures/while.xml
+++ b/language/control-structures/while.xml
@@ -25,7 +25,7 @@ while (expr)
   each time at the beginning of the loop, so even if this value
   changes during the execution of the nested statement(s), execution
   will not stop until the end of the iteration (each time PHP runs
-  the statements in the loop is one iteration).  Sometimes, if the
+  the statements in the loop is one iteration). If the
   <literal>while</literal> expression evaluates to
   &false; from the very beginning, the nested
   statement(s) won't even be run once.


### PR DESCRIPTION
The statement(s) nested in `while` won't run if the conditional evaluates to `FALSE`. Not even "Sometimes".