### PR TITLE
Document changes to json_encode in php 5.5.

### DIFF
--- a/appendices/migration55.xml
+++ b/appendices/migration55.xml
@@ -155,6 +155,16 @@ if (version_compare(PHP_VERSION, '5.5.0-dev', '>=')) {
     </programlisting>
    </informalexample>
   </sect2>
+  <sect2 xml:id="migration55.incompatible.json">
+   <title><function>json_encode</function> changes</title>
+   <para>
+     When the <parameter>value</parameter> passed to <function>json_encode</function> triggers a JSON encoding error,
+     &false; is returned instead of partial output,
+     unless <parameter>options</parameter> contains <constant>JSON_PARTIAL_OUTPUT_ON_ERROR</constant>.
+     See <function>json_last_error</function> for the full list of reasons that can cause JSON encoding to fail.
+     One of the potential failure reasons is that <parameter>value</parameter> contains strings containing invalid UTF-8.
+   </para>
+  </sect2>
 
   <sect2 xml:id="migration55.incompatible.self-parent-static">
    <title><literal>self</literal>, <literal>parent</literal> and <literal>static</literal> are now always case insensitive</title>
@@ -1634,6 +1644,11 @@ Name\Space\ClassName
     <listitem>
      <simpara>
       <link linkend="constant.json-error-unsupported-type"><constant>JSON_ERROR_UNSUPPORTED_TYPE</constant></link>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <link linkend="constant.json-partial-output-on-error"><constant>JSON_PARTIAL_OUTPUT_ON_ERROR</constant></link>
      </simpara>
     </listitem>
    </itemizedlist>

--- a/reference/json/functions/json-encode.xml
+++ b/reference/json/functions/json-encode.xml
@@ -151,6 +151,22 @@
       <row>
        <entry>5.5.0</entry>
        <entry>
+        When <parameter>value</parameter> triggers a JSON encoding error,
+        &false; is returned instead of partial output,
+        unless <parameter>options</parameter> contains <constant>JSON_PARTIAL_OUTPUT_ON_ERROR</constant>.
+        See <function>json_last_error</function> for the full list of reasons that can cause JSON encoding to fail.
+        One of the potential failure reasons is that <parameter>value</parameter> contains strings containing invalid UTF-8.
+       </entry>
+      </row>
+      <row>
+       <entry>5.5.0</entry>
+       <entry>
+        <constant>E_WARNING</constant> is no longer emitted for an invalid <parameter>value</parameter>.
+       </entry>
+      </row>
+      <row>
+       <entry>5.5.0</entry>
+       <entry>
         The return value on failure was changed from <literal>null</literal>
         string to &false;.
        </entry>


### PR DESCRIPTION
Returning false is an improvement,
but would be backwards incompatible if applications depended on the
implicit `JSON_PARTIAL_OUTPUT_ON_ERROR` behavior of PHP 5.4 and earlier.

A user-submitted comment mentioned this in
https://www.php.net/manual/en/function.json-encode.php#115733

e.g. `json_encode(NAN)` is `'0'` in php 5.4,
and `json_encode(array("field" => "\x00"))` is `'{"field":null}` in 5.4,
but is `false` instead of a string in 5.4 without
`JSON_PARTIAL_OUTPUT_ON_ERROR`.
The following difference is seen between 5.4 and 5.5.

Related to https://bugs.php.net/bug.php?id=67469
(Earlier svn changes documented `JSON_PARTIAL_OUTPUT_ON_ERROR`
but not the change to the return value.

```patch
-       ZVAL_STRINGL(return_value, buf.c, buf.len, 1);
+       if (JSON_G(error_code) != PHP_JSON_ERROR_NONE && !(options & PHP_JSON_PARTIAL_OUTPUT_ON_ERROR)) {
+               ZVAL_FALSE(return_value);
+       } else {
+               ZVAL_STRINGL(return_value, buf.c, buf.len, 1);
+       }
```