### PR TITLE
Remove useless declare statement from example

### DIFF
--- a/reference/strings/functions/chr.xml
+++ b/reference/strings/functions/chr.xml
@@ -101,7 +101,6 @@ aA
     <programlisting role="php">
 <![CDATA[
 <?php
-declare(encoding='UTF-8');
 $str = chr(240) . chr(159) . chr(144) . chr(152);
 echo $str;
 ?>


### PR DESCRIPTION
declare(encoding) is only needed when including UTF-8 directly in the code, which it isn't in this example. It even produces additional errors, see https://3v4l.org/fWYRr while it works fine in https://3v4l.org/ePTAk