### PR TITLE
IntlCalendar::setMinimalDaysInFirstWeek: fix procedural function name

### DIFF
--- a/reference/intl/intlcalendar/setminimaldaysinfirstweek.xml
+++ b/reference/intl/intlcalendar/setminimaldaysinfirstweek.xml
@@ -20,7 +20,7 @@
    &style.procedural;
   </para>
   <methodsynopsis>
-   <type>bool</type><methodname>intlcal_get_minimal_days_in_first_week</methodname>
+   <type>bool</type><methodname>intlcal_set_minimal_days_in_first_week</methodname>
    <methodparam><type>IntlCalendar</type><parameter>cal</parameter></methodparam>
    <methodparam><type>int</type><parameter>minimalDays</parameter></methodparam>
   </methodsynopsis>


### PR DESCRIPTION
See: https://github.com/php/php-src/blob/b452d5923de3bfef3268bcea289d59d6bc789437/ext/intl/calendar/calendar.stub.php#L145