### PR TITLE
FDF: extension was moved to PECL / no longer bundled with PHP as of PHP 5.3

### DIFF
--- a/reference/fdf/versions.xml
+++ b/reference/fdf/versions.xml
@@ -4,41 +4,41 @@
   Do NOT translate this file
 -->
 <versions> 
- <function name='fdf_add_doc_javascript' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='fdf_add_template' from='PHP 4, PHP 5, PHP 7'/>
- <function name='fdf_close' from='PHP 4, PHP 5, PHP 7'/>
- <function name='fdf_create' from='PHP 4, PHP 5, PHP 7'/>
- <function name='fdf_enum_values' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='fdf_errno' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='fdf_error' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='fdf_get_ap' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='fdf_get_attachment' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='fdf_get_encoding' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='fdf_get_file' from='PHP 4, PHP 5, PHP 7'/>
- <function name='fdf_get_flags' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='fdf_get_opt' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='fdf_get_status' from='PHP 4, PHP 5, PHP 7'/>
- <function name='fdf_get_value' from='PHP 4, PHP 5, PHP 7'/>
- <function name='fdf_get_version' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='fdf_header' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='fdf_next_field_name' from='PHP 4, PHP 5, PHP 7'/>
- <function name='fdf_open' from='PHP 4, PHP 5, PHP 7'/>
- <function name='fdf_open_string' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='fdf_remove_item' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='fdf_save' from='PHP 4, PHP 5, PHP 7'/>
- <function name='fdf_save_string' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='fdf_set_ap' from='PHP 4, PHP 5, PHP 7'/>
- <function name='fdf_set_encoding' from='PHP 4 &gt;= 4.0.7, PHP 5, PHP 7'/>
- <function name='fdf_set_file' from='PHP 4, PHP 5, PHP 7'/>
- <function name='fdf_set_flags' from='PHP 4 &gt;= 4.0.2, PHP 5, PHP 7'/>
- <function name='fdf_set_javascript_action' from='PHP 4 &gt;= 4.0.2, PHP 5, PHP 7'/>
- <function name='fdf_set_on_import_javascript' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='fdf_set_opt' from='PHP 4 &gt;= 4.0.2, PHP 5, PHP 7'/>
- <function name='fdf_set_status' from='PHP 4, PHP 5, PHP 7'/>
- <function name='fdf_set_submit_form_action' from='PHP 4 &gt;= 4.0.2, PHP 5, PHP 7'/>
- <function name='fdf_set_target_frame' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='fdf_set_value' from='PHP 4, PHP 5, PHP 7'/>
- <function name='fdf_set_version' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
+ <function name='fdf_add_doc_javascript' from='PHP 4 &gt;= 4.3.0, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_add_template' from='PHP 4, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_close' from='PHP 4, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_create' from='PHP 4, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_enum_values' from='PHP 4 &gt;= 4.3.0, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_errno' from='PHP 4 &gt;= 4.3.0, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_error' from='PHP 4 &gt;= 4.3.0, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_get_ap' from='PHP 4 &gt;= 4.3.0, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_get_attachment' from='PHP 4 &gt;= 4.3.0, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_get_encoding' from='PHP 4 &gt;= 4.3.0, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_get_file' from='PHP 4, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_get_flags' from='PHP 4 &gt;= 4.3.0, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_get_opt' from='PHP 4 &gt;= 4.3.0, PHP 5 &lt; 5.3.0, PECLv'/>
+ <function name='fdf_get_status' from='PHP 4, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_get_value' from='PHP 4, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_get_version' from='PHP 4 &gt;= 4.3.0, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_header' from='PHP 4 &gt;= 4.3.0, PHP 5 &lt; 5.3.0, PECL fdf SVNf'/>
+ <function name='fdf_next_field_name' from='PHP 4, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_open' from='PHP 4, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_open_string' from='PHP 4 &gt;= 4.3.0, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_remove_item' from='PHP 4 &gt;= 4.3.0, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_save' from='PHP 4, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_save_string' from='PHP 4 &gt;= 4.3.0, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_set_ap' from='PHP 4, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_set_encoding' from='PHP 4 &gt;= 4.0.7, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_set_file' from='PHP 4, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_set_flags' from='PHP 4 &gt;= 4.0.2, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_set_javascript_action' from='PHP 4 &gt;= 4.0.2, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_set_on_import_javascript' from='PHP 4 &gt;= 4.3.0, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_set_opt' from='PHP 4 &gt;= 4.0.2, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_set_status' from='PHP 4, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_set_submit_form_action' from='PHP 4 &gt;= 4.0.2, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_set_target_frame' from='PHP 4 &gt;= 4.3.0, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_set_value' from='PHP 4, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
+ <function name='fdf_set_version' from='PHP 4 &gt;= 4.3.0, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
 </versions>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
As per: https://www.php.net/manual/en/fdf.installation.php

It is unclear to me what the current version nr is of the PECL extension, but showing the functions as if they are available in PHP > 5.4 seems very wrong either way.