### PR TITLE
Ming: extension was moved to PECL / no longer bundled with PHP as of PHP 5.3

### DIFF
--- a/reference/ming/versions.xml
+++ b/reference/ming/versions.xml
@@ -5,9 +5,9 @@
 -->
 <versions>
  <function name="ming_keypress" from="PHP 5 &lt; 5.3.0, PECL ming SVN"/>
- <function name="ming_setcubicthreshold" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PECL ming SVN"/>
- <function name="ming_setscale" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PECL ming SVN"/>
- <function name="ming_setswfcompression" from="PHP 5.2.1-5.3.0, PHP 7, PECL ming SVN"/>
+ <function name="ming_setcubicthreshold" from="PHP 4 &gt;= 4.0.5, PHP 5 &lt; 5.3.0, PECL ming SVN"/>
+ <function name="ming_setscale" from="PHP 4 &gt;= 4.0.5, PHP 5 &lt; 5.3.0, PECL ming SVN"/>
+ <function name="ming_setswfcompression" from="PHP 5.2.1-5.3.0, PECL ming SVN"/>
  <function name="ming_useconstants" from="PHP 5 &lt; 5.3.0, PECL ming SVN"/>
  <function name="ming_useswfversion" from="PHP 4 &gt;= 4.2.0, PHP 5 &lt; 5.3.0, PECL ming SVN"/>
 
@@ -102,11 +102,11 @@
  <function name="swfmovie::importchar" from="PHP 5 &lt; 5.3.0, PECL ming SVN"/>
  <function name="swfmovie::importfont" from="PHP 5 &lt; 5.3.0, PECL ming SVN"/>
  <function name="swfmovie::labelframe" from="PHP 5 &lt; 5.3.0, PECL ming SVN"/>
- <function name="swfmovie::namedanchor" from="PHP 5.2.1-5.3.0, PHP 7, PECL ming SVN"/>
+ <function name="swfmovie::namedanchor" from="PHP 5.2.1-5.3.0, PECL ming SVN"/>
  <function name="swfmovie::nextframe" from="PHP 5 &lt; 5.3.0, PECL ming SVN"/>
  <function name="swfmovie::output" from="PHP 5 &lt; 5.3.0, PECL ming SVN"/>
- <function name="swfmovie::protect" from="PHP 5.2.1-5.3.0, PHP 7, PECL ming SVN"/>
- <function name="swfmovie::remove" from="PHP 5.2.1-5.3.0, PHP 7, PECL ming SVN"/>
+ <function name="swfmovie::protect" from="PHP 5.2.1-5.3.0, PECL ming SVN"/>
+ <function name="swfmovie::remove" from="PHP 5.2.1-5.3.0, PECL ming SVN"/>
  <function name="swfmovie::save" from="PHP 5 &lt; 5.3.0, PECL ming SVN"/>
  <function name="swfmovie::savetofile" from="PHP 5 &lt; 5.3.0, PECL ming SVN"/>
  <function name="swfmovie::setbackground" from="PHP 5 &lt; 5.3.0, PECL ming SVN"/>
@@ -118,8 +118,8 @@
  <function name="swfmovie::streammp3" from="PHP 5 &lt; 5.3.0, PECL ming SVN"/>
  <function name="swfmovie::writeexports" from="PHP 5 &lt; 5.3.0, PECL ming SVN"/>
 
- <function name="swfprebuiltclip" from="PHP 5.0.5-5.3.0, PHP 7, PECL ming SVN"/>
- <function name="swfprebuiltclip::__construct" from="PHP 5.0.5-5.3.0, PHP 7, PECL ming SVN"/>
+ <function name="swfprebuiltclip" from="PHP 5.0.5-5.3.0, PECL ming SVN"/>
+ <function name="swfprebuiltclip::__construct" from="PHP 5.0.5-5.3.0, PECL ming SVN"/>
 
  <function name="swfshape" from="PHP 5 &lt; 5.3.0, PECL ming SVN"/>
  <function name="swfshape::__construct" from="PHP 5 &lt; 5.3.0, PECL ming SVN"/>
@@ -192,10 +192,10 @@
  <function name="swftextfield::setpadding" from="PHP 5 &lt; 5.3.0, PECL ming SVN"/>
  <function name="swftextfield::setrightmargin" from="PHP 5 &lt; 5.3.0, PECL ming SVN"/>
 
- <function name="swfvideostream" from="PHP 5.0.5-5.3.0, PHP 7, PECL ming SVN"/>
- <function name="swfvideostream::__construct" from="PHP 5.0.5-5.3.0, PHP 7, PECL ming SVN"/>
- <function name="swfvideostream::getnumframes" from="PHP 5.0.5-5.3.0, PHP 7, PECL ming SVN"/>
- <function name="swfvideostream::setdimension" from="PHP 5.0.5-5.3.0, PHP 7, PECL ming SVN"/>
+ <function name="swfvideostream" from="PHP 5.0.5-5.3.0, PECL ming SVN"/>
+ <function name="swfvideostream::__construct" from="PHP 5.0.5-5.3.0, PECL ming SVN"/>
+ <function name="swfvideostream::getnumframes" from="PHP 5.0.5-5.3.0, PECL ming SVN"/>
+ <function name="swfvideostream::setdimension" from="PHP 5.0.5-5.3.0, PECL ming SVN"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
As per: https://www.php.net/manual/en/ming.install.php

A number of functions/classes/methods still showed as if they were available in PHP 7.