### PR TITLE
XLSWriter: extension is not bundled with PHP

### DIFF
--- a/reference/xlswriter/versions.xml
+++ b/reference/xlswriter/versions.xml
@@ -2,28 +2,28 @@
 <!-- $Revision$ -->
 
 <versions>
- <function name='Vtiful\Kernel\Excel'                from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Excel::__construct'   from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Excel::fileName'      from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Excel::addSheet'      from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Excel::constMemory'   from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Excel::header'        from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Excel::data'          from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Excel::output'        from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Excel::getHandle'     from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Excel::autoFilter'    from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Excel::insertText'    from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Excel::insertImage'   from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Excel::insertFormula' from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Excel::mergeCells'    from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Excel::setColumn'     from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Excel::setRow'        from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Excel'                from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Excel::__construct'   from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Excel::fileName'      from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Excel::addSheet'      from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Excel::constMemory'   from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Excel::header'        from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Excel::data'          from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Excel::output'        from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Excel::getHandle'     from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Excel::autoFilter'    from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Excel::insertText'    from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Excel::insertImage'   from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Excel::insertFormula' from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Excel::mergeCells'    from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Excel::setColumn'     from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Excel::setRow'        from='PECL xlswriter &gt;= 1.2.1'/>
 
- <function name='Vtiful\Kernel\Format'               from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Format::bold'         from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Format::italic'       from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Format::underline'    from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
- <function name='Vtiful\Kernel\Format::align'        from='PHP 7 &gt;= 7.0.0, PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Format'               from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Format::bold'         from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Format::italic'       from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Format::underline'    from='PECL xlswriter &gt;= 1.2.1'/>
+ <function name='Vtiful\Kernel\Format::align'        from='PECL xlswriter &gt;= 1.2.1'/>
 </versions>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
As per: https://www.php.net/manual/en/xlswriter.installation.php

So the version information shouldn't give the impression that the classes/methods are available in PHP itself. They are only available in the PECL extension.