### PR TITLE
Swoole: extension is not bundled with PHP

### DIFF
--- a/reference/swoole/versions.xml
+++ b/reference/swoole/versions.xml
@@ -6,895 +6,895 @@
 
 <versions>
  <!-- Functions -->
- <function name='swoole_version' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_cpu_num' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_last_error' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_event_add' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_event_set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_event_del' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_event_exit' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_event_wait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_event_write' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_event_defer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_timer_after' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_timer_tick' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_timer_exists' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_timer_clear' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_async_set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_async_read' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_async_write' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_async_readfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_async_writefile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_async_dns_lookup' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_client_select' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_select' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_set_process_name' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_get_local_ip' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_strerror' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_errno' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole_load_module' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_version' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_cpu_num' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_last_error' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_event_add' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_event_set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_event_del' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_event_exit' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_event_wait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_event_write' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_event_defer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_timer_after' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_timer_tick' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_timer_exists' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_timer_clear' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_async_set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_async_read' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_async_write' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_async_readfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_async_writefile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_async_dns_lookup' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_client_select' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_select' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_set_process_name' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_get_local_ip' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_strerror' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_errno' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole_load_module' from='PECL swoole &gt;= 1.9.0'/>
  <!-- Classes and Methods -->
 
- <function name='swoole\server' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::listen' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::addlistener' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::on' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::start' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::send' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::sendto' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::sendwait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::exist' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::protect' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::sendfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::close' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::confirm' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::pause' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::resume' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::task' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::taskwait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::taskwaitmulti' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::finish' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::reload' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::shutdown' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::stop' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::getlasterror' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::heartbeat' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::connection_info' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::connection_list' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::getclientinfo' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::getclientlist' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::after' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::tick' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::cleartimer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::defer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::sendmessage' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::addprocess' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::stats' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::bind' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::listen' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::addlistener' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::on' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::start' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::send' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::sendto' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::sendwait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::exist' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::protect' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::sendfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::close' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::confirm' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::pause' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::resume' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::task' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::taskwait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::taskwaitmulti' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::finish' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::reload' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::shutdown' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::stop' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::getlasterror' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::heartbeat' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::connection_info' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::connection_list' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::getclientinfo' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::getclientlist' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::after' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::tick' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::cleartimer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::defer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::sendmessage' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::addprocess' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::stats' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::bind' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\server' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::listen' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::addlistener' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::on' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::start' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::send' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::sendto' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::sendwait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::exist' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::protect' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::sendfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::close' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::confirm' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::pause' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::resume' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::task' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::taskwait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::taskwaitmulti' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::finish' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::reload' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::shutdown' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::stop' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::getlasterror' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::heartbeat' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::connection_info' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::connection_list' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::getclientinfo' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::getclientlist' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::after' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::tick' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::cleartimer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::defer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::sendmessage' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::addprocess' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::stats' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server::bind' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::listen' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::addlistener' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::on' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::start' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::send' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::sendto' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::sendwait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::exist' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::protect' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::sendfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::close' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::confirm' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::pause' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::resume' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::task' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::taskwait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::taskwaitmulti' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::finish' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::reload' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::shutdown' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::stop' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::getlasterror' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::heartbeat' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::connection_info' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::connection_list' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::getclientinfo' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::getclientlist' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::after' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::tick' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::cleartimer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::defer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::sendmessage' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::addprocess' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::stats' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server::bind' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\timer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\timer::tick' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\timer::after' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\timer::exists' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\timer::clear' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\timer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\timer::tick' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\timer::after' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\timer::exists' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\timer::clear' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\timer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\timer::tick' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\timer::after' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\timer::exists' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\timer::clear' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\timer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\timer::tick' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\timer::after' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\timer::exists' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\timer::clear' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\event' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\event::add' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\event::del' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\event::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\event::exit' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\event::write' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\event::wait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\event::defer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\event' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\event::add' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\event::del' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\event::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\event::exit' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\event::write' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\event::wait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\event::defer' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\event' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\event::add' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\event::del' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\event::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\event::exit' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\event::write' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\event::wait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\event::defer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\event' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\event::add' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\event::del' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\event::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\event::exit' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\event::write' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\event::wait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\event::defer' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\async' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\async::read' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\async::write' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\async::readfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\async::writefile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\async::dnslookup' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\async::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\async' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\async::read' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\async::write' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\async::readfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\async::writefile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\async::dnslookup' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\async::set' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\async' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\async::read' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\async::write' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\async::readfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\async::writefile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\async::dnslookup' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\async::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\async' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\async::read' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\async::write' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\async::readfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\async::writefile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\async::dnslookup' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\async::set' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\connection\iterator' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::rewind' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::next' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::current' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::key' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::valid' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::count' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::offsetexists' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::offsetget' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::offsetset' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::offsetunset' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::rewind' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::next' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::current' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::key' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::valid' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::count' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::offsetexists' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::offsetget' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::offsetset' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::offsetunset' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\connection\iterator' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::rewind' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::next' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::current' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::key' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::valid' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::count' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::offsetexists' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::offsetget' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::offsetset' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\connection\iterator::offsetunset' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::rewind' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::next' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::current' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::key' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::valid' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::count' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::offsetexists' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::offsetget' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::offsetset' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\connection\iterator::offsetunset' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\exception' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::__clone' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::__wakeup' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::getmessage' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::getcode' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::getfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::getline' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::gettrace' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::getprevious' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::gettraceasstring' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::__tostring' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::__clone' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::__wakeup' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::getmessage' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::getcode' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::getfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::getline' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::gettrace' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::getprevious' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::gettraceasstring' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::__tostring' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\exception' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::__clone' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::__wakeup' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::getmessage' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::getcode' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::getfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::getline' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::gettrace' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::getprevious' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::gettraceasstring' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\exception::__tostring' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::__clone' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::__wakeup' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::getmessage' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::getcode' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::getfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::getline' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::gettrace' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::getprevious' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::gettraceasstring' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\exception::__tostring' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\server\port' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server\port::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server\port::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server\port::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server\port::on' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server\port' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server\port::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server\port::__destruct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server\port::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server\port::on' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\server\port' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server\port::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server\port::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server\port::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\server\port::on' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server\port' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server\port::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server\port::__destruct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server\port::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\server\port::on' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\client' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::connect' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::recv' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::send' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::pipe' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::sendfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::sendto' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::sleep' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::wakeup' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::pause' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::resume' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::isconnected' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::getsockname' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::getpeername' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::close' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::on' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::__destruct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::connect' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::recv' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::send' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::pipe' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::sendfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::sendto' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::sleep' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::wakeup' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::pause' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::resume' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::isconnected' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::getsockname' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::getpeername' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::close' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::on' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\client' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::connect' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::recv' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::send' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::pipe' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::sendfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::sendto' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::sleep' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::wakeup' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::pause' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::resume' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::isconnected' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::getsockname' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::getpeername' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::close' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\client::on' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::__destruct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::connect' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::recv' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::send' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::pipe' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::sendfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::sendto' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::sleep' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::wakeup' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::pause' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::resume' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::isconnected' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::getsockname' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::getpeername' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::close' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\client::on' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\coroutine\client' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::__construct' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::__destruct' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::set' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::connect' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::recv' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::send' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::sendfile' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::sendto' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::isconnected' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::getsockname' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::getpeername' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::close' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::__construct' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::__destruct' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::set' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::connect' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::recv' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::send' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::sendfile' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::sendto' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::isconnected' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::getsockname' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::getpeername' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::close' from='PECL swoole &gt;= 2.0.0'/>
 
- <function name='swoole\coroutine\client' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::__construct' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::__destruct' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::set' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::connect' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::recv' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::send' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::sendfile' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::sendto' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::isconnected' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::getsockname' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::getpeername' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\client::close' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::__construct' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::__destruct' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::set' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::connect' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::recv' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::send' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::sendfile' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::sendto' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::isconnected' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::getsockname' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::getpeername' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\client::close' from='PECL swoole &gt;= 2.0.0'/>
 
- <function name='swoole\coroutine\mysql' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql::__construct' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql::__destruct' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql::connect' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql::query' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql::recv' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql::setdefer' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql::getdefer' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql::close' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql::__construct' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql::__destruct' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql::connect' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql::query' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql::recv' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql::setdefer' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql::getdefer' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql::close' from='PECL swoole &gt;= 2.0.0'/>
 
- <function name='swoole\coroutine\mysql\exception' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql\exception::__clone' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql\exception::__construct' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql\exception::__wakeup' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql\exception::getmessage' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql\exception::getcode' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql\exception::getfile' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql\exception::getline' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql\exception::gettrace' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql\exception::getprevious' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql\exception::gettraceasstring' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\mysql\exception::__tostring' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql\exception' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql\exception::__clone' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql\exception::__construct' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql\exception::__wakeup' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql\exception::getmessage' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql\exception::getcode' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql\exception::getfile' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql\exception::getline' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql\exception::gettrace' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql\exception::getprevious' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql\exception::gettraceasstring' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\mysql\exception::__tostring' from='PECL swoole &gt;= 2.0.0'/>
 
- <function name='swoole\coroutine\http\client' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::__construct' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::__destruct' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::set' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::setmethod' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::setheaders' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::setcookies' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::setdata' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::execute' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::get' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::post' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::addfile' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::isconnected' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::close' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::setdefer' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::getdefer' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::recv' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::__construct' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::__destruct' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::set' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::setmethod' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::setheaders' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::setcookies' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::setdata' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::execute' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::get' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::post' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::addfile' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::isconnected' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::close' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::setdefer' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::getdefer' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::recv' from='PECL swoole &gt;= 2.0.0'/>
 
- <function name='swoole\coroutine\http\client' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::__construct' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::__destruct' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::set' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::setmethod' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::setheaders' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::setcookies' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::setdata' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::execute' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::get' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::post' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::addfile' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::isconnected' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::close' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::setdefer' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::getdefer' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine\http\client::recv' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::__construct' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::__destruct' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::set' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::setmethod' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::setheaders' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::setcookies' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::setdata' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::execute' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::get' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::post' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::addfile' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::isconnected' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::close' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::setdefer' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::getdefer' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine\http\client::recv' from='PECL swoole &gt;= 2.0.0'/>
 
- <function name='swoole\coroutine' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine::create' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine::cli_wait' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine::suspend' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine::resume' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine::getuid' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine::call_user_func' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine::call_user_func_array' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine::create' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine::cli_wait' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine::suspend' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine::resume' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine::getuid' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine::call_user_func' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine::call_user_func_array' from='PECL swoole &gt;= 2.0.0'/>
 
- <function name='swoole\coroutine' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine::create' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine::cli_wait' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine::suspend' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine::resume' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine::getuid' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine::call_user_func' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
- <function name='swoole\coroutine::call_user_func_array' from='PHP 7, PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine::create' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine::cli_wait' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine::suspend' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine::resume' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine::getuid' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine::call_user_func' from='PECL swoole &gt;= 2.0.0'/>
+ <function name='swoole\coroutine::call_user_func_array' from='PECL swoole &gt;= 2.0.0'/>
 
- <function name='swoole\http\client' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::setmethod' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::setheaders' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::setcookies' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::setdata' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::addfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::execute' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::push' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::get' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::post' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::upgrade' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::download' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::isconnected' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::close' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::on' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::__destruct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::setmethod' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::setheaders' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::setcookies' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::setdata' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::addfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::execute' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::push' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::get' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::post' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::upgrade' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::download' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::isconnected' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::close' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::on' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\http\client' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::setmethod' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::setheaders' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::setcookies' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::setdata' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::addfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::execute' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::push' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::get' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::post' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::upgrade' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::download' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::isconnected' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::close' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\client::on' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::__destruct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::setmethod' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::setheaders' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::setcookies' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::setdata' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::addfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::execute' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::push' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::get' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::post' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::upgrade' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::download' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::isconnected' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::close' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\client::on' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\process' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::wait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::signal' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::alarm' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::kill' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::daemon' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::usequeue' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::statqueue' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::freequeue' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::start' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::write' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::close' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::read' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::push' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::pop' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::exit' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::exec' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::name' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::__destruct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::wait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::signal' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::alarm' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::kill' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::daemon' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::usequeue' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::statqueue' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::freequeue' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::start' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::write' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::close' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::read' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::push' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::pop' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::exit' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::exec' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::name' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\process' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::wait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::signal' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::alarm' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::kill' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::daemon' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::usequeue' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::statqueue' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::freequeue' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::start' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::write' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::close' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::read' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::push' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::pop' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::exit' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::exec' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\process::name' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::__destruct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::wait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::signal' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::alarm' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::kill' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::daemon' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::usequeue' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::statqueue' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::freequeue' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::start' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::write' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::close' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::read' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::push' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::pop' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::exit' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::exec' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\process::name' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\table' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::column' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::create' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::destroy' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::get' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::count' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::del' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::exist' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::incr' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::decr' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::rewind' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::next' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::current' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::key' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::valid' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::column' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::create' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::destroy' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::get' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::count' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::del' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::exist' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::incr' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::decr' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::rewind' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::next' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::current' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::key' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::valid' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\table' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::column' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::create' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::destroy' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::get' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::count' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::del' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::exist' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::incr' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::decr' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::rewind' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::next' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::current' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::key' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\table::valid' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::column' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::create' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::destroy' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::get' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::count' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::del' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::exist' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::incr' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::decr' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::rewind' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::next' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::current' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::key' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\table::valid' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\lock' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\lock::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\lock::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\lock::lock' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\lock::trylock' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\lock::lock_read' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\lock::trylock_read' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\lock::unlock' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\lock' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\lock::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\lock::__destruct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\lock::lock' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\lock::trylock' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\lock::lock_read' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\lock::trylock_read' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\lock::unlock' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\lock' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\lock::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\lock::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\lock::lock' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\lock::trylock' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\lock::lock_read' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\lock::trylock_read' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\lock::unlock' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\lock' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\lock::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\lock::__destruct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\lock::lock' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\lock::trylock' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\lock::lock_read' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\lock::trylock_read' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\lock::unlock' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\atomic' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\atomic::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\atomic::add' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\atomic::sub' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\atomic::get' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\atomic::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\atomic::cmpset' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\atomic' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\atomic::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\atomic::add' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\atomic::sub' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\atomic::get' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\atomic::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\atomic::cmpset' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\atomic' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\atomic::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\atomic::add' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\atomic::sub' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\atomic::get' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\atomic::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\atomic::cmpset' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\atomic' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\atomic::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\atomic::add' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\atomic::sub' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\atomic::get' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\atomic::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\atomic::cmpset' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\http\server' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::on' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::start' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::listen' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::addlistener' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::send' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::sendto' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::sendwait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::exist' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::protect' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::sendfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::close' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::confirm' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::pause' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::resume' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::task' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::taskwait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::taskwaitmulti' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::finish' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::reload' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::shutdown' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::stop' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::getlasterror' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::heartbeat' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::connection_info' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::connection_list' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::getclientinfo' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::getclientlist' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::after' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::tick' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::cleartimer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::defer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::sendmessage' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::addprocess' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::stats' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::bind' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::on' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::start' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::listen' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::addlistener' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::send' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::sendto' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::sendwait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::exist' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::protect' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::sendfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::close' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::confirm' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::pause' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::resume' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::task' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::taskwait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::taskwaitmulti' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::finish' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::reload' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::shutdown' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::stop' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::getlasterror' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::heartbeat' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::connection_info' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::connection_list' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::getclientinfo' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::getclientlist' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::after' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::tick' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::cleartimer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::defer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::sendmessage' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::addprocess' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::stats' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::bind' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\http\server' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::on' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::start' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::listen' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::addlistener' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::send' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::sendto' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::sendwait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::exist' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::protect' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::sendfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::close' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::confirm' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::pause' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::resume' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::task' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::taskwait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::taskwaitmulti' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::finish' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::reload' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::shutdown' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::stop' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::getlasterror' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::heartbeat' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::connection_info' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::connection_list' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::getclientinfo' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::getclientlist' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::after' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::tick' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::cleartimer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::defer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::sendmessage' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::addprocess' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::stats' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\server::bind' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::on' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::start' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::listen' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::addlistener' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::send' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::sendto' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::sendwait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::exist' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::protect' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::sendfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::close' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::confirm' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::pause' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::resume' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::task' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::taskwait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::taskwaitmulti' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::finish' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::reload' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::shutdown' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::stop' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::getlasterror' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::heartbeat' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::connection_info' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::connection_list' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::getclientinfo' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::getclientlist' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::after' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::tick' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::cleartimer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::defer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::sendmessage' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::addprocess' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::stats' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\server::bind' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\http\response' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::initheader' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::cookie' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::rawcookie' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::status' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::gzip' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::header' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::write' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::end' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::sendfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::initheader' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::cookie' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::rawcookie' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::status' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::gzip' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::header' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::write' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::end' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::sendfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::__destruct' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\http\response' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::initheader' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::cookie' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::rawcookie' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::status' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::gzip' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::header' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::write' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::end' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::sendfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\response::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::initheader' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::cookie' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::rawcookie' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::status' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::gzip' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::header' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::write' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::end' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::sendfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\response::__destruct' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\http\request' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\request::rawcontent' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\request::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\request' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\request::rawcontent' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\request::__destruct' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\http\request' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\request::rawcontent' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\http\request::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\request' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\request::rawcontent' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\http\request::__destruct' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\buffer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::__tostring' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::substr' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::write' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::read' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::append' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::expand' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::recycle' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::clear' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::__destruct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::__tostring' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::substr' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::write' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::read' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::append' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::expand' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::recycle' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::clear' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\buffer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::__tostring' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::substr' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::write' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::read' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::append' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::expand' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::recycle' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\buffer::clear' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::__destruct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::__tostring' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::substr' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::write' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::read' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::append' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::expand' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::recycle' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\buffer::clear' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\websocket\server' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::on' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::push' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::exist' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::pack' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::unpack' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::start' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::listen' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::addlistener' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::send' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::sendto' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::sendwait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::protect' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::sendfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::close' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::confirm' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::pause' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::resume' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::task' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::taskwait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::taskwaitmulti' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::finish' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::reload' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::shutdown' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::stop' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::getlasterror' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::heartbeat' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::connection_info' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::connection_list' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::getclientinfo' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::getclientlist' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::after' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::tick' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::cleartimer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::defer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::sendmessage' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::addprocess' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::stats' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::bind' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::on' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::push' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::exist' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::pack' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::unpack' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::start' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::listen' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::addlistener' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::send' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::sendto' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::sendwait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::protect' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::sendfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::close' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::confirm' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::pause' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::resume' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::task' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::taskwait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::taskwaitmulti' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::finish' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::reload' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::shutdown' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::stop' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::getlasterror' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::heartbeat' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::connection_info' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::connection_list' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::getclientinfo' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::getclientlist' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::after' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::tick' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::cleartimer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::defer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::sendmessage' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::addprocess' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::stats' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::bind' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\websocket\server' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::on' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::push' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::exist' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::pack' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::unpack' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::start' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::listen' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::addlistener' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::send' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::sendto' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::sendwait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::protect' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::sendfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::close' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::confirm' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::pause' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::resume' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::task' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::taskwait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::taskwaitmulti' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::finish' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::reload' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::shutdown' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::stop' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::getlasterror' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::heartbeat' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::connection_info' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::connection_list' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::getclientinfo' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::getclientlist' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::after' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::tick' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::cleartimer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::defer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::sendmessage' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::addprocess' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::stats' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\websocket\server::bind' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::on' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::push' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::exist' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::pack' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::unpack' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::start' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::listen' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::addlistener' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::send' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::sendto' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::sendwait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::protect' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::sendfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::close' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::confirm' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::pause' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::resume' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::task' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::taskwait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::taskwaitmulti' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::finish' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::reload' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::shutdown' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::stop' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::getlasterror' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::heartbeat' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::connection_info' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::connection_list' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::getclientinfo' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::getclientlist' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::after' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::tick' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::cleartimer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::defer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::sendmessage' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::addprocess' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::stats' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\server::bind' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\websocket\frame' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\frame' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\websocket\frame' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\websocket\frame' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\mysql' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql::connect' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql::query' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql::getbuffer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql::close' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql::on' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql::__destruct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql::connect' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql::query' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql::getbuffer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql::close' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql::on' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\mysql' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql::connect' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql::query' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql::getbuffer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql::close' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql::on' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql::__destruct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql::connect' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql::query' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql::getbuffer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql::close' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql::on' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\mysql\exception' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::__clone' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::__wakeup' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::getmessage' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::getcode' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::getfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::getline' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::gettrace' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::getprevious' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::gettraceasstring' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::__tostring' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::__clone' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::__wakeup' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::getmessage' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::getcode' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::getfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::getline' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::gettrace' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::getprevious' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::gettraceasstring' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::__tostring' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\mysql\exception' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::__clone' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::__wakeup' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::getmessage' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::getcode' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::getfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::getline' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::gettrace' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::getprevious' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::gettraceasstring' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mysql\exception::__tostring' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::__clone' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::__wakeup' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::getmessage' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::getcode' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::getfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::getline' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::gettrace' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::getprevious' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::gettraceasstring' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mysql\exception::__tostring' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\module' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\module' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\module' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\module' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\mmap' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mmap::open' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mmap' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mmap::open' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\mmap' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\mmap::open' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mmap' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\mmap::open' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\channel' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\channel::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\channel::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\channel::push' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\channel::pop' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\channel::stats' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\channel' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\channel::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\channel::__destruct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\channel::push' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\channel::pop' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\channel::stats' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\channel' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\channel::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\channel::__destruct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\channel::push' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\channel::pop' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\channel::stats' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\channel' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\channel::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\channel::__destruct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\channel::push' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\channel::pop' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\channel::stats' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\serialize' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\serialize::pack' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\serialize::unpack' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\serialize' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\serialize::pack' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\serialize::unpack' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\serialize' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\serialize::pack' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\serialize::unpack' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\serialize' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\serialize::pack' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\serialize::unpack' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\redis\server' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::start' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::sethandler' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::format' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::listen' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::addlistener' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::on' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::send' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::sendto' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::sendwait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::exist' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::protect' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::sendfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::close' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::confirm' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::pause' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::resume' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::task' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::taskwait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::taskwaitmulti' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::finish' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::reload' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::shutdown' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::stop' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::getlasterror' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::heartbeat' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::connection_info' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::connection_list' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::getclientinfo' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::getclientlist' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::after' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::tick' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::cleartimer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::defer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::sendmessage' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::addprocess' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::stats' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::bind' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::start' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::sethandler' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::format' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::listen' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::addlistener' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::on' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::send' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::sendto' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::sendwait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::exist' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::protect' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::sendfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::close' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::confirm' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::pause' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::resume' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::task' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::taskwait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::taskwaitmulti' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::finish' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::reload' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::shutdown' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::stop' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::getlasterror' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::heartbeat' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::connection_info' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::connection_list' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::getclientinfo' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::getclientlist' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::after' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::tick' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::cleartimer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::defer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::sendmessage' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::addprocess' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::stats' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::bind' from='PECL swoole &gt;= 1.9.0'/>
 
- <function name='swoole\redis\server' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::start' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::sethandler' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::format' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::__construct' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::listen' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::addlistener' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::on' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::set' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::send' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::sendto' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::sendwait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::exist' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::protect' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::sendfile' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::close' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::confirm' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::pause' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::resume' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::task' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::taskwait' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::taskwaitmulti' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::finish' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::reload' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::shutdown' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::stop' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::getlasterror' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::heartbeat' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::connection_info' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::connection_list' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::getclientinfo' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::getclientlist' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::after' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::tick' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::cleartimer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::defer' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::sendmessage' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::addprocess' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::stats' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
- <function name='swoole\redis\server::bind' from='PHP 5 &gt;= 5.2.0, PHP 7, PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::start' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::sethandler' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::format' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::__construct' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::listen' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::addlistener' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::on' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::set' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::send' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::sendto' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::sendwait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::exist' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::protect' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::sendfile' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::close' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::confirm' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::pause' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::resume' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::task' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::taskwait' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::taskwaitmulti' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::finish' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::reload' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::shutdown' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::stop' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::getlasterror' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::heartbeat' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::connection_info' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::connection_list' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::getclientinfo' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::getclientlist' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::after' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::tick' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::cleartimer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::defer' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::sendmessage' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::addprocess' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::stats' from='PECL swoole &gt;= 1.9.0'/>
+ <function name='swoole\redis\server::bind' from='PECL swoole &gt;= 1.9.0'/>
 </versions>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
As per: https://www.php.net/manual/en/swoole.installation.php

So the version information shouldn't give the impression that the classes/methods are available in PHP itself. They are only available in the PECL extension.