### PR TITLE
SPLObjectStorage: fix class version nr

### DIFF
--- a/reference/spl/versions.xml
+++ b/reference/spl/versions.xml
@@ -977,7 +977,7 @@
  <function name="splsubject::detach" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
  <function name="splsubject::notify" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
 
- <function name="splobjectstorage" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="splobjectstorage" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
  <function name="splobjectstorage::addall" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
  <function name="splobjectstorage::attach" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
  <function name="splobjectstorage::contains" from="PHP 5 &gt;= 5.1.0, PHP 7"/>


### PR DESCRIPTION
If the class wasn't introduced until PHP 5.3.0, how can it be that certain methods would have existed before PHP 5.3 ?

_Updated to reflect @nikic's feedback - not the method version nrs were wrong, but the class version nr._