### PR TITLE
Filter: add missing constants

### DIFF
--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -113,7 +113,7 @@
    </term>
    <listitem>
     <simpara>
-      Require an array as input. 
+      Require an array as input.
     </simpara>
    </listitem>
   </varlistentry>
@@ -135,7 +135,7 @@
    </term>
    <listitem>
     <simpara>
-     Use NULL instead of FALSE on failure. 
+     Use NULL instead of FALSE on failure.
     </simpara>
    </listitem>
   </varlistentry>
@@ -191,6 +191,18 @@
    <listitem>
     <simpara>
      ID of "validate_url" filter.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.filter-validate-domain">
+   <term>
+    <constant>FILTER_VALIDATE_DOMAIN</constant>
+     (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     ID of "validate_domain" filter.
+     (Available as of PHP 7.0.0)
     </simpara>
    </listitem>
   </varlistentry>
@@ -347,6 +359,19 @@
    <listitem>
     <simpara>
      ID of "magic_quotes" filter.
+     (Deprecated per PHP 7.3.0, use FILTER_SANITIZE_ADD_SLASHES instead.)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.filter-sanitize-add-slashes">
+   <term>
+    <constant>FILTER_SANITIZE_ADD_SLASHES</constant>
+     (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     ID of "add_slashes" filter.
+     (Available as of PHP 7.3.0)
     </simpara>
    </listitem>
   </varlistentry>
@@ -402,6 +427,18 @@
    <listitem>
     <simpara>
      Strip characters with ASCII value greater than 127.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.filter-flag-strip-backtick">
+   <term>
+    <constant>FILTER_FLAG_STRIP_BACKTICK</constant>
+     (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Strips backtick characters.
+     (Available as of PHP 5.3.2)
     </simpara>
    </listitem>
   </varlistentry>
@@ -513,6 +550,43 @@
    <listitem>
     <simpara>
      Require query in "validate_url" filter.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.filter-flag-scheme-required">
+   <term>
+    <constant>FILTER_FLAG_SCHEME_REQUIRED</constant>
+     (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Require scheme in "validate_url" filter.
+     (Deprecated per PHP 7.3 as it is implied in the filter already.)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.filter-flag-host-required">
+   <term>
+    <constant>FILTER_FLAG_HOST_REQUIRED</constant>
+     (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Require host in "validate_url" filter.
+     (Deprecated per PHP 7.3 as it is implied in the filter already.)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.filter-flag-hostname">
+   <term>
+    <constant>FILTER_FLAG_HOSTNAME</constant>
+     (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Require hostnames to start with an alphanumeric character and contain
+     only alphanumerics or hyphens.
+     (Available as of PHP 7.0.0)
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
Add a number of constants missing from the Predefined Constants page of the Filter extension.