### PR TITLE
DOMImplementation: fix typo

### DIFF
--- a/reference/dom/domimplementation.xml
+++ b/reference/dom/domimplementation.xml
@@ -16,7 +16,7 @@ Remove me once you perform substitutions
   <section xml:id="domimplementation.intro">
    &reftitle.intro;
    <para>
-    The <classname>DOMImplementation</classname> interface provides a number
+    The <classname>DOMImplementation</classname> class provides a number
     of methods for performing operations that are independent of any 
     particular instance of the document object model.
    </para>


### PR DESCRIPTION
If I read the source correctly, `DOMImplementation` is a class, not an interface.

Ref: https://github.com/php/php-src/blob/5322de1ba8428c0231c972586217f9b1b705c45d/ext/dom/domimplementation.stub.php