### PR TITLE
SimpleXML: add missing changelog entries for $is_prefix

### DIFF
--- a/reference/simplexml/functions/simplexml-load-file.xml
+++ b/reference/simplexml/functions/simplexml-load-file.xml
@@ -94,7 +94,31 @@
   </para>
   &return.falseproblem;
  </refsect1>
- 
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>5.2.0</entry>
+       <entry>
+        The optional parameter <parameter>is_prefix</parameter> was added.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="errors"><!-- {{{ -->
   &reftitle.errors;
   <para>

--- a/reference/simplexml/functions/simplexml-load-string.xml
+++ b/reference/simplexml/functions/simplexml-load-string.xml
@@ -85,6 +85,30 @@
   &return.falseproblem;
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>5.2.0</entry>
+       <entry>
+        The optional parameter <parameter>is_prefix</parameter> was added.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="errors"><!-- {{{ -->
   &reftitle.errors;
   <para>

--- a/reference/simplexml/simplexmlelement/attributes.xml
+++ b/reference/simplexml/simplexmlelement/attributes.xml
@@ -55,6 +55,30 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>5.2.0</entry>
+       <entry>
+        The optional parameter <parameter>is_prefix</parameter> was added.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>


### PR DESCRIPTION
According to the PHP 5.2 migration guide, the `$is_prefix` parameter was added to three methods and two functions in PHP 5.2, but only two of those had a changelog entry about this change.

Ref: https://www.php.net/manual/en/migration52.parameters.php