### PR TITLE
WDDX: update installation instructions

### DIFF
--- a/reference/wddx/configure.xml
+++ b/reference/wddx/configure.xml
@@ -2,12 +2,27 @@
 <!-- $Revision$ -->
 <section xml:id="wddx.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
- <para>
-  After installing the required expat library, compile PHP with
-  <option role="configure">--enable-wddx</option>, and use
-  <option role="configure">--with-libexpat-dir</option> for expat.
- </para>
- &windows.builtin;
+
+ <section xml:id="wddx.installation.php74">
+  <title>PHP 7.4</title>
+  <para>
+   &pecl.moved-ver;7.4.0
+  </para>
+  <para>
+   &pecl.info;
+   <link xlink:href="&url.pecl.package;wddx">&url.pecl.package;wddx</link>.
+  </para>
+ </section>
+
+ <section xml:id="wddx.installation.phplt74">
+  <title>PHP &lt; 7.4</title>
+  <para>
+   After installing the required expat library, compile PHP with
+   <option role="configure">--enable-wddx</option>, and use
+   <option role="configure">--with-libexpat-dir</option> for expat.
+  </para>
+  &windows.builtin;
+ </section>
 </section>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
As of PHP 7.4, the extension is no longer bundled with PHP, but moved to PECL.

The way I've annotated this emulates the installation instructions for [POSIX regex](https://www.php.net/manual/en/regex.installation.php).