### PR TITLE
Recode: update installation instructions

### DIFF
--- a/reference/recode/configure.xml
+++ b/reference/recode/configure.xml
@@ -2,28 +2,41 @@
 <!-- $Revision$ -->
 <section xml:id="recode.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
- <para>
-  To be able to use the functions defined in this
-  module you must compile your PHP interpreter using the
-  <option role="configure">--with-recode[=DIR]</option>
-  option.
- </para>
- <warning>
-  <para>
-   Crashes and startup problems of PHP may be encountered
-   when loading the recode as extension <emphasis
-   role="strong">after</emphasis> loading any extension of <link
-   linkend="ref.mysql">mysql</link> or <link
-   linkend="ref.imap">imap</link>. Loading the recode before those
-   extension has proved to fix the problem.  This is due a technical problem
-   that both the c-client library used by imap and recode have their own
-   <literal>hash_lookup()</literal> function and both mysql and recode have
-   their own <literal>hash_insert</literal> function.
-  </para>
- </warning>
- 
- &warn.imaprecodeyaz;
 
+ <section xml:id="recode.installation.php74">
+  <title>PHP 7.4</title>
+  <para>
+   &pecl.moved-ver;7.4.0
+  </para>
+  <para>
+   &pecl.info;
+   <link xlink:href="&url.pecl.package;recode">&url.pecl.package;recode</link>.
+  </para>
+ </section>
+
+ <section xml:id="recode.installation.phplt74">
+  <title>PHP &lt; 7.4</title>
+  <para>
+   To be able to use the functions defined in this
+   module you must compile your PHP interpreter using the
+   <option role="configure">--with-recode[=DIR]</option>
+   option.
+  </para>
+  <warning>
+   <para>
+    Crashes and startup problems of PHP may be encountered
+    when loading the recode as extension <emphasis
+    role="strong">after</emphasis> loading any extension of <link
+    linkend="ref.mysql">mysql</link> or <link
+    linkend="ref.imap">imap</link>. Loading the recode before those
+    extension has proved to fix the problem.  This is due a technical problem
+    that both the c-client library used by imap and recode have their own
+    <literal>hash_lookup()</literal> function and both mysql and recode have
+    their own <literal>hash_insert</literal> function.
+   </para>
+  </warning>
+  &warn.imaprecodeyaz;
+ </section>
 </section>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
As of PHP 7.4, the extension is no longer bundled with PHP, but moved to PECL.

The way I've annotated this emulates the installation instructions for [POSIX regex](https://www.php.net/manual/en/regex.installation.php).