### PR TITLE
XMLWriter: fix version nrs of a few functions

### DIFF
--- a/reference/xmlwriter/versions.xml
+++ b/reference/xmlwriter/versions.xml
@@ -58,7 +58,7 @@
  <function name="xmlwriter_end_dtd" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
  <function name="xmlwriter_end_dtd_attlist" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
  <function name="xmlwriter_end_dtd_element" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
- <function name="xmlwriter_end_dtd_entity" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
+ <function name="xmlwriter_end_dtd_entity" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
  <function name="xmlwriter_end_element" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
  <function name="xmlwriter_end_pi" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
  <function name="xmlwriter_flush" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 1.0.0"/>
@@ -76,7 +76,7 @@
  <function name="xmlwriter_start_dtd" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
  <function name="xmlwriter_start_dtd_attlist" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
  <function name="xmlwriter_start_dtd_element" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
- <function name="xmlwriter_start_dtd_entity" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
+ <function name="xmlwriter_start_dtd_entity" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
  <function name="xmlwriter_start_element" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
  <function name="xmlwriter_start_element_ns" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
  <function name="xmlwriter_start_pi" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
@@ -88,7 +88,7 @@
  <function name="xmlwriter_write_dtd" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
  <function name="xmlwriter_write_dtd_attlist" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
  <function name="xmlwriter_write_dtd_element" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
- <function name="xmlwriter_write_dtd_entity" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
+ <function name="xmlwriter_write_dtd_entity" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
  <function name="xmlwriter_write_element" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
  <function name="xmlwriter_write_element_ns" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>
  <function name="xmlwriter_write_pi" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL xmlwriter &gt;= 0.1.0"/>


### PR DESCRIPTION
Per https://www.php.net/manual/en/migration52.functions.php, these functions were added in PHP 5.2 and looking at the commits, that seems correct.

Ref: https://github.com/php/php-src/commit/3cd6518f392db926d439c0a277b11de7035ab959