### PR TITLE
Add missing Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+os: linux
+dist: bionic
 language: php
 php:
   - 7.2


### PR DESCRIPTION
These warnings can be seen in the `View Config` tab of any Travis CI job, e.g.: https://travis-ci.org/github/php/doc-en/jobs/686900419/config