### PR TITLE
DBX/installation: extension was moved to PECL

### DIFF
--- a/reference/dbx/configure.xml
+++ b/reference/dbx/configure.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<section xml:id="dbx.installation" xmlns="http://docbook.org/ns/docbook">
+<section xml:id="dbx.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
+ <para>
+  &pecl.moved-ver;5.1.0
+ </para>
+ <para>
+  &pecl.info;
+  <link xlink:href="&url.pecl.package;dbx">&url.pecl.package;dbx</link>.
+ </para>
  <para>
   In order to have these functions available, you must compile PHP with
   dbx support by using the <option role="configure">--enable-dbx</option>


### PR DESCRIPTION
Updating: https://www.php.net/manual/en/dbx.installation.php

The extension has not been bundled with PHP since 5.1.0.

Ref: https://www.php.net/manual/en/intro.dbx.php