### PR TITLE
Frontbase/installation: extension was moved to PECL

### DIFF
--- a/reference/fbsql/configure.xml
+++ b/reference/fbsql/configure.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<section xml:id="fbsql.installation" xmlns="http://docbook.org/ns/docbook">
+<section xml:id="fbsql.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
+ <para>
+  &pecl.moved-ver;5.3.0
+ </para>
+ <para>
+  &pecl.info;.
+ </para>
  <para>
   In order to have these functions available, you must compile PHP with
   fbsql support by using the

--- a/reference/fbsql/versions.xml
+++ b/reference/fbsql/versions.xml
@@ -4,67 +4,67 @@
   Do NOT translate this file
 -->
 <versions> 
- <function name='fbsql' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_affected_rows' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_autocommit' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_blob_size' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='fbsql_change_user' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_clob_size' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='fbsql_close' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_commit' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_connect' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_create_blob' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='fbsql_create_clob' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='fbsql_create_db' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_data_seek' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_database' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_database_password' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_db_query' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_db_status' from='PHP 4 &gt;= 4.0.7, PHP 5, PHP 7'/>
- <function name='fbsql_drop_db' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_errno' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_error' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_fetch_array' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_fetch_assoc' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_fetch_field' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_fetch_lengths' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_fetch_object' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_fetch_row' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_field_flags' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_field_len' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_field_name' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_field_seek' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_field_table' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_field_type' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_free_result' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_get_autostart_info' from='PHP 4 &gt;= 4.0.7, PHP 5, PHP 7'/>
- <function name='fbsql_hostname' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_insert_id' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_list_dbs' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_list_fields' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_list_tables' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_next_result' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_num_fields' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_num_rows' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_password' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_pconnect' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_query' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_read_blob' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='fbsql_read_clob' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='fbsql_result' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_rollback' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_rows_fetched' from='PHP 5 &gt;= 5.1.0, PHP 7'/>
- <function name='fbsql_select_db' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_set_characterset' from='PHP 5 &gt;= 5.1.0, PHP 7'/>
- <function name='fbsql_set_lob_mode' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='fbsql_set_password' from='PHP 5, PHP 7'/>
- <function name='fbsql_set_transaction' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='fbsql_start_db' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_stop_db' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_table_name' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='fbsql_tablename' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='fbsql_username' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='fbsql_warnings' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
+ <function name='fbsql' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_affected_rows' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_autocommit' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_blob_size' from='PHP 4 &gt;= 4.2.0, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_change_user' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_clob_size' from='PHP 4 &gt;= 4.2.0, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_close' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_commit' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_connect' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_create_blob' from='PHP 4 &gt;= 4.2.0, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_create_clob' from='PHP 4 &gt;= 4.2.0, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_create_db' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_data_seek' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_database' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_database_password' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_db_query' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_db_status' from='PHP 4 &gt;= 4.0.7, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_drop_db' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_errno' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_error' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_fetch_array' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_fetch_assoc' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_fetch_field' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_fetch_lengths' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_fetch_object' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_fetch_row' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_field_flags' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_field_len' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_field_name' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_field_seek' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_field_table' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_field_type' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_free_result' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_get_autostart_info' from='PHP 4 &gt;= 4.0.7, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_hostname' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_insert_id' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_list_dbs' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_list_fields' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_list_tables' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_next_result' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_num_fields' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_num_rows' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_password' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_pconnect' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_query' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_read_blob' from='PHP 4 &gt;= 4.2.0, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_read_clob' from='PHP 4 &gt;= 4.2.0, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_result' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_rollback' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_rows_fetched' from='PHP 5 &gt;= 5.1.0 &lt; 5.3.0'/>
+ <function name='fbsql_select_db' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_set_characterset' from='PHP 5 &gt;= 5.1.0 &lt; 5.3.0'/>
+ <function name='fbsql_set_lob_mode' from='PHP 4 &gt;= 4.2.0, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_set_password' from='PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_set_transaction' from='PHP 4 &gt;= 4.2.0, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_start_db' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_stop_db' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_table_name' from='PHP 4 &gt;= 4.2.0, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_tablename' from='PHP 4 &gt;= 4.2.0, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_username' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
+ <function name='fbsql_warnings' from='PHP 4 &gt;= 4.0.6, PHP 5 &lt; 5.3.0'/>
 </versions>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Updating: https://www.php.net/manual/en/fbsql.installation.php

The extension has not been bundled with PHP since 5.3.0.

As I couldn't find the extension on PECL anymore, I have not included a link to the PECL package.

Ref: https://www.php.net/manual/en/intro.fbsql.php

----

[Edit] I've added a second commit as the function version nrs appear incorrect as well.

#### Frontbase: fix function version nrs

The extension has not been bundled with PHP since 5.3.0, so shouldn't give the impression that the functions are available in all PHP 5 versions, as well as PHP 7.

As I couldn't find the extension on PECL anymore, I have not included "PECL/fbsql SVN" in the version nr.
