### PR TITLE
fix ugly bug in sample code

### DIFF
--- a/reference/curl/functions/curl-multi-info-read.xml
+++ b/reference/curl/functions/curl-multi-info-read.xml
@@ -113,8 +113,7 @@ do {
     if ($active) {
         curl_multi_select($mh);
     }
-    $info = curl_multi_info_read($mh);
-    if (false !== $info) {
+    while (false !== ($info=curl_multi_info_read($mh))) {
         var_dump($info);
     }
 } while ($active && $status == CURLM_OK);


### PR DESCRIPTION
imagine if 2 handles finish in the same multi_exec(), before exec() $active is 2 and after the call $active is 0, then we read the first message, and the the message from the 2nd handle will be lost/ignored!

this has caused real bugs in the wild, see https://stackoverflow.com/questions/61920359/count-how-many-curl-multi-requests-have-been-made/61923372