### PR TITLE
filePro: extension was moved to PECL / no longer bundled with PHP as of PHP 5.2

### DIFF
--- a/reference/filepro/configure.xml
+++ b/reference/filepro/configure.xml
@@ -3,6 +3,9 @@
 <section xml:id="filepro.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
  <para>
+  &pecl.moved-ver;5.2.0
+ </para>
+ <para>
   &pecl.info;
   <link xlink:href="&url.pecl.package;filepro">&url.pecl.package;filepro</link>.
  </para>

--- a/reference/filepro/versions.xml
+++ b/reference/filepro/versions.xml
@@ -4,13 +4,13 @@
   Do NOT translate this file
 -->
 <versions> 
- <function name='filepro' from='PHP 4, PHP 5 &lt; 5.2.0, PHP 7'/>
- <function name='filepro_fieldcount' from='PHP 4, PHP 5 &lt; 5.2.0, PHP 7'/>
- <function name='filepro_fieldname' from='PHP 4, PHP 5 &lt; 5.2.0, PHP 7'/>
- <function name='filepro_fieldtype' from='PHP 4, PHP 5 &lt; 5.2.0, PHP 7'/>
- <function name='filepro_fieldwidth' from='PHP 4, PHP 5 &lt; 5.2.0, PHP 7'/>
- <function name='filepro_retrieve' from='PHP 4, PHP 5 &lt; 5.2.0, PHP 7'/>
- <function name='filepro_rowcount' from='PHP 4, PHP 5 &lt; 5.2.0, PHP 7'/>
+ <function name='filepro' from='PHP 4, PHP 5 &lt; 5.2.0, PECL filepro SVN'/>
+ <function name='filepro_fieldcount' from='PHP 4, PHP 5 &lt; 5.2.0, PECL filepro SVN'/>
+ <function name='filepro_fieldname' from='PHP 4, PHP 5 &lt; 5.2.0, PECL filepro SVN'/>
+ <function name='filepro_fieldtype' from='PHP 4, PHP 5 &lt; 5.2.0, PECL filepro SVN'/>
+ <function name='filepro_fieldwidth' from='PHP 4, PHP 5 &lt; 5.2.0, PECL filepro SVN'/>
+ <function name='filepro_retrieve' from='PHP 4, PHP 5 &lt; 5.2.0, PECL filepro SVN'/>
+ <function name='filepro_rowcount' from='PHP 4, PHP 5 &lt; 5.2.0, PECL filepro SVN'/>
 </versions>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
As per: https://www.php.net/manual/en/intro.filepro.php

It is unclear to me what the current version nr is of the PECL extension, but showing the functions as if they are available in PHP > 5.2 seems wrong either way.

Includes adding a mention of when the extension was moved to PECL on the "Installing/Configuring" page.