### PR TITLE
Firebird/Interbase: extension was moved to PECL as of PHP 7.4

### DIFF
--- a/reference/ibase/book.xml
+++ b/reference/ibase/book.xml
@@ -30,6 +30,9 @@
   </para>
   <note>
    <para>
+    &pecl.moved-ver;7.4.0
+   </para>
+   <para>
     This extension supports InterBase versions 6 and up and Firebird version 2.0 and up.
    </para>
    <para>

--- a/reference/ibase/configure.xml
+++ b/reference/ibase/configure.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<section xml:id="ibase.installation" xmlns="http://docbook.org/ns/docbook">
+<section xml:id="ibase.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
+ <para>
+  &pecl.moved-ver;7.4.0
+ </para>
+ <para>
+  &pecl.info;
+  <link xlink:href="&url.pecl.package;ibase">&url.pecl.package;ibase</link>.
+ </para>
  <para>
   To enable Firebird/InterBase support configure PHP
   <option role="configure">--with-interbase[=DIR]</option>, where DIR is the

--- a/reference/ibase/versions.xml
+++ b/reference/ibase/versions.xml
@@ -3,106 +3,106 @@
 <!--
   Do NOT translate this file
 -->
-<versions> 
- <function name="ibase_add_user" from="PHP 5, PHP 7"/>
- <function name="ibase_affected_rows" from="PHP 5, PHP 7"/>
- <function name="ibase_backup" from="PHP 5, PHP 7"/>
- <function name="ibase_blob_add" from="PHP 5, PHP 7"/>
- <function name="ibase_blob_cancel" from="PHP 5, PHP 7"/>
- <function name="ibase_blob_close" from="PHP 5, PHP 7"/>
- <function name="ibase_blob_create" from="PHP 5, PHP 7"/>
- <function name="ibase_blob_echo" from="PHP 5, PHP 7"/>
- <function name="ibase_blob_get" from="PHP 5, PHP 7"/>
- <function name="ibase_blob_import" from="PHP 5, PHP 7"/>
- <function name="ibase_blob_info" from="PHP 5, PHP 7"/>
- <function name="ibase_blob_open" from="PHP 5, PHP 7"/>
- <function name="ibase_close" from="PHP 5, PHP 7"/>
- <function name="ibase_commit" from="PHP 5, PHP 7"/>
- <function name="ibase_commit_ret" from="PHP 5, PHP 7"/>
- <function name="ibase_connect" from="PHP 5, PHP 7"/>
- <function name="ibase_db_info" from="PHP 5, PHP 7"/>
- <function name="ibase_delete_user" from="PHP 5, PHP 7"/>
- <function name="ibase_drop_db" from="PHP 5, PHP 7"/>
- <function name="ibase_errcode" from="PHP 5, PHP 7"/>
- <function name="ibase_errmsg" from="PHP 5, PHP 7"/>
- <function name="ibase_execute" from="PHP 5, PHP 7"/>
- <function name="ibase_fetch_assoc" from="PHP 5, PHP 7"/>
- <function name="ibase_fetch_object" from="PHP 5, PHP 7"/>
- <function name="ibase_fetch_row" from="PHP 5, PHP 7"/>
- <function name="ibase_field_info" from="PHP 5, PHP 7"/>
- <function name="ibase_free_event_handler" from="PHP 5, PHP 7"/>
- <function name="ibase_free_query" from="PHP 5, PHP 7"/>
- <function name="ibase_free_result" from="PHP 5, PHP 7"/>
- <function name="ibase_gen_id" from="PHP 5, PHP 7"/>
- <function name="ibase_maintain_db" from="PHP 5, PHP 7"/>
- <function name="ibase_modify_user" from="PHP 5, PHP 7"/>
- <function name="ibase_name_result" from="PHP 5, PHP 7"/>
- <function name="ibase_num_fields" from="PHP 5, PHP 7"/>
- <function name="ibase_num_params" from="PHP 5, PHP 7"/>
- <function name="ibase_num_rows" from="PHP 5, PHP 7"/>
- <function name="ibase_param_info" from="PHP 5, PHP 7"/>
- <function name="ibase_pconnect" from="PHP 5, PHP 7"/>
- <function name="ibase_prepare" from="PHP 5, PHP 7"/>
- <function name="ibase_query" from="PHP 5, PHP 7"/>
- <function name="ibase_restore" from="PHP 5, PHP 7"/>
- <function name="ibase_rollback" from="PHP 5, PHP 7"/>
- <function name="ibase_rollback_ret" from="PHP 5, PHP 7"/>
- <function name="ibase_server_info" from="PHP 5, PHP 7"/>
- <function name="ibase_service_attach" from="PHP 5, PHP 7"/>
- <function name="ibase_service_detach" from="PHP 5, PHP 7"/>
- <function name="ibase_set_event_handler" from="PHP 5, PHP 7"/>
- <function name="ibase_trans" from="PHP 5, PHP 7"/>
- <function name="ibase_wait_event" from="PHP 5, PHP 7"/>
+<versions>
+ <function name="ibase_add_user" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_affected_rows" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_backup" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_blob_add" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_blob_cancel" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_blob_close" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_blob_create" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_blob_echo" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_blob_get" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_blob_import" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_blob_info" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_blob_open" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_close" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_commit" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_commit_ret" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_connect" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_db_info" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_delete_user" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_drop_db" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_errcode" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_errmsg" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_execute" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_fetch_assoc" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_fetch_object" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_fetch_row" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_field_info" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_free_event_handler" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_free_query" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_free_result" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_gen_id" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_maintain_db" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_modify_user" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_name_result" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_num_fields" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_num_params" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_num_rows" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_param_info" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_pconnect" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_prepare" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_query" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_restore" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_rollback" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_rollback_ret" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_server_info" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_service_attach" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_service_detach" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_set_event_handler" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_trans" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="ibase_wait_event" from="PHP 5, PHP 7 &lt; 7.4.0"/>
  <!-- Firebird alias functions for future use -->
- <function name="fbird_add_user" from="PHP 5, PHP 7"/>
- <function name="fbird_affected_rows" from="PHP 5, PHP 7"/>
- <function name="fbird_backup" from="PHP 5, PHP 7"/>
- <function name="fbird_blob_add" from="PHP 5, PHP 7"/>
- <function name="fbird_blob_cancel" from="PHP 5, PHP 7"/>
- <function name="fbird_blob_close" from="PHP 5, PHP 7"/>
- <function name="fbird_blob_create" from="PHP 5, PHP 7"/>
- <function name="fbird_blob_echo" from="PHP 5, PHP 7"/>
- <function name="fbird_blob_get" from="PHP 5, PHP 7"/>
- <function name="fbird_blob_import" from="PHP 5, PHP 7"/>
- <function name="fbird_blob_info" from="PHP 5, PHP 7"/>
- <function name="fbird_blob_open" from="PHP 5, PHP 7"/>
- <function name="fbird_close" from="PHP 5, PHP 7"/>
- <function name="fbird_commit" from="PHP 5, PHP 7"/>
- <function name="fbird_commit_ret" from="PHP 5, PHP 7"/>
- <function name="fbird_connect" from="PHP 5, PHP 7"/>
- <function name="fbird_db_info" from="PHP 5, PHP 7"/>
- <function name="fbird_delete_user" from="PHP 5, PHP 7"/>
- <function name="fbird_drop_db" from="PHP 5, PHP 7"/>
- <function name="fbird_errcode" from="PHP 5, PHP 7"/>
- <function name="fbird_errmsg" from="PHP 5, PHP 7"/>
- <function name="fbird_execute" from="PHP 5, PHP 7"/>
- <function name="fbird_fetch_assoc" from="PHP 5, PHP 7"/>
- <function name="fbird_fetch_object" from="PHP 5, PHP 7"/>
- <function name="fbird_fetch_row" from="PHP 5, PHP 7"/>
- <function name="fbird_field_info" from="PHP 5, PHP 7"/>
- <function name="fbird_free_event_handler" from="PHP 5, PHP 7"/>
- <function name="fbird_free_query" from="PHP 5, PHP 7"/>
- <function name="fbird_free_result" from="PHP 5, PHP 7"/>
- <function name="fbird_gen_id" from="PHP 5, PHP 7"/>
- <function name="fbird_maintain_db" from="PHP 5, PHP 7"/>
- <function name="fbird_modify_user" from="PHP 5, PHP 7"/>
- <function name="fbird_name_result" from="PHP 5, PHP 7"/>
- <function name="fbird_num_fields" from="PHP 5, PHP 7"/>
- <function name="fbird_num_params" from="PHP 5, PHP 7"/>
- <function name="fbird_num_rows" from="PHP 5, PHP 7"/>
- <function name="fbird_param_info" from="PHP 5, PHP 7"/>
- <function name="fbird_pconnect" from="PHP 5, PHP 7"/>
- <function name="fbird_prepare" from="PHP 5, PHP 7"/>
- <function name="fbird_query" from="PHP 5, PHP 7"/>
- <function name="fbird_restore" from="PHP 5, PHP 7"/>
- <function name="fbird_rollback" from="PHP 5, PHP 7"/>
- <function name="fbird_rollback_ret" from="PHP 5, PHP 7"/>
- <function name="fbird_server_info" from="PHP 5, PHP 7"/>
- <function name="fbird_service_attach" from="PHP 5, PHP 7"/>
- <function name="fbird_service_detach" from="PHP 5, PHP 7"/>
- <function name="fbird_set_event_handler" from="PHP 5, PHP 7"/>
- <function name="fbird_trans" from="PHP 5, PHP 7"/>
- <function name="fbird_wait_event" from="PHP 5, PHP 7"/>
+ <function name="fbird_add_user" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_affected_rows" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_backup" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_blob_add" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_blob_cancel" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_blob_close" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_blob_create" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_blob_echo" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_blob_get" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_blob_import" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_blob_info" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_blob_open" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_close" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_commit" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_commit_ret" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_connect" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_db_info" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_delete_user" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_drop_db" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_errcode" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_errmsg" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_execute" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_fetch_assoc" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_fetch_object" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_fetch_row" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_field_info" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_free_event_handler" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_free_query" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_free_result" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_gen_id" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_maintain_db" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_modify_user" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_name_result" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_num_fields" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_num_params" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_num_rows" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_param_info" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_pconnect" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_prepare" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_query" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_restore" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_rollback" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_rollback_ret" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_server_info" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_service_attach" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_service_detach" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_set_event_handler" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_trans" from="PHP 5, PHP 7 &lt; 7.4.0"/>
+ <function name="fbird_wait_event" from="PHP 5, PHP 7 &lt; 7.4.0"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
As per: https://www.php.net/manual/en/migration74.removed-extensions.php

Adjustments include:
* Adding a note about the move on the [introduction](https://www.php.net/manual/en/intro.ibase.php) page.
* Adding a note about the move on the [installation](https://www.php.net/manual/en/ibase.installation.php) page.
* Adjusting the version numbers for all functions.