### PR TITLE
DB++/installation: extension was moved to PECL

### DIFF
--- a/reference/dbplus/book.xml
+++ b/reference/dbplus/book.xml
@@ -22,6 +22,11 @@
    languages, db++ has had Perl and Tcl call interfaces for years
    now and uses Tcl as its internal stored procedure language.
   </para>
+  <note>
+   <para>
+    &pecl.moved-ver;4.1.0
+   </para>
+  </note>
   &warn.experimental;
  </preface>
  <!-- }}} -->

--- a/reference/dbplus/configure.xml
+++ b/reference/dbplus/configure.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<section xml:id="dbplus.installation" xmlns="http://docbook.org/ns/docbook">
+<section xml:id="dbplus.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
+ <para>
+  &pecl.moved-ver;4.1.0
+ </para>
+ <para>
+  &pecl.info;
+  <link xlink:href="&url.pecl.package;dbplus">&url.pecl.package;dbplus</link>.
+ </para>
  <para>
   In order to build this extension yourself you need the db++ client libraries
   and header files to be installed on your system (these are included in the


### PR DESCRIPTION
Based on the version nrs used for the functions, this extension has not been bundled with PHP since 4.1.0.

Ref: https://www.php.net/manual/en/ref.dbplus.php