### PR TITLE
MaxDB/installation: extension is PECL only

### DIFF
--- a/reference/maxdb/configure.xml
+++ b/reference/maxdb/configure.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<section xml:id="maxdb.installation" xmlns="http://docbook.org/ns/docbook">
+<section xml:id="maxdb.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
+ <para>
+  &pecl.info;
+  <link xlink:href="&url.pecl.package;maxdb">&url.pecl.package;maxdb</link>.
+ </para>
  <para xml:id="maxdb.configure">
   By using the <option role="configure">--with-maxdb[=DIR]</option>
   configuration option you enable PHP to access MaxDB


### PR DESCRIPTION
Updating: https://www.php.net/manual/en/maxdb.installation.php

This extension is not bundled with PHP, so people need to download the PECL extension before they can use the extension.