### PR TITLE
Informix/installation: extension was moved to PECL

### DIFF
--- a/reference/ifx/configure.xml
+++ b/reference/ifx/configure.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<section xml:id="ifx.installation" xmlns="http://docbook.org/ns/docbook">
+<section xml:id="ifx.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
+ <para>
+  &pecl.moved-ver;5.2.1
+ </para>
+ <para>
+  &pecl.info;
+  <link xlink:href="&url.pecl.package;informix">&url.pecl.package;informix</link>.
+ </para>
  <para>
   To be able to use the functions defined in this module you must compile
   your PHP interpreter using the configure line


### PR DESCRIPTION
Updating: https://www.php.net/manual/en/ifx.installation.php

The Informix extension was moved to PECL as of PHP 5.2.1.

Ref: https://www.php.net/manual/en/book.ifx.php