### PR TITLE
MySQLi: various updates

### DIFF
--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -37,6 +37,41 @@
      </para>
     </listitem>
    </varlistentry>
+   <varlistentry xml:id="constantmysqli-opt-int-and-float-native">
+    <term><constant>MYSQLI_OPT_INT_AND_FLOAT_NATIVE</constant></term>
+    <listitem>
+     <para>
+      Convert integer and float columns back to PHP numbers. Only valid for mysqlnd.
+      Available since PHP 5.3.0.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constantmysqli-opt-net-cmd-buffer-size">
+    <term><constant>MYSQLI_OPT_NET_CMD_BUFFER_SIZE</constant></term>
+    <listitem>
+     <para>
+      The size of the internal command/network buffer. Only valid for mysqlnd.
+      Available since PHP 5.3.0.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constantmysqli-opt-net-read-buffer-size">
+    <term><constant>MYSQLI_OPT_NET_READ_BUFFER_SIZE</constant></term>
+    <listitem>
+     <para>
+      Maximum read chunk size in bytes when reading the body of a MySQL command packet.
+      Only valid for mysqlnd. Available since PHP 5.3.0.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constantmysqli-opt-ssl-verify-server-cert">
+    <term><constant>MYSQLI_OPT_SSL_VERIFY_SERVER_CERT</constant></term>
+    <listitem>
+     <para>
+      Available since PHP 5.3.0. (MySQL 5.1.10 and up)
+     </para>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="constantmysqli-init-command">
     <term><constant>MYSQLI_INIT_COMMAND</constant></term>
     <listitem>
@@ -626,6 +661,14 @@
      </para>
     </listitem>
    </varlistentry>
+   <varlistentry xml:id="constantmysqli-server-public-key">
+    <term><constant>MYSQLI_SERVER_PUBLIC_KEY</constant></term>
+    <listitem>
+     <para>
+      Available since PHP 5.5.0.
+     </para>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="constantmysqli-refresh-grant">
     <term><constant>MYSQLI_REFRESH_GRANT</constant></term>
     <listitem>
@@ -761,7 +804,14 @@
      </para>
     </listitem>
    </varlistentry>
-
+   <varlistentry xml:id="constantmysqli-client-ssl-dont-verify-server-cert">
+    <term><constant>MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT</constant></term>
+    <listitem>
+     <para>
+      Available since PHP 5.6.16. (MySQL 5.6.5 and up)
+     </para>
+    </listitem>
+   </varlistentry>
   </variablelist>
 </appendix>
 

--- a/reference/mysqli/mysqli/autocommit.xml
+++ b/reference/mysqli/mysqli/autocommit.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::autocommit</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::autocommit</methodname>
    <methodparam><type>bool</type><parameter>mode</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/begin-transaction.xml
+++ b/reference/mysqli/mysqli/begin-transaction.xml
@@ -10,12 +10,12 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>&style.oop; (method):</para>
-   <methodsynopsis>
+  <para>&style.oop;</para>
+  <methodsynopsis role="oop">
    <modifier>public</modifier> <type>bool</type><methodname>mysqli::begin_transaction</methodname>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>name</parameter></methodparam>
-   </methodsynopsis>
+  </methodsynopsis>
   <para>&style.procedural;:</para>
   <methodsynopsis>
    <type>bool</type><methodname>mysqli_begin_transaction</methodname>

--- a/reference/mysqli/mysqli/change-user.xml
+++ b/reference/mysqli/mysqli/change-user.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::change_user</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::change_user</methodname>
    <methodparam><type>string</type><parameter>user</parameter></methodparam>
    <methodparam><type>string</type><parameter>password</parameter></methodparam>
    <methodparam><type>string</type><parameter>database</parameter></methodparam>

--- a/reference/mysqli/mysqli/character-set-name.xml
+++ b/reference/mysqli/mysqli/character-set-name.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>string</type><methodname>mysqli::character_set_name</methodname>
+   <modifier>public</modifier> <type>string</type><methodname>mysqli::character_set_name</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/close.xml
+++ b/reference/mysqli/mysqli/close.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::close</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::close</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/commit.xml
+++ b/reference/mysqli/mysqli/commit.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::commit</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::commit</methodname>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -12,7 +12,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <constructorsynopsis>
-   <methodname>mysqli::__construct</methodname>
+   <modifier>public</modifier> <methodname>mysqli::__construct</methodname>
    <methodparam choice="opt"><type>string</type><parameter>host</parameter><initializer>ini_get("mysqli.default_host")</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>username</parameter><initializer>ini_get("mysqli.default_user")</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>passwd</parameter><initializer>ini_get("mysqli.default_pw")</initializer></methodparam>
@@ -21,7 +21,7 @@
    <methodparam choice="opt"><type>string</type><parameter>socket</parameter><initializer>ini_get("mysqli.default_socket")</initializer></methodparam>
   </constructorsynopsis>
   <methodsynopsis role="oop">
-   <type>void</type><methodname>mysqli::connect</methodname>
+   <modifier>public</modifier> <type>void</type><methodname>mysqli::connect</methodname>
    <methodparam choice="opt"><type>string</type><parameter>host</parameter><initializer>ini_get("mysqli.default_host")</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>username</parameter><initializer>ini_get("mysqli.default_user")</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>passwd</parameter><initializer>ini_get("mysqli.default_pw")</initializer></methodparam>

--- a/reference/mysqli/mysqli/debug.xml
+++ b/reference/mysqli/mysqli/debug.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::debug</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::debug</methodname>
    <methodparam><type>string</type><parameter>message</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/dump-debug-info.xml
+++ b/reference/mysqli/mysqli/dump-debug-info.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::dump_debug_info</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::dump_debug_info</methodname>
    <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/get-charset.xml
+++ b/reference/mysqli/mysqli/get-charset.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>object</type><methodname>mysqli::get_charset</methodname>
+   <modifier>public</modifier> <type>object</type><methodname>mysqli::get_charset</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/get-client-info.xml
+++ b/reference/mysqli/mysqli/get-client-info.xml
@@ -13,7 +13,7 @@
   <para>&style.oop;</para>
   <fieldsynopsis><type>string</type><varname linkend="mysqli.get-client-info">mysqli->client_info</varname></fieldsynopsis>
   <methodsynopsis role="oop">
-   <type>string</type><methodname>mysqli::get_client_info</methodname>
+   <modifier>public</modifier> <type>string</type><methodname>mysqli::get_client_info</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/get-connection-stats.xml
+++ b/reference/mysqli/mysqli/get-connection-stats.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::get_connection_stats</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::get_connection_stats</methodname>
    <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/get-server-info.xml
+++ b/reference/mysqli/mysqli/get-server-info.xml
@@ -13,7 +13,7 @@
   <para>&style.oop;</para>
   <fieldsynopsis><type>string</type><varname linkend="mysqli.get-server-info">mysqli->server_info</varname></fieldsynopsis>
   <methodsynopsis role="oop">
-   <type>string</type><methodname>mysqli_stmt::get_server_info</methodname>
+   <modifier>public</modifier> <type>string</type><methodname>mysqli::get_server_info</methodname>
    <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/get-warnings.xml
+++ b/reference/mysqli/mysqli/get-warnings.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>mysqli_warning</type><methodname>mysqli::get_warnings</methodname>
+   <modifier>public</modifier> <type>mysqli_warning</type><methodname>mysqli::get_warnings</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/init.xml
+++ b/reference/mysqli/mysqli/init.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>mysqli</type><methodname>mysqli::init</methodname>
+   <modifier>public</modifier> <type>mysqli</type><methodname>mysqli::init</methodname>
    <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/kill.xml
+++ b/reference/mysqli/mysqli/kill.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::kill</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::kill</methodname>
    <methodparam><type>int</type><parameter>processid</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/more-results.xml
+++ b/reference/mysqli/mysqli/more-results.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::more_results</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::more_results</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/multi-query.xml
+++ b/reference/mysqli/mysqli/multi-query.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::multi_query</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::multi_query</methodname>
    <methodparam><type>string</type><parameter>query</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/next-result.xml
+++ b/reference/mysqli/mysqli/next-result.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::next_result</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::next_result</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/options.xml
+++ b/reference/mysqli/mysqli/options.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::options</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::options</methodname>
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>

--- a/reference/mysqli/mysqli/options.xml
+++ b/reference/mysqli/mysqli/options.xml
@@ -84,32 +84,34 @@
            <entry><constant>MYSQLI_SERVER_PUBLIC_KEY</constant></entry>
            <entry>
              RSA public key file used with the SHA-256 based authentication.
+             Available since PHP 5.5.0.
            </entry>
           </row>
           <row>
            <entry><constant>MYSQLI_OPT_NET_CMD_BUFFER_SIZE</constant></entry>
            <entry>
              The size of the internal command/network buffer. Only valid for
-             mysqlnd.
+             mysqlnd. Available since PHP 5.3.0.
            </entry>
           </row>
           <row>
            <entry><constant>MYSQLI_OPT_NET_READ_BUFFER_SIZE</constant></entry>
            <entry>
              Maximum read chunk size in bytes when reading the body of a MySQL
-             command packet. Only valid for mysqlnd.
+             command packet. Only valid for mysqlnd. Available since PHP 5.3.0.
            </entry>
           </row>
           <row>
            <entry><constant>MYSQLI_OPT_INT_AND_FLOAT_NATIVE</constant></entry>
            <entry>
              Convert integer and float columns back to PHP numbers. Only valid
-             for mysqlnd.
+             for mysqlnd. Available since PHP 5.3.0.
            </entry>
           </row>
           <row>
            <entry><constant>MYSQLI_OPT_SSL_VERIFY_SERVER_CERT</constant></entry>
            <entry>
+            Available since PHP 5.3.0.
            </entry>
           </row>
          </tbody>
@@ -152,8 +154,7 @@
       <row>
        <entry>5.5.0</entry>
        <entry>
-        The <constant>MYSQLI_SERVER_PUBLIC_KEY</constant> and
-        <constant>MYSQLI_SERVER_PUBLIC_KEY</constant> options were added.
+        The <constant>MYSQLI_SERVER_PUBLIC_KEY</constant> option was added.
        </entry>
       </row>
       <row>

--- a/reference/mysqli/mysqli/ping.xml
+++ b/reference/mysqli/mysqli/ping.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::ping</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::ping</methodname>
    <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/prepare.xml
+++ b/reference/mysqli/mysqli/prepare.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>mysqli_stmt</type><methodname>mysqli::prepare</methodname>
+   <modifier>public</modifier> <type>mysqli_stmt</type><methodname>mysqli::prepare</methodname>
    <methodparam><type>string</type><parameter>query</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/query.xml
+++ b/reference/mysqli/mysqli/query.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>mixed</type><methodname>mysqli::query</methodname>
+   <modifier>public</modifier> <type>mixed</type><methodname>mysqli::query</methodname>
    <methodparam><type>string</type><parameter>query</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>resultmode</parameter><initializer>MYSQLI_STORE_RESULT</initializer></methodparam>
   </methodsynopsis>

--- a/reference/mysqli/mysqli/real-connect.xml
+++ b/reference/mysqli/mysqli/real-connect.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::real_connect</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::real_connect</methodname>
    <methodparam choice="opt"><type>string</type><parameter>host</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>username</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>passwd</parameter></methodparam>

--- a/reference/mysqli/mysqli/real-escape-string.xml
+++ b/reference/mysqli/mysqli/real-escape-string.xml
@@ -12,7 +12,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>string</type><methodname>mysqli::escape_string</methodname>
+   <modifier>public</modifier> <type>string</type><methodname>mysqli::escape_string</methodname>
    <methodparam><type>string</type><parameter>escapestr</parameter></methodparam>
   </methodsynopsis>
   <methodsynopsis role="oop">

--- a/reference/mysqli/mysqli/real-query.xml
+++ b/reference/mysqli/mysqli/real-query.xml
@@ -10,10 +10,10 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-   <methodsynopsis role="oop">
-    <type>bool</type><methodname>mysqli::real_query</methodname>
-    <methodparam><type>string</type><parameter>query</parameter></methodparam>
-   </methodsynopsis>
+  <methodsynopsis role="oop">
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::real_query</methodname>
+   <methodparam><type>string</type><parameter>query</parameter></methodparam>
+  </methodsynopsis>
   <para>&style.procedural;</para>
   <methodsynopsis>
    <type>bool</type><methodname>mysqli_real_query</methodname>

--- a/reference/mysqli/mysqli/release-savepoint.xml
+++ b/reference/mysqli/mysqli/release-savepoint.xml
@@ -10,11 +10,11 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>&style.oop; (method):</para>
-   <methodsynopsis>
+  <para>&style.oop;</para>
+  <methodsynopsis role="oop">
    <modifier>public</modifier> <type>bool</type><methodname>mysqli::release_savepoint</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   </methodsynopsis>
+  </methodsynopsis>
   <para>&style.procedural;:</para>
   <methodsynopsis>
    <type>bool</type><methodname>mysqli_release_savepoint</methodname>

--- a/reference/mysqli/mysqli/rollback.xml
+++ b/reference/mysqli/mysqli/rollback.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::rollback</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::rollback</methodname>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>

--- a/reference/mysqli/mysqli/rpl-query-type.xml
+++ b/reference/mysqli/mysqli/rpl-query-type.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>int</type><methodname>mysqli::rpl_query_type</methodname>
+   <modifier>public</modifier> <type>int</type><methodname>mysqli::rpl_query_type</methodname>
    <methodparam><type>string</type><parameter>query</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/savepoint.xml
+++ b/reference/mysqli/mysqli/savepoint.xml
@@ -10,11 +10,11 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>&style.oop; (method):</para>
-   <methodsynopsis>
+  <para>&style.oop;</para>
+  <methodsynopsis role="oop">
    <modifier>public</modifier> <type>bool</type><methodname>mysqli::savepoint</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   </methodsynopsis>
+  </methodsynopsis>
   <para>&style.procedural;:</para>
   <methodsynopsis>
    <type>bool</type><methodname>mysqli_savepoint</methodname>

--- a/reference/mysqli/mysqli/select-db.xml
+++ b/reference/mysqli/mysqli/select-db.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::select_db</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::select_db</methodname>
    <methodparam><type>string</type><parameter>dbname</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/send-query.xml
+++ b/reference/mysqli/mysqli/send-query.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::send_query</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::send_query</methodname>
    <methodparam><type>string</type><parameter>query</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/set-charset.xml
+++ b/reference/mysqli/mysqli/set-charset.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::set_charset</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::set_charset</methodname>
    <methodparam><type>string</type><parameter>charset</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/set-local-infile-default.xml
+++ b/reference/mysqli/mysqli/set-local-infile-default.xml
@@ -9,6 +9,12 @@
 
  <refsect1 role="description">
   &reftitle.description;
+  <para>&style.oop;</para>
+  <methodsynopsis role="oop">
+   <modifier>public</modifier> <type>void</type><methodname>mysqli::set_local_infile_default</methodname>
+   <void />
+  </methodsynopsis>
+  <para>&style.procedural;</para>
   <methodsynopsis>
    <type>void</type><methodname>mysqli_set_local_infile_default</methodname>
    <methodparam><type>mysqli</type><parameter>link</parameter></methodparam>

--- a/reference/mysqli/mysqli/set-local-infile-handler.xml
+++ b/reference/mysqli/mysqli/set-local-infile-handler.xml
@@ -11,8 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::set_local_infile_handler</methodname>
-   <methodparam><type>mysqli</type><parameter>link</parameter></methodparam>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::set_local_infile_handler</methodname>
    <methodparam><type>callable</type><parameter>read_func</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/ssl-set.xml
+++ b/reference/mysqli/mysqli/ssl-set.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli::ssl_set</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::ssl_set</methodname>
    <methodparam><type>string</type><parameter>key</parameter></methodparam>
    <methodparam><type>string</type><parameter>cert</parameter></methodparam>
    <methodparam><type>string</type><parameter>ca</parameter></methodparam>

--- a/reference/mysqli/mysqli/stat.xml
+++ b/reference/mysqli/mysqli/stat.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>string</type><methodname>mysqli::stat</methodname>
+   <modifier>public</modifier> <type>string</type><methodname>mysqli::stat</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/stmt-init.xml
+++ b/reference/mysqli/mysqli/stmt-init.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>mysqli_stmt</type><methodname>mysqli::stmt_init</methodname>
+   <modifier>public</modifier> <type>mysqli_stmt</type><methodname>mysqli::stmt_init</methodname>
    <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/store-result.xml
+++ b/reference/mysqli/mysqli/store-result.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>mysqli_result</type><methodname>mysqli::store_result</methodname>
+   <modifier>public</modifier> <type>mysqli_result</type><methodname>mysqli::store_result</methodname>
    <methodparam choice="opt"><type>int</type><parameter>option</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli/thread-safe.xml
+++ b/reference/mysqli/mysqli/thread-safe.xml
@@ -9,6 +9,11 @@
 
  <refsect1 role="description">
   &reftitle.description;
+  <para>&style.oop;</para>
+  <methodsynopsis role="oop">
+   <modifier>public</modifier> <type>void</type><methodname>mysqli::thread_safe</methodname>
+   <void />
+  </methodsynopsis>
   <para>&style.procedural;</para>
   <methodsynopsis>
    <type>bool</type><methodname>mysqli_thread_safe</methodname>

--- a/reference/mysqli/mysqli/use-result.xml
+++ b/reference/mysqli/mysqli/use-result.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>mysqli_result</type><methodname>mysqli::use_result</methodname>
+   <modifier>public</modifier> <type>mysqli_result</type><methodname>mysqli::use_result</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_driver/embedded-server-end.xml
+++ b/reference/mysqli/mysqli_driver/embedded-server-end.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>void</type><methodname>mysqli_driver::embedded_server_end</methodname>
+   <modifier>public</modifier> <type>void</type><methodname>mysqli_driver::embedded_server_end</methodname>
    <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_driver/embedded-server-start.xml
+++ b/reference/mysqli/mysqli_driver/embedded-server-start.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli_driver::embedded_server_start</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli_driver::embedded_server_start</methodname>
    <methodparam><type>int</type><parameter>start</parameter></methodparam>
    <methodparam><type>array</type><parameter>arguments</parameter></methodparam>
    <methodparam><type>array</type><parameter>groups</parameter></methodparam>

--- a/reference/mysqli/mysqli_result/data-seek.xml
+++ b/reference/mysqli/mysqli_result/data-seek.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli_result::data_seek</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli_result::data_seek</methodname>
    <methodparam><type>int</type><parameter>offset</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_result/fetch-all.xml
+++ b/reference/mysqli/mysqli_result/fetch-all.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>mixed</type><methodname>mysqli_result::fetch_all</methodname>
+   <modifier>public</modifier> <type>mixed</type><methodname>mysqli_result::fetch_all</methodname>
    <methodparam choice="opt"><type>int</type><parameter>resulttype</parameter><initializer>MYSQLI_NUM</initializer></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_result/fetch-array.xml
+++ b/reference/mysqli/mysqli_result/fetch-array.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>mixed</type><methodname>mysqli_result::fetch_array</methodname>
+   <modifier>public</modifier> <type>mixed</type><methodname>mysqli_result::fetch_array</methodname>
    <methodparam choice="opt"><type>int</type><parameter>resulttype</parameter><initializer>MYSQLI_BOTH</initializer></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_result/fetch-assoc.xml
+++ b/reference/mysqli/mysqli_result/fetch-assoc.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>array</type><methodname>mysqli_result::fetch_assoc</methodname>
+   <modifier>public</modifier> <type>array</type><methodname>mysqli_result::fetch_assoc</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_result/fetch-field-direct.xml
+++ b/reference/mysqli/mysqli_result/fetch-field-direct.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>object</type><methodname>mysqli_result::fetch_field_direct</methodname>
+   <modifier>public</modifier> <type>object</type><methodname>mysqli_result::fetch_field_direct</methodname>
    <methodparam><type>int</type><parameter>fieldnr</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_result/fetch-field.xml
+++ b/reference/mysqli/mysqli_result/fetch-field.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>object</type><methodname>mysqli_result::fetch_field</methodname>
+   <modifier>public</modifier> <type>object</type><methodname>mysqli_result::fetch_field</methodname>
    <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_result/fetch-fields.xml
+++ b/reference/mysqli/mysqli_result/fetch-fields.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>array</type><methodname>mysqli_result::fetch_fields</methodname>
+   <modifier>public</modifier> <type>array</type><methodname>mysqli_result::fetch_fields</methodname>
    <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_result/fetch-object.xml
+++ b/reference/mysqli/mysqli_result/fetch-object.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>object</type><methodname>mysqli_result::fetch_object</methodname>
+   <modifier>public</modifier> <type>object</type><methodname>mysqli_result::fetch_object</methodname>
    <methodparam choice="opt"><type>string</type><parameter>class_name</parameter><initializer>"stdClass"</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>params</parameter></methodparam>
   </methodsynopsis>

--- a/reference/mysqli/mysqli_result/fetch-row.xml
+++ b/reference/mysqli/mysqli_result/fetch-row.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>mixed</type><methodname>mysqli_result::fetch_row</methodname>
+   <modifier>public</modifier> <type>mixed</type><methodname>mysqli_result::fetch_row</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_result/field-seek.xml
+++ b/reference/mysqli/mysqli_result/field-seek.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli_result::field_seek</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli_result::field_seek</methodname>
    <methodparam><type>int</type><parameter>fieldnr</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_result/free.xml
+++ b/reference/mysqli/mysqli_result/free.xml
@@ -13,7 +13,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>void</type><methodname>mysqli_result::free</methodname>
+   <modifier>public</modifier> <type>void</type><methodname>mysqli_result::free</methodname>
    <void />
   </methodsynopsis>
   <methodsynopsis>

--- a/reference/mysqli/mysqli_result/free.xml
+++ b/reference/mysqli/mysqli_result/free.xml
@@ -16,12 +16,12 @@
    <modifier>public</modifier> <type>void</type><methodname>mysqli_result::free</methodname>
    <void />
   </methodsynopsis>
-  <methodsynopsis>
-   <type>void</type><methodname>mysqli_result::close</methodname>
+  <methodsynopsis role="oop">
+   <modifier>public</modifier> <type>void</type><methodname>mysqli_result::close</methodname>
    <void />
   </methodsynopsis>
-  <methodsynopsis>
-   <type>void</type><methodname>mysqli_result::free_result</methodname>
+  <methodsynopsis role="oop">
+   <modifier>public</modifier> <type>void</type><methodname>mysqli_result::free_result</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_stmt/attr-get.xml
+++ b/reference/mysqli/mysqli_stmt/attr-get.xml
@@ -12,7 +12,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>int</type><methodname>mysqli_stmt::attr_get</methodname>
+   <modifier>public</modifier> <type>int</type><methodname>mysqli_stmt::attr_get</methodname>
    <methodparam><type>int</type><parameter>attr</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_stmt/attr-set.xml
+++ b/reference/mysqli/mysqli_stmt/attr-set.xml
@@ -12,7 +12,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli_stmt::attr_set</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli_stmt::attr_set</methodname>
    <methodparam><type>int</type><parameter>attr</parameter></methodparam>
    <methodparam><type>int</type><parameter>mode</parameter></methodparam>
   </methodsynopsis>

--- a/reference/mysqli/mysqli_stmt/bind-param.xml
+++ b/reference/mysqli/mysqli_stmt/bind-param.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli_stmt::bind_param</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli_stmt::bind_param</methodname>
    <methodparam><type>string</type><parameter>types</parameter></methodparam>
    <methodparam><type>mixed</type><parameter role="reference">var1</parameter></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter role="reference">...</parameter></methodparam>

--- a/reference/mysqli/mysqli_stmt/bind-result.xml
+++ b/reference/mysqli/mysqli_stmt/bind-result.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli_stmt::bind_result</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli_stmt::bind_result</methodname>
    <methodparam><type>mixed</type><parameter role="reference">var1</parameter></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter role="reference">...</parameter></methodparam>
   </methodsynopsis>

--- a/reference/mysqli/mysqli_stmt/close.xml
+++ b/reference/mysqli/mysqli_stmt/close.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli_stmt::close</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli_stmt::close</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_stmt/construct.xml
+++ b/reference/mysqli/mysqli_stmt/construct.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <constructorsynopsis>
-   <methodname>mysqli_stmt::__construct</methodname>
+   <modifier>public</modifier> <methodname>mysqli_stmt::__construct</methodname>
    <methodparam><type>mysqli</type><parameter>link</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>query</parameter></methodparam>
   </constructorsynopsis>

--- a/reference/mysqli/mysqli_stmt/data-seek.xml
+++ b/reference/mysqli/mysqli_stmt/data-seek.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>void</type><methodname>mysqli_stmt::data_seek</methodname>
+   <modifier>public</modifier> <type>void</type><methodname>mysqli_stmt::data_seek</methodname>
    <methodparam><type>int</type><parameter>offset</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_stmt/execute.xml
+++ b/reference/mysqli/mysqli_stmt/execute.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli_stmt::execute</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli_stmt::execute</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_stmt/fetch.xml
+++ b/reference/mysqli/mysqli_stmt/fetch.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli_stmt::fetch</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli_stmt::fetch</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_stmt/free-result.xml
+++ b/reference/mysqli/mysqli_stmt/free-result.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>void</type><methodname>mysqli_stmt::free_result</methodname>
+   <modifier>public</modifier> <type>void</type><methodname>mysqli_stmt::free_result</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_stmt/get-result.xml
+++ b/reference/mysqli/mysqli_stmt/get-result.xml
@@ -12,7 +12,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>mysqli_result</type><methodname>mysqli_stmt::get_result</methodname>
+   <modifier>public</modifier> <type>mysqli_result</type><methodname>mysqli_stmt::get_result</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_stmt/get-warnings.xml
+++ b/reference/mysqli/mysqli_stmt/get-warnings.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>object</type><methodname>mysqli_stmt::get_warnings</methodname>
+   <modifier>public</modifier> <type>object</type><methodname>mysqli_stmt::get_warnings</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_stmt/more-results.xml
+++ b/reference/mysqli/mysqli_stmt/more-results.xml
@@ -10,11 +10,11 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>&style.oop; (method):</para>
-   <methodsynopsis>
+  <para>&style.oop;</para>
+  <methodsynopsis role="oop">
    <modifier>public</modifier> <type>bool</type><methodname>mysqli_stmt::more_results</methodname>
    <void />
-   </methodsynopsis>
+  </methodsynopsis>
   <para>&style.procedural;:</para>
   <methodsynopsis>
    <type>bool</type><methodname>mysqli_stmt_more_results</methodname>

--- a/reference/mysqli/mysqli_stmt/next-result.xml
+++ b/reference/mysqli/mysqli_stmt/next-result.xml
@@ -10,11 +10,11 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>&style.oop; (method):</para>
-   <methodsynopsis>
+  <para>&style.oop;</para>
+  <methodsynopsis role="oop">
    <modifier>public</modifier> <type>bool</type><methodname>mysqli_stmt::next_result</methodname>
    <void />
-   </methodsynopsis>
+  </methodsynopsis>
   <para>&style.procedural;:</para>
   <methodsynopsis>
    <type>bool</type><methodname>mysqli_stmt_next_result</methodname>

--- a/reference/mysqli/mysqli_stmt/num-rows.xml
+++ b/reference/mysqli/mysqli_stmt/num-rows.xml
@@ -13,7 +13,7 @@
   <para>&style.oop;</para>
   <fieldsynopsis><type>int</type><varname linkend="mysqli-stmt.num-rows">mysqli_stmt->num_rows</varname></fieldsynopsis>
   <methodsynopsis role="oop">
-   <type>int</type><methodname>mysqli_stmt::num_rows</methodname>
+   <modifier>public</modifier> <type>int</type><methodname>mysqli_stmt::num_rows</methodname>
    <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_stmt/prepare.xml
+++ b/reference/mysqli/mysqli_stmt/prepare.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>mixed</type><methodname>mysqli_stmt::prepare</methodname>
+   <modifier>public</modifier> <type>mixed</type><methodname>mysqli_stmt::prepare</methodname>
    <methodparam><type>string</type><parameter>query</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_stmt/reset.xml
+++ b/reference/mysqli/mysqli_stmt/reset.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli_stmt::reset</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli_stmt::reset</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_stmt/result-metadata.xml
+++ b/reference/mysqli/mysqli_stmt/result-metadata.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>mysqli_result</type><methodname>mysqli_stmt::result_metadata</methodname>
+   <modifier>public</modifier> <type>mysqli_result</type><methodname>mysqli_stmt::result_metadata</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_stmt/send-long-data.xml
+++ b/reference/mysqli/mysqli_stmt/send-long-data.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli_stmt::send_long_data</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli_stmt::send_long_data</methodname>
    <methodparam><type>int</type><parameter>param_nr</parameter></methodparam>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>

--- a/reference/mysqli/mysqli_stmt/store-result.xml
+++ b/reference/mysqli/mysqli_stmt/store-result.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <type>bool</type><methodname>mysqli_stmt::store_result</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli_stmt::store_result</methodname>
    <void />
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_warning/next.xml
+++ b/reference/mysqli/mysqli_warning/next.xml
@@ -4,13 +4,20 @@
 <refentry xml:id="mysqli-warning.next" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mysqli_warning::next</refname>
+  <refname>mysqli_warning_next</refname>
   <refpurpose>Fetch next warning</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
+  <para>&style.oop;</para>
   <methodsynopsis role="oop">
    <modifier>public</modifier> <type>bool</type><methodname>mysqli_warning::next</methodname>
+   <void />
+  </methodsynopsis>
+  <para>&style.procedural;</para>
+  <methodsynopsis>
+   <type>bool</type><methodname>mysqli_warning_next</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/mysqli/versions.xml
+++ b/reference/mysqli/versions.xml
@@ -3,13 +3,7 @@
 <!--
   Do NOT translate this file
 -->
-<!--
- FIXME: Add OOP goodness
--->
 <versions>
- <!-- A few mysqli procedural function names differ from their OOP counterparts, or don't exist -->
- <function name="mysqli_warning::__construct" from="PHP 5, PHP 7"/>
-
  <function name="mysqli_affected_rows" from="PHP 5, PHP 7"/>
  <function name="mysqli_autocommit" from="PHP 5, PHP 7"/>
  <function name="mysqli_begin_transaction" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
@@ -255,6 +249,9 @@
  <function name="mysqli_driver::embedded_server_start" from="PHP 5 &gt;= 5.1.0, PHP 7 &lt; 7.4.0"/>
 
  <function name="mysqli_warning" from="PHP 5, PHP 7"/>
+ <function name="mysqli_warning::__construct" from="PHP 5, PHP 7"/>
+ <function name="mysqli_warning::next" from="PHP 5, PHP 7"/>
+
  <function name="mysqli_sql_exception" from="PHP 5, PHP 7"/>
 </versions>
 <!-- Keep this comment at the end of the file

--- a/reference/mysqli/versions.xml
+++ b/reference/mysqli/versions.xml
@@ -236,6 +236,20 @@
  <function name="mysqli_stmt::store_result" from="PHP 5, PHP 7"/>
 
  <function name="mysqli_result" from="PHP 5, PHP 7"/>
+ <function name="mysqli_result::close" from="PHP 5, PHP 7"/>
+ <function name="mysqli_result::data_seek" from="PHP 5, PHP 7"/>
+ <function name="mysqli_result::fetch_all" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="mysqli_result::fetch_array" from="PHP 5, PHP 7"/>
+ <function name="mysqli_result::fetch_assoc" from="PHP 5, PHP 7"/>
+ <function name="mysqli_result::fetch_field_direct" from="PHP 5, PHP 7"/>
+ <function name="mysqli_result::fetch_field" from="PHP 5, PHP 7"/>
+ <function name="mysqli_result::fetch_fields" from="PHP 5, PHP 7"/>
+ <function name="mysqli_result::fetch_object" from="PHP 5, PHP 7"/>
+ <function name="mysqli_result::fetch_row" from="PHP 5, PHP 7"/>
+ <function name="mysqli_result::field_seek" from="PHP 5, PHP 7"/>
+ <function name="mysqli_result::free" from="PHP 5, PHP 7"/>
+ <function name="mysqli_result::free_result" from="PHP 5, PHP 7"/>
+
  <function name="mysqli_driver" from="PHP 5, PHP 7"/>
  <function name="mysqli_warning" from="PHP 5, PHP 7"/>
  <function name="mysqli_sql_exception" from="PHP 5, PHP 7"/>

--- a/reference/mysqli/versions.xml
+++ b/reference/mysqli/versions.xml
@@ -9,7 +9,6 @@
 <versions>
  <!-- A few mysqli procedural function names differ from their OOP counterparts, or don't exist -->
  <function name="mysqli_warning::__construct" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt::__construct" from="PHP 5, PHP 7"/>
 
  <function name="mysqli_affected_rows" from="PHP 5, PHP 7"/>
  <function name="mysqli_autocommit" from="PHP 5, PHP 7"/>
@@ -215,6 +214,27 @@
  <function name="mysqli::use_result" from="PHP 5, PHP 7"/>
 
  <function name="mysqli_stmt" from="PHP 5, PHP 7"/>
+ <function name="mysqli_stmt::__construct" from="PHP 5, PHP 7"/>
+ <function name="mysqli_stmt::attr_get" from="PHP 5, PHP 7"/>
+ <function name="mysqli_stmt::attr_set" from="PHP 5, PHP 7"/>
+ <function name="mysqli_stmt::bind_param" from="PHP 5, PHP 7"/>
+ <function name="mysqli_stmt::bind_result" from="PHP 5, PHP 7"/>
+ <function name="mysqli_stmt::close" from="PHP 5, PHP 7"/>
+ <function name="mysqli_stmt::data_seek" from="PHP 5, PHP 7"/>
+ <function name="mysqli_stmt::execute" from="PHP 5, PHP 7"/>
+ <function name="mysqli_stmt::fetch" from="PHP 5, PHP 7"/>
+ <function name="mysqli_stmt::free_result" from="PHP 5, PHP 7"/>
+ <function name="mysqli_stmt::get_result" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="mysqli_stmt::get_warnings" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="mysqli_stmt::more_results" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="mysqli_stmt::next_result" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="mysqli_stmt::num_rows" from="PHP 5, PHP 7"/>
+ <function name="mysqli_stmt::prepare" from="PHP 5, PHP 7"/>
+ <function name="mysqli_stmt::reset" from="PHP 5, PHP 7"/>
+ <function name="mysqli_stmt::result_metadata" from="PHP 5, PHP 7"/>
+ <function name="mysqli_stmt::send_long_data" from="PHP 5, PHP 7"/>
+ <function name="mysqli_stmt::store_result" from="PHP 5, PHP 7"/>
+
  <function name="mysqli_result" from="PHP 5, PHP 7"/>
  <function name="mysqli_driver" from="PHP 5, PHP 7"/>
  <function name="mysqli_warning" from="PHP 5, PHP 7"/>

--- a/reference/mysqli/versions.xml
+++ b/reference/mysqli/versions.xml
@@ -251,6 +251,9 @@
  <function name="mysqli_result::free_result" from="PHP 5, PHP 7"/>
 
  <function name="mysqli_driver" from="PHP 5, PHP 7"/>
+ <function name="mysqli_driver::embedded_server_end" from="PHP 5 &gt;= 5.1.0, PHP 7 &lt; 7.4.0"/>
+ <function name="mysqli_driver::embedded_server_start" from="PHP 5 &gt;= 5.1.0, PHP 7 &lt; 7.4.0"/>
+
  <function name="mysqli_warning" from="PHP 5, PHP 7"/>
  <function name="mysqli_sql_exception" from="PHP 5, PHP 7"/>
 </versions>

--- a/reference/mysqli/versions.xml
+++ b/reference/mysqli/versions.xml
@@ -8,7 +8,6 @@
 -->
 <versions>
  <!-- A few mysqli procedural function names differ from their OOP counterparts, or don't exist -->
- <function name="mysqli::__construct" from="PHP 5, PHP 7"/>
  <function name="mysqli_warning::__construct" from="PHP 5, PHP 7"/>
  <function name="mysqli_stmt::__construct" from="PHP 5, PHP 7"/>
 
@@ -166,6 +165,55 @@
 
  <!-- Classes -->
  <function name="mysqli" from="PHP 5, PHP 7"/>
+ <function name="mysqli::__construct" from="PHP 5, PHP 7"/>
+ <function name="mysqli::autocommit" from="PHP 5, PHP 7"/>
+ <function name="mysqli::begin_transaction" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
+ <function name="mysqli::change_user" from="PHP 5, PHP 7"/>
+ <function name="mysqli::character_set_name" from="PHP 5, PHP 7"/>
+ <function name="mysqli::close" from="PHP 5, PHP 7"/>
+ <function name="mysqli::commit" from="PHP 5, PHP 7"/>
+ <function name="mysqli::connect" from="PHP 5, PHP 7"/>
+ <function name="mysqli::debug" from="PHP 5, PHP 7"/>
+ <function name="mysqli::disable_reads_from_master" from="PHP 5 &lt; 5.3.0"/>
+ <function name="mysqli::dump_debug_info" from="PHP 5, PHP 7"/>
+ <function name="mysqli::escape_string" from="PHP 5, PHP 7"/>
+ <function name="mysqli::get_charset" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="mysqli::get_client_info" from="PHP 5, PHP 7"/>
+ <function name="mysqli::get_connection_stats" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="mysqli::get_server_info" from="PHP 5, PHP 7"/>
+ <function name="mysqli::get_warnings" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="mysqli::init" from="PHP 5, PHP 7"/>
+ <function name="mysqli::kill" from="PHP 5, PHP 7"/>
+ <function name="mysqli::more_results" from="PHP 5, PHP 7"/>
+ <function name="mysqli::multi_query" from="PHP 5, PHP 7"/>
+ <function name="mysqli::next_result" from="PHP 5, PHP 7"/>
+ <function name="mysqli::options" from="PHP 5, PHP 7"/>
+ <function name="mysqli::ping" from="PHP 5, PHP 7"/>
+ <function name="mysqli::poll" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="mysqli::prepare" from="PHP 5, PHP 7"/>
+ <function name="mysqli::query" from="PHP 5, PHP 7"/>
+ <function name="mysqli::real_connect" from="PHP 5, PHP 7"/>
+ <function name="mysqli::real_escape_string" from="PHP 5, PHP 7"/>
+ <function name="mysqli::real_query" from="PHP 5, PHP 7"/>
+ <function name="mysqli::reap_async_query" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="mysqli::refresh" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="mysqli::release_savepoint" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
+ <function name="mysqli::rollback" from="PHP 5, PHP 7"/>
+ <function name="mysqli::rpl_query_type" from="PHP 5, PHP 7"/>
+ <function name="mysqli::savepoint" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
+ <function name="mysqli::select_db" from="PHP 5, PHP 7"/>
+ <function name="mysqli::send_query" from="PHP 5, PHP 7"/>
+ <function name="mysqli::set_charset" from="PHP 5 &gt;= 5.0.5, PHP 7"/>
+ <function name="mysqli::set_local_infile_default" from="PHP 5, PHP 7"/>
+ <function name="mysqli::set_local_infile_handler" from="PHP 5, PHP 7"/>
+ <function name="mysqli::set_opt" from="PHP 5, PHP 7"/>
+ <function name="mysqli::ssl_set" from="PHP 5, PHP 7"/>
+ <function name="mysqli::stat" from="PHP 5, PHP 7"/>
+ <function name="mysqli::stmt_init" from="PHP 5, PHP 7"/>
+ <function name="mysqli::store_result" from="PHP 5, PHP 7"/>
+ <function name="mysqli::thread_safe" from="PHP 5, PHP 7"/>
+ <function name="mysqli::use_result" from="PHP 5, PHP 7"/>
+
  <function name="mysqli_stmt" from="PHP 5, PHP 7"/>
  <function name="mysqli_result" from="PHP 5, PHP 7"/>
  <function name="mysqli_driver" from="PHP 5, PHP 7"/>


### PR DESCRIPTION
Various updates to the docs of the MySQLi extensions.

I've split the PR into logical commits to allow for easier reviewing and, if necessary, partial committing to SVN.

I have a feeling that the [`mysqli.stub.php`](https://github.com/php/php-src/blob/master/ext/mysqli/mysqli.stub.php) file in the src could probably also use an update, but haven't done a detailed compare.

Critical review of this PR is warranted and appreciated.

## Commit summary

### MySQLi: various updates [1] - constants

* Add constants missing from the [Predefined Constants](https://www.php.net/manual/en/mysqli.constants.php) page.
    These constants were added after the initial introduction of the extension.
    Descriptions based on the descriptions for the `$options` parameter of [mysqli::options()](https://www.php.net/manual/en/mysqli.options.php)
    Version nrs based on the [extension changelog](https://www.php.net/manual/en/changelog.mysqli.php) and [src](https://github.com/php/php-src/blob/7c33644fedbb44b8c671311a7f49f9e280b82249/ext/mysqli/mysqli.c#L672-L678)
* Annotated the "since" version for various options for the `$options` parameter of [mysqli::options()](https://www.php.net/manual/en/mysqli.options.php)
* Removed duplicate constant name in the [mysqli::options() changelog](https://www.php.net/manual/en/mysqli.options.php#refsect1-mysqli.options-changelog)

### MySQLi: various updates [2] - method modifiers (mysqli)

Add modifiers to the class methods for the mysqli class to make the [Class Synopsos](https://www.php.net/manual/en/class.mysqli.php#mysqli.synopsis) more consistent.

Based on the [stub](https://github.com/php/php-src/blob/master/ext/mysqli/mysqli.stub.php) all methods in the class are `public`, so I've annotated them as such.

Includes minor indentation fixes.

### MySQLi: various updates [3] - mysqli class synopsis incomplete

A number of methods weren't showing in the [Class Synopsos](https://www.php.net/manual/en/class.mysqli.php#mysqli.synopsis).

Looking at the docs, I suspect this was caused by the ` (method):` after the `&style.oop;` annotation and/or the missing `role="oop"` for the `methodsynopsis` element.

Includes minor indentation fixes.

### MySQLi: various updates [4] - missing OO style method signatures (mysqli)

Two documentation pages did display the procedural style method signature, but were missing the OO-style signature.

### MySQLi: various updates [5] - fix typo (mysqli)

* Fix typo - method was referring to the wrong class in its signature.
* Add the method visibility modifier.

### MySQLi: various updates [6] - remove superfluous param (mysqli)

* When called OO-style, the `mysqli $link` does not need to be passed AFAIK. Verification recommended.
* Add the method visibility modifier.

### MySQLi: various updates [7] - add mysqli methods to versions

The OO-style methods were not included in the `versions.xml` file. This is a known issue based on the `FIXME` comment at the top of the file.

This commit adds the methods from the `mysqli` class to the `versions.xml` file.

Version numbers based on the versions as set for the procedural functions. This may need verification.

### MySQLi: various updates [8] - method modifiers (mysqli_stmt)

Add modifiers to the class methods for the `mysqli_stmt` class to make the [Class Synopsos](https://www.php.net/manual/en/class.mysqli-stmt.php#mysqli-stmt.synopsis) more consistent.

Based on the [stub](https://github.com/php/php-src/blob/master/ext/mysqli/mysqli.stub.php) all methods in the class are `public`, so I've annotated them as such.

### MySQLi: various updates [9] - mysqli_stmt class synopsis incomplete

A number of methods weren't showing in the [Class Synopsos](https://www.php.net/manual/en/class.mysqli-stmt.php#mysqli-stmt.synopsis).

Looking at the docs, I suspect this was caused by the ` (method):` after the `&style.oop;` annotation and/or the missing `role="oop"` for the `methodsynopsis` element.

Includes minor indentation fixes.

### MySQLi: various updates [10] - add mysqli_stmt methods to versions

The OO-style methods were not included in the `versions.xml` file. This is a known issue based on the `FIXME` comment at the top of the file.

This commit adds the methods from the `mysqli_stmt` class to the `versions.xml` file.

Version numbers based on the versions as set for the procedural functions. This may need verification.

### MySQLi: various updates [11] - method modifiers (mysqli_result)

Add modifiers to the class methods for the `mysqli_result` class to make the [Class Synopsos](https://www.php.net/manual/en/class.mysqli-result.php#mysqli-result.synopsis) more consistent.

Based on the [stub](https://github.com/php/php-src/blob/master/ext/mysqli/mysqli.stub.php) all methods in the class are `public`, so I've annotated them as such.

### MySQLi: various updates [12] - mysqli_result class synopsis incomplete

A number of methods weren't showing in the [Class Synopsos](https://www.php.net/manual/en/class.mysqli-result.php#mysqli-result.synopsis).

I suspect this was caused by the missing `role="oop"` for the `methodsynopsis` element.

### MySQLi: various updates [13] - add mysqli_result methods to versions

The OO-style methods were not included in the `versions.xml` file. This is a known issue based on the `FIXME` comment at the top of the file.

This commit adds the methods from the `mysqli_result` class to the `versions.xml` file.

Version numbers based on the versions as set for the procedural functions. This may need verification.

### MySQLi: various updates [14] - method modifiers (mysqli_driver)

Add modifiers to the class methods for the `mysqli_driver` class to make the [Class Synopsos](https://www.php.net/manual/en/class.mysqli-driver.php#mysqli-driver.synopsis) more consistent.

Based on the [stub](https://github.com/php/php-src/blob/master/ext/mysqli/mysqli.stub.php) all methods in the class are `public`, so I've annotated them as such.

### MySQLi: various updates [15] - add mysqli_driver methods to versions

The OO-style methods were not included in the `versions.xml` file. This is a known issue based on the `FIXME` comment at the top of the file.

This commit adds the methods from the `mysqli_driver` class to the `versions.xml` file.

Version numbers based on the versions as set for the procedural functions. **This will need verification.**

### MySQLi: various updates [16] - missing procedural style method signature (mysqli_warning)

This documentation page did display the OO-style method signature, but was missing the procedural-style signature.

### MySQLi: various updates [17] - add mysqli_warning methods to versions

The OO-style methods were not included in the `versions.xml` file. This is a known issue based on the `FIXME` comment at the top of the file.

This commit adds the methods from the `mysqli_warning` class to the `versions.xml` file.

Version numbers based on the versions as set for the procedural functions. This may need verification.

Includes removing the `FIXME` comments as AFAICS all methods have now been added.

