### PR TITLE
OCI8: various tweaks to the function version numbers

### DIFF
--- a/reference/oci8/versions.xml
+++ b/reference/oci8/versions.xml
@@ -96,9 +96,9 @@
 
  <function name="ocibindbyname" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
  <function name="ocicancel" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocicloselob" from="PHP 4 &gt;= 4.0.6, PECL OCI8 1.0"/>
+ <function name="ocicloselob" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PECL OCI8 1.0"/>
  <function name="ocicollappend" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocicollassign" from="PHP 4 &gt;= 4.0.6, PECL OCI8 1.0"/>
+ <function name="ocicollassign" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PECL OCI8 1.0"/>
  <function name="ocicollassignelem" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
  <function name="ocicollgetelem" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
  <function name="ocicollmax" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
@@ -145,7 +145,7 @@
  <function name="ocisetprefetch" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
  <function name="ocistatementtype" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
  <function name="ociwritelobtofile" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ociwritetemporarylob" from="PHP 4 &gt;= 4.0.6, PECL OCI8 1.0"/>
+ <function name="ociwritetemporarylob" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PECL OCI8 1.0"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/oci8/versions.xml
+++ b/reference/oci8/versions.xml
@@ -86,7 +86,7 @@
  <function name="oci_set_call_timeout" from="PHP 7.2 &gt;= 7.2.14, PHP 7 &gt;= 7.3.1, PECL OCI8 &gt;= 2.2.0"/>
  <function name="oci_set_client_info" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL OCI8 &gt;= 1.4.0"/>
  <function name="oci_set_client_identifier" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL OCI8 &gt;= 1.4.0"/>
- <function name="oci_set_db_operation" from="PHP 7 &gt;= 7.2.14, PHP 7.3.1 &gt; 7.3 PECL OCI8 &gt;= 2.2.0"/>
+ <function name="oci_set_db_operation" from="PHP 7 &gt;= 7.2.14, PHP 7 &gt;= 7.3.1, PECL OCI8 &gt;= 2.2.0"/>
  <function name="oci_set_edition" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL OCI8 &gt;= 1.4.0"/>
  <function name="oci_set_module_name" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL OCI8 &gt;= 1.4.0"/>
  <function name="oci_set_prefetch" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>

--- a/reference/oci8/versions.xml
+++ b/reference/oci8/versions.xml
@@ -83,7 +83,7 @@
  <function name="oci_rollback" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
  <function name="oci_server_version" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
  <function name="oci_set_action" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL OCI8 &gt;= 1.4.0"/>
- <function name="oci_set_call_timeout" from="PHP 7 &gt;= 7.2.14, PHP 7.3.1 &gt; 7.3 PECL OCI8 &gt;= 2.2.0"/>
+ <function name="oci_set_call_timeout" from="PHP 7.2 &gt;= 7.2.14, PHP 7 &gt;= 7.3.1, PECL OCI8 &gt;= 2.2.0"/>
  <function name="oci_set_client_info" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL OCI8 &gt;= 1.4.0"/>
  <function name="oci_set_client_identifier" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL OCI8 &gt;= 1.4.0"/>
  <function name="oci_set_db_operation" from="PHP 7 &gt;= 7.2.14, PHP 7.3.1 &gt; 7.3 PECL OCI8 &gt;= 2.2.0"/>

--- a/reference/oci8/versions.xml
+++ b/reference/oci8/versions.xml
@@ -91,7 +91,7 @@
  <function name="oci_set_module_name" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL OCI8 &gt;= 1.4.0"/>
  <function name="oci_set_prefetch" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
  <function name="oci_statement_type" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_unregister_taf_callback" from="PHP 7.0 &gt;= 7.0.23, PHP 7 &gt;= 7.1.9, PHP 7.2, PECL OCI8 &gt;= 2.1.7"/>
+ <function name="oci_unregister_taf_callback" from="PHP 7.0 &gt;= 7.0.23, PHP 7 &gt;= 7.1.9, PECL OCI8 &gt;= 2.1.7"/>
  <function name="oci_register_taf_callback" from="PHP 7.0 &gt;= 7.0.21, PHP 7 &gt;= 7.1.7, PECL OCI8 &gt;= 2.1.7"/>
 
  <function name="ocibindbyname" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>


### PR DESCRIPTION
Various updates to the docs of the MySQLi extensions.

I've split the PR into logical commits to allow for easier reviewing and, if necessary, partial committing to SVN.

Critical review of this PR is warranted and appreciated.

## Commit Summary

### OCI8: various tweaks to the function version numbers [1]

[`oci_set_call_timeout()`](https://www.php.net/manual/en/function.oci-set-call-timout.php)

I'm questioning whether the current version numbering: "(PHP 7 >= 7.2.14, PHP 7.3.1 > 7.3 PECL OCI8 >= 2.2.0)" is correct.
This would imply that the function was added in PHP 7.2.14 and removed in PHP 7.3.1.

I believe this this should be showing that the function was added in both PHP 7.2.14 and PHP 7.3.1 and is currently still available.

### OCI8: various tweaks to the function version numbers [2]

[`oci_set_db_operation()`](https://www.php.net/manual/en/function.oci-set-db-operation.php)

I'm questioning whether the current version numbering: "(PHP 7 >= 7.2.14, PHP 7.3.1 > 7.3 PECL OCI8 >= 2.2.0)" is correct.
This would imply that the function was added in PHP 7.2.14 and removed in PHP 7.3.1.

I believe this this should be showing that the function was added in both PHP 7.2.14 and PHP 7.3.1 and is currently still available.

### OCI8: various tweaks to the function version numbers [3]

[`oci_unregister_taf_callback()`](https://www.php.net/manual/en/function.oci-unregister-taf-callback.php)

I'm questioning whether the current version numbering: "(PHP 7.0 >= 7.0.23, PHP 7 >= 7.1.9, PHP 7.2, PECL OCI8 >= 2.1.7)" is correct.
This would imply that the function was added in PHP 7.0.23 and 7.1.9 and removed in PHP 7.3.0 (not available in 7.3/7.4).

I believe this this should be showing that the function was added in both PHP 7.0.23 and 7.1.9 and is currently still available.

### OCI8: various tweaks to the function version numbers [4]

* [`ocicloselob()`](https://www.php.net/manual/en/function.ocicloselob.php)
* [`ocicollassign()`](https://www.php.net/manual/en/function.ocicollassign.php)
* [`ociwritetemporarylob()`](https://www.php.net/manual/en/function.ociwritetemporarylob.php)

Each of these functions has a warning showing that the function was deprecated in PHP 5.4.0, but according to the version numbers "(PHP 4 >= 4.0.6, PECL OCI8 1.0)", the function didn't exist in PHP 5 at all.

I'm presuming this is an oversight in the version numbering and have fixed those.
Alternatively, the deprecation warning should be removed/replaced with a removal warning.

### OCI8: various tweaks to the function version numbers [5]

In line with what I saw in various other `versions.xml` files, adding the `deprecated` attribute to various functions for which it seems to apply.

