### PR TITLE
PostgreSQL: add missing constants & annotate since version

### DIFF
--- a/reference/pgsql/constants.xml
+++ b/reference/pgsql/constants.xml
@@ -87,9 +87,31 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.pgsql-connection-auth-ok">
+   <term>
+    <constant>PGSQL_CONNECTION_AUTH_OK</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+      Available since PHP 5.6.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pgsql-connection-awaiting-response">
+   <term>
+    <constant>PGSQL_CONNECTION_AWAITING_RESPONSE</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+      Available since PHP 5.6.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.pgsql-connection-bad">
    <term>
-    <constant>PGSQL_CONNECTION_BAD</constant> 
+    <constant>PGSQL_CONNECTION_BAD</constant>
     (<type>integer</type>)
    </term>
    <listitem>
@@ -99,15 +121,59 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.pgsql-connection-made">
+   <term>
+    <constant>PGSQL_CONNECTION_MADE</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+      Available since PHP 5.6.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.pgsql-connection-ok">
    <term>
-    <constant>PGSQL_CONNECTION_OK</constant> 
+    <constant>PGSQL_CONNECTION_OK</constant>
     (<type>integer</type>)
    </term>
    <listitem>
     <simpara>
       Returned by <function>pg_connection_status</function> indicating that the database
-      connection is in a valid state.     
+      connection is in a valid state.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pgsql-connection-setenv">
+   <term>
+    <constant>PGSQL_CONNECTION_SETENV</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+      Available since PHP 5.6.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pgsql-connection-ssl-startup">
+   <term>
+    <constant>PGSQL_CONNECTION_SSL_STARTUP</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+      Available since PHP 5.6.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pgsql-connection-started">
+   <term>
+    <constant>PGSQL_CONNECTION_STARTED</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+      Available since PHP 5.6.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -457,13 +523,68 @@
   </varlistentry>
   <varlistentry xml:id="constant.pgsql-diag-source-function">
    <term>
-    <constant>PGSQL_DIAG_SOURCE_FUNCTION</constant> 
+    <constant>PGSQL_DIAG_SOURCE_FUNCTION</constant>
     (<type>integer</type>)
    </term>
    <listitem>
     <simpara>
      Passed to <function>pg_result_error_field</function>.
      The name of the PostgreSQL source-code function reporting the error.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pgsql-diag-schema-name">
+   <term>
+    <constant>PGSQL_DIAG_SCHEMA_NAME</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pgsql-diag-table-name">
+   <term>
+    <constant>PGSQL_DIAG_TABLE_NAME</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pgsql-diag-column-name">
+   <term>
+    <constant>PGSQL_DIAG_COLUMN_NAME</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pgsql-diag-datatype-name">
+   <term>
+    <constant>PGSQL_DIAG_DATATYPE_NAME</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pgsql-diag-constraint-name">
+   <term>
+    <constant>PGSQL_DIAG_CONSTRAINT_NAME</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 7.3.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -510,7 +631,7 @@
 
   <varlistentry xml:id="constant.pgsql-notice-last">
    <term>
-    <constant>PGSQL_NOTICE_LAST</constant> 
+    <constant>PGSQL_NOTICE_LAST</constant>
     (<type>integer</type>)
    </term>
    <listitem>
@@ -522,7 +643,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.pgsql-notice-all">
    <term>
-    <constant>PGSQL_NOTICE_ALL</constant> 
+    <constant>PGSQL_NOTICE_ALL</constant>
     (<type>integer</type>)
    </term>
    <listitem>
@@ -673,6 +794,7 @@
      Apply escape to all parameters instead of calling <function>pg_convert</function>
      internally. This option omits meta data look up. Query could be as fast as
      <function>pg_query</function> and <function>pg_send_query</function>.
+     Available since PHP 5.6.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -685,6 +807,7 @@
     <simpara>
      Returned by <function>pg_connect_poll</function> to indicate that the
      connection attempt failed.
+     Available since PHP 5.6.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -697,6 +820,7 @@
     <simpara>
      Returned by <function>pg_connect_poll</function> to indicate that the
      connection is waiting for the PostgreSQL socket to be readable.
+     Available since PHP 5.6.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -709,6 +833,7 @@
     <simpara>
      Returned by <function>pg_connect_poll</function> to indicate that the
      connection is waiting for the PostgreSQL socket to be writable.
+     Available since PHP 5.6.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -721,6 +846,7 @@
     <simpara>
      Returned by <function>pg_connect_poll</function> to indicate that the
      connection is ready to be used.
+     Available since PHP 5.6.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -733,6 +859,7 @@
     <simpara>
      Returned by <function>pg_connect_poll</function> to indicate that the
      connection is currently active.
+     Available since PHP 5.6.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -743,7 +870,7 @@
    </term>
    <listitem>
     <simpara>
-    The severity; the field contents are ERROR, FATAL, or PANIC (in an error message), or WARNING, NOTICE, DEBUG, INFO, or LOG (in a notice message). This is identical to the PG_DIAG_SEVERITY field except that the contents are never localized. This is present only in versions 9.6 and later.
+    The severity; the field contents are ERROR, FATAL, or PANIC (in an error message), or WARNING, NOTICE, DEBUG, INFO, or LOG (in a notice message). This is identical to the PG_DIAG_SEVERITY field except that the contents are never localized. This is present only in versions 9.6 and later / PHP 7.3.0 and later.
     </simpara>
    </listitem>
   </varlistentry>  


### PR DESCRIPTION
Updating: https://www.php.net/manual/en/pgsql.constants.php

* Add a few constants which weren't listed, but were added in PHP 5.6 / PHP 7.3.
* Annotate the `since` version for various constants.

Refs:
* https://www.php.net/manual/en/migration56.constants.php#migration56.constants.pgsql
* https://www.php.net/manual/en/migration73.constants.php#migration73.constants.pgsql