### PR TITLE
add info about accessing typed property

### DIFF
--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -134,7 +134,7 @@ EOT;
   
   <para>
    As of PHP 7.4.0, property definitions can include a type declaration, with the exception of
-   the <literal>callable</literal> type.
+   the <literal>callable</literal> type. Typed properties must be initialized before accessing. If a typed property is accessed prior to initialization, a fatal error occurs.
    <example>
     <title>Example of typed properties</title>
     <programlisting role="php">

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -4,10 +4,10 @@
   <title>Properties</title>
 
   <para>
-   Class member variables are called "properties". You may also see
-   them referred to using other terms such as "attributes" or
-   "fields", but for the purposes of this reference we will use
-   "properties". They are defined by using one of the
+   Class member variables are called <emphasis>properties</emphasis>. You may also see
+   them referred to using other terms such as <emphasis>attributes</emphasis> or
+   <emphasis>fields</emphasis>, but for the purposes of this reference we will use
+   <emphasis>properties</emphasis>. They are defined by using one of the
    keywords <literal>public</literal>, <literal>protected</literal>,
    or <literal>private</literal>, optionally followed by a type declaration,
    followed by a normal variable declaration. This declaration may
@@ -100,7 +100,7 @@ EOD;
     the <link linkend="ref.classobj">Class/Object Functions</link>.
    </para>
   </note>
-
+  <sect2 xml:id="language.oop5.properties.heredoc-nowdoc">
   <para>
    As of PHP 5.3.0
    <link linkend="language.types.string.syntax.heredoc">heredocs</link> and 
@@ -131,12 +131,14 @@ EOT;
     Nowdoc and Heredoc support was added in PHP 5.3.0.
    </para>
   </note>
+  </sect2>
   
-  <para>
-   As of PHP 7.4.0, property definitions can include a type declaration. 
-   <example>
-    <title>Example of typed properties</title>
-    <programlisting role="php">
+  <sect2 xml:id="language.oop5.properties.typed-properties">
+   <para>
+    As of PHP 7.4.0, property definitions can include a type declaration. 
+    <example>
+     <title>Example of typed properties</title>
+     <programlisting role="php">
 <![CDATA[
 <?php
 
@@ -159,23 +161,23 @@ var_dump($user->name);
 
 ?>
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+     </programlisting>
+     &example.outputs;
+     <screen>
 <![CDATA[
 int(1234)
 NULL
 ]]>
-    </screen>
-   </example>
-  </para>
+     </screen>
+    </example>
+   </para>
 
-  <para>
-   Typed properties must be initialized before accessing, otherwise an
-   <classname>Error</classname> is thrown.
-   <example>
-    <title>Accessing properties</title>
-    <programlisting role="php">
+   <para>
+    Typed properties must be initialized before accessing, otherwise an
+    <classname>Error</classname> is thrown.
+    <example>
+     <title>Accessing properties</title>
+     <programlisting role="php">
 <![CDATA[
 <?php
 
@@ -217,9 +219,9 @@ var_dump($circle->getName());
 var_dump($circle->getNumberOfSides());
 ?>
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+     </programlisting>
+     &example.outputs;
+     <screen>
 <![CDATA[
 string(8) "triangle"
 int(3)
@@ -227,105 +229,108 @@ string(6) "circle"
 
 Fatal error: Uncaught Error: Typed property Shape::$numberOfSides must not be accessed before initialization
 ]]>
-    </screen>
-   </example>
-  </para>
+     </screen>
+    </example>
+   </para>
 
-  <title>Valid property types</title>
-  <informaltable>
-   <tgroup cols="3">
-    <thead>
-     <row>
-      <entry>Type</entry>
-      <entry>Description</entry>
-      <entry>Minimum PHP version</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry><type>bool</type></entry>
-      <entry>
-       The property must be <type>boolean</type> value.
-      </entry>
-      <entry>PHP 7.0.0</entry>
-     </row>
-     <row>
-      <entry><type>int</type></entry>
-      <entry>
-       The property must be an <type>integer</type>.
-      </entry>
-      <entry>PHP 7.0.0</entry>
-     </row>
-     <row>
-      <entry><type>float</type></entry>
-      <entry>
-       The property must be a <type>float</type>ing point number.
-      </entry>
-      <entry>PHP 7.0.0</entry>
-     </row>
-     <row>
-      <entry><type>string</type></entry>
-      <entry>
-       The property must be a <type>string</type>.
-      </entry>
-      <entry>PHP 7.0.0</entry>
-     </row>
-     <row>
-      <entry><type>array</type></entry>
-      <entry>
-       The property must be an <type>array</type>.
-      </entry>
-      <entry>PHP 5.1.0</entry>
-     </row>
-     <row>
-      <entry><literal>object</literal></entry>
-      <entry>
-       The property must be an <type>object</type>.
-      </entry>
-      <entry>PHP 7.2.0</entry>
-     </row>
-     <row>
-      <entry><literal>iterable</literal></entry>
-      <entry>
-       The property must be either an <type>array</type> or an &instanceof; 
-       <classname>Traversable</classname>.
-      </entry>
-      <entry>PHP 7.1.0</entry>
-     </row>
-     <row>
-      <entry><literal>self</literal></entry>
-      <entry>
-       The property must be an &instanceof; the same class as the same class 
-       in which it is defined.
-      </entry>
-      <entry>PHP 5.0.0</entry>
-     </row>
-     <row>
-      <entry><literal>parent</literal></entry>
-      <entry>
-       The property must be a parent of the class in which it is defined.
-       Optionally, the class may be a sub-class of the parent instance.
-      </entry>
-      <entry>PHP 5.0.0</entry>
-     </row>
-     <row>
-      <entry>Class/interface name</entry>
-      <entry>
-       The property must be an &instanceof; the given class or interface
-       name.
-      </entry>
-      <entry>PHP 5.0.0</entry>
-     </row>
-     <row>
-      <entry>?type</entry>
-      <entry>
-       The property may optionally be nullable.
-      </entry>
-      <entry>PHP 7.1.0</entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </informaltable>
+  <sect3 xml:id="language.oop5.properties.typed-properties.valid-types">
+   <title>Valid property types</title>
+   <informaltable>
+     <tgroup cols="3">
+      <thead>
+       <row>
+        <entry>Type</entry>
+        <entry>Description</entry>
+        <entry>Minimum PHP version</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry><type>bool</type></entry>
+        <entry>
+         The property must be <type>boolean</type> value.
+        </entry>
+        <entry>PHP 7.0.0</entry>
+       </row>
+       <row>
+        <entry><type>int</type></entry>
+        <entry>
+         The property must be an <type>integer</type>.
+        </entry>
+        <entry>PHP 7.0.0</entry>
+       </row>
+       <row>
+        <entry><type>float</type></entry>
+        <entry>
+         The property must be a <type>float</type>ing point number.
+        </entry>
+        <entry>PHP 7.0.0</entry>
+       </row>
+       <row>
+        <entry><type>string</type></entry>
+        <entry>
+         The property must be a <type>string</type>.
+        </entry>
+        <entry>PHP 7.0.0</entry>
+       </row>
+       <row>
+        <entry><type>array</type></entry>
+        <entry>
+         The property must be an <type>array</type>.
+        </entry>
+        <entry>PHP 5.1.0</entry>
+       </row>
+       <row>
+        <entry><literal>object</literal></entry>
+        <entry>
+         The property must be an <type>object</type>.
+        </entry>
+        <entry>PHP 7.2.0</entry>
+       </row>
+       <row>
+        <entry><literal>iterable</literal></entry>
+        <entry>
+         The property must be either an <type>array</type> or an &instanceof; 
+         <classname>Traversable</classname>.
+        </entry>
+        <entry>PHP 7.1.0</entry>
+       </row>
+       <row>
+        <entry><literal>self</literal></entry>
+        <entry>
+         The property must be an &instanceof; the same class as the same class 
+         in which it is defined.
+        </entry>
+        <entry>PHP 5.0.0</entry>
+       </row>
+       <row>
+        <entry><literal>parent</literal></entry>
+        <entry>
+         The property must be a parent of the class in which it is defined.
+         Optionally, the class may be a sub-class of the parent instance.
+        </entry>
+        <entry>PHP 5.0.0</entry>
+       </row>
+       <row>
+        <entry>Class/interface name</entry>
+        <entry>
+         The property must be an &instanceof; the given class or interface
+         name.
+        </entry>
+        <entry>PHP 5.0.0</entry>
+       </row>
+       <row>
+        <entry>?type</entry>
+        <entry>
+         The property may optionally be nullable.
+        </entry>
+        <entry>PHP 7.1.0</entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </sect3>
+  </sect2>
 
  </sect1>
  

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -134,7 +134,8 @@ EOT;
   
   <para>
    As of PHP 7.4.0, property definitions can include a type declaration, with the exception of
-   the <literal>callable</literal> type. Typed properties must be initialized before accessing. If a typed property is accessed prior to initialization, a fatal error occurs.
+   the <literal>callable</literal> type. Typed properties must be initialized before accessing. 
+   If a typed property is accessed prior to initialization, a fatal error occurs.
    <example>
     <title>Example of typed properties</title>
     <programlisting role="php">

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -101,15 +101,16 @@ EOD;
    </para>
   </note>
   <sect2 xml:id="language.oop5.properties.heredoc-nowdoc">
-  <para>
-   As of PHP 5.3.0
-   <link linkend="language.types.string.syntax.heredoc">heredocs</link> and 
-   <link linkend="language.types.string.syntax.nowdoc">nowdocs</link>
-   can be used in any static data context, including property
-   declarations.
-   <example>
-    <title>Example of using a nowdoc to initialize a property</title>
-    <programlisting role="php">
+   <title>Heredoc and Nowdoc</title>
+   <para>
+    As of PHP 5.3.0
+    <link linkend="language.types.string.syntax.heredoc">heredocs</link> and 
+    <link linkend="language.types.string.syntax.nowdoc">nowdocs</link>
+    can be used in any static data context, including property
+    declarations.
+    <example>
+     <title>Example of using a nowdoc to initialize a property</title>
+     <programlisting role="php">
 <![CDATA[
 <?php
 class foo {
@@ -123,17 +124,18 @@ EOT;
 }
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
-  <note>
-   <para>
-    Nowdoc and Heredoc support was added in PHP 5.3.0.
+     </programlisting>
+    </example>
    </para>
-  </note>
+   <note>
+    <para>
+     Nowdoc and Heredoc support was added in PHP 5.3.0.
+    </para>
+   </note>
   </sect2>
   
   <sect2 xml:id="language.oop5.properties.typed-properties">
+   <title>Type declarations</title>
    <para>
     As of PHP 7.4.0, property definitions can include a type declaration. 
     <example>
@@ -291,23 +293,23 @@ Fatal error: Uncaught Error: Typed property Shape::$numberOfSides must not be ac
         <entry><literal>iterable</literal></entry>
         <entry>
          The property must be either an <type>array</type> or an &instanceof; 
-         <classname>Traversable</classname>.
+         <interfacename>Traversable</interfacename>.
         </entry>
         <entry>PHP 7.1.0</entry>
        </row>
        <row>
         <entry><literal>self</literal></entry>
         <entry>
-         The property must be an &instanceof; the same class as the same class 
-         in which it is defined.
+         The property must be an &instanceof; the same class in which the 
+         property is defined.
         </entry>
         <entry>PHP 5.0.0</entry>
        </row>
        <row>
         <entry><literal>parent</literal></entry>
         <entry>
-         The property must be a parent of the class in which it is defined.
-         Optionally, the class may be a sub-class of the parent instance.
+         The property must be an &instanceof; the parent class of the class 
+         in which the property is defined.
         </entry>
         <entry>PHP 5.0.0</entry>
        </row>
@@ -322,7 +324,7 @@ Fatal error: Uncaught Error: Typed property Shape::$numberOfSides must not be ac
        <row>
         <entry>?type</entry>
         <entry>
-         The property may optionally be nullable.
+         The property must be the specified type, or &null;.
         </entry>
         <entry>PHP 7.1.0</entry>
        </row>

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -134,11 +134,6 @@ EOT;
   
   <para>
    As of PHP 7.4.0, property definitions can include a type declaration. 
-   Any <link linkend="functions.arguments.type-declaration">valid type 
-   declaration</link>, with the exception of the <literal>callable</literal> 
-   type. Typed properties must be initialized before accessing. If a typed 
-   property is accessed prior to initialization, an <link linkend="class.error">
-   Error</link> is thrown. 
    <example>
     <title>Example of typed properties</title>
     <programlisting role="php">
@@ -148,19 +143,19 @@ EOT;
 class User
 {
     public int $id;
-    public string $name;
+    public ?string $name;
 
-    public function __construct(int $id, string $name)
+    public function __construct(int $id, ?string $name)
     {
         $this->id = $id;
         $this->name = $name;
     }
 }
 
-$user = new User(1234, "php");
-echo "ID: " . $user->id;
-echo "\n";
-echo "Name: " . $user->name;
+$user = new User(1234, null);
+
+var_dump($user->id);
+var_dump($user->name);
 
 ?>
 ]]>
@@ -168,12 +163,172 @@ echo "Name: " . $user->name;
     &example.outputs;
     <screen>
 <![CDATA[
-ID: 1234
-Name: php
+int(1234)
+NULL
 ]]>
     </screen>
    </example>
   </para>
+
+  <para>
+   Typed properties must be initialized before accessing, otherwise an
+   <classname>Error</classname> is thrown.
+   <example>
+    <title>Accessing properties</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+class Shape
+{
+    public int $numberOfSides;
+    public string $name;
+    
+    public function setNumberOfSides(int $numberOfSides): void
+    {
+        $this->numberOfSides = $numberOfSides;
+    }
+    
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+    
+    public function getNumberOfSides(): int
+    {
+        return $this->numberOfSides;
+    }
+    
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}
+
+$triangle = new Shape();
+$triangle->setName("triangle");
+$triangle->setNumberofSides(3);
+var_dump($triangle->getName());
+var_dump($triangle->getNumberOfSides());
+
+$circle = new Shape();
+$circle->setName("circle");
+var_dump($circle->getName());
+var_dump($circle->getNumberOfSides());
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+string(8) "triangle"
+int(3)
+string(6) "circle"
+
+Fatal error: Uncaught Error: Typed property Shape::$numberOfSides must not be accessed before initialization
+]]>
+    </screen>
+   </example>
+  </para>
+
+  <title>Valid property types</title>
+  <informaltable>
+   <tgroup cols="3">
+    <thead>
+     <row>
+      <entry>Type</entry>
+      <entry>Description</entry>
+      <entry>Minimum PHP version</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry><type>bool</type></entry>
+      <entry>
+       The property must be <type>boolean</type> value.
+      </entry>
+      <entry>PHP 7.0.0</entry>
+     </row>
+     <row>
+      <entry><type>int</type></entry>
+      <entry>
+       The property must be an <type>integer</type>.
+      </entry>
+      <entry>PHP 7.0.0</entry>
+     </row>
+     <row>
+      <entry><type>float</type></entry>
+      <entry>
+       The property must be a <type>float</type>ing point number.
+      </entry>
+      <entry>PHP 7.0.0</entry>
+     </row>
+     <row>
+      <entry><type>string</type></entry>
+      <entry>
+       The property must be a <type>string</type>.
+      </entry>
+      <entry>PHP 7.0.0</entry>
+     </row>
+     <row>
+      <entry><type>array</type></entry>
+      <entry>
+       The property must be an <type>array</type>.
+      </entry>
+      <entry>PHP 5.1.0</entry>
+     </row>
+     <row>
+      <entry><literal>object</literal></entry>
+      <entry>
+       The property must be an <type>object</type>.
+      </entry>
+      <entry>PHP 7.2.0</entry>
+     </row>
+     <row>
+      <entry><literal>iterable</literal></entry>
+      <entry>
+       The property must be either an <type>array</type> or an &instanceof; 
+       <classname>Traversable</classname>.
+      </entry>
+      <entry>PHP 7.1.0</entry>
+     </row>
+     <row>
+      <entry><literal>self</literal></entry>
+      <entry>
+       The property must be an &instanceof; the same class as the same class 
+       in which it is defined.
+      </entry>
+      <entry>PHP 5.0.0</entry>
+     </row>
+     <row>
+      <entry><literal>parent</literal></entry>
+      <entry>
+       The property must be a parent of the class in which it is defined.
+       Optionally, the class may be a sub-class of the parent instance.
+      </entry>
+      <entry>PHP 5.0.0</entry>
+     </row>
+     <row>
+      <entry>Class/interface name</entry>
+      <entry>
+       The property must be an &instanceof; the given class or interface
+       name.
+      </entry>
+      <entry>PHP 5.0.0</entry>
+     </row>
+     <row>
+      <entry>?type</entry>
+      <entry>
+       The property may optionally be nullable.
+      </entry>
+      <entry>PHP 7.1.0</entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+
+
+   
 
  </sect1>
  

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -133,9 +133,12 @@ EOT;
   </note>
   
   <para>
-   As of PHP 7.4.0, property definitions can include a type declaration, with the exception of
-   the <literal>callable</literal> type. Typed properties must be initialized before accessing. 
-   If a typed property is accessed prior to initialization, a fatal error occurs.
+   As of PHP 7.4.0, property definitions can include a type declaration. 
+   Any <link linkend="functions.arguments.type-declaration">valid type 
+   declaration</link>, with the exception of the <literal>callable</literal> 
+   type. Typed properties must be initialized before accessing. If a typed 
+   property is accessed prior to initialization, an <link linkend="class.error">
+   Error</link> is thrown. 
    <example>
     <title>Example of typed properties</title>
     <programlisting role="php">

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -327,9 +327,6 @@ Fatal error: Uncaught Error: Typed property Shape::$numberOfSides must not be ac
    </tgroup>
   </informaltable>
 
-
-   
-
  </sect1>
  
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
In reference to [Bug #79620](https://bugs.php.net/bug.php?id=79620), I added information explaining that a typed property cannot be accessed before initialization, otherwise a fatal error occurs.