### PR TITLE
Update instanceof behavior considering PHP >= 7.3.0

### DIFF
--- a/language/operators.xml
+++ b/language/operators.xml
@@ -2400,8 +2400,8 @@ bool(false)
     </example>
    </para>
    <para>
-    instanceof does not throw any error if the variable being tested is not
-    an object, it simply returns &false;. Constants, however, are not allowed.
+    As of PHP 7.3.0, instanceof does not throw any error if the variable being tested is not
+    an object; it simply returns &false;. Before PHP 7.3.0, constants, however, are not allowed.
     <example>
      <title>Using <literal>instanceof</literal> to test other variables</title>
      <programlisting role="php">
@@ -2413,7 +2413,7 @@ $c = imagecreate(5, 5);
 var_dump($a instanceof stdClass); // $a is an integer
 var_dump($b instanceof stdClass); // $b is NULL
 var_dump($c instanceof stdClass); // $c is a resource
-var_dump(FALSE instanceof stdClass);
+var_dump(FALSE instanceof stdClass); // Before PHP 7.3.0, this throws a fatal error
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
As of PHP 7.3.0, constants don't throw a fatal error anymore (https://3v4l.org/TMt0J)

This PR clarifies that behavior.