### PR TITLE
Add FPM access.format placeholders

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -459,7 +459,7 @@
       </term>
       <listitem>
        <para>
-        The number of seconds after which an idle process will be killed. 
+        The number of seconds after which an idle process will be killed.
         Used only when <literal>pm</literal> is set to <literal>ondemand</literal>.
         Available units: s(econds)(default), m(inutes), h(ours), or d(ays).
         Default value: 10s.
@@ -721,8 +721,129 @@
       </term>
       <listitem>
        <para>
-        The access log format.
-        Default value: "%R - %u %t \"%m %r\" %s"
+       The access log format.
+       Default value: "%R - %u %t \"%m %r\" %s":
+        <table xml:id="fpm.configuration.access.format">
+         <title>Valid options</title>
+         <tgroup cols="2">
+          <thead>
+           <row>
+            <entry>Placeholder</entry>
+            <entry>Description</entry>
+           </row>
+          </thead>
+          <tbody>
+           <row>
+            <entry>
+             <constant>%C</constant>
+            </entry>
+            <entry>%CPU</entry>
+           </row>
+           <row>
+            <entry>
+             <constant>%d</constant>
+            </entry>
+            <entry>duration µs</entry>
+           </row>
+           <row>
+            <entry>
+             <constant>%e</constant>
+            </entry>
+            <entry>fastcgi env</entry>
+           </row>
+           <row>
+            <entry>
+             <constant>%f</constant>
+            </entry>
+            <entry>script</entry>
+           </row>
+           <row>
+            <entry>
+             <constant>%l</constant>
+            </entry>
+            <entry>content length</entry>
+           </row>
+           <row>
+            <entry>
+             <constant>%m</constant>
+            </entry>
+            <entry>method</entry>
+           </row>
+           <row>
+            <entry>
+             <constant>%M</constant>
+            </entry>
+            <entry>memory</entry>
+           </row>
+           <row>
+            <entry>
+             <constant>%n</constant>
+            </entry>
+            <entry>pool name</entry>
+           </row>
+           <row>
+            <entry>
+             <constant>%o</constant>
+            </entry>
+            <entry>header output</entry>
+           </row>
+           <row>
+            <entry>
+             <constant>%p</constant>
+            </entry>
+            <entry>PID</entry>
+           </row>
+           <row>
+            <entry>
+             <constant>%q</constant>
+            </entry>
+            <entry>query string</entry>
+           </row>
+           <row>
+            <entry>
+             <constant>%Q</constant>
+            </entry>
+            <entry>the glue between %q and %r</entry>
+           </row>
+           <row>
+            <entry>
+             <constant>%r</constant>
+            </entry>
+            <entry>request URI</entry>
+           </row>
+           <row>
+            <entry>
+             <constant>%R</constant>
+            </entry>
+            <entry>remote IP address</entry>
+           </row>
+           <row>
+            <entry>
+             <constant>%s</constant>
+            </entry>
+            <entry>status</entry>
+           </row>
+           <row>
+            <entry>
+             <constant>%T</constant>
+            </entry>
+            <entry>time</entry>
+           </row>
+           <row>
+            <entry>
+             <constant>%t</constant>
+            </entry>
+            <entry>time</entry>
+           </row>
+           <row>
+            <entry>
+             <constant>%u</constant>
+            </entry>
+            <entry>remote user</entry>
+           </row>
+          </tbody>
+         </tgroup>
+        </table>
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
Found the placeholders at: https://github.com/php/php-src/blob/27066154185210e8532636612e5121423d70870f/sapi/fpm/fpm/fpm_log.c#L176-L405
Comes out as: 
![Screenshot from 2021-03-08 22-11-07](https://user-images.githubusercontent.com/147145/110382450-397ffb00-805b-11eb-971a-7d851ecf3a7b.png)
