### PR TITLE
Add QuickStart with homebrew

### DIFF
--- a/install/macos/packages.xml
+++ b/install/macos/packages.xml
@@ -13,7 +13,24 @@
    version of PHP with the features you need.
   </simpara>
   <simpara>
-   The following resources offer easy to install packages and 
+   The quickest way to install php on macOS is with homebrew:
+  </simpara>
+  <para>
+   <orderedlist>
+    <listitem>
+     <para>
+      install homebrew, by following the instructions at <link xlink:href="https://brew.sh/">brew.sh</link>
+     </para>
+    </listitem>
+    <listitem>
+     <simpara>
+      brew install php
+     </simpara>
+    </listitem>
+   </orderedlist>
+  </para>
+  <simpara>
+   The following alternative resources also offer easy to install packages and
    precompiled binaries for PHP on Mac OS:
   </simpara>
   <para>
@@ -34,12 +51,6 @@
      <simpara>
       Fink: 
       <link xlink:href="&url.mac.fink;">&url.mac.fink;</link>
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      Homebrew: 
-      <link xlink:href="&url.mac.homebrew;">&url.mac.homebrew;</link>
      </simpara>
     </listitem>
    </itemizedlist>


### PR DESCRIPTION
Add a quick start how to install PHP using homebrew on macOS/OX. Comes out as this: 

![Screenshot from 2020-06-10 16-00-25](https://user-images.githubusercontent.com/147145/84277593-07755300-ab34-11ea-8bde-25528801c0ff.png)

![Screenshot from 2020-06-10 16-00-17](https://user-images.githubusercontent.com/147145/84277598-080de980-ab34-11ea-8aa4-496bb6c0e49b.png)
