### PR TITLE
Add note on behavior of ArrayIterator::offsetUnset when used on current iteration index

### DIFF
--- a/reference/spl/arrayiterator/offsetunset.xml
+++ b/reference/spl/arrayiterator/offsetunset.xml
@@ -16,8 +16,15 @@
   <para>
    Unsets a value for an offset.
   </para>
-
-  &warn.undocumented.func;
+  <para>
+   If iteration is in progress, and <methodname>ArrayIterator::offsetUnset</methodname> is used to
+   unset the current index of iteration, the iteration position will be advanced to the next index.
+   Since the iteration position is also advanced at the end of a
+   <link linkend="control-structures.foreach"><literal>foreach</literal></link> loop body, use of
+   <methodname>ArrayIterator::offsetUnset</methodname> inside a
+   <link linkend="control-structures.foreach"><literal>foreach</literal></link> loop may result in
+   indices being skipped.
+  </para>
 
  </refsect1>
 

--- a/reference/spl/arrayiterator/offsetunset.xml
+++ b/reference/spl/arrayiterator/offsetunset.xml
@@ -20,7 +20,7 @@
    If iteration is in progress, and <methodname>ArrayIterator::offsetUnset</methodname> is used to
    unset the current index of iteration, the iteration position will be advanced to the next index.
    Since the iteration position is also advanced at the end of a
-   <link linkend="control-structures.foreach"><literal>foreach</literal></link> loop body, use of
+   &foreach; loop body, use of
    <methodname>ArrayIterator::offsetUnset</methodname> inside a
    <link linkend="control-structures.foreach"><literal>foreach</literal></link> loop may result in
    indices being skipped.


### PR DESCRIPTION
Bug report #55157 (which is not really a "bug") is based on a misunderstanding of the behavior
of `offsetUnset` as regards iteration. Although not all users will read the documentation, it
is better to have documentation addressing this issue, since it is obviously a source of
confusion.