### PR TITLE
Clarify handling of 3rd parameter for assert callbacks

### DIFF
--- a/reference/info/functions/assert-options.xml
+++ b/reference/info/functions/assert-options.xml
@@ -124,8 +124,7 @@
          <term><parameter>assertion</parameter></term>
          <listitem>
           <simpara>
-           The assertion that has been passed to <function>assert</function>,
-           converted to a string.
+           Prior to PHP 8, the assertion which has been passed to <function>assert</function>, but only when the assertion is given as a string. (If the assertion is a boolean condition, this parameter will be an empty string.) From PHP 8, this parameter is always &null;.
           </simpara>
          </listitem>
         </varlistentry>

--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -31,10 +31,9 @@
     If the <parameter>assertion</parameter> is given as a string it
     will be evaluated as PHP code by <function>assert</function>.
     If you pass a boolean condition as <parameter>assertion</parameter>,
-    this condition will not show up as parameter to the assertion function
+    this condition will not be passed as a parameter to the assertion callback
     which you may have defined with <function>assert_options</function>.
-    The condition is converted to a string before calling that handler
-    function, and the boolean &false; is converted as the empty string.
+    Rather, the callback will receive an empty string.
    </para>
    <para>
     Assertions should be used as a debugging feature only. You may


### PR DESCRIPTION
The handling of the 3rd parameter for assert callbacks set via `assert_options`
changed with the implementation of the expectations RFC, and changed again in
PHP 8. Update the documentation accordingly.

This one seems to be a cause for confusion; witness Bug [#79602](https://bugs.php.net/bug.php?id=79602).