### PR TITLE
Warn about different behavior of chdir() under ZTS

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -86,6 +86,9 @@ implemented on Windows platforms.</simpara></note>'>
 <!ENTITY note.no-windows.extension '<note xmlns="http://docbook.org/ns/docbook"><simpara>This extension is not
 available on Windows platforms.</simpara></note>'>
 
+<!ENTITY note.no-zts '<note xmlns="http://docbook.org/ns/docbook"><simpara>This function is not
+available in PHP interpreters built with ZTS (Zend Thread Safety) enabled. To check whether your copy of PHP was built with ZTS enabled, use <command>php -i</command> or test the built-in constant <constant>PHP_ZTS</constant>.</simpara></note>'>
+
 <!ENTITY note.randomseed '<note xmlns="http://docbook.org/ns/docbook"><simpara>There is no need
 to seed the random number generator with <function>srand</function> or
 <function>mt_srand</function> as this is done automatically.

--- a/reference/dir/functions/chdir.xml
+++ b/reference/dir/functions/chdir.xml
@@ -83,6 +83,18 @@ echo getcwd() . "\n";
  <refsect1 role="notes">
   &reftitle.notes;
   &note.sm.uidcheck.dir;
+  <caution>
+   <para>
+    If the PHP interpreter has been built with ZTS (Zend Thread Safety) enabled,
+    any changes to the current directory made through <function>chdir</function>
+    will be invisible to the operating system. All built-in PHP functions will
+    still respect the change in current directory; but external library
+    functions called using <link linkend="book.ffi">FFI</link> will not. You
+    can tell whether your copy of PHP was built with ZTS enabled using
+    <command>php -i</command> or the built-in constant
+    <constant>PHP_ZTS</constant>.
+   </para>
+  </caution>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/dir/functions/chroot.xml
+++ b/reference/dir/functions/chroot.xml
@@ -73,6 +73,7 @@ echo getcwd();
  <refsect1 role="notes">
   &reftitle.notes;
   &note.no-windows;
+  &note.no-zts;
  </refsect1>
 </refentry>
 

--- a/reference/dir/functions/getcwd.xml
+++ b/reference/dir/functions/getcwd.xml
@@ -32,7 +32,19 @@
    modes and permissions.
   </para>
  </refsect1>
- 
+
+ <refsect1 role="notes">
+  <caution>
+   <para>
+    If the PHP interpreter has been built with ZTS (Zend Thread Safety) enabled,
+    the current working directory returned by <function>getcwd</function>
+    may be different from that returned by operating system interfaces.
+    External libraries (invoked through <link linkend="book.ffi">FFI</link>)
+    which depend on the current working directory will be affected.
+   </para>
+  </caution>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>


### PR DESCRIPTION
In response to [Bug #79439](https://bugs.php.net/bug.php?id=79439), where a user
reported the (correct, but surprising) behavior of `chdir` as a bug.