### PR TITLE
Fully document behavior of negative arguments to mb_strcut

### DIFF
--- a/reference/mbstring/functions/mb-strcut.xml
+++ b/reference/mbstring/functions/mb-strcut.xml
@@ -52,7 +52,10 @@
       <para>
        If <parameter>start</parameter> is negative, the returned string
        will start at the <parameter>start</parameter>'th byte
-       from the end of <parameter>str</parameter>.
+       counting back from the end of <parameter>str</parameter>. However, if the
+       magnitude of a negative <parameter>start</parameter> is greater than the
+       length of the string, the returned portion will start from the beginning of
+       <parameter>str</parameter>.
       </para>
      </listitem>
     </varlistentry>
@@ -62,6 +65,14 @@
       <para>
        Length in <emphasis>bytes</emphasis>. If omitted or <literal>NULL</literal>
        is passed, extract all bytes to the end of the string.
+      </para>
+      <para>
+       If <parameter>length</parameter> is negative, the returned string will
+       end at the <parameter>length</parameter>'th byte counting back from the
+       end of <parameter>str</parameter>. However, if the magnitude of a negative
+       <parameter>length</parameter> is greater than the number of characters
+       after the <parameter>start</parameter> position, an empty string will
+       be returned.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
When reading the source code, I noticed there is some special handling of
negative 'start' and 'length' arguments which is not mentioned in the
manual.