### PR TITLE
Clarify what the 'width' in mb_strimwidth means; it takes East Asian width into account

### DIFF
--- a/reference/mbstring/functions/mb-strimwidth.xml
+++ b/reference/mbstring/functions/mb-strimwidth.xml
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>string</type><parameter>encoding</parameter><initializer>mb_internal_encoding()</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Truncates <type>string</type> <parameter>str</parameter> to specified <parameter>width</parameter>. 
+   Truncates <type>string</type> <parameter>str</parameter> to specified <parameter>width</parameter>. Takes the East Asian width property of characters into account; "fullwidth" characters contribute two units to the total width of a string, while "halfwidth" characters contribute one.
   </para>
  </refsect1>
 


### PR DESCRIPTION
If a link to an external resource can be included, this might be a good one:
http://www.unicode.org/reports/tr11/tr11-38.html