### PR TITLE
Improve typehinting for phar

### DIFF
--- a/reference/phar/Phar/extractTo.xml
+++ b/reference/phar/Phar/extractTo.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Phar::extractTo</methodname>
    <methodparam><type>string</type><parameter>pathto</parameter></methodparam>
-   <methodparam choice="opt"><type>string|array</type><parameter>files</parameter></methodparam>
+   <methodparam choice="opt"><type>string|array|null</type><parameter>files</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>overwrite</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
 

--- a/reference/phar/PharData/extractTo.xml
+++ b/reference/phar/PharData/extractTo.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>PharData::extractTo</methodname>
    <methodparam><type>string</type><parameter>pathto</parameter></methodparam>
-   <methodparam choice="opt"><type>string|array</type><parameter>files</parameter></methodparam>
+   <methodparam choice="opt"><type>string|array|null</type><parameter>files</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>overwrite</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
 


### PR DESCRIPTION
We ran into the following error when using phpstan to scan our code:

```php
Parameter #2 $files of method Phar::extractTo() expects array\|string,
--
null given.
```

We were using this method as the following:
```php
$pharData = new PharData($newPathToTar);
$pharData->extractTo($pathToExport, null, $overwriteExistingFiles);
```

We had no need for the second parameter of the ```extractTo``` method, so that is why we nulled it.
However, the current DocBlock of PharData, triggers phpstan(version 0.12.32) to throw the aforementioned error.

The ```$files``` argument of the ```PharData::extractTo()``` is defaulted to null, but the DocBlock is "not allowing it" to be null.
```php
/**
* (Unknown)<br/>
* Extract the contents of a phar archive to a directory
* @link https://php.net/manual/en/phar.extractto.php
* @param string $pathto <p>
* Path within an archive to the file to delete.
* </p>
* @param string|array $files [optional] <p>
* The name of a file or directory to extract, or an array of files/directories to extract
* </p>
* @param bool $overwrite [optional] <p>
* Set to <b>TRUE</b> to enable overwriting existing files
* </p>
* @return bool returns <b>TRUE</b> on success, but it is better to check for thrown exception,
* and assume success if none is thrown.
*/
public function extractTo ($pathto, $files = null, $overwrite = false) {}
```

We can circumvent this by adjusting the way we are using the method, nevertheless this simple PR would tackle this issue.