### PR TITLE
Add exception_ignore_args

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -100,7 +100,7 @@
         <entry>Available since PHP 7.1.0.</entry>
        </row>
        <row>
-        <entry><link linkend="ini.zend.exception_ignore_args">zend.exception_ignore_args</link></entry>
+        <entry><link linkend="ini.zend.exception-ignore-args">zend.exception_ignore_args</link></entry>
         <entry>"0"</entry>
         <entry>PHP_INI_ALL</entry>
         <entry>Available since PHP 7.4.0</entry>
@@ -453,7 +453,7 @@
       </listitem>
      </varlistentry>
      
-     <varlistentry xml:id="ini.zend.exception_ignore_args">
+     <varlistentry xml:id="ini.zend.exception-ignore-args">
       <term>
        <parameter>zend.exception_ignore_args</parameter>
        <type>boolean</type>

--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -100,6 +100,12 @@
         <entry>Available since PHP 7.1.0.</entry>
        </row>
        <row>
+        <entry><link linkend="ini.zend.exception_ignore_args">zend.exception_ignore_args</link></entry>
+        <entry>"0"</entry>
+        <entry>PHP_INI_ALL</entry>
+        <entry>Available since PHP 7.4.0</entry>
+       </row>
+       <row>
         <entry><link linkend="ini.zend.multibyte">zend.multibyte</link></entry>
         <entry>"0"</entry>
         <entry>PHP_INI_ALL</entry>
@@ -447,6 +453,18 @@
       </listitem>
      </varlistentry>
      
+     <varlistentry xml:id="ini.zend.exception_ignore_args">
+      <term>
+       <parameter>zend.exception_ignore_args</parameter>
+       <type>boolean</type>
+      </term>
+      <listitem>
+       <para>
+        Excludes arguments from stack traces generated from exceptions.
+       </para>
+      </listitem>
+     </varlistentry>
+
      <varlistentry xml:id="ini.zend.multibyte">
       <term>
        <parameter>zend.multibyte</parameter>


### PR DESCRIPTION
It was added to PHP 7.4:
https://www.php.net/manual/en/migration74.other-changes.php#migration74.other-changes.ini