### PR TITLE
The 2nd argument to mb_parse_str is not optional

### DIFF
--- a/reference/mbstring/functions/mb-parse-str.xml
+++ b/reference/mbstring/functions/mb-parse-str.xml
@@ -5,13 +5,13 @@
   <refname>mb_parse_str</refname>
   <refpurpose>Parse GET/POST/COOKIE data and set global variable</refpurpose>
  </refnamediv>
-   
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>mb_parse_str</methodname>
    <methodparam><type>string</type><parameter>encoded_string</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter role="reference">result</parameter></methodparam>
+   <methodparam><type>array</type><parameter role="reference">result</parameter></methodparam>
   </methodsynopsis>
   <para>
    Parses GET/POST/COOKIE data and
@@ -46,14 +46,38 @@
    </variablelist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.success;
   </para>
  </refsect1>
- 
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>7.2.0</entry>
+      <entry>Calling <function>mb_parse_str</function> without the second parameter was deprecated.
+     </row>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>The second parameter was no longer optional.</entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>


### PR DESCRIPTION
Using mb_parse_str without the 2nd argument was deprecated in PHP 7.2. Nikita Popov made it a required argument in ff780feca4f1b2dd5c1b7cf692781070d49df7cb.