### PR TITLE
Updated hash_algos doc for PHP 7.4

### DIFF
--- a/reference/hash/functions/hash-algos.xml
+++ b/reference/hash/functions/hash-algos.xml
@@ -40,7 +40,7 @@
        </entry>
       </row>
       <row>
-       <entry>7.4.0</entry>
+       <entry>7.1.0</entry>
        <entry>
         Support for sha512/224, sha512/256, sha3-224, sha3-256, sha3-384 and
         sha3-512 has been added.

--- a/reference/hash/functions/hash-algos.xml
+++ b/reference/hash/functions/hash-algos.xml
@@ -34,7 +34,13 @@
      </thead>
      <tbody>
       <row>
-       <entry>7.1.0</entry>
+       <entry>7.4.0</entry>
+       <entry>
+        Support for crc32c has been added.
+       </entry>
+      </row>
+      <row>
+       <entry>7.4.0</entry>
        <entry>
         Support for sha512/224, sha512/256, sha3-224, sha3-256, sha3-384 and
         sha3-512 has been added.
@@ -68,7 +74,7 @@
    <example>
     <title><function>hash_algos</function> example</title>
     <para>
-     As of PHP 5.6.0, <function>hash_algos</function> will return the
+     As of PHP 7.4.0, <function>hash_algos</function> will return the
      following list of algorithm names.
     </para>
     <programlisting role="php">
@@ -90,45 +96,52 @@ Array
     [4] => sha224
     [5] => sha256
     [6] => sha384
-    [7] => sha512
-    [8] => ripemd128
-    [9] => ripemd160
-    [10] => ripemd256
-    [11] => ripemd320
-    [12] => whirlpool
-    [13] => tiger128,3
-    [14] => tiger160,3
-    [15] => tiger192,3
-    [16] => tiger128,4
-    [17] => tiger160,4
-    [18] => tiger192,4
-    [19] => snefru
-    [20] => snefru256
-    [21] => gost
-    [22] => gost-crypto
-    [23] => adler32
-    [24] => crc32
-    [25] => crc32b
-    [26] => fnv132
-    [27] => fnv1a32
-    [28] => fnv164
-    [29] => fnv1a64
-    [30] => joaat
-    [31] => haval128,3
-    [32] => haval160,3
-    [33] => haval192,3
-    [34] => haval224,3
-    [35] => haval256,3
-    [36] => haval128,4
-    [37] => haval160,4
-    [38] => haval192,4
-    [39] => haval224,4
-    [40] => haval256,4
-    [41] => haval128,5
-    [42] => haval160,5
-    [43] => haval192,5
-    [44] => haval224,5
-    [45] => haval256,5
+    [7] => sha512/224
+    [8] => sha512/256
+    [9] => sha512
+    [10] => sha3-224
+    [11] => sha3-256
+    [12] => sha3-384
+    [13] => sha3-512
+    [14] => ripemd128
+    [15] => ripemd160
+    [16] => ripemd256
+    [17] => ripemd320
+    [18] => whirlpool
+    [19] => tiger128,3
+    [20] => tiger160,3
+    [21] => tiger192,3
+    [22] => tiger128,4
+    [23] => tiger160,4
+    [24] => tiger192,4
+    [25] => snefru
+    [26] => snefru256
+    [27] => gost
+    [28] => gost-crypto
+    [29] => adler32
+    [30] => crc32
+    [31] => crc32b
+    [32] => crc32c
+    [33] => fnv132
+    [34] => fnv1a32
+    [35] => fnv164
+    [36] => fnv1a64
+    [37] => joaat
+    [38] => haval128,3
+    [39] => haval160,3
+    [40] => haval192,3
+    [41] => haval224,3
+    [42] => haval256,3
+    [43] => haval128,4
+    [44] => haval160,4
+    [45] => haval192,4
+    [46] => haval224,4
+    [47] => haval256,4
+    [48] => haval128,5
+    [49] => haval160,5
+    [50] => haval192,5
+    [51] => haval224,5
+    [52] => haval256,5
 )
 ]]>
     </screen>


### PR DESCRIPTION
Support for crc32c was added in PHP 7.4: https://3v4l.org/NCnDY.