### PR TITLE
Number of bits is an integer, not a GMP number

### DIFF
--- a/reference/gmp/functions/gmp_random_bits.xml
+++ b/reference/gmp/functions/gmp_random_bits.xml
@@ -31,7 +31,6 @@
       <para>
        The number of bits.
       </para>
-      &gmp.parameter; 
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Source: https://github.com/php/php-src/blob/e208cb23c6bda00737a9bfd227b82beaba350fa7/ext/gmp/gmp.c#L1738