### PR TITLE
ucwords() cleanup

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -28,6 +28,11 @@ cryptographically secure value, consider using <function>random_int</function>, 
 <!ENTITY note.bin-safe '<note xmlns="http://docbook.org/ns/docbook"><simpara>This function is
 binary-safe.</simpara></note>'>
 
+<!ENTITY note.locale-single-byte '<note xmlns="http://docbook.org/ns/docbook"><simpara>This function is locale-aware
+and will handle input according to the currently set locale.  However, it only works on single-byte character sets.
+If you need to use multibyte characters (most non-western-European languages) look at the
+<link linkend="book.mbstring">multibyte</link> or <link linkend="book.intl">intl</link> extensions instead.</simpara></note>'>
+
 <!ENTITY note.clearstatcache '<note xmlns="http://docbook.org/ns/docbook"><simpara>The results of this
 function are cached. See <function>clearstatcache</function> for
 more details.</simpara></note>'>

--- a/reference/strings/functions/ucwords.xml
+++ b/reference/strings/functions/ucwords.xml
@@ -123,7 +123,7 @@ $baz = ucwords($foo, "|");        // Hello|World!
     <programlisting role="php">
      <![CDATA[
 <?php
-$foo = 'mike o'hara';
+$foo = "mike o'hara";
 $bar = ucwords($foo);             // Mike O'hara
 
 $baz = ucwords($foo, " \t\r\n\f\v'");        // Mike O'Hara

--- a/reference/strings/functions/ucwords.xml
+++ b/reference/strings/functions/ucwords.xml
@@ -24,11 +24,6 @@
    after any character listed in the <parameter>delimiters</parameter> parameter
    (By default these are: space, form-feed, newline, carriage return, horizontal tab, and vertical tab).
   </para>
-  <para>
-   This function assumes the string is a basic ASCII string, and is therefore binary safe. If you need
-   to handle strings in non-ASCII character sets (such as UTF-8), use
-   <function><link linkend="function.mb-convert-case">mb_convert_case</link></function> instead.
-  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -141,6 +136,7 @@ $baz = ucwords($foo, " \t\r\n\f\v'");        // Mike O'Hara
 
  <refsect1 role="notes">
   &reftitle.notes;
+  &note.locale-single-byte;
   &note.bin-safe;
  </refsect1>
 

--- a/reference/strings/functions/ucwords.xml
+++ b/reference/strings/functions/ucwords.xml
@@ -24,6 +24,11 @@
    after any character listed in the <parameter>delimiters</parameter> parameter
    (By default these are: space, form-feed, newline, carriage return, horizontal tab, and vertical tab).
   </para>
+  <para>
+   This function assumes the string is a basic ASCII string, and is therefore binary safe. If you need
+   to handle strings in non-ASCII character sets (such as UTF-8), use
+   <function><link linkend="function.mb_convert_case">mb_convert_case</link></function> instead.
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/strings/functions/ucwords.xml
+++ b/reference/strings/functions/ucwords.xml
@@ -27,7 +27,7 @@
   <para>
    This function assumes the string is a basic ASCII string, and is therefore binary safe. If you need
    to handle strings in non-ASCII character sets (such as UTF-8), use
-   <function><link linkend="function.mb_convert_case">mb_convert_case</link></function> instead.
+   <function><link linkend="function.mb-convert-case">mb_convert_case</link></function> instead.
   </para>
  </refsect1>
 

--- a/reference/strings/functions/ucwords.xml
+++ b/reference/strings/functions/ucwords.xml
@@ -110,7 +110,7 @@ $bar = ucwords(strtolower($bar)); // Hello World!
    <example>
     <title><function>ucwords</function> example with custom delimiter</title>
     <programlisting role="php">
-     <![CDATA[
+<![CDATA[
 <?php
 $foo = 'hello|world!';
 $bar = ucwords($foo);             // Hello|world!

--- a/reference/strings/functions/ucwords.xml
+++ b/reference/strings/functions/ucwords.xml
@@ -110,12 +110,28 @@ $bar = ucwords(strtolower($bar)); // Hello World!
    <example>
     <title><function>ucwords</function> example with custom delimiter</title>
     <programlisting role="php">
-<![CDATA[
+     <![CDATA[
 <?php
 $foo = 'hello|world!';
 $bar = ucwords($foo);             // Hello|world!
 
 $baz = ucwords($foo, "|");        // Hello|World!
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+
+  <para>
+   <example>
+    <title><function>ucwords</function> example with additional delimiters</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+$foo = 'mike o'hara';
+$bar = ucwords($foo);             // Mike O'hara
+
+$baz = ucwords($foo, " \t\r\n\f\v'");        // Mike O'Hara
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
About half the comments I removed were variations on working around the lack of delimiters, especially for complex or non-English names.  So make those examples more robust.