### PR TITLE
Add `AddressInfo` and `Socket` resources

### DIFF
--- a/appendices/resources.xml
+++ b/appendices/resources.xml
@@ -27,6 +27,21 @@
      </thead>
      <tbody>
    <row>
+   <entry>AddressInfo</entry>
+    <entry>
+     <function>socket_addrinfo_lookup</function>
+    </entry>
+    <entry>
+     <function>socket_addrinfo_bind</function>,
+     <function>socket_addrinfo_connect</function>,
+     <function>socket_addrinfo_explain</function>,
+    </entry>
+    <entry>
+     None
+    </entry>
+    <entry>Socket (sockets extension)</entry>
+   </row>
+   <row>
    <entry>bzip2</entry>
     <entry>
      <function>bzopen</function>
@@ -1896,6 +1911,48 @@
      <function>shmop_close</function>
     </entry>
     <entry>Shared memory block handle (as of PHP 7.0.0)</entry>
+   </row>
+   <row>
+    <entry>Socket</entry>
+    <entry>
+     <function>socket_accept</function>,
+     <function>socket_addrinfo_bind</function>,
+     <function>socket_addrinfo_connect</function>,
+     <function>socket_create</function>,
+     <function>socket_create_listen</function>,
+     <function>socket_import_stream</function>,
+     <function>socket_wsaprotocol_info_import</function>
+    </entry>
+    <entry>
+     <function>socket_accept</function>,
+     <function>socket_bind</function>,
+     <function>socket_clear_error</function>,
+     <function>socket_connect</function>,
+     <function>socket_get_option</function>,
+     <function>socket_getpeername</function>,
+     <function>socket_getsockname</function>,
+     <function>socket_last_error</function>,
+     <function>socket_listen</function>,
+     <function>socket_read</function>,
+     <function>socket_recv</function>,
+     <function>socket_recvfrom</function>,
+     <function>socket_recvmsg</function>,
+     <function>socket_select</function>,
+     <function>socket_send</function>,
+     <function>socket_sendmsg</function>,
+     <function>socket_sendto</function>,
+     <function>socket_set_block</function>,
+     <function>socket_set_nonblock</function>,
+     <function>socket_set_option</function>,
+     <function>socket_shutdown</function>,
+     <function>socket_write</function>,
+     <function>socket_wsaprotocol_info_export</function>,
+     <function>socket_wsaprotocol_info_release</function>
+    </entry>
+    <entry>
+     <function>socket_close</function>
+    </entry>
+    <entry>Socket (sockets extension)</entry>
    </row>
    <row>
     <entry>sockets file descriptor set</entry>


### PR DESCRIPTION
Adds documentation for the `Socket` and `AddressInfo` resource types from the `sockets` extension.
There resource types are migrated to [AddressInfo and Socket objects in PHP 8.0](https://php.watch/versions/8.0/sockets-sockets-addressinfo), but this documentation will help for older PHP versions.