### PR TITLE
Improve docs of round()

### DIFF
--- a/reference/math/functions/round.xml
+++ b/reference/math/functions/round.xml
@@ -215,6 +215,7 @@ var_dump(round(9.5, 0, PHP_ROUND_HALF_DOWN));
 var_dump(round(9.5, 0, PHP_ROUND_HALF_EVEN));
 var_dump(round(9.5, 0, PHP_ROUND_HALF_ODD));
 
+echo PHP_EOL;
 echo 'Rounding modes with 8.5' . PHP_EOL;
 var_dump(round(8.5, 0, PHP_ROUND_HALF_UP));
 var_dump(round(8.5, 0, PHP_ROUND_HALF_DOWN));
@@ -231,6 +232,7 @@ float(10)
 float(9)
 float(10)
 float(9)
+
 Rounding modes with 8.5
 float(9)
 float(8)
@@ -248,30 +250,22 @@ float(9)
 <?php
 echo 'Using PHP_ROUND_HALF_UP with 1 decimal digit precision' . PHP_EOL;
 var_dump(round( 1.55, 1, PHP_ROUND_HALF_UP));
-var_dump(round( 1.54, 1, PHP_ROUND_HALF_UP));
 var_dump(round(-1.55, 1, PHP_ROUND_HALF_UP));
-var_dump(round(-1.54, 1, PHP_ROUND_HALF_UP));
 
 echo PHP_EOL;
 echo 'Using PHP_ROUND_HALF_DOWN with 1 decimal digit precision' . PHP_EOL;
 var_dump(round( 1.55, 1, PHP_ROUND_HALF_DOWN));
-var_dump(round( 1.54, 1, PHP_ROUND_HALF_DOWN));
 var_dump(round(-1.55, 1, PHP_ROUND_HALF_DOWN));
-var_dump(round(-1.54, 1, PHP_ROUND_HALF_DOWN));
 
 echo PHP_EOL;
 echo 'Using PHP_ROUND_HALF_EVEN with 1 decimal digit precision' . PHP_EOL;
 var_dump(round( 1.55, 1, PHP_ROUND_HALF_EVEN));
-var_dump(round( 1.54, 1, PHP_ROUND_HALF_EVEN));
 var_dump(round(-1.55, 1, PHP_ROUND_HALF_EVEN));
-var_dump(round(-1.54, 1, PHP_ROUND_HALF_EVEN));
 
 echo PHP_EOL;
 echo 'Using PHP_ROUND_HALF_ODD with 1 decimal digit precision' . PHP_EOL;
 var_dump(round( 1.55, 1, PHP_ROUND_HALF_ODD));
-var_dump(round( 1.54, 1, PHP_ROUND_HALF_ODD));
 var_dump(round(-1.55, 1, PHP_ROUND_HALF_ODD));
-var_dump(round(-1.54, 1, PHP_ROUND_HALF_ODD));
 ?>
 ]]>
     </programlisting>
@@ -280,26 +274,18 @@ var_dump(round(-1.54, 1, PHP_ROUND_HALF_ODD));
 <![CDATA[
 Using PHP_ROUND_HALF_UP with 1 decimal digit precision
 float(1.6)
-float(1.5)
 float(-1.6)
-float(-1.5)
 
 Using PHP_ROUND_HALF_DOWN with 1 decimal digit precision
 float(1.5)
-float(1.5)
-float(-1.5)
 float(-1.5)
 
 Using PHP_ROUND_HALF_EVEN with 1 decimal digit precision
 float(1.6)
-float(1.5)
 float(-1.6)
-float(-1.5)
 
 Using PHP_ROUND_HALF_ODD with 1 decimal digit precision
 float(1.5)
-float(1.5)
-float(-1.5)
 float(-1.5)
 ]]>
     </screen>

--- a/reference/math/functions/round.xml
+++ b/reference/math/functions/round.xml
@@ -93,29 +93,29 @@
           <row>
            <entry><constant>PHP_ROUND_HALF_UP</constant></entry>
            <entry>
-            Round <parameter>val</parameter> up to <parameter>precision</parameter> decimal places
-            away from zero, when it is half way there. Making 1.5 into 2 and -1.5 into -2.
+            Rounds <parameter>val</parameter> away from zero when it is half way there,
+            making 1.5 into 2 and -1.5 into -2.
            </entry>
           </row>
           <row>
            <entry><constant>PHP_ROUND_HALF_DOWN</constant></entry>
            <entry>
-            Round <parameter>val</parameter> down to <parameter>precision</parameter> decimal places
-            towards zero, when it is half way there. Making 1.5 into 1 and -1.5 into -1.
+            Rounds <parameter>val</parameter> towards zero when it is half way there,
+            making 1.5 into 1 and -1.5 into -1.
            </entry>
           </row>
           <row>
            <entry><constant>PHP_ROUND_HALF_EVEN</constant></entry>
            <entry>
-            Round <parameter>val</parameter> to <parameter>precision</parameter> decimal places
-            towards the nearest even value.
+            Rounds <parameter>val</parameter> towards the nearest even value when it is half way
+            there, making both 1.5 and 2.5 into 2.
            </entry>
           </row>
           <row>
            <entry><constant>PHP_ROUND_HALF_ODD</constant></entry>
            <entry>
-            Round <parameter>val</parameter> to <parameter>precision</parameter> decimal places
-            towards the nearest odd value.      
+            Rounds <parameter>val</parameter> towards the nearest odd value when it is half way
+            there, making 1.5 into 1 and and 2.5 into 3.
            </entry>
           </row>
          </tbody>

--- a/reference/math/functions/round.xml
+++ b/reference/math/functions/round.xml
@@ -70,8 +70,9 @@
       <para>
        If the <parameter>precision</parameter> is negative, <parameter>val</parameter> is
        rounded to <parameter>precision</parameter> significant digits before the decimal point,
-       i.e. for a <parameter>precision</parameter> of -1 <parameter>val</parameter> is rounded
-       to tens, for a <parameter>precision</parameter> of -2 to hundreds, etc.
+       i.e. to the nearest multiple of <literal>pow(10, -precision)</literal>, e.g. for a
+       <parameter>precision</parameter> of -1 <parameter>val</parameter> is rounded to tens,
+       for a <parameter>precision</parameter> of -2 to hundreds, etc.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/math/functions/round.xml
+++ b/reference/math/functions/round.xml
@@ -64,12 +64,14 @@
        The optional number of decimal digits to round to.
       </para>
       <para>
-       If the <parameter>precision</parameter> is positive,
-       the rounding will occur after the decimal point.
+       If the <parameter>precision</parameter> is positive, <parameter>val</parameter> is
+       rounded to <parameter>precision</parameter> significant digits after the decimal point.
       </para>
       <para>
-       If the <parameter>precision</parameter> is negative,
-       the rounding will occur before the decimal point.
+       If the <parameter>precision</parameter> is negative, <parameter>val</parameter> is
+       rounded to <parameter>precision</parameter> significant digits before the decimal point,
+       i.e. for a <parameter>precision</parameter> of -1 <parameter>val</parameter> is rounded
+       to tens, for a <parameter>precision</parameter> of -2 to hundreds, etc.
       </para>
      </listitem>
     </varlistentry>
@@ -142,10 +144,12 @@ var_dump(round(3.4));
 var_dump(round(3.5));
 var_dump(round(3.6));
 var_dump(round(3.6, 0));
-var_dump(round(1.95583, 2));
-var_dump(round(1241757, -3));
 var_dump(round(5.045, 2));
 var_dump(round(5.055, 2));
+var_dump(round(345, -2));
+var_dump(round(345, -3));
+var_dump(round(678, -2));
+var_dump(round(678, -3));
 ?>
 ]]>
     </programlisting>
@@ -156,10 +160,12 @@ float(3)
 float(4)
 float(4)
 float(4)
-float(1.96)
-float(1242000)
 float(5.05)
 float(5.06)
+float(300)
+float(0)
+float(700)
+float(1000)
 ]]>
     </screen>
    </example>
@@ -170,27 +176,27 @@ float(5.06)
     <programlisting role="php">
 <![CDATA[
 <?php
-$number = 1346.21;
+$number = 135.79;
 
+var_dump(round($number, 3));
 var_dump(round($number, 2));
 var_dump(round($number, 1));
 var_dump(round($number, 0));
 var_dump(round($number, -1));
 var_dump(round($number, -2));
 var_dump(round($number, -3));
-var_dump(round($number, -4));
 ?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen role="php">
 <![CDATA[
-float(1346.21)
-float(1346.2)
-float(1346)
-float(1350)
-float(1300)
-float(1000)
+float(135.79)
+float(135.79)
+float(135.8)
+float(136)
+float(140)
+float(100)
 float(0)
 ]]>
     </screen>

--- a/reference/math/functions/round.xml
+++ b/reference/math/functions/round.xml
@@ -70,9 +70,6 @@
       <para>
        If the <parameter>precision</parameter> is negative,
        the rounding will occur before the decimal point.
-       If the absolute value of the <parameter>precision</parameter>
-       is greater than or equal to the number of digits, the result
-       of the rounding is equal to <literal>0</literal>
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Passing a negative precision with an absolute value greater than or equal to the number of digits is NOT treated specially, `round(987, 3)` yields the correct result of `float(1000)`, even though the docs incorrectly imply `float(0)`. See https://3v4l.org/HjU7W