### PR TITLE
Add array destructuring documentation to array syntax section

### DIFF
--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -488,10 +488,45 @@ Array
 )
 ]]>
      </screen>
-    </informalexample>       
+    </informalexample>
 
    </note>
 
+  </sect3>
+
+  <sect3 xml:id="language.types.array.syntax.destructuring">
+   <title>Array destructuring</title>
+
+   <note>
+    <para>
+     Array destructuring is available only in PHP versions 7.1 and newer.
+    </para>
+   </note>
+
+   <para>
+    Arrays can be destructured symmetrically. What this means is you can
+    define local scope variables using values from an existing array.
+   </para>
+
+   <para>
+    This feature is similar to what the <function>list</function> construct offers.
+   </para>
+
+   <informalexample>
+    <programlisting role="php">
+ <![CDATA[
+ <?php
+
+ $source_array = ['foo', 'bar', 'baz'];
+
+ [$foo, $bar, $baz] = $source_array;
+
+ assert($foo === 'foo');
+ assert($bar === 'bar');
+ assert($baz === 'baz');
+ ]]>
+    </programlisting>
+   </informalexample>
   </sect3>
  </sect2><!-- end syntax -->
  


### PR DESCRIPTION
This redoes the original PR I made against this repo, but which got stale: #19 

Adds basic syntax documentation for array destructuring.