### PR TITLE
MySQLi updating the documentation: removed functions mysqli_set_local_infile_handler and mysqli_set_local_infile_default

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -425,6 +425,16 @@ currently not documented; only its argument list is available.
 </para>
 '>
 
+<!ENTITY warn.removed.function.5-5-0.alternatives '
+<para xmlns="http://docbook.org/ns/docbook">
+ This function was <emphasis>DEPRECATED</emphasis> and
+ <emphasis>REMOVED</emphasis> in PHP 7.0.0.
+</para>
+<para xmlns="http://docbook.org/ns/docbook">
+ Alternatives to this function include:
+</para>
+'>
+
 <!ENTITY warn.removed.feature.7-0-0.alternatives '
 <para xmlns="http://docbook.org/ns/docbook">
  This feature was <emphasis>REMOVED</emphasis> in PHP 7.0.0.
@@ -1487,9 +1497,6 @@ linkend="book.mysqlnd">mysqlnd</link>.'>
 hand-shake/authentication, which mysqlnd will use.</para><para>Libmysqlclient uses the default charset set in the
 <filename>my.cnf</filename> or by an explicit call to <function>mysqli_options</function> prior to
 calling <function>mysqli_real_connect</function>, but after <function>mysqli_init</function>.</para></note>'>
-
-<!ENTITY mysqli.warn.removed.function-5-5-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
-<emphasis>REMOVED</emphasis> in PHP 5.5.0.</simpara></warning>'>
 
 <!-- Notes for SAPI/Apache -->
 <!ENTITY apache.req.module '<simpara xmlns="http://docbook.org/ns/docbook">This function is supported when PHP

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1488,6 +1488,9 @@ hand-shake/authentication, which mysqlnd will use.</para><para>Libmysqlclient us
 <filename>my.cnf</filename> or by an explicit call to <function>mysqli_options</function> prior to
 calling <function>mysqli_real_connect</function>, but after <function>mysqli_init</function>.</para></note>'>
 
+<!ENTITY mysqli.warn.removed.function-5-5-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
+<emphasis>REMOVED</emphasis> in PHP 5.5.0.</simpara></warning>'>
+
 <!-- Notes for SAPI/Apache -->
 <!ENTITY apache.req.module '<simpara xmlns="http://docbook.org/ns/docbook">This function is supported when PHP
 is installed as an Apache module or by the <link linkend="book.nsapi">NSAPI server module</link> in Netscape/iPlanet/SunONE

--- a/reference/mysqli/mysqli/set-local-infile-default.xml
+++ b/reference/mysqli/mysqli/set-local-infile-default.xml
@@ -8,14 +8,12 @@
  </refnamediv>
 
  <refsynopsisdiv>
-   &mysqli.warn.removed.function-5-5-0;
-   <para>Using these functions is known to lead to stability problems in
-	mysqli. It was only enabled when compiling against libmysql. mysqlnd
-	doesn't have this support for local infile. However, with mysqlnd it can
-	be emulated by using stream handlers like in:
-
-	<literal>$c->query("LOAD DATA LOCAL INFILE "http://example.com/import.csv" INTO ...")</literal>
-	All available protocols, as well as user implemented ones can be added.</para>
+  <warning>
+    warn.removed.function.5-5-0.alternatives;
+    <simplelist role="alternatives"> 
+      <literal>$c->query("LOAD DATA LOCAL INFILE "http://example.com/import.csv" INTO ...")</literal>
+    </simplelist>
+  </warning>
  </refsynopsisdiv>
 
  <refsect1 role="description">

--- a/reference/mysqli/mysqli/set-local-infile-default.xml
+++ b/reference/mysqli/mysqli/set-local-infile-default.xml
@@ -7,6 +7,17 @@
   <refpurpose>Unsets user defined handler for load local infile command</refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+   &mysqli.warn.removed.function-5-5-0;
+   <para>Using these functions is known to lead to stability problems in
+	mysqli. It was only enabled when compiling against libmysql. mysqlnd
+	doesn't have this support for local infile. However, with mysqlnd it can
+	be emulated by using stream handlers like in:
+
+	<literal>$c->query("LOAD DATA LOCAL INFILE "http://example.com/import.csv" INTO ...")</literal>
+	All available protocols, as well as user implemented ones can be added.</para>
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>

--- a/reference/mysqli/mysqli/set-local-infile-handler.xml
+++ b/reference/mysqli/mysqli/set-local-infile-handler.xml
@@ -8,14 +8,12 @@
  </refnamediv>
 
  <refsynopsisdiv>
-   &mysqli.warn.removed.function-5-5-0;
-   <para>Using these functions is known to lead to stability problems in
-	mysqli. It was only enabled when compiling against libmysql. mysqlnd
-	doesn't have this support for local infile. However, with mysqlnd it can
-	be emulated by using stream handlers like in:
-
-	<literal>$c->query("LOAD DATA LOCAL INFILE "http://example.com/import.csv" INTO ...")</literal>
-	All available protocols, as well as user implemented ones can be added.</para>
+  <warning>
+    warn.removed.function.5-5-0.alternatives;
+    <simplelist role="alternatives"> 
+      <literal>$c->query("LOAD DATA LOCAL INFILE "http://example.com/import.csv" INTO ...")</literal>
+    </simplelist>
+  </warning>
  </refsynopsisdiv>
 
  <refsect1 role="description">

--- a/reference/mysqli/mysqli/set-local-infile-handler.xml
+++ b/reference/mysqli/mysqli/set-local-infile-handler.xml
@@ -7,6 +7,17 @@
   <refpurpose>Set callback function for LOAD DATA LOCAL INFILE command</refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+   &mysqli.warn.removed.function-5-5-0;
+   <para>Using these functions is known to lead to stability problems in
+	mysqli. It was only enabled when compiling against libmysql. mysqlnd
+	doesn't have this support for local infile. However, with mysqlnd it can
+	be emulated by using stream handlers like in:
+
+	<literal>$c->query("LOAD DATA LOCAL INFILE "http://example.com/import.csv" INTO ...")</literal>
+	All available protocols, as well as user implemented ones can be added.</para>
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>

--- a/reference/mysqli/versions.xml
+++ b/reference/mysqli/versions.xml
@@ -107,8 +107,8 @@
  <function name="mysqli_server_end" from="PHP 5 &lt; 5.1.0"/>
  <function name="mysqli_server_init" from="PHP 5 &lt; 5.1.0"/>
  <function name="mysqli_set_charset" from="PHP 5 &gt;= 5.0.5, PHP 7"/>
- <function name="mysqli_set_local_infile_default" from="PHP 5 &lt; 5.4.0"/>
- <function name="mysqli_set_local_infile_handler" from="PHP 5, PHP 7"/>
+ <function name="mysqli_set_local_infile_default" from="PHP 5 &lt; 5.5.0"/>
+ <function name="mysqli_set_local_infile_handler" from="PHP 5 &lt; 5.5.0"/>
  <function name="mysqli_set_opt" from="PHP 5, PHP 7"/>
  <function name="mysqli_slave_query" from="PHP 5 &lt; 5.3.0"/>
  <function name="mysqli_sqlstate" from="PHP 5, PHP 7"/>
@@ -190,8 +190,8 @@
  <function name="mysqli::select_db" from="PHP 5, PHP 7"/>
  <function name="mysqli::send_query" from="PHP 5, PHP 7"/>
  <function name="mysqli::set_charset" from="PHP 5 &gt;= 5.0.5, PHP 7"/>
- <function name="mysqli::set_local_infile_default" from="PHP 5 &lt; 5.4.0"/>
- <function name="mysqli::set_local_infile_handler" from="PHP 5, PHP 7"/>
+ <function name="mysqli::set_local_infile_default" from="PHP 5 &lt; 5.5.0"/>
+ <function name="mysqli::set_local_infile_handler" from="PHP 5 &lt; 5.5.0"/>
  <function name="mysqli::set_opt" from="PHP 5, PHP 7"/>
  <function name="mysqli::ssl_set" from="PHP 5, PHP 7"/>
  <function name="mysqli::stat" from="PHP 5, PHP 7"/>


### PR DESCRIPTION
As was explained in [the commit for PHP 5.5.0](https://github.com/php/php-src/commit/522595086b8d654a2fd954977f7f443f2578de22) these functions have been removed. 

Added warning banner to both functions. 
Modified versions.xml with `from="PHP 5 &lt; 5.5.0"`
Added language snippet for `mysqli.warn.removed.function-5-5-0`