### PR TITLE
ReflectionMethod accepts string|object, not mixed

### DIFF
--- a/reference/reflection/reflectionmethod/construct.xml
+++ b/reference/reflection/reflectionmethod/construct.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <methodname>ReflectionMethod::__construct</methodname>
-   <methodparam><type>mixed</type><parameter>class</parameter></methodparam>
+   <methodparam><type>string|object</type><parameter>class</parameter></methodparam>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
   <methodsynopsis>


### PR DESCRIPTION
ReflectionMethod's constructor currently uses `mixed` for its `$class` parameter, when it actually accepts either a `string` or an `object`.

There is precedence in the docs to use union types notation (see [this](https://www.php.net/manual/fr/resourcebundle.get.php) for example), so is it OK if I convert more `mixed` to union types in the future?