### PR TITLE
Note case-sensitivity of the parameter name.

### DIFF
--- a/reference/pgsql/functions/pg-parameter-status.xml
+++ b/reference/pgsql/functions/pg-parameter-status.xml
@@ -72,7 +72,7 @@
         <literal>server_encoding</literal>, <literal>client_encoding</literal>, 
         <literal>is_superuser</literal>, <literal>session_authorization</literal>, 
         <literal>DateStyle</literal>, <literal>TimeZone</literal>, and 
-        <literal>integer_datetimes</literal>.
+        <literal>integer_datetimes</literal>.  Note that this value is case-sensitive.
         </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
One of the comments said this was the case.  No sense leaving it to a comment.  (I'll delete the comment afterward.)