### PR TITLE
Properly mark up nullable and union types

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2199,7 +2199,7 @@ used.</para>'>
 <!ENTITY mongodb.option.collation '
          <row xmlns="http://docbook.org/ns/docbook">
           <entry>collation</entry>
-          <entry><type>array|object</type></entry>
+          <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
            <para>
             <link xlink:href="&url.mongodb.docs.collation;" xmlns:xlink="http://www.w3.org/1999/xlink">Collation</link> allows users to specify language-specific rules for string comparison, such as rules for lettercase and accent marks. When specifying collation, the <literal>"locale"</literal> field is mandatory; all other collation fields are optional. For descriptions of the fields, see <link xlink:href="&url.mongodb.docs.collation;#collation-document" xmlns:xlink="http://www.w3.org/1999/xlink">Collation Document</link>.
@@ -2400,7 +2400,7 @@ local: {
 '>
 <!ENTITY mongodb.parameter.filter '
    <varlistentry xmlns="http://docbook.org/ns/docbook">
-    <term><parameter>filter</parameter> (<type>array|object</type>)</term>
+    <term><parameter>filter</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
     <listitem>
      <para>
       The <link xlink:href="&url.mongodb.docs;tutorial/query-documents/" xmlns:xlink="http://www.w3.org/1999/xlink">query predicate</link>.

--- a/language/predefined/weakreference/get.xml
+++ b/language/predefined/weakreference/get.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>?object</type><methodname>WeakReference::get</methodname>
+   <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>WeakReference::get</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/language/types.xml
+++ b/language/types.xml
@@ -116,7 +116,7 @@
  
    <listitem>
     <simpara>
-     <type>array|object</type>
+     <type class="union"><type>array</type><type>object</type></type>
     </simpara>
    </listitem>
 

--- a/language/types.xml
+++ b/language/types.xml
@@ -116,12 +116,6 @@
  
    <listitem>
     <simpara>
-     <type class="union"><type>array</type><type>object</type></type>
-    </simpara>
-   </listitem>
-
-   <listitem>
-    <simpara>
      <type>void</type>
     </simpara>
    </listitem>

--- a/language/types/pseudo-types.xml
+++ b/language/types/pseudo-types.xml
@@ -31,16 +31,6 @@
 
  </sect2>
 
- <sect2 xml:id="language.types.array-object">
-  <title>array|object</title>
-
-  <para>
-   <literal>array|object</literal> indicates that a parameter can be either
-   <type>array</type> or <type>object</type>.
-  </para>
-
- </sect2>
-
  <sect2 xml:id="language.types.void">
   <title>void</title>
 

--- a/reference/cmark/commonmark.node.codeblock.xml
+++ b/reference/cmark/commonmark.node.codeblock.xml
@@ -43,7 +43,7 @@
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>public</modifier>
-     <type>?string</type>
+     <type class="union"><type>string</type><type>null</type></type>
      <varname>fence</varname>
     </fieldsynopsis>
 

--- a/reference/cmark/commonmark.node.customblock.xml
+++ b/reference/cmark/commonmark.node.customblock.xml
@@ -43,12 +43,12 @@
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>public</modifier>
-     <type>?string</type>
+     <type class="union"><type>string</type><type>null</type></type>
      <varname>onEnter</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
-     <type>?string</type>
+     <type class="union"><type>string</type><type>null</type></type>
      <varname>onLeave</varname>
     </fieldsynopsis>    
 

--- a/reference/cmark/commonmark.node.custominline.xml
+++ b/reference/cmark/commonmark.node.custominline.xml
@@ -42,12 +42,12 @@
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>public</modifier>
-     <type>?string</type>
+     <type class="union"><type>string</type><type>null</type></type>
      <varname>onEnter</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
-     <type>?string</type>
+     <type class="union"><type>string</type><type>null</type></type>
      <varname>onLeave</varname>
     </fieldsynopsis>    
     

--- a/reference/cmark/commonmark.node.image.xml
+++ b/reference/cmark/commonmark.node.image.xml
@@ -42,12 +42,12 @@
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>public</modifier>
-     <type>?string</type>
+     <type class="union"><type>string</type><type>null</type></type>
      <varname>url</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
-     <type>?string</type>
+     <type class="union"><type>string</type><type>null</type></type>
      <varname>title</varname>
     </fieldsynopsis>
 

--- a/reference/cmark/commonmark.node.link.xml
+++ b/reference/cmark/commonmark.node.link.xml
@@ -43,12 +43,12 @@
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>public</modifier>
-     <type>?string</type>
+     <type class="union"><type>string</type><type>null</type></type>
      <varname>url</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
-     <type>?string</type>
+     <type class="union"><type>string</type><type>null</type></type>
      <varname>title</varname>
     </fieldsynopsis>
 

--- a/reference/cmark/commonmark.node.text.xml
+++ b/reference/cmark/commonmark.node.text.xml
@@ -42,7 +42,7 @@
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>public</modifier>
-     <type>?string</type>
+     <type class="union"><type>string</type><type>null</type></type>
      <varname>literal</varname>
     </fieldsynopsis>
 

--- a/reference/cmark/commonmark.node.xml
+++ b/reference/cmark/commonmark.node.xml
@@ -46,31 +46,31 @@
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>readonly</modifier>
-     <type>?Node</type>
+     <type class="union"><type>Node</type><type>null</type></type>
      <varname>parent</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>readonly</modifier>
-     <type>?Node</type>
+     <type class="union"><type>Node</type><type>null</type></type>
      <varname>previous</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>readonly</modifier>
-     <type>?Node</type>
+     <type class="union"><type>Node</type><type>null</type></type>
      <varname>next</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>readonly</modifier>
-     <type>?Node</type>
+     <type class="union"><type>Node</type><type>null</type></type>
      <varname>lastChild</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>readonly</modifier>
-     <type>?Node</type>
+     <type class="union"><type>Node</type><type>null</type></type>
      <varname>firstChild</varname>
     </fieldsynopsis>
     <fieldsynopsis>

--- a/reference/cmark/commonmark/cql/invoke.xml
+++ b/reference/cmark/commonmark/cql/invoke.xml
@@ -36,7 +36,7 @@
      <para>
       should have the prototype:
       <methodsynopsis role="procedural">
-      <type>?bool</type><methodname>handler</methodname>
+      <type class="union"><type>bool</type><type>null</type></type><methodname>handler</methodname>
       <methodparam><type>CommonMark\Node</type><parameter>root</parameter></methodparam>
       <methodparam><type>CommonMark\Node</type><parameter>entering</parameter></methodparam>
       </methodsynopsis>

--- a/reference/cmark/commonmark/interfaces/ivisitor/enter.xml
+++ b/reference/cmark/commonmark/interfaces/ivisitor/enter.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>?int|IVisitable</type><methodname>CommonMark\Interfaces\IVisitor::enter</methodname>
+   <modifier>abstract</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>IVisitable</type><type>null</type></type><methodname>CommonMark\Interfaces\IVisitor::enter</methodname>
    <methodparam><type>IVisitable</type><parameter>visitable</parameter></methodparam>
   </methodsynopsis>
 

--- a/reference/cmark/commonmark/interfaces/ivisitor/leave.xml
+++ b/reference/cmark/commonmark/interfaces/ivisitor/leave.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>?int|IVisitable</type><methodname>CommonMark\Interfaces\IVisitor::leave</methodname>
+   <modifier>abstract</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>IVisitable</type><type>null</type></type><methodname>CommonMark\Interfaces\IVisitor::leave</methodname>
    <methodparam><type>IVisitable</type><parameter>visitable</parameter></methodparam>
   </methodsynopsis>
 

--- a/reference/intl/resourcebundle/get.xml
+++ b/reference/intl/resourcebundle/get.xml
@@ -16,7 +16,7 @@
    <modifier>public</modifier>
    <type>mixed</type>
    <methodname>ResourceBundle::get</methodname>
-   <methodparam><type>string|int</type><parameter>index</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>int</type></type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>fallback</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
   <para>
@@ -26,7 +26,7 @@
    <type>mixed</type>
    <methodname>resourcebundle_get</methodname>
    <methodparam><type>ResourceBundle</type><parameter>r</parameter></methodparam>
-   <methodparam><type>string|int</type><parameter>index</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>int</type></type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>fallback</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/luasandbox/luasandbox/callfunction.xml
+++ b/reference/luasandbox/luasandbox/callfunction.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>array|bool</type><methodname>LuaSandbox::callFunction</methodname>
+   <modifier>public</modifier> <type class="union"><type>array</type><type>bool</type></type><methodname>LuaSandbox::callFunction</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
   </methodsynopsis>

--- a/reference/luasandbox/luasandbox/setcpulimit.xml
+++ b/reference/luasandbox/luasandbox/setcpulimit.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>LuaSandbox::setCPULimit</methodname>
-   <methodparam><type>float|bool</type><parameter>limit</parameter></methodparam>
+   <methodparam><type class="union"><type>float</type><type>bool</type></type><parameter>limit</parameter></methodparam>
   </methodsynopsis>
   <para>
    Sets the CPU time limit for the Lua environment.

--- a/reference/luasandbox/luasandboxfunction/call.xml
+++ b/reference/luasandbox/luasandboxfunction/call.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>array|bool</type><methodname>LuaSandboxFunction::call</methodname>
+   <modifier>public</modifier> <type class="union"><type>array</type><type>bool</type></type><methodname>LuaSandboxFunction::call</methodname>
    <methodparam choice="opt"><type>string</type><parameter>...</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/misc/functions/sapi-windows-cp-conv.xml
+++ b/reference/misc/functions/sapi-windows-cp-conv.xml
@@ -11,8 +11,8 @@
   &reftitle.description;
   <methodsynopsis role="procedural">
    <type>string</type><methodname>sapi_windows_cp_conv</methodname>
-   <methodparam><type>int|string</type><parameter>in_codepage</parameter></methodparam>
-   <methodparam><type>int|string</type><parameter>out_codepage</parameter></methodparam>
+   <methodparam><type class="union"><type>int</type><type>string</type></type><parameter>in_codepage</parameter></methodparam>
+   <methodparam><type class="union"><type>int</type><type>string</type></type><parameter>out_codepage</parameter></methodparam>
    <methodparam><type>string</type><parameter>subject</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/mongo/mongoclient/close.xml
+++ b/reference/mongo/mongoclient/close.xml
@@ -17,7 +17,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>MongoClient::close</methodname>
-   <methodparam choice="opt"><type>boolean|string</type><parameter>connection</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>bool</type><type>string</type></type><parameter>connection</parameter></methodparam>
   </methodsynopsis>
   <para>
    The <function>MongoClient::close</function> method forcefully closes a

--- a/reference/mongo/mongoclient/killcursor.xml
+++ b/reference/mongo/mongoclient/killcursor.xml
@@ -16,7 +16,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>MongoClient::killCursor</methodname>
    <methodparam><type>string</type><parameter>server_hash</parameter></methodparam>
-   <methodparam><type>int|MongoInt64</type><parameter>id</parameter></methodparam>
+   <methodparam><type class="union"><type>int</type><type>MongoInt64</type></type><parameter>id</parameter></methodparam>
   </methodsynopsis>
   <para>
    In certain situations it might be needed to kill a cursor on the server.

--- a/reference/mongo/mongocollection/deleteindex.xml
+++ b/reference/mongo/mongocollection/deleteindex.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>array</type><methodname>MongoCollection::deleteIndex</methodname>
-   <methodparam><type>string|array</type><parameter>keys</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
   </methodsynopsis>
   <para>
    This method is identical to:

--- a/reference/mongo/mongocollection/ensureindex.xml
+++ b/reference/mongo/mongocollection/ensureindex.xml
@@ -13,7 +13,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>MongoCollection::ensureIndex</methodname>
-   <methodparam><type>string|array</type><parameter>key|keys</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>key|keys</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
   </methodsynopsis>
   <warning>

--- a/reference/mongo/mongocollection/insert.xml
+++ b/reference/mongo/mongocollection/insert.xml
@@ -10,8 +10,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>bool|array</type><methodname>MongoCollection::insert</methodname>
-   <methodparam><type>array|object</type><parameter>document</parameter></methodparam>
+   <modifier>public</modifier> <type class="union"><type>bool</type><type>array</type></type><methodname>MongoCollection::insert</methodname>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>document</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/mongo/mongocollection/remove.xml
+++ b/reference/mongo/mongocollection/remove.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>bool|array</type><methodname>MongoCollection::remove</methodname>
+   <modifier>public</modifier> <type class="union"><type>bool</type><type>array</type></type><methodname>MongoCollection::remove</methodname>
    <methodparam choice="opt"><type>array</type><parameter>criteria</parameter><initializer>array()</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
   </methodsynopsis>

--- a/reference/mongo/mongocollection/save.xml
+++ b/reference/mongo/mongocollection/save.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>MongoCollection::save</methodname>
-   <methodparam><type>array|object</type><parameter>document</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>document</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/mongo/mongocollection/update.xml
+++ b/reference/mongo/mongocollection/update.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>bool|array</type><methodname>MongoCollection::update</methodname>
+   <modifier>public</modifier> <type class="union"><type>bool</type><type>array</type></type><methodname>MongoCollection::update</methodname>
    <methodparam><type>array</type><parameter>criteria</parameter></methodparam>
    <methodparam><type>array</type><parameter>new_object</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>

--- a/reference/mongo/mongocursor/key.xml
+++ b/reference/mongo/mongocursor/key.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>string|int</type><methodname>MongoCursor::key</methodname>
+   <modifier>public</modifier> <type class="union"><type>string</type><type>int</type></type><methodname>MongoCursor::key</methodname>
    <void/>
   </methodsynopsis>
  </refsect1>

--- a/reference/mongo/mongogridfs/delete.xml
+++ b/reference/mongo/mongogridfs/delete.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>bool|array</type><methodname>MongoGridFS::delete</methodname>
+   <modifier>public</modifier> <type class="union"><type>bool</type><type>array</type></type><methodname>MongoGridFS::delete</methodname>
    <methodparam><type>mixed</type><parameter>id</parameter></methodparam>
   </methodsynopsis>
 

--- a/reference/mongo/mongogridfs/remove.xml
+++ b/reference/mongo/mongogridfs/remove.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>bool|array</type><methodname>MongoGridFS::remove</methodname>
+   <modifier>public</modifier> <type class="union"><type>bool</type><type>array</type></type><methodname>MongoGridFS::remove</methodname>
    <methodparam choice="opt"><type>array</type><parameter>criteria</parameter><initializer>array()</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
   </methodsynopsis>

--- a/reference/mongo/mongogridfs/storefile.xml
+++ b/reference/mongo/mongogridfs/storefile.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>MongoGridFS::storeFile</methodname>
-   <methodparam><type>string|resource</type><parameter>filename</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>resource</type></type><parameter>filename</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>metadata</parameter><initializer>array()</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
   </methodsynopsis>

--- a/reference/mongo/mongoid/construct.xml
+++ b/reference/mongo/mongoid/construct.xml
@@ -20,7 +20,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <methodname>MongoId::__construct</methodname>
-   <methodparam choice="opt"><type>string|MongoId</type><parameter>id</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>MongoId</type></type><parameter>id</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
  </refsect1>
 

--- a/reference/mongodb/bson/javascript/construct.xml
+++ b/reference/mongodb/bson/javascript/construct.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\BSON\Javascript::__construct</methodname>
    <methodparam><type>string</type><parameter>code</parameter></methodparam>
-   <methodparam choice="opt"><type>array|object</type><parameter>scope</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>object</type></type><parameter>scope</parameter></methodparam>
   </methodsynopsis>
  </refsect1>
 
@@ -28,7 +28,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>scope</parameter> (<type>array|object</type>)</term>
+    <term><parameter>scope</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
     <listitem>
      <para>
       Javascript scope.

--- a/reference/mongodb/bson/javascript/getscope.xml
+++ b/reference/mongodb/bson/javascript/getscope.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>object|null</type><methodname>MongoDB\BSON\Javascript::getScope</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\BSON\Javascript::getScope</methodname>
    <void />
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/bson/javascriptinterface/getscope.xml
+++ b/reference/mongodb/bson/javascriptinterface/getscope.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>object|null</type><methodname>MongoDB\BSON\JavascriptInterface::getScope</methodname>
+   <modifier>abstract</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\BSON\JavascriptInterface::getScope</methodname>
    <void />
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/bson/serializable/bsonserialize.xml
+++ b/reference/mongodb/bson/serializable/bsonserialize.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>array|object</type><methodname>MongoDB\BSON\Serializable::bsonSerialize</methodname>
+   <modifier>abstract</modifier> <modifier>public</modifier> <type class="union"><type>array</type><type>object</type></type><methodname>MongoDB\BSON\Serializable::bsonSerialize</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/mongodb/bson/utcdatetime/construct.xml
+++ b/reference/mongodb/bson/utcdatetime/construct.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\BSON\UTCDateTime::__construct</methodname>
-   <methodparam choice="opt"><type>integer|float|string|DateTimeInterface</type><parameter>milliseconds</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>float</type><type>string</type><type>DateTimeInterface</type></type><parameter>milliseconds</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
  </refsect1>
 
@@ -19,7 +19,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>milliseconds</parameter> (<type>integer|float|string|DateTimeInterface</type>)</term>
+    <term><parameter>milliseconds</parameter> (<type class="union"><type>int</type><type>float</type><type>string</type><type>DateTimeInterface</type></type>)</term>
     <listitem>
      <para>
       Number of milliseconds since the Unix epoch (Jan 1, 1970). Negative values

--- a/reference/mongodb/functions/bson/fromphp.xml
+++ b/reference/mongodb/functions/bson/fromphp.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>string</type><methodname>MongoDB\BSON\fromPHP</methodname>
-   <methodparam><type>array|object</type><parameter>value</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
    Serializes a PHP array or object (e.g. document) to its
@@ -24,7 +24,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>value</parameter> (<type>array|object</type>)</term>
+    <term><parameter>value</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
     <listitem>
      <para>
       PHP value to be serialized.

--- a/reference/mongodb/functions/bson/tophp.xml
+++ b/reference/mongodb/functions/bson/tophp.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array|object</type><methodname>MongoDB\BSON\toPHP</methodname>
+   <type class="union"><type>array</type><type>object</type></type><methodname>MongoDB\BSON\toPHP</methodname>
    <methodparam><type>string</type><parameter>bson</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>typeMap</parameter><initializer>array()</initializer></methodparam>
   </methodsynopsis>

--- a/reference/mongodb/mongodb/driver/bulkwrite/delete.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/delete.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\BulkWrite::delete</methodname>
-   <methodparam><type>array|object</type><parameter>filter</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>deleteOptions</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -44,7 +44,7 @@
          &mongodb.option.collation;
          <row>
           <entry>hint</entry>
-          <entry><type>string|array|object</type></entry>
+          <entry><type class="union"><type>string</type><type>array</type><type>object</type></type></entry>
           <entry>
            <para>
             Index specification. Specify either the index name as a string or

--- a/reference/mongodb/mongodb/driver/bulkwrite/insert.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/insert.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>MongoDB\Driver\BulkWrite::insert</methodname>
-   <methodparam><type>array|object</type><parameter>document</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>document</parameter></methodparam>
   </methodsynopsis>
   <para>
    Adds an insert operation to the
@@ -24,7 +24,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>document</parameter> (<type>array|object</type>)</term>
+    <term><parameter>document</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
     <listitem>
      <para>
       A document to insert.

--- a/reference/mongodb/mongodb/driver/bulkwrite/update.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/update.xml
@@ -11,8 +11,8 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\BulkWrite::update</methodname>
-   <methodparam><type>array|object</type><parameter>filter</parameter></methodparam>
-   <methodparam><type>array|object</type><parameter>newObj</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>newObj</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>updateOptions</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -27,7 +27,7 @@
   <variablelist>
    &mongodb.parameter.filter;
    <varlistentry>
-    <term><parameter>newObj</parameter> (<type>array|object</type>)</term>
+    <term><parameter>newObj</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
     <listitem>
      <para>
       A document containing either update operators (e.g.
@@ -73,7 +73,7 @@
          &mongodb.option.collation;
          <row>
           <entry>hint</entry>
-          <entry><type>string|array|object</type></entry>
+          <entry><type class="union"><type>string</type><type>array</type><type>object</type></type></entry>
           <entry>
            <para>
             Index specification. Specify either the index name as a string or

--- a/reference/mongodb/mongodb/driver/command/construct.xml
+++ b/reference/mongodb/mongodb/driver/command/construct.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\Command::__construct</methodname>
-   <methodparam><type>array|object</type><parameter>document</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>document</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>commandOptions</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/mongodb/mongodb/driver/exception/runtimeexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/runtimeexception.xml
@@ -44,7 +44,7 @@
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>protected</modifier>
-     <type>array|null</type>
+     <type class="union"><type>array</type><type>null</type></type>
      <varname linkend="mongodb-driver-exception-runtimeexception.props.errorlabels">errorLabels</varname>
     </fieldsynopsis>
 

--- a/reference/mongodb/mongodb/driver/manager/construct.xml
+++ b/reference/mongodb/mongodb/driver/manager/construct.xml
@@ -612,7 +612,7 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
          </row>
          <row>
           <entry>w</entry>
-          <entry><type>integer|string</type></entry>
+          <entry><type class="union"><type>int</type><type>string</type></type></entry>
           <entry>
            <para>
             Corresponds to the default write concern's <parameter>w</parameter>
@@ -623,7 +623,7 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
          </row>
          <row>
           <entry>wTimeoutMS</entry>
-          <entry><type>integer|string</type></entry>
+          <entry><type class="union"><type>int</type><type>string</type></type></entry>
           <entry>
            <para>
             Corresponds to the default write concern's

--- a/reference/mongodb/mongodb/driver/query/construct.xml
+++ b/reference/mongodb/mongodb/driver/query/construct.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\Query::__construct</methodname>
-   <methodparam><type>array|object</type><parameter>filter</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>queryOptions</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -150,7 +150,7 @@
          </row>
          <row>
           <entry>hint</entry>
-          <entry><type>string|array|object</type></entry>
+          <entry><type class="union"><type>string</type><type>array</type><type>object</type></type></entry>
           <entry>
            <para>
             Index specification. Specify either the index name as a string or
@@ -182,7 +182,7 @@
          </row>
          <row>
           <entry>max</entry>
-          <entry><type>array|object</type></entry>
+          <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
            <para>
             The <emphasis>exclusive</emphasis> upper bound for a specific index.
@@ -242,7 +242,7 @@
          </row>
          <row>
           <entry>min</entry>
-          <entry><type>array|object</type></entry>
+          <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
            <para>
             The <emphasis>inclusive</emphasis> lower bound for a specific index.
@@ -290,7 +290,7 @@
          </row>
          <row>
           <entry>projection</entry>
-          <entry><type>array|object</type></entry>
+          <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
            <para>
             The <link xlink:href="&url.mongodb.docs;tutorial/project-fields-from-query-results/">projection specification</link>
@@ -394,7 +394,7 @@
          </row>
          <row>
           <entry>sort</entry>
-          <entry><type>array|object</type></entry>
+          <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
            <para>The sort specification for the ordering of the results.</para>
            <para>

--- a/reference/mongodb/mongodb/driver/readconcern/getlevel.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/getlevel.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>string|null</type><methodname>MongoDB\Driver\ReadConcern::getLevel</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>MongoDB\Driver\ReadConcern::getLevel</methodname>
    <void />
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/mongodb/driver/readpreference/construct.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/construct.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\ReadPreference::__construct</methodname>
-   <methodparam><type>string|integer</type><parameter>mode</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>int</type></type><parameter>mode</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>tagSets</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
   </methodsynopsis>
@@ -129,7 +129,7 @@
         <tbody>
          <row>
           <entry>hedge</entry>
-          <entry><type>object|array</type></entry>
+          <entry><type class="union"><type>object</type><type>array</type></type></entry>
           <entry>
            <para>Specifies whether to use <link xlink:href="&url.mongodb.docs;core/sharded-cluster-query-router/#mongos-hedged-reads">hedged reads</link>, which are supported by MongoDB 4.4+ for sharded queries.</para>
            <para>

--- a/reference/mongodb/mongodb/driver/readpreference/gethedge.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/gethedge.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>object|null</type><methodname>MongoDB\Driver\ReadPreference::getHedge</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\ReadPreference::getHedge</methodname>
    <void />
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/mongodb/driver/session/advanceclustertime.xml
+++ b/reference/mongodb/mongodb/driver/session/advanceclustertime.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::advanceClusterTime</methodname>
-   <methodparam><type>array|object</type><parameter>clusterTime</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>clusterTime</parameter></methodparam>
   </methodsynopsis>
   <para>
    Advances the cluster time for this session. If the cluster time is less than

--- a/reference/mongodb/mongodb/driver/session/getclustertime.xml
+++ b/reference/mongodb/mongodb/driver/session/getclustertime.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>object|null</type><methodname>MongoDB\Driver\Session::getClusterTime</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\Session::getClusterTime</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/mongodb/mongodb/driver/session/getoperationtime.xml
+++ b/reference/mongodb/mongodb/driver/session/getoperationtime.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\BSON\Timestamp|null</type><methodname>MongoDB\Driver\Session::getOperationTime</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\BSON\Timestamp</type><type>null</type></type><methodname>MongoDB\Driver\Session::getOperationTime</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/mongodb/mongodb/driver/session/getserver.xml
+++ b/reference/mongodb/mongodb/driver/session/getserver.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Server|null</type><methodname>MongoDB\Driver\Session::getServer</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\Driver\Server</type><type>null</type></type><methodname>MongoDB\Driver\Session::getServer</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/mongodb/mongodb/driver/session/gettransactionoptions.xml
+++ b/reference/mongodb/mongodb/driver/session/gettransactionoptions.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>array|null</type><methodname>MongoDB\Driver\Session::getTransactionOptions</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>array</type><type>null</type></type><methodname>MongoDB\Driver\Session::getTransactionOptions</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/mongodb/mongodb/driver/writeconcern/construct.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/construct.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\WriteConcern::__construct</methodname>
-   <methodparam><type>string|integer</type><parameter>w</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>int</type></type><parameter>w</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>wtimeout</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>journal</parameter></methodparam>
   </methodsynopsis>

--- a/reference/mongodb/mongodb/driver/writeconcern/getjournal.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/getjournal.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>boolean|null</type><methodname>MongoDB\Driver\WriteConcern::getJournal</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>boolean</type><type>null</type></type><methodname>MongoDB\Driver\WriteConcern::getJournal</methodname>
    <void />
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/mongodb/driver/writeconcern/getw.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/getw.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>string|integer|null</type><methodname>MongoDB\Driver\WriteConcern::getW</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>string</type><type>integer</type><type>null</type></type><methodname>MongoDB\Driver\WriteConcern::getW</methodname>
    <void />
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/mongodb/driver/writeconcern/getwtimeout.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/getwtimeout.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>int|MongoDB\BSON\Int64</type><methodname>MongoDB\Driver\WriteConcern::getWtimeout</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>MongoDB\BSON\Int64</type></type><methodname>MongoDB\Driver\WriteConcern::getWtimeout</methodname>
    <void />
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/mongodb/driver/writeconcernerror/getinfo.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror/getinfo.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>object|null</type><methodname>MongoDB\Driver\WriteConcernError::getInfo</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\WriteConcernError::getInfo</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/mongodb/mongodb/driver/writeerror/getinfo.xml
+++ b/reference/mongodb/mongodb/driver/writeerror/getinfo.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>object|null</type><methodname>MongoDB\Driver\WriteError::getInfo</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\WriteError::getInfo</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/mongodb/mongodb/driver/writeresult/getdeletedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getdeletedcount.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>integer|null</type><methodname>MongoDB\Driver\WriteResult::getDeletedCount</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>MongoDB\Driver\WriteResult::getDeletedCount</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/mongodb/mongodb/driver/writeresult/getinsertedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getinsertedcount.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>integer|null</type><methodname>MongoDB\Driver\WriteResult::getInsertedCount</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>MongoDB\Driver\WriteResult::getInsertedCount</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/mongodb/mongodb/driver/writeresult/getmatchedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getmatchedcount.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>integer|null</type><methodname>MongoDB\Driver\WriteResult::getMatchedCount</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>MongoDB\Driver\WriteResult::getMatchedCount</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/mongodb/mongodb/driver/writeresult/getmodifiedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getmodifiedcount.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>integer|null</type><methodname>MongoDB\Driver\WriteResult::getModifiedCount</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>MongoDB\Driver\WriteResult::getModifiedCount</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/mongodb/mongodb/driver/writeresult/getupsertedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getupsertedcount.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>integer|null</type><methodname>MongoDB\Driver\WriteResult::getUpsertedCount</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>MongoDB\Driver\WriteResult::getUpsertedCount</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/mongodb/mongodb/driver/writeresult/getwriteconcernerror.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getwriteconcernerror.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\WriteConcernError|null</type><methodname>MongoDB\Driver\WriteResult::getWriteConcernError</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\Driver\WriteConcernError</type><type>null</type></type><methodname>MongoDB\Driver\WriteResult::getWriteConcernError</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/parallel/functions/parallel.run.xml
+++ b/reference/parallel/functions/parallel.run.xml
@@ -10,14 +10,14 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>?Future</type><methodname>parallel\run</methodname>
+   <type class="union"><type>Future</type><type>null</type></type><methodname>parallel\run</methodname>
    <methodparam><type>Closure</type><parameter>task</parameter></methodparam>
   </methodsynopsis>
   <para>
    Shall schedule <parameter>task</parameter> for execution in parallel.
   </para>
   <methodsynopsis>
-   <type>?Future</type><methodname>parallel\run</methodname>
+   <type class="union"><type>Future</type><type>null</type></type><methodname>parallel\run</methodname>
    <methodparam><type>Closure</type><parameter>task</parameter></methodparam>
    <methodparam><type>array</type><parameter>argv</parameter></methodparam>
   </methodsynopsis>

--- a/reference/parallel/parallel/events/poll.xml
+++ b/reference/parallel/parallel/events/poll.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description" audience="polling">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>?Event</type><methodname>parallel\Events::poll</methodname>
+   <modifier>public</modifier> <type class="union"><type>Event</type><type>null</type></type><methodname>parallel\Events::poll</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/parallel/parallel/runtime/run.xml
+++ b/reference/parallel/parallel/runtime/run.xml
@@ -10,14 +10,14 @@
  <refsect1 role="description" audience="execute">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>?Future</type><methodname>parallel\Runtime::run</methodname>
+   <modifier>public</modifier> <type class="union"><type>Future</type><type>null</type></type><methodname>parallel\Runtime::run</methodname>
    <methodparam><type>Closure</type><parameter>task</parameter></methodparam>
   </methodsynopsis>
   <para>
    Shall schedule <parameter>task</parameter> for execution in parallel.
   </para>
   <methodsynopsis>
-   <modifier>public</modifier> <type>?Future</type><methodname>parallel\Runtime::run</methodname>
+   <modifier>public</modifier> <type class="union"><type>Future</type><type>null</type></type><methodname>parallel\Runtime::run</methodname>
    <methodparam><type>Closure</type><parameter>task</parameter></methodparam>
    <methodparam><type>array</type><parameter>argv</parameter></methodparam>
   </methodsynopsis>

--- a/reference/pcntl/functions/pcntl-signal.xml
+++ b/reference/pcntl/functions/pcntl-signal.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>pcntl_signal</methodname>
    <methodparam><type>int</type><parameter>signo</parameter></methodparam>
-   <methodparam><type>callable|int</type><parameter>handler</parameter></methodparam>
+   <methodparam><type class="union"><type>callable</type><type>int</type></type><parameter>handler</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>restart_syscalls</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/phar/Phar/extractTo.xml
+++ b/reference/phar/Phar/extractTo.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Phar::extractTo</methodname>
    <methodparam><type>string</type><parameter>pathto</parameter></methodparam>
-   <methodparam choice="opt"><type>string|array</type><parameter>files</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>array</type></type><parameter>files</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>overwrite</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
 

--- a/reference/phar/PharData/extractTo.xml
+++ b/reference/phar/PharData/extractTo.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>PharData::extractTo</methodname>
    <methodparam><type>string</type><parameter>pathto</parameter></methodparam>
-   <methodparam choice="opt"><type>string|array</type><parameter>files</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>array</type></type><parameter>files</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>overwrite</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
 

--- a/reference/reflection/reflectionproperty/gettype.xml
+++ b/reference/reflection/reflectionproperty/gettype.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>?ReflectionType</type><methodname>ReflectionProperty::getType</methodname>
+   <modifier>public</modifier> <type class="union"><type>ReflectionType</type><type>null</type></type><methodname>ReflectionProperty::getType</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/spl/recursivetreeiterator/construct.xml
+++ b/reference/spl/recursivetreeiterator/construct.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <methodname>RecursiveTreeIterator::__construct</methodname>
-   <methodparam><type>RecursiveIterator|IteratorAggregate</type><parameter>it</parameter></methodparam>
+   <methodparam><type class="union"><type>RecursiveIterator</type><type>IteratorAggregate</type></type><parameter>it</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>RecursiveTreeIterator::BYPASS_KEY</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>cit_flags</parameter><initializer>CachingIterator::CATCH_GET_CHILD</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer>RecursiveIteratorIterator::SELF_FIRST</initializer></methodparam>

--- a/reference/spl/splfileobject/current.xml
+++ b/reference/spl/splfileobject/current.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>string|array</type><methodname>SplFileObject::current</methodname>
+   <modifier>public</modifier> <type class="union"><type>string</type><type>array</type></type><methodname>SplFileObject::current</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/varnish/varnishadmin/setparam.xml
+++ b/reference/varnish/varnishadmin/setparam.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>int</type><methodname>VarnishAdmin::setParam</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam><type>string|integer</type><parameter>value</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>int</type></type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
 

--- a/reference/wkhtmltox/wkhtmltox/image/converter/convert.xml
+++ b/reference/wkhtmltox/wkhtmltox/image/converter/convert.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>?string</type><methodname>wkhtmltox\Image\Converter::convert</methodname>
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>wkhtmltox\Image\Converter::convert</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/wkhtmltox/wkhtmltox/pdf/converter/convert.xml
+++ b/reference/wkhtmltox/wkhtmltox/pdf/converter/convert.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>?string</type><methodname>wkhtmltox\PDF\Converter::convert</methodname>
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>wkhtmltox\PDF\Converter::convert</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/yac/yac/delete.xml
+++ b/reference/yac/yac/delete.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Yac::delete</methodname>
-   <methodparam><type>string|array</type><parameter>keys</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/yac/yac/get.xml
+++ b/reference/yac/yac/get.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>Yac::get</methodname>
-   <methodparam><type>string|array</type><parameter>key</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>key</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter role="reference">cas</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/yaf/yaf_loader/registernamespace.xml
+++ b/reference/yaf/yaf_loader/registernamespace.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Yaf_Loader::registerNamespace</methodname>
-   <methodparam><type>string|array</type><parameter>namespaces</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>namespaces</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>path</parameter></methodparam>
   </methodsynopsis>
   <para>


### PR DESCRIPTION
We change all existing nullable and union types to use the dedicated DocBook markup for union types. This requires support in PhD for proper rendering; see https://github.com/php/phd/pull/30.