### PR TITLE
Link to __serialize()/__unserialize() from Serializable

### DIFF
--- a/language/predefined/serializable/serialize.xml
+++ b/language/predefined/serializable/serialize.xml
@@ -44,6 +44,7 @@
   <para>
    <simplelist>
     <member><link linkend="object.sleep">__sleep()</link></member>
+    <member><link linkend="object.serialize">__serialize()</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/language/predefined/serializable/unserialize.xml
+++ b/language/predefined/serializable/unserialize.xml
@@ -55,6 +55,7 @@
   <para>
    <simplelist>
     <member><link linkend="object.wakeup">__wakeup()</link></member>
+    <member><link linkend="object.unserialize">__unserialize()</link></member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
Those magic methods were introduced in php 7.4 to resolve some of the
limitations with __wakeup() or Serializable

Related to https://github.com/php/doc-en/pull/63