### PR TITLE
Fix #78142: Function prototype return value does not contain type in …

### DIFF
--- a/reference/mbstring/functions/mb-strpos.xml
+++ b/reference/mbstring/functions/mb-strpos.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>int</type><methodname>mb_strpos</methodname>
+   <type class="union"><type>int</type><type>false</type></type><methodname>mb_strpos</methodname>
    <methodparam><type>string</type><parameter>haystack</parameter></methodparam>
    <methodparam><type>string</type><parameter>needle</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>offset</parameter><initializer>0</initializer></methodparam>


### PR DESCRIPTION
…case of failure

---

This is blocked by missing support for union type rendering in PhD (see https://github.com/php/phd/pull/30).