### PR TITLE
Don't use FQNs for types

### DIFF
--- a/reference/componere/componere/abstract/definition/addmethod.xml
+++ b/reference/componere/componere/abstract/definition/addmethod.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>Definition</type><methodname>Componere\Abstract\Definition::addMethod</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam><type>\Componere\Method</type><parameter>method</parameter></methodparam>
+   <methodparam><type>Componere\Method</type><parameter>method</parameter></methodparam>
   </methodsynopsis>
   <para>
     Shall create or override a method on the current definition.
@@ -35,7 +35,7 @@
     <term><parameter>method</parameter></term>
     <listitem>
      <para>
-      <type>\Componere\Method</type> not previously added to another <type>Definition</type>
+      <type>Componere\Method</type> not previously added to another <type>Definition</type>
      </para>
     </listitem>
    </varlistentry>

--- a/reference/componere/componere/abstract/definition/getreflector.xml
+++ b/reference/componere/componere/abstract/definition/getreflector.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>\ReflectionClass</type><methodname>Componere\Abstract\Definition::getReflector</methodname>
+   <modifier>public</modifier> <type>ReflectionClass</type><methodname>Componere\Abstract\Definition::getReflector</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/componere/componere/definition/addconstant.xml
+++ b/reference/componere/componere/definition/addconstant.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>Definition</type><methodname>Componere\Definition::addConstant</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam><type>\Componere\Value</type><parameter>value</parameter></methodparam>
+   <methodparam><type>Componere\Value</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
    Shall declare a class constant on the current Definition

--- a/reference/componere/componere/definition/addproperty.xml
+++ b/reference/componere/componere/definition/addproperty.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>Definition</type><methodname>Componere\Definition::addProperty</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam><type>\Componere\Value</type><parameter>value</parameter></methodparam>
+   <methodparam><type>Componere\Value</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
    Shall declare a class property on the current Definition

--- a/reference/componere/componere/definition/getclosure.xml
+++ b/reference/componere/componere/definition/getclosure.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>\Closure</type><methodname>Componere\Definition::getClosure</methodname>
+   <modifier>public</modifier> <type>Closure</type><methodname>Componere\Definition::getClosure</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/componere/componere/method/construct.xml
+++ b/reference/componere/componere/method/construct.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <constructorsynopsis>
    <modifier>public</modifier> <methodname>Componere\Method::__construct</methodname>
-   <methodparam><type>\Closure</type><parameter>closure</parameter></methodparam>
+   <methodparam><type>Closure</type><parameter>closure</parameter></methodparam>
   </constructorsynopsis>
 
  </refsect1>

--- a/reference/componere/componere/method/getreflector.xml
+++ b/reference/componere/componere/method/getreflector.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>\ReflectionMethod</type><methodname>Componere\Method::getReflector</methodname>
+   <modifier>public</modifier> <type>ReflectionMethod</type><methodname>Componere\Method::getReflector</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/componere/componere/patch/getclosure.xml
+++ b/reference/componere/componere/patch/getclosure.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>\Closure</type><methodname>Componere\Patch::getClosure</methodname>
+   <modifier>public</modifier> <type>Closure</type><methodname>Componere\Patch::getClosure</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
   <para>


### PR DESCRIPTION
Using fully qualified names for identifiers in the manual is uncommon;
at least identifiers of the global namespace are (almost) always
written unqualified.  Furthermore, FQNs are not supported by the auto-
linking of PhD.

---

This PR covers Componere, but it is actually more about establishing a convention. If other prefer fully qualified names, we should go that route, but at least be consistent in the rendered manual (i.e. add proper support for FQNs, and render possibly missing leading backslashes).