### PR TITLE
Document ArrayAccess in PHP-DS

### DIFF
--- a/reference/ds/ds.deque.xml
+++ b/reference/ds/ds.deque.xml
@@ -113,6 +113,29 @@
   </section>
 <!-- }}} -->
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>1.3.0</entry>
+        <entry>
+         The class now implements <classname>ArrayAccess</classname>.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
 
  </partintro>
 

--- a/reference/ds/ds.deque.xml
+++ b/reference/ds/ds.deque.xml
@@ -126,7 +126,7 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.3.0</entry>
+        <entry>PECL ds 1.3.0</entry>
         <entry>
          The class now implements <classname>ArrayAccess</classname>.
         </entry>

--- a/reference/ds/ds.map.xml
+++ b/reference/ds/ds.map.xml
@@ -59,6 +59,9 @@
      <oointerface>
       <interfacename>Ds\Collection</interfacename>
      </oointerface>
+     <oointerface>
+      <interfacename>ArrayAccess</interfacename>
+     </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
     <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
@@ -92,6 +95,29 @@
   </section>
 <!-- }}} -->
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>1.3.0</entry>
+        <entry>
+         The class now implements <classname>ArrayAccess</classname>.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
 
  </partintro>
 

--- a/reference/ds/ds.map.xml
+++ b/reference/ds/ds.map.xml
@@ -108,7 +108,7 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.3.0</entry>
+        <entry>PECL ds 1.3.0</entry>
         <entry>
          The class now implements <classname>ArrayAccess</classname>.
         </entry>

--- a/reference/ds/ds.queue.xml
+++ b/reference/ds/ds.queue.xml
@@ -84,7 +84,7 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.3.0</entry>
+        <entry>PECL ds 1.3.0</entry>
         <entry>
          The class now implements <classname>ArrayAccess</classname>.
         </entry>

--- a/reference/ds/ds.queue.xml
+++ b/reference/ds/ds.queue.xml
@@ -35,6 +35,9 @@
      <oointerface>
       <interfacename>Ds\Collection</interfacename>
      </oointerface>
+     <oointerface>
+      <interfacename>ArrayAccess</interfacename>
+     </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
     <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
@@ -68,6 +71,29 @@
   </section>
 <!-- }}} -->
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>1.3.0</entry>
+        <entry>
+         The class now implements <classname>ArrayAccess</classname>.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
 
  </partintro>
 

--- a/reference/ds/ds.sequence.xml
+++ b/reference/ds/ds.sequence.xml
@@ -45,6 +45,7 @@
 
     <ooclass><classname>Ds\Sequence</classname></ooclass>
     <oointerface><interfacename>Ds\Collection</interfacename></oointerface>
+    <oointerface><interfacename>ArrayAccess</interfacename></oointerface>
 
     </classsynopsisinfo>
 <!-- }}} -->
@@ -54,6 +55,30 @@
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>1.3.0</entry>
+        <entry>
+         The interface now extends <classname>ArrayAccess</classname>.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/ds/ds.sequence.xml
+++ b/reference/ds/ds.sequence.xml
@@ -70,7 +70,7 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.3.0</entry>
+        <entry>PECL ds 1.3.0</entry>
         <entry>
          The interface now extends <classname>ArrayAccess</classname>.
         </entry>

--- a/reference/ds/ds.set.xml
+++ b/reference/ds/ds.set.xml
@@ -121,7 +121,7 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.3.0</entry>
+        <entry>PECL ds 1.3.0</entry>
         <entry>
          The class now implements <classname>ArrayAccess</classname>.
         </entry>

--- a/reference/ds/ds.set.xml
+++ b/reference/ds/ds.set.xml
@@ -72,6 +72,9 @@
      <oointerface>
       <interfacename>Ds\Collection</interfacename>
      </oointerface>
+     <oointerface>
+      <interfacename>ArrayAccess</interfacename>
+     </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
     <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
@@ -105,6 +108,29 @@
   </section>
 <!-- }}} -->
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>1.3.0</entry>
+        <entry>
+         The class now implements <classname>ArrayAccess</classname>.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
 
  </partintro>
 

--- a/reference/ds/ds.stack.xml
+++ b/reference/ds/ds.stack.xml
@@ -38,6 +38,9 @@
      <oointerface>
       <interfacename>Ds\Collection</interfacename>
      </oointerface>
+     <oointerface>
+      <interfacename>ArrayAccess</interfacename>
+     </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
 
@@ -46,6 +49,30 @@
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>1.3.0</entry>
+        <entry>
+         The class now implements <classname>ArrayAccess</classname>.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/ds/ds.stack.xml
+++ b/reference/ds/ds.stack.xml
@@ -64,7 +64,7 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.3.0</entry>
+        <entry>PECL ds 1.3.0</entry>
         <entry>
          The class now implements <classname>ArrayAccess</classname>.
         </entry>

--- a/reference/ds/ds.vector.xml
+++ b/reference/ds/ds.vector.xml
@@ -103,6 +103,29 @@
   </section>
 <!-- }}} -->
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>1.3.0</entry>
+        <entry>
+         The class now implements <classname>ArrayAccess</classname>.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
 
  </partintro>
 

--- a/reference/ds/ds.vector.xml
+++ b/reference/ds/ds.vector.xml
@@ -116,7 +116,7 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.3.0</entry>
+        <entry>PECL ds 1.3.0</entry>
         <entry>
          The class now implements <classname>ArrayAccess</classname>.
         </entry>


### PR DESCRIPTION
The following classes/interfaces in PHP-DS implement `ArrayAccess`:

- `Map`
- `Stack`
- `Sequence` (`Deque`, `Vector`)

But this is not currently documented.

---

Script to check which classes/interfaces implement `ArrayAccess`:

```php
$classes = array_merge(get_declared_interfaces(), get_declared_classes());

foreach ($classes as $class) {
    if (substr($class, 0, 3) === 'Ds\\') {
        if ((new ReflectionClass($class))->implementsInterface(ArrayAccess::class)) {
            echo "$class\n";
        }
    }
}
```

```
Ds\Sequence
Ds\Vector
Ds\Deque
Ds\Stack
Ds\Map
```