### PR TITLE
Add PECL in front of version numbers in changelogs

### DIFF
--- a/reference/apcu/functions/apcu-cache-info.xml
+++ b/reference/apcu/functions/apcu-cache-info.xml
@@ -62,13 +62,13 @@
      </thead>
      <tbody>
       <row>
-       <entry>3.0.11</entry>
+       <entry>PECL apcu 3.0.11</entry>
        <entry>
         The <parameter>limited</parameter> parameter was introduced.
        </entry>
       </row>
       <row>
-       <entry>3.0.16</entry>
+       <entry>PECL apcu 3.0.16</entry>
        <entry>
         The "<literal>filehits</literal>" option for the
         <parameter>cache_type</parameter> parameter was introduced.

--- a/reference/apcu/functions/apcu-fetch.xml
+++ b/reference/apcu/functions/apcu-fetch.xml
@@ -86,7 +86,7 @@ string(3) "BAR"
     </thead>
     <tbody>
      <row>
-      <entry>3.0.17</entry>
+      <entry>PECL apcu 3.0.17</entry>
       <entry>
        The <parameter>success</parameter> parameter was added.
       </entry>

--- a/reference/event/eventbuffer/appendfrom.xml
+++ b/reference/event/eventbuffer/appendfrom.xml
@@ -69,7 +69,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.6.0</entry>
+       <entry>PECL event 1.6.0</entry>
        <entry>
         Renamed <methodname>EventBuffer::appendFrom</methodname>(the old
           method name) to <methodname>EventBuffer::appendFrom</methodname>.

--- a/reference/event/eventbuffer/read.xml
+++ b/reference/event/eventbuffer/read.xml
@@ -59,7 +59,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.6.0</entry>
+       <entry>PECL event 1.6.0</entry>
        <entry>
         Renamed <methodname>EventBuffer::read</methodname>(the old method
         name) to <methodname>EventBuffer::read</methodname>.

--- a/reference/event/eventbufferevent/createpair.xml
+++ b/reference/event/eventbufferevent/createpair.xml
@@ -83,7 +83,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.9.0</entry>
+       <entry>PECL event 1.9.0</entry>
        <entry>
         Method made static.
        </entry>

--- a/reference/event/eventhttp/construct.xml
+++ b/reference/event/eventhttp/construct.xml
@@ -85,7 +85,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.9.0</entry>
+       <entry>PECL event 1.9.0</entry>
        <entry>
         OpenSSL support (<parameter>ctx</parameter>) added.
        </entry>

--- a/reference/event/eventhttpconnection/construct.xml
+++ b/reference/event/eventhttpconnection/construct.xml
@@ -125,7 +125,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.9.0</entry>
+       <entry>PECL event 1.9.0</entry>
        <entry>
         OpenSSL support (<parameter>ctx</parameter>) added.
        </entry>

--- a/reference/event/eventlistener/construct.xml
+++ b/reference/event/eventlistener/construct.xml
@@ -153,7 +153,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.5.0</entry>
+       <entry>PECL event 1.5.0</entry>
        <entry>
         UNIX domain sockets&apos; support added.
        </entry>

--- a/reference/expect/functions/expect-expectl.xml
+++ b/reference/expect/functions/expect-expectl.xml
@@ -121,7 +121,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>0.2.1</entry>
+       <entry>PECL expect 0.2.1</entry>
        <entry>
        Prior to version 0.2.1, in <parameter>match</parameter> parameter a match string was returned,
        not an array of match substrings.

--- a/reference/geoip/functions/geoip-record-by-name.xml
+++ b/reference/geoip/functions/geoip-record-by-name.xml
@@ -125,13 +125,13 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.0.4</entry>
+       <entry>PECL geoip 1.0.4</entry>
        <entry>
         Adding the continent_code with GeoIP Library 1.4.3 or newer only
        </entry>
       </row>
       <row>
-       <entry>1.0.3</entry>
+       <entry>PECL geoip 1.0.3</entry>
        <entry>
         Adding country_code3 and country_name
        </entry>

--- a/reference/imagick/imagick/adaptiveresizeimage.xml
+++ b/reference/imagick/imagick/adaptiveresizeimage.xml
@@ -84,11 +84,11 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>Added optional fit parameter.</entry>
       </row>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
        This method now supports proportional scaling.
        Pass zero as either parameter for proportional scaling.  

--- a/reference/imagick/imagick/blackthresholdimage.xml
+++ b/reference/imagick/imagick/blackthresholdimage.xml
@@ -54,7 +54,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
         Now allows a string representing the color as a parameter.
         Previous versions allow only an ImagickPixel object.

--- a/reference/imagick/imagick/borderimage.xml
+++ b/reference/imagick/imagick/borderimage.xml
@@ -71,7 +71,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
         Now allows a string representing the color as the first parameter.
         Previous versions allow only an ImagickPixel object.

--- a/reference/imagick/imagick/clone.xml
+++ b/reference/imagick/imagick/clone.xml
@@ -64,7 +64,7 @@ $newImage = clone $image;
      </thead>
      <tbody>
       <row>
-       <entry>3.1.0</entry>
+       <entry>PECL imagick 3.1.0</entry>
        <entry>
         The method was deprecated in favour of the
         <link linkend="language.oop5.cloning">clone</link> keyword.

--- a/reference/imagick/imagick/colorfloodfillimage.xml
+++ b/reference/imagick/imagick/colorfloodfillimage.xml
@@ -103,7 +103,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
         Now allows a string representing the color as first and third
         parameter. Previous versions allow only an ImagickPixel object.

--- a/reference/imagick/imagick/colorizeimage.xml
+++ b/reference/imagick/imagick/colorizeimage.xml
@@ -71,7 +71,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
         Now allows a string representing the color as the first parameter and
         a float representing the opacity value as the second parameter.

--- a/reference/imagick/imagick/frameimage.xml
+++ b/reference/imagick/imagick/frameimage.xml
@@ -100,7 +100,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
         Now allows a string representing the color as the first parameter.
         Previous versions allow only an ImagickPixel object.

--- a/reference/imagick/imagick/mattefloodfillimage.xml
+++ b/reference/imagick/imagick/mattefloodfillimage.xml
@@ -106,7 +106,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
         Now allows a string representing the color as the third parameter.
         Previous versions allow only an <classname>ImagickPixel</classname> object.

--- a/reference/imagick/imagick/newimage.xml
+++ b/reference/imagick/imagick/newimage.xml
@@ -87,7 +87,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
         Now allows a string representing the color as the third parameter.
         Previous versions allow only an ImagickPixel object.

--- a/reference/imagick/imagick/paintopaqueimage.xml
+++ b/reference/imagick/imagick/paintopaqueimage.xml
@@ -96,7 +96,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
         Now allows a string representing the color as first and second parameter.
         Previous versions allow only an ImagickPixel object.

--- a/reference/imagick/imagick/painttransparentimage.xml
+++ b/reference/imagick/imagick/painttransparentimage.xml
@@ -84,7 +84,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
         Now allows a string representing the color as the first parameter.
         Previous versions allow only an ImagickPixel object.

--- a/reference/imagick/imagick/resizeimage.xml
+++ b/reference/imagick/imagick/resizeimage.xml
@@ -92,7 +92,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
        Added optional fit parameter. This method now supports proportional scaling.
        Pass zero as either parameter for proportional scaling.  

--- a/reference/imagick/imagick/rotateimage.xml
+++ b/reference/imagick/imagick/rotateimage.xml
@@ -65,7 +65,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
         Now allows a string representing the color as the first parameter.
         Previous versions allow only an ImagickPixel object.

--- a/reference/imagick/imagick/scaleimage.xml
+++ b/reference/imagick/imagick/scaleimage.xml
@@ -78,7 +78,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
        Added optional fit parameter. This method now supports proportional scaling.
        Pass zero as either parameter for proportional scaling.  

--- a/reference/imagick/imagick/setbackgroundcolor.xml
+++ b/reference/imagick/imagick/setbackgroundcolor.xml
@@ -52,7 +52,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
         Now allows a string representing the color as a parameter.
         Previous versions allow only an ImagickPixel object.

--- a/reference/imagick/imagick/setimagebackgroundcolor.xml
+++ b/reference/imagick/imagick/setimagebackgroundcolor.xml
@@ -59,7 +59,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
         Now allows a string representing the color as the parameter.
         Previous versions allow only an ImagickPixel object.

--- a/reference/imagick/imagick/setimagebordercolor.xml
+++ b/reference/imagick/imagick/setimagebordercolor.xml
@@ -60,7 +60,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
         Now allows a string representing the color as a parameter.
         Previous versions allow only an ImagickPixel object.

--- a/reference/imagick/imagick/setimagemattecolor.xml
+++ b/reference/imagick/imagick/setimagemattecolor.xml
@@ -63,7 +63,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
         Now allows a string representing the color as the parameter.
         Previous versions allow only an ImagickPixel object.

--- a/reference/imagick/imagick/shearimage.xml
+++ b/reference/imagick/imagick/shearimage.xml
@@ -77,7 +77,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
         Now allows a string representing the color as the first parameter.
         Previous versions allow only an ImagickPixel object.

--- a/reference/imagick/imagick/tintimage.xml
+++ b/reference/imagick/imagick/tintimage.xml
@@ -70,7 +70,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
         Now allows a string representing the color as the first parameter and
         a float representing the opacity value as the second parameter.

--- a/reference/imagick/imagick/whitethresholdimage.xml
+++ b/reference/imagick/imagick/whitethresholdimage.xml
@@ -53,7 +53,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.1.0</entry>
+       <entry>PECL imagick 2.1.0</entry>
        <entry>
         Now allows a string representing the color as a parameter.
         Previous versions allow only an ImagickPixel object.

--- a/reference/memcached/memcached/get.xml
+++ b/reference/memcached/memcached/get.xml
@@ -131,7 +131,7 @@ if (!($ip = $m->get('ip_block'))) {
     </thead>
     <tbody>
      <row>
-      <entry>3.0.0</entry>
+      <entry>PECL memcached 3.0.0</entry>
       <entry>
        The <parameter role="reference">cas_token</parameter> parameter was removed.
        Instead <parameter>flags</parameter> was added and when it is given the value of <constant>Memcached::GET_EXTENDED</constant> it will ensure the CAS token to be fetched.

--- a/reference/memcached/memcached/getbykey.xml
+++ b/reference/memcached/memcached/getbykey.xml
@@ -86,7 +86,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>3.0.0</entry>
+      <entry>PECL memcached 3.0.0</entry>
       <entry>
        The <parameter role="reference">cas_token</parameter> parameter was removed.
        Instead <parameter>flags</parameter> was added and when it is given the value of <constant>Memcached::GET_EXTENDED</constant> it will ensure the CAS token to be fetched.

--- a/reference/memcached/memcached/getmulti.xml
+++ b/reference/memcached/memcached/getmulti.xml
@@ -255,7 +255,7 @@ zoo
     </thead>
     <tbody>
      <row>
-      <entry>3.0.0</entry>
+      <entry>PECL memcached 3.0.0</entry>
       <entry>
        The <parameter role="reference">cas_tokens</parameter> parameter was removed.
        The <constant>Memcached::GET_EXTENDED</constant> was added and when passed as a flag it ensures the CAS tokens to be fetched.

--- a/reference/memcached/memcached/getmultibykey.xml
+++ b/reference/memcached/memcached/getmultibykey.xml
@@ -75,7 +75,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>3.0.0</entry>
+      <entry>PECL memcached 3.0.0</entry>
       <entry>
        The <parameter role="reference">cas_tokens</parameter> parameter was removed.
        The <constant>Memcached::GET_EXTENDED</constant> was added and when passed as a flag it ensures the CAS tokens to be fetched.

--- a/reference/mongo/context/log-cmd-delete.xml
+++ b/reference/mongo/context/log-cmd-delete.xml
@@ -79,7 +79,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>1.5.0</entry>
+      <entry>PECL mongo 1.5.0</entry>
       <entry>
        Only available when connected to MongoDB 2.6.0+
       </entry>

--- a/reference/mongo/context/log-cmd-insert.xml
+++ b/reference/mongo/context/log-cmd-insert.xml
@@ -60,7 +60,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>1.5.0</entry>
+      <entry>PECL mongo 1.5.0</entry>
       <entry>
        Only available when connected to MongoDB 2.6.0+
       </entry>

--- a/reference/mongo/context/log-cmd-update.xml
+++ b/reference/mongo/context/log-cmd-update.xml
@@ -87,7 +87,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>1.5.0</entry>
+      <entry>PECL mongo 1.5.0</entry>
       <entry>
        Only available when connected to MongoDB 2.6.0+
       </entry>

--- a/reference/mongo/context/log-write-batch.xml
+++ b/reference/mongo/context/log-write-batch.xml
@@ -60,7 +60,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>1.5.0</entry>
+      <entry>PECL mongo 1.5.0</entry>
       <entry>
        Only available when connected to MongoDB 2.6.0+
       </entry>

--- a/reference/mongo/mongo/getpoolsize.xml
+++ b/reference/mongo/mongo/getpoolsize.xml
@@ -48,7 +48,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>Emits <constant>E_DEPRECATED</constant> when used.</entry>
       </row>
      </tbody>

--- a/reference/mongo/mongo/getslave.xml
+++ b/reference/mongo/mongo/getslave.xml
@@ -74,7 +74,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>Emits <constant>E_DEPRECATED</constant> when used.</entry>
       </row>
      </tbody>

--- a/reference/mongo/mongo/getslaveokay.xml
+++ b/reference/mongo/mongo/getslaveokay.xml
@@ -50,7 +50,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>Emits <constant>E_DEPRECATED</constant> when used.</entry>
       </row>
      </tbody>

--- a/reference/mongo/mongo/pooldebug.xml
+++ b/reference/mongo/mongo/pooldebug.xml
@@ -110,7 +110,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>Emits <constant>E_DEPRECATED</constant> when used.</entry>
       </row>
      </tbody>

--- a/reference/mongo/mongo/setslaveokay.xml
+++ b/reference/mongo/mongo/setslaveokay.xml
@@ -59,7 +59,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>Emits <constant>E_DEPRECATED</constant> when used.</entry>
       </row>
      </tbody>

--- a/reference/mongo/mongo/switchslave.xml
+++ b/reference/mongo/mongo/switchslave.xml
@@ -73,7 +73,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>Emits <constant>E_DEPRECATED</constant> when used.</entry>
       </row>
      </tbody>

--- a/reference/mongo/mongobindata/construct.xml
+++ b/reference/mongo/mongobindata/construct.xml
@@ -85,7 +85,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.5.0</entry>
+       <entry>PECL mongo 1.5.0</entry>
        <entry>
         The default changed from <literal>2</literal>
         (<constant>MongoBinData::BYTE_ARRAY</constant>) to
@@ -93,7 +93,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>
         Emits <constant>E_DEPRECATED</constant> when the second argument is not
         used. The default value for <parameter>type</parameter> may change in

--- a/reference/mongo/mongoclient/close.xml
+++ b/reference/mongo/mongoclient/close.xml
@@ -120,7 +120,7 @@ Closing 'whisky:13001;X;4948': ok
      </thead>
      <tbody>
       <row>
-       <entry>1.3.0</entry>
+       <entry>PECL mongo 1.3.0</entry>
        <entry>
         <para>
          The <parameter>connection</parameter> parameter to this function was
@@ -130,7 +130,7 @@ Closing 'whisky:13001;X;4948': ok
        </entry>
       </row>
       <row>
-       <entry>1.2.0</entry>
+       <entry>PECL mongo 1.2.0</entry>
        <entry>
         <para>
          Before version 1.2.0 the driver would not use persistent connections

--- a/reference/mongo/mongoclient/construct.xml
+++ b/reference/mongo/mongoclient/construct.xml
@@ -675,7 +675,7 @@ $m = new MongoClient($uri, array('replicaSet' => 'rs'));
      </thead>
      <tbody>
       <row>
-       <entry>1.6.0</entry>
+       <entry>PECL mongo 1.6.0</entry>
        <entry>
         <para>
          Added support for <literal>"SCRAM-SHA-1"</literal> in
@@ -684,7 +684,7 @@ $m = new MongoClient($uri, array('replicaSet' => 'rs'));
        </entry>
       </row>
       <row>
-       <entry>1.5.0</entry>
+       <entry>PECL mongo 1.5.0</entry>
        <entry>
         <para>
          Added <literal>"authMechanism"</literal>, <literal>"gssapiServiceName"</literal>, and <literal>"secondaryAcceptableLatencyMS"</literal>.
@@ -692,7 +692,7 @@ $m = new MongoClient($uri, array('replicaSet' => 'rs'));
        </entry>
       </row>
       <row>
-       <entry>1.4.0</entry>
+       <entry>PECL mongo 1.4.0</entry>
        <entry>
         <para>
          Added <literal>"ssl"</literal> option and support for
@@ -709,7 +709,7 @@ $m = new MongoClient($uri, array('replicaSet' => 'rs'));
        </entry>
       </row>
       <row>
-       <entry>1.5.0</entry>
+       <entry>PECL mongo 1.5.0</entry>
        <entry>
         <para>
          Added <literal>"authSource"</literal>.
@@ -717,7 +717,7 @@ $m = new MongoClient($uri, array('replicaSet' => 'rs'));
        </entry>
       </row>
       <row>
-       <entry>1.3.4</entry>
+       <entry>PECL mongo 1.3.4</entry>
        <entry>
         <para>
          Added <literal>"connectTimeoutMS"</literal> and
@@ -726,7 +726,7 @@ $m = new MongoClient($uri, array('replicaSet' => 'rs'));
        </entry>
       </row>
       <row>
-       <entry>1.3.0</entry>
+       <entry>PECL mongo 1.3.0</entry>
        <entry>
         <para>
          Added <literal>"readPreference"</literal>,
@@ -736,7 +736,7 @@ $m = new MongoClient($uri, array('replicaSet' => 'rs'));
        </entry>
       </row>
       <row>
-       <entry>1.2.0</entry>
+       <entry>PECL mongo 1.2.0</entry>
        <entry>
         <para>
          Added <literal>"username"</literal> and <literal>"password"</literal>
@@ -772,11 +772,11 @@ $m = new MongoClient($uri, array('replicaSet' => 'rs'));
        </entry>
       </row>
       <row>
-       <entry>1.0.9</entry>
+       <entry>PECL mongo 1.0.9</entry>
        <entry>Added <literal>"replicaSet"</literal> option.</entry>
       </row>
       <row>
-       <entry>1.0.2</entry>
+       <entry>PECL mongo 1.0.2</entry>
        <entry>
         <para>
          Changed constructor to take an array of options. Pre-1.0.2, the

--- a/reference/mongo/mongoclient/gethosts.xml
+++ b/reference/mongo/mongoclient/gethosts.xml
@@ -114,7 +114,7 @@ array(3) {
      </thead>
      <tbody>
       <row>
-       <entry>1.2.10</entry>
+       <entry>PECL mongo 1.2.10</entry>
        <entry>
         <para>
          Support for non-replicasets was added.

--- a/reference/mongo/mongoclient/getreadpreference.xml
+++ b/reference/mongo/mongoclient/getreadpreference.xml
@@ -42,7 +42,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.3.3</entry>
+       <entry>PECL mongo 1.3.3</entry>
        <entry>
         The return value has changed to be consistent with
         <methodname>MongoClient::setReadPreference</methodname>. The

--- a/reference/mongo/mongocollection/aggregate.xml
+++ b/reference/mongo/mongocollection/aggregate.xml
@@ -146,7 +146,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>1.5.0</entry>
+      <entry>PECL mongo 1.5.0</entry>
       <entry>
        Added optional <parameter>options</parameter> argument
       </entry>

--- a/reference/mongo/mongocollection/batchinsert.xml
+++ b/reference/mongo/mongocollection/batchinsert.xml
@@ -127,7 +127,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.5.0</entry>
+       <entry>PECL mongo 1.5.0</entry>
        <entry>
         <para>
          Added the <literal>"wTimeoutMS"</literal> option, which replaces
@@ -146,19 +146,19 @@
        </entry>
       </row>
       <row>
-       <entry>1.3.4</entry>
+       <entry>PECL mongo 1.3.4</entry>
        <entry>Added <literal>"wtimeout"</literal> option.</entry>
       </row>
       <row>
-       <entry>1.3.0</entry>
+       <entry>PECL mongo 1.3.0</entry>
        <entry>Added <literal>"w"</literal> option.</entry>
       </row>
       <row>
-       <entry>1.2.7</entry>
+       <entry>PECL mongo 1.2.7</entry>
        <entry>Added <literal>"continueOnError"</literal> option.</entry>
       </row>
       <row>
-       <entry>1.0.9</entry>
+       <entry>PECL mongo 1.0.9</entry>
        <entry>
         <para>
          Added ability to pass integers to the <literal>"safe"</literal> option,
@@ -170,7 +170,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.0.5</entry>
+       <entry>PECL mongo 1.0.5</entry>
        <entry>Added <parameter>options</parameter> parameter.</entry>
       </row>
      </tbody>

--- a/reference/mongo/mongocollection/count.xml
+++ b/reference/mongo/mongocollection/count.xml
@@ -128,7 +128,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.6.0</entry>
+       <entry>PECL mongo 1.6.0</entry>
        <entry>
         The second parameter is now an <parameter>options</parameter> array.
         Passing <parameter>limit</parameter> and <parameter>skip</parameter> as
@@ -136,7 +136,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.0.7</entry>
+       <entry>PECL mongo 1.0.7</entry>
        <entry>
         Added <parameter>limit</parameter> and <parameter>skip</parameter> as
         second and third parameters, respectively.

--- a/reference/mongo/mongocollection/ensureindex.xml
+++ b/reference/mongo/mongocollection/ensureindex.xml
@@ -143,7 +143,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.5.0</entry>
+       <entry>PECL mongo 1.5.0</entry>
        <entry>
         <para>
          Renamed the <literal>"wtimeout"</literal> option to
@@ -164,11 +164,11 @@
        </entry>
       </row>
       <row>
-       <entry>1.3.4</entry>
+       <entry>PECL mongo 1.3.4</entry>
        <entry>Added <literal>"wtimeout"</literal> option.</entry>
       </row>
       <row>
-       <entry>1.3.0</entry>
+       <entry>PECL mongo 1.3.0</entry>
        <entry>
         <para>Added <literal>"w"</literal> option.</para>
         <para>
@@ -179,18 +179,18 @@
        </entry>
       </row>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>
         Emits <constant>E_DEPRECATED</constant> when
         <parameter>options</parameter> is <type>scalar</type>.
        </entry>
       </row>
       <row>
-       <entry>1.2.0</entry>
+       <entry>PECL mongo 1.2.0</entry>
        <entry>Added <literal>"timeout"</literal> option.</entry>
       </row>
       <row>
-       <entry>1.0.11</entry>
+       <entry>PECL mongo 1.0.11</entry>
        <entry>
         <para>
          The <literal>"safe"</literal> option will trigger a primary failover,
@@ -203,14 +203,14 @@
        </entry>
       </row>
       <row>
-       <entry>1.0.5</entry>
+       <entry>PECL mongo 1.0.5</entry>
        <entry>
         Added the <literal>"name"</literal> option to override index name
         creation.
        </entry>
       </row>
       <row>
-       <entry>1.0.2</entry>
+       <entry>PECL mongo 1.0.2</entry>
        <entry>
         Changed <parameter>options</parameter> parameter from boolean to array.
         Pre-1.0.2, the second parameter was an optional boolean value specifying

--- a/reference/mongo/mongocollection/findone.xml
+++ b/reference/mongo/mongocollection/findone.xml
@@ -105,7 +105,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>1.5.0</entry>
+      <entry>PECL mongo 1.5.0</entry>
       <entry>
        Added optional <parameter>options</parameter> argument.
       </entry>

--- a/reference/mongo/mongocollection/getreadpreference.xml
+++ b/reference/mongo/mongocollection/getreadpreference.xml
@@ -38,7 +38,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.3.3</entry>
+       <entry>PECL mongo 1.3.3</entry>
        <entry>
         The return value has changed to be consistent with
         <methodname>MongoCollection::setReadPreference</methodname>. The

--- a/reference/mongo/mongocollection/getslaveokay.xml
+++ b/reference/mongo/mongocollection/getslaveokay.xml
@@ -45,7 +45,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>Emits <constant>E_DEPRECATED</constant> when used.</entry>
       </row>
      </tbody>

--- a/reference/mongo/mongocollection/group.xml
+++ b/reference/mongo/mongocollection/group.xml
@@ -113,11 +113,11 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.5.0</entry>
+       <entry>PECL mongo 1.5.0</entry>
        <entry>Added <literal>"maxTimeMS"</literal> option.</entry>
       </row>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>
         Emits <constant>E_DEPRECATED</constant> when
         <parameter>options</parameter> is <type>scalar</type>.

--- a/reference/mongo/mongocollection/insert.xml
+++ b/reference/mongo/mongocollection/insert.xml
@@ -227,7 +227,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.5.0</entry>
+       <entry>PECL mongo 1.5.0</entry>
        <entry>
         <para>
          Added the <literal>"wTimeoutMS"</literal> option, which replaces
@@ -246,11 +246,11 @@
        </entry>
       </row>
       <row>
-       <entry>1.3.4</entry>
+       <entry>PECL mongo 1.3.4</entry>
        <entry>Added <literal>"wtimeout"</literal> option.</entry>
       </row>
       <row>
-       <entry>1.3.0</entry>
+       <entry>PECL mongo 1.3.0</entry>
        <entry>
         <para>Added <literal>"w"</literal> option.</para>
         <para>
@@ -262,17 +262,17 @@
        </entry>
       </row>
       <row>
-       <entry>1.2.0</entry>
+       <entry>PECL mongo 1.2.0</entry>
        <entry>Added <literal>"timeout"</literal> option.</entry>
       </row>
       <row>
-       <entry>1.0.11</entry>
+       <entry>PECL mongo 1.0.11</entry>
        <entry>
         Disconnects on "not master" errors if <literal>"safe"</literal> is set.
        </entry>
       </row>
       <row>
-       <entry>1.0.9</entry>
+       <entry>PECL mongo 1.0.9</entry>
        <entry>
         <para>
          Added ability to pass integers to the <literal>"safe"</literal> option,
@@ -289,7 +289,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.0.2</entry>
+       <entry>PECL mongo 1.0.2</entry>
        <entry>
         Changed second parameter to be an array of options. Pre-1.0.2, the
         second parameter was a boolean indicating the <literal>"safe"</literal>
@@ -297,7 +297,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.0.1</entry>
+       <entry>PECL mongo 1.0.1</entry>
        <entry>
         Throw a <classname>MongoCursorException</classname> if the
         <literal>"safe"</literal> option is set and the insert fails.

--- a/reference/mongo/mongocollection/remove.xml
+++ b/reference/mongo/mongocollection/remove.xml
@@ -100,7 +100,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.5.0</entry>
+       <entry>PECL mongo 1.5.0</entry>
        <entry>
         <para>
          Added <literal>"wTimeoutMS"</literal> option, which replaces
@@ -119,11 +119,11 @@
        </entry>
       </row>
       <row>
-       <entry>1.3.4</entry>
+       <entry>PECL mongo 1.3.4</entry>
        <entry>Added <literal>"wtimeout"</literal> option.</entry>
       </row>
       <row>
-       <entry>1.3.0</entry>
+       <entry>PECL mongo 1.3.0</entry>
        <entry>
         <para>Added <literal>"w"</literal> option.</para>
         <para>
@@ -134,24 +134,24 @@
        </entry>
       </row>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>
         Emits <constant>E_DEPRECATED</constant> when
         <parameter>options</parameter> is <type>scalar</type>.
        </entry>
       </row>
       <row>
-       <entry>1.2.0</entry>
+       <entry>PECL mongo 1.2.0</entry>
        <entry>Added <literal>"timeout"</literal> option.</entry>
       </row>
       <row>
-       <entry>1.0.11</entry>
+       <entry>PECL mongo 1.0.11</entry>
        <entry>
         Disconnects on "not master" errors if <literal>"safe"</literal> is set.
        </entry>
       </row>
       <row>
-       <entry>1.0.9</entry>
+       <entry>PECL mongo 1.0.9</entry>
        <entry>
         <para>
          Added ability to pass integers to the <literal>"safe"</literal> option,
@@ -168,7 +168,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.0.5</entry>
+       <entry>PECL mongo 1.0.5</entry>
        <entry>
         Changed second parameter to be an array of options. Pre-1.0.5, the
         second parameter was a boolean indicating the <literal>"safe"</literal>

--- a/reference/mongo/mongocollection/save.xml
+++ b/reference/mongo/mongocollection/save.xml
@@ -99,7 +99,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.5.0</entry>
+       <entry>PECL mongo 1.5.0</entry>
        <entry>
         <para>
          Added <literal>"wTimeoutMS"</literal> option, which replaces
@@ -118,17 +118,17 @@
        </entry>
       </row>
       <row>
-       <entry>1.2.0</entry>
+       <entry>PECL mongo 1.2.0</entry>
        <entry>Added <literal>"timeout"</literal> option.</entry>
       </row>
       <row>
-       <entry>1.0.11</entry>
+       <entry>PECL mongo 1.0.11</entry>
        <entry>
         Disconnects on "not master" errors if <literal>"safe"</literal> is set.
        </entry>
       </row>
       <row>
-       <entry>1.0.9</entry>
+       <entry>PECL mongo 1.0.9</entry>
        <entry>
         <para>
          Added <literal>"fsync"</literal> option.
@@ -136,7 +136,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.0.5</entry>
+       <entry>PECL mongo 1.0.5</entry>
        <entry>Added <parameter>options</parameter> parameter.</entry>
       </row>
      </tbody>

--- a/reference/mongo/mongocollection/setslaveokay.xml
+++ b/reference/mongo/mongocollection/setslaveokay.xml
@@ -60,7 +60,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>Emits <constant>E_DEPRECATED</constant> when used.</entry>
       </row>
      </tbody>

--- a/reference/mongo/mongocollection/toindexstring.xml
+++ b/reference/mongo/mongocollection/toindexstring.xml
@@ -95,7 +95,7 @@ echo MyCollection::toIndexString(array('name' => 1, 'age' => -1)), "\n";
      </thead>
      <tbody>
       <row>
-       <entry>1.5.0</entry>
+       <entry>PECL mongo 1.5.0</entry>
        <entry>
         This method has been deprecated.
        </entry>

--- a/reference/mongo/mongocollection/update.xml
+++ b/reference/mongo/mongocollection/update.xml
@@ -135,7 +135,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.5.0</entry>
+       <entry>PECL mongo 1.5.0</entry>
        <entry>
         <para>
          Added the <literal>"wTimeoutMS"</literal> option, which replaces
@@ -154,11 +154,11 @@
        </entry>
       </row>
       <row>
-       <entry>1.3.4</entry>
+       <entry>PECL mongo 1.3.4</entry>
        <entry>Added <literal>"wtimeout"</literal> option.</entry>
       </row>
       <row>
-       <entry>1.3.0</entry>
+       <entry>PECL mongo 1.3.0</entry>
        <entry>
         <para>Added <literal>"w"</literal> option.</para>
         <para>
@@ -169,24 +169,24 @@
        </entry>
       </row>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>
         Emits <constant>E_DEPRECATED</constant> when
         <parameter>options</parameter> is <type>scalar</type>.
        </entry>
       </row>
       <row>
-       <entry>1.2.0</entry>
+       <entry>PECL mongo 1.2.0</entry>
        <entry>Added <literal>"timeout"</literal> option.</entry>
       </row>
       <row>
-       <entry>1.0.11</entry>
+       <entry>PECL mongo 1.0.11</entry>
        <entry>
         Disconnects on "not master" errors if <literal>"safe"</literal> is set.
        </entry>
       </row>
       <row>
-       <entry>1.0.9</entry>
+       <entry>PECL mongo 1.0.9</entry>
        <entry>
         <para>
          Added ability to pass integers to the <literal>"safe"</literal> option,
@@ -203,11 +203,11 @@
        </entry>
       </row>
       <row>
-       <entry>1.0.5</entry>
+       <entry>PECL mongo 1.0.5</entry>
        <entry>Added <literal>"safe"</literal> option.</entry>
       </row>
       <row>
-       <entry>1.0.1</entry>
+       <entry>PECL mongo 1.0.1</entry>
        <entry>
         Changed <parameter>options</parameter> parameter from boolean to array.
         Pre-1.0.1, the second parameter was an optional boolean value specifying

--- a/reference/mongo/mongocursor/batchsize.xml
+++ b/reference/mongo/mongocursor/batchsize.xml
@@ -149,7 +149,7 @@ $cursor->limit(30)->batchSize(7)
      </thead>
      <tbody>
       <row>
-       <entry>1.4.5</entry>
+       <entry>PECL mongo 1.4.5</entry>
        <entry>
         <para>
          Before 1.4.5, this method would throw an

--- a/reference/mongo/mongocursor/doquery.xml
+++ b/reference/mongo/mongocursor/doquery.xml
@@ -64,7 +64,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>Emits <constant>E_DEPRECATED</constant> when used.</entry>
       </row>
      </tbody>

--- a/reference/mongo/mongocursor/hint.xml
+++ b/reference/mongo/mongocursor/hint.xml
@@ -63,7 +63,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.4.0</entry>
+       <entry>PECL mongo 1.4.0</entry>
        <entry>
         <para>
          The <parameter>index</parameter> argument now supports index names as

--- a/reference/mongo/mongocursor/info.xml
+++ b/reference/mongo/mongocursor/info.xml
@@ -45,7 +45,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.1.0</entry>
+       <entry>PECL mongo 1.1.0</entry>
        <entry>
         Added a number of other fields, including <literal>id</literal> (the 
         cursor id), <literal>at</literal> (the driver's counter of which 
@@ -57,7 +57,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.0.10</entry>
+       <entry>PECL mongo 1.0.10</entry>
        <entry>
         Added <literal>started_iterating</literal> field, a boolean indicating
         if cursor is pre- or post-query.

--- a/reference/mongo/mongocursor/setflag.xml
+++ b/reference/mongo/mongocursor/setflag.xml
@@ -81,7 +81,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.4.0</entry>
+       <entry>PECL mongo 1.4.0</entry>
        <entry>
         Support for flag 3 (OPLOG_REPLAY) is added. Versions before 1.4.0
         would throw a warning saying that the flag is unsupported.

--- a/reference/mongo/mongocursor/slaveokay.xml
+++ b/reference/mongo/mongocursor/slaveokay.xml
@@ -145,7 +145,7 @@ $cursor = $collection->find()->slaveOkay(false);
      </thead>
      <tbody>
       <row>
-       <entry>1.5.0</entry>
+       <entry>PECL mongo 1.5.0</entry>
        <entry>
         This method has been deprecated in favour of
         <methodname>MongoCursor::setReadPreference</methodname> and <xref

--- a/reference/mongo/mongodb/authenticate.xml
+++ b/reference/mongo/mongodb/authenticate.xml
@@ -143,7 +143,7 @@ array("ok" => 0, "errmsg" => "auth fails");
      </thead>
      <tbody>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>
         Emits <constant>E_DEPRECATED</constant> when used. Please pass in the
         authentication details to the constructor.

--- a/reference/mongo/mongodb/command.xml
+++ b/reference/mongo/mongodb/command.xml
@@ -103,7 +103,7 @@ public function command($data) {
      </thead>
      <tbody>
       <row>
-       <entry>1.5.0</entry>
+       <entry>PECL mongo 1.5.0</entry>
        <entry>
         <para>
          Renamed the <literal>"timeout"</literal> option to
@@ -117,7 +117,7 @@ public function command($data) {
        </entry>
       </row>
       <row>
-       <entry>1.2.0</entry>
+       <entry>PECL mongo 1.2.0</entry>
        <entry>
         Added <literal>options</literal> parameter with a single option: 
         <literal>"timeout"</literal>.

--- a/reference/mongo/mongodb/createcollection.xml
+++ b/reference/mongo/mongodb/createcollection.xml
@@ -197,7 +197,7 @@ sample log message #99
      </thead>
      <tbody>
       <row>
-       <entry>1.4.0</entry>
+       <entry>PECL mongo 1.4.0</entry>
        <entry>
         <para>
          In versions before 1.4.0, the options were all arguments to the method. The

--- a/reference/mongo/mongodb/execute.xml
+++ b/reference/mongo/mongodb/execute.xml
@@ -224,7 +224,7 @@ Goodbye, Joe, says Fred
      </thead>
      <tbody>
       <row>
-       <entry>1.7.0</entry>
+       <entry>PECL mongo 1.7.0</entry>
        <entry>
         This method has been deprecated as a result of the underlaying
         <link xlink:href="&url.mongodb.docs.command;eval/">eval</link> command

--- a/reference/mongo/mongodb/forceerror.xml
+++ b/reference/mongo/mongodb/forceerror.xml
@@ -59,7 +59,7 @@ public function forceError() {
      </thead>
      <tbody>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>Emits <constant>E_DEPRECATED</constant> when used.</entry>
       </row>
      </tbody>

--- a/reference/mongo/mongodb/getcollectionnames.xml
+++ b/reference/mongo/mongodb/getcollectionnames.xml
@@ -75,7 +75,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>1.6.0</entry>
+      <entry>PECL mongo 1.6.0</entry>
       <entry>
        Changed first parameter to be an array of options. Pre-1.6.0, the
        first parameter was a boolean indicating the

--- a/reference/mongo/mongodb/getreadpreference.xml
+++ b/reference/mongo/mongodb/getreadpreference.xml
@@ -38,7 +38,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.3.3</entry>
+       <entry>PECL mongo 1.3.3</entry>
        <entry>
         The return value has changed to be consistent with
         <methodname>MongoDB::setReadPreference</methodname>. The

--- a/reference/mongo/mongodb/getslaveokay.xml
+++ b/reference/mongo/mongodb/getslaveokay.xml
@@ -45,7 +45,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>Emits <constant>E_DEPRECATED</constant> when used.</entry>
       </row>
      </tbody>

--- a/reference/mongo/mongodb/listcollections.xml
+++ b/reference/mongo/mongodb/listcollections.xml
@@ -75,7 +75,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>1.6.0</entry>
+      <entry>PECL mongo 1.6.0</entry>
       <entry>
        Changed first parameter to be an array of options. Pre-1.6.0, the
        first parameter was a boolean indicating the
@@ -83,7 +83,7 @@
       </entry>
      </row>
      <row>
-      <entry>1.3.0</entry>
+      <entry>PECL mongo 1.3.0</entry>
       <entry>
        Added the <parameter>includeSystemCollections</parameter> parameter.
       </entry>

--- a/reference/mongo/mongodb/preverror.xml
+++ b/reference/mongo/mongodb/preverror.xml
@@ -45,7 +45,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>Emits <constant>E_DEPRECATED</constant> when used.</entry>
       </row>
      </tbody>

--- a/reference/mongo/mongodb/reseterror.xml
+++ b/reference/mongo/mongodb/reseterror.xml
@@ -59,7 +59,7 @@ public function resetError() {
      </thead>
      <tbody>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>Emits <constant>E_DEPRECATED</constant> when used.</entry>
       </row>
      </tbody>

--- a/reference/mongo/mongodb/setslaveokay.xml
+++ b/reference/mongo/mongodb/setslaveokay.xml
@@ -59,7 +59,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>Emits <constant>E_DEPRECATED</constant> when used.</entry>
       </row>
      </tbody>

--- a/reference/mongo/mongogridfs/storeupload.xml
+++ b/reference/mongo/mongogridfs/storeupload.xml
@@ -86,7 +86,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.5</entry>
+       <entry>PECL mongo 1.2.5</entry>
        <entry>
         Changed second parameter to an array of metadata. Pre-1.2.5, the
         second parameter was an optional string overriding the filename.

--- a/reference/mongo/mongogridfscursor/key.xml
+++ b/reference/mongo/mongogridfscursor/key.xml
@@ -40,7 +40,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.3.0</entry>
+       <entry>PECL mongo 1.3.0</entry>
        <entry>
         The document's <literal>_id</literal> is returned as a string value,
         since the key should be unique. Pre-1.3.0, <literal>filename</literal>

--- a/reference/mongo/mongoid/construct.xml
+++ b/reference/mongo/mongoid/construct.xml
@@ -62,7 +62,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>1.4.0</entry>
+      <entry>PECL mongo 1.4.0</entry>
       <entry>
        An exception is thrown when passed invalid string
       </entry>

--- a/reference/mongo/mongolog.xml
+++ b/reference/mongo/mongolog.xml
@@ -306,7 +306,7 @@ MongoLog::setModule(MongoLog::RS|MongoLog::CON);
       </thead>
       <tbody>
        <row>
-        <entry>1.3.0</entry>
+        <entry>PECL mongo 1.3.0</entry>
         <entry>
          Added <constant>MongoLog::CON</constant> and deprecated
          <constant>MongoLog::POOL</constant> and

--- a/reference/mongo/mongopool.xml
+++ b/reference/mongo/mongopool.xml
@@ -55,7 +55,7 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.3.0</entry>
+        <entry>PECL mongo 1.3.0</entry>
         <entry>
          This functionality has been removed and no longer does anything other
          than emit deprecation warnings. This class is only kept around for
@@ -63,7 +63,7 @@
         </entry>
        </row>
        <row>
-        <entry>1.2.11</entry>
+        <entry>PECL mongo 1.2.11</entry>
         <entry>
         Emits <constant>E_DEPRECATED</constant> when used.
         </entry>

--- a/reference/mongo/mongopool/getsize.xml
+++ b/reference/mongo/mongopool/getsize.xml
@@ -39,7 +39,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>Emits <constant>E_DEPRECATED</constant> when used.</entry>
       </row>
      </tbody>

--- a/reference/mongo/mongopool/info.xml
+++ b/reference/mongo/mongopool/info.xml
@@ -128,7 +128,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>Emits <constant>E_DEPRECATED</constant> when used.</entry>
       </row>
      </tbody>

--- a/reference/mongo/mongopool/setsize.xml
+++ b/reference/mongo/mongopool/setsize.xml
@@ -59,7 +59,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.11</entry>
+       <entry>PECL mongo 1.2.11</entry>
        <entry>Emits <constant>E_DEPRECATED</constant> when used.</entry>
       </row>
      </tbody>

--- a/reference/mongodb/bson/binary.xml
+++ b/reference/mongodb/bson/binary.xml
@@ -187,13 +187,13 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.3.0</entry>
+        <entry>PECL mongodb 1.3.0</entry>
         <entry>
          Implements <interfacename>MongoDB\BSON\BinaryInterface</interfacename>.
         </entry>
        </row>
        <row>
-        <entry>1.2.0</entry>
+        <entry>PECL mongodb 1.2.0</entry>
         <entry>
          Implements <interfacename>Serializable</interfacename> and
          <interfacename>JsonSerializable</interfacename>.

--- a/reference/mongodb/bson/binary/construct.xml
+++ b/reference/mongodb/bson/binary/construct.xml
@@ -60,7 +60,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.3.0</entry>
+       <entry>PECL mongodb 1.3.0</entry>
        <entry>
         <para>
          <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
@@ -72,7 +72,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.1.3</entry>
+       <entry>PECL mongodb 1.1.3</entry>
        <entry>
         <para>
          <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>

--- a/reference/mongodb/bson/decimal128.xml
+++ b/reference/mongodb/bson/decimal128.xml
@@ -80,13 +80,13 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.3.0</entry>
+        <entry>PECL mongodb 1.3.0</entry>
         <entry>
          Implements <interfacename>MongoDB\BSON\Decimal128Interface</interfacename>.
         </entry>
        </row>
        <row>
-        <entry>1.2.0</entry>
+        <entry>PECL mongodb 1.2.0</entry>
         <entry>
          Implements <interfacename>Serializable</interfacename> and
          <interfacename>JsonSerializable</interfacename>.

--- a/reference/mongodb/bson/javascript.xml
+++ b/reference/mongodb/bson/javascript.xml
@@ -78,13 +78,13 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.3.0</entry>
+        <entry>PECL mongodb 1.3.0</entry>
         <entry>
          Implements <interfacename>MongoDB\BSON\JavascriptInterface</interfacename>.
         </entry>
        </row>
        <row>
-        <entry>1.2.0</entry>
+        <entry>PECL mongodb 1.2.0</entry>
         <entry>
          Implements <interfacename>Serializable</interfacename> and
          <interfacename>JsonSerializable</interfacename>.

--- a/reference/mongodb/bson/javascript/construct.xml
+++ b/reference/mongodb/bson/javascript/construct.xml
@@ -59,7 +59,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.0</entry>
+       <entry>PECL mongodb 1.2.0</entry>
        <entry>
         <para>
          <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>

--- a/reference/mongodb/bson/maxkey.xml
+++ b/reference/mongodb/bson/maxkey.xml
@@ -75,13 +75,13 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.3.0</entry>
+        <entry>PECL mongodb 1.3.0</entry>
         <entry>
          Implements <interfacename>MongoDB\BSON\MaxKeyInterface</interfacename>.
         </entry>
        </row>
        <row>
-        <entry>1.2.0</entry>
+        <entry>PECL mongodb 1.2.0</entry>
         <entry>
          Implements <interfacename>Serializable</interfacename> and
          <interfacename>JsonSerializable</interfacename>.

--- a/reference/mongodb/bson/minkey.xml
+++ b/reference/mongodb/bson/minkey.xml
@@ -75,13 +75,13 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.3.0</entry>
+        <entry>PECL mongodb 1.3.0</entry>
         <entry>
          Implements <interfacename>MongoDB\BSON\MinKeyInterface</interfacename>.
         </entry>
        </row>
        <row>
-        <entry>1.2.0</entry>
+        <entry>PECL mongodb 1.2.0</entry>
         <entry>
          Implements <interfacename>Serializable</interfacename> and
          <interfacename>JsonSerializable</interfacename>.

--- a/reference/mongodb/bson/objectid.xml
+++ b/reference/mongodb/bson/objectid.xml
@@ -91,7 +91,7 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.3.0</entry>
+        <entry>PECL mongodb 1.3.0</entry>
         <entry>
          <para>
           Renamed from <literal>MongoDB\BSON\ObjectID</literal> to
@@ -103,7 +103,7 @@
         </entry>
        </row>
        <row>
-        <entry>1.2.0</entry>
+        <entry>PECL mongodb 1.2.0</entry>
         <entry>
          Implements <interfacename>Serializable</interfacename> and
          <interfacename>JsonSerializable</interfacename>.

--- a/reference/mongodb/bson/regex.xml
+++ b/reference/mongodb/bson/regex.xml
@@ -78,13 +78,13 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.3.0</entry>
+        <entry>PECL mongodb 1.3.0</entry>
         <entry>
          Implements <interfacename>MongoDB\BSON\RegexInterface</interfacename>.
         </entry>
        </row>
        <row>
-        <entry>1.2.0</entry>
+        <entry>PECL mongodb 1.2.0</entry>
         <entry>
          Implements <interfacename>Serializable</interfacename> and
          <interfacename>JsonSerializable</interfacename>.

--- a/reference/mongodb/bson/regex/construct.xml
+++ b/reference/mongodb/bson/regex/construct.xml
@@ -66,7 +66,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.0</entry>
+       <entry>PECL mongodb 1.2.0</entry>
        <entry>
         <para>
          The <parameter>flags</parameter> argument is optional and defaults to

--- a/reference/mongodb/bson/timestamp.xml
+++ b/reference/mongodb/bson/timestamp.xml
@@ -79,13 +79,13 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.3.0</entry>
+        <entry>PECL mongodb 1.3.0</entry>
         <entry>
          Implements <interfacename>MongoDB\BSON\TimestampInterface</interfacename>.
         </entry>
        </row>
        <row>
-        <entry>1.2.0</entry>
+        <entry>PECL mongodb 1.2.0</entry>
         <entry>
          Implements <interfacename>Serializable</interfacename> and
          <interfacename>JsonSerializable</interfacename>.

--- a/reference/mongodb/bson/utcdatetime.xml
+++ b/reference/mongodb/bson/utcdatetime.xml
@@ -72,13 +72,13 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.3.0</entry>
+        <entry>PECL mongodb 1.3.0</entry>
         <entry>
          Implements <interfacename>MongoDB\BSON\UTCDateTimeInterface</interfacename>.
         </entry>
        </row>
        <row>
-        <entry>1.2.0</entry>
+        <entry>PECL mongodb 1.2.0</entry>
         <entry>
          Implements <interfacename>Serializable</interfacename> and
          <interfacename>JsonSerializable</interfacename>.

--- a/reference/mongodb/bson/utcdatetime/construct.xml
+++ b/reference/mongodb/bson/utcdatetime/construct.xml
@@ -65,7 +65,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.0</entry>
+       <entry>PECL mongodb 1.2.0</entry>
        <entry>
         <para>
          The <parameter>milliseconds</parameter> argument is optional and

--- a/reference/mongodb/functions/bson/tophp.xml
+++ b/reference/mongodb/functions/bson/tophp.xml
@@ -81,7 +81,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.4.0</entry>
+       <entry>PECL mongodb 1.4.0</entry>
        <entry>
         <para>
          If the input contains an unsupported, deprecated BSON type, the
@@ -91,7 +91,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.3.2</entry>
+       <entry>PECL mongodb 1.3.2</entry>
        <entry>
         <para>
          <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname>
@@ -103,7 +103,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.3.0</entry>
+       <entry>PECL mongodb 1.3.0</entry>
        <entry>
         <para>
          <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname>

--- a/reference/mongodb/mongodb/driver/bulkwrite/construct.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/construct.xml
@@ -94,7 +94,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.1.0</entry>
+       <entry>PECL mongodb 1.1.0</entry>
        <entry>
         Added the <literal>"bypassDocumentValidation"</literal> option.
        </entry>

--- a/reference/mongodb/mongodb/driver/bulkwrite/count.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/count.xml
@@ -53,7 +53,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.2.0</entry>
+       <entry>PECL mongodb 1.2.0</entry>
        <entry>
         Returns the number of write operations added to the
         <classname>MongoDB\Driver\BulkWrite</classname> object. Earlier versions

--- a/reference/mongodb/mongodb/driver/bulkwrite/delete.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/delete.xml
@@ -100,13 +100,13 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.8.0</entry>
+       <entry>PECL mongodb 1.8.0</entry>
        <entry>
         Added the <literal>"hint"</literal> option.
        </entry>
       </row>
       <row>
-       <entry>1.2.0</entry>
+       <entry>PECL mongodb 1.2.0</entry>
        <entry>
         Added the <literal>"collation"</literal> option.
        </entry>

--- a/reference/mongodb/mongodb/driver/bulkwrite/insert.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/insert.xml
@@ -64,7 +64,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.3.0</entry>
+       <entry>PECL mongodb 1.3.0</entry>
        <entry>
         The <literal>_id</literal> of the inserted document is always returned.
         Previously, the method only returned a value if a

--- a/reference/mongodb/mongodb/driver/bulkwrite/update.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/update.xml
@@ -146,13 +146,13 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.7.0</entry>
+       <entry>PECL mongodb 1.7.0</entry>
        <entry>
         Added the <literal>"hint"</literal> option.
        </entry>
       </row>
       <row>
-       <entry>1.6.0</entry>
+       <entry>PECL mongodb 1.6.0</entry>
        <entry>
         The <parameter>newObj</parameter> parameter now accepts an aggregation
         pipeline. This feature requires MongoDB 4.2+ and will result in an
@@ -160,7 +160,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.5.0</entry>
+       <entry>PECL mongodb 1.5.0</entry>
        <entry>
         Using the <literal>"arrayFilters"</literal> option will result in an
         exception at execution time if unsupported by the server. Previously,
@@ -168,13 +168,13 @@
        </entry>
       </row>
       <row>
-       <entry>1.4.0</entry>
+       <entry>PECL mongodb 1.4.0</entry>
        <entry>
         Added the <literal>"arrayFilters"</literal> option.
        </entry>
       </row>
       <row>
-       <entry>1.2.0</entry>
+       <entry>PECL mongodb 1.2.0</entry>
        <entry>
         Added the <literal>"collation"</literal> option.
        </entry>

--- a/reference/mongodb/mongodb/driver/command/construct.xml
+++ b/reference/mongodb/mongodb/driver/command/construct.xml
@@ -106,7 +106,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.4.0</entry>
+       <entry>PECL mongodb 1.4.0</entry>
        <entry>
         <para>
          Added a second <parameter>commandOptions</parameter> argument, which supports

--- a/reference/mongodb/mongodb/driver/cursor.xml
+++ b/reference/mongodb/mongodb/driver/cursor.xml
@@ -60,7 +60,7 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.6.0</entry>
+        <entry>PECL mongodb 1.6.0</entry>
         <entry>
          Implements <interfacename>MongoDB\Driver\CursorInterface</interfacename>,
          which extends <interfacename>Traversable</interfacename>.

--- a/reference/mongodb/mongodb/driver/cursorid.xml
+++ b/reference/mongodb/mongodb/driver/cursorid.xml
@@ -59,7 +59,7 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.7.0</entry>
+        <entry>PECL mongodb 1.7.0</entry>
         <entry>
          Implements <interfacename>Serializable</interfacename>.
         </entry>

--- a/reference/mongodb/mongodb/driver/exception/executiontimeoutexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/executiontimeoutexception.xml
@@ -73,7 +73,7 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.5.0</entry>
+        <entry>PECL mongodb 1.5.0</entry>
         <entry>
          <para>
           This class now extends

--- a/reference/mongodb/mongodb/driver/exception/runtimeexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/runtimeexception.xml
@@ -100,7 +100,7 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.6.0</entry>
+        <entry>PECL mongodb 1.6.0</entry>
         <entry>
          <para>
           The

--- a/reference/mongodb/mongodb/driver/exception/writeexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/writeexception.xml
@@ -100,7 +100,7 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.5.0</entry>
+        <entry>PECL mongodb 1.5.0</entry>
         <entry>
          <para>
           This class now extends

--- a/reference/mongodb/mongodb/driver/manager/construct.xml
+++ b/reference/mongodb/mongodb/driver/manager/construct.xml
@@ -947,7 +947,7 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
      </thead>
      <tbody>
       <row>
-       <entry>1.8.0</entry>
+       <entry>PECL mongodb 1.8.0</entry>
        <entry>
         <para>
          Added the <literal>"directConnection"</literal>,
@@ -960,7 +960,7 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
        </entry>
       </row>
       <row>
-       <entry>1.7.0</entry>
+       <entry>PECL mongodb 1.7.0</entry>
        <entry>
         <para>
          Added the <literal>"autoEncryption"</literal> driver option.
@@ -973,7 +973,7 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
        </entry>
       </row>
       <row>
-       <entry>1.6.0</entry>
+       <entry>PECL mongodb 1.6.0</entry>
        <entry>
         <para>
          Added the <literal>"retryReads"</literal>, <literal>"tls"</literal>,
@@ -998,7 +998,7 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
        </entry>
       </row>
       <row>
-       <entry>1.5.0</entry>
+       <entry>PECL mongodb 1.5.0</entry>
        <entry>
         <para>
          <literal>"wtimeoutMS"</literal> is now always validated and applied to
@@ -1009,7 +1009,7 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
        </entry>
       </row>
       <row>
-       <entry>1.4.0</entry>
+       <entry>PECL mongodb 1.4.0</entry>
        <entry>
         <para>
          Added the <literal>"compressors"</literal>,
@@ -1019,7 +1019,7 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
        </entry>
       </row>
       <row>
-       <entry>1.3.0</entry>
+       <entry>PECL mongodb 1.3.0</entry>
        <entry>
         <para>
          The <parameter>uriOptions</parameter> argument now accepts
@@ -1030,7 +1030,7 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
        </entry>
       </row>
       <row>
-       <entry>1.2.0</entry>
+       <entry>PECL mongodb 1.2.0</entry>
        <entry>
         <para>
          The <parameter>uri</parameter> argument defaults to
@@ -1059,7 +1059,7 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
        </entry>
       </row>
       <row>
-       <entry>1.1.0</entry>
+       <entry>PECL mongodb 1.1.0</entry>
        <entry>
         <para>
          The <parameter>uri</parameter> argument is optional and defaults to

--- a/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
@@ -87,7 +87,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.4.4</entry>
+       <entry>PECL mongodb 1.4.4</entry>
        <entry>
         <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
         will be thrown if the <literal>"session"</literal> option is used in
@@ -95,7 +95,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.4.0</entry>
+       <entry>PECL mongodb 1.4.0</entry>
        <entry>
         The third parameter is now an <parameter>options</parameter> array.
         For backwards compatibility, this paramater will still accept a
@@ -103,7 +103,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.3.0</entry>
+       <entry>PECL mongodb 1.3.0</entry>
        <entry>
         <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
         is now thrown if <parameter>bulk</parameter> does not contain any write

--- a/reference/mongodb/mongodb/driver/manager/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executecommand.xml
@@ -95,7 +95,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.4.4</entry>
+       <entry>PECL mongodb 1.4.4</entry>
        <entry>
         <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
         will be thrown if the <literal>"session"</literal> option is used in
@@ -103,7 +103,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.4.0</entry>
+       <entry>PECL mongodb 1.4.0</entry>
        <entry>
         The third parameter is now an <parameter>options</parameter> array.
         For backwards compatibility, this paramater will still accept a

--- a/reference/mongodb/mongodb/driver/manager/executequery.xml
+++ b/reference/mongodb/mongodb/driver/manager/executequery.xml
@@ -80,7 +80,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.4.0</entry>
+       <entry>PECL mongodb 1.4.0</entry>
        <entry>
         The third parameter is now an <parameter>options</parameter> array.
         For backwards compatibility, this paramater will still accept a

--- a/reference/mongodb/mongodb/driver/manager/executereadwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executereadwritecommand.xml
@@ -91,7 +91,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.4.4</entry>
+       <entry>PECL mongodb 1.4.4</entry>
        <entry>
         <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
         will be thrown if the <literal>"session"</literal> option is used in

--- a/reference/mongodb/mongodb/driver/manager/executewritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executewritecommand.xml
@@ -99,7 +99,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.4.4</entry>
+       <entry>PECL mongodb 1.4.4</entry>
        <entry>
         <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
         will be thrown if the <literal>"session"</literal> option is used in

--- a/reference/mongodb/mongodb/driver/manager/startsession.xml
+++ b/reference/mongodb/mongodb/driver/manager/startsession.xml
@@ -134,7 +134,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.6.0</entry>
+       <entry>PECL mongodb 1.6.0</entry>
        <entry>
         <para>
          The <literal>"maxCommitTimeMS"</literal> option was added to
@@ -143,7 +143,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.5.0</entry>
+       <entry>PECL mongodb 1.5.0</entry>
        <entry>
         <para>
          The <literal>"defaultTransactionOptions"</literal> option was added.

--- a/reference/mongodb/mongodb/driver/query/construct.xml
+++ b/reference/mongodb/mongodb/driver/query/construct.xml
@@ -437,7 +437,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.8.0</entry>
+       <entry>PECL mongodb 1.8.0</entry>
        <entry>
         <para>
          Added the <literal>"allowDiskUse"</literal> option.
@@ -448,7 +448,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.5.0</entry>
+       <entry>PECL mongodb 1.5.0</entry>
        <entry>
         <para>
          The <literal>"maxScan"</literal> and <literal>"snapshot"</literal>
@@ -457,7 +457,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.3.0</entry>
+       <entry>PECL mongodb 1.3.0</entry>
        <entry>
         <para>
          Added the <literal>"maxAwaitTimeMS"</literal> option.
@@ -465,7 +465,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.2.0</entry>
+       <entry>PECL mongodb 1.2.0</entry>
        <entry>
         <para>
          Added the <literal>"allowPartialResults"</literal>,
@@ -491,7 +491,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.1.0</entry>
+       <entry>PECL mongodb 1.1.0</entry>
        <entry>Added the <literal>"readConcern"</literal> option.</entry>
       </row>
      </tbody>

--- a/reference/mongodb/mongodb/driver/readconcern.xml
+++ b/reference/mongodb/mongodb/driver/readconcern.xml
@@ -200,13 +200,13 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.7.0</entry>
+        <entry>PECL mongodb 1.7.0</entry>
         <entry>
          Implements <interfacename>Serializable</interfacename>.
         </entry>
        </row>
        <row>
-        <entry>1.4.0</entry>
+        <entry>PECL mongodb 1.4.0</entry>
         <entry>
          <para>
           Added the <constant>MongoDB\Driver\ReadConcern::AVAILABLE</constant>
@@ -215,7 +215,7 @@
         </entry>
        </row>
        <row>
-        <entry>1.2.0</entry>
+        <entry>PECL mongodb 1.2.0</entry>
         <entry>
          <para>
           Added the

--- a/reference/mongodb/mongodb/driver/readpreference.xml
+++ b/reference/mongodb/mongodb/driver/readpreference.xml
@@ -267,7 +267,7 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.7.0</entry>
+        <entry>PECL mongodb 1.7.0</entry>
         <entry>
          <para>
           Added the
@@ -283,7 +283,7 @@
         </entry>
        </row>
        <row>
-        <entry>1.2.0</entry>
+        <entry>PECL mongodb 1.2.0</entry>
         <entry>
          <para>
           Added the

--- a/reference/mongodb/mongodb/driver/readpreference/construct.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/construct.xml
@@ -205,13 +205,13 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.8.0</entry>
+       <entry>PECL mongodb 1.8.0</entry>
        <entry>
         Added the <literal>"hedge"</literal> option.
        </entry>
       </row>
       <row>
-       <entry>1.3.0</entry>
+       <entry>PECL mongodb 1.3.0</entry>
        <entry>
         <para>
          The <parameter>mode</parameter> argument now accepts a string value,
@@ -221,7 +221,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.2.0</entry>
+       <entry>PECL mongodb 1.2.0</entry>
        <entry>
         <para>
          Added a third <parameter>options</parameter> argument, which supports

--- a/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
@@ -87,7 +87,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.4.4</entry>
+       <entry>PECL mongodb 1.4.4</entry>
        <entry>
         <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
         will be thrown if the <literal>"session"</literal> option is used in
@@ -95,7 +95,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.4.0</entry>
+       <entry>PECL mongodb 1.4.0</entry>
        <entry>
         The third parameter is now an <parameter>options</parameter> array.
         For backwards compatibility, this paramater will still accept a
@@ -103,7 +103,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.3.0</entry>
+       <entry>PECL mongodb 1.3.0</entry>
        <entry>
         <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
         is now thrown if <parameter>bulk</parameter> does not contain any write

--- a/reference/mongodb/mongodb/driver/server/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executecommand.xml
@@ -93,7 +93,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.4.4</entry>
+       <entry>PECL mongodb 1.4.4</entry>
        <entry>
         <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
         will be thrown if the <literal>"session"</literal> option is used in
@@ -101,7 +101,7 @@
        </entry>
       </row>
       <row>
-       <entry>1.4.0</entry>
+       <entry>PECL mongodb 1.4.0</entry>
        <entry>
         The third parameter is now an <parameter>options</parameter> array.
         For backwards compatibility, this paramater will still accept a

--- a/reference/mongodb/mongodb/driver/server/executequery.xml
+++ b/reference/mongodb/mongodb/driver/server/executequery.xml
@@ -87,7 +87,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.4.0</entry>
+       <entry>PECL mongodb 1.4.0</entry>
        <entry>
         The third parameter is now an <parameter>options</parameter> array.
         For backwards compatibility, this paramater will still accept a

--- a/reference/mongodb/mongodb/driver/server/executereadwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executereadwritecommand.xml
@@ -91,7 +91,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.4.4</entry>
+       <entry>PECL mongodb 1.4.4</entry>
        <entry>
         <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
         will be thrown if the <literal>"session"</literal> option is used in

--- a/reference/mongodb/mongodb/driver/server/executewritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executewritecommand.xml
@@ -99,7 +99,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.4.4</entry>
+       <entry>PECL mongodb 1.4.4</entry>
        <entry>
         <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
         will be thrown if the <literal>"session"</literal> option is used in

--- a/reference/mongodb/mongodb/driver/session/starttransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/starttransaction.xml
@@ -99,7 +99,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.6.0</entry>
+       <entry>PECL mongodb 1.6.0</entry>
        <entry>
         <para>
          The <literal>"maxCommitTimeMS"</literal> option was added.

--- a/reference/mongodb/mongodb/driver/writeconcern.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern.xml
@@ -92,13 +92,13 @@
       </thead>
       <tbody>
        <row>
-        <entry>1.7.0</entry>
+        <entry>PECL mongodb 1.7.0</entry>
         <entry>
          Implements <interfacename>Serializable</interfacename>.
         </entry>
        </row>
        <row>
-        <entry>1.2.0</entry>
+        <entry>PECL mongodb 1.2.0</entry>
         <entry>
          Implements <interfacename>MongoDB\BSON\Serializable</interfacename>.
         </entry>

--- a/reference/mongodb/mongodb/driver/writeconcern/construct.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/construct.xml
@@ -167,7 +167,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.7.0</entry>
+       <entry>PECL mongodb 1.7.0</entry>
        <entry>
         The <parameter>wTimeout</parameter> parameter now accepts 64-bit values.
        </entry>

--- a/reference/mongodb/mongodb/driver/writeconcern/getwtimeout.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/getwtimeout.xml
@@ -47,7 +47,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.7.0</entry>
+       <entry>PECL mongodb 1.7.0</entry>
        <entry>
         On 32-bit systems, this method will return a <classname>MongoDB\BSON\Int64</classname>
         instance if the WriteConcern object was created with a <literal>wTimeout</literal>

--- a/reference/oauth/oauth/disabledebug.xml
+++ b/reference/oauth/oauth/disabledebug.xml
@@ -45,7 +45,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>0.99.8</entry>
+       <entry>PECL oauth 0.99.8</entry>
        <entry>
         The related <link linkend="oauth.props.debug">debug</link> property was added.
        </entry>

--- a/reference/oauth/oauth/disablesslchecks.xml
+++ b/reference/oauth/oauth/disablesslchecks.xml
@@ -46,7 +46,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>0.99.8</entry>
+       <entry>PECL oauth 0.99.8</entry>
        <entry>
         The <parameter>sslChecks</parameter> member was added
        </entry>

--- a/reference/oauth/oauth/enabledebug.xml
+++ b/reference/oauth/oauth/enabledebug.xml
@@ -46,7 +46,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>0.99.8</entry>
+       <entry>PECL oauth 0.99.8</entry>
        <entry>
         The <parameter>debug</parameter> and <parameter>debugInfo</parameter> members were added
        </entry>

--- a/reference/oauth/oauth/enablesslchecks.xml
+++ b/reference/oauth/oauth/enablesslchecks.xml
@@ -43,7 +43,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>0.99.8</entry>
+       <entry>PECL oauth 0.99.8</entry>
        <entry>
         The <parameter>sslChecks</parameter> member was added
        </entry>

--- a/reference/oauth/oauth/fetch.xml
+++ b/reference/oauth/oauth/fetch.xml
@@ -88,19 +88,19 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.0.0</entry>
+       <entry>PECL oauth 1.0.0</entry>
        <entry>
         &oauth.changelog.error.null;
        </entry>
       </row>
       <row>
-       <entry>0.99.5</entry>
+       <entry>PECL oauth 0.99.5</entry>
        <entry>
         The <parameter>http_method</parameter> parameter was added
        </entry>
       </row>
       <row>
-       <entry>0.99.8</entry>
+       <entry>PECL oauth 0.99.8</entry>
        <entry>
         The <parameter>http_headers</parameter> parameter was added
        </entry>

--- a/reference/oauth/oauth/getaccesstoken.xml
+++ b/reference/oauth/oauth/getaccesstoken.xml
@@ -92,13 +92,13 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.0.0</entry>
+       <entry>PECL oauth 1.0.0</entry>
        <entry>
         &oauth.changelog.error.null;
        </entry>
       </row>
       <row>
-       <entry>0.99.9</entry>
+       <entry>PECL oauth 0.99.9</entry>
        <entry>
         The <parameter>verifier_token</parameter> parameter was added
        </entry>

--- a/reference/oauth/oauth/getrequesttoken.xml
+++ b/reference/oauth/oauth/getrequesttoken.xml
@@ -72,13 +72,13 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.0.0</entry>
+       <entry>PECL oauth 1.0.0</entry>
        <entry>
         &oauth.changelog.error.null;
        </entry>
       </row>
       <row>
-       <entry>0.99.9</entry>
+       <entry>PECL oauth 0.99.9</entry>
        <entry>
         The <parameter>callback_url</parameter> parameter was added
        </entry>

--- a/reference/oauth/oauth/setauthtype.xml
+++ b/reference/oauth/oauth/setauthtype.xml
@@ -89,7 +89,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.0.0</entry>
+       <entry>PECL oauth 1.0.0</entry>
        <entry>
         &oauth.changelog.error.null;
        </entry>

--- a/reference/oauth/oauth/setcapath.xml
+++ b/reference/oauth/oauth/setcapath.xml
@@ -67,7 +67,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.0.0</entry>
+       <entry>PECL oauth 1.0.0</entry>
        <entry>
         &oauth.changelog.error.null;
        </entry>

--- a/reference/oauth/oauth/setnonce.xml
+++ b/reference/oauth/oauth/setnonce.xml
@@ -55,7 +55,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.0.0</entry>
+       <entry>PECL oauth 1.0.0</entry>
        <entry>
         &oauth.changelog.error.null;
        </entry>

--- a/reference/oauth/oauth/setrsacertificate.xml
+++ b/reference/oauth/oauth/setrsacertificate.xml
@@ -56,7 +56,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.0.0</entry>
+       <entry>PECL oauth 1.0.0</entry>
        <entry>
         &oauth.changelog.error.null;
        </entry>

--- a/reference/oauth/oauth/settimestamp.xml
+++ b/reference/oauth/oauth/settimestamp.xml
@@ -56,7 +56,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.0.0</entry>
+       <entry>PECL oauth 1.0.0</entry>
        <entry>
         &oauth.changelog.error.null;
        </entry>

--- a/reference/rar/rararchive/close.xml
+++ b/reference/rar/rararchive/close.xml
@@ -61,7 +61,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.0.0</entry>
+       <entry>PECL rar 2.0.0</entry>
        <entry>
         The RAR entries returned by <methodname>RarArchive::getEntry</methodname>
         and <methodname>RarArchive::getEntries</methodname> are now invalidated when

--- a/reference/rar/rararchive/getentries.xml
+++ b/reference/rar/rararchive/getentries.xml
@@ -72,7 +72,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>3.0.0</entry>
+       <entry>PECL rar 3.0.0</entry>
        <entry>
         Support for RAR archives with repeated entry names is no longer defective.
        </entry>

--- a/reference/rar/rararchive/open.xml
+++ b/reference/rar/rararchive/open.xml
@@ -104,7 +104,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>3.0.0</entry>
+       <entry>PECL rar 3.0.0</entry>
        <entry>
         <parameter>volume_callback</parameter> was added.
        </entry>

--- a/reference/rar/rarentry/extract.xml
+++ b/reference/rar/rarentry/extract.xml
@@ -101,13 +101,13 @@
      </thead>
      <tbody>
       <row>
-       <entry>3.0.0</entry>
+       <entry>PECL rar 3.0.0</entry>
        <entry>
         <parameter>extended_data</parameter> was added.
        </entry>
       </row>
       <row>
-       <entry>3.0.0</entry>
+       <entry>PECL rar 3.0.0</entry>
        <entry>
         Support for RAR archives with repeated entry names is no longer defective.
        </entry>

--- a/reference/rar/rarentry/getcrc.xml
+++ b/reference/rar/rarentry/getcrc.xml
@@ -43,7 +43,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.0.0</entry>
+       <entry>PECL rar 2.0.0</entry>
        <entry>
         This method now returns correct values for multiple volume archives.
        </entry>

--- a/reference/rar/rarentry/getname.xml
+++ b/reference/rar/rarentry/getname.xml
@@ -43,7 +43,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.0.0</entry>
+       <entry>PECL rar 2.0.0</entry>
        <entry>
         As of version 2.0.0, the returned string is encoded in Unicode/UTF-8.
        </entry>

--- a/reference/rar/rarentry/getpackedsize.xml
+++ b/reference/rar/rarentry/getpackedsize.xml
@@ -48,7 +48,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.0.0</entry>
+       <entry>PECL rar 2.0.0</entry>
        <entry>
         This method now returns correct values of packed sizes bigger than 2 GiB
         on platforms with 64-bit <type>integer</type>s and never

--- a/reference/rar/rarentry/getstream.xml
+++ b/reference/rar/rarentry/getstream.xml
@@ -70,7 +70,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>3.0.0</entry>
+       <entry>PECL rar 3.0.0</entry>
        <entry>
         Support for RAR archives with repeated entry names is no longer defective.
        </entry>

--- a/reference/rar/rarentry/getunpackedsize.xml
+++ b/reference/rar/rarentry/getunpackedsize.xml
@@ -48,7 +48,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.0.0</entry>
+       <entry>PECL rar 2.0.0</entry>
        <entry>
         This method now returns correct values of unpacked sizes bigger than
         2 GiB on platforms with 64-bit <type>integer</type>s and never

--- a/reference/sdo/sdo_das_datafactory/addPropertyToType.xml
+++ b/reference/sdo/sdo_das_datafactory/addPropertyToType.xml
@@ -168,7 +168,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>0.5.2</entry>
+       <entry>PECL sdo 0.5.2</entry>
        <entry>Optional parameters <varname>many</varname>, 
         <varname>readOnly</varname>, and <varname>containment</varname>
         deprecated in favour of the <varname>options</varname> array.

--- a/reference/solr/solrclient/commit.xml
+++ b/reference/solr/solrclient/commit.xml
@@ -88,20 +88,20 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.1.0, 2.0.0</entry>
+       <entry>PECL solr 1.1.0, 2.0.0</entry>
        <entry>
         $maxSegments removed
        </entry>
       </row>
       <row>
-       <entry>2.0.0b</entry>
+       <entry>PECL solr 2.0.0b</entry>
        <entry>
         API Changed: SolrClient::commit ([ int $maxSegments = 0 [, bool $softCommit = false [, bool $waitSearcher = true[, bool $expungeDeletes = false ]]] )
        </entry>
       </row>
       
       <row>
-       <entry>0.9.2</entry>
+       <entry>PECL solr 0.9.2</entry>
        <entry>
         Signature: SolrClient::commit ([ int $maxSegments = 1 [, bool $waitFlush = true [, bool $waitSearcher = true ]]] ). 
         $waitFlush: Block until index changes are flushed to disk.

--- a/reference/solr/solrquery/construct.xml
+++ b/reference/solr/solrquery/construct.xml
@@ -60,7 +60,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>2.0.0</entry>
+       <entry>PECL solr 2.0.0</entry>
        <entry>
         If <parameter>q</parameter> was invalid, then a
         <classname>SolrIllegalArgumentException</classname> is now thrown. Previously an error was emitted.

--- a/reference/sphinx/sphinxclient/close.xml
+++ b/reference/sphinx/sphinxclient/close.xml
@@ -36,7 +36,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.0.3</entry>
+       <entry>PECL sphinx 1.0.3</entry>
        <entry>
         Added SphinxClient::close(), available only if compiled with
         libsphinxclient >= 0.9.9.

--- a/reference/sphinx/sphinxclient/open.xml
+++ b/reference/sphinx/sphinxclient/open.xml
@@ -36,7 +36,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.0.3</entry>
+       <entry>PECL sphinx 1.0.3</entry>
        <entry>
         Added SphinxClient::open(), available only if compiled with
         libsphinxclient >= 0.9.9.

--- a/reference/sphinx/sphinxclient/setoverride.xml
+++ b/reference/sphinx/sphinxclient/setoverride.xml
@@ -69,7 +69,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.0.3</entry>
+       <entry>PECL sphinx 1.0.3</entry>
        <entry>
         Added SphinxClient::setOverride(), available only if compiled with
         libsphinxclient >= 0.9.9.

--- a/reference/sphinx/sphinxclient/setselect.xml
+++ b/reference/sphinx/sphinxclient/setselect.xml
@@ -48,7 +48,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.0.1</entry>
+       <entry>PECL sphinx 1.0.1</entry>
        <entry>
         Added SphinxClient::setSelect(), available only if compiled with
         libsphinxclient >= 0.9.9.

--- a/reference/sphinx/sphinxclient/status.xml
+++ b/reference/sphinx/sphinxclient/status.xml
@@ -37,7 +37,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.0.3</entry>
+       <entry>PECL sphinx 1.0.3</entry>
        <entry>
         Added SphinxClient::status(), available only if compiled with
         libsphinxclient >= 0.9.9.

--- a/reference/stomp/stomp/construct.xml
+++ b/reference/stomp/stomp/construct.xml
@@ -82,7 +82,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.0.1</entry>
+       <entry>PECL stomp 1.0.1</entry>
        <entry>
         The <parameter>headers</parameter> parameter was added
        </entry>

--- a/reference/sync/syncevent/construct.xml
+++ b/reference/sync/syncevent/construct.xml
@@ -109,7 +109,7 @@ $event->wait();
      </thead>
      <tbody>
       <row>
-       <entry>1.1.0</entry>
+       <entry>PECL sync 1.1.0</entry>
        <entry>
         <para>
          Added <parameter>prefire</parameter>.

--- a/reference/win32service/functions/win32-continue-service.xml
+++ b/reference/win32service/functions/win32-continue-service.xml
@@ -65,7 +65,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>0.3.0</entry>
+       <entry>PECL win32service 0.3.0</entry>
        <entry>
         This function does not longer require an administrator account if ACL is set for another account.
        </entry>

--- a/reference/win32service/functions/win32-create-service.xml
+++ b/reference/win32service/functions/win32-create-service.xml
@@ -387,7 +387,7 @@ debug_zval_dump($x);
      </thead>
      <tbody>
       <row>
-       <entry>0.4.0</entry>
+       <entry>PECL win32service 0.4.0</entry>
        <entry>
         The <parameter>dependencies</parameter>, <parameter>recovery_delay</parameter>,
         <parameter>recovery_action_1</parameter>, <parameter>recovery_action_2</parameter>,

--- a/reference/win32service/functions/win32-get-last-control-message.xml
+++ b/reference/win32service/functions/win32-get-last-control-message.xml
@@ -60,7 +60,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>0.2.0</entry>
+       <entry>PECL win32service 0.2.0</entry>
        <entry>
         This function works only in the <literal>"cli"</literal> SAPI.
        </entry>

--- a/reference/win32service/functions/win32-pause-service.xml
+++ b/reference/win32service/functions/win32-pause-service.xml
@@ -64,7 +64,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>0.3.0</entry>
+       <entry>PECL win32service 0.3.0</entry>
        <entry>
         This function does not longer require an administrator account if ACL is set for another account.
        </entry>

--- a/reference/win32service/functions/win32-set-service-status.xml
+++ b/reference/win32service/functions/win32-set-service-status.xml
@@ -95,7 +95,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>0.2.0</entry>
+       <entry>PECL win32service 0.2.0</entry>
        <entry>
         This function works only in the <literal>"cli"</literal> SAPI.
        </entry>

--- a/reference/win32service/functions/win32-start-service-ctrl-dispatcher.xml
+++ b/reference/win32service/functions/win32-start-service-ctrl-dispatcher.xml
@@ -126,13 +126,13 @@ while (WIN32_SERVICE_CONTROL_STOP != win32_get_last_control_message()) {
      </thead>
      <tbody>
       <row>
-       <entry>0.4.0</entry>
+       <entry>PECL win32service 0.4.0</entry>
        <entry>
         The parameter <parameter>gracefulMode</parameter> has been added.
        </entry>
       </row>
       <row>
-       <entry>0.2.0</entry>
+       <entry>PECL win32service 0.2.0</entry>
        <entry>
         This function works only in the <literal>"cli"</literal> SAPI.
        </entry>

--- a/reference/win32service/functions/win32-start-service.xml
+++ b/reference/win32service/functions/win32-start-service.xml
@@ -64,7 +64,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>0.3.0</entry>
+       <entry>PECL win32service 0.3.0</entry>
        <entry>
         This function does not longer require an administrator account if ACL is set for another account.
        </entry>

--- a/reference/win32service/functions/win32-stop-service.xml
+++ b/reference/win32service/functions/win32-stop-service.xml
@@ -64,7 +64,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>0.3.0</entry>
+       <entry>PECL win32service 0.3.0</entry>
        <entry>
         This function does not longer require an administrator account if ACL is set for another account.
        </entry>

--- a/reference/xhprof/functions/xhprof-enable.xml
+++ b/reference/xhprof/functions/xhprof-enable.xml
@@ -67,7 +67,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>0.9.2</entry>
+      <entry>PECL xhprof 0.9.2</entry>
       <entry>
        The optional <parameter>options</parameter> parameter was added.
       </entry>

--- a/reference/yaml/functions/yaml-emit-file.xml
+++ b/reference/yaml/functions/yaml-emit-file.xml
@@ -103,7 +103,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.1.0</entry>
+       <entry>PECL yaml 1.1.0</entry>
        <entry>
         The <parameter>callbacks</parameter> parameter was added.
        </entry>

--- a/reference/yaml/functions/yaml-emit.xml
+++ b/reference/yaml/functions/yaml-emit.xml
@@ -93,7 +93,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.1.0</entry>
+       <entry>PECL yaml 1.1.0</entry>
        <entry>
         The <parameter>callbacks</parameter> parameter was added.
        </entry>


### PR DESCRIPTION
As discussed in https://github.com/php/doc-en/pull/161#discussion_r511020631 with @cmb69, this PR adds the PECL package name in front of the PECL versions in the changelogs, to avoid confusing them with PHP versions.

The changes in this PR were generated using this script:
https://gist.github.com/BenMorel/19499bf5c918cd0ea0f0b3f27a5a8254

Open question: is `/reference/<name>/` always a PECL package name?