### PR TITLE
Remove PHP 5 from static keyword page

### DIFF
--- a/language/oop5/static.xml
+++ b/language/oop5/static.xml
@@ -39,16 +39,9 @@
     not available inside the method declared as static.
    </para>
 
-   <caution>
-    <simpara>
-     In PHP 5, calling non-static methods statically generates an
-     <constant>E_STRICT</constant> level warning.
-    </simpara>
-   </caution>
-
    <warning>
     <simpara>
-     In PHP 7, calling non-static methods statically is deprecated, and will
+     Calling non-static methods statically is deprecated, and will
      generate an <constant>E_DEPRECATED</constant> warning. Support for
      calling non-static methods statically may be removed in the future.
     </simpara>
@@ -67,7 +60,7 @@ class Foo {
 
 Foo::aStaticMethod();
 $classname = 'Foo';
-$classname::aStaticMethod(); // As of PHP 5.3.0
+$classname::aStaticMethod();
 ?> 
 ]]>
      </programlisting>
@@ -84,14 +77,13 @@ $classname::aStaticMethod(); // As of PHP 5.3.0
 
    <para>
     Like any other PHP static variable, static properties may only be
-    initialized using a literal or constant before PHP 5.6; expressions are
-    not allowed. In PHP 5.6 and later, the same rules apply as &const;
-    expressions: some limited expressions are possible, provided they can be
-    evaluated at compile time.
+    initialized using a literal or constant; expressions are not allowed. 
+    The same rules apply as &const; expressions: some limited expressions 
+    are possible, provided they can be evaluated at compile time.
    </para>
 
    <para>
-    As of PHP 5.3.0, it's possible to reference the class using a variable.
+    It's possible to reference the class using a variable.
     The variable's value cannot be a keyword (e.g. <literal>self</literal>,
     <literal>parent</literal> and <literal>static</literal>).
    </para>
@@ -126,7 +118,7 @@ print $foo->my_static . "\n";      // Undefined "Property" my_static
 
 print $foo::$my_static . "\n";
 $classname = 'Foo';
-print $classname::$my_static . "\n"; // As of PHP 5.3.0
+print $classname::$my_static . "\n";
 
 print Bar::$my_static . "\n";
 $bar = new Bar();


### PR DESCRIPTION
I'll start working on removal of PHP 5 from OOP section, this was a file I encountered while browsing the manual. I'll add more files as I go through.