### PR TITLE
Proper variadics instead of pseudo variadics

### DIFF
--- a/language/oop5/decon.xml
+++ b/language/oop5/decon.xml
@@ -7,8 +7,7 @@
    <title>Constructor</title>
    <methodsynopsis xml:id="object.construct">
     <type>void</type><methodname>__construct</methodname>
-    <methodparam choice="opt"><type>mixed</type><parameter>args</parameter><initializer>""</initializer></methodparam>
-    <methodparam choice="opt"><parameter>...</parameter></methodparam>
+    <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter><initializer>""</initializer></methodparam>
    </methodsynopsis>
    <para>
     PHP 5 allows developers to declare constructor methods for classes.

--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -299,7 +299,7 @@ Hello
    <title><link linkend="object.invoke">__invoke()</link></title>
    <methodsynopsis xml:id="object.invoke">
     <type>mixed</type><methodname>__invoke</methodname>
-    <methodparam choice="opt"><parameter>...</parameter></methodparam>
+    <methodparam rep="repeat"><parameter>values</parameter></methodparam>
    </methodsynopsis>
    <para>
     The <link linkend="object.invoke">__invoke()</link> method is called when a script tries to

--- a/language/predefined/closure/call.xml
+++ b/language/predefined/closure/call.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>Closure::call</methodname>
    <methodparam><type>object</type><parameter>newthis</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
    Temporarily binds the closure to <parameter>newthis</parameter>, and calls
@@ -31,7 +31,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>...</parameter></term>
+    <term><parameter>values</parameter></term>
     <listitem>
      <para>
       Zero or more parameters, which will be given as parameters to the

--- a/language/types.xml
+++ b/language/types.xml
@@ -122,10 +122,6 @@
 
   </itemizedlist>
   
-  <para>
-   And the pseudo-variable <parameter>$...</parameter>.
-  </para>
-
   <simpara>
    Some references to the type "double" may remain in the manual. Consider
    double the same as float; the two names exist only for historic reasons.

--- a/language/types/pseudo-types.xml
+++ b/language/types/pseudo-types.xml
@@ -42,16 +42,6 @@
 
  </sect2>
 
- <sect2 xml:id="language.types.dotdotdot">
-  <title>...</title>
-
-  <para>
-   <parameter>$...</parameter> in function prototypes means
-   <literal>and so on</literal>. This variable name is used when a function can
-   take an endless number of arguments.
-  </para>
-
- </sect2>
 </sect1>
  
 <!-- Keep this comment at the end of the file

--- a/reference/array/functions/array-diff-assoc.xml
+++ b/reference/array/functions/array-diff-assoc.xml
@@ -10,12 +10,11 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_diff_assoc</methodname>
-   <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam><type>array</type><parameter>array2</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Compares <parameter>array1</parameter> against <parameter>array2</parameter> and
+   Compares <parameter>array</parameter> against <parameter>arrays</parameter> and
    returns the difference. Unlike <function>array_diff</function> the array
    keys are also used in the comparison.
   </para>
@@ -27,7 +26,7 @@
    <variablelist>
 
     <varlistentry>
-     <term><parameter>array1</parameter></term>
+     <term><parameter>array</parameter></term>
      <listitem>
       <para>
        The array to compare from
@@ -36,19 +35,10 @@
     </varlistentry>
 
     <varlistentry>
-     <term><parameter>array2</parameter></term>
+     <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       An array to compare against
-      </para>
-     </listitem>
-    </varlistentry>
-
-    <varlistentry>
-     <term><parameter>...</parameter></term>
-     <listitem>
-      <para>
-       More arrays to compare against
+       Arrays to compare against
       </para>
      </listitem>
     </varlistentry>
@@ -61,7 +51,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an <type>array</type> containing all the values from
-   <parameter>array1</parameter> that are not present in any of the other arrays.
+   <parameter>array</parameter> that are not present in any of the other arrays.
   </para>
  </refsect1>
 

--- a/reference/array/functions/array-diff-key.xml
+++ b/reference/array/functions/array-diff-key.xml
@@ -10,13 +10,12 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_diff_key</methodname>
-   <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam><type>array</type><parameter>array2</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Compares the keys from <parameter>array1</parameter> against the keys
-   from <parameter>array2</parameter> and returns the difference.
+   Compares the keys from <parameter>array</parameter> against the keys
+   from <parameter>arrays</parameter> and returns the difference.
    This function is like <function>array_diff</function> except the
    comparison is done on the keys instead of the values.
   </para>
@@ -28,7 +27,7 @@
    <variablelist>
 
     <varlistentry>
-     <term><parameter>array1</parameter></term>
+     <term><parameter>array</parameter></term>
      <listitem>
       <para>
        The array to compare from
@@ -37,19 +36,10 @@
     </varlistentry>
 
     <varlistentry>
-     <term><parameter>array2</parameter></term>
+     <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       An array to compare against
-      </para>
-     </listitem>
-    </varlistentry>
-
-    <varlistentry>
-     <term><parameter>...</parameter></term>
-     <listitem>
-      <para>
-       More arrays to compare against
+       Arrays to compare against
       </para>
      </listitem>
     </varlistentry>
@@ -62,7 +52,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an <type>array</type> containing all the entries from
-   <parameter>array1</parameter> whose keys are absent from all of the
+   <parameter>array</parameter> whose keys are absent from all of the
    other arrays.
   </para>
  </refsect1>

--- a/reference/array/functions/array-diff-uassoc.xml
+++ b/reference/array/functions/array-diff-uassoc.xml
@@ -10,13 +10,12 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_diff_uassoc</methodname>
-   <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam><type>array</type><parameter>array2</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
    <methodparam><type>callable</type><parameter>key_compare_func</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Compares <parameter>array1</parameter> against <parameter>array2</parameter> and
+   Compares <parameter>array</parameter> against <parameter>arrays</parameter> and
    returns the difference. Unlike <function>array_diff</function> the array
    keys are used in the comparison.
   </para>
@@ -32,7 +31,7 @@
    <variablelist>
 
     <varlistentry>
-     <term><parameter>array1</parameter></term>
+     <term><parameter>array</parameter></term>
      <listitem>
       <para>
        The array to compare from
@@ -41,19 +40,10 @@
     </varlistentry>
 
     <varlistentry>
-     <term><parameter>array2</parameter></term>
+     <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       An array to compare against
-      </para>
-     </listitem>
-    </varlistentry>
-
-    <varlistentry>
-     <term><parameter>...</parameter></term>
-     <listitem>
-      <para>
-       More arrays to compare against
+       Arrays to compare against
       </para>
      </listitem>
     </varlistentry>
@@ -76,7 +66,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an <type>array</type> containing all the entries from
-   <parameter>array1</parameter> that are not present in any of the other arrays.
+   <parameter>array</parameter> that are not present in any of the other arrays.
   </para>
  </refsect1>
 

--- a/reference/array/functions/array-diff-ukey.xml
+++ b/reference/array/functions/array-diff-ukey.xml
@@ -10,14 +10,13 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_diff_ukey</methodname>
-   <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam><type>array</type><parameter>array2</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
    <methodparam><type>callable</type><parameter>key_compare_func</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Compares the keys from <parameter>array1</parameter> against the keys
-   from <parameter>array2</parameter> and returns the difference.
+   Compares the keys from <parameter>array</parameter> against the keys
+   from <parameter>arrays</parameter> and returns the difference.
    This function is like <function>array_diff</function> except the
    comparison is done on the keys instead of the values.
   </para>
@@ -33,7 +32,7 @@
    <variablelist>
 
     <varlistentry>
-     <term><parameter>array1</parameter></term>
+     <term><parameter>array</parameter></term>
      <listitem>
       <para>
        The array to compare from
@@ -42,19 +41,10 @@
     </varlistentry>
 
     <varlistentry>
-     <term><parameter>array2</parameter></term>
+     <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       An array to compare against
-      </para>
-     </listitem>
-    </varlistentry>
-
-    <varlistentry>
-     <term><parameter>...</parameter></term>
-     <listitem>
-      <para>
-       More arrays to compare against
+       Arrays to compare against
       </para>
      </listitem>
     </varlistentry>
@@ -77,7 +67,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an <type>array</type> containing all the entries from
-   <parameter>array1</parameter> that are not present in any of the other arrays.
+   <parameter>array</parameter> that are not present in any of the other arrays.
   </para>
  </refsect1>
 

--- a/reference/array/functions/array-diff.xml
+++ b/reference/array/functions/array-diff.xml
@@ -10,13 +10,12 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_diff</methodname>
-   <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam><type>array</type><parameter>array2</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Compares <parameter>array1</parameter> against one or more other arrays and
-   returns the values in <parameter>array1</parameter> that are not present in
+   Compares <parameter>array</parameter> against one or more other arrays and
+   returns the values in <parameter>array</parameter> that are not present in
    any of the other arrays.
   </para>
  </refsect1>
@@ -26,7 +25,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>array1</parameter></term>
+     <term><parameter>array</parameter></term>
      <listitem>
       <para>
        The array to compare from
@@ -34,18 +33,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>array2</parameter></term>
+     <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       An array to compare against
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>...</parameter></term>
-     <listitem>
-      <para>
-       More arrays to compare against
+       Arrays to compare against
       </para>
      </listitem>
     </varlistentry>
@@ -57,8 +48,8 @@
   &reftitle.returnvalues;
   <para>
    Returns an <type>array</type> containing all the entries from
-   <parameter>array1</parameter> that are not present in any of the other arrays.
-   Keys in the <parameter>array1</parameter> array are preserved.
+   <parameter>array</parameter> that are not present in any of the other arrays.
+   Keys in the <parameter>array</parameter> array are preserved.
   </para>
  </refsect1>
 

--- a/reference/array/functions/array-intersect-assoc.xml
+++ b/reference/array/functions/array-intersect-assoc.xml
@@ -10,13 +10,12 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_intersect_assoc</methodname>
-   <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam><type>array</type><parameter>array2</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
   </methodsynopsis>
   <simpara>
    <function>array_intersect_assoc</function> returns an array
-   containing all the values of <parameter>array1</parameter>
+   containing all the values of <parameter>array</parameter>
    that are present in all the arguments. Note that the keys are also used in
    the comparison unlike in <function>array_intersect</function>.
   </simpara>
@@ -27,7 +26,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>array1</parameter></term>
+     <term><parameter>array</parameter></term>
      <listitem>
       <para>
        The array with master values to check.
@@ -35,18 +34,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>array2</parameter></term>
+     <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       An array to compare values against.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>...</parameter></term>
-     <listitem>
-      <para>
-       A variable list of arrays to compare.
+       Arrays to compare values against.
       </para>
      </listitem>
     </varlistentry>
@@ -58,7 +49,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an associative array containing all the values in 
-   <parameter>array1</parameter> that are present in all of the arguments.
+   <parameter>array</parameter> that are present in all of the arguments.
   </para>
  </refsect1>
 

--- a/reference/array/functions/array-intersect-key.xml
+++ b/reference/array/functions/array-intersect-key.xml
@@ -10,13 +10,12 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_intersect_key</methodname>
-   <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam><type>array</type><parameter>array2</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>array_intersect_key</function> returns an array
-   containing all the entries of <parameter>array1</parameter>
+   containing all the entries of <parameter>array</parameter>
    which have keys that are present in all the arguments.
   </para>
  </refsect1>
@@ -26,7 +25,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>array1</parameter></term>
+     <term><parameter>array</parameter></term>
      <listitem>
       <para>
        The array with master keys to check.
@@ -34,18 +33,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>array2</parameter></term>
+     <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       An array to compare keys against.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>...</parameter></term>
-     <listitem>
-      <para>
-       A variable list of arrays to compare.
+       Arrays to compare keys against.
       </para>
      </listitem>
     </varlistentry>
@@ -57,7 +48,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an associative array containing all the entries of 
-   <parameter>array1</parameter> which have keys that are present in all
+   <parameter>array</parameter> which have keys that are present in all
    arguments.
   </para>      
  </refsect1>
@@ -96,7 +87,7 @@ array(2) {
    returned. Also notice that the values for the keys
    <literal>'blue'</literal> and <literal>'green'</literal> differ between
    the two arrays. A match still occurs because only the keys are checked.
-   The values returned are those of <parameter>array1</parameter>.
+   The values returned are those of <parameter>array</parameter>.
   </para>
   <para>
    The two keys from the <literal>key =&gt; value</literal> pairs are

--- a/reference/array/functions/array-intersect-uassoc.xml
+++ b/reference/array/functions/array-intersect-uassoc.xml
@@ -10,14 +10,13 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_intersect_uassoc</methodname>
-   <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam><type>array</type><parameter>array2</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
    <methodparam><type>callable</type><parameter>key_compare_func</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>array_intersect_uassoc</function> returns an array
-   containing all the values of <parameter>array1</parameter>
+   containing all the values of <parameter>array</parameter>
    that are present in all the arguments. Note that the keys are used in
    the comparison unlike in <function>array_intersect</function>.
   </para>
@@ -28,7 +27,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>array1</parameter></term>
+     <term><parameter>array</parameter></term>
      <listitem>
       <para>
        Initial array for comparison of the arrays.
@@ -36,18 +35,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>array2</parameter></term>
+     <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       First array to compare keys against.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>...</parameter></term>
-     <listitem>
-      <para>
-       Variable list of array arguments to compare values against.
+       Arrays to compare keys against.
       </para>
      </listitem>
     </varlistentry>
@@ -67,7 +58,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the values of <parameter>array1</parameter> whose values exist
+   Returns the values of <parameter>array</parameter> whose values exist
    in all of the arguments.
   </para>
  </refsect1>

--- a/reference/array/functions/array-intersect-ukey.xml
+++ b/reference/array/functions/array-intersect-ukey.xml
@@ -9,14 +9,13 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_intersect_ukey</methodname>
-   <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam><type>array</type><parameter>array2</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
    <methodparam><type>callable</type><parameter>key_compare_func</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>array_intersect_ukey</function> returns an array
-   containing all the values of <parameter>array1</parameter>
+   containing all the values of <parameter>array</parameter>
    which have matching keys that are present in all the arguments.
   </para>
  </refsect1>
@@ -26,7 +25,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>array1</parameter></term>
+     <term><parameter>array</parameter></term>
      <listitem>
       <para>
        Initial array for comparison of the arrays.
@@ -34,18 +33,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>array2</parameter></term>
+     <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       First array to compare keys against.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>...</parameter></term>
-     <listitem>
-      <para>
-       Variable list of array arguments to compare keys against.
+       Arrays to compare keys against.
       </para>
      </listitem>
     </varlistentry>
@@ -65,7 +56,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the values of <parameter>array1</parameter> whose keys exist
+   Returns the values of <parameter>array</parameter> whose keys exist
    in all the arguments.
   </para>
  </refsect1>
@@ -114,7 +105,7 @@ array(2) {
    returned. Also notice that the values for the keys
    <literal>'blue'</literal> and <literal>'green'</literal> differ between
    the two arrays. A match still occurs because only the keys are checked.
-   The values returned are those of <parameter>array1</parameter>.
+   The values returned are those of <parameter>array</parameter>.
   </para>
  </refsect1>
 

--- a/reference/array/functions/array-intersect.xml
+++ b/reference/array/functions/array-intersect.xml
@@ -10,13 +10,12 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_intersect</methodname>
-   <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam><type>array</type><parameter>array2</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>array_intersect</function> returns an array
-   containing all the values of <parameter>array1</parameter>
+   containing all the values of <parameter>array</parameter>
    that are present in all the arguments.
    Note that keys are preserved.
   </para>
@@ -27,7 +26,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>array1</parameter></term>
+     <term><parameter>array</parameter></term>
      <listitem>
       <para>
        The array with master values to check.
@@ -35,18 +34,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>array2</parameter></term>
+     <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       An array to compare values against.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>...</parameter></term>
-     <listitem>
-      <para>
-       A variable list of arrays to compare.
+       Arrays to compare values against.
       </para>
      </listitem>
     </varlistentry>
@@ -58,7 +49,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an array containing all of the values in 
-   <parameter>array1</parameter> whose values exist in all of the parameters.
+   <parameter>array</parameter> whose values exist in all of the parameters.
   </para>
  </refsect1> 
 

--- a/reference/array/functions/array-map.xml
+++ b/reference/array/functions/array-map.xml
@@ -11,14 +11,14 @@
   <methodsynopsis>
    <type>array</type><methodname>array_map</methodname>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
-   <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>array_map</function> returns an &array; containing
    the results of applying the <parameter>callback</parameter>
-   to the corresponding index of <parameter>array1</parameter>
-   (and <parameter>...</parameter> if more arrays are provided)
+   to the corresponding index of <parameter>array</parameter>
+   (and <parameter>arrays</parameter> if more arrays are provided)
    used as arguments for the callback.
    The number of parameters that the <parameter>callback</parameter>
    function accepts should match the number of arrays
@@ -39,13 +39,13 @@
       <para>
        &null; can be passed as a value to <parameter>callback</parameter>
        to perform a zip operation on multiple arrays.
-       If only <parameter>array1</parameter> is provided,
+       If only <parameter>array</parameter> is provided,
        <methodname>array_map</methodname> will return the input array.
       </para>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>array1</parameter></term>
+     <term><parameter>array</parameter></term>
      <listitem>
       <para>
        An array to run through the <parameter>callback</parameter> function.
@@ -53,7 +53,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
        Supplementary variable list of array arguments to run through the
@@ -69,8 +69,8 @@
   &reftitle.returnvalues;
   <para>
    Returns an array containing the results of applying the <parameter>callback</parameter>
-   function to the corresponding index of <parameter>array1</parameter>
-   (and <parameter>...</parameter> if more arrays are provided)
+   function to the corresponding index of <parameter>array</parameter>
+   (and <parameter>arrays</parameter> if more arrays are provided)
    used as arguments for the callback.
   </para>
   <para>
@@ -294,7 +294,7 @@ Array
    <example>
     <title>
      &null; <parameter>callback</parameter> with only
-     <parameter>array1</parameter>
+     <parameter>array</parameter>
     </title>
     <programlisting role="php">
 <![CDATA[

--- a/reference/array/functions/array-merge-recursive.xml
+++ b/reference/array/functions/array-merge-recursive.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_merge_recursive</methodname>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>array_merge_recursive</function> merges the elements of
@@ -32,7 +32,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
        Variable list of arrays to recursively merge.

--- a/reference/array/functions/array-merge.xml
+++ b/reference/array/functions/array-merge.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_merge</methodname>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
   </methodsynopsis>
   <para>
    Merges the elements of one or more arrays together so that the values of
@@ -33,7 +33,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
        Variable list of arrays to merge.

--- a/reference/array/functions/array-multisort.xml
+++ b/reference/array/functions/array-multisort.xml
@@ -12,7 +12,7 @@
    <methodparam><type>array</type><parameter role="reference">array1</parameter></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>array1_sort_order</parameter><initializer>SORT_ASC</initializer></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>array1_sort_flags</parameter><initializer>SORT_REGULAR</initializer></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>rest</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>array_multisort</function> can be used to sort several
@@ -101,7 +101,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>rest</parameter></term>
      <listitem>
       <para>
        More arrays, optionally followed by sort order and flags. Only elements

--- a/reference/array/functions/array-push.xml
+++ b/reference/array/functions/array-push.xml
@@ -10,7 +10,7 @@
   <methodsynopsis>
    <type>int</type><methodname>array_push</methodname>
    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>array_push</function> treats <parameter>array</parameter> as a
@@ -54,7 +54,7 @@ $array[] = $var;
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>values</parameter></term>
      <listitem>
       <para>
        The values to push onto the end of the <parameter>array</parameter>.

--- a/reference/array/functions/array-replace-recursive.xml
+++ b/reference/array/functions/array-replace-recursive.xml
@@ -9,12 +9,12 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_replace_recursive</methodname>
-   <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter>replacements</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>array_replace_recursive</function> replaces the values of
-   <parameter>array1</parameter> with the same values from all the following
+   <parameter>array</parameter> with the same values from all the following
    arrays. If a key from the first array exists in the second array, its value
    will be replaced by the value from the second array. If the key exists in the
    second array, and not the first, it will be created in the first array.
@@ -39,7 +39,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>array1</parameter></term>
+     <term><parameter>array</parameter></term>
      <listitem>
       <para>
        The array in which elements are replaced.
@@ -47,10 +47,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>replacements</parameter></term>
      <listitem>
       <para>
-       Optional. Arrays from which elements will be extracted.
+       Arrays from which elements will be extracted.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/array/functions/array-replace.xml
+++ b/reference/array/functions/array-replace.xml
@@ -9,12 +9,12 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_replace</methodname>
-   <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter>replacements</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>array_replace</function> replaces the values of
-   <parameter>array1</parameter> with values having the same keys in each of the following
+   <parameter>array</parameter> with values having the same keys in each of the following
    arrays. If a key from the first array exists in the second array, its value
    will be replaced by the value from the second array. If the key exists in the
    second array, and not the first, it will be created in the first array.
@@ -32,7 +32,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>array1</parameter></term>
+     <term><parameter>array</parameter></term>
      <listitem>
       <para>
        The array in which elements are replaced.
@@ -40,7 +40,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>replacements</parameter></term>
      <listitem>
       <para>
        Arrays from which elements will be extracted.

--- a/reference/array/functions/array-udiff-assoc.xml
+++ b/reference/array/functions/array-udiff-assoc.xml
@@ -10,7 +10,7 @@
   <methodsynopsis>
    <type>array</type><methodname>array_udiff_assoc</methodname>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
-   <methodparam rep="repeat"><type>array</type><parameter>rest</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
    <methodparam><type>callable</type><parameter>value_compare_func</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -38,7 +38,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>rest</parameter></term>
+     <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
        Arrays to compare against.

--- a/reference/array/functions/array-udiff-assoc.xml
+++ b/reference/array/functions/array-udiff-assoc.xml
@@ -9,9 +9,8 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_udiff_assoc</methodname>
-   <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam><type>array</type><parameter>array2</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>rest</parameter></methodparam>
    <methodparam><type>callable</type><parameter>value_compare_func</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -31,7 +30,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>array1</parameter></term>
+     <term><parameter>array</parameter></term>
      <listitem>
       <para>
        The first array.
@@ -39,10 +38,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>array2</parameter></term>
+     <term><parameter>rest</parameter></term>
      <listitem>
       <para>
-       The second array.
+       Arrays to compare against.
       </para>
      </listitem>
     </varlistentry>
@@ -62,7 +61,7 @@
   &reftitle.returnvalues;
   <para>
    <function>array_udiff_assoc</function> returns an <type>array</type>
-   containing all the values from <parameter>array1</parameter>
+   containing all the values from <parameter>array</parameter>
    that are not present in any of the other arguments.
    Note that the keys are used in the comparison unlike
    <function>array_diff</function> and <function>array_udiff</function>.

--- a/reference/array/functions/array-udiff-uassoc.xml
+++ b/reference/array/functions/array-udiff-uassoc.xml
@@ -9,9 +9,8 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_udiff_uassoc</methodname>
-   <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam><type>array</type><parameter>array2</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>rest</parameter></methodparam>
    <methodparam><type>callable</type><parameter>value_compare_func</parameter></methodparam>
    <methodparam><type>callable</type><parameter>key_compare_func</parameter></methodparam>
   </methodsynopsis>
@@ -29,7 +28,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>array1</parameter></term>
+     <term><parameter>array</parameter></term>
      <listitem>
       <para>
        The first array.
@@ -37,10 +36,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>array2</parameter></term>
+     <term><parameter>rest</parameter></term>
      <listitem>
       <para>
-       The second array.
+       Arrays to compare against.
       </para>
      </listitem>
     </varlistentry>
@@ -71,7 +70,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an <type>array</type> containing all the values from
-   <parameter>array1</parameter> that are not present in any of the other
+   <parameter>array</parameter> that are not present in any of the other
    arguments.
   </para>
  </refsect1>

--- a/reference/array/functions/array-udiff-uassoc.xml
+++ b/reference/array/functions/array-udiff-uassoc.xml
@@ -10,7 +10,7 @@
   <methodsynopsis>
    <type>array</type><methodname>array_udiff_uassoc</methodname>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
-   <methodparam rep="repeat"><type>array</type><parameter>rest</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
    <methodparam><type>callable</type><parameter>value_compare_func</parameter></methodparam>
    <methodparam><type>callable</type><parameter>key_compare_func</parameter></methodparam>
   </methodsynopsis>
@@ -36,7 +36,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>rest</parameter></term>
+     <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
        Arrays to compare against.

--- a/reference/array/functions/array-udiff.xml
+++ b/reference/array/functions/array-udiff.xml
@@ -9,9 +9,8 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_udiff</methodname>
-   <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam><type>array</type><parameter>array2</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>rest</parameter></methodparam>
    <methodparam><type>callable</type><parameter>value_compare_func</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -25,7 +24,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>array1</parameter></term>
+     <term><parameter>array</parameter></term>
      <listitem>
       <para>
        The first array.
@@ -33,10 +32,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>array2</parameter></term>
+     <term><parameter>rest</parameter></term>
      <listitem>
       <para>
-       The second array.
+       Arrays to compare against.
       </para>
      </listitem>
     </varlistentry>
@@ -58,7 +57,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an array containing all the values of <parameter>array1</parameter>
+   Returns an array containing all the values of <parameter>array</parameter>
    that are not present in any of the other arguments.
   </para>
  </refsect1>

--- a/reference/array/functions/array-udiff.xml
+++ b/reference/array/functions/array-udiff.xml
@@ -10,7 +10,7 @@
   <methodsynopsis>
    <type>array</type><methodname>array_udiff</methodname>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
-   <methodparam rep="repeat"><type>array</type><parameter>rest</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
    <methodparam><type>callable</type><parameter>value_compare_func</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -32,7 +32,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>rest</parameter></term>
+     <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
        Arrays to compare against.

--- a/reference/array/functions/array-uintersect-assoc.xml
+++ b/reference/array/functions/array-uintersect-assoc.xml
@@ -10,7 +10,7 @@
   <methodsynopsis>
    <type>array</type><methodname>array_uintersect_assoc</methodname>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
-   <methodparam rep="repeat"><type>array</type><parameter>rest</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
    <methodparam><type>callable</type><parameter>value_compare_func</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -36,7 +36,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>rest</parameter></term>
+     <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
        Arrays to compare against.

--- a/reference/array/functions/array-uintersect-assoc.xml
+++ b/reference/array/functions/array-uintersect-assoc.xml
@@ -9,9 +9,8 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_uintersect_assoc</methodname>
-   <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam><type>array</type><parameter>array2</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>rest</parameter></methodparam>
    <methodparam><type>callable</type><parameter>value_compare_func</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -29,7 +28,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>array1</parameter></term>
+     <term><parameter>array</parameter></term>
      <listitem>
       <para>
        The first array.
@@ -37,10 +36,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>array2</parameter></term>
+     <term><parameter>rest</parameter></term>
      <listitem>
       <para>
-       The second array.
+       Arrays to compare against.
       </para>
      </listitem>
     </varlistentry>
@@ -60,7 +59,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an array containing all the values of
-   <parameter>array1</parameter> that are present in all the arguments.
+   <parameter>array</parameter> that are present in all the arguments.
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/array/functions/array-uintersect-uassoc.xml
+++ b/reference/array/functions/array-uintersect-uassoc.xml
@@ -11,7 +11,7 @@
    <type>array</type><methodname>array_uintersect_uassoc</methodname>
    <methodparam><type>array</type><parameter>array1</parameter></methodparam>
    <methodparam><type>array</type><parameter>array2</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
    <methodparam><type>callable</type><parameter>value_compare_func</parameter></methodparam>
    <methodparam><type>callable</type><parameter>key_compare_func</parameter></methodparam>
   </methodsynopsis>
@@ -37,6 +37,14 @@
      <listitem>
       <para>
        The second array.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>arrays</parameter></term>
+     <listitem>
+      <para>
+       Further arrays.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/array/functions/array-uintersect-uassoc.xml
+++ b/reference/array/functions/array-uintersect-uassoc.xml
@@ -10,7 +10,6 @@
   <methodsynopsis>
    <type>array</type><methodname>array_uintersect_uassoc</methodname>
    <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam><type>array</type><parameter>array2</parameter></methodparam>
    <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
    <methodparam><type>callable</type><parameter>value_compare_func</parameter></methodparam>
    <methodparam><type>callable</type><parameter>key_compare_func</parameter></methodparam>
@@ -29,14 +28,6 @@
      <listitem>
       <para>
        The first array.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>array2</parameter></term>
-     <listitem>
-      <para>
-       The second array.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/array/functions/array-uintersect.xml
+++ b/reference/array/functions/array-uintersect.xml
@@ -10,7 +10,7 @@
   <methodsynopsis>
    <type>array</type><methodname>array_uintersect</methodname>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
-   <methodparam rep="repeat"><type>array</type><parameter>rest</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>arrays</parameter></methodparam>
    <methodparam><type>callable</type><parameter>value_compare_func</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -30,7 +30,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>rest</parameter></term>
+     <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
        Arrays to compare against.

--- a/reference/array/functions/array-uintersect.xml
+++ b/reference/array/functions/array-uintersect.xml
@@ -9,9 +9,8 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array_uintersect</methodname>
-   <methodparam><type>array</type><parameter>array1</parameter></methodparam>
-   <methodparam><type>array</type><parameter>array2</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>rest</parameter></methodparam>
    <methodparam><type>callable</type><parameter>value_compare_func</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -23,7 +22,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>array1</parameter></term>
+     <term><parameter>array</parameter></term>
      <listitem>
       <para>
        The first array.
@@ -31,10 +30,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>array2</parameter></term>
+     <term><parameter>rest</parameter></term>
      <listitem>
       <para>
-       The second array.
+       Arrays to compare against.
       </para>
      </listitem>
     </varlistentry>
@@ -53,7 +52,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an array containing all the values of <parameter>array1</parameter>
+   Returns an array containing all the values of <parameter>array</parameter>
    that are present in all the arguments.
   </para>
  </refsect1>

--- a/reference/array/functions/array-unshift.xml
+++ b/reference/array/functions/array-unshift.xml
@@ -10,7 +10,7 @@
   <methodsynopsis>
    <type>int</type><methodname>array_unshift</methodname>
    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>array_unshift</function> prepends passed elements to the front
@@ -33,7 +33,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>values</parameter></term>
      <listitem>
       <para>
        The values to prepend.

--- a/reference/array/functions/array.xml
+++ b/reference/array/functions/array.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>array</methodname>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
    Creates an array. Read the section on the
@@ -22,7 +22,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>values</parameter></term>
      <listitem>
       <para>
        Syntax "index =&gt; values", separated by commas, define index

--- a/reference/array/functions/compact.xml
+++ b/reference/array/functions/compact.xml
@@ -9,8 +9,8 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>compact</methodname>
-   <methodparam><type>mixed</type><parameter>varname1</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>var_name</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>var_names</parameter></methodparam>
   </methodsynopsis>
   <para>
    Creates an array containing variables and their values.
@@ -33,7 +33,8 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>varname1</parameter></term>
+     <term><parameter>var_name</parameter></term>
+     <term><parameter>var_names</parameter></term>
      <listitem>
       <para>
        <function>compact</function> takes a variable number of parameters.

--- a/reference/array/functions/list.xml
+++ b/reference/array/functions/list.xml
@@ -9,8 +9,8 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>list</methodname>
-   <methodparam><type>mixed</type><parameter>var1</parameter></methodparam>
-   <methodparam rep="repeat" choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>var</parameter></methodparam>
+   <methodparam rep="repeat" choice="opt"><type>mixed</type><parameter>vars</parameter></methodparam>
   </methodsynopsis>
   <para>
    Like <function>array</function>, this is not really a function,
@@ -47,10 +47,20 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>var1</parameter></term>
+     <term><parameter>var</parameter></term>
      <listitem>
       <para>
        A variable.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>vars</parameter></term>
+     <listitem>
+      <para>
+       Further variables.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dba/functions/dba-open.xml
+++ b/reference/dba/functions/dba-open.xml
@@ -12,7 +12,7 @@
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
    <methodparam><type>string</type><parameter>mode</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>handler</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>dba_open</function> establishes a database instance for
@@ -161,7 +161,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>args</parameter></term>
      <listitem>
       <para>
        Optional &string; parameters which are passed to the driver.

--- a/reference/dba/functions/dba-popen.xml
+++ b/reference/dba/functions/dba-popen.xml
@@ -12,7 +12,7 @@
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
    <methodparam><type>string</type><parameter>mode</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>handler</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>dba_popen</function> establishes a persistent database instance
@@ -51,6 +51,33 @@
        shall be used for accessing <parameter>path</parameter>. It is passed 
        all optional parameters given to <function>dba_popen</function> and 
        can act on behalf of them.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>args</parameter></term>
+     <listitem>
+      <para>
+       Optional &string; parameters which are passed to the driver.
+      </para>
+      <para>
+       The <literal>cdb</literal>, <literal>cdb_make</literal>, <literal>flatfile</literal>,
+       <literal>inifile</literal>, <literal>qdbm</literal> and <literal>tcadb</literal> drivers
+       do not support additional parameters.
+      </para>
+      <para>
+       The <literal>db1</literal>, <literal>db2</literal>, <literal>db3</literal>,
+       <literal>db4</literal>, <literal>dbm</literal>, <literal>gdbm</literal>,
+       and <literal>ndbm</literal> drivers supports a single additional parameter <literal>$filemode</literal>,
+       which has the same meaning as the <literal>$mode</literal> parameter of <function>chmod</function>,
+       and defaults to <literal>0644</literal>.
+      </para>
+      <para>
+       The <literal>lmdb</literal> driver accepts two additional parameters. The first
+       allows to specify the <literal>$filemode</literal> (see description above), and the
+       second to specify the <literal>$mapsize</literal>, where the value should be a multiple
+       of the page size of the OS, or zero, to use the default mapsize. The <literal>$mapsize</literal>
+       parameter is supported as of PHP 7.3.14 and 7.4.2, respectively.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/ds/ds/deque/contains.xml
+++ b/reference/ds/ds/deque/contains.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Ds\Deque::contains</methodname>
-   <methodparam choice="opt"><type>mixed</type><parameter>...values</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
     Determines if the deque contains all values.

--- a/reference/ds/ds/deque/insert.xml
+++ b/reference/ds/ds/deque/insert.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>Ds\Deque::insert</methodname>
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...values</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
     Inserts values into the deque at a given index.

--- a/reference/ds/ds/deque/push.xml
+++ b/reference/ds/ds/deque/push.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>Ds\Deque::push</methodname>
-   <methodparam choice="opt"><type>mixed</type><parameter>...values</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
     Adds values to the end of the deque.

--- a/reference/ds/ds/map/construct.xml
+++ b/reference/ds/ds/map/construct.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <constructorsynopsis>
    <modifier>public</modifier> <methodname>Ds\Map::__construct</methodname>
-   <methodparam choice="opt"><type>mixed</type><parameter>...values</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </constructorsynopsis>
   <para>
     Creates a new instance, using either a <classname>traversable</classname>

--- a/reference/ds/ds/queue/push.xml
+++ b/reference/ds/ds/queue/push.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>Ds\Queue::push</methodname>
-   <methodparam choice="opt"><type>mixed</type><parameter>...values</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
     Pushes <parameter>values</parameter> into the queue.

--- a/reference/ds/ds/sequence/contains.xml
+++ b/reference/ds/ds/sequence/contains.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>abstract</modifier> <modifier>public</modifier> <type>bool</type><methodname>Ds\Sequence::contains</methodname>
-   <methodparam choice="opt"><type>mixed</type><parameter>...values</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
     Determines if the sequence contains all values.

--- a/reference/ds/ds/sequence/insert.xml
+++ b/reference/ds/ds/sequence/insert.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>Ds\Sequence::insert</methodname>
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...values</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
     Inserts values into the sequence at a given index.

--- a/reference/ds/ds/sequence/push.xml
+++ b/reference/ds/ds/sequence/push.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>Ds\Sequence::push</methodname>
-   <methodparam choice="opt"><type>mixed</type><parameter>...values</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
     Adds values to the end of the sequence.

--- a/reference/ds/ds/set/add.xml
+++ b/reference/ds/ds/set/add.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>Ds\Set::add</methodname>
-   <methodparam choice="opt"><type>mixed</type><parameter>...values</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
     Adds all given values to the set that haven't already been added.

--- a/reference/ds/ds/set/construct.xml
+++ b/reference/ds/ds/set/construct.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <constructorsynopsis>
    <modifier>public</modifier> <methodname>Ds\Set::__construct</methodname>
-   <methodparam choice="opt"><type>mixed</type><parameter>...values</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </constructorsynopsis>
   <para>
     Creates a new instance, using either a <classname>traversable</classname>

--- a/reference/ds/ds/set/contains.xml
+++ b/reference/ds/ds/set/contains.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Ds\Set::contains</methodname>
-   <methodparam choice="opt"><type>mixed</type><parameter>...values</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
     Determines if the set contains all values.

--- a/reference/ds/ds/set/remove.xml
+++ b/reference/ds/ds/set/remove.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>Ds\Set::remove</methodname>
-   <methodparam choice="opt"><type>mixed</type><parameter>...values</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
     Removes all given <parameter>values</parameter> from the set, ignoring any that are not in the set.

--- a/reference/ds/ds/stack/push.xml
+++ b/reference/ds/ds/stack/push.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>Ds\Stack::push</methodname>
-   <methodparam choice="opt"><type>mixed</type><parameter>...values</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
     Pushes <parameter>values</parameter> onto the stack.

--- a/reference/ds/ds/vector/contains.xml
+++ b/reference/ds/ds/vector/contains.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Ds\Vector::contains</methodname>
-   <methodparam choice="opt"><type>mixed</type><parameter>...values</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
     Determines if the vector contains all values.

--- a/reference/ds/ds/vector/insert.xml
+++ b/reference/ds/ds/vector/insert.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>Ds\Vector::insert</methodname>
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...values</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
     Inserts values into the vector at a given index.

--- a/reference/ds/ds/vector/push.xml
+++ b/reference/ds/ds/vector/push.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>Ds\Vector::push</methodname>
-   <methodparam choice="opt"><type>mixed</type><parameter>...values</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
     Adds values to the end of the vector.

--- a/reference/fann/functions/fann-create-shortcut.xml
+++ b/reference/fann/functions/fann-create-shortcut.xml
@@ -14,7 +14,7 @@
    <methodparam><type>int</type><parameter>num_layers</parameter></methodparam>
    <methodparam><type>int</type><parameter>num_neurons1</parameter></methodparam>
    <methodparam><type>int</type><parameter>num_neurons2</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>int</type><parameter>num_neuronsN</parameter></methodparam>
   </methodsynopsis>
   <para>
    Creates a standard backpropagation neural network, which is not fully connected and which also has shortcut connections.
@@ -53,7 +53,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>...</parameter></term>
+    <term><parameter>num_neuronsN</parameter></term>
     <listitem>
      <para>
       Number of neurons in other layers.

--- a/reference/fann/functions/fann-create-sparse.xml
+++ b/reference/fann/functions/fann-create-sparse.xml
@@ -15,7 +15,7 @@
    <methodparam><type>int</type><parameter>num_layers</parameter></methodparam>
    <methodparam><type>int</type><parameter>num_neurons1</parameter></methodparam>
    <methodparam><type>int</type><parameter>num_neurons2</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>int</type><parameter>num_neuronsN</parameter></methodparam>
   </methodsynopsis>
   <para>
    Creates a standard backpropagation neural network, which is not fully connected.
@@ -60,7 +60,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>...</parameter></term>
+    <term><parameter>num_neuronsN</parameter></term>
     <listitem>
      <para>
       Number of neurons in other layers.

--- a/reference/fann/functions/fann-create-standard.xml
+++ b/reference/fann/functions/fann-create-standard.xml
@@ -14,7 +14,7 @@
    <methodparam><type>int</type><parameter>num_layers</parameter></methodparam>
    <methodparam><type>int</type><parameter>num_neurons1</parameter></methodparam>
    <methodparam><type>int</type><parameter>num_neurons2</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>int</type><parameter>num_neuronsN</parameter></methodparam>
   </methodsynopsis>
   <para>
    Creates a standard fully connected backpropagation neural network.
@@ -57,7 +57,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>...</parameter></term>
+    <term><parameter>num_neuronsN</parameter></term>
     <listitem>
      <para>
       Number of neurons in other layers.

--- a/reference/filesystem/functions/fscanf.xml
+++ b/reference/filesystem/functions/fscanf.xml
@@ -12,7 +12,7 @@
    <type>mixed</type><methodname>fscanf</methodname>
    <methodparam><type>resource</type><parameter>handle</parameter></methodparam>
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter role="reference">...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
   <para>
    The function <function>fscanf</function> is similar to
@@ -43,7 +43,7 @@
     </varlistentry>
     &strings.parameter.format;
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>vars</parameter></term>
      <listitem>
       <para>
        The optional assigned values.

--- a/reference/funchand/functions/call-user-func.xml
+++ b/reference/funchand/functions/call-user-func.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>mixed</type><methodname>call_user_func</methodname>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <para>
    Calls the <parameter>callback</parameter> given by the first parameter and passes
@@ -32,7 +32,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>args</parameter></term>
      <listitem>
       <para>
        Zero or more parameters to be passed to the callback.

--- a/reference/funchand/functions/forward-static-call.xml
+++ b/reference/funchand/functions/forward-static-call.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>mixed</type><methodname>forward_static_call</methodname>
    <methodparam><type>callable</type><parameter>function</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <para>
    Calls a user defined function or method given by the <parameter>function</parameter>
@@ -37,7 +37,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>args</parameter></term>
      <listitem>
       <para>
        Zero or more parameters to be passed to the function.

--- a/reference/funchand/functions/register-shutdown-function.xml
+++ b/reference/funchand/functions/register-shutdown-function.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>void</type><methodname>register_shutdown_function</methodname>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <para>
    Registers a <parameter>callback</parameter> to be executed after script
@@ -43,7 +43,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>args</parameter></term>
      <listitem>
       <para>
        It is possible to pass parameters to the shutdown function by passing

--- a/reference/funchand/functions/register-tick-function.xml
+++ b/reference/funchand/functions/register-tick-function.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>register_tick_function</methodname>
    <methodparam><type>callable</type><parameter>function</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <simpara>
    Registers the given <parameter>function</parameter> to be executed when a
@@ -32,7 +32,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>args</parameter></term>
      <listitem>
       <para>
       </para>

--- a/reference/ibase/functions/ibase-execute.xml
+++ b/reference/ibase/functions/ibase-execute.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>resource</type><methodname>ibase_execute</methodname>
    <methodparam><type>resource</type><parameter>query</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
    Execute a query prepared by <function>ibase_prepare</function>. 
@@ -36,7 +36,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>values</parameter></term>
      <listitem>
       <para>
       </para>

--- a/reference/ibase/functions/ibase-set-event-handler.xml
+++ b/reference/ibase/functions/ibase-set-event-handler.xml
@@ -11,15 +11,15 @@
   <methodsynopsis>
    <type>resource</type><methodname>ibase_set_event_handler</methodname>
    <methodparam><type>callable</type><parameter>event_handler</parameter></methodparam>
-   <methodparam><type>string</type><parameter>event_name1</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>...</parameter></methodparam>
+   <methodparam><type>string</type><parameter>event_name</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter>even_names</parameter></methodparam>
   </methodsynopsis>
   <methodsynopsis>
    <type>resource</type><methodname>ibase_set_event_handler</methodname>
    <methodparam><type>resource</type><parameter>connection</parameter></methodparam>
    <methodparam><type>callable</type><parameter>event_handler</parameter></methodparam>
-   <methodparam><type>string</type><parameter>event_name1</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>...</parameter></methodparam>
+   <methodparam><type>string</type><parameter>event_name</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter>event_names</parameter></methodparam>
   </methodsynopsis>
   <para>
    This function registers a PHP user function as event handler for the
@@ -47,7 +47,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>event_name1</parameter></term>
+     <term><parameter>event_name</parameter></term>
      <listitem>
       <para>
        An event name.
@@ -55,7 +55,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>event_names</parameter></term>
      <listitem>
       <para>
        At most 15 events allowed.

--- a/reference/ibase/functions/ibase-wait-event.xml
+++ b/reference/ibase/functions/ibase-wait-event.xml
@@ -10,14 +10,14 @@
   &reftitle.description;
   <methodsynopsis>
    <type>string</type><methodname>ibase_wait_event</methodname>
-   <methodparam><type>string</type><parameter>event_name1</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>...</parameter></methodparam>
+   <methodparam><type>string</type><parameter>event_name</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter>event_names</parameter></methodparam>
   </methodsynopsis>
   <methodsynopsis>
    <type>string</type><methodname>ibase_wait_event</methodname>
    <methodparam><type>resource</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>event_name1</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>...</parameter></methodparam>
+   <methodparam><type>string</type><parameter>event_name</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter>event_names</parameter></methodparam>
   </methodsynopsis>
   <para>
    This function suspends execution of the script until one of the specified events
@@ -31,7 +31,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>event_name1</parameter></term>
+     <term><parameter>event_name</parameter></term>
      <listitem>
       <para>
        The event name.
@@ -39,7 +39,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>event_names</parameter></term>
      <listitem>
       <para>
       </para>

--- a/reference/lua/luaclosure/invoke.xml
+++ b/reference/lua/luaclosure/invoke.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>LuaClosure::__invoke</methodname>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <para>
 
@@ -25,7 +25,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>...</parameter></term>
+    <term><parameter>args</parameter></term>
     <listitem>
      <para>
       

--- a/reference/luasandbox/luasandbox/callfunction.xml
+++ b/reference/luasandbox/luasandbox/callfunction.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type class="union"><type>array</type><type>bool</type></type><methodname>LuaSandbox::callFunction</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <para>
    Calls a function in a Lua global variable.
@@ -43,7 +43,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>...</parameter></term>
+    <term><parameter>args</parameter></term>
     <listitem>
      <para>
       Arguments to the function.

--- a/reference/luasandbox/luasandboxfunction/call.xml
+++ b/reference/luasandbox/luasandboxfunction/call.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type class="union"><type>array</type><type>bool</type></type><methodname>LuaSandboxFunction::call</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <para>
    Calls a Lua function.
@@ -119,7 +119,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>...</parameter></term>
+    <term><parameter>args</parameter></term>
     <listitem>
      <para>
       Arguments passed to the function.

--- a/reference/math/functions/max.xml
+++ b/reference/math/functions/max.xml
@@ -63,7 +63,7 @@
      <listitem>
       <para>
        Any <link linkend="language.operators.comparison">comparable</link>
-       value.
+       values.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/math/functions/max.xml
+++ b/reference/math/functions/max.xml
@@ -9,12 +9,12 @@
   &reftitle.description;
   <methodsynopsis>
    <type>mixed</type><methodname>max</methodname>
-   <methodparam><type>array</type><parameter>values</parameter></methodparam>
+   <methodparam><type>array</type><parameter>value_array</parameter></methodparam>
   </methodsynopsis>
   <methodsynopsis>
    <type>mixed</type><methodname>max</methodname>
-   <methodparam><type>mixed</type><parameter>value1</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
    If the first and only parameter is an array, <function>max</function>
@@ -42,7 +42,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>values</parameter></term>
+     <term><parameter>value_array</parameter></term>
      <listitem>
       <para>
        An array containing the values.
@@ -50,7 +50,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>value1</parameter></term>
+     <term><parameter>value</parameter></term>
      <listitem>
       <para>
        Any <link linkend="language.operators.comparison">comparable</link>
@@ -59,7 +59,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>values</parameter></term>
      <listitem>
       <para>
        Any <link linkend="language.operators.comparison">comparable</link>

--- a/reference/math/functions/min.xml
+++ b/reference/math/functions/min.xml
@@ -9,12 +9,12 @@
   &reftitle.description;
    <methodsynopsis>
     <type>mixed</type><methodname>min</methodname>
-    <methodparam><type>array</type><parameter>values</parameter></methodparam>
+    <methodparam><type>array</type><parameter>value_array</parameter></methodparam>
    </methodsynopsis>
    <methodsynopsis>
     <type>mixed</type><methodname>min</methodname>
-    <methodparam><type>mixed</type><parameter>value1</parameter></methodparam>
-    <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+    <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
    </methodsynopsis>
   <para>
    If the first and only parameter is an array, <function>min</function>
@@ -42,7 +42,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>values</parameter></term>
+     <term><parameter>value_array</parameter></term>
      <listitem>
       <para>
        An array containing the values.
@@ -50,7 +50,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>value1</parameter></term>
+     <term><parameter>value</parameter></term>
      <listitem>
       <para>
        Any <link linkend="language.operators.comparison">comparable</link>
@@ -59,7 +59,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>values</parameter></term>
      <listitem>
       <para>
        Any <link linkend="language.operators.comparison">comparable</link>

--- a/reference/math/functions/min.xml
+++ b/reference/math/functions/min.xml
@@ -63,7 +63,7 @@
      <listitem>
       <para>
        Any <link linkend="language.operators.comparison">comparable</link>
-       value.
+       values.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mbstring/functions/mb-convert-variables.xml
+++ b/reference/mbstring/functions/mb-convert-variables.xml
@@ -12,12 +12,12 @@
    <type>string</type><methodname>mb_convert_variables</methodname>
    <methodparam><type>string</type><parameter>to_encoding</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>from_encoding</parameter></methodparam>
-   <methodparam><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter role="reference">...</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter role="reference">var</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
   <para>
    Converts 
-   character encoding of variables <parameter>vars</parameter> in
+   character encoding of variables <parameter>var</parameter> and <parameter>vars</parameter> in
    encoding <parameter>from_encoding</parameter> to encoding 
    <parameter>to_encoding</parameter>. 
   </para>
@@ -53,10 +53,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>vars</parameter></term>
+     <term><parameter>var</parameter></term>
      <listitem>
       <para>
-       <parameter>vars</parameter> is the reference to the
+       <parameter>var</parameter> is the reference to the
        variable being converted. String, Array and Object are accepted.
        <function>mb_convert_variables</function> assumes all parameters
        have the same encoding.
@@ -64,10 +64,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>vars</parameter></term>
      <listitem>
       <para>
-       Additional <parameter>vars</parameter>.
+       Additional <parameter>var</parameter>s.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/misc/functions/pack.xml
+++ b/reference/misc/functions/pack.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>string</type><methodname>pack</methodname>
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
    Pack given arguments into a binary string according to
@@ -179,7 +179,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>values</parameter></term>
      <listitem>
       <para>
       </para>

--- a/reference/mongo/mongocollection/aggregate.xml
+++ b/reference/mongo/mongocollection/aggregate.xml
@@ -17,8 +17,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>array</type><methodname>MongoCollection::aggregate</methodname>
    <methodparam><type>array</type><parameter>op</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>op</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>array</type><parameter>ops</parameter></methodparam>
   </methodsynopsis>
   <para>
    The MongoDB
@@ -84,15 +83,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>op</parameter></term>
-    <listitem>
-     <para>
-      The second pipeline operator.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><parameter>...</parameter></term>
+    <term><parameter>ops</parameter></term>
     <listitem>
      <para>
       Additional pipeline operators.

--- a/reference/mysql_xdevapi/mysql_xdevapi/table/insert.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/table/insert.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>mysql_xdevapi\TableInsert</type><methodname>mysql_xdevapi\Table::insert</methodname>
    <methodparam><type>mixed</type><parameter>columns</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>more_columns</parameter></methodparam>
   </methodsynopsis>
   <para>
    Inserts rows into a table.
@@ -33,7 +33,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>...</parameter></term>
+    <term><parameter>more_columns</parameter></term>
     <listitem>
      <para>
       Additional columns definitions.

--- a/reference/mysql_xdevapi/mysql_xdevapi/table/select.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/table/select.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>mysql_xdevapi\TableSelect</type><methodname>mysql_xdevapi\Table::select</methodname>
    <methodparam><type>mixed</type><parameter>columns</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>more_columns</parameter></methodparam>
   </methodsynopsis>
   <para>
    Fetches data from a table.
@@ -33,7 +33,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>...</parameter></term>
+    <term><parameter>more_columns</parameter></term>
     <listitem>
      <para>
       Additional columns parameter definitions.

--- a/reference/mysql_xdevapi/mysql_xdevapi/tableselect/orderby.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/tableselect/orderby.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>mysql_xdevapi\TableSelect</type><methodname>mysql_xdevapi\TableSelect::orderby</methodname>
    <methodparam><type>mixed</type><parameter>sort_expr</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>sort_exprs</parameter></methodparam>
   </methodsynopsis>
   <para>
    Sets the order by criteria.
@@ -33,7 +33,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>...</parameter></term>
+    <term><parameter>sort_expr</parameter></term>
     <listitem>
      <para>
       Additional sort_expr parameters.

--- a/reference/mysql_xdevapi/mysql_xdevapi/tableupdate/orderby.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/tableupdate/orderby.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>mysql_xdevapi\TableUpdate</type><methodname>mysql_xdevapi\TableUpdate::orderby</methodname>
    <methodparam><type>mixed</type><parameter>orderby_expr</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>orderby_exprs</parameter></methodparam>
   </methodsynopsis>
   <para>
    Sets the sorting criteria.
@@ -33,7 +33,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>...</parameter></term>
+    <term><parameter>orderby_exprs</parameter></term>
     <listitem>
      <para>
       Additional sort_expr parameters.

--- a/reference/pdo_sqlite/PDO/sqliteCreateAggregate.xml
+++ b/reference/pdo_sqlite/PDO/sqliteCreateAggregate.xml
@@ -56,8 +56,8 @@
         <type>mixed</type><methodname><replaceable>step</replaceable></methodname>
         <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
         <methodparam><type>int</type><parameter>rownumber</parameter></methodparam>
-        <methodparam><type>mixed</type><parameter>value1</parameter></methodparam>
-        <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+        <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
         <varlistentry>
@@ -79,7 +79,7 @@
          </listitem>
         </varlistentry>
         <varlistentry>
-         <term><parameter>value1</parameter></term>
+         <term><parameter>value</parameter></term>
          <listitem>
           <para>
            The first argument passed to the aggregate.
@@ -87,7 +87,7 @@
          </listitem>
         </varlistentry>
         <varlistentry>
-         <term><parameter>...</parameter></term>
+         <term><parameter>values</parameter></term>
          <listitem>
           <para>
            Further arguments passed to the aggregate.

--- a/reference/pdo_sqlite/PDO/sqliteCreateFunction.xml
+++ b/reference/pdo_sqlite/PDO/sqliteCreateFunction.xml
@@ -58,12 +58,12 @@
        This function need to be defined as:
        <methodsynopsis>
         <type>mixed</type><methodname><replaceable>callback</replaceable></methodname>
-        <methodparam><type>mixed</type><parameter>value1</parameter></methodparam>
-        <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+        <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
         <varlistentry>
-         <term><parameter>value1</parameter></term>
+         <term><parameter>value</parameter></term>
          <listitem>
           <para>
            The first argument passed to the SQL function.
@@ -71,7 +71,7 @@
          </listitem>
         </varlistentry>
         <varlistentry>
-         <term><parameter>...</parameter></term>
+         <term><parameter>values</parameter></term>
          <listitem>
           <para>
            Further arguments passed to the SQL function.

--- a/reference/pht/thread/addClassTask.xml
+++ b/reference/pht/thread/addClassTask.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>pht\Thread::addClassTask</methodname>
    <methodparam><type>string</type><parameter>className</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...ctorArgs</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>ctorArgs</parameter></methodparam>
   </methodsynopsis>
   <para>
    Adds a new class task to a <classname>pht\Thread</classname>s internal task queue.
@@ -32,7 +32,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>...ctorArgs</parameter></term>
+    <term><parameter>ctorArgs</parameter></term>
     <listitem>
      <para>
       An optional list of arguments for the threaded class' constructor. These

--- a/reference/pht/thread/addFileTask.xml
+++ b/reference/pht/thread/addFileTask.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>pht\Thread::addFileTask</methodname>
    <methodparam><type>string</type><parameter>fileName</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...globals</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>globals</parameter></methodparam>
   </methodsynopsis>
   <para>
    Adds a new file task to a <classname>pht\Thread</classname>s internal task queue.
@@ -31,7 +31,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>...globals</parameter></term>
+    <term><parameter>globals</parameter></term>
     <listitem>
      <para>
       An optional list of arguments for the file. These arguments will be

--- a/reference/pht/thread/addFunctionTask.xml
+++ b/reference/pht/thread/addFunctionTask.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>pht\Thread::addFunctionTask</methodname>
    <methodparam><type>callable</type><parameter>func</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...funcArgs</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>funcArgs</parameter></methodparam>
   </methodsynopsis>
   <para>
    Adds a new function task to a <classname>pht\Thread</classname>s internal task queue.
@@ -32,7 +32,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>...funcArgs</parameter></term>
+    <term><parameter>funcArgs</parameter></term>
     <listitem>
      <para>
       An optional list of arguments for the function. These arguments will be

--- a/reference/pthreads/threaded/synchronized.xml
+++ b/reference/pthreads/threaded/synchronized.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>Threaded::synchronized</methodname>
    <methodparam><type>Closure</type><parameter>block</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <para>
   Executes the block while retaining the referenced objects synchronization lock for the calling context
@@ -31,7 +31,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>...</parameter></term>
+    <term><parameter>args</parameter></term>
     <listitem>
      <para>
   Variable length list of arguments to use as function arguments to the block

--- a/reference/reflection/reflectionclass/newinstance.xml
+++ b/reference/reflection/reflectionclass/newinstance.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>object</type><methodname>ReflectionClass::newInstance</methodname>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <para>
    Creates a new instance of the class. The given arguments are passed to the
@@ -25,7 +25,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>args</parameter></term>
      <listitem>
       <para>
        Accepts a variable number of arguments which are passed to the class
@@ -51,7 +51,7 @@
   </para>
   <para>
    A <classname>ReflectionException</classname> if the class does not have a constructor
-   and the <parameter>...</parameter> parameter contains one or more parameters.
+   and the <parameter>args</parameter> parameter contains one or more parameters.
   </para>
  </refsect1>
 

--- a/reference/reflection/reflectionfunction/invoke.xml
+++ b/reference/reflection/reflectionfunction/invoke.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>ReflectionFunction::invoke</methodname>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <para>
    Invokes a reflected function.
@@ -23,7 +23,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>args</parameter></term>
      <listitem>
       <para>
        The passed in argument list. It accepts a variable number of

--- a/reference/reflection/reflectionmethod/invoke.xml
+++ b/reference/reflection/reflectionmethod/invoke.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>ReflectionMethod::invoke</methodname>
    <methodparam><type>object</type><parameter>object</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <para>
    Invokes a reflected method.
@@ -34,7 +34,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>args</parameter></term>
      <listitem>
       <para>
        Zero or more parameters to be passed to the method.

--- a/reference/session/functions/session-register.xml
+++ b/reference/session/functions/session-register.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>session_register</methodname>
    <methodparam><type>mixed</type><parameter>name</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>names</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>session_register</function> accepts a variable number of
@@ -61,7 +61,7 @@ $_SESSION["zim"] = "An invader from another planet.";
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>names</parameter></term>
      <listitem>
       <para>
       </para>

--- a/reference/soap/soapserver/setclass.xml
+++ b/reference/soap/soapserver/setclass.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>SoapServer::setClass</methodname>
    <methodparam><type>string</type><parameter>class_name</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <para>
    Exports all methods from specified class.
@@ -36,7 +36,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>args</parameter></term>
      <listitem>
       <para>
        These optional parameters will be passed to the default class constructor

--- a/reference/spl/splfileobject/fscanf.xml
+++ b/reference/spl/splfileobject/fscanf.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>SplFileObject::fscanf</methodname>
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter role="reference">...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
   <para>
    Reads a line from the file and interprets it according to the specified <parameter>format</parameter>, which is
@@ -30,7 +30,7 @@
    <variablelist>
     &strings.parameter.format;
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>vars</parameter></term>
      <listitem>
       <para>
        The optional assigned values.

--- a/reference/sqlite3/sqlite3/createaggregate.xml
+++ b/reference/sqlite3/sqlite3/createaggregate.xml
@@ -48,8 +48,8 @@
         <type>mixed</type><methodname><replaceable>step</replaceable></methodname>
         <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
         <methodparam><type>int</type><parameter>rownumber</parameter></methodparam>
-        <methodparam><type>mixed</type><parameter>value1</parameter></methodparam>
-        <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+        <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
         <varlistentry>
@@ -71,7 +71,7 @@
          </listitem>
         </varlistentry>
         <varlistentry>
-         <term><parameter>value1</parameter></term>
+         <term><parameter>value</parameter></term>
          <listitem>
           <para>
            The first argument passed to the aggregate.
@@ -79,7 +79,7 @@
          </listitem>
         </varlistentry>
         <varlistentry>
-         <term><parameter>...</parameter></term>
+         <term><parameter>values</parameter></term>
          <listitem>
           <para>
            Further arguments passed to the aggregate.

--- a/reference/sqlite3/sqlite3/createfunction.xml
+++ b/reference/sqlite3/sqlite3/createfunction.xml
@@ -45,12 +45,12 @@
        This function need to be defined as:
        <methodsynopsis>
         <type>mixed</type><methodname><replaceable>callback</replaceable></methodname>
-        <methodparam><type>mixed</type><parameter>value1</parameter></methodparam>
-        <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+        <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
         <varlistentry>
-         <term><parameter>value1</parameter></term>
+         <term><parameter>value</parameter></term>
          <listitem>
           <para>
            The first argument passed to the SQL function.
@@ -58,7 +58,7 @@
          </listitem>
         </varlistentry>
         <varlistentry>
-         <term><parameter>...</parameter></term>
+         <term><parameter>values</parameter></term>
          <listitem>
           <para>
            Further arguments passed to the SQL function.

--- a/reference/strings/functions/echo.xml
+++ b/reference/strings/functions/echo.xml
@@ -10,8 +10,8 @@
   &reftitle.description;
   <methodsynopsis>
    <type>void</type><methodname>echo</methodname>
-   <methodparam><type>string</type><parameter>arg1</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>...</parameter></methodparam>
+   <methodparam><type>string</type><parameter>arg</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <simpara>
    Outputs all parameters. No additional newline is appended.
@@ -50,7 +50,7 @@ I have <?=$foo?> foo.
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>arg1</parameter></term>
+     <term><parameter>arg</parameter></term>
      <listitem>
       <para>
        The parameter to output.
@@ -58,7 +58,7 @@ I have <?=$foo?> foo.
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>args</parameter></term>
      <listitem>
       <para>
       </para>

--- a/reference/strings/functions/fprintf.xml
+++ b/reference/strings/functions/fprintf.xml
@@ -12,7 +12,7 @@
    <type>int</type><methodname>fprintf</methodname>
    <methodparam><type>resource</type><parameter>handle</parameter></methodparam>
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
    Write a string produced according to <parameter>format</parameter> to the
@@ -32,7 +32,7 @@
     </varlistentry>
     &strings.parameter.format;
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>values</parameter></term>
      <listitem>
       <para>
       </para>

--- a/reference/strings/functions/printf.xml
+++ b/reference/strings/functions/printf.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>int</type><methodname>printf</methodname>
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <simpara>
    Produces output according to <parameter>format</parameter>.
@@ -24,7 +24,7 @@
    <variablelist>
     &strings.parameter.format;
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>values</parameter></term>
      <listitem>
       <para>
       </para>

--- a/reference/strings/functions/setlocale.xml
+++ b/reference/strings/functions/setlocale.xml
@@ -12,7 +12,7 @@
    <type>string</type><methodname>setlocale</methodname>
    <methodparam><type>int</type><parameter>category</parameter></methodparam>
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter>locales</parameter></methodparam>
   </methodsynopsis>
   <methodsynopsis>
    <type>string</type><methodname>setlocale</methodname>
@@ -115,7 +115,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>locales</parameter></term>
      <listitem>
       <para>
        (Optional string or array parameters to try as locale settings until

--- a/reference/strings/functions/sprintf.xml
+++ b/reference/strings/functions/sprintf.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>string</type><methodname>sprintf</methodname>
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
    Returns a string produced according to the formatting string
@@ -25,7 +25,7 @@
    <variablelist>
     &strings.parameter.format;
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>values</parameter></term>
      <listitem>
       <para>
       </para>

--- a/reference/strings/functions/sscanf.xml
+++ b/reference/strings/functions/sscanf.xml
@@ -12,7 +12,7 @@
    <type>mixed</type><methodname>sscanf</methodname>
    <methodparam><type>string</type><parameter>str</parameter></methodparam>
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter role="reference">...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
   <para>
    The function <function>sscanf</function> is the input analog of
@@ -72,7 +72,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>vars</parameter></term>
      <listitem>
       <para>
        Optionally pass in variables by reference that will contain the parsed values.

--- a/reference/swoole/swoole/coroutine/call-user-func.xml
+++ b/reference/swoole/swoole/coroutine/call-user-func.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type>mixed</type><methodname>Swoole\Coroutine::call_user_func</methodname>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <para>
     Calls the <parameter>callback</parameter> given by the first parameter and passes the remaining parameters as arguments.
@@ -33,7 +33,7 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>args</parameter></term>
      <listitem>
       <para>
        Zero or more parameters to be passed to the callback.

--- a/reference/taint/functions/taint.xml
+++ b/reference/taint/functions/taint.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>taint</methodname>
    <methodparam><type>string</type><parameter role="reference">string</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter>strings</parameter></methodparam>
   </methodsynopsis>
   <para>
    Make a string tainted. This is used for testing purpose only.
@@ -31,7 +31,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>...</parameter></term>
+    <term><parameter>strings</parameter></term>
     <listitem>
      <para>
      </para>

--- a/reference/taint/functions/untaint.xml
+++ b/reference/taint/functions/untaint.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>untaint</methodname>
    <methodparam><type>string</type><parameter role="reference">string</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter>strings</parameter></methodparam>
   </methodsynopsis>
   <para>
     Untaint strings
@@ -31,7 +31,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>...</parameter></term>
+    <term><parameter>strings</parameter></term>
     <listitem>
      <para>
       

--- a/reference/var/functions/debug-zval-dump.xml
+++ b/reference/var/functions/debug-zval-dump.xml
@@ -10,7 +10,7 @@
   <methodsynopsis>
    <type>void</type><methodname>debug_zval_dump</methodname>
    <methodparam><type>mixed</type><parameter>variable</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>variables</parameter></methodparam>
   </methodsynopsis>
   <para>
    Dumps a string representation of an internal zend value to output.
@@ -25,6 +25,14 @@
      <listitem>
       <para>
        The variable being evaluated.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>variables</parameter></term>
+     <listitem>
+      <para>
+
       </para>
      </listitem>
     </varlistentry>

--- a/reference/var/functions/debug-zval-dump.xml
+++ b/reference/var/functions/debug-zval-dump.xml
@@ -24,7 +24,7 @@
      <term><parameter>variable</parameter></term>
      <listitem>
       <para>
-       The variable being evaluated.
+       The variable to dump.
       </para>
      </listitem>
     </varlistentry>
@@ -32,7 +32,7 @@
      <term><parameter>variables</parameter></term>
      <listitem>
       <para>
-
+       Further variables to dump.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/var/functions/isset.xml
+++ b/reference/var/functions/isset.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>isset</methodname>
    <methodparam><type>mixed</type><parameter>var</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>vars</parameter></methodparam>
   </methodsynopsis>
   <para>
    Determine if a variable is considered set,
@@ -48,10 +48,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>vars</parameter></term>
      <listitem>
       <para>
-       Another variable ...
+       Further variables.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/var/functions/unset.xml
+++ b/reference/var/functions/unset.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>void</type><methodname>unset</methodname>
    <methodparam><type>mixed</type><parameter>var</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>vars</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>unset</function> destroys the specified variables. 
@@ -165,10 +165,10 @@ Before unset: 3, after unset: 23
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>vars</parameter></term>
      <listitem>
       <para>
-       Another variable ...
+       Further variables.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/var/functions/var-dump.xml
+++ b/reference/var/functions/var-dump.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <type>void</type><methodname>var_dump</methodname>
    <methodparam><type>mixed</type><parameter>expression</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>expressions</parameter></methodparam>
   </methodsynopsis>
   <simpara>
    This function displays structured information about one or more
@@ -36,7 +36,15 @@
      <term><parameter>expression</parameter></term>
      <listitem>
       <para>
-       The variable you want to dump.
+       The expression to dump.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>expressions</parameter></term>
+     <listitem>
+      <para>
+       Further expressions to dump.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/wddx/functions/wddx-add-vars.xml
+++ b/reference/wddx/functions/wddx-add-vars.xml
@@ -16,7 +16,7 @@
    <type>bool</type><methodname>wddx_add_vars</methodname>
    <methodparam><type>resource</type><parameter>packet_id</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>var_name</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>var_names</parameter></methodparam>
   </methodsynopsis>
   <para>
    Serializes the passed variables and add the result to the given packet.
@@ -46,7 +46,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>var_names</parameter></term>
      <listitem>
       <para>
       </para>

--- a/reference/wddx/functions/wddx-serialize-vars.xml
+++ b/reference/wddx/functions/wddx-serialize-vars.xml
@@ -15,7 +15,7 @@
   <methodsynopsis>
    <type>string</type><methodname>wddx_serialize_vars</methodname>
    <methodparam><type>mixed</type><parameter>var_name</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>var_names</parameter></methodparam>
   </methodsynopsis>
   <para>
    Creates a WDDX packet with a structure that contains the serialized
@@ -38,7 +38,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>...</parameter></term>
+     <term><parameter>var_names</parameter></term>
      <listitem>
       <para>
       </para>

--- a/reference/yaf/yaf_action_abstract/execute.xml
+++ b/reference/yaf/yaf_action_abstract/execute.xml
@@ -11,9 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>abstract</modifier> <modifier>public</modifier><type>mixed</type><methodname>Yaf_Action_Abstract::execute</methodname>
-   <methodparam choice="opt"><type>mixed</type><parameter>arg</parameter></methodparam>
-   <methodparam
-    choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <para>
    user should always define this method for a action, this is the entry point
@@ -30,7 +28,16 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  &no.function.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>args</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/yaf/yaf_application/execute.xml
+++ b/reference/yaf/yaf_application/execute.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>Yaf_Application::execute</methodname>
    <methodparam><type>callable</type><parameter>entry</parameter></methodparam>
-   <methodparam><type>string</type><parameter>...</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <para>
    This method is typically used to run Yaf_Application in a crontab work.
@@ -32,7 +32,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>...</parameter></term>
+    <term><parameter>args</parameter></term>
     <listitem>
      <para>
       parameters will pass to the callback


### PR DESCRIPTION
We markup variadic parameters with the `rep=repeat` standard DocBook
attribute of `<methodparam>`, and use proper variable names instead of
using the old pseudo variable name `...`.

---

This does not yet render as desired, but would rather need something like https://github.com/php/phd/pull/29.