### PR TITLE
Replace "number" type with built-in types

### DIFF
--- a/language/operators.xml
+++ b/language/operators.xml
@@ -1573,8 +1573,8 @@ echo $a <=> $b; // 1
        </entry>
       </row>
       <row>
-       <entry><type>string</type>, <type>resource</type> or <type>number</type></entry>
-       <entry><type>string</type>, <type>resource</type> or <type>number</type></entry>
+       <entry><type>string</type>, <type>resource</type>, <type>int</type> or <type>float</type></entry>
+       <entry><type>string</type>, <type>resource</type>, <type>int</type> or <type>float</type></entry>
        <entry>Translate strings and resources to numbers, usual math</entry>
       </row>
       <row>

--- a/language/types.xml
+++ b/language/types.xml
@@ -110,12 +110,6 @@
  
    <listitem>
     <simpara>
-     <type>number</type>
-    </simpara>
-   </listitem>
- 
-   <listitem>
-    <simpara>
      <type>void</type>
     </simpara>
    </listitem>

--- a/language/types/pseudo-types.xml
+++ b/language/types/pseudo-types.xml
@@ -21,16 +21,6 @@
 
  </sect2>
 
- <sect2 xml:id="language.types.number">
-  <title>number</title>
-
-  <para>
-   <literal>number</literal> indicates that a parameter can be either
-   <type>integer</type> or <type>float</type>.
-  </para>
-
- </sect2>
-
  <sect2 xml:id="language.types.void">
   <title>void</title>
 

--- a/reference/array/functions/array-product.xml
+++ b/reference/array/functions/array-product.xml
@@ -9,7 +9,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>number</type><methodname>array_product</methodname>
+   <type class="union"><type>int</type><type>float</type></type><methodname>array_product</methodname>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/array/functions/array-sum.xml
+++ b/reference/array/functions/array-sum.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>number</type><methodname>array_sum</methodname>
+   <type class="union"><type>int</type><type>float</type></type><methodname>array_sum</methodname>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/array/functions/range.xml
+++ b/reference/array/functions/range.xml
@@ -11,7 +11,7 @@
    <type>array</type><methodname>range</methodname>
    <methodparam><type>mixed</type><parameter>start</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>end</parameter></methodparam>
-   <methodparam choice="opt"><type>number</type><parameter>step</parameter><initializer>1</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>float</type></type><parameter>step</parameter><initializer>1</initializer></methodparam>
   </methodsynopsis>
   <para>
    Create an array containing a range of elements.

--- a/reference/ds/ds/deque/sum.xml
+++ b/reference/ds/ds/deque/sum.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>number</type><methodname>Ds\Deque::sum</methodname>
+   <modifier>public</modifier> <type class="union"><type>int</type><type>float</type></type><methodname>Ds\Deque::sum</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/ds/ds/map/sum.xml
+++ b/reference/ds/ds/map/sum.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>number</type><methodname>Ds\Map::sum</methodname>
+   <modifier>public</modifier> <type class="union"><type>int</type><type>float</type></type><methodname>Ds\Map::sum</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/ds/ds/sequence/sum.xml
+++ b/reference/ds/ds/sequence/sum.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>number</type><methodname>Ds\Sequence::sum</methodname>
+   <modifier>abstract</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>float</type></type><methodname>Ds\Sequence::sum</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/ds/ds/set/sum.xml
+++ b/reference/ds/ds/set/sum.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>number</type><methodname>Ds\Set::sum</methodname>
+   <modifier>public</modifier> <type class="union"><type>int</type><type>float</type></type><methodname>Ds\Set::sum</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/ds/ds/vector/sum.xml
+++ b/reference/ds/ds/vector/sum.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>number</type><methodname>Ds\Vector::sum</methodname>
+   <modifier>public</modifier> <type class="union"><type>int</type><type>float</type></type><methodname>Ds\Vector::sum</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/imagick/imagickpixel/getcolorvaluequantum.xml
+++ b/reference/imagick/imagickpixel/getcolorvaluequantum.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>number</type><methodname>ImagickPixel::getColorValueQuantum</methodname>
+   <modifier>public</modifier> <type class="union"><type>int</type><type>float</type></type><methodname>ImagickPixel::getColorValueQuantum</methodname>
    <methodparam><type>int</type><parameter>color</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/imagick/imagickpixel/setcolorvaluequantum.xml
+++ b/reference/imagick/imagickpixel/setcolorvaluequantum.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>ImagickPixel::setColorValueQuantum</methodname>
    <methodparam><type>int</type><parameter>color</parameter></methodparam>
-   <methodparam><type>number</type><parameter>value</parameter></methodparam>
+   <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
    Sets the quantum value of a color element of the ImagickPixel.

--- a/reference/intl/numberformatter/format.xml
+++ b/reference/intl/numberformatter/format.xml
@@ -16,7 +16,7 @@
    <modifier>public</modifier>
    <type>string</type>
    <methodname>NumberFormatter::format</methodname>
-   <methodparam><type>number</type><parameter>value</parameter></methodparam>
+   <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>value</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>type</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -26,7 +26,7 @@
    <type>string</type>
    <methodname>numfmt_format</methodname>
    <methodparam><type>NumberFormatter</type><parameter>fmt</parameter></methodparam>
-   <methodparam><type>number</type><parameter>value</parameter></methodparam>
+   <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>value</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>type</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/intl/spoofchecker.xml
+++ b/reference/intl/spoofchecker.xml
@@ -42,37 +42,37 @@
     <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
-     <type>number</type>
+     <type class="union"><type>int</type><type>float</type></type>
      <varname linkend="spoofchecker.constants.ascii">Spoofchecker::ASCII</varname>
      <initializer>0x10000000</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
-     <type>number</type>
+     <type class="union"><type>int</type><type>float</type></type>
      <varname linkend="spoofchecker.constants.char-limit">Spoofchecker::HIGHLY_RESTRICTIVE</varname>
      <initializer>0x30000000</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
-     <type>number</type>
+     <type class="union"><type>int</type><type>float</type></type>
      <varname linkend="spoofchecker.constants.char-limit">Spoofchecker::MODERATELY_RESTRICTIVE</varname>
      <initializer>0x40000000</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
-     <type>number</type>
+     <type class="union"><type>int</type><type>float</type></type>
      <varname linkend="spoofchecker.constants.char-limit">Spoofchecker::MINIMALLY_RESTRICTIVE</varname>
      <initializer>0x50000000</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
-     <type>number</type>
+     <type class="union"><type>int</type><type>float</type></type>
      <varname linkend="spoofchecker.constants.char-limit">Spoofchecker::UNRESTRICTIVE</varname>
      <initializer>0x60000000</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
-     <type>number</type>
+     <type class="union"><type>int</type><type>float</type></type>
      <varname linkend="spoofchecker.constants.char-limit">Spoofchecker::SINGLE_SCRIPT_RESTRICTIVE</varname>
      <initializer>0x20000000</initializer>
     </fieldsynopsis>

--- a/reference/math/functions/abs.xml
+++ b/reference/math/functions/abs.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
    <methodsynopsis>
-    <type>number</type><methodname>abs</methodname>
+    <type class="union"><type>int</type><type>float</type></type><methodname>abs</methodname>
     <methodparam><type>mixed</type><parameter>number</parameter></methodparam>
    </methodsynopsis>
   <para>

--- a/reference/math/functions/bindec.xml
+++ b/reference/math/functions/bindec.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
    <methodsynopsis>
-    <type>number</type><methodname>bindec</methodname>
+    <type class="union"><type>int</type><type>float</type></type><methodname>bindec</methodname>
     <methodparam><type>string</type><parameter>binary_string</parameter></methodparam>
    </methodsynopsis>
   <para>

--- a/reference/math/functions/hexdec.xml
+++ b/reference/math/functions/hexdec.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
    <methodsynopsis>
-    <type>number</type><methodname>hexdec</methodname>
+    <type class="union"><type>int</type><type>float</type></type><methodname>hexdec</methodname>
     <methodparam><type>string</type><parameter>hex_string</parameter></methodparam>
    </methodsynopsis>
   <para>

--- a/reference/math/functions/octdec.xml
+++ b/reference/math/functions/octdec.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
    <methodsynopsis>
-    <type>number</type><methodname>octdec</methodname>
+    <type class="union"><type>int</type><type>float</type></type><methodname>octdec</methodname>
     <methodparam><type>string</type><parameter>octal_string</parameter></methodparam>
    </methodsynopsis>
   <para>

--- a/reference/math/functions/pow.xml
+++ b/reference/math/functions/pow.xml
@@ -8,9 +8,9 @@
  <refsect1 role="description">
   &reftitle.description;
    <methodsynopsis>
-    <type>number</type><methodname>pow</methodname>
-    <methodparam><type>number</type><parameter>base</parameter></methodparam>
-    <methodparam><type>number</type><parameter>exp</parameter></methodparam>
+    <type class="union"><type>int</type><type>float</type></type><methodname>pow</methodname>
+    <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>base</parameter></methodparam>
+    <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>exp</parameter></methodparam>
    </methodsynopsis>
   <para>
    Returns <parameter>base</parameter> raised to the power of

--- a/reference/tokyo_tyrant/tokyotyrant/add.xml
+++ b/reference/tokyo_tyrant/tokyotyrant/add.xml
@@ -10,9 +10,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>number</type><methodname>TokyoTyrant::add</methodname>
+   <modifier>public</modifier> <type class="union"><type>int</type><type>float</type></type><methodname>TokyoTyrant::add</methodname>
    <methodparam><type>string</type><parameter>key</parameter></methodparam>
-   <methodparam><type>number</type><parameter>increment</parameter></methodparam>
+   <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>increment</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>


### PR DESCRIPTION
There is really no need for a pseudo type here; we can either use the
`int|float` union, or spell out the abbreviation, instead.

---

See also https://github.com/php/doc-en/pull/174#discussion_r515682273.

Oh, and of course, if we wanted, we could define a `type.number` entity for brevity.