### PR TITLE
Updating mysqli docs: mysqli::__construct

### DIFF
--- a/reference/mysqli/functions/mysqli-connect.xml
+++ b/reference/mysqli/functions/mysqli-connect.xml
@@ -11,44 +11,13 @@
   <para>
    &info.function.alias; <methodname>mysqli::__construct</methodname>
   </para>
-  <para>
-   Although the <methodname>mysqli::__construct</methodname> documentation also includes
-   procedural examples that use the <function>mysqli_connect</function> function, here
-   is a short example:
-  </para>
- </refsect1>
-
- <refsect1 role="examples">
-  &reftitle.examples;
-  <example>
-   <title><function>mysqli_connect</function> example</title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-$link = mysqli_connect("127.0.0.1", "my_user", "my_password", "my_db");
-
-if (!$link) {
-    echo "Error: Unable to connect to MySQL." . PHP_EOL;
-    echo "Debugging errno: " . mysqli_connect_errno() . PHP_EOL;
-    echo "Debugging error: " . mysqli_connect_error() . PHP_EOL;
-    exit;
-}
-
-echo "Success: A proper connection to MySQL was made! The my_db database is great." . PHP_EOL;
-echo "Host information: " . mysqli_get_host_info($link) . PHP_EOL;
-
-mysqli_close($link);
-?>
-]]>
-   </programlisting>
-   &examples.outputs.similar;
-   <screen>
-<![CDATA[
-Success: A proper connection to MySQL was made! The my_db database is great.
-Host information: localhost via TCP/IP
-]]>
-   </screen>
-  </example>
+  <note>
+   <para>
+    If mysqli exception mode is not enabled and a connection fails 
+    then <function>mysqli_connect</function> returns &false; instead of an object. 
+    <function>mysqli_connect_error</function> function can be used to fetch the connection error.
+   </para>
+  </note>
  </refsect1>
 </refentry>
 

--- a/reference/mysqli/functions/mysqli-connect.xml
+++ b/reference/mysqli/functions/mysqli-connect.xml
@@ -13,7 +13,7 @@
   </para>
   <note>
    <para>
-    If mysqli exception mode is not enabled and a connection fails 
+    If mysqli exception mode is not enabled and a connection fails, 
     then <function>mysqli_connect</function> returns &false; instead of an object. 
     <function>mysqli_connect_error</function> function can be used to fetch the connection error.
    </para>
@@ -41,4 +41,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -158,7 +158,7 @@ mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
 $mysqli = new mysqli('localhost', 'my_user', 'my_password', 'my_db');
 
-/* Setting the proper charset after establishing a connection */
+/* Set the desired charset after establishing a connection */
 $mysqli->set_charset('utf8mb4');
 
 printf("Success... %s\n", $mysqli->host_info);
@@ -174,7 +174,7 @@ mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
 $mysqli = mysqli_connect('localhost', 'my_user', 'my_password', 'my_db');
 
-/* Setting the proper charset after establishing a connection */
+/* Set the desired charset after establishing a connection */
 mysqli_set_charset($mysqli, 'utf8mb4');
 
 printf("Success... %s\n", mysqli_get_host_info($mysqli));
@@ -207,7 +207,7 @@ $db = new MyMysqli('localhost', 'my_user', 'my_password', 'my_db', 3306, null, '
   </example>
   <example>
    <title>Manual error handling</title>
-   <para>If error reporting is disabled, the developer is responsible for failure checking and their proper handling</para>
+   <para>If error reporting is disabled, the developer is responsible for checking and handling failures</para>
    <para>&style.oop;</para>
    <programlisting role="php">
 <![CDATA[
@@ -219,7 +219,7 @@ if ($mysqli->connect_errno) {
 	exit;
 }
 
-/* Setting the proper charset after establishing a connection */
+/* Set the desired charset after establishing a connection */
 $mysqli->set_charset('utf8mb4');
 if ($mysqli->errno) {
 	error_log($mysqli->error);
@@ -238,7 +238,7 @@ if (mysqli_connect_errno()) {
 	exit;
 }
 
-/* Setting the proper charset after establishing a connection */
+/* Set the desired charset after establishing a connection */
 mysqli_set_charset($mysqli, 'utf8mb4');
 if (mysqli_errno($mysqli)) {
 	error_log(mysqli_error($mysqli));
@@ -254,8 +254,8 @@ if (mysqli_errno($mysqli)) {
   &mysqli.charset.note;
   <note>
    <para>
-    &style.oop; only: If the connection fails an object is still returned. To check 
-    if the connection failed, use either the 
+    &style.oop; only: If the connection fails, an object is still returned. To check 
+    whether the connection failed, use either the 
     <function>mysqli_connect_error</function> function or the <link 
     linkend="mysqli.connect-error">mysqli->connect_error</link> property as in 
     the preceding examples.

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -193,7 +193,7 @@ Success... localhost via TCP/IP
 <![CDATA[
 <?php
 
-class MyMysqli extends mysqli {
+class FooMysqli extends mysqli {
 	public function __construct($host, $user, $pass, $db, $port, $socket, $charset) {
 		mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 		parent::__construct($host, $user, $pass, $db, $port, $socket);
@@ -201,7 +201,7 @@ class MyMysqli extends mysqli {
 	}
 }
 
-$db = new MyMysqli('localhost', 'my_user', 'my_password', 'my_db', 3306, null, 'utf8mb4');
+$db = new FooMysqli('localhost', 'my_user', 'my_password', 'my_db', 3306, null, 'utf8mb4');
 ]]>
    </programlisting>
   </example>

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -194,11 +194,11 @@ Success... localhost via TCP/IP
 <?php
 
 class FooMysqli extends mysqli {
-	public function __construct($host, $user, $pass, $db, $port, $socket, $charset) {
-		mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
-		parent::__construct($host, $user, $pass, $db, $port, $socket);
-		$this->set_charset($charset);
-	}
+    public function __construct($host, $user, $pass, $db, $port, $socket, $charset) {
+        mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+        parent::__construct($host, $user, $pass, $db, $port, $socket);
+        $this->set_charset($charset);
+    }
 }
 
 $db = new FooMysqli('localhost', 'my_user', 'my_password', 'my_db', 3306, null, 'utf8mb4');

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -52,10 +52,10 @@
      <term><parameter>host</parameter></term>
      <listitem>
       <para>
-       Can be either a host name or an IP address. Passing the &null; value
-       or the string "localhost" to this parameter, the local host is
-       assumed. When possible, pipes will be used instead of the TCP/IP
-       protocol.
+       Can be either a host name or an IP address. The local host is 
+       assumed when passing the &null; value or the string "localhost" to this parameter. 
+       When possible, pipes will be used instead of the TCP/IP protocol. 
+       The TCP/IP protocol is used if a host name and port number are provided together e.g. <literal>localhost:3308</literal>.
       </para>
       <para>
        Prepending host by <literal>p:</literal> opens a persistent connection.
@@ -124,8 +124,23 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an object which represents the connection to a MySQL Server,
+   <methodname>mysqli::__construct</methodname> always returns an object which represents the connection to a MySQL Server, 
+   regardless of it being successful or not.
+  </para>
+  <para>
+   <function>mysqli_connect</function> returns an object which represents the connection to a MySQL Server,
    &return.falseforfailure;.
+  </para>
+  <para>
+   <methodname>mysqli::connect</methodname> returns &null; on success&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   If <constant>MYSQLI_REPORT_STRICT</constant> is enabled and the attempt to connect 
+   to the requested database fails, a <classname>mysqli_sql_exception</classname> is thrown.
   </para>
  </refsect1>
 
@@ -137,79 +152,100 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+
+/* You should enable error reporting for mysqli before attempting to make a connection */
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
 $mysqli = new mysqli('localhost', 'my_user', 'my_password', 'my_db');
 
-/*
- * This is the "official" OO way to do it,
- * BUT $connect_error was broken until PHP 5.2.9 and 5.3.0.
- */
-if ($mysqli->connect_error) {
-    die('Connect Error (' . $mysqli->connect_errno . ') '
-            . $mysqli->connect_error);
-}
+/* Setting the proper charset after establishing a connection */
+$mysqli->set_charset('utf8mb4');
 
-/*
- * Use this instead of $connect_error if you need to ensure
- * compatibility with PHP versions prior to 5.2.9 and 5.3.0.
- */
-if (mysqli_connect_error()) {
-    die('Connect Error (' . mysqli_connect_errno() . ') '
-            . mysqli_connect_error());
-}
-
-echo 'Success... ' . $mysqli->host_info . "\n";
-
-$mysqli->close();
-?>
-]]>
-   </programlisting>
-   <para>&style.oop; when extending mysqli class</para>
-   <programlisting role="php">
-<![CDATA[
-<?php
-
-class foo_mysqli extends mysqli {
-    public function __construct($host, $user, $pass, $db) {
-        parent::__construct($host, $user, $pass, $db);
-
-        if (mysqli_connect_error()) {
-            die('Connect Error (' . mysqli_connect_errno() . ') '
-                    . mysqli_connect_error());
-        }
-    }
-}
-
-$db = new foo_mysqli('localhost', 'my_user', 'my_password', 'my_db');
-
-echo 'Success... ' . $db->host_info . "\n";
-
-$db->close();
-?>
+printf("Success... %s\n", $mysqli->host_info);
 ]]>
    </programlisting>
    <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
-$link = mysqli_connect('localhost', 'my_user', 'my_password', 'my_db');
 
-if (!$link) {
-    die('Connect Error (' . mysqli_connect_errno() . ') '
-            . mysqli_connect_error());
-}
+/* You should enable error reporting for mysqli before attempting to make a connection */
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
-echo 'Success... ' . mysqli_get_host_info($link) . "\n";
+$mysqli = mysqli_connect('localhost', 'my_user', 'my_password', 'my_db');
 
-mysqli_close($link);
-?>
+/* Setting the proper charset after establishing a connection */
+mysqli_set_charset($mysqli, 'utf8mb4');
+
+printf("Success... %s\n", mysqli_get_host_info($mysqli));
 ]]>
    </programlisting>
-   &examples.outputs;
+   &examples.outputs.similar;
    <screen>
 <![CDATA[
-Success... MySQL host info: localhost via TCP/IP
+Success... localhost via TCP/IP
 ]]>
    </screen>
+  </example>
+  <example>
+   <title>Extending mysqli class</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+class MyMysqli extends mysqli {
+	public function __construct($host, $user, $pass, $db, $port, $socket, $charset) {
+		mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+		parent::__construct($host, $user, $pass, $db, $port, $socket);
+		$this->set_charset($charset);
+	}
+}
+
+$db = new MyMysqli('localhost', 'my_user', 'my_password', 'my_db', 3306, null, 'utf8mb4');
+]]>
+   </programlisting>
+  </example>
+  <example>
+   <title>Manual error handling</title>
+   <para>If error reporting is disabled, the developer is responsible for failure checking and their proper handling</para>
+   <para>&style.oop;</para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$mysqli = @new mysqli('localhost', 'my_user', 'my_password', 'my_db');
+if ($mysqli->connect_errno) {
+	error_log($mysqli->connect_error);
+	exit;
+}
+
+/* Setting the proper charset after establishing a connection */
+$mysqli->set_charset('utf8mb4');
+if ($mysqli->errno) {
+	error_log($mysqli->error);
+	exit;
+}
+]]>
+   </programlisting>
+   <para>&style.procedural;</para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$mysqli = @mysqli_connect('localhost', 'my_user', 'my_password', 'my_db');
+if (mysqli_connect_errno()) {
+	error_log(mysqli_connect_error());
+	exit;
+}
+
+/* Setting the proper charset after establishing a connection */
+mysqli_set_charset($mysqli, 'utf8mb4');
+if (mysqli_errno($mysqli)) {
+	error_log(mysqli_error($mysqli));
+	exit;
+}
+]]>
+   </programlisting>
   </example>
  </refsect1>
 
@@ -218,8 +254,8 @@ Success... MySQL host info: localhost via TCP/IP
   &mysqli.charset.note;
   <note>
    <para>
-    OO syntax only: If a connection fails an object is still returned. To check 
-    if the connection failed then use either the 
+    &style.oop; only: If the connection fails an object is still returned. To check 
+    if the connection failed, use either the 
     <function>mysqli_connect_error</function> function or the <link 
     linkend="mysqli.connect-error">mysqli->connect_error</link> property as in 
     the preceding examples.

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -213,17 +213,17 @@ $db = new FooMysqli('localhost', 'my_user', 'my_password', 'my_db', 3306, null, 
 <![CDATA[
 <?php
 
-$mysqli = @new mysqli('localhost', 'my_user', 'my_password', 'my_db');
+error_reporting(0);
+mysqli_report(MYSQLI_REPORT_OFF);
+$mysqli = new mysqli('localhost', 'my_user', 'my_password', 'my_db');
 if ($mysqli->connect_errno) {
-	error_log($mysqli->connect_error);
-	exit;
+    throw new RuntimeException('mysqli connection error: ' . $mysqli->connect_error);
 }
 
 /* Set the desired charset after establishing a connection */
 $mysqli->set_charset('utf8mb4');
 if ($mysqli->errno) {
-	error_log($mysqli->error);
-	exit;
+    throw new RuntimeException('mysqli error: ' . $mysqli->error);
 }
 ]]>
    </programlisting>
@@ -232,17 +232,17 @@ if ($mysqli->errno) {
 <![CDATA[
 <?php
 
-$mysqli = @mysqli_connect('localhost', 'my_user', 'my_password', 'my_db');
+error_reporting(0);
+mysqli_report(MYSQLI_REPORT_OFF);
+$mysqli = mysqli_connect('localhost', 'my_user', 'my_password', 'my_db');
 if (mysqli_connect_errno()) {
-	error_log(mysqli_connect_error());
-	exit;
+    throw new RuntimeException('mysqli connection error: ' . mysqli_connect_error());
 }
 
 /* Set the desired charset after establishing a connection */
 mysqli_set_charset($mysqli, 'utf8mb4');
 if (mysqli_errno($mysqli)) {
-	error_log(mysqli_error($mysqli));
-	exit;
+    throw new RuntimeException('mysqli error: ' . mysqli_error($mysqli));
 }
 ]]>
    </programlisting>


### PR DESCRIPTION
This is yet another PR attempting to modernize and explain better mysqli manual. 
Changes:
1. Provided new code examples.  
First, examples with exception mode enabled and setting the correct charset (the typo in output was fixed, but also changed to "or similar"). Then, a modernized example of extending mysqli class. Followed by the examples of manual error checking for completeness. 
2. Added a new sentence to the first parameter "The TCP/IP protocol is used if a host name and port number are provided together e.g. `localhost:3308`"
3. Return section now split up for all 3 "variants". Constructor only returns an instance, function returns an instance or false, and the method returns null or false. 
4. Added errors section. I was not sure about this, but I decided that it is very relevant for people who would like to catch the exception and are looking for its name. 
5. Changed the wording of some sentences for easier reading.
6. Removed the outdated and unnecessary example from `mysqli_connect` page. We should either keep a separate documentation page for each variant (e.g. like we do with `mysqli_real_connect`) or maintain all of them together and keep `mysqli_connect` page as an alias stub page only. However, given that the only difference is the return value I added a note pointing it out. 