### PR TITLE
add CRYPT_SHA256 and CRYPT_SHA512 constants

### DIFF
--- a/reference/strings/constants.xml
+++ b/reference/strings/constants.xml
@@ -22,7 +22,7 @@
    </term>
    <listitem>
     <simpara>
-
+     Indicates whether standard DES-based hashes are supported in <function>crypt</function>. Always <literal>1</literal>.
     </simpara>
    </listitem>
   </varlistentry>
@@ -33,7 +33,7 @@
    </term>
    <listitem>
     <simpara>
-
+     Indicates whether extended DES-based hashes are supported in <function>crypt</function>. Always <literal>1</literal>.
     </simpara>
    </listitem>
   </varlistentry>
@@ -44,7 +44,7 @@
    </term>
    <listitem>
     <simpara>
-
+     Indicates whether MD5 hashes are supported in <function>crypt</function>. Always <literal>1</literal>.
     </simpara>
    </listitem>
   </varlistentry>
@@ -55,7 +55,7 @@
    </term>
    <listitem>
     <simpara>
-
+     Indicates whether Blowfish hashes are supported in <function>crypt</function>. Always <literal>1</literal>.
     </simpara>
    </listitem>
   </varlistentry>
@@ -66,7 +66,7 @@
    </term>
    <listitem>
     <simpara>
-
+     Indicates whether SHA-256 hashes are supported in <function>crypt</function>. Always <literal>1</literal>.
     </simpara>
    </listitem>
   </varlistentry>
@@ -77,7 +77,7 @@
    </term>
    <listitem>
     <simpara>
-
+     Indicates whether SHA-512 hashes are supported in <function>crypt</function>. Always <literal>1</literal>.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/strings/constants.xml
+++ b/reference/strings/constants.xml
@@ -59,6 +59,28 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.crypt-sha256">
+   <term>
+    <constant>CRYPT_SHA256</constant>
+     <type>int</type>
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.crypt-sha512">
+   <term>
+    <constant>CRYPT_SHA512</constant>
+     <type>int</type>
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
    <varlistentry xml:id="constant.html-specialchars">
    <term>
     <constant>HTML_SPECIALCHARS</constant>


### PR DESCRIPTION
While the description is available at the `crypt()` function since a3e8136e4e9ed855110b15a65d26f52bb34780cc, it was never added to the list of predefined constants.