### PR TITLE
Updating mysqli: Remove embedded leftovers

### DIFF
--- a/reference/mysqli/mysqli_driver.xml
+++ b/reference/mysqli/mysqli_driver.xml
@@ -54,7 +54,7 @@
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>readonly</modifier>
-     <type>string</type>
+     <type>bool</type>
      <varname linkend="mysqli-driver.props.embedded">embedded</varname>
     </fieldsynopsis>
     <fieldsynopsis>

--- a/reference/mysqli/mysqli_driver/embedded-server-end.xml
+++ b/reference/mysqli/mysqli_driver/embedded-server-end.xml
@@ -6,6 +6,10 @@
   <refname>mysqli_embedded_server_end</refname>
   <refpurpose>Stop embedded server</refpurpose>
  </refnamediv>
+ 
+ <refsynopsisdiv>
+  &warn.removed.function-7-4-0;
+ </refsynopsisdiv>
 
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/mysqli/mysqli_driver/embedded-server-start.xml
+++ b/reference/mysqli/mysqli_driver/embedded-server-start.xml
@@ -6,6 +6,10 @@
   <refname>mysqli_embedded_server_start</refname>
   <refpurpose>Initialize and start embedded server</refpurpose>
  </refnamediv>
+ 
+ <refsynopsisdiv>
+  &warn.removed.function-7-4-0;
+ </refsynopsisdiv>
 
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/mysqli/overview.xml
+++ b/reference/mysqli/overview.xml
@@ -237,12 +237,6 @@
         </para>
       </listitem>
 
-      <listitem>
-        <para>
-          Embedded server support
-        </para>
-      </listitem>
-
     </itemizedlist>
   </para>
 

--- a/reference/mysqli/versions.xml
+++ b/reference/mysqli/versions.xml
@@ -16,8 +16,6 @@
  <function name="mysqli_connect_error" from="PHP 5, PHP 7"/>
  <function name="mysqli_data_seek" from="PHP 5, PHP 7"/>
  <function name="mysqli_debug" from="PHP 5, PHP 7"/>
- <function name="mysqli_driver_embedded_server_end" from="PHP 5, PHP 7"/>
- <function name="mysqli_driver_embedded_server_start" from="PHP 5, PHP 7"/>
  <function name="mysqli_dump_debug_info" from="PHP 5, PHP 7"/>
  <function name="mysqli_embedded_server_end" from="PHP 5 &gt;= 5.1.0, PHP 7 &lt; 7.4.0"/>
  <function name="mysqli_embedded_server_start" from="PHP 5 &gt;= 5.1.0, PHP 7 &lt; 7.4.0"/>


### PR DESCRIPTION
The support for mysqli embedded server has been completely removed from PHP 8 and has not been functional for quite some time. 
See https://github.com/php/php-src/commit/7be0e06b482e5bf14eaf4fe9a882d8b72d644038