### PR TITLE
Updating mysqli: Improving Quick Start guide

### DIFF
--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -168,19 +168,14 @@ Possible but bad style.
     <programlisting role="php">
 <![CDATA[
 <?php
+
 $mysqli = new mysqli("localhost", "user", "password", "database");
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
-}
+
 echo $mysqli->host_info . "\n";
 
 $mysqli = new mysqli("127.0.0.1", "user", "password", "database", 3306);
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
-}
 
 echo $mysqli->host_info . "\n";
-?>
 ]]>
     </programlisting>
     &example.outputs;

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -1263,6 +1263,47 @@ do {
 } while ($stmt->next_result());
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+---
+array(3) {
+  [0]=>
+  array(1) {
+    [0]=>
+    int(1)
+  }
+  [1]=>
+  array(1) {
+    [0]=>
+    int(2)
+  }
+  [2]=>
+  array(1) {
+    [0]=>
+    int(3)
+  }
+}
+---
+array(3) {
+  [0]=>
+  array(1) {
+    [0]=>
+    int(2)
+  }
+  [1]=>
+  array(1) {
+    [0]=>
+    int(3)
+  }
+  [2]=>
+  array(1) {
+    [0]=>
+    int(4)
+  }
+}
+]]>
+    </screen>
    </example>
   </para>
   <para>
@@ -1299,6 +1340,17 @@ do {
 } while ($stmt->next_result());
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+id = 1
+id = 2
+id = 3
+id = 2
+id = 3
+id = 4
+]]>
+    </screen>
    </example>
   </para>
   <para>

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -1528,14 +1528,12 @@ $mysqli->commit();
     <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("example.com", "user", "password", "database");
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
-}
 
 $res = $mysqli->query("SELECT 1 AS _one, 'Hello' AS _two FROM DUAL");
 var_dump($res->fetch_fields());
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -1619,11 +1617,14 @@ array(2) {
     <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = new mysqli("example.com", "user", "password", "database");
+
 $stmt = $mysqli->prepare("SELECT 1 AS _one, 'Hello' AS _two FROM DUAL");
 $stmt->execute();
 $res = $stmt->result_metadata();
 var_dump($res->fetch_fields());
-?>
 ]]>
     </programlisting>
    </example>

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -120,7 +120,7 @@ $mysqli = new mysqli("example.com", "user", "password", "database");
 $res = mysqli_query($mysqli, "SELECT 'Possible but bad style.' AS _msg FROM DUAL");
 
 if ($row = $res->fetch_assoc()) {
-	echo $row['_msg'];
+    echo $row['_msg'];
 }
 ]]>
     </programlisting>
@@ -336,7 +336,7 @@ mysqli.default_socket=/tmp/mysql.sock
   <para>
    Statements can be executed with the
    <methodname>mysqli::query</methodname>, <methodname>mysqli::real_query</methodname>
-   and <methodname>mysqli::multi_query</methodname> functions.
+   and <methodname>mysqli::multi_query</methodname>.
    The <methodname>mysqli::query</methodname> function is the most
    common, and combines the executing statement with a
    buffered fetch of its result set, if any, in one call.
@@ -346,21 +346,16 @@ mysqli.default_socket=/tmp/mysql.sock
   </para>
   <para>
    <example>
-    <title>Connecting to MySQL</title>
+    <title>Executing queries</title>
     <programlisting role="php">
 <![CDATA[
 <?php
-$mysqli = new mysqli("example.com", "user", "password", "database");
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
-}
 
-if (!$mysqli->query("DROP TABLE IF EXISTS test") ||
-    !$mysqli->query("CREATE TABLE test(id INT)") ||
-    !$mysqli->query("INSERT INTO test(id) VALUES (1)")) {
-    echo "Table creation failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
-?>
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = new mysqli("example.com", "user", "password", "database");
+
+$mysqli->query("DROP TABLE IF EXISTS test");
+$mysqli->query("CREATE TABLE test(id INT)");
 ]]>
     </programlisting>
    </example>
@@ -369,9 +364,9 @@ if (!$mysqli->query("DROP TABLE IF EXISTS test") ||
    <emphasis role="bold">Buffered result sets</emphasis>
   </para>
   <para>
-   After statement execution results can be retrieved at once to be buffered
-   by the client or by read row by row. Client-side result set buffering
-   allows the server to free resources associated with the statement
+   After statement execution, results can be either retrieved all at once 
+   or read row by row from the server. Client-side result set buffering
+   allows the server to free resources associated with the statement's
    results as early as possible. Generally speaking, clients are slow
    consuming result sets. Therefore, it is recommended to use buffered
    result sets. <methodname>mysqli::query</methodname> combines statement
@@ -389,32 +384,27 @@ if (!$mysqli->query("DROP TABLE IF EXISTS test") ||
     <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("example.com", "user", "password", "database");
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
-}
 
-if (!$mysqli->query("DROP TABLE IF EXISTS test") ||
-    !$mysqli->query("CREATE TABLE test(id INT)") ||
-    !$mysqli->query("INSERT INTO test(id) VALUES (1), (2), (3)")) {
-    echo "Table creation failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$mysqli->query("DROP TABLE IF EXISTS test");
+$mysqli->query("CREATE TABLE test(id INT)");
+$mysqli->query("INSERT INTO test(id) VALUES (1), (2), (3)");
 
-$res = $mysqli->query("SELECT id FROM test ORDER BY id ASC");
+$result = $mysqli->query("SELECT id FROM test ORDER BY id ASC");
 
 echo "Reverse order...\n";
-for ($row_no = $res->num_rows - 1; $row_no >= 0; $row_no--) {
-    $res->data_seek($row_no);
-    $row = $res->fetch_assoc();
+for ($row_no = $result->num_rows - 1; $row_no >= 0; $row_no--) {
+    $result->data_seek($row_no);
+    $row = $result->fetch_assoc();
     echo " id = " . $row['id'] . "\n";
 }
 
 echo "Result set order...\n";
-$res->data_seek(0);
-while ($row = $res->fetch_assoc()) {
+foreach ($result as $row) {
     echo " id = " . $row['id'] . "\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -447,14 +437,14 @@ Result set order...
     <programlisting role="php">
 <![CDATA[
 <?php
+
 $mysqli->real_query("SELECT id FROM test ORDER BY id ASC");
-$res = $mysqli->use_result();
+$result = $mysqli->use_result();
 
 echo "Result set order...\n";
-while ($row = $res->fetch_assoc()) {
+foreach ($result as $row) {
     echo " id = " . $row['id'] . "\n";
 }
-?>
 ]]>
     </programlisting>
    </example>
@@ -480,23 +470,19 @@ while ($row = $res->fetch_assoc()) {
     <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("example.com", "user", "password", "database");
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
-}
 
-if (!$mysqli->query("DROP TABLE IF EXISTS test") ||
-    !$mysqli->query("CREATE TABLE test(id INT, label CHAR(1))") ||
-    !$mysqli->query("INSERT INTO test(id, label) VALUES (1, 'a')")) {
-    echo "Table creation failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$mysqli->query("DROP TABLE IF EXISTS test");
+$mysqli->query("CREATE TABLE test(id INT, label CHAR(1))");
+$mysqli->query("INSERT INTO test(id, label) VALUES (1, 'a')");
 
-$res = $mysqli->query("SELECT id, label FROM test WHERE id = 1");
-$row = $res->fetch_assoc();
+$result = $mysqli->query("SELECT id, label FROM test WHERE id = 1");
+$row = $result->fetch_assoc();
 
 printf("id = %s (%s)\n", $row['id'], gettype($row['id']));
 printf("label = %s (%s)\n", $row['label'], gettype($row['label']));
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -522,26 +508,22 @@ label = a (string)
     <programlisting role="php">
 <![CDATA[
 <?php
-$mysqli = mysqli_init();
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$mysqli = new mysqli();
 $mysqli->options(MYSQLI_OPT_INT_AND_FLOAT_NATIVE, 1);
 $mysqli->real_connect("example.com", "user", "password", "database");
 
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
-}
+$mysqli->query("DROP TABLE IF EXISTS test");
+$mysqli->query("CREATE TABLE test(id INT, label CHAR(1))");
+$mysqli->query("INSERT INTO test(id, label) VALUES (1, 'a')");
 
-if (!$mysqli->query("DROP TABLE IF EXISTS test") ||
-    !$mysqli->query("CREATE TABLE test(id INT, label CHAR(1))") ||
-    !$mysqli->query("INSERT INTO test(id, label) VALUES (1, 'a')")) {
-    echo "Table creation failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
-
-$res = $mysqli->query("SELECT id, label FROM test WHERE id = 1");
-$row = $res->fetch_assoc();
+$result = $mysqli->query("SELECT id, label FROM test WHERE id = 1");
+$row = $result->fetch_assoc();
 
 printf("id = %s (%s)\n", $row['id'], gettype($row['id']));
 printf("label = %s (%s)\n", $row['label'], gettype($row['label']));
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -559,14 +541,12 @@ label = a (string)
   <para>
    <simplelist>
     <member><methodname>mysqli::__construct</methodname></member>
-    <member><function>mysqli_init</function></member>
     <member><methodname>mysqli::options</methodname></member>
     <member><methodname>mysqli::real_connect</methodname></member>
     <member><methodname>mysqli::query</methodname></member>
     <member><methodname>mysqli::multi_query</methodname></member>
     <member><methodname>mysqli::use_result</methodname></member>
     <member><methodname>mysqli::store_result</methodname></member>
-    <member><methodname>mysqli_result::free</methodname></member>
    </simplelist>
   </para>
  </section>

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -338,7 +338,7 @@ mysqli.default_socket=/tmp/mysql.sock
   <para>
    <simplelist>
     <member><methodname>mysqli::__construct</methodname></member>
-    <member><methodname>mysqli::init</methodname></member>
+    <member><function>mysqli_init</function></member>
     <member><methodname>mysqli::options</methodname></member>
     <member><methodname>mysqli::real_connect</methodname></member>
     <member><methodname>mysqli::change_user</methodname></member>
@@ -577,7 +577,7 @@ label = a (string)
   <para>
    <simplelist>
     <member><methodname>mysqli::__construct</methodname></member>
-    <member><methodname>mysqli::init</methodname></member>
+    <member><function>mysqli_init</function></member>
     <member><methodname>mysqli::options</methodname></member>
     <member><methodname>mysqli::real_connect</methodname></member>
     <member><methodname>mysqli::query</methodname></member>
@@ -1469,8 +1469,8 @@ do {
    <simplelist>
     <member><methodname>mysqli::query</methodname></member>
     <member><methodname>mysqli::multi_query</methodname></member>
-    <member><methodname>mysqli_result::next-result</methodname></member>
-    <member><methodname>mysqli_result::more-results</methodname></member>
+    <member><methodname>mysqli::next_result</methodname></member>
+    <member><methodname>mysqli::more_results</methodname></member>
    </simplelist>
   </para>
  </section>
@@ -1595,8 +1595,8 @@ to use near 'DROP TABLE mysql.user' at line 1
    <simplelist>
     <member><methodname>mysqli::query</methodname></member>
     <member><methodname>mysqli::multi_query</methodname></member>
-    <member><methodname>mysqli_result::next-result</methodname></member>
-    <member><methodname>mysqli_result::more-results</methodname></member>
+    <member><methodname>mysqli::next_result</methodname></member>
+    <member><methodname>mysqli::more_results</methodname></member>
    </simplelist>
   </para>
  </section>

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -556,7 +556,7 @@ label = a (string)
   <para>
    The MySQL database supports prepared statements. A prepared statement
    or a parameterized statement is used to execute the same statement
-   repeatedly with high efficiency.
+   repeatedly with high efficiency and protect against SQL injections.
   </para>
   <para>
    <emphasis role="bold">Basic workflow</emphasis>
@@ -572,31 +572,6 @@ label = a (string)
    with <literal>?</literal>.
   </para>
   <para>
-   <example>
-    <title>First stage: prepare</title>
-    <programlisting role="php">
-<![CDATA[
-<?php
-$mysqli = new mysqli("example.com", "user", "password", "database");
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
-}
-
-/* Non-prepared statement */
-if (!$mysqli->query("DROP TABLE IF EXISTS test") || !$mysqli->query("CREATE TABLE test(id INT)")) {
-    echo "Table creation failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
-
-/* Prepared statement, stage 1: prepare */
-if (!($stmt = $mysqli->prepare("INSERT INTO test(id) VALUES (?)"))) {
-    echo "Prepare failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
-?>
-]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
    Prepare is followed by execute. During execute the client binds
    parameter values and sends them to the server. The server creates a
    statement from the statement template and the bound values to
@@ -604,20 +579,27 @@ if (!($stmt = $mysqli->prepare("INSERT INTO test(id) VALUES (?)"))) {
   </para>
   <para>
    <example>
-    <title>Second stage: bind and execute</title>
+    <title>Prepared statement</title>
     <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = new mysqli("example.com", "user", "password", "database");
+
+/* Non-prepared statement */
+$mysqli->query("DROP TABLE IF EXISTS test");
+$mysqli->query("CREATE TABLE test(id INT, label TEXT)");
+
+/* Prepared statement, stage 1: prepare */
+$stmt = $mysqli->prepare("INSERT INTO test(id, label) VALUES (?, ?)");
+
 /* Prepared statement, stage 2: bind and execute */
 $id = 1;
-if (!$stmt->bind_param("i", $id)) {
-    echo "Binding parameters failed: (" . $stmt->errno . ") " . $stmt->error;
-}
+$label = 'PHP';
+$stmt->bind_param("is", $id, $label);
 
-if (!$stmt->execute()) {
-    echo "Execute failed: (" . $stmt->errno . ") " . $stmt->error;
-}
-?>
+$stmt->execute();
 ]]>
     </programlisting>
    </example>
@@ -637,70 +619,57 @@ if (!$stmt->execute()) {
     <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("example.com", "user", "password", "database");
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
-}
 
 /* Non-prepared statement */
-if (!$mysqli->query("DROP TABLE IF EXISTS test") || !$mysqli->query("CREATE TABLE test(id INT)")) {
-    echo "Table creation failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$mysqli->query("DROP TABLE IF EXISTS test");
+$mysqli->query("CREATE TABLE test(id INT, label TEXT)");
 
 /* Prepared statement, stage 1: prepare */
-if (!($stmt = $mysqli->prepare("INSERT INTO test(id) VALUES (?)"))) {
-     echo "Prepare failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$stmt = $mysqli->prepare("INSERT INTO test(id, label) VALUES (?, ?)");
 
 /* Prepared statement, stage 2: bind and execute */
-$id = 1;
-if (!$stmt->bind_param("i", $id)) {
-    echo "Binding parameters failed: (" . $stmt->errno . ") " . $stmt->error;
+$stmt->bind_param("is", $id, $label);
+
+$data = [
+    1 => 'PHP',
+    2 => 'Java',
+    3 => 'C++'
+];
+foreach ($data as $id => $label) {
+    $stmt->execute();
 }
 
-if (!$stmt->execute()) {
-    echo "Execute failed: (" . $stmt->errno . ") " . $stmt->error;
-}
-
-/* Prepared statement: repeated execution, only data transferred from client to server */
-for ($id = 2; $id < 5; $id++) {
-    if (!$stmt->execute()) {
-        echo "Execute failed: (" . $stmt->errno . ") " . $stmt->error;
-    }
-}
-
-/* explicit close recommended */
-$stmt->close();
-
-/* Non-prepared statement */
-$res = $mysqli->query("SELECT id FROM test");
-var_dump($res->fetch_all());
-?>
+$result = $mysqli->query('SELECT id, label FROM test');
+var_dump($result->fetch_all(MYSQLI_ASSOC));
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-array(4) {
+array(3) {
   [0]=>
-  array(1) {
-    [0]=>
+  array(2) {
+    ["id"]=>
     string(1) "1"
+    ["label"]=>
+    string(3) "PHP"
   }
   [1]=>
-  array(1) {
-    [0]=>
+  array(2) {
+    ["id"]=>
     string(1) "2"
+    ["label"]=>
+    string(4) "Java"
   }
   [2]=>
-  array(1) {
-    [0]=>
+  array(2) {
+    ["id"]=>
     string(1) "3"
-  }
-  [3]=>
-  array(1) {
-    [0]=>
-    string(1) "4"
+    ["label"]=>
+    string(3) "C++"
   }
 }
 ]]>
@@ -726,20 +695,6 @@ array(4) {
    the server and client than the prepared statement shown above.
   </para>
   <para>
-   <example>
-    <title>Less round trips using multi-INSERT SQL</title>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if (!$mysqli->query("INSERT INTO test(id) VALUES (1), (2), (3), (4)")) {
-    echo "Multi-INSERT failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
-?>
-]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
    <emphasis role="bold">Result set values data types</emphasis>
   </para>
   <para>
@@ -747,8 +702,7 @@ if (!$mysqli->query("INSERT INTO test(id) VALUES (1), (2), (3), (4)")) {
    for prepared statements and non-prepared statements. Prepared statements
    are using the so called binary protocol. The MySQL server sends result
    set data "as is" in binary format. Results are not serialized into
-   strings before sending. The client libraries do not receive strings only.
-   Instead, they will receive binary data and try to convert the values into
+   strings before sending. Client libraries receive binary data and try to convert the values into
    appropriate PHP data types. For example, results from an SQL
    <literal>INT</literal> column will be provided as PHP integer variables.
   </para>
@@ -758,32 +712,29 @@ if (!$mysqli->query("INSERT INTO test(id) VALUES (1), (2), (3), (4)")) {
     <programlisting role="php">
 <![CDATA[
 <?php
-$mysqli = new mysqli("example.com", "user", "password", "database");
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
-}
 
-if (!$mysqli->query("DROP TABLE IF EXISTS test") ||
-    !$mysqli->query("CREATE TABLE test(id INT, label CHAR(1))") ||
-    !$mysqli->query("INSERT INTO test(id, label) VALUES (1, 'a')")) {
-    echo "Table creation failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = new mysqli("example.com", "user", "password", "database");
+
+/* Non-prepared statement */
+$mysqli->query("DROP TABLE IF EXISTS test");
+$mysqli->query("CREATE TABLE test(id INT, label TEXT)");
+$mysqli->query("INSERT INTO test(id, label) VALUES (1, 'PHP')");
 
 $stmt = $mysqli->prepare("SELECT id, label FROM test WHERE id = 1");
 $stmt->execute();
-$res = $stmt->get_result();
-$row = $res->fetch_assoc();
+$result = $stmt->get_result();
+$row = $result->fetch_assoc();
 
 printf("id = %s (%s)\n", $row['id'], gettype($row['id']));
 printf("label = %s (%s)\n", $row['label'], gettype($row['label']));
-?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
 id = 1 (integer)
-label = a (string)
+label = PHP (string)
 ]]>
     </screen>
    </example>
@@ -811,41 +762,29 @@ label = a (string)
     <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("example.com", "user", "password", "database");
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
-}
 
-if (!$mysqli->query("DROP TABLE IF EXISTS test") ||
-    !$mysqli->query("CREATE TABLE test(id INT, label CHAR(1))") ||
-    !$mysqli->query("INSERT INTO test(id, label) VALUES (1, 'a')")) {
-    echo "Table creation failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+/* Non-prepared statement */
+$mysqli->query("DROP TABLE IF EXISTS test");
+$mysqli->query("CREATE TABLE test(id INT, label TEXT)");
+$mysqli->query("INSERT INTO test(id, label) VALUES (1, 'PHP')");
 
-if (!($stmt = $mysqli->prepare("SELECT id, label FROM test"))) {
-    echo "Prepare failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$stmt = $mysqli->prepare("SELECT id, label FROM test WHERE id = 1");
+$stmt->execute();
 
-if (!$stmt->execute()) {
-    echo "Execute failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
-
-$out_id    = NULL;
-$out_label = NULL;
-if (!$stmt->bind_result($out_id, $out_label)) {
-    echo "Binding output parameters failed: (" . $stmt->errno . ") " . $stmt->error;
-}
+$stmt->bind_result($out_id, $out_label);
 
 while ($stmt->fetch()) {
-    printf("id = %s (%s), label = %s (%s)\n", $out_id, gettype($out_id), $out_label, gettype($out_label));
+	printf("id = %s (%s), label = %s (%s)\n", $out_id, gettype($out_id), $out_label, gettype($out_label));
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-id = 1 (integer), label = a (string)
+id = 1 (integer), label = PHP (string)
 ]]>
     </screen>
    </example>
@@ -877,31 +816,21 @@ id = 1 (integer), label = a (string)
     <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("example.com", "user", "password", "database");
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
-}
 
-if (!$mysqli->query("DROP TABLE IF EXISTS test") ||
-    !$mysqli->query("CREATE TABLE test(id INT, label CHAR(1))") ||
-    !$mysqli->query("INSERT INTO test(id, label) VALUES (1, 'a')")) {
-    echo "Table creation failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+/* Non-prepared statement */
+$mysqli->query("DROP TABLE IF EXISTS test");
+$mysqli->query("CREATE TABLE test(id INT, label TEXT)");
+$mysqli->query("INSERT INTO test(id, label) VALUES (1, 'PHP')");
 
-if (!($stmt = $mysqli->prepare("SELECT id, label FROM test ORDER BY id ASC"))) {
-    echo "Prepare failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$stmt = $mysqli->prepare("SELECT id, label FROM test WHERE id = 1");
+$stmt->execute();
 
-if (!$stmt->execute()) {
-     echo "Execute failed: (" . $stmt->errno . ") " . $stmt->error;
-}
+$result = $stmt->get_result();
 
-if (!($res = $stmt->get_result())) {
-    echo "Getting result set failed: (" . $stmt->errno . ") " . $stmt->error;
-}
-
-var_dump($res->fetch_all());
-?>
+var_dump($result->fetch_all(MYSQLI_ASSOC));
 ]]>
     </programlisting>
     &example.outputs;
@@ -910,10 +839,10 @@ var_dump($res->fetch_all());
 array(1) {
   [0]=>
   array(2) {
-    [0]=>
+    ["id"]=>
     int(1)
-    [1]=>
-    string(1) "a"
+    ["label"]=>
+    string(3) "PHP"
   }
 }
 ]]>
@@ -921,7 +850,7 @@ array(1) {
    </example>
   </para>
   <para>
-   Using the <classname>mysqli_result interface</classname> offers the additional benefit of
+   Using the <classname>mysqli_result</classname> interface offers the additional benefit of
    flexible client-side result set navigation.
   </para>
   <para>
@@ -930,35 +859,24 @@ array(1) {
     <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("example.com", "user", "password", "database");
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
-}
 
-if (!$mysqli->query("DROP TABLE IF EXISTS test") ||
-    !$mysqli->query("CREATE TABLE test(id INT, label CHAR(1))") ||
-    !$mysqli->query("INSERT INTO test(id, label) VALUES (1, 'a'), (2, 'b'), (3, 'c')")) {
-    echo "Table creation failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+/* Non-prepared statement */
+$mysqli->query("DROP TABLE IF EXISTS test");
+$mysqli->query("CREATE TABLE test(id INT, label TEXT)");
+$mysqli->query("INSERT INTO test(id, label) VALUES (1, 'PHP'), (2, 'Java'), (3, 'C++')");
 
-if (!($stmt = $mysqli->prepare("SELECT id, label FROM test"))) {
-    echo "Prepare failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$stmt = $mysqli->prepare("SELECT id, label FROM test");
+$stmt->execute();
 
-if (!$stmt->execute()) {
-     echo "Execute failed: (" . $stmt->errno . ") " . $stmt->error;
-}
+$result = $stmt->get_result();
 
-if (!($res = $stmt->get_result())) {
-    echo "Getting result set failed: (" . $stmt->errno . ") " . $stmt->error;
+for ($row_no = $result->num_rows - 1; $row_no >= 0; $row_no--) {
+	$result->data_seek($row_no);
+	var_dump($result->fetch_assoc());
 }
-
-for ($row_no = ($res->num_rows - 1); $row_no >= 0; $row_no--) {
-    $res->data_seek($row_no);
-    var_dump($res->fetch_assoc());
-}
-$res->close();
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -968,19 +886,19 @@ array(2) {
   ["id"]=>
   int(3)
   ["label"]=>
-  string(1) "c"
+  string(3) "C++"
 }
 array(2) {
   ["id"]=>
   int(2)
   ["label"]=>
-  string(1) "b"
+  string(4) "Java"
 }
 array(2) {
   ["id"]=>
   int(1)
   ["label"]=>
-  string(1) "a"
+  string(3) "PHP"
 }
 ]]>
     </screen>
@@ -1014,7 +932,7 @@ array(2) {
    The API does not include emulation for client-side prepared statement emulation.
   </para>
   <para>
-   <emphasis role="bold">Quick prepared - non-prepared statement comparison</emphasis>
+   <emphasis role="bold">Quick prepared/non-prepared statement comparison</emphasis>
   </para>
   <para>
    The table below compares server-side prepared and non-prepared statements.
@@ -1048,11 +966,11 @@ array(2) {
      <row>
       <entry>Statement string transferred from client to server</entry>
       <entry>1 template, n times bound parameter, if any</entry>
-      <entry>n times together with parameter, if any</entry>
+      <entry>n times and parsed every time</entry>
      </row>
      <row>
       <entry>Input parameter binding API</entry>
-      <entry>Yes, automatic input escaping</entry>
+      <entry>Yes</entry>
       <entry>No, manual input escaping</entry>
      </row>
      <row>

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -1337,30 +1337,25 @@ do {
     <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("example.com", "user", "password", "database");
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
-}
 
-if (!$mysqli->query("DROP TABLE IF EXISTS test") || !$mysqli->query("CREATE TABLE test(id INT)")) {
-    echo "Table creation failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$mysqli->query("DROP TABLE IF EXISTS test");
+$mysqli->query("CREATE TABLE test(id INT)");
 
-$sql = "SELECT COUNT(*) AS _num FROM test; ";
-$sql.= "INSERT INTO test(id) VALUES (1); ";
-$sql.= "SELECT COUNT(*) AS _num FROM test; ";
+$sql = "SELECT COUNT(*) AS _num FROM test;
+        INSERT INTO test(id) VALUES (1); 
+        SELECT COUNT(*) AS _num FROM test; ";
 
-if (!$mysqli->multi_query($sql)) {
-    echo "Multi query failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$mysqli->multi_query($sql);
 
 do {
     if ($res = $mysqli->store_result()) {
         var_dump($res->fetch_all(MYSQLI_ASSOC));
         $res->free();
     }
-} while ($mysqli->more_results() && $mysqli->next_result());
-?>
+} while ($mysqli->next_result());
 ]]>
     </programlisting>
     &example.outputs;

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -45,7 +45,6 @@ mysql_select_db("test");
 $res = mysql_query("SELECT 'the mysql extension for new developments.' AS _msg FROM DUAL", $mysql);
 $row = mysql_fetch_assoc($res);
 echo $row['_msg'];
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -76,24 +75,18 @@ Please, do not use the mysql extension for new developments.
     <programlisting role="php">
 <![CDATA[
 <?php
+
 $mysqli = mysqli_connect("example.com", "user", "password", "database");
-if (mysqli_connect_errno()) {
-    echo "Failed to connect to MySQL: " . mysqli_connect_error();
-}
 
 $res = mysqli_query($mysqli, "SELECT 'A world full of ' AS _msg FROM DUAL");
 $row = mysqli_fetch_assoc($res);
 echo $row['_msg'];
 
 $mysqli = new mysqli("example.com", "user", "password", "database");
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: " . $mysqli->connect_error;
-}
 
 $res = $mysqli->query("SELECT 'choices to please everybody.' AS _msg FROM DUAL");
 $row = $res->fetch_assoc();
 echo $row['_msg'];
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -121,20 +114,14 @@ A world full of choices to please everybody.
     <programlisting role="php">
 <![CDATA[
 <?php
+
 $mysqli = new mysqli("example.com", "user", "password", "database");
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: " . $mysqli->connect_error;
-}
 
 $res = mysqli_query($mysqli, "SELECT 'Possible but bad style.' AS _msg FROM DUAL");
-if (!$res) {
-    echo "Failed to run query: (" . $mysqli->errno . ") " . $mysqli->error;
-}
 
 if ($row = $res->fetch_assoc()) {
-    echo $row['_msg'];
+	echo $row['_msg'];
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -777,7 +777,7 @@ $stmt->execute();
 $stmt->bind_result($out_id, $out_label);
 
 while ($stmt->fetch()) {
-	printf("id = %s (%s), label = %s (%s)\n", $out_id, gettype($out_id), $out_label, gettype($out_label));
+    printf("id = %s (%s), label = %s (%s)\n", $out_id, gettype($out_id), $out_label, gettype($out_label));
 }
 ]]>
     </programlisting>
@@ -874,8 +874,8 @@ $stmt->execute();
 $result = $stmt->get_result();
 
 for ($row_no = $result->num_rows - 1; $row_no >= 0; $row_no--) {
-	$result->data_seek($row_no);
-	var_dump($result->fetch_assoc());
+    $result->data_seek($row_no);
+    var_dump($result->fetch_assoc());
 }
 ]]>
     </programlisting>
@@ -1063,30 +1063,21 @@ array(2) {
     <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("example.com", "user", "password", "database");
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
-}
 
-if (!$mysqli->query("DROP TABLE IF EXISTS test") || !$mysqli->query("CREATE TABLE test(id INT)")) {
-    echo "Table creation failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$mysqli->query("DROP TABLE IF EXISTS test");
+$mysqli->query("CREATE TABLE test(id INT)");
 
-if (!$mysqli->query("DROP PROCEDURE IF EXISTS p") ||
-    !$mysqli->query("CREATE PROCEDURE p(IN id_val INT) BEGIN INSERT INTO test(id) VALUES(id_val); END;")) {
-    echo "Stored procedure creation failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$mysqli->query("DROP PROCEDURE IF EXISTS p");
+$mysqli->query("CREATE PROCEDURE p(IN id_val INT) BEGIN INSERT INTO test(id) VALUES(id_val); END;");
 
-if (!$mysqli->query("CALL p(1)")) {
-    echo "CALL failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$mysqli->query("CALL p(1)");
 
-if (!($res = $mysqli->query("SELECT id FROM test"))) {
-    echo "SELECT failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$result = $mysqli->query("SELECT id FROM test");
 
-var_dump($res->fetch_assoc());
-?>
+var_dump($result->fetch_assoc());
 ]]>
     </programlisting>
     &example.outputs;
@@ -1113,28 +1104,20 @@ array(1) {
     <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("example.com", "user", "password", "database");
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
-}
 
-if (!$mysqli->query("DROP PROCEDURE IF EXISTS p") ||
-    !$mysqli->query('CREATE PROCEDURE p(OUT msg VARCHAR(50)) BEGIN SELECT "Hi!" INTO msg; END;')) {
-    echo "Stored procedure creation failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$mysqli->query("DROP PROCEDURE IF EXISTS p");
+$mysqli->query('CREATE PROCEDURE p(OUT msg VARCHAR(50)) BEGIN SELECT "Hi!" INTO msg; END;');
 
+$mysqli->query("SET @msg = ''");
+$mysqli->query("CALL p(@msg)");
 
-if (!$mysqli->query("SET @msg = ''") || !$mysqli->query("CALL p(@msg)")) {
-    echo "CALL failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
-
-if (!($res = $mysqli->query("SELECT @msg as _p_out"))) {
-    echo "Fetch failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$res = $mysqli->query("SELECT @msg as _p_out");
 
 $row = $res->fetch_assoc();
 echo $row['_p_out'];
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -1176,38 +1159,26 @@ Hi!
     <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("example.com", "user", "password", "database");
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
-}
 
-if (!$mysqli->query("DROP TABLE IF EXISTS test") ||
-    !$mysqli->query("CREATE TABLE test(id INT)") ||
-    !$mysqli->query("INSERT INTO test(id) VALUES (1), (2), (3)")) {
-    echo "Table creation failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$mysqli->query("DROP TABLE IF EXISTS test");
+$mysqli->query("CREATE TABLE test(id INT)");
+$mysqli->query("INSERT INTO test(id) VALUES (1), (2), (3)");
 
-if (!$mysqli->query("DROP PROCEDURE IF EXISTS p") ||
-    !$mysqli->query('CREATE PROCEDURE p() READS SQL DATA BEGIN SELECT id FROM test; SELECT id + 1 FROM test; END;')) {
-    echo "Stored procedure creation failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$mysqli->query("DROP PROCEDURE IF EXISTS p");
+$mysqli->query('CREATE PROCEDURE p() READS SQL DATA BEGIN SELECT id FROM test; SELECT id + 1 FROM test; END;');
 
-if (!$mysqli->multi_query("CALL p()")) {
-    echo "CALL failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$mysqli->multi_query("CALL p()");
 
 do {
-    if ($res = $mysqli->store_result()) {
+    if ($result = $mysqli->store_result()) {
         printf("---\n");
-        var_dump($res->fetch_all());
-        $res->free();
-    } else {
-        if ($mysqli->errno) {
-            echo "Store failed: (" . $mysqli->errno . ") " . $mysqli->error;
-        }
+        var_dump($result->fetch_all());
+        $result->free();
     }
-} while ($mysqli->more_results() && $mysqli->next_result());
-?>
+} while ($mysqli->next_result());
 ]]>
     </programlisting>
     &example.outputs;
@@ -1269,42 +1240,28 @@ array(3) {
     <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("example.com", "user", "password", "database");
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
-}
 
-if (!$mysqli->query("DROP TABLE IF EXISTS test") ||
-    !$mysqli->query("CREATE TABLE test(id INT)") ||
-    !$mysqli->query("INSERT INTO test(id) VALUES (1), (2), (3)")) {
-    echo "Table creation failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$mysqli->query("DROP TABLE IF EXISTS test");
+$mysqli->query("CREATE TABLE test(id INT)");
+$mysqli->query("INSERT INTO test(id) VALUES (1), (2), (3)");
 
-if (!$mysqli->query("DROP PROCEDURE IF EXISTS p") ||
-    !$mysqli->query('CREATE PROCEDURE p() READS SQL DATA BEGIN SELECT id FROM test; SELECT id + 1 FROM test; END;')) {
-    echo "Stored procedure creation failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$mysqli->query("DROP PROCEDURE IF EXISTS p");
+$mysqli->query('CREATE PROCEDURE p() READS SQL DATA BEGIN SELECT id FROM test; SELECT id + 1 FROM test; END;');
 
-if (!($stmt = $mysqli->prepare("CALL p()"))) {
-    echo "Prepare failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
+$stmt = $mysqli->prepare("CALL p()");
 
-if (!$stmt->execute()) {
-    echo "Execute failed: (" . $stmt->errno . ") " . $stmt->error;
-}
+$stmt->execute();
 
 do {
-    if ($res = $stmt->get_result()) {
+    if ($result = $stmt->get_result()) {
         printf("---\n");
-        var_dump(mysqli_fetch_all($res));
-        mysqli_free_result($res);
-    } else {
-        if ($stmt->errno) {
-            echo "Store failed: (" . $stmt->errno . ") " . $stmt->error;
-        }
+        var_dump($result->fetch_all());
+        $result->free();
     }
-} while ($stmt->more_results() && $stmt->next_result());
-?>
+} while ($stmt->next_result());
 ]]>
     </programlisting>
    </example>
@@ -1318,26 +1275,29 @@ do {
     <programlisting role="php">
 <![CDATA[
 <?php
-if (!($stmt = $mysqli->prepare("CALL p()"))) {
-    echo "Prepare failed: (" . $mysqli->errno . ") " . $mysqli->error;
-}
 
-if (!$stmt->execute()) {
-    echo "Execute failed: (" . $stmt->errno . ") " . $stmt->error;
-}
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = new mysqli("example.com", "user", "password", "database");
+
+$mysqli->query("DROP TABLE IF EXISTS test");
+$mysqli->query("CREATE TABLE test(id INT)");
+$mysqli->query("INSERT INTO test(id) VALUES (1), (2), (3)");
+
+$mysqli->query("DROP PROCEDURE IF EXISTS p");
+$mysqli->query('CREATE PROCEDURE p() READS SQL DATA BEGIN SELECT id FROM test; SELECT id + 1 FROM test; END;');
+
+$stmt = $mysqli->prepare("CALL p()");
+
+$stmt->execute();
 
 do {
-
-    $id_out = NULL;
-    if (!$stmt->bind_result($id_out)) {
-        echo "Bind failed: (" . $stmt->errno . ") " . $stmt->error;
+    if ($stmt->store_result()) {
+        $stmt->bind_result($id_out);
+        while ($stmt->fetch()) {
+            echo "id = $id_out\n";
+        }
     }
- 
-    while ($stmt->fetch()) {
-        echo "id = $id_out\n";
-    }
-} while ($stmt->more_results() && $stmt->next_result());
-?>
+} while ($stmt->next_result());
 ]]>
     </programlisting>
    </example>

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -693,6 +693,28 @@ array(3) {
    For the example, multi-INSERT requires fewer round-trips between
    the server and client than the prepared statement shown above.
   </para>
+  <para>	
+   <example>	
+    <title>Less round trips using multi-INSERT SQL</title>	
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = new mysqli("example.com", "user", "password", "database");
+
+$mysqli->query("DROP TABLE IF EXISTS test");
+$mysqli->query("CREATE TABLE test(id INT)");
+
+$values = [1, 2, 3, 4];
+
+$stmt = $mysqli->prepare("INSERT INTO test(id) VALUES (?), (?), (?), (?)");
+$stmt->bind_param('iiii', ...$values);
+$stmt->execute();
+]]>
+    </programlisting>	
+   </example>	
+  </para>
   <para>
    <emphasis role="bold">Result set values data types</emphasis>
   </para>

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -691,7 +691,7 @@ array(3) {
   </para>
   <para>
    Also, consider the use of the MySQL multi-INSERT SQL syntax for INSERTs.
-   For the example, multi-INSERT requires less round-trips between
+   For the example, multi-INSERT requires fewer round-trips between
    the server and client than the prepared statement shown above.
   </para>
   <para>
@@ -932,7 +932,7 @@ array(2) {
    The API does not include emulation for client-side prepared statement emulation.
   </para>
   <para>
-   <emphasis role="bold">Quick prepared/non-prepared statement comparison</emphasis>
+   <emphasis role="bold">Quick comparison of prepared and non-prepared statements</emphasis>
   </para>
   <para>
    The table below compares server-side prepared and non-prepared statements.

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -573,9 +573,8 @@ label = a (string)
   </para>
   <para>
    Prepare is followed by execute. During execute the client binds
-   parameter values and sends them to the server. The server creates a
-   statement from the statement template and the bound values to
-   execute it using the previously created internal resources.
+   parameter values and sends them to the server. The server executes
+   the statement with the bound values using the previously created internal resources.
   </para>
   <para>
    <example>
@@ -597,7 +596,7 @@ $stmt = $mysqli->prepare("INSERT INTO test(id, label) VALUES (?, ?)");
 /* Prepared statement, stage 2: bind and execute */
 $id = 1;
 $label = 'PHP';
-$stmt->bind_param("is", $id, $label);
+$stmt->bind_param("is", $id, $label); // "is" means that the first parameter is bound as an integer and the second as a string
 
 $stmt->execute();
 ]]>
@@ -631,7 +630,7 @@ $mysqli->query("CREATE TABLE test(id INT, label TEXT)");
 $stmt = $mysqli->prepare("INSERT INTO test(id, label) VALUES (?, ?)");
 
 /* Prepared statement, stage 2: bind and execute */
-$stmt->bind_param("is", $id, $label);
+$stmt->bind_param("is", $id, $label); // "is" means that the first parameter is bound as an integer and the second as a string
 
 $data = [
     1 => 'PHP',

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -270,9 +270,9 @@ mysqli.default_socket=/tmp/mysql.sock
   <para>
    For setting a connection option, the connect operation has to be
    performed in three steps: creating a connection handle with
-   <function>mysqli_init</function>, setting the requested options using
-   <function>mysqli_options</function>, and establishing the network
-   connection with <function>mysqli_real_connect</function>.
+   <function>mysqli_init</function> or <methodname>mysqli::__construct</methodname>, 
+   setting the requested options using <methodname>mysqli::options</methodname>, 
+   and establishing the network connection with <methodname>mysqli::real_connect</methodname>.
   </para>
   <para>
    <emphasis role="bold">Connection pooling</emphasis>
@@ -318,12 +318,12 @@ mysqli.default_socket=/tmp/mysql.sock
    The mysqli extension supports both interpretations of a persistent connection:
    state persisted, and state reset before reuse. The default is reset.
    Before a persistent connection is reused, the mysqli extension implicitly
-   calls <function>mysqli_change_user</function> to reset the state. The
+   calls <methodname>mysqli::change_user</methodname> to reset the state. The
    persistent connection appears to the user as if it was just opened. No
    artifacts from previous usages are visible.
   </para>
   <para>
-   The <function>mysqli_change_user</function> function is an expensive operation.
+   The <methodname>mysqli::change_user</methodname> call is an expensive operation.
    For best performance, users may want to recompile the extension with the
    compile flag <constant>MYSQLI_NO_CHANGE_USER_ON_PCONNECT</constant> being set.
   </para>
@@ -353,14 +353,14 @@ mysqli.default_socket=/tmp/mysql.sock
   <title>Executing statements</title>
   <para>
    Statements can be executed with the
-   <function>mysqli_query</function>, <function>mysqli_real_query</function>
-   and <function>mysqli_multi_query</function> functions.
-   The <function>mysqli_query</function> function is the most
+   <methodname>mysqli::query</methodname>, <methodname>mysqli::real_query</methodname>
+   and <methodname>mysqli::multi_query</methodname> functions.
+   The <methodname>mysqli::query</methodname> function is the most
    common, and combines the executing statement with a
    buffered fetch of its result set, if any, in one call.
-   Calling <function>mysqli_query</function> is identical to
-   calling <function>mysqli_real_query</function>
-   followed by <function>mysqli_store_result</function>.
+   Calling <methodname>mysqli::query</methodname> is identical to
+   calling <methodname>mysqli::real_query</methodname>
+   followed by <methodname>mysqli::store_result</methodname>.
   </para>
   <para>
    <example>
@@ -392,7 +392,7 @@ if (!$mysqli->query("DROP TABLE IF EXISTS test") ||
    allows the server to free resources associated with the statement
    results as early as possible. Generally speaking, clients are slow
    consuming result sets. Therefore, it is recommended to use buffered
-   result sets. <function>mysqli_query</function> combines statement
+   result sets. <methodname>mysqli::query</methodname> combines statement
    execution and result set buffering.
   </para>
   <para>
@@ -481,9 +481,9 @@ while ($row = $res->fetch_assoc()) {
    <emphasis role="bold">Result set values data types</emphasis>
   </para>
   <para>
-   The <function>mysqli_query</function>, <function>mysqli_real_query</function>
-   and <function>mysqli_multi_query</function> functions are used to execute
-   non-prepared statements.  At the level of the MySQL Client Server Protocol,
+   The <methodname>mysqli::query</methodname>, <methodname>mysqli::real_query</methodname>
+   and <methodname>mysqli::multi_query</methodname> functions are used to execute
+   non-prepared statements. At the level of the MySQL Client Server Protocol,
    the command <literal>COM_QUERY</literal> and the text protocol are used
    for statement execution. With the text protocol, the MySQL server converts
    all data of a result sets into strings before sending. This conversion is done
@@ -899,14 +899,14 @@ id = 1 (integer), label = a (string)
   </para>
   <para>
    It is also possible to buffer the results of a prepared statement
-   using <function>mysqli_stmt_store_result</function>.
+   using <methodname>mysqli_stmt::store_result</methodname>.
   </para>
   <para>
    <emphasis role="bold">Fetching results using mysqli_result interface</emphasis>
   </para>
   <para>
    Instead of using bound results, results can also be retrieved through the
-   mysqli_result interface. <function>mysqli_stmt_get_result</function>
+   mysqli_result interface. <methodname>mysqli_stmt::get_result</methodname>
    returns a buffered result set.
   </para>
   <para>
@@ -1034,7 +1034,7 @@ array(2) {
    need to be escaped as they are never substituted into the query string
    directly. A hint must be provided to the server for the type of bound
    variable, to create an appropriate conversion. 
-   See the <function>mysqli_stmt_bind_param</function> function for more
+   See the <methodname>mysqli_stmt::bind_param</methodname> function for more
    information.
   </para>
   <para>
@@ -1100,23 +1100,23 @@ array(2) {
      </row>
      <row>
       <entry>Supports use of mysqli_result API</entry>
-      <entry>Yes, use <function>mysqli_stmt_get_result</function></entry>
+      <entry>Yes, use <methodname>mysqli_stmt::get_result</methodname></entry>
       <entry>Yes</entry>
      </row>
      <row>
       <entry>Buffered result sets</entry>
       <entry>
-       Yes, use <function>mysqli_stmt_get_result</function> or
-       binding with <function>mysqli_stmt_store_result</function>
+       Yes, use <methodname>mysqli_stmt::get_result</methodname> or
+       binding with <methodname>mysqli_stmt::store_result</methodname>
       </entry>
-      <entry>Yes, default of <function>mysqli_query</function></entry>
+      <entry>Yes, default of <methodname>mysqli::query</methodname></entry>
      </row>
      <row>
       <entry>Unbuffered result sets</entry>
       <entry>Yes, use output binding API</entry>
       <entry>
-       Yes, use <function>mysqli_real_query</function> with
-       <function>mysqli_use_result</function>
+       Yes, use <methodname>mysqli::real_query</methodname> with
+       <methodname>mysqli::use_result</methodname>
       </entry>
      </row>
      <row>
@@ -1276,16 +1276,16 @@ Hi!
   </para>
   <para>
    Stored procedures can return result sets. Result sets returned from a
-   stored procedure cannot be fetched correctly using <function>mysqli_query</function>.
-   The <function>mysqli_query</function> function combines statement execution
+   stored procedure cannot be fetched correctly using <methodname>mysqli::query</methodname>.
+   The <methodname>mysqli::query</methodname> function combines statement execution
    and fetching the first result set into a buffered result set, if any.
    However, there are additional stored procedure result sets hidden
-   from the user which cause <function>mysqli_query</function> to fail
+   from the user which cause <methodname>mysqli::query</methodname> to fail
    returning the user expected result sets.
   </para>
   <para>
    Result sets returned from a stored procedure are fetched using
-   <function>mysqli_real_query</function> or <function>mysqli_multi_query</function>.
+   <methodname>mysqli::real_query</methodname> or <methodname>mysqli::multi_query</methodname>.
    Both functions allow fetching any number of result sets returned by a
    statement, such as <literal>CALL</literal>. Failing to fetch all
    result sets returned by a stored procedure causes an error.
@@ -1484,7 +1484,7 @@ do {
   </para>
   <para>
    Multiple statements or multi queries must be executed
-   with <function>mysqli_multi_query</function>. The individual statements
+   with <methodname>mysqli::multi_query</methodname>. The individual statements
    of the statement string are separated by semicolon.
    Then, all result sets returned by the executed statements must be fetched.
   </para>
@@ -1549,8 +1549,8 @@ array(1) {
    <emphasis role="bold">Security considerations</emphasis>
   </para>
   <para>
-   The API functions <function>mysqli_query</function> and
-   <function>mysqli_real_query</function> do not set a connection flag necessary
+   The API functions <methodname>mysqli::query</methodname> and
+   <methodname>mysqli::real_query</methodname> do not set a connection flag necessary
    for activating multi queries in the server. An extra API call is used for
    multiple statements to reduce the likeliness of accidental SQL injection
    attacks. An attacker may try to add statements such as
@@ -1777,7 +1777,7 @@ array(2) {
   <para>
    Meta data of result sets created using prepared statements are accessed
    the same way. A suitable <classname>mysqli_result</classname> handle is
-   returned by <function>mysqli_stmt_result_metadata</function>.
+   returned by <methodname>mysqli_stmt::result_metadata</methodname>.
   </para>
   <para>
    <example>

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -158,9 +158,9 @@ Possible but bad style.
   </para>
   <para>
    The hostname <literal>localhost</literal> has a special meaning.
-   It is bound to the use of Unix domain sockets. It is not possible
-   to open a TCP/IP connection using the hostname <literal>localhost</literal>
-   you must use <literal>127.0.0.1</literal> instead.
+   It is bound to the use of Unix domain sockets. If you would like 
+   to open a TCP/IP connection to the localhost, you must use 
+   <literal>127.0.0.1</literal> instead of the hostname <literal>localhost</literal>.
   </para>
   <para>
    <example>
@@ -283,14 +283,14 @@ mysqli.default_socket=/tmp/mysql.sock
    <emphasis role="bold">Persistent connection</emphasis>
   </para>
   <para>
-   If a unused persistent connection for a given combination of host, username,
-   password, socket, port and default database can not be found in the connection pool,
+   If an unused persistent connection for a given combination of host, username,
+   password, socket, port and default database cannot be found in the connection pool,
    then mysqli opens a new connection. The use of persistent connections can be
    enabled and disabled using the PHP directive <link linkend="ini.mysqli.allow-persistent">mysqli.allow_persistent</link>.
    The total number of connections opened by a script can be limited with
    <link linkend="ini.mysqli.max-links">mysqli.max_links</link>. The maximum number of persistent connections
    per PHP process can be restricted with <link linkend="ini.mysqli.max-persistent">mysqli.max_persistent</link>.
-   Please note, that the web server may spawn many PHP processes.
+   Please note that the web server may spawn many PHP processes.
   </para>
   <para>
    A common complain about persistent connections is that their state is

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -36,13 +36,13 @@
 <![CDATA[
 <?php
 $mysqli = mysqli_connect("example.com", "user", "password", "database");
-$result = mysqli_query($mysqli, "SELECT 'Please, do not use ' AS _msg FROM DUAL");
+$result = mysqli_query($mysqli, "SELECT 'Please do not use the deprecated mysql extension for new development. ' AS _msg FROM DUAL");
 $row = mysqli_fetch_assoc($result);
 echo $row['_msg'];
 
 $mysql = mysql_connect("example.com", "user", "password");
 mysql_select_db("test");
-$result = mysql_query("SELECT 'the mysql extension for new developments.' AS _msg FROM DUAL", $mysql);
+$result = mysql_query("SELECT 'Use the mysqli extension instead.' AS _msg FROM DUAL", $mysql);
 $row = mysql_fetch_assoc($result);
 echo $row['_msg'];
 ]]>
@@ -50,7 +50,7 @@ echo $row['_msg'];
     &example.outputs;
     <screen>
 <![CDATA[
-Please, do not use the mysql extension for new developments.
+Please do not use the deprecated mysql extension for new development. Use the mysqli extension instead.
 ]]>
     </screen>
    </example>

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -1478,9 +1478,8 @@ do {
  <section xml:id="mysqli.quickstart.multiple-statement">
   <title>Multiple Statements</title>
   <para>
-   MySQL optionally allows having multiple statements in one statement string.
-   Sending multiple statements at once reduces client-server
-   round trips but requires special handling.
+   MySQL optionally allows having multiple statements in one statement string, 
+   but it requires special handling.
   </para>
   <para>
    Multiple statements or multi queries must be executed
@@ -1552,12 +1551,12 @@ array(1) {
    The API functions <methodname>mysqli::query</methodname> and
    <methodname>mysqli::real_query</methodname> do not set a connection flag necessary
    for activating multi queries in the server. An extra API call is used for
-   multiple statements to reduce the likeliness of accidental SQL injection
+   multiple statements to reduce the damage of accidental SQL injection
    attacks. An attacker may try to add statements such as
    <literal>; DROP DATABASE mysql</literal> or <literal>; SELECT SLEEP(999)</literal>.
    If the attacker succeeds in adding SQL to the statement string but
-   <literal>mysqli_multi_query</literal> is not used, the server will not
-   execute the second, injected and malicious SQL statement.
+   <literal>mysqli::multi_query</literal> is not used, the server will not
+   execute the injected and malicious SQL statement.
   </para>
   <para>
    <example>

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -36,14 +36,14 @@
 <![CDATA[
 <?php
 $mysqli = mysqli_connect("example.com", "user", "password", "database");
-$res = mysqli_query($mysqli, "SELECT 'Please, do not use ' AS _msg FROM DUAL");
-$row = mysqli_fetch_assoc($res);
+$result = mysqli_query($mysqli, "SELECT 'Please, do not use ' AS _msg FROM DUAL");
+$row = mysqli_fetch_assoc($result);
 echo $row['_msg'];
 
 $mysql = mysql_connect("example.com", "user", "password");
 mysql_select_db("test");
-$res = mysql_query("SELECT 'the mysql extension for new developments.' AS _msg FROM DUAL", $mysql);
-$row = mysql_fetch_assoc($res);
+$result = mysql_query("SELECT 'the mysql extension for new developments.' AS _msg FROM DUAL", $mysql);
+$row = mysql_fetch_assoc($result);
 echo $row['_msg'];
 ]]>
     </programlisting>
@@ -78,14 +78,14 @@ Please, do not use the mysql extension for new developments.
 
 $mysqli = mysqli_connect("example.com", "user", "password", "database");
 
-$res = mysqli_query($mysqli, "SELECT 'A world full of ' AS _msg FROM DUAL");
-$row = mysqli_fetch_assoc($res);
+$result = mysqli_query($mysqli, "SELECT 'A world full of ' AS _msg FROM DUAL");
+$row = mysqli_fetch_assoc($result);
 echo $row['_msg'];
 
 $mysqli = new mysqli("example.com", "user", "password", "database");
 
-$res = $mysqli->query("SELECT 'choices to please everybody.' AS _msg FROM DUAL");
-$row = $res->fetch_assoc();
+$result = $mysqli->query("SELECT 'choices to please everybody.' AS _msg FROM DUAL");
+$row = $result->fetch_assoc();
 echo $row['_msg'];
 ]]>
     </programlisting>
@@ -117,9 +117,9 @@ A world full of choices to please everybody.
 
 $mysqli = new mysqli("example.com", "user", "password", "database");
 
-$res = mysqli_query($mysqli, "SELECT 'Possible but bad style.' AS _msg FROM DUAL");
+$result = mysqli_query($mysqli, "SELECT 'Possible but bad style.' AS _msg FROM DUAL");
 
-if ($row = $res->fetch_assoc()) {
+if ($row = $result->fetch_assoc()) {
     echo $row['_msg'];
 }
 ]]>
@@ -1114,9 +1114,9 @@ $mysqli->query('CREATE PROCEDURE p(OUT msg VARCHAR(50)) BEGIN SELECT "Hi!" INTO 
 $mysqli->query("SET @msg = ''");
 $mysqli->query("CALL p(@msg)");
 
-$res = $mysqli->query("SELECT @msg as _p_out");
+$result = $mysqli->query("SELECT @msg as _p_out");
 
-$row = $res->fetch_assoc();
+$row = $result->fetch_assoc();
 echo $row['_p_out'];
 ]]>
     </programlisting>
@@ -1351,9 +1351,9 @@ $sql = "SELECT COUNT(*) AS _num FROM test;
 $mysqli->multi_query($sql);
 
 do {
-    if ($res = $mysqli->store_result()) {
-        var_dump($res->fetch_all(MYSQLI_ASSOC));
-        $res->free();
+    if ($result = $mysqli->store_result()) {
+        var_dump($result->fetch_all(MYSQLI_ASSOC));
+        $result->free();
     }
 } while ($mysqli->next_result());
 ]]>
@@ -1400,8 +1400,8 @@ array(1) {
 <![CDATA[
 <?php
 $mysqli = new mysqli("example.com", "user", "password", "database");
-$res    = $mysqli->query("SELECT 1; DROP TABLE mysql.user");
-if (!$res) {
+$result    = $mysqli->query("SELECT 1; DROP TABLE mysql.user");
+if (!$result) {
     echo "Error executing query: (" . $mysqli->errno . ") " . $mysqli->error;
 }
 ?>
@@ -1532,8 +1532,8 @@ $mysqli->commit();
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("example.com", "user", "password", "database");
 
-$res = $mysqli->query("SELECT 1 AS _one, 'Hello' AS _two FROM DUAL");
-var_dump($res->fetch_fields());
+$result = $mysqli->query("SELECT 1 AS _one, 'Hello' AS _two FROM DUAL");
+var_dump($result->fetch_fields());
 ]]>
     </programlisting>
     &example.outputs;
@@ -1623,8 +1623,8 @@ $mysqli = new mysqli("example.com", "user", "password", "database");
 
 $stmt = $mysqli->prepare("SELECT 1 AS _one, 'Hello' AS _two FROM DUAL");
 $stmt->execute();
-$res = $stmt->result_metadata();
-var_dump($res->fetch_fields());
+$result = $stmt->result_metadata();
+var_dump($result->fetch_fields());
 ]]>
     </programlisting>
    </example>


### PR DESCRIPTION
This PR aims to fix Quick Start guide in mysqli by removing manual error checking where possible, using OO style for function names and in the code (to encourage developers to use it more in new code), and fixing See also links. 

Other changes:
- Fixed grammar and typos in some places
- Changed the wording on Multiple Statements page. Previous text sounded as if SQL injection is only possible with multiple statements. 
- See also links were removed/added in some place. Although there seems to be no consistency or logic in them.
- Closing tags were removed from examples. They were not there in the beginning and adding them is a bad coding practice.
- It is possible to open TCP/IP connection using `localhost:3306`. That sentence has been changed to reflect what can be done rather than what can't be done.
- Some examples were removed as they were unnecessary and only bloated the page.
- Variable `$res` was renamed to `$result`
- Examples of executing queries were simplified. 
- Call to `$stmt->more_results()` in SP examples was removed. It was confusing and not needed in this context.
- `$stmt->store_result()` was added to the last example in SP to avoid the "Out of sync" error.
- As part of the move from procedural to OO style `mysqli_init()` was replaced with `new mysqli()`. A PR was created to deprecate `mysqli::init()`

Hopefully, this will make the page more useful to people who are only starting with mysqli. Having simple examples showing the best practices is very important. 