### PR TITLE
Fix return type documentation of gmp_hamdist

### DIFF
--- a/reference/gmp/functions/gmp-hamdist.xml
+++ b/reference/gmp/functions/gmp-hamdist.xml
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &gmp.return;
+   The hamming distance between <parameter>a</parameter> and <parameter>b</parameter>, as an <type>int</type>.
   </para>
  </refsect1>
 


### PR DESCRIPTION
It's an integer since the function was added in php 5.5+.
See https://3v4l.org/DgIdi