### PR TITLE
Updating mysqli: fetch functions

### DIFF
--- a/reference/mysqli/mysqli_result/fetch-array.xml
+++ b/reference/mysqli/mysqli_result/fetch-array.xml
@@ -73,7 +73,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an array of strings that corresponds to the fetched row or &null; if there
+   Returns an array of values that corresponds to the fetched row or &null; if there
    are no more rows in resultset.
   </para>
  </refsect1>

--- a/reference/mysqli/mysqli_result/fetch-array.xml
+++ b/reference/mysqli/mysqli_result/fetch-array.xml
@@ -22,15 +22,12 @@
   </methodsynopsis>
   <para>
    Returns an array that corresponds to the fetched row or &null; if there
-   are no more rows for the resultset represented by the
-   <parameter>result</parameter> parameter.
+   are no more rows for the result set.
   </para>
   <para>
-   <function>mysqli_fetch_array</function> is an extended version of the
-   <function>mysqli_fetch_row</function> function. In addition to storing the
-   data in the numeric indices of the result array, the 
-   <function>mysqli_fetch_array</function> function can also store the data
-   in associative indices, using the field names of the result set as keys.
+   In addition to storing the data in the numeric indices of the result array, 
+   this function can also store the data in associative indices 
+   by using the field names of the result set as keys.
   </para>
   &database.field-case;
   &database.fetch-null;
@@ -74,86 +71,63 @@
   &reftitle.returnvalues;
   <para>
    Returns an array of values that corresponds to the fetched row or &null; if there
-   are no more rows in resultset.
+   are no more rows in result set.
   </para>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>&style.oop;</title>
+   <title><methodname>mysqli_result::fetch_array</methodname> example</title>
+   <para>&style.oop;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("localhost", "my_user", "my_password", "world");
 
-/* check connection */
-if ($mysqli->connect_errno) {
-    printf("Connect failed: %s\n", $mysqli->connect_error);
-    exit();
-}
-
-$query = "SELECT Name, CountryCode FROM City ORDER by ID LIMIT 3";
+$query = "SELECT Name, CountryCode FROM City ORDER BY ID LIMIT 3";
 $result = $mysqli->query($query);
 
 /* numeric array */
 $row = $result->fetch_array(MYSQLI_NUM);
-printf ("%s (%s)\n", $row[0], $row[1]);
+printf("%s (%s)\n", $row[0], $row[1]);
 
 /* associative array */
 $row = $result->fetch_array(MYSQLI_ASSOC);
-printf ("%s (%s)\n", $row["Name"], $row["CountryCode"]);
+printf("%s (%s)\n", $row["Name"], $row["CountryCode"]);
 
 /* associative and numeric array */
 $row = $result->fetch_array(MYSQLI_BOTH);
-printf ("%s (%s)\n", $row[0], $row["CountryCode"]);
-
-/* free result set */
-$result->free();
-
-/* close connection */
-$mysqli->close();
-?>
+printf("%s (%s)\n", $row[0], $row["CountryCode"]);
 ]]>
    </programlisting>
-  </example>
-  <example>
-   <title>&style.procedural;</title>
+   <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
-$link = mysqli_connect("localhost", "my_user", "my_password", "world");
 
-/* check connection */
-if (mysqli_connect_errno()) {
-    printf("Connect failed: %s\n", mysqli_connect_error());
-    exit();
-}
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = mysqli_connect("localhost", "my_user", "my_password", "world");
 
 $query = "SELECT Name, CountryCode FROM City ORDER by ID LIMIT 3";
-$result = mysqli_query($link, $query);
+$result = mysqli_query($mysqli, $query);
 
 /* numeric array */
 $row = mysqli_fetch_array($result, MYSQLI_NUM);
-printf ("%s (%s)\n", $row[0], $row[1]);
+printf("%s (%s)\n", $row[0], $row[1]);
 
 /* associative array */
 $row = mysqli_fetch_array($result, MYSQLI_ASSOC);
-printf ("%s (%s)\n", $row["Name"], $row["CountryCode"]);
+printf("%s (%s)\n", $row["Name"], $row["CountryCode"]);
 
 /* associative and numeric array */
 $row = mysqli_fetch_array($result, MYSQLI_BOTH);
-printf ("%s (%s)\n", $row[0], $row["CountryCode"]);
-
-/* free result set */
-mysqli_free_result($result);
-
-/* close connection */
-mysqli_close($link);
-?>
+printf("%s (%s)\n", $row[0], $row["CountryCode"]);
 ]]>
    </programlisting>
-   &examples.outputs;
+   &examples.outputs.similar;
    <screen>
 <![CDATA[
 Kabul (AFG)

--- a/reference/mysqli/mysqli_result/fetch-assoc.xml
+++ b/reference/mysqli/mysqli_result/fetch-assoc.xml
@@ -104,7 +104,10 @@ Santa Clara (USA)
   </example>
   <example xml:id="mysqli-result.example.iterator">
    <title>Comparison of <classname>mysqli_result</classname> <classname>iterator</classname> and <methodname>mysqli_result::fetch_assoc</methodname> usage</title>
-   <para><classname>mysqli_result</classname> can be iterated using &foreach;. The result set will always be iterated from the beginning until the end.</para>
+   <para>
+    <classname>mysqli_result</classname> can be iterated using &foreach;. 
+    The result set will always be iterated from the first row, regardless of the current position.
+   </para>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/mysqli/mysqli_result/fetch-assoc.xml
+++ b/reference/mysqli/mysqli_result/fetch-assoc.xml
@@ -41,7 +41,7 @@
   <para>
    Returns an associative array of strings representing the fetched row in the result
    set, where each key in the array represents the name of one of the result
-   set's columns or &null; if there are no more rows in resultset.
+   set's columns or &null; if there are no more rows in result set.
   </para>
   <para>
    If two or more columns of the result have the same field names, the last
@@ -54,69 +54,44 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>&style.oop;</title>
+   <title><methodname>mysqli_result::fetch_assoc</methodname> example</title>
+   <para>&style.oop;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("localhost", "my_user", "my_password", "world");
 
-/* check connection */
-if ($mysqli->connect_errno) {
-    printf("Connect failed: %s\n", $mysqli->connect_error);
-    exit();
+$query = "SELECT Name, CountryCode FROM City ORDER BY ID DESC";
+
+$result = $mysqli->query($query);
+
+/* fetch associative array */
+while ($row = $result->fetch_assoc()) {
+    printf("%s (%s)\n", $row["Name"], $row["CountryCode"]);
 }
-
-$query = "SELECT Name, CountryCode FROM City ORDER by ID DESC LIMIT 50,5";
-
-if ($result = $mysqli->query($query)) {
-
-    /* fetch associative array */
-    while ($row = $result->fetch_assoc()) {
-        printf ("%s (%s)\n", $row["Name"], $row["CountryCode"]);
-    }
-
-    /* free result set */
-    $result->free();
-}
-
-/* close connection */
-$mysqli->close();
-?>
 ]]>
    </programlisting>
-  </example>
-  <example>
-   <title>&style.procedural;</title>
+   <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
-$link = mysqli_connect("localhost", "my_user", "my_password", "world");
 
-/* check connection */
-if (mysqli_connect_errno()) {
-    printf("Connect failed: %s\n", mysqli_connect_error());
-    exit();
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = mysqli_connect("localhost", "my_user", "my_password", "world");
+
+$query = "SELECT Name, CountryCode FROM City ORDER BY ID DESC";
+
+$result = mysqli_query($mysqli, $query);
+
+/* fetch associative array */
+while ($row = mysqli_fetch_assoc($result)) {
+    printf("%s (%s)\n", $row["Name"], $row["CountryCode"]);
 }
-
-$query = "SELECT Name, CountryCode FROM City ORDER by ID DESC LIMIT 50,5";
-
-if ($result = mysqli_query($link, $query)) {
-
-    /* fetch associative array */
-    while ($row = mysqli_fetch_assoc($result)) {
-        printf ("%s (%s)\n", $row["Name"], $row["CountryCode"]);
-    }
-
-    /* free result set */
-    mysqli_free_result($result);
-}
-
-/* close connection */
-mysqli_close($link);
-?>
 ]]>
    </programlisting>
-   &examples.outputs;
+   &examples.outputs.similar;
    <screen>
 <![CDATA[
 Pueblo (USA)
@@ -128,42 +103,48 @@ Santa Clara (USA)
    </screen>
   </example>
   <example xml:id="mysqli-result.example.iterator">
-   <title>A <classname>mysqli_result</classname> example comparing <classname>iterator</classname> usage</title>
+   <title>Comparison of <classname>mysqli_result</classname> <classname>iterator</classname> and <methodname>mysqli_result::fetch_assoc</methodname> usage</title>
+   <para><classname>mysqli_result</classname> can be iterated using &foreach;. The result set will always be iterated from the beginning until the end.</para>
    <programlisting role="php">
 <![CDATA[
 <?php
-$c = mysqli_connect('127.0.0.1','user', 'pass');
 
-// Using iterators (support was added with PHP 5.4)
-foreach ( $c->query('SELECT user,host FROM mysql.user') as $row ) {
-    printf("'%s'@'%s'\n", $row['user'], $row['host']);
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = new mysqli("localhost", "my_user", "my_password", "world");
+
+$query = 'SELECT Name, CountryCode FROM City ORDER BY ID DESC';
+
+// Using iterators
+$result = $mysqli->query($query);
+foreach ($result as $row) {
+    printf("%s (%s)\n", $row["Name"], $row["CountryCode"]);
 }
 
 echo "\n==================\n";
 
 // Not using iterators
-$result = $c->query('SELECT user,host FROM mysql.user');
+$result = $mysqli->query($query);
 while ($row = $result->fetch_assoc()) {
-    printf("'%s'@'%s'\n", $row['user'], $row['host']);
+    printf("%s (%s)\n", $row["Name"], $row["CountryCode"]);
 }
-
-?>
 ]]>
    </programlisting>
    &example.outputs.similar;
    <screen>
 <![CDATA[
-'root'@'192.168.1.1'
-'root'@'127.0.0.1'
-'dude'@'localhost'
-'lebowski'@'localhost'
+Pueblo (USA)
+Arvada (USA)
+Cape Coral (USA)
+Green Bay (USA)
+Santa Clara (USA)
 
 ==================
+Pueblo (USA)
+Arvada (USA)
+Cape Coral (USA)
+Green Bay (USA)
+Santa Clara (USA)
 
-'root'@'192.168.1.1'
-'root'@'127.0.0.1'
-'dude'@'localhost'
-'lebowski'@'localhost'
 ]]>
    </screen>
   </example>

--- a/reference/mysqli/mysqli_result/fetch-assoc.xml
+++ b/reference/mysqli/mysqli_result/fetch-assoc.xml
@@ -39,7 +39,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an associative array of strings representing the fetched row in the result
+   Returns an associative array of values representing the fetched row in the result
    set, where each key in the array represents the name of one of the result
    set's columns or &null; if there are no more rows in result set.
   </para>

--- a/reference/mysqli/mysqli_result/fetch-object.xml
+++ b/reference/mysqli/mysqli_result/fetch-object.xml
@@ -63,8 +63,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an object with string properties that corresponds to the fetched
-   row or &null; if there are no more rows in resultset.
+   Returns an object that corresponds to the fetched
+   row or &null; if there are no more rows in result set.
   </para>
   &database.field-case;
   &database.fetch-null;

--- a/reference/mysqli/mysqli_result/fetch-object.xml
+++ b/reference/mysqli/mysqli_result/fetch-object.xml
@@ -23,14 +23,18 @@
    <methodparam choice="opt"><type>array</type><parameter>params</parameter></methodparam>
   </methodsynopsis>
   <para>
-   The <function>mysqli_fetch_object</function> will return the current row
+   Returns the current row
    result set as an object where the attributes of the object represent the
    names of the fields found within the result set.
   </para>
-  <para>
-    Note that <function>mysqli_fetch_object</function> sets the properties
-    of the object before calling the object constructor.
-  </para>
+  <note xmlns="http://docbook.org/ns/docbook">
+   <simpara>
+     This function sets the properties
+     of the object before calling the object constructor.
+   </simpara>
+  </note>
+  &database.field-case;
+  &database.fetch-null;
  </refsect1>
 
  <refsect1 role="parameters">
@@ -66,76 +70,49 @@
    Returns an object that corresponds to the fetched
    row or &null; if there are no more rows in result set.
   </para>
-  &database.field-case;
-  &database.fetch-null;
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>&style.oop;</title>
+   <title><methodname>mysqli_result::fetch_object</methodname> example</title>
+   <para>&style.oop;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("localhost", "my_user", "my_password", "world");
-
-/* check connection */
-if (mysqli_connect_errno()) {
-    printf("Connect failed: %s\n", mysqli_connect_error());
-    exit();
-}
  
-$query = "SELECT Name, CountryCode FROM City ORDER by ID DESC LIMIT 50,5";
+$query = "SELECT Name, CountryCode FROM City ORDER BY ID DESC";
 
-if ($result = $mysqli->query($query)) {
+$result = $mysqli->query($query);
 
-    /* fetch object array */
-    while ($obj = $result->fetch_object()) {
-        printf ("%s (%s)\n", $obj->Name, $obj->CountryCode);
-    }
-
-    /* free result set */
-    $result->close();
+/* fetch object array */
+while ($obj = $result->fetch_object()) {
+    printf("%s (%s)\n", $obj->Name, $obj->CountryCode);
 }
-
-/* close connection */
-$mysqli->close();
-?>
 ]]>
    </programlisting>
-  </example>
-  <example>
-   <title>&style.procedural;</title>
+   <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $link = mysqli_connect("localhost", "my_user", "my_password", "world");
 
-/* check connection */
-if (mysqli_connect_errno()) {
-    printf("Connect failed: %s\n", mysqli_connect_error());
-    exit();
+$query = "SELECT Name, CountryCode FROM City ORDER BY ID DESC";
+
+$result = mysqli_query($link, $query);
+
+/* fetch associative array */
+while ($obj = mysqli_fetch_object($result)) {
+    printf("%s (%s)\n", $obj->Name, $obj->CountryCode);
 }
-
-$query = "SELECT Name, CountryCode FROM City ORDER by ID DESC LIMIT 50,5";
-
-if ($result = mysqli_query($link, $query)) {
-
-    /* fetch associative array */
-    while ($obj = mysqli_fetch_object($result)) {
-        printf ("%s (%s)\n", $obj->Name, $obj->CountryCode);
-    }
-
-    /* free result set */
-    mysqli_free_result($result);
-}
-
-/* close connection */
-mysqli_close($link);
-?>
 ]]>
    </programlisting>
-   &examples.outputs;
+   &examples.outputs.similar;
    <screen>
 <![CDATA[
 Pueblo (USA)

--- a/reference/mysqli/mysqli_result/fetch-row.xml
+++ b/reference/mysqli/mysqli_result/fetch-row.xml
@@ -25,6 +25,7 @@
    Each subsequent call to this function will return the next row within the
    result set, or &null; if there are no more rows.
   </para>
+  &database.fetch-null;
  </refsect1>
 
  <refsect1 role="parameters">
@@ -42,7 +43,6 @@
    <function>mysqli_fetch_row</function> returns an array of values that corresponds to the fetched row
    or &null; if there are no more rows in result set.
   </para>
-  &database.fetch-null;
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mysqli/mysqli_result/fetch-row.xml
+++ b/reference/mysqli/mysqli_result/fetch-row.xml
@@ -48,69 +48,44 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>&style.oop;</title>
+   <title><methodname>mysqli_result::fetch_row</methodname> example</title>
+   <para>&style.oop;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("localhost", "my_user", "my_password", "world");
 
-/* check connection */
-if (mysqli_connect_errno()) {
-    printf("Connect failed: %s\n", mysqli_connect_error());
-    exit();
+$query = "SELECT Name, CountryCode FROM City ORDER BY ID DESC";
+
+$result = $mysqli->query($query);
+
+/* fetch object array */
+while ($row = $result->fetch_row()) {
+    printf("%s (%s)\n", $row[0], $row[1]);
 }
-
-$query = "SELECT Name, CountryCode FROM City ORDER by ID DESC LIMIT 50,5";
-
-if ($result = $mysqli->query($query)) {
-
-    /* fetch object array */
-    while ($row = $result->fetch_row()) {
-        printf ("%s (%s)\n", $row[0], $row[1]);
-    }
-
-    /* free result set */
-    $result->close();
-}
-
-/* close connection */
-$mysqli->close();
-?>
 ]]>
    </programlisting>
-  </example>
-  <example>
-   <title>&style.procedural;</title>
+   <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
-$link = mysqli_connect("localhost", "my_user", "my_password", "world");
 
-/* check connection */
-if (mysqli_connect_errno()) {
-    printf("Connect failed: %s\n", mysqli_connect_error());
-    exit();
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = mysqli_connect("localhost", "my_user", "my_password", "world");
+
+$query = "SELECT Name, CountryCode FROM City ORDER BY ID DESC";
+
+$result = mysqli_query($mysqli, $query);
+
+/* fetch associative array */
+while ($row = mysqli_fetch_row($result)) {
+    printf("%s (%s)\n", $row[0], $row[1]);
 }
-
-$query = "SELECT Name, CountryCode FROM City ORDER by ID DESC LIMIT 50,5";
-
-if ($result = mysqli_query($link, $query)) {
-
-    /* fetch associative array */
-    while ($row = mysqli_fetch_row($result)) {
-        printf ("%s (%s)\n", $row[0], $row[1]);
-    }
-
-    /* free result set */
-    mysqli_free_result($result);
-}
-
-/* close connection */
-mysqli_close($link);
-?>
 ]]>
    </programlisting>
-   &examples.outputs;
+   &examples.outputs.similar;
    <screen>
 <![CDATA[
 Pueblo (USA)

--- a/reference/mysqli/mysqli_result/fetch-row.xml
+++ b/reference/mysqli/mysqli_result/fetch-row.xml
@@ -39,7 +39,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <function>mysqli_fetch_row</function> returns an array of strings that corresponds to the fetched row
+   <function>mysqli_fetch_row</function> returns an array of values that corresponds to the fetched row
    or &null; if there are no more rows in result set.
   </para>
   &database.fetch-null;


### PR DESCRIPTION
Pushed by this comment https://stackoverflow.com/questions/64933761/how-to-return-integer-of-count-mysql-query-result-in-php/64933840?noredirect=1#comment114809131_64933840 I updated the mysqli docs to show the best practices usage

Fixes:
- Aligned examples. OO and procedural examples where using different variable names. An example of iterator was using different style and data
- Improved descriptions. Some words were confusing and even wrong. 
- Aligned notes. All notes are in the same place and follow similar grammar
- Removed manual error checking from examples
- Removed unnecessary LIMIT 50,5
- Added .similar to the example results