### PR TITLE
PDOStatement::fetchObject() returns object|false

### DIFF
--- a/reference/pdo/pdostatement/fetchobject.xml
+++ b/reference/pdo/pdostatement/fetchobject.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>mixed</type><methodname>PDOStatement::fetchObject</methodname>
+   <modifier>public</modifier> <type class="union"><type>object</type><type>false</type></type><methodname>PDOStatement::fetchObject</methodname>
    <methodparam choice="opt"><type>string</type><parameter>class_name</parameter><initializer>"stdClass"</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>ctor_args</parameter></methodparam>
   </methodsynopsis>


### PR DESCRIPTION
https://www.php.net/manual/en/pdostatement.fetchobject.php

> Returns an instance of the required class with property names that correspond to the column names or FALSE on failure.