### PR TITLE
IntlCalendar::set() - Move month sequence description to month parameter

### DIFF
--- a/reference/intl/intlcalendar/set.xml
+++ b/reference/intl/intlcalendar/set.xml
@@ -97,6 +97,9 @@
     <listitem>
      <para>
       The new value for <constant>IntlCalendar::FIELD_MONTH</constant>.
+      The month sequence is zero-based, i.e., January is represented by 0,
+      February by 1, …, December is 11 and Undecember (if the calendar has
+      it) is 12.
      </para>
     </listitem>
    </varlistentry>
@@ -105,9 +108,6 @@
     <listitem>
      <para>
       The new value for <constant>IntlCalendar::FIELD_DAY_OF_MONTH</constant>.
-      The month sequence is zero-based, i.e., January is represented by 0,
-      February by 1, …, December is 11 and Undecember (if the calendar has
-      it) is 12.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
The month sequence information is relevant to the month parameter not the dayOfMonth parameter.

The `FIELD_MONTH` constant has a slightly different description. Don't know if they should be the same.