### PR TITLE
rename misspelled methods

### DIFF
--- a/appendices/migration80/new-features.xml
+++ b/appendices/migration80/new-features.xml
@@ -560,12 +560,12 @@ array_intersect(...$arrays);
    </listitem>
    <listitem>
     <para>
-     New <methodname>ZipArchive::setProgressCallback</methodname> to provide updates during archive close.
+     New <methodname>ZipArchive::registerProgressCallback</methodname> to provide updates during archive close.
     </para>
    </listitem>
    <listitem>
     <para>
-     New <methodname>ZipArchive::setCancelCallback</methodname> to allow cancellation during archive
+     New <methodname>ZipArchive::registerCancelCallback</methodname> to allow cancellation during archive
      close.
     </para>
    </listitem>


### PR DESCRIPTION
Hey there,

by going through https://github.com/php/php-tasks/issues/26 I found that these two methods actually are named `registerProgressCallback` and `registerCancelCallback` instead of `setProgressCallback` and `setCancelCallback`.

/Flo