### PR TITLE
Order the JIT configuration options in definition order.

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -948,15 +948,21 @@
       For advanced usage, this option accepts a 4-digit integer <literal>CRTO</literal>, where the digits mean:
       <variablelist>
        <varlistentry>
-        <term><literal>O</literal> (optimization level)</term>
+        <term><literal>C</literal> (CPU-specific optimization flags)</term>
         <listitem>
          <simplelist>
-          <member><literal>0</literal>: No JIT.</member>
-          <member><literal>1</literal>: Minimal JIT (call standard VM handlers).</member>
-          <member><literal>2</literal>: Inline VM handlers.</member>
-          <member><literal>3</literal>: Use type inference.</member>
-          <member><literal>4</literal>: Use call graph.</member>
-          <member><literal>5</literal>: Optimize whole script.</member>
+          <member><literal>0</literal>: Disable CPU-specific optimization.</member>
+          <member><literal>1</literal>: Enable use of AVX, if the CPU supports it.</member>
+         </simplelist>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><literal>R</literal> (register allocation)</term>
+        <listitem>
+         <simplelist>
+          <member><literal>0</literal>: Don't perform register allocation.</member>
+          <member><literal>1</literal>: Perform block-local register allocation.</member>
+          <member><literal>2</literal>: Perform global register allocation.</member>
          </simplelist>
         </listitem>
        </varlistentry>
@@ -977,24 +983,18 @@
            compile traces for hot code segments.
           </member>
          </simplelist>
-        </listitem> 
-       </varlistentry>
-       <varlistentry>
-        <term><literal>R</literal> (register allocation)</term>
-        <listitem>
-         <simplelist>
-          <member><literal>0</literal>: Don't perform register allocation.</member>
-          <member><literal>1</literal>: Perform block-local register allocation.</member>
-          <member><literal>2</literal>: Perform global register allocation.</member>
-         </simplelist>
         </listitem>
        </varlistentry>
        <varlistentry>
-        <term><literal>C</literal> (CPU-specific optimization flags)</term>
+        <term><literal>O</literal> (optimization level)</term>
         <listitem>
          <simplelist>
-          <member><literal>0</literal>: Disable CPU-specific optimization.</member>
-          <member><literal>1</literal>: Enable use of AVX, if the CPU supports it.</member>
+          <member><literal>0</literal>: No JIT.</member>
+          <member><literal>1</literal>: Minimal JIT (call standard VM handlers).</member>
+          <member><literal>2</literal>: Inline VM handlers.</member>
+          <member><literal>3</literal>: Use type inference.</member>
+          <member><literal>4</literal>: Use call graph.</member>
+          <member><literal>5</literal>: Optimize whole script.</member>
          </simplelist>
         </listitem>
        </varlistentry>


### PR DESCRIPTION
The diff looks weird because Git, but all this does is change the order to CTRO, since that's what everything else in the section uses as the order.  Why they were listed backwards, I have no idea.