### PR TITLE
Document p date formatter code.

### DIFF
--- a/reference/datetime/datetimeinterface/format.xml
+++ b/reference/datetime/datetimeinterface/format.xml
@@ -272,7 +272,12 @@
          </row>
          <row>
           <entry><literal>P</literal></entry>
-          <entry>Difference to Greenwich time (GMT) with colon between hours and minutes (added in PHP 5.1.3)</entry>
+          <entry>Difference to Greenwich time (GMT) with colon between hours and minutes</entry>
+          <entry>Example: <literal>+02:00</literal></entry>
+         </row>
+         <row>
+          <entry><literal>p</literal></entry>
+          <entry>The same as <literal>P</literal>, but returns <literal>Z</literal> instead of <literal>+00:00</literal></entry>
           <entry>Example: <literal>+02:00</literal></entry>
          </row>
          <row>


### PR DESCRIPTION
This is already in the migration guide, but never made it into the main docs.  Let's do that.

Also kill a PHP 5 reference while we're there, on principle.