### PR TITLE
Generate curl methodsynopses based on stubs

### DIFF
--- a/reference/curl/curlfile.xml
+++ b/reference/curl/curlfile.xml
@@ -51,6 +51,9 @@
 
     
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.curlfile')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
+     <xi:fallback />
+    </xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.curlfile')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/curl/curlfile/construct.xml
+++ b/reference/curl/curlfile/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="curlfile.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>CURLFile::__construct</refname>
@@ -11,18 +10,18 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-  <methodsynopsis>
+  <constructorsynopsis>
    <modifier>public</modifier> <methodname>CURLFile::__construct</methodname>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>mimetype</parameter><initializer>""</initializer></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>postname</parameter><initializer>""</initializer></methodparam>
-  </methodsynopsis>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>mime_type</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>posted_filename</parameter><initializer>&null;</initializer></methodparam>
+  </constructorsynopsis>
   <para>&style.procedural;</para>
   <methodsynopsis>
    <type>CURLFile</type><methodname>curl_file_create</methodname>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>mimetype</parameter><initializer>""</initializer></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>postname</parameter><initializer>""</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>mime_type</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>posted_filename</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Creates a <classname>CURLFile</classname> object, used to upload a file with <constant>CURLOPT_POSTFIELDS</constant>.
@@ -41,7 +40,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>mimetype</parameter></term>
+    <term><parameter>mime_type</parameter></term>
     <listitem>
      <para>
       Mimetype of the file.
@@ -49,7 +48,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>postname</parameter></term>
+    <term><parameter>posted_filename</parameter></term>
     <listitem>
      <para>
       Name of the file to be used in the upload data.
@@ -262,7 +261,6 @@ array(26) {
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/curlfile/setmimetype.xml
+++ b/reference/curl/curlfile/setmimetype.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="curlfile.setmimetype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>CURLFile::setMimeType</refname>
@@ -11,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>CURLFile::setMimeType</methodname>
-   <methodparam><type>string</type><parameter>mime</parameter></methodparam>
+   <methodparam><type>string</type><parameter>mime_type</parameter></methodparam>
   </methodsynopsis>
  </refsect1>
 
@@ -19,7 +18,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>mime</parameter></term>
+    <term><parameter>mime_type</parameter></term>
     <listitem>
      <para>
       MIME type to be used in POST data.
@@ -37,7 +36,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/curlfile/setpostfilename.xml
+++ b/reference/curl/curlfile/setpostfilename.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="curlfile.setpostfilename" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>CURLFile::setPostFilename</refname>
@@ -11,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>CURLFile::setPostFilename</methodname>
-   <methodparam><type>string</type><parameter>postname</parameter></methodparam>
+   <methodparam><type>string</type><parameter>posted_filename</parameter></methodparam>
   </methodsynopsis>
  </refsect1>
 
@@ -19,7 +18,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>postname</parameter></term>
+    <term><parameter>posted_filename</parameter></term>
     <listitem>
      <para>
       Filename to be used in POST data.
@@ -37,7 +36,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-close.xml
+++ b/reference/curl/functions/curl-close.xml
@@ -10,11 +10,11 @@
   &reftitle.description;
   <methodsynopsis>
    <type>void</type><methodname>curl_close</methodname>
-   <methodparam><type>resource</type><parameter>ch</parameter></methodparam>
+   <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
   </methodsynopsis>
   <para>
    Closes a cURL session and frees all resources.  The cURL handle,
-   <parameter>ch</parameter>, is also deleted.
+   <parameter>handle</parameter>, is also deleted.
   </para>
  </refsect1>
 
@@ -71,7 +71,6 @@ curl_close($ch);
   </para>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-copy-handle.xml
+++ b/reference/curl/functions/curl-copy-handle.xml
@@ -9,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>resource</type><methodname>curl_copy_handle</methodname>
-   <methodparam><type>resource</type><parameter>ch</parameter></methodparam>
+   <type class="union"><type>CurlHandle</type><type>false</type></type><methodname>curl_copy_handle</methodname>
+   <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
   </methodsynopsis>
   <para>
    Copies a cURL handle keeping the same preferences.
@@ -64,7 +64,6 @@ curl_close($ch);
   </para>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-errno.xml
+++ b/reference/curl/functions/curl-errno.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id='function.curl-errno' xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="function.curl-errno" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_errno</refname>
   <refpurpose>Return the last error number</refpurpose>
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>curl_errno</methodname>
-   <methodparam><type>resource</type><parameter>ch</parameter></methodparam>
+   <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
   </methodsynopsis>
   <para>
    Returns the error number for the last cURL operation.
@@ -75,7 +75,6 @@ curl_close($ch);
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-error.xml
+++ b/reference/curl/functions/curl-error.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id='function.curl-error' xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="function.curl-error" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_error</refname>
   <refpurpose>Return a string containing the last error for the current session</refpurpose>
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>string</type><methodname>curl_error</methodname>
-   <methodparam><type>resource</type><parameter>ch</parameter></methodparam>
+   <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
   </methodsynopsis>
   <para>
    Returns a clear text error message for the last cURL operation.
@@ -75,7 +75,6 @@ curl_close($ch);
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-escape.xml
+++ b/reference/curl/functions/curl-escape.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.curl-escape" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_escape</refname>
@@ -11,8 +10,8 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>curl_escape</methodname>
-   <methodparam><type>resource</type><parameter>ch</parameter></methodparam>
-   <methodparam><type>string</type><parameter>str</parameter></methodparam>
+   <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
    This function URL encodes the given string according to <link xlink:href="&url.rfc;3986">RFC 3986</link>.
@@ -25,7 +24,7 @@
   <variablelist>
    &curl.ch.description;
    <varlistentry>
-    <term><parameter>str</parameter></term>
+    <term><parameter>string</parameter></term>
     <listitem>
      <para>
       The string to be encoded.
@@ -86,7 +85,6 @@ curl_close($ch);
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-exec.xml
+++ b/reference/curl/functions/curl-exec.xml
@@ -9,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>mixed</type><methodname>curl_exec</methodname>
-   <methodparam><type>resource</type><parameter>ch</parameter></methodparam>
+   <type class="union"><type>string</type><type>bool</type></type><methodname>curl_exec</methodname>
+   <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
   </methodsynopsis>
   <para>
    Execute the given cURL session.
@@ -84,7 +84,6 @@ curl_close($ch);
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id='function.curl-getinfo' xmlns="http://docbook.org/ns/docbook">
+<refentry xml:id="function.curl-getinfo" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>curl_getinfo</refname>
   <refpurpose>Get information regarding a specific transfer</refpurpose>
@@ -10,8 +10,8 @@
   &reftitle.description;
   <methodsynopsis>
    <type>mixed</type><methodname>curl_getinfo</methodname>
-   <methodparam><type>resource</type><parameter>ch</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>opt</parameter></methodparam>
+   <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>option</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Gets information about the last transfer. 
@@ -24,7 +24,7 @@
    <variablelist>
     &curl.ch.description;
     <varlistentry>
-     <term><parameter>opt</parameter></term>
+     <term><parameter>option</parameter></term>
      <listitem>
       <para>
        This may be one of the following constants:
@@ -349,9 +349,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   If <parameter>opt</parameter> is given, returns its value.
+   If <parameter>option</parameter> is given, returns its value.
    Otherwise, returns an associative array with the following elements 
-   (which correspond to <parameter>opt</parameter>), or &false; on failure:
+   (which correspond to <parameter>option</parameter>), or &false; on failure:
    <itemizedlist>
     <listitem>
      <simpara>
@@ -564,7 +564,7 @@ curl_close($ch);
   </para>
   <para>
    <example>
-    <title><function>curl_getinfo</function> example with <parameter>opt</parameter> parameter</title>
+    <title><function>curl_getinfo</function> example with <parameter>option</parameter> parameter</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -604,7 +604,6 @@ curl_close($ch);
   </note>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-init.xml
+++ b/reference/curl/functions/curl-init.xml
@@ -9,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>resource</type><methodname>curl_init</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>url</parameter><initializer>&null;</initializer></methodparam>
+   <type class="union"><type>CurlHandle</type><type>false</type></type><methodname>curl_init</methodname>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>url</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Initializes a new session and return a cURL handle for use with the
@@ -90,7 +90,6 @@ curl_close($ch);
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-multi-add-handle.xml
+++ b/reference/curl/functions/curl-multi-add-handle.xml
@@ -10,12 +10,12 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>curl_multi_add_handle</methodname>
-   <methodparam><type>resource</type><parameter>mh</parameter></methodparam>
-   <methodparam><type>resource</type><parameter>ch</parameter></methodparam>
+   <methodparam><type>CurlMultiHandle</type><parameter>multi_handle</parameter></methodparam>
+   <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Adds the <parameter>ch</parameter> handle to the multi handle 
-   <parameter>mh</parameter>
+   Adds the <parameter>handle</parameter> handle to the multi handle 
+   <parameter>multi_handle</parameter>
   </para>
  </refsect1>
  
@@ -97,7 +97,6 @@ curl_multi_close($mh);
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-multi-close.xml
+++ b/reference/curl/functions/curl-multi-close.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>void</type><methodname>curl_multi_close</methodname>
-   <methodparam><type>resource</type><parameter>mh</parameter></methodparam>
+   <methodparam><type>CurlMultiHandle</type><parameter>multi_handle</parameter></methodparam>
   </methodsynopsis>
   <para>
    Closes a set of cURL handles.
@@ -95,7 +95,6 @@ curl_multi_close($mh);
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-multi-errno.xml
+++ b/reference/curl/functions/curl-multi-errno.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.curl-multi-errno" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_multi_errno</refname>
@@ -10,8 +9,8 @@
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
   <methodsynopsis role="procedural">
-   <type class="union"><type>int</type><type>false</type></type><methodname>curl_multi_errno</methodname>
-   <methodparam><type>resource</type><parameter>mh</parameter></methodparam>
+   <type>int</type><methodname>curl_multi_errno</methodname>
+   <methodparam><type>CurlMultiHandle</type><parameter>multi_handle</parameter></methodparam>
   </methodsynopsis>
   <para>
    Return an integer containing the last multi curl error number.
@@ -41,7 +40,6 @@
  </refsect1><!-- }}} -->
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-multi-exec.xml
+++ b/reference/curl/functions/curl-multi-exec.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>curl_multi_exec</methodname>
-   <methodparam><type>resource</type><parameter>mh</parameter></methodparam>
+   <methodparam><type>CurlMultiHandle</type><parameter>multi_handle</parameter></methodparam>
    <methodparam><type>int</type><parameter role="reference">still_running</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -112,7 +112,6 @@ curl_multi_close($mh);
  </refsect1>
  
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-multi-getcontent.xml
+++ b/reference/curl/functions/curl-multi-getcontent.xml
@@ -9,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>curl_multi_getcontent</methodname>
-   <methodparam><type>resource</type><parameter>ch</parameter></methodparam>
+   <type class="union"><type>string</type><type>null</type></type><methodname>curl_multi_getcontent</methodname>
+   <methodparam><type>CurlHandle</type><parameter>multi_handle</parameter></methodparam>
   </methodsynopsis>
   <para>
    If <constant>CURLOPT_RETURNTRANSFER</constant> is an option that is set for a specific handle, 
@@ -45,7 +45,6 @@
  </refsect1>
  
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-multi-info-read.xml
+++ b/reference/curl/functions/curl-multi-info-read.xml
@@ -9,9 +9,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>curl_multi_info_read</methodname>
-   <methodparam><type>resource</type><parameter>mh</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter role="reference">msgs_in_queue</parameter><initializer>&null;</initializer></methodparam>
+   <type class="union"><type>array</type><type>false</type></type><methodname>curl_multi_info_read</methodname>
+   <methodparam><type>CurlMultiHandle</type><parameter>multi_handle</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter role="reference">queued_messages</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Ask the multi handle if there are any messages or information from the individual transfers. 
@@ -21,7 +21,7 @@
   <para>   
    Repeated calls to this function will return a new result each time, until a &false; is returned 
    as a signal that there is no more to get at this point. The integer pointed to with 
-   <parameter>msgs_in_queue</parameter> will contain the number of remaining messages after this 
+   <parameter>queued_messages</parameter> will contain the number of remaining messages after this 
    function was called.
   </para>
   <warning>
@@ -38,7 +38,7 @@
    <variablelist>
     &curl.mh.description;
     <varlistentry>
-     <term><parameter>msgs_in_queue</parameter></term>
+     <term><parameter>queued_messages</parameter></term>
      <listitem>
       <para>
        Number of messages that are still in the queue
@@ -172,7 +172,6 @@ bool(false)
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-multi-init.xml
+++ b/reference/curl/functions/curl-multi-init.xml
@@ -9,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>resource</type><methodname>curl_multi_init</methodname>
-   <void />
+   <type>CurlMultiHandle</type><methodname>curl_multi_init</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Allows the processing of multiple cURL handles asynchronously.
@@ -89,7 +89,6 @@ curl_multi_close($mh);
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-multi-remove-handle.xml
+++ b/reference/curl/functions/curl-multi-remove-handle.xml
@@ -10,13 +10,13 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>curl_multi_remove_handle</methodname>
-   <methodparam><type>resource</type><parameter>mh</parameter></methodparam>
-   <methodparam><type>resource</type><parameter>ch</parameter></methodparam>
+   <methodparam><type>CurlMultiHandle</type><parameter>multi_handle</parameter></methodparam>
+   <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Removes a given <parameter>ch</parameter> handle from the given <parameter>mh</parameter>
-   handle. When the <parameter>ch</parameter> handle has been removed, it is again perfectly 
-   legal to run <function>curl_exec</function> on this handle.  Removing the <parameter>ch</parameter> handle while being 
+   Removes a given <parameter>handle</parameter> handle from the given <parameter>multi_handle</parameter>
+   handle. When the <parameter>handle</parameter> handle has been removed, it is again perfectly 
+   legal to run <function>curl_exec</function> on this handle.  Removing the <parameter>handle</parameter> handle while being 
    used, will effectively halt the transfer in progress involving that handle.
   </para>
  </refsect1>
@@ -51,7 +51,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-multi-select.xml
+++ b/reference/curl/functions/curl-multi-select.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>curl_multi_select</methodname>
-   <methodparam><type>resource</type><parameter>mh</parameter></methodparam>
+   <methodparam><type>CurlMultiHandle</type><parameter>multi_handle</parameter></methodparam>
    <methodparam choice="opt"><type>float</type><parameter>timeout</parameter><initializer>1.0</initializer></methodparam>
   </methodsynopsis>
   <para>
@@ -56,7 +56,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-multi-setopt.xml
+++ b/reference/curl/functions/curl-multi-setopt.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.curl-multi-setopt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_multi_setopt</refname>
@@ -11,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>curl_multi_setopt</methodname>
-   <methodparam><type>resource</type><parameter>mh</parameter></methodparam>
+   <methodparam><type>CurlMultiHandle</type><parameter>multi_handle</parameter></methodparam>
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
@@ -27,7 +26,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>mh</parameter></term>
+    <term><parameter>multi_handle</parameter></term>
     <listitem>
      <para>
       
@@ -216,7 +215,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-multi-strerror.xml
+++ b/reference/curl/functions/curl-multi-strerror.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.curl-multi-strerror" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_multi_strerror</refname>
@@ -10,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>curl_multi_strerror</methodname>
-   <methodparam><type>int</type><parameter>errornum</parameter></methodparam>
+   <type class="union"><type>string</type><type>null</type></type><methodname>curl_multi_strerror</methodname>
+   <methodparam><type>int</type><parameter>error_code</parameter></methodparam>
   </methodsynopsis>
   <para>
    Returns a text error message describing the given CURLM error code.
@@ -23,7 +22,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>errornum</parameter></term>
+    <term><parameter>error_code</parameter></term>
     <listitem>
      <para>
       One of the <link xlink:href="&url.curl.error;">CURLM error codes</link> constants.
@@ -91,7 +90,6 @@ if ($status != CURLM_OK) {
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-pause.xml
+++ b/reference/curl/functions/curl-pause.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.curl-pause" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_pause</refname>
@@ -11,8 +10,8 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>curl_pause</methodname>
-   <methodparam><type>resource</type><parameter>ch</parameter></methodparam>
-   <methodparam><type>int</type><parameter>bitmask</parameter></methodparam>
+   <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
+   <methodparam><type>int</type><parameter>flags</parameter></methodparam>
   </methodsynopsis>
   <para>
 
@@ -27,7 +26,7 @@
   <variablelist>
    &curl.ch.description;
    <varlistentry>
-    <term><parameter>bitmask</parameter></term>
+    <term><parameter>flags</parameter></term>
     <listitem>
      <para>
       One of <constant>CURLPAUSE_*</constant> constants.
@@ -45,7 +44,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-reset.xml
+++ b/reference/curl/functions/curl-reset.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.curl-reset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_reset</refname>
@@ -11,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>void</type><methodname>curl_reset</methodname>
-   <methodparam><type>resource</type><parameter>ch</parameter></methodparam>
+   <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
   </methodsynopsis>
   <para>
    This function re-initializes all options set on the given cURL handle to the default values.
@@ -82,7 +81,6 @@ curl_close($ch);
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-setopt-array.xml
+++ b/reference/curl/functions/curl-setopt-array.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>curl_setopt_array</methodname>
-   <methodparam><type>resource</type><parameter>ch</parameter></methodparam>
+   <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
    <methodparam><type>array</type><parameter>options</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -126,7 +126,6 @@ if (!function_exists('curl_setopt_array')) {
   </para>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>curl_setopt</methodname>
-   <methodparam><type>resource</type><parameter>ch</parameter></methodparam>
+   <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
@@ -320,7 +320,7 @@
             formerly it defaulted to &true;.
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.15 and 7.4.3, respectively, if built against libcurl >= 7.64.0 
+            Available since PHP 7.3.15 and 7.4.3, respectively, if built against libcurl &gt;= 7.64.0 
            </entry>
           </row>
           <row>
@@ -347,7 +347,7 @@
             &false; to get the raw HTTP response body.
            </entry>
            <entry valign="top">
-            Available as of PHP 5.5.0 if built against libcurl >= 7.16.2.
+            Available as of PHP 5.5.0 if built against libcurl &gt;= 7.16.2.
            </entry>
           </row>
           <row>
@@ -359,7 +359,7 @@
             Most applications do not need this option.
            </entry>
            <entry valign="top">
-            Available as of PHP 7.3.0 if built against libcurl >= 7.51.0.
+            Available as of PHP 7.3.0 if built against libcurl &gt;= 7.51.0.
            </entry>
           </row>
           <row>
@@ -530,7 +530,7 @@
             When set to false, the peer certificate verification succeeds regardless.
            </entry>
            <entry valign="top">
-            &true; by default. Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+            &true; by default. Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -975,7 +975,7 @@
             </para>
            </entry>
            <entry valign="top">
-            Available as of 7.3.0 and curl >= 7.55.0.
+            Available as of 7.3.0 and curl &gt;= 7.55.0.
            </entry>
           </row>
           <row>
@@ -1049,15 +1049,15 @@
             <simpara>
              <constant>CURLSSLOPT_NO_REVOKE</constant>: disable certificate
              revocation checks for those SSL backends where such behavior is
-             present. (curl >= 7.44.0)
+             present. (curl &gt;= 7.44.0)
             </simpara>
             <simpara>
              <constant>CURLSSLOPT_NO_PARTIALCHAIN</constant>: do not accept "partial" 
-             certificate chains, which it otherwise does by default. (curl >= 7.68.0)
+             certificate chains, which it otherwise does by default. (curl &gt;= 7.68.0)
             </simpara>
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -1072,7 +1072,7 @@
             In production environments the value of this option should be kept at <literal>2</literal> (default value).
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -1098,7 +1098,7 @@
             </note>
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -1577,7 +1577,7 @@
             Defaults to using port 1080 for proxies if a port is not specified.
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -1608,7 +1608,7 @@
             to be stored.
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -1617,7 +1617,7 @@
             The directory holding multiple CA certificates to verify the HTTPS proxy with.
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -1628,7 +1628,7 @@
             the SSL exchange.
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -1640,7 +1640,7 @@
             This option is for connecting to an HTTPS proxy, not an HTTPS server.
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -1652,7 +1652,7 @@
             "sha256//" and separated by ";"
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -1667,7 +1667,7 @@
             "./" prefix, in order to avoid confusion with a nickname.
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -1680,7 +1680,7 @@
             PKCS#12-encoded files. Defaults to "PEM".
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -1692,7 +1692,7 @@
             but colons are normally used, !, - and + can be used as operators.
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -1706,7 +1706,7 @@
             TLS 1.3 cipher suites by using the <constant>CURLOPT_PROXY_SSL_CIPHER_LIST</constant> option.
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.61.0. Available when built with OpenSSL >= 1.1.1.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.61.0. Available when built with OpenSSL &gt;= 1.1.1.
            </entry>
           </row>
           <row>
@@ -1718,7 +1718,7 @@
             (iOS and Mac OS X only) This option is ignored if curl was built against Secure Transport.
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0. Available if built TLS enabled.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0. Available if built TLS enabled.
            </entry>
           </row>
           <row>
@@ -1727,7 +1727,7 @@
             The format of your private key. Supported formats are "PEM", "DER" and "ENG".
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -1738,7 +1738,7 @@
             <constant>CURLOPT_PROXY_TLSAUTH_USERNAME</constant> option to also be set.
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -1755,7 +1755,7 @@
             </note>
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -1766,7 +1766,7 @@
             <constant>CURLOPT_PROXY_TLSAUTH_PASSWORD</constant> option to also be set.
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.52.0.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0.
            </entry>
           </row>
           <row>
@@ -1954,7 +1954,7 @@
             TLS 1.3 cipher suites by using the <constant>CURLOPT_SSL_CIPHER_LIST</constant> option.
            </entry>
            <entry valign="top">
-            Available since PHP 7.3.0 and libcurl >= cURL 7.61.0. Available when built with OpenSSL >= 1.1.1.
+            Available since PHP 7.3.0 and libcurl &gt;= cURL 7.61.0. Available when built with OpenSSL &gt;= 1.1.1.
            </entry>
           </row>
           <row>
@@ -2391,7 +2391,6 @@ curl_close($ch);
  </refsect1>
  
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-share-close.xml
+++ b/reference/curl/functions/curl-share-close.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.curl-share-close" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_share_close</refname>
@@ -11,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>void</type><methodname>curl_share_close</methodname>
-   <methodparam><type>resource</type><parameter>sh</parameter></methodparam>
+   <methodparam><type>CurlShareHandle</type><parameter>share_handle</parameter></methodparam>
   </methodsynopsis>
   <para>
    Closes a cURL share handle and frees all resources.
@@ -23,7 +22,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>sh</parameter></term>
+    <term><parameter>share_handle</parameter></term>
     <listitem>
      <para>
       A cURL share handle returned by <function>curl_share_init</function>
@@ -94,7 +93,6 @@ curl_close($ch2);
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-share-errno.xml
+++ b/reference/curl/functions/curl-share-errno.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.curl-share-errno" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_share_errno</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
-  <methodsynopsis role="procedural">
-   <type class="union"><type>int</type><type>false</type></type><methodname>curl_share_errno</methodname>
-   <methodparam><type>resource</type><parameter>sh</parameter></methodparam>
+  <methodsynopsis>
+   <type>int</type><methodname>curl_share_errno</methodname>
+   <methodparam><type>CurlShareHandle</type><parameter>share_handle</parameter></methodparam>
   </methodsynopsis>
   <para>
    Return an integer containing the last share curl error number.
@@ -22,7 +21,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>sh</parameter></term>
+    <term><parameter>share_handle</parameter></term>
     <listitem>
      <para>
       A cURL share handle returned by <function>curl_share_init</function>.
@@ -48,7 +47,6 @@
  </refsect1><!-- }}} -->
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-share-init.xml
+++ b/reference/curl/functions/curl-share-init.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.curl-share-init" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_share_init</refname>
@@ -10,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>resource</type><methodname>curl_share_init</methodname>
-   <void />
+   <type>CurlShareHandle</type><methodname>curl_share_init</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Allows to share data between cURL handles.
@@ -86,7 +85,6 @@ curl_close($ch2);
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-share-setopt.xml
+++ b/reference/curl/functions/curl-share-setopt.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.curl-share-setopt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_share_setopt</refname>
@@ -11,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>curl_share_setopt</methodname>
-   <methodparam><type>resource</type><parameter>sh</parameter></methodparam>
+   <methodparam><type>CurlShareHandle</type><parameter>share_handle</parameter></methodparam>
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
@@ -25,7 +24,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>sh</parameter></term>
+    <term><parameter>share_handle</parameter></term>
     <listitem>
      <para>
       A cURL share handle returned by <function>curl_share_init</function>.
@@ -159,7 +158,6 @@ curl_close($ch2);
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-share-strerror.xml
+++ b/reference/curl/functions/curl-share-strerror.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.curl-share-strerror" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_share_strerror</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
-  <methodsynopsis role="procedural">
-   <type>string</type><methodname>curl_share_strerror</methodname>
-   <methodparam><type>int</type><parameter>errornum</parameter></methodparam>
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>null</type></type><methodname>curl_share_strerror</methodname>
+   <methodparam><type>int</type><parameter>error_code</parameter></methodparam>
   </methodsynopsis>
   <para>
    Returns a text error message describing the given error code.
@@ -22,7 +21,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>errornum</parameter></term>
+    <term><parameter>error_code</parameter></term>
     <listitem>
      <para>
       One of the <link xlink:href="&url.curl.error;">cURL error codes</link> constants.
@@ -48,7 +47,6 @@
  </refsect1><!-- }}} -->
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-strerror.xml
+++ b/reference/curl/functions/curl-strerror.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.curl-strerror" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_strerror</refname>
@@ -10,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>curl_strerror</methodname>
-   <methodparam><type>int</type><parameter>errornum</parameter></methodparam>
+   <type class="union"><type>string</type><type>null</type></type><methodname>curl_strerror</methodname>
+   <methodparam><type>int</type><parameter>error_code</parameter></methodparam>
   </methodsynopsis>
   <para>
    Returns a text error message describing the given error code.
@@ -23,7 +22,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>errornum</parameter></term>
+    <term><parameter>error_code</parameter></term>
     <listitem>
      <para>
       One of the <link xlink:href="&url.curl.error;">cURL error codes</link> constants.
@@ -88,7 +87,6 @@ cURL error (1):
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-unescape.xml
+++ b/reference/curl/functions/curl-unescape.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.curl-unescape" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_unescape</refname>
@@ -11,8 +10,8 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>curl_unescape</methodname>
-   <methodparam><type>resource</type><parameter>ch</parameter></methodparam>
-   <methodparam><type>string</type><parameter>str</parameter></methodparam>
+   <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
    This function decodes the given URL encoded string.
@@ -24,7 +23,7 @@
   <variablelist>
    &curl.ch.description;
    <varlistentry>
-    <term><parameter>str</parameter></term>
+    <term><parameter>string</parameter></term>
     <listitem>
      <para>
       The URL encoded string to be decoded.
@@ -96,7 +95,6 @@ curl_close($ch);
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/curl/functions/curl-version.xml
+++ b/reference/curl/functions/curl-version.xml
@@ -9,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>curl_version</methodname>
-   <methodparam choice="opt"><type>int</type><parameter>age</parameter><initializer>CURLVERSION_NOW</initializer></methodparam>
+   <type class="union"><type>array</type><type>false</type></type><methodname>curl_version</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns information about the cURL version.
@@ -71,7 +71,7 @@
       </row>
       <row>
        <entry>age</entry>
-       <entry></entry>
+       <entry/>
       </row>
       <row>
        <entry>features</entry>
@@ -125,7 +125,6 @@ foreach($bitfields as $feature)
   </para>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
There is a page for `CURLFile::__wakeup()` (https://www.php.net/manual/en/curlfile.wakeup.php), but the stubs doesn't define such method... Should we do anything in this case?