### PR TITLE
Updating mysqli: free result

### DIFF
--- a/reference/mysqli/mysqli_result/free.xml
+++ b/reference/mysqli/mysqli_result/free.xml
@@ -32,13 +32,6 @@
   <para>
    Frees the memory associated with the result.
   </para>
-  <note>
-   <para>
-    You should always free your result with 
-    <function>mysqli_free_result</function>, when your result object is not
-    needed anymore.
-   </para>
-  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -62,7 +55,7 @@
   <para>
    <simplelist>
     <member><function>mysqli_query</function></member>
-    <member><function>mysqli_stmt_store_result</function></member>
+    <member><function>mysqli_stmt_get_result</function></member>
     <member><function>mysqli_store_result</function></member>
     <member><function>mysqli_use_result</function></member>
    </simplelist>


### PR DESCRIPTION
Inspired by the bug report https://bugs.php.net/bug.php?id=71392 I decided to remove the misleading and confusing note. The reasons for it being:
- This is the only one of the 4 close/free methods that deallocate internal memory, which recommends closing the object
- There is no explanation given why would one ever need to close the object, and I can't think of any either
- Trying to follow this guidance has lead many astray as they tried to use it immediately after INSERT/UPDATE query

Also, fixed see also, which was pointing to store_result instead of get_result