### PR TITLE
Function trailing commas

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -200,7 +200,31 @@ function takes_array($input)
 ]]>
      </programlisting>
     </example>
-   </para>   
+   </para>
+   <para>
+    As of PHP 8.0.0, the list of function arguments may include a trailing comma, which
+    will be ignored.  That is particularly useful in cases where the list of arguments is
+    long or contains long variable names, making it convenient to list arguments vertically.
+   </para>
+   <example>
+    <title>Passing arrays to functions</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+function takes_many_args(
+    $first_arg,
+    $second_arg,
+    $a_very_long_argument_name,
+    $arg_with_default = 5,
+    $again = 'a default string', // This trailing comma is optional as of PHP 8.0.0
+)
+{
+    // ...
+}
+?>
+]]>
+    </programlisting>
+   </example>
    <sect2 xml:id="functions.arguments.by-reference">
     <title>Passing arguments by reference</title>
  

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -216,7 +216,7 @@ function takes_many_args(
     $second_arg,
     $a_very_long_argument_name,
     $arg_with_default = 5,
-    $again = 'a default string', // This trailing comma is optional as of PHP 8.0.0
+    $again = 'a default string', // This trailing comma was not permitted before 8.0.0.
 )
 {
     // ...

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -909,7 +909,7 @@ $greet('PHP');
    <simpara>
     Closures may also inherit variables from the parent scope. Any such
     variables must be passed to the <literal>use</literal> language construct.
-    From PHP 7.1, these variables must not include &link.superglobals;,
+    As of PHP 7.1, these variables must not include &link.superglobals;,
     <varname>$this</varname>, or variables with the same name as a parameter.
    </simpara>
 
@@ -973,6 +973,10 @@ string(11) "hello world"
     </screen>
    </example>
 
+   <para>
+    As of PHP 8.0.0, the list of scope-inherited variables may include a trailing
+    comma, which will be ignored.
+   </para>
    <simpara>
     Inheriting variables from the parent scope is <emphasis>not</emphasis> 
     the same as using global variables. 


### PR DESCRIPTION
* Trailing commas in function parameter list.
* Trailing commas in use clause.
* Minor language change along the way.
* I have no idea what the difference is between para and simplepara...