### PR TITLE
Update ext/ldap signatures to match PHP-8

### DIFF
--- a/reference/ldap/functions/ldap-connect.xml
+++ b/reference/ldap/functions/ldap-connect.xml
@@ -9,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>resource</type><methodname>ldap_connect</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>ldap_uri</parameter><initializer>&null;</initializer></methodparam>
+   <type class="union"><type>resource</type><type>false</type></type><methodname>ldap_connect</methodname>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>uri</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <warning>
    <simpara>
@@ -19,13 +19,13 @@
    </simpara>
   </warning> 
   <methodsynopsis>
-   <type>resource</type><methodname>ldap_connect</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>host</parameter><initializer>&null;</initializer></methodparam>
+   <type class="union"><type>resource</type><type>false</type></type><methodname>ldap_connect</methodname>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>host</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>port</parameter><initializer>389</initializer></methodparam>
   </methodsynopsis>
   <para>
    Creates an LDAP link identifier and checks whether the given
-   <parameter>host</parameter> and <parameter>port</parameter> are plausible.
+   <parameter>uri</parameter> is plausible.
   </para>
   <note>
    <simpara>
@@ -41,7 +41,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>ldap_uri</parameter></term>
+     <term><parameter>uri</parameter></term>
      <listitem>
       <para>
        A full LDAP URI of the form <literal>ldap://hostname:port</literal>
@@ -52,22 +52,6 @@
       </para>
       <para>
        Note that <literal>hostname:port</literal> is not a supported LDAP URI as the schema is missing.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>host</parameter></term>
-     <listitem>
-      <para>
-       The hostname to connect to.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>port</parameter></term>
-     <listitem>
-      <para>
-       The port to connect to.
       </para>
      </listitem>
     </varlistentry>
@@ -144,7 +128,6 @@ $ldapconn = ldap_connect($ldaphost)
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/ldap/functions/ldap-get-option.xml
+++ b/reference/ldap/functions/ldap-get-option.xml
@@ -5,7 +5,7 @@
   <refname>ldap_get_option</refname>
   <refpurpose>Get the current value for given option</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -80,7 +80,7 @@
            <entry><constant>LDAP_OPT_DIAGNOSTIC_MESSAGE</constant></entry>
            <entry><type>int</type></entry>
            <entry/>
-          </row> 
+          </row>
           <row>
            <entry><constant>LDAP_OPT_REFERRALS</constant></entry>
            <entry><type>int</type></entry>

--- a/reference/ldap/functions/ldap-list.xml
+++ b/reference/ldap/functions/ldap-list.xml
@@ -9,16 +9,16 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>resource</type><methodname>ldap_list</methodname>
-   <methodparam><type>resource</type><parameter>link_identifier</parameter></methodparam>
-   <methodparam><type>string</type><parameter>base_dn</parameter></methodparam>
-   <methodparam><type>string</type><parameter>filter</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>attributes</parameter><initializer>array("*")</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>attrsonly</parameter><initializer>0</initializer></methodparam>
+   <type class="union"><type>resource</type><type>false</type></type><methodname>ldap_list</methodname>
+   <methodparam><type class="union"><type>resource</type><type>array</type></type><parameter>ldap</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>string</type></type><parameter>base</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>string</type></type><parameter>filter</parameter></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter>attributes</parameter><initializer>[]</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>attributes_only</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>sizelimit</parameter><initializer>-1</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>timelimit</parameter><initializer>-1</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>deref</parameter><initializer>LDAP_DEREF_NEVER</initializer></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>serverctrls</parameter><initializer>array()</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>deref</parameter><initializer><constant>LDAP_DEREF_NEVER</constant></initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>controls</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Performs the search for a specified <parameter>filter</parameter> on the
@@ -27,7 +27,7 @@
   <para>
    <constant>LDAP_SCOPE_ONELEVEL</constant> means that the search should only
    return information that is at the level immediately below the
-   <parameter>base_dn</parameter> given in the call.
+   <parameter>base</parameter> given in the call.
    (Equivalent to typing "<command>ls</command>" and getting a list of files and folders in the
    current working directory.)
   </para>
@@ -38,7 +38,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>link_identifier</parameter></term>
+     <term><parameter>ldap</parameter></term>
      <listitem>
       <para>
        An LDAP link identifier, returned by <function>ldap_connect</function>.
@@ -46,7 +46,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>base_dn</parameter></term>
+     <term><parameter>base</parameter></term>
      <listitem>
       <para>
        The base DN for the directory.
@@ -77,7 +77,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>attrsonly</parameter></term>
+     <term><parameter>attributes_only</parameter></term>
      <listitem>
       <para>
        Should be set to 1 if only attribute types are wanted. If set to 0
@@ -159,7 +159,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>serverctrls</parameter></term>
+     <term><parameter>controls</parameter></term>
      <listitem>
       <para>
        Array of <link linkend="ldap.controls">LDAP Controls</link> to send with the request.
@@ -192,7 +192,7 @@
       <row>
        <entry>7.3</entry>
        <entry>
-        Support for <parameter>serverctrls</parameter> added
+        Support for <parameter>controls</parameter> added
        </entry>
       </row>
      </tbody>
@@ -238,7 +238,6 @@ for ($i=0; $i < $info["count"]; $i++) {
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/ldap/functions/ldap-read.xml
+++ b/reference/ldap/functions/ldap-read.xml
@@ -9,16 +9,16 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>resource</type><methodname>ldap_read</methodname>
-   <methodparam><type>resource</type><parameter>link_identifier</parameter></methodparam>
-   <methodparam><type>string</type><parameter>base_dn</parameter></methodparam>
-   <methodparam><type>string</type><parameter>filter</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>attributes</parameter><initializer>array("*")</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>attrsonly</parameter><initializer>0</initializer></methodparam>
+   <type class="union"><type>resource</type><type>false</type></type><methodname>ldap_read</methodname>
+   <methodparam><type class="union"><type>resource</type><type>array</type></type><parameter>ldap</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>string</type></type><parameter>base</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>string</type></type><parameter>filter</parameter></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter>attributes</parameter><initializer>[]</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>attributes_only</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>sizelimit</parameter><initializer>-1</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>timelimit</parameter><initializer>-1</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>deref</parameter><initializer>LDAP_DEREF_NEVER</initializer></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>serverctrls</parameter><initializer>array()</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>deref</parameter><initializer><constant>LDAP_DEREF_NEVER</constant></initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>controls</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Performs the search for a specified <parameter>filter</parameter> on the
@@ -32,7 +32,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>link_identifier</parameter></term>
+     <term><parameter>ldap</parameter></term>
      <listitem>
       <para>
        An LDAP link identifier, returned by <function>ldap_connect</function>.
@@ -40,7 +40,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>base_dn</parameter></term>
+     <term><parameter>base</parameter></term>
      <listitem>
       <para>
        The base DN for the directory.
@@ -76,7 +76,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>attrsonly</parameter></term>
+     <term><parameter>attributes_only</parameter></term>
      <listitem>
       <para>
        Should be set to 1 if only attribute types are wanted. If set to 0
@@ -158,7 +158,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>serverctrls</parameter></term>
+     <term><parameter>controls</parameter></term>
      <listitem>
       <para>
        Array of <link linkend="ldap.controls">LDAP Controls</link> to send with the request.
@@ -198,7 +198,7 @@
       <row>
        <entry>7.3</entry>
        <entry>
-        Support for <parameter>serverctrls</parameter> added
+        Support for <parameter>controls</parameter> added
        </entry>
       </row>
      </tbody>
@@ -208,7 +208,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/ldap/functions/ldap-search.xml
+++ b/reference/ldap/functions/ldap-search.xml
@@ -9,16 +9,16 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>resource</type><methodname>ldap_search</methodname>
-   <methodparam><type>resource</type><parameter>link_identifier</parameter></methodparam>
-   <methodparam><type>string</type><parameter>base_dn</parameter></methodparam>
-   <methodparam><type>string</type><parameter>filter</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>attributes</parameter><initializer>array("*")</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>attrsonly</parameter><initializer>0</initializer></methodparam>
+   <type class="union"><type>resource</type><type>false</type></type><methodname>ldap_search</methodname>
+   <methodparam><type class="union"><type>resource</type><type>array</type></type><parameter>ldap</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>string</type></type><parameter>base</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>string</type></type><parameter>filter</parameter></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter>attributes</parameter><initializer>[]</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>attributes_only</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>sizelimit</parameter><initializer>-1</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>timelimit</parameter><initializer>-1</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>deref</parameter><initializer>LDAP_DEREF_NEVER</initializer></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>serverctrls</parameter><initializer>array()</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>deref</parameter><initializer><constant>LDAP_DEREF_NEVER</constant></initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>controls</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Performs the search for a specified filter on the directory with the scope
@@ -48,7 +48,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>link_identifier</parameter></term>
+     <term><parameter>ldap</parameter></term>
      <listitem>
       <para>
        An LDAP link identifier, returned by <function>ldap_connect</function>.
@@ -56,7 +56,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>base_dn</parameter></term>
+     <term><parameter>base</parameter></term>
      <listitem>
       <para>
        The base DN for the directory.
@@ -68,8 +68,7 @@
      <listitem>
       <para>
        The search filter can be simple or advanced, using boolean operators in
-       the format described in the LDAP documentation (see the <link
-       xlink:href="&url.ldap.filters;">Netscape Directory SDK</link> or
+       the format described in the LDAP documentation (see the <link xlink:href="&url.ldap.filters;">Netscape Directory SDK</link> or
        <link xlink:href="&url.rfc;4515">RFC4515</link> for full
        information on filters).
       </para>
@@ -92,7 +91,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>attrsonly</parameter></term>
+     <term><parameter>attributes_only</parameter></term>
      <listitem>
       <para>
        Should be set to 1 if only attribute types are wanted. If set to 0
@@ -174,7 +173,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>serverctrls</parameter></term>
+     <term><parameter>controls</parameter></term>
      <listitem>
       <para>
        Array of <link linkend="ldap.controls">LDAP Controls</link> to send with the request.
@@ -207,7 +206,7 @@
       <row>
        <entry>7.3</entry>
        <entry>
-        Support for <parameter>serverctrls</parameter> added
+        Support for <parameter>controls</parameter> added
        </entry>
       </row>
      </tbody>
@@ -250,7 +249,6 @@ echo $info["count"]." entries returned\n";
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/ldap/functions/ldap-set-option.xml
+++ b/reference/ldap/functions/ldap-set-option.xml
@@ -191,7 +191,7 @@
        </informaltable>
       </para>
       <para>
-       <constant>LDAP_OPT_SERVER_CONTROLS</constant> and 
+       <constant>LDAP_OPT_SERVER_CONTROLS</constant> and
        <constant>LDAP_OPT_CLIENT_CONTROLS</constant> require a list of
        controls, this means that the value must be an array of controls. A
        control consists of an <emphasis>oid</emphasis> identifying the control,
@@ -202,8 +202,7 @@
        elements are key <emphasis>value</emphasis> with string value
        and key <emphasis>iscritical</emphasis> with boolean value.
        <emphasis>iscritical</emphasis> defaults to <emphasis>&false;</emphasis>
-       if not supplied. See <link 
-       xlink:href="&url.ldap.openldap-c-api;">draft-ietf-ldapext-ldap-c-api-xx.txt</link>
+       if not supplied. See <link xlink:href="&url.ldap.openldap-c-api;">draft-ietf-ldapext-ldap-c-api-xx.txt</link>
        for details. See also the second example below.
       </para>
      </listitem>


### PR DESCRIPTION
Used gen_stub.php to update information in method synopses.
Had to fix ldap_connect by hand because of the deprecated signature
 information.