### PR TITLE
Argument of sapi_windows_cp_get is optional

### DIFF
--- a/reference/misc/functions/sapi-windows-cp-get.xml
+++ b/reference/misc/functions/sapi-windows-cp-get.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis role="procedural">
    <type>int</type><methodname>sapi_windows_cp_get</methodname>
-   <methodparam><type>string</type><parameter>kind</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>kind</parameter><initializer>""</initializer></methodparam>
   </methodsynopsis>
   <para>
    Get the identifier of the codepage of the current process.


### PR DESCRIPTION
I'm a bit confused on how to document the rest of this since I havent used it myself. "If the value is the empty string (or an unrecognized value), this returns the current code page without restricting it to ansi or oem categories"? 

An example use of `sapi_windows_cp_get()` with no args would be to fetch the old code page, set it to run a command, then restore the old code page https://github.com/search?l=PHP&p=2&q=sapi_windows_cp_get&type=Code

```c
// win32/codepage.c
	if (kind_len == sizeof("ansi")-1 && !strncasecmp(kind, "ansi", kind_len)) {
		RETURN_LONG(GetACP());
	} else if (kind_len == sizeof("oem")-1 && !strncasecmp(kind, "oem", kind_len)) {
		RETURN_LONG(GetOEMCP());
	} else {
		const struct php_win32_cp *cp = php_win32_cp_get_current();
		RETURN_LONG(cp->id);
	}
```