### PR TITLE
Updating mysqli: Remove PHP 5 mentions from options and fix bug #68923

### DIFF
--- a/reference/mysqli/mysqli/options.xml
+++ b/reference/mysqli/mysqli/options.xml
@@ -57,24 +57,29 @@
          <tbody>
           <row>
            <entry><constant>MYSQLI_OPT_CONNECT_TIMEOUT</constant></entry>
-           <entry>connection timeout in seconds</entry>
+           <entry>Connection timeout in seconds</entry>
           </row>
           <row>
            <entry><constant>MYSQLI_OPT_READ_TIMEOUT</constant></entry>
-           <entry>command execution result timeout in seconds. Available as of PHP 7.2.0.</entry>
+           <entry>Command execution result timeout in seconds. Available as of PHP 7.2.0.</entry>
           </row>
           <row>
            <entry><constant>MYSQLI_OPT_LOCAL_INFILE</constant></entry>
-           <entry>enable/disable use of <literal>LOAD LOCAL INFILE</literal></entry>
+           <entry>Enable/disable use of <literal>LOAD LOCAL INFILE</literal></entry>
           </row>
           <row>
            <entry><constant>MYSQLI_INIT_COMMAND</constant></entry>
-           <entry>command to execute after when connecting to MySQL server</entry>
+           <entry>Command to execute after when connecting to MySQL server</entry>
+          </row>
+          <row>
+           <entry><constant>MYSQLI_SET_CHARSET_NAME</constant></entry>
+           <entry>The charset to be set as default.</entry>
           </row>
           <row>
            <entry><constant>MYSQLI_READ_DEFAULT_FILE</constant></entry>
            <entry>
             Read options from named option file instead of <filename>my.cnf</filename>
+            Not supported by mysqlnd.
            </entry>
           </row>
           <row>
@@ -82,40 +87,40 @@
            <entry>
             Read options from the named group from <filename>my.cnf</filename>
             or the file specified with <constant>MYSQL_READ_DEFAULT_FILE</constant>.
+            Not supported by mysqlnd.
            </entry>
           </row>
           <row>
            <entry><constant>MYSQLI_SERVER_PUBLIC_KEY</constant></entry>
            <entry>
              RSA public key file used with the SHA-256 based authentication.
-             Available since PHP 5.5.0.
            </entry>
           </row>
           <row>
            <entry><constant>MYSQLI_OPT_NET_CMD_BUFFER_SIZE</constant></entry>
            <entry>
              The size of the internal command/network buffer. Only valid for
-             mysqlnd. Available since PHP 5.3.0.
+             mysqlnd.
            </entry>
           </row>
           <row>
            <entry><constant>MYSQLI_OPT_NET_READ_BUFFER_SIZE</constant></entry>
            <entry>
              Maximum read chunk size in bytes when reading the body of a MySQL
-             command packet. Only valid for mysqlnd. Available since PHP 5.3.0.
+             command packet. Only valid for mysqlnd.
            </entry>
           </row>
           <row>
            <entry><constant>MYSQLI_OPT_INT_AND_FLOAT_NATIVE</constant></entry>
            <entry>
              Convert integer and float columns back to PHP numbers. Only valid
-             for mysqlnd. Available since PHP 5.3.0.
+             for mysqlnd.
            </entry>
           </row>
           <row>
            <entry><constant>MYSQLI_OPT_SSL_VERIFY_SERVER_CERT</constant></entry>
            <entry>
-            Available since PHP 5.3.0.
+            Whether to verify server certificate or not.
            </entry>
           </row>
          </tbody>


### PR DESCRIPTION
This PR partially fixes https://bugs.php.net/bug.php?id=68923 but listing all possible options would be too much. The options given there are the most common options given as an example. That list is not exhaustive. 

I was not sure whether the note _"mysqli_options() should be called after mysqli_init() and before mysqli_real_connect()"_ should be reworded. This is not entirely true as some options can be changed at any given time e.g. `MYSQLI_OPT_INT_AND_FLOAT_NATIVE`