### PR TITLE
Updating mysqli: Remove pre-deprecation notice

### DIFF
--- a/reference/mysqli/mysqli_stmt/construct.xml
+++ b/reference/mysqli/mysqli_stmt/construct.xml
@@ -17,17 +17,6 @@
   <para>
    This method constructs a new <classname>mysqli_stmt</classname> object.
   </para>
-  <note>
-   <para>
-    In general, you should use either <function>mysqli_prepare</function> or
-    <function>mysqli_stmt_init</function> to create a
-    <classname>mysqli_stmt</classname> object, rather than directly
-    instantiating the object with <literal>new mysqli_stmt</literal>. This
-    method (and the ability to directly instantiate
-    <classname>mysqli_stmt</classname> objects) may be deprecated and removed
-    in the future.
-   </para>
-  </note>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
After giving it some thought I decided that there is absolutely no reason to have a confusing pre-deprecation notice in the documentation for this constructor. There are no plans to deprecate it, it works as designed, and there are no technical downsides to using it. If this function were going to be deprecated then it would have happened in the past 15 years. 
The only reason why someone might not want to use it is a personal preference. Telling people not to use something because **it might be** deprecated is a terrible practice. 
Also, using procedural style functions over OO style is arguably a worse suggestion. 