### PR TITLE
Removed literal tags from title for readability

### DIFF
--- a/language/control-structures/break.xml
+++ b/language/control-structures/break.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 
 <sect1 xml:id="control-structures.break" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title><literal>break</literal></title>
+ <title>break</title>
  <?phpdoc print-version-for="break"?>
  <simpara>
   <literal>break</literal> ends execution of the current

--- a/language/control-structures/continue.xml
+++ b/language/control-structures/continue.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 
 <sect1 xml:id="control-structures.continue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title><literal>continue</literal></title>
+ <title>continue</title>
  <?phpdoc print-version-for="continue"?>
  <simpara>
   <literal>continue</literal> is used within looping structures to

--- a/language/control-structures/declare.xml
+++ b/language/control-structures/declare.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 
 <sect1 xml:id="control-structures.declare" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title><literal>declare</literal></title>
+ <title>declare</title>
  <?phpdoc print-version-for="declare"?>
  <para>
   The <literal>declare</literal> construct is used to

--- a/language/control-structures/do-while.xml
+++ b/language/control-structures/do-while.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 
 <sect1 xml:id="control-structures.do.while" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title><literal>do-while</literal></title>
+ <title>do-while</title>
  <?phpdoc print-version-for="dowhile"?>
  <simpara>
   <literal>do-while</literal> loops are very similar to

--- a/language/control-structures/else.xml
+++ b/language/control-structures/else.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 
 <sect1 xml:id="control-structures.else" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title><literal>else</literal></title>
+ <title>else</title>
  <?phpdoc print-version-for="else"?>
  <para>
   Often you'd want to execute a statement if a certain condition is

--- a/language/control-structures/elseif.xml
+++ b/language/control-structures/elseif.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 
 <sect1 xml:id="control-structures.elseif" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title><literal>elseif</literal>/<literal>else if</literal></title>
+ <title>elseif/else if</title>
  <?phpdoc print-version-for="elseif"?>
  <para>
   <literal>elseif</literal>, as its name suggests, is a combination

--- a/language/control-structures/for.xml
+++ b/language/control-structures/for.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 
 <sect1 xml:id="control-structures.for" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title><literal>for</literal></title>
+ <title>for</title>
  <?phpdoc print-version-for="for"?>
  <para>
   <literal>for</literal> loops are the most complex loops in PHP.

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 
 <sect1 xml:id="control-structures.foreach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title><literal>foreach</literal></title>
+ <title>foreach</title>
  <?phpdoc print-version-for="foreach"?>
  <para>
   The <literal>foreach</literal> construct provides an easy way to

--- a/language/control-structures/goto.xml
+++ b/language/control-structures/goto.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 
 <sect1 xml:id="control-structures.goto" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title><literal>goto</literal></title>
+ <title>goto</title>
  <?phpdoc print-version-for="goto"?>
  <para>
   <mediaobject>

--- a/language/control-structures/if.xml
+++ b/language/control-structures/if.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 
 <sect1 xml:id="control-structures.if" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title><literal>if</literal></title>
+ <title>if</title>
  <?phpdoc print-version-for="if"?>
  <para>
   The <literal>if</literal> construct is one of the most important

--- a/language/control-structures/match.xml
+++ b/language/control-structures/match.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 
 <sect1 xml:id="control-structures.match" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title><literal>match</literal></title>
+ <title>match</title>
  <?phpdoc print-version-for="match"?>
  <para>
   The <literal>match</literal> expression branches evaluation based on an

--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 
 <sect1 xml:id="control-structures.switch" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title><literal>switch</literal></title>
+ <title>switch</title>
  <?phpdoc print-version-for="switch"?>
  <simpara>
   The <literal>switch</literal> statement is similar to a series of

--- a/language/control-structures/while.xml
+++ b/language/control-structures/while.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 
 <sect1 xml:id="control-structures.while" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title><literal>while</literal></title>
+ <title>while</title>
  <?phpdoc print-version-for="while"?>
  <para>
   <literal>while</literal> loops are the simplest type of loop in


### PR DESCRIPTION
After recent changes the headers for control structures look really small. I removed the code highlighted which seems pretty useless in the title to improve readability. 