### PR TITLE
utf8 has been deprecated for past 10 years

### DIFF
--- a/reference/mysqli/mysqli/set-charset.xml
+++ b/reference/mysqli/mysqli/set-charset.xml
@@ -86,9 +86,9 @@ if (mysqli_connect_errno()) {
 
 printf("Initial character set: %s\n", $mysqli->character_set_name());
 
-/* change character set to utf8 */
-if (!$mysqli->set_charset("utf8")) {
-    printf("Error loading character set utf8: %s\n", $mysqli->error);
+/* change character set to utf8mb4 */
+if (!$mysqli->set_charset("utf8mb4")) {
+    printf("Error loading character set utf8mb4: %s\n", $mysqli->error);
     exit();
 } else {
     printf("Current character set: %s\n", $mysqli->character_set_name());
@@ -112,9 +112,9 @@ if (mysqli_connect_errno()) {
 
 printf("Initial character set: %s\n", mysqli_character_set_name($link));
 
-/* change character set to utf8 */
-if (!mysqli_set_charset($link, "utf8")) {
-    printf("Error loading character set utf8: %s\n", mysqli_error($link));
+/* change character set to utf8mb4 */
+if (!mysqli_set_charset($link, "utf8mb4")) {
+    printf("Error loading character set utf8mb4: %s\n", mysqli_error($link));
     exit();
 } else {
     printf("Current character set: %s\n", mysqli_character_set_name($link));
@@ -128,7 +128,7 @@ mysqli_close($link);
    <screen>
 <![CDATA[
 Initial character set: latin1
-Current character set: utf8
+Current character set: utf8mb4
 ]]>
    </screen>
   </example>

--- a/reference/mysqlinfo/concepts.xml
+++ b/reference/mysqlinfo/concepts.xml
@@ -146,16 +146,16 @@ if ($uresult) {
 $mysqli = new mysqli("localhost", "my_user", "my_password", "world");
 
 // Will NOT affect $mysqli->real_escape_string();
-$mysqli->query("SET NAMES utf8");
+$mysqli->query("SET NAMES utf8mb4");
 
 // Will NOT affect $mysqli->real_escape_string();
-$mysqli->query("SET CHARACTER SET utf8");
+$mysqli->query("SET CHARACTER SET utf8mb4");
 
 // But, this will affect $mysqli->real_escape_string();
-$mysqli->set_charset('utf8');
+$mysqli->set_charset('utf8mb4');
 
-// But, this will NOT affect it (utf-8 vs utf8) -- don't use dashes here
-$mysqli->set_charset('utf-8');
+// But, this will NOT affect it (UTF-8 vs utf8mb4) -- don't use dashes here
+$mysqli->set_charset('UTF-8');
 
 ?>
 ]]>
@@ -171,9 +171,8 @@ $mysqli->set_charset('utf-8');
    <title>Possible UTF-8 confusion</title>
    <para>
     Because character set names in MySQL do not contain dashes, the string 
-    "utf8" is valid in MySQL to set the character set to UTF-8. The string 
-    "utf-8" is not valid, as using "utf-8" will fail to change the
-    character set.
+    "utf8" is valid in MySQL to set the character set to UTF-8 (3-Byte UTF-8 Unicode Encoding). The string 
+    "UTF-8" is not valid, as using "UTF-8" will fail to change the character set and will throw an error.
    </para>
   </note>
 
@@ -186,8 +185,8 @@ $mysqli = new mysqli("localhost", "my_user", "my_password", "world");
 
 printf("Initial character set: %s\n", $mysqli->character_set_name());
 
-if (!$mysqli->set_charset('utf8')) {
-    printf("Error loading character set utf8: %s\n", $mysqli->error);
+if (!$mysqli->set_charset('utf8mb4')) {
+    printf("Error loading character set utf8mb4: %s\n", $mysqli->error);
     exit;
 }
 
@@ -207,7 +206,7 @@ print_r( $mysqli->get_charset() );
    <programlisting role="php">
 <![CDATA[
 <?php
-$pdo = new PDO("mysql:host=localhost;dbname=world;charset=utf8", 'my_user', 'my_pass');
+$pdo = new PDO("mysql:host=localhost;dbname=world;charset=utf8mb4", 'my_user', 'my_pass');
 ?>
 ]]>
    </programlisting>
@@ -223,7 +222,7 @@ $db   = mysql_select_db("world");
 
 echo 'Initial character set: ' .  mysql_client_encoding($conn) . "\n";
 
-if (!mysql_set_charset('utf8', $conn)) {
+if (!mysql_set_charset('utf8mb4', $conn)) {
     echo "Error: Unable to set the character set.\n";
     exit;
 }

--- a/reference/mysqlnd_ms/setup.xml
+++ b/reference/mysqlnd_ms/setup.xml
@@ -2389,7 +2389,7 @@ function pick_server($connected, $query, $masters, $slaves, $last_used_connectio
             }
         },
         "lazy_connections": 1,
-        "server_charset" : "utf8"
+        "server_charset" : "utf8mb4"
     }
 }
 ]]>
@@ -2398,10 +2398,10 @@ function pick_server($connected, $query, $masters, $slaves, $last_used_connectio
 <![CDATA[
 <?php
 $mysqli = new mysqli("myapp", "username", "password", "database");
-$mysqli->real_escape("this will be escaped using the server_charset setting - utf8");
+$mysqli->real_escape("this will be escaped using the server_charset setting - utf8mb4");
 $mysqli->set_charset("latin1");
 $mysqli->real_escape("this will be escaped using latin1");
-/* server_charset implicitly set - utf8 connection */
+/* server_charset implicitly set - utf8mb4 connection */
 $mysqli->query("SELECT 'This connection will be set to server_charset upon establishing' AS _msg FROM DUAL");
 /* latin1 used from now on */
 $mysqli->set_charset("latin1");


### PR DESCRIPTION
Following MySQL's recommendation from here https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-utf8.html I changed the examples to talk about `utf8mb4` instead. 
As we know, MySQL deprecated the ill-conceived `utf8` charset in 2010.  Some explanation can be found in this document https://mysqlserverteam.com/mysql-8-0-when-to-use-utf8mb3-over-utf8mb4/