### PR TITLE
Remove PHP 5 from mysqli, PDO_MySQL and mysqlnd

### DIFF
--- a/reference/mysqli/book.xml
+++ b/reference/mysqli/book.xml
@@ -60,6 +60,12 @@
  &reference.mysqli.mysqli-sql-exception;
  &reference.mysqli.reference;
 
+<appendix xmlns="http://docbook.org/ns/docbook" xml:id="changelog.mysqli">
+ <title>&ChangelogListingTitle;</title>
+ <para>&ChangelogListingDescription;</para>
+ <?phpdoc generate-changelog-for="ref.mysqli class.mysqli class.mysqli-stmt class.mysqli-result class.mysqli-driver class.mysqli-warning class.mysqli-sql-exception"?>
+</appendix>
+
 </book>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mysqli/book.xml
+++ b/reference/mysqli/book.xml
@@ -60,12 +60,6 @@
  &reference.mysqli.mysqli-sql-exception;
  &reference.mysqli.reference;
 
-<appendix xmlns="http://docbook.org/ns/docbook" xml:id="changelog.mysqli">
- <title>&ChangelogListingTitle;</title>
- <para>&ChangelogListingDescription;</para>
- <?phpdoc generate-changelog-for="ref.mysqli class.mysqli class.mysqli-stmt class.mysqli-result class.mysqli-driver class.mysqli-warning class.mysqli-sql-exception"?>
-</appendix>
-
 </book>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -74,6 +74,7 @@
     <term><constant>MYSQLI_OPT_SSL_VERIFY_SERVER_CERT</constant></term>
     <listitem>
      <para>
+      Requires MySQL 5.1.10 and up
      </para>
     </listitem>
    </varlistentry>
@@ -528,7 +529,7 @@
     <term><constant>MYSQLI_DATA_TRUNCATED</constant></term>
     <listitem>
      <para>
-      Data truncation occurred.
+      Data truncation occurred. Available since MySQL 5.0.5.
      </para>
     </listitem>
    </varlistentry>
@@ -812,6 +813,7 @@
     <term><constant>MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT</constant></term>
     <listitem>
      <para>
+      Requires MySQL 5.6.5 and up.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -50,7 +50,6 @@
     <listitem>
      <para>
       Convert integer and float columns back to PHP numbers. Only valid for mysqlnd.
-      Available since PHP 5.3.0.
      </para>
     </listitem>
    </varlistentry>
@@ -59,7 +58,6 @@
     <listitem>
      <para>
       The size of the internal command/network buffer. Only valid for mysqlnd.
-      Available since PHP 5.3.0.
      </para>
     </listitem>
    </varlistentry>
@@ -68,7 +66,7 @@
     <listitem>
      <para>
       Maximum read chunk size in bytes when reading the body of a MySQL command packet.
-      Only valid for mysqlnd. Available since PHP 5.3.0.
+      Only valid for mysqlnd.
      </para>
     </listitem>
    </varlistentry>
@@ -76,7 +74,6 @@
     <term><constant>MYSQLI_OPT_SSL_VERIFY_SERVER_CERT</constant></term>
     <listitem>
      <para>
-      Available since PHP 5.3.0. (MySQL 5.1.10 and up)
      </para>
     </listitem>
    </varlistentry>
@@ -531,7 +528,7 @@
     <term><constant>MYSQLI_DATA_TRUNCATED</constant></term>
     <listitem>
      <para>
-      Data truncation occurred. Available since PHP 5.1.0 and MySQL 5.0.5.
+      Data truncation occurred.
      </para>
     </listitem>
    </varlistentry>
@@ -539,7 +536,7 @@
     <term><constant>MYSQLI_ENUM_FLAG</constant></term>
     <listitem>
      <para>
-     Field is defined as <literal>ENUM</literal>. Available since PHP 5.3.0.
+     Field is defined as <literal>ENUM</literal>.
      </para>
     </listitem>
    </varlistentry>
@@ -547,7 +544,7 @@
     <term><constant>MYSQLI_BINARY_FLAG</constant></term>
     <listitem>
      <para>
-      Field is defined as <literal>BINARY</literal>. Available since PHP 5.3.0.
+      Field is defined as <literal>BINARY</literal>.
      </para>
     </listitem>
    </varlistentry>
@@ -673,7 +670,6 @@
     <term><constant>MYSQLI_SERVER_PUBLIC_KEY</constant></term>
     <listitem>
      <para>
-      Available since PHP 5.5.0.
      </para>
     </listitem>
    </varlistentry>
@@ -816,7 +812,6 @@
     <term><constant>MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT</constant></term>
     <listitem>
      <para>
-      Available since PHP 5.6.16. (MySQL 5.6.5 and up)
      </para>
     </listitem>
    </varlistentry>

--- a/reference/mysqli/ini.xml
+++ b/reference/mysqli/ini.xml
@@ -20,7 +20,7 @@
       <entry><link linkend="ini.mysqli.allow-local-infile">mysqli.allow_local_infile</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available as of PHP 5.2.4. Before PHP 7.2.16 and 7.3.3 the default was "1".</entry>
+      <entry>Before PHP 7.2.16 and 7.3.3 the default was "1".</entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqli.local-infile-directory">mysqli.local_infile_directory</link></entry>
@@ -32,13 +32,13 @@
       <entry><link linkend="ini.mysqli.allow-persistent">mysqli.allow_persistent</link></entry>
       <entry>"1"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available as of PHP 5.3.0.</entry>
+      <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqli.max-persistent">mysqli.max_persistent</link></entry>
       <entry>"-1"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available as of PHP 5.3.0.</entry>
+      <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqli.max-links">mysqli.max_links</link></entry>
@@ -86,7 +86,7 @@
       <entry><link linkend="ini.mysqli.rollback-on-cached-plink">mysqli.rollback_on_cached_plink</link></entry>
       <entry>TRUE</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available as of PHP 5.6.0.</entry>
+      <entry></entry>
      </row>
     </tbody>
    </tgroup>

--- a/reference/mysqli/mysqli/commit.xml
+++ b/reference/mysqli/mysqli/commit.xml
@@ -69,31 +69,6 @@
   </note>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>5.5.0</entry>
-       <entry>
-        Added <parameter>flags</parameter> and <parameter>name</parameter>
-        parameters.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/mysqli/mysqli/connect-error.xml
+++ b/reference/mysqli/mysqli/connect-error.xml
@@ -39,7 +39,6 @@
 <?php
 $mysqli = @new mysqli('localhost', 'fake_user', 'my_password', 'my_db');
 
-// Works as of PHP 5.2.9 and 5.3.0.
 if ($mysqli->connect_error) {
     die('Connect Error: ' . $mysqli->connect_error);
 }
@@ -65,18 +64,6 @@ Connect Error: Access denied for user 'fake_user'@'localhost' (using password: Y
 ]]>
    </screen>
   </example>
- </refsect1>
-
- <refsect1 role="notes">
-  &reftitle.notes;
-  <warning>
-   <para>
-    The mysqli-&gt;connect_error property only works properly
-    as of PHP versions 5.2.9 and 5.3.0.
-    Use the <function>mysqli_connect_error</function>
-    function if compatibility with earlier PHP versions is required.
-   </para>
-  </warning>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mysqli/mysqli/real-connect.xml
+++ b/reference/mysqli/mysqli/real-connect.xml
@@ -190,30 +190,6 @@
    </variablelist>
   </para>
  </refsect1>
- 
- <refsect1 role="changelog"><!-- {{{ -->
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>5.6.16</entry>
-       <entry>
-        Added the <constant>MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT</constant> flag for MySQL Native Driver
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1><!-- }}} -->
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;

--- a/reference/mysqli/mysqli/rollback.xml
+++ b/reference/mysqli/mysqli/rollback.xml
@@ -69,31 +69,6 @@
   </note>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>5.5.0</entry>
-       <entry>
-        Added <parameter>flags</parameter> and <parameter>name</parameter>
-        parameters.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/mysqli/mysqli/ssl-set.xml
+++ b/reference/mysqli/mysqli/ssl-set.xml
@@ -34,13 +34,6 @@
    nothing unless OpenSSL support is enabled.
   </para>
 
-  <para>
-    Note that MySQL Native Driver does not support SSL before PHP 5.3.3, 
-    so calling this function when using MySQL Native Driver will result 
-    in an error. MySQL Native Driver is enabled by default on Microsoft 
-    Windows from PHP version 5.3 onwards.
-  </para>
-
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli/store-result.xml
+++ b/reference/mysqli/mysqli/store-result.xml
@@ -53,7 +53,7 @@
            mysqlnd will use a reference logic to avoid copying and duplicating results held in memory.
            For certain result sets, for example, result sets with many small rows, the copy approach can
            reduce the overall memory usage because PHP variables holding results may be
-           released earlier (available with mysqlnd only, since PHP 5.6.0)</entry>
+           released earlier (available with mysqlnd only)</entry>
           </row>
          </tbody>
         </tgroup>

--- a/reference/mysqli/mysqli_result.xml
+++ b/reference/mysqli/mysqli_result.xml
@@ -12,32 +12,6 @@
    <para>
     Represents the result set obtained from a query against the database.
    </para>
-   
-   <para>
-    <emphasis role="bold">&Changelog;</emphasis>
-   </para>
-
-   <table>
-    <title>&Changelog;</title>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>5.4.0</entry>
-       <entry>
-        <classname>Iterator</classname> support was added, as <classname>mysqli_result</classname>
-        now implements <classname>Traversable</classname>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </table>  
-   
   </section>
 <!-- }}} -->
  

--- a/reference/mysqli/mysqli_result/fetch-field.xml
+++ b/reference/mysqli/mysqli_result/fetch-field.xml
@@ -74,11 +74,11 @@
      </row>
      <row>
       <entry>db</entry>
-      <entry>Database (since PHP 5.3.6)</entry>
+      <entry>The name of the database</entry>
      </row>
      <row>
       <entry>catalog</entry>
-      <entry>The catalog name, always "def" (since PHP 5.3.6)</entry>
+      <entry>The catalog name, always "def"</entry>
      </row>
      <row>
       <entry>max_length</entry>

--- a/reference/mysqli/persistconns.xml
+++ b/reference/mysqli/persistconns.xml
@@ -5,9 +5,7 @@
  <title>The mysqli Extension and Persistent Connections</title>
 
  <para>
-  Persistent connection support was introduced in PHP 5.3 for the
-  <literal>mysqli</literal> extension. Support was already present in
-  PDO MYSQL and ext/mysql. The idea behind persistent connections is
+  The idea behind persistent connections is
   that a connection between a client process and a database can be
   reused by a client process, rather than being created and destroyed
   multiple times. This reduces the overhead of creating fresh

--- a/reference/mysqlinfo/concepts.xml
+++ b/reference/mysqlinfo/concepts.xml
@@ -201,9 +201,6 @@ print_r( $mysqli->get_charset() );
 
   <example>
    <title>Setting the character set example: <link linkend="ref.pdo-mysql.connection">pdo_mysql</link></title>
-   <para>
-    Note: This only works as of PHP 5.3.6.
-   </para>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/mysqlnd/config.xml
+++ b/reference/mysqlnd/config.xml
@@ -22,70 +22,70 @@
       <entry><link linkend="ini.mysqlnd.collect-statistics">mysqlnd.collect_statistics</link></entry>
       <entry>"1"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since PHP 5.3.0.</entry>
+      <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqlnd.collect-memory-statistics">mysqlnd.collect_memory_statistics</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since PHP 5.3.0.</entry>
+      <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqlnd.debug">mysqlnd.debug</link></entry>
       <entry>""</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since PHP 5.3.0.</entry>
+      <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqlnd.log-mask">mysqlnd.log_mask</link></entry>
       <entry>0</entry>
       <entry>PHP_INI_ALL</entry>
-      <entry>Available since PHP 5.3.0</entry>
+      <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqlnd.mempool-default-size">mysqlnd.mempool_default_size</link></entry>
       <entry>16000</entry>
       <entry>PHP_INI_ALL</entry>
-      <entry>Available since PHP 5.3.3</entry>
+      <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqlnd.net-read-timeout">mysqlnd.net_read_timeout</link></entry>
       <entry>"86400"</entry>
       <entry>PHP_INI_ALL</entry>
       <entry>
-       Available since PHP 5.3.0. Before PHP 7.2.0 the default value was "31536000"
+       Before PHP 7.2.0 the default value was "31536000"
        and the changeability was <constant>PHP_INI_SYSTEM</constant>
       </entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqlnd.net-cmd-buffer-size">mysqlnd.net_cmd_buffer_size</link></entry>
-      <entry>5.3.0 - "2048", 5.3.1 - "4096"</entry>
+      <entry>"4096"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since PHP 5.3.0.</entry>
+      <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqlnd.net-read-buffer-size">mysqlnd.net_read_buffer_size</link></entry>
       <entry>"32768"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since PHP 5.3.0.</entry>
+      <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqlnd.sha256-server-public-key">mysqlnd.sha256_server_public_key</link></entry>
       <entry>""</entry>
       <entry>PHP_INI_PERDIR</entry>
-      <entry>Available since PHP 5.5.0.</entry>
+      <entry></entry>
      </row>
       <row>
        <entry><link linkend="ini.mysqlnd.trace-alloc">mysqlnd.trace_alloc</link></entry>
        <entry>""</entry>
        <entry>PHP_INI_SYSTEM</entry>
-       <entry>Available since PHP 5.5.0.</entry>
+       <entry></entry>
       </row>
      <row>
       <entry><link linkend="ini.mysqlnd.fetch_data_copy">mysqlnd.fetch_data_copy</link></entry>
       <entry>0</entry>
       <entry>PHP_INI_ALL</entry>
-      <entry>Available since PHP 5.6.0.</entry>
+      <entry></entry>
      </row>
     </tbody>
    </tgroup>
@@ -354,28 +354,7 @@ d:t:x:O,/tmp/mysqlnd.trace
       the default size to avoid re-allocations.
      </para>
      <para>
-      The default buffer size is 2048 bytes in PHP 5.3.0. In later
-      versions the default is 4096 bytes.
-     </para>
-     <para>
-      It is recommended that the buffer size be set to no less than 4096
-      bytes because <literal>mysqlnd</literal> also uses it when reading
-      certain communication packet from MySQL. In PHP 5.3.0,
-      <literal>mysqlnd</literal> will not grow the buffer if MySQL sends
-      a packet that is larger than the current size of the buffer. As a
-      consequence, <literal>mysqlnd</literal> is unable to decode the
-      packet and the client application will get an error. There are
-      only two situations when the packet can be larger than the 2048
-      bytes default of <literal>mysqlnd.net_cmd_buffer_size</literal> in
-      PHP 5.3.0: the packet transports a very long error message, or the
-      packet holds column meta data from
-      <literal>COM_LIST_FIELD</literal>
-      (<literal>mysql_list_fields()</literal> and the meta data come
-      from a string column with a very long default value (>1900 bytes).
-     </para>
-     <para>
-      As of PHP 5.3.2 mysqlnd does not allow setting buffers smaller
-      than 4096 bytes.
+      The default buffer size is 4096 bytes, which is the smallest value possible.
      </para>
      <para>
       The value can also be set using <literal>mysqli_options(link,

--- a/reference/mysqlnd/install.xml
+++ b/reference/mysqlnd/install.xml
@@ -5,47 +5,6 @@
   <title>Installation</title>
 
   <para>
-   <emphasis role="bold">&Changelog;</emphasis>
-  </para>
-
-  <table>
-   <title>&Changelog;</title>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>&Version;</entry>
-      <entry>&Description;</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>5.3.0</entry>
-      <entry>
-       The MySQL Native Driver was added, with support for all MySQL
-       extensions (i.e., mysql, mysqli and PDO_MYSQL). Passing in
-       <literal>mysqlnd</literal> to the appropriate configure switch
-       enables this support.
-      </entry>
-     </row>
-     <row>
-      <entry>5.4.0</entry>
-      <entry>
-       The MySQL Native Driver is now the default for all MySQL
-       extensions (i.e., mysql, mysqli and PDO_MYSQL). Passing
-       in <literal>mysqlnd</literal> to configure is now optional.
-      </entry>
-     </row>
-     <row>
-      <entry>5.5.0</entry>
-      <entry>
-       SHA-256 Authentication Plugin support was added
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </table>
-
-  <para>
     <emphasis role="bold">Installation on Unix</emphasis>
   </para>
 
@@ -77,7 +36,7 @@
   </para>
 
   <para>
-    In the official PHP Windows distributions from 5.3 onwards, MySQL Native
+    In the official PHP Windows distributions, MySQL Native
     Driver is enabled by default, so no additional configuration is
     required to use it. All MySQL database extensions will use MySQL
     Native Driver in this case.

--- a/reference/mysqlnd/overview.xml
+++ b/reference/mysqlnd/overview.xml
@@ -97,6 +97,12 @@
   with the <literal>mysqli</literal> extension.
  </para>
  <para>
+  <emphasis role="bold">SSL Support</emphasis>
+ </para>
+ <para>
+  MySQL Native Driver supports SSL.
+ </para>
+ <para>
   <emphasis role="bold">Compressed Protocol Support</emphasis>
  </para>
  <para>
@@ -104,6 +110,12 @@
   server protocol. Extension <literal>ext/mysqli</literal>, if configured to use MySQL Native Driver, 
   can also take advantage of this feature. Note that <literal>PDO_MYSQL</literal> 
   does <emphasis>NOT</emphasis> support compression when used together with mysqlnd.
+ </para>
+ <para>
+  <emphasis role="bold">Named Pipes Support</emphasis>
+ </para>
+ <para>
+  Named pipes can be used to connect on Windows platforms.
  </para>
 </chapter>
 <!-- Keep this comment at the end of the file

--- a/reference/mysqlnd/overview.xml
+++ b/reference/mysqlnd/overview.xml
@@ -97,27 +97,13 @@
   with the <literal>mysqli</literal> extension.
  </para>
  <para>
-  <emphasis role="bold">SSL Support</emphasis>
- </para>
- <para>
-  MySQL Native Driver has supported SSL since PHP version 5.3.3 
- </para>
- <para>
   <emphasis role="bold">Compressed Protocol Support</emphasis>
  </para>
  <para>
-  As of PHP 5.3.2 MySQL Native Driver supports the compressed client
-  server protocol. MySQL Native Driver did not support this in 5.3.0 and
-  5.3.1. Extensions such as <literal>ext/mysql</literal>,
-  <literal>ext/mysqli</literal>, that are configured to use MySQL Native Driver, 
+  MySQL Native Driver supports the compressed client
+  server protocol. Extension <literal>ext/mysqli</literal>, if configured to use MySQL Native Driver, 
   can also take advantage of this feature. Note that <literal>PDO_MYSQL</literal> 
   does <emphasis>NOT</emphasis> support compression when used together with mysqlnd.
- </para>
- <para>
-  <emphasis role="bold">Named Pipes Support</emphasis>
- </para>
- <para>
-  Named pipes support for Windows was added in PHP version 5.4.0. 
  </para>
 </chapter>
 <!-- Keep this comment at the end of the file

--- a/reference/mysqlnd/overview.xml
+++ b/reference/mysqlnd/overview.xml
@@ -115,7 +115,7 @@
   <emphasis role="bold">Named Pipes Support</emphasis>
  </para>
  <para>
-  Named pipes can be used to connect on Windows platforms.
+  Named pipes can be used to connect on Windows environments.
  </para>
 </chapter>
 <!-- Keep this comment at the end of the file

--- a/reference/mysqlnd/plugin.xml
+++ b/reference/mysqlnd/plugin.xml
@@ -282,43 +282,6 @@
    source snapshot downloads.
   </para>
   <para>
-   The following table shows PHP versions and the corresponding
-   <literal>mysqlnd</literal> version contained within.
-  </para>
-  <table>
-   <title>The bundled mysqlnd version per PHP release</title>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>PHP Version</entry>
-      <entry>MySQL Native Driver version</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>5.3.0</entry>
-      <entry>5.0.5</entry>
-     </row>
-     <row>
-      <entry>5.3.1</entry>
-      <entry>5.0.5</entry>
-     </row>
-     <row>
-      <entry>5.3.2</entry>
-      <entry>5.0.7</entry>
-     </row>
-     <row>
-      <entry>5.3.3</entry>
-      <entry>5.0.7</entry>
-     </row>
-     <row>
-      <entry>5.3.4</entry>
-      <entry>5.0.7</entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </table>
-  <para>
    Plugin developers can determine the <literal>mysqlnd</literal>
    version through accessing <literal>MYSQLND_VERSION</literal>, which
    is a string of the format <quote>mysqlnd 5.0.7-dev - 091210 -
@@ -886,16 +849,6 @@ static MY_CONN_PROPERTIES** get_conn_properties(const MYSQLND *conn TSRMLS_DC) {
    free your memory and call the parent implementation immediately
    following this.
   </para>
-  <caution>
-   <para>
-    Due to a bug in PHP versions 5.3.0 to 5.3.3, plugins do not
-    associate plugin data with a persistent connection. This is because
-    <literal>ext/mysql</literal> and <literal>ext/mysqli</literal> do
-    not trigger all the necessary <literal>mysqlnd</literal>
-    <literal>end_psession()</literal> method calls and the plugin may
-    therefore leak memory. This has been fixed in PHP 5.3.4.
-   </para>
-  </caution>
  </section>
  <section xml:id="mysqlnd.plugin.api">
   <title>The mysqlnd plugin API</title>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -369,9 +369,7 @@ $res = $mysqli->query("SELECT 'abc'");
 $res->close();
 ]]>
 </programlisting>
-      <para>
-       This statistic is available as of PHP version 5.3.4.
-      </para></entry>
+      </entry>
     </row>
     <row>
      <entry><literal>bytes_received_real_data_ps</literal></entry>
@@ -385,8 +383,7 @@ $res->close();
       full result set may have been pulled from MySQL by
       <literal>mysqlnd</literal>, this statistic only counts actual data
       pulled from <literal>mysqlnd</literal> by the PHP client. See also
-      <literal>bytes_received_real_data_normal</literal>. This statistic
-      is available as of PHP version 5.3.4.</entry>
+      <literal>bytes_received_real_data_normal</literal>.</entry>
     </row>
    </tbody>
   </tgroup>
@@ -1170,34 +1167,11 @@ $link = new mysqli(...); $link->connect(...)
       </para>
 
       <para>
-       The default buffer size is 2048 bytes in PHP 5.3.0. In future
-       versions the default will be 4kB or larger. The default can
+       The default buffer size is 4096 bytes, which is the smallest value possible. The default can
        changed either through the <filename>php.ini</filename> setting
        <literal>mysqlnd.net_cmd_buffer_size</literal> or using
        <literal>mysqli_options(MYSQLI_OPT_NET_CMD_BUFFER_SIZE, int
        size)</literal>.
-      </para>
-
-      <para>
-       It is recommended to set the buffer size to no less than 4096
-       bytes because mysqlnd also uses it when reading certain
-       communication packet from MySQL. In PHP 5.3.0, mysqlnd will not
-       grow the buffer if MySQL sends a packet that is larger than the
-       current size of the buffer. As a consequence mysqlnd is unable to
-       decode the packet and the client application will get an error.
-       There are only two situations when the packet can be larger than
-       the 2048 bytes default of
-       <literal>mysqlnd.net_cmd_buffer_size</literal> in PHP 5.3.0: the
-       packet transports a very long error message or the packet holds
-       column meta data from <literal>COM_LIST_FIELD</literal>
-       (<function>mysql_list_fields</function>) and the meta data comes
-       from a string column with a very long default value (>1900
-       bytes). No bug report on this exists - it should happen rarely.
-      </para>
-
-      <para>
-       As of PHP 5.3.2 mysqlnd does not allow setting buffers smaller
-       than 4096 bytes.
       </para></entry>
     </row>
     <row>

--- a/reference/mysqlnd_memcache/book.xml
+++ b/reference/mysqlnd_memcache/book.xml
@@ -36,7 +36,7 @@
   </note>
   <para>
    The MySQL native driver for PHP is a C library that ships together with
-   PHP as of PHP 5.3.0. It serves as a drop-in replacement for the
+   PHP. It serves as a drop-in replacement for the
    MySQL Client Library (libmysqlclient). Using mysqlnd has
    several advantages: no extra downloads are required because it's bundled with PHP,
    it's under the PHP license, there is lower memory consumption in certain cases, and

--- a/reference/mysqlnd_ms/book.xml
+++ b/reference/mysqlnd_ms/book.xml
@@ -21,7 +21,7 @@
   </para>
   <para>
    The MySQL native driver for PHP is a C library that ships together with
-   PHP as of PHP 5.3.0. It serves as a drop-in replacement for the
+   PHP. It serves as a drop-in replacement for the
    MySQL Client Library (libmysqlclient). Using mysqlnd has
    several advantages: no extra downloads are required because it's bundled with PHP,
    it's under the PHP license, there is lower memory consumption in certain cases, and

--- a/reference/pdo_mysql/configure.xml
+++ b/reference/pdo_mysql/configure.xml
@@ -55,45 +55,6 @@ $ ./configure --with-pdo-mysql --with-mysql-sock=/var/mysql/mysql.sock
   MySQL with SSL</link>.
  </para>
 
- <table>
-  <title>&Changelog;</title>
-  <tgroup cols="2">
-   <thead>
-    <row>
-     <entry>&Version;</entry>
-     <entry>&Description;</entry>
-    </row>
-   </thead>
-   <tbody>
-    <row>
-     <entry>5.4.0</entry>
-     <entry>
-      <link linkend="book.mysqlnd">mysqlnd</link> became the default MySQL library 
-      when compiling PDO_MYSQL. Previously, libmysqlclient was the default MySQL library.
-     </entry>
-    </row>
-    <row>
-     <entry>5.4.0</entry>
-     <entry>
-      MySQL client libraries 4.1 and below are no longer supported. 
-     </entry>
-    </row>
-    <row>
-     <entry>5.3.9</entry>
-     <entry>
-      Added SSL support with mysqlnd and OpenSSL.
-     </entry>
-    </row>
-    <row>
-     <entry>5.3.7</entry>
-     <entry>
-      Added SSL support with libmysqlclient and OpenSSL.
-     </entry>
-    </row>
-   </tbody>
-  </tgroup>
- </table>
-
 </section>
 
 <!-- Keep this comment at the end of the file

--- a/reference/pdo_mysql/constants.xml
+++ b/reference/pdo_mysql/constants.xml
@@ -163,8 +163,7 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
    </term>
    <listitem>
     <para>
-     Enable network communication compression. This is also supported when 
-     compiled against mysqlnd as of PHP 5.3.11.
+     Enable network communication compression.
     </para>
    </listitem>
   </varlistentry>
@@ -177,9 +176,6 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
    <listitem>
     <para>
      The file path to the SSL certificate authority.
-    </para>
-    <para>
-     &version.exists.asof; 5.3.7.
     </para>
    </listitem>
   </varlistentry>
@@ -194,9 +190,6 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
      The file path to the directory that contains the trusted SSL
      CA certificates, which are stored in PEM format.
     </para>
-    <para>
-     &version.exists.asof; 5.3.7.
-    </para>
    </listitem>
   </varlistentry>
 
@@ -208,9 +201,6 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
    <listitem>
     <para>
      The file path to the SSL certificate.
-    </para>
-    <para>
-     &version.exists.asof; 5.3.7.
     </para>
    </listitem>
   </varlistentry>
@@ -225,9 +215,6 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
      A list of one or more permissible ciphers to use for SSL encryption, in a format
      understood by OpenSSL. For example: <literal>DHE-RSA-AES256-SHA:AES128-SHA</literal>
     </para>
-    <para>
-     &version.exists.asof; 5.3.7.
-    </para>
    </listitem>
   </varlistentry>
 
@@ -239,9 +226,6 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
    <listitem>
     <para>
      The file path to the SSL key.
-    </para>
-    <para>
-     &version.exists.asof; 5.3.7.
     </para>
    </listitem>
   </varlistentry>
@@ -274,9 +258,6 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     <para>
      Note, this constant can only be used in the <parameter>driver_options</parameter> 
      array when constructing a new database handle.
-    </para>
-    <para>
-     &version.exists.asof; 5.5.21 and PHP 5.6.5.
     </para>
    </listitem>
   </varlistentry>

--- a/reference/pdo_mysql/reference.xml
+++ b/reference/pdo_mysql/reference.xml
@@ -15,10 +15,7 @@
      to enable access from PHP to MySQL databases.
     </para>
     <para>
-     As of PHP 5.2.1, PDO_MYSQL uses emulated prepares by default.
-     Formerly, PDO_MYSQL defaulted to native prepared statement support
-     present in MySQL 4.1 and higher, and emulated them for older versions of the
-     mysql client libraries.
+     PDO_MYSQL uses emulated prepares by default.
     </para>
 
     <para>
@@ -115,43 +112,6 @@
         <para>
          The character set. See the <link linkend="mysqlinfo.concepts.charset">character set</link>
          concepts documentation for more information.
-        </para>
-        <para>
-         Prior to PHP 5.3.6, this element was silently ignored. The same
-         behaviour can be partly replicated with the
-         <constant>PDO::MYSQL_ATTR_INIT_COMMAND</constant> driver option, as
-         the following example shows.
-        </para>
-        <warning>
-         <simpara>
-          The method in the below example can only be used with character sets
-          that share the same lower 7 bit representation as ASCII, such as
-          ISO-8859-1 and UTF-8. Users using character sets that have different
-          representations (such as UTF-16 or Big5) <emphasis>must</emphasis>
-          use the <literal>charset</literal> option provided in PHP 5.3.6
-          and later versions.
-         </simpara>
-        </warning>
-        <para>
-         <example>
-          <title>
-           Setting the connection character set to UTF-8 prior to PHP 5.3.6
-          </title>
-          <programlisting role="php">
-<![CDATA[
-<?php
-$dsn = 'mysql:host=localhost;dbname=testdb';
-$username = 'username';
-$password = 'password';
-$options = array(
-    PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8',
-); 
-
-$dbh = new PDO($dsn, $username, $password, $options);
-?>
-]]>
-          </programlisting>
-         </example>
         </para>
        </listitem>
       </varlistentry>


### PR DESCRIPTION
I was not sure what to do about https://www.php.net/manual/en/mysqli.installation.php