### PR TITLE
Fixed typo

### DIFF
--- a/reference/tidy/tidy/parsestring.xml
+++ b/reference/tidy/tidy/parsestring.xml
@@ -76,7 +76,7 @@
   &reftitle.returnvalues;
   <para>
    <methodname>tidy::parseString</methodname> returns &true; on success.
-   <function>tidy_parse_srting</function> returns a new <classname>tidy</classname>
+   <function>tidy_parse_string</function> returns a new <classname>tidy</classname>
    instance on success.
    Both, the method and the function return &false; on failure.
   </para>


### PR DESCRIPTION
`tidy_parse_srting` => `tidy_parse_string`