### PR TITLE
ImagickPixel::getColor() takes an int, not a bool

### DIFF
--- a/reference/imagick/imagickpixel/getcolor.xml
+++ b/reference/imagick/imagickpixel/getcolor.xml
@@ -26,8 +26,46 @@
      <term><parameter>normalized</parameter></term>
      <listitem>
       <para>
-       Normalize the color values
+       Normalize the color values. Possible values are 0, 1 or 2.
       </para>
+
+      <table>
+       <title>
+        List of possible values for <parameter>normalized</parameter>
+       </title>
+       <tgroup cols="2">
+        <thead>
+         <row>
+          <entry>
+           <parameter>normalized</parameter>
+          </entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry>
+           <constant>0</constant>
+          </entry>
+          <entry>Values returned in the range 0,255 and will be ints, except
+           for legacy reasons alpha which is 0-1</entry>
+         </row>
+         <row>
+          <entry>
+           <constant>1</constant>
+          </entry>
+          <entry>Values returned in the range 0,1 and will be floats</entry>
+         </row>
+         <row>
+          <entry>
+           <constant>2</constant>
+          </entry>
+          <entry>Values returned in the range 0,255 and will be ints including alpha
+           values i.e. float if ImageMagick was compiled with HDRI, or integers normally.</entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -37,8 +75,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An array of channel values, each normalized if &true; is given as param. Throws
-   ImagickPixelException on error.
+   An array of channel values. Throws ImagickPixelException on error.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Verified in source:

https://github.com/Imagick/imagick/blob/06116aa24b76edaf6b1693198f79e6c295eda8a9/imagickpixel_class.c#L605

(This should definitely be a float, though! Not sure if this can be changed now.)