### PR TITLE
Add new IntlDateFormatter constants.

### DIFF
--- a/reference/intl/dateformatter-constants.xml
+++ b/reference/intl/dateformatter-constants.xml
@@ -52,6 +52,50 @@
      <simpara>Most abbreviated style, only essential data (12/13/52 or 3:30pm)</simpara>
     </listitem>
    </varlistentry>
+   <varlistentry xml:id="intldateformatter.constants.relative_full">
+    <term>
+     <constant>IntlDateFormatter::RELATIVE_FULL</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>The same as <constant>IntlDateFormatter::FULL</constant>, but yesterday, today, and tomorrow
+      show as <literal>yesterday</literal>, <literal>today</literal>, and <literal>tomorrow</literal>,
+      respectively.</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="intldateformatter.constants.relative_long">
+    <term>
+     <constant>IntlDateFormatter::RELATIVE_LONG</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>The same as <constant>IntlDateFormatter::LONG</constant>, but yesterday, today, and tomorrow
+      show as <literal>yesterday</literal>, <literal>today</literal>, and <literal>tomorrow</literal>,
+      respectively.</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="intldateformatter.constants.relative_medium">
+    <term>
+     <constant>IntlDateFormatter::RELATIVE_MEDIUM</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>The same as <constant>IntlDateFormatter::MEDIUM</constant>, but yesterday, today, and tomorrow
+      show as <literal>yesterday</literal>, <literal>today</literal>, and <literal>tomorrow</literal>,
+      respectively.</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="intldateformatter.constants.relative_short">
+    <term>
+     <constant>IntlDateFormatter::RELATIVE_SHORT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>The same as <constant>IntlDateFormatter::SHORT</constant>, but yesterday, today, and tomorrow
+      show as <literal>yesterday</literal>, <literal>today</literal>, and <literal>tomorrow</literal>,
+      respectively.</simpara>
+    </listitem>
+   </varlistentry>
   </variablelist>
  </para>
 

--- a/reference/intl/dateformatter-constants.xml
+++ b/reference/intl/dateformatter-constants.xml
@@ -60,7 +60,7 @@
     <listitem>
      <simpara>The same as <constant>IntlDateFormatter::FULL</constant>, but yesterday, today, and tomorrow
       show as <literal>yesterday</literal>, <literal>today</literal>, and <literal>tomorrow</literal>,
-      respectively.</simpara>
+      respectively.  Available as of PHP 8.0.0</simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="intldateformatter.constants.relative_long">
@@ -71,7 +71,7 @@
     <listitem>
      <simpara>The same as <constant>IntlDateFormatter::LONG</constant>, but yesterday, today, and tomorrow
       show as <literal>yesterday</literal>, <literal>today</literal>, and <literal>tomorrow</literal>,
-      respectively.</simpara>
+      respectively.  Available as of PHP 8.0.0</simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="intldateformatter.constants.relative_medium">
@@ -82,7 +82,7 @@
     <listitem>
      <simpara>The same as <constant>IntlDateFormatter::MEDIUM</constant>, but yesterday, today, and tomorrow
       show as <literal>yesterday</literal>, <literal>today</literal>, and <literal>tomorrow</literal>,
-      respectively.</simpara>
+      respectively.  Available as of PHP 8.0.0</simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="intldateformatter.constants.relative_short">
@@ -93,7 +93,7 @@
     <listitem>
      <simpara>The same as <constant>IntlDateFormatter::SHORT</constant>, but yesterday, today, and tomorrow
       show as <literal>yesterday</literal>, <literal>today</literal>, and <literal>tomorrow</literal>,
-      respectively.</simpara>
+      respectively.  Available as of PHP 8.0.0</simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/intl/dateformatter-constants.xml
+++ b/reference/intl/dateformatter-constants.xml
@@ -60,7 +60,7 @@
     <listitem>
      <simpara>The same as <constant>IntlDateFormatter::FULL</constant>, but yesterday, today, and tomorrow
       show as <literal>yesterday</literal>, <literal>today</literal>, and <literal>tomorrow</literal>,
-      respectively.  Available as of PHP 8.0.0</simpara>
+      respectively.  Available as of PHP 8.0.0, for <literal>$datetype</literal> only.</simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="intldateformatter.constants.relative_long">
@@ -71,7 +71,7 @@
     <listitem>
      <simpara>The same as <constant>IntlDateFormatter::LONG</constant>, but yesterday, today, and tomorrow
       show as <literal>yesterday</literal>, <literal>today</literal>, and <literal>tomorrow</literal>,
-      respectively.  Available as of PHP 8.0.0</simpara>
+      respectively.  Available as of PHP 8.0.0, for <literal>$datetype</literal> only.</simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="intldateformatter.constants.relative_medium">
@@ -82,7 +82,7 @@
     <listitem>
      <simpara>The same as <constant>IntlDateFormatter::MEDIUM</constant>, but yesterday, today, and tomorrow
       show as <literal>yesterday</literal>, <literal>today</literal>, and <literal>tomorrow</literal>,
-      respectively.  Available as of PHP 8.0.0</simpara>
+      respectively.  Available as of PHP 8.0.0, for <literal>$datetype</literal> only.</simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="intldateformatter.constants.relative_short">
@@ -93,7 +93,7 @@
     <listitem>
      <simpara>The same as <constant>IntlDateFormatter::SHORT</constant>, but yesterday, today, and tomorrow
       show as <literal>yesterday</literal>, <literal>today</literal>, and <literal>tomorrow</literal>,
-      respectively.  Available as of PHP 8.0.0</simpara>
+      respectively.  Available as of PHP 8.0.0, for <literal>$datetype</literal> only.</simpara>
     </listitem>
    </varlistentry>
   </variablelist>


### PR DESCRIPTION
I'm not certain of the "right" way to denote the version for these.  I'd think a Changelog block, but that looks non-small to add from a quick glance at other pages.