### PR TITLE
fixed description about passing [mandatory|optional] parameter order.

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -226,7 +226,7 @@ function takes_many_args(
     </programlisting>
    </example>
    <para>
-    As of PHP 8.0.0, passing optional arguments after mandatory arguments
+    As of PHP 8.0.0, passing mandatory arguments after optional arguments
     is deprecated. This can generally be resolved by dropping the default value.
     One exception to this rule are arguments of the form
     <code>Type $param = null</code>, where the &null; default makes the type implicitly


### PR DESCRIPTION
It is inconsistent with migration guide (*1).

(*1) https://www.php.net/manual/en/migration80.deprecated.php#migration80.deprecated.core
