### PR TITLE
Fix instances of siginfo and signinfo being used interchangably on pcntl_signal page

### DIFF
--- a/reference/pcntl/functions/pcntl-signal.xml
+++ b/reference/pcntl/functions/pcntl-signal.xml
@@ -50,7 +50,7 @@
        <methodsynopsis>
         <type>void</type><methodname><replaceable>handler</replaceable></methodname>
         <methodparam><type>int</type><parameter>signo</parameter></methodparam>
-        <methodparam><type>mixed</type><parameter>signinfo</parameter></methodparam>
+        <methodparam><type>mixed</type><parameter>siginfo</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
         <varlistentry>
@@ -116,8 +116,8 @@
        <entry>7.1.0</entry>
        <entry>
         As of PHP 7.1.0 the handler callback is given a second argument
-        containing the signinfo of the specific signal.  This data is only
-        supplied if the operating system has the signinfo_t structure.
+        containing the siginfo of the specific signal.  This data is only
+        supplied if the operating system has the siginfo_t structure.
         If the OS does not implement siginfo_t NULL is supplied.
        </entry>
       </row>


### PR DESCRIPTION
As far as I can tell, `siginfo` and `siginfo_t` are correct and `signinfo` and `signinfo_t` are typos. This simple PR corrects that.

For example, at https://www.php.net/manual/en/function.pcntl-signal.php, clicking `signo` in the handler callback synopsis jumps you to the anchor on line 57, whereas clicking `signinfo` does nothing (it should jump to line 65).

According to the RFC, the intended struct is https://www.mkssoftware.com/docs/man5/siginfo_t.5.asp.