### PR TITLE
json_decode: better explanation and example of 'depth' parameter

### DIFF
--- a/reference/json/functions/json-decode.xml
+++ b/reference/json/functions/json-decode.xml
@@ -52,7 +52,7 @@
      <term><parameter>depth</parameter></term>
      <listitem>
       <para>
-       User specified recursion depth.
+       Maximum nesting depth of the structure being decoded.
       </para>
      </listitem>
     </varlistentry>
@@ -219,7 +219,7 @@ json_decode($bad_json); // null
     <programlisting role="php">
 <![CDATA[
 <?php
-// Encode the data.
+// Encode some data with a maximum depth  of 4 (array -> array -> array -> string)
 $json = json_encode(
     array(
         1 => array(
@@ -235,20 +235,12 @@ $json = json_encode(
     )
 );
 
-// Define the errors.
-$constants = get_defined_constants(true);
-$json_errors = array();
-foreach ($constants["json"] as $name => $value) {
-    if (!strncmp($name, "JSON_ERROR_", 11)) {
-        $json_errors[$value] = $name;
-    }
-}
-
 // Show the errors for different depths.
-foreach (range(4, 3, -1) as $depth) {
-    var_dump(json_decode($json, true, $depth));
-    echo 'Last error: ', $json_errors[json_last_error()], PHP_EOL, PHP_EOL;
-}
+var_dump(json_decode($json, true, 4));
+echo 'Last error: ', json_last_error_msg(), PHP_EOL, PHP_EOL;
+
+var_dump(json_decode($json, true, 3));
+echo 'Last error: ', json_last_error_msg(), PHP_EOL, PHP_EOL;
 ?>
 ]]>
     </programlisting>
@@ -274,10 +266,10 @@ array(1) {
     }
   }
 }
-Last error: JSON_ERROR_NONE
+Last error: No error
 
 NULL
-Last error: JSON_ERROR_DEPTH
+Last error: Maximum stack depth exceeded
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
- Talk about "nesting depth" not "recursion depth", because
  whether or not JSON is recursive isn't really relevant here.
- Make clear that the example document has a depth of 4, which
  wasn't obvious to me looking at it.
- Use json_last_error_msg() to simplify example; it presumably
  didn't exist when this example was written.
- Remove confusing foreach loop in favour of two hard-coded calls;
  it took me ages to realise that range(4,3,-1) just meant [4,3]