### PR TITLE
set_error_handler: clarify callback parameters and PHP 8.0 changes

### DIFF
--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -116,7 +116,8 @@
     </listitem>
     <listitem>
      <para>
-      The <parameter>errcontext</parameter> argument for custom error handlers has been removed.
+      The <parameter>errcontext</parameter> argument will no longer be passed to custom error handlers
+      set with <function>set_error_handler</function>.
      </para>
     </listitem>
     <listitem>

--- a/reference/errorfunc/functions/set-error-handler.xml
+++ b/reference/errorfunc/functions/set-error-handler.xml
@@ -85,7 +85,7 @@
          <term><parameter>errno</parameter></term>
          <listitem>
           <simpara>
-           The first parameter, <parameter>errno</parameter>, contains the
+           The first parameter, <parameter>errno</parameter>, will be passed the
            level of the error raised, as an integer.
           </simpara>
          </listitem>
@@ -94,7 +94,7 @@
          <term><parameter>errstr</parameter></term>
          <listitem>
           <simpara>
-           The second parameter, <parameter>errstr</parameter>, contains the
+           The second parameter, <parameter>errstr</parameter>, will be passed the
            error message, as a string.
           </simpara>
          </listitem>
@@ -103,8 +103,8 @@
          <term><parameter>errfile</parameter></term>
          <listitem>
           <simpara>
-           The third parameter is optional, <parameter>errfile</parameter>,
-           which contains the filename that the error was raised in, as a string.
+           If the callback accepts a third parameter, <parameter>errfile</parameter>,
+           it will be passed the filename that the error was raised in, as a string.
           </simpara>
          </listitem>
         </varlistentry>
@@ -112,8 +112,8 @@
          <term><parameter>errline</parameter></term>
          <listitem>
           <simpara>
-           The fourth parameter is optional, <parameter>errline</parameter>,
-           which contains the line number the error was raised at, as an integer.
+           If the callback accepts a fourth parameter, <parameter>errline</parameter>,
+           it will be passed the line number where the error was raised, as an integer.
           </simpara>
          </listitem>
         </varlistentry>
@@ -121,17 +121,19 @@
          <term><parameter>errcontext</parameter></term>
          <listitem>
           <simpara>
-           The fifth parameter is optional, <parameter>errcontext</parameter>,
-           which is an array that points to the active symbol table at the point
-           the error occurred.  In other words, <parameter>errcontext</parameter>
+           If the callback accepts a fifth parameter, <parameter>errcontext</parameter>,
+           it will be passed an array that points to the active symbol table at the
+           point the error occurred. In other words, <parameter>errcontext</parameter>
            will contain an array of every variable that existed in the scope the
            error was triggered in.
-           User error handler must not modify error context.
+           User error handlers must not modify the error context.
           </simpara>
           <warning xmlns="http://docbook.org/ns/docbook">
            <simpara>
-            This parameter has been <emphasis>DEPRECATED</emphasis> as of PHP 7.2.0.
-            Relying on it is highly discouraged.
+            This parameter has been <emphasis>DEPRECATED</emphasis> as of PHP 7.2.0,
+            and <emphasis>REMOVED</emphasis> as of PHP 8.0.0. If your function defines
+            this parameter without a default, an error of "too few arguments" will be
+            raised when it is called.
            </simpara>
           </warning>
          </listitem>
@@ -184,6 +186,12 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        <parameter>errcontext</parameter> was removed, and will no longer be passed to user callbacks.
+       </entry>
+      </row>
       <row>
        <entry>7.2.0</entry>
        <entry>


### PR DESCRIPTION
Link to reference page from migration guide, and update that
reference page with the changes applied in 8.0.

Additionally, the wording of the callback description was slightly
confusing regarding parameters being "optional" and "removed". This
patch aims to make clear that it is PHP providing the values, and
the user is just choosing whether to accept them.

This was inspired by [this Stack Overflow question](https://stackoverflow.com/q/65201307/157957).