### PR TITLE
Fixed oop return type of DateTimeInterface::getOffset.

### DIFF
--- a/reference/datetime/datetimeinterface/getoffset.xml
+++ b/reference/datetime/datetimeinterface/getoffset.xml
@@ -13,15 +13,15 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>DateTime::getOffset</methodname>
+   <modifier>public</modifier><type>int</type><methodname>DateTime::getOffset</methodname>
    <void/>
   </methodsynopsis>
   <methodsynopsis role="DateTimeImmutable">
-   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>DateTimeImmutable::getOffset</methodname>
+   <modifier>public</modifier><type>int</type><methodname>DateTimeImmutable::getOffset</methodname>
    <void/>
   </methodsynopsis>
   <methodsynopsis role="DateTimeInterface">
-   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>DateTimeInterface::getOffset</methodname>
+   <modifier>public</modifier><type>int</type><methodname>DateTimeInterface::getOffset</methodname>
    <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>


### PR DESCRIPTION
It does not return false, but zero.

https://github.com/php/php-src/blob/caa710037e663fd78f67533b29611183090068b2/ext/date/php_date.c#L3099-L3130

Note: if this fix is correct, we need to fix ext/date/php_date.stub.php.