### PR TITLE
ReflectionUnionType::getTypes() returns ReflectionNamedType[]

### DIFF
--- a/reference/reflection/reflectionuniontype/gettypes.xml
+++ b/reference/reflection/reflectionuniontype/gettypes.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An array of <classname>ReflectionType</classname> objects.
+   An array of <classname>ReflectionNamedType</classname> objects.
   </para>
  </refsect1>
 


### PR DESCRIPTION
AFAIK, `ReflectionUnionType::getTypes()` can only ever return instances of `ReflectionNamedType`.