### PR TITLE
Improved parameter markup in strtok function description.

### DIFF
--- a/reference/strings/functions/strtok.xml
+++ b/reference/strings/functions/strtok.xml
@@ -21,19 +21,19 @@
   <para>
    <function>strtok</function> splits a string (<parameter>string</parameter>)
    into smaller strings (tokens), with each token being delimited by any
-   character from <parameter>string</parameter>.
+   character from <parameter>token</parameter>.
    That is, if you have a string like "This is an example string" you
    could tokenize this string into its individual words by using the
-   space character as the token.
+   space character as the <parameter>token</parameter>.
   </para>
   <para>
-   Note that only the first call to strtok uses the string argument.
-   Every subsequent call to strtok only needs the token to use, as
+   Note that only the first call to strtok uses the <parameter>string</parameter> argument.
+   Every subsequent call to strtok only needs the <parameter>token</parameter> to use, as
    it keeps track of where it is in the current string.  To start
    over, or to tokenize a new string you simply call strtok with the
-   string argument again to initialize it.  Note that you may put
-   multiple tokens in the token parameter.  The string will be
-   tokenized when any one of the characters in the argument is
+   <parameter>string</parameter> argument again to initialize it.  Note that you may put
+   multiple tokens in the <parameter>token</parameter> parameter.  The string will be
+   tokenized when any one of the characters in the <parameter>token</parameter> argument is
    found.
   </para>
  </refsect1>


### PR DESCRIPTION
We use `<parameter>` tag to distinguish parameter "token" with the smaller strings token.
Ditto with `string` parameter.