### PR TITLE
Whitespace fix for datetime.getoffset

### DIFF
--- a/reference/datetime/datetimeinterface/getoffset.xml
+++ b/reference/datetime/datetimeinterface/getoffset.xml
@@ -13,15 +13,15 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <modifier>public</modifier><type>int</type><methodname>DateTime::getOffset</methodname>
+   <modifier>public</modifier> <type>int</type><methodname>DateTime::getOffset</methodname>
    <void/>
   </methodsynopsis>
   <methodsynopsis role="DateTimeImmutable">
-   <modifier>public</modifier><type>int</type><methodname>DateTimeImmutable::getOffset</methodname>
+   <modifier>public</modifier> <type>int</type><methodname>DateTimeImmutable::getOffset</methodname>
    <void/>
   </methodsynopsis>
   <methodsynopsis role="DateTimeInterface">
-   <modifier>public</modifier><type>int</type><methodname>DateTimeInterface::getOffset</methodname>
+   <modifier>public</modifier> <type>int</type><methodname>DateTimeInterface::getOffset</methodname>
    <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>


### PR DESCRIPTION
Fix for the missing space in for the getOffset function:
https://www.php.net/manual/en/datetime.getoffset
https://www.php.net/manual/en/class.datetime.php
https://www.php.net/manual/en/class.datetimeimmutable.php