### PR TITLE
fixed XPointer evaluation failed build warning.

### DIFF
--- a/reference/dom/domcharacterdata.xml
+++ b/reference/dom/domcharacterdata.xml
@@ -58,9 +58,6 @@
     </xi:include>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback />
-    </xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
  
 <!-- Again, if the class extends a class use this -->

--- a/reference/dom/domcomment.xml
+++ b/reference/dom/domcomment.xml
@@ -50,7 +50,6 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcomment')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
      <xi:fallback />
     </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcomment')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
  
 <!-- Again, if the class extends a class use this -->
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>

--- a/reference/dom/domdocumentfragment.xml
+++ b/reference/dom/domdocumentfragment.xml
@@ -55,9 +55,6 @@
     </xi:include>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocumentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback />
-    </xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocumentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
  
 <!-- Again, if the class extends a class use this -->

--- a/reference/dom/domentityreference.xml
+++ b/reference/dom/domentityreference.xml
@@ -66,7 +66,6 @@ Remove me once you perform substitutions
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domentityreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
      <xi:fallback />
     </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domentityreference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
  
 <!-- Again, if the class extends a class use this -->
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>

--- a/reference/dom/domimplementation/construct.xml
+++ b/reference/dom/domimplementation/construct.xml
@@ -9,10 +9,10 @@
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis>
    <methodname>DOMImplementation::__construct</methodname>
    <void/>
-  </methodsynopsis>
+  </constructorsynopsis>
   <para>
    Creates a new <classname>DOMImplementation</classname> object.
   </para>

--- a/reference/dom/domnamednodemap.xml
+++ b/reference/dom/domnamednodemap.xml
@@ -55,9 +55,6 @@ Remove me once you perform substitutions
     </fieldsynopsis>
  
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnamednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback />
-    </xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnamednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
  
    </classsynopsis>

--- a/reference/dom/domnode.xml
+++ b/reference/dom/domnode.xml
@@ -127,9 +127,6 @@
      <varname linkend="domnode.props.textcontent">textContent</varname>
     </fieldsynopsis>
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback />
-    </xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/dom/domnodelist.xml
+++ b/reference/dom/domnodelist.xml
@@ -55,9 +55,6 @@ Remove me once you perform substitutions
     </fieldsynopsis>
  
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnodelist')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback />
-    </xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnodelist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
  
    </classsynopsis>

--- a/reference/dom/domprocessinginstruction.xml
+++ b/reference/dom/domprocessinginstruction.xml
@@ -62,7 +62,6 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domprocessinginstruction')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
      <xi:fallback />
     </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domprocessinginstruction')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
  
 <!-- Again, if the class extends a class use this -->
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>


### PR DESCRIPTION
Now, I got `XPointer evaluation failed` docbook build warning, but at least build result is fine.
This is caused by needless `<xi:include>` pointer related to dom, so I deleted these tag.

http://git.php.net/?p=doc/en.git;a=commitdiff;h=926842882dbed9c74ab7b951e78db96d42ee43ea

@cmb69 If you are going to fix this later, close this PR.

```
php doc-base/configure.php --with-lang=en --enable-xml-details
Cannot load Zend OPcache - it was already loaded
configure.php: $Id$
PHP version: 8.0.0

Checking for source directory... /home/mumumu/work/phpdoc/doc-base
Checking for output filename... /home/mumumu/work/phpdoc/doc-base/.manual.xml
Checking whether to include CHM... no
Checking for PHP executable... /home/mumumu/.phpenv/versions/8.0.0/bin/php
Checking for language to build... en
Checking whether the language is supported... yes
Checking for partial build... no
Checking whether to enable detailed XML error messages... yes
Checking libxml version... 2.9.10
Checking whether to enable detailed error reporting (may segfault)... yes
Checking whether to optimize out the DTD (performance gain, but segfaults)... yes
Generating /home/mumumu/work/phpdoc/doc-base/manual.xml... done
Generating /home/mumumu/work/phpdoc/doc-base/install-unix.xml... done
Generating /home/mumumu/work/phpdoc/doc-base/install-win.xml... done
Generating /home/mumumu/work/phpdoc/doc-base/developer.template.xml... done
Generating /home/mumumu/work/phpdoc/doc-base/scripts/file-entities.php... done
Iterating over extension specific version files... OK
Saving it... OK
Cannot load Zend OPcache - it was already loaded
Creating file /home/mumumu/work/phpdoc/doc-base/entities/file-entities.ent... done
Checking for if we should generate a simplified file... no
Checking whether to save an invalid .manual.xml... no
Loading and parsing manual.xml... done.
Validating manual.xml... 
ERROR (/home/mumumu/work/phpdoc/doc-base/manual.xml:61:0)
  &install.cloud.index;
^
 XPointer evaluation failed: #xmlns(db=http://docbook.org/ns/docbook)
 xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])

ERROR (/home/mumumu/work/phpdoc/doc-base/manual.xml:53:0)
 </book>
^
 XPointer evaluation failed: #xmlns(db=http://docbook.org/ns/docbook)
 xpointer(id('class.domcomment')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])

ERROR (/home/mumumu/work/phpdoc/doc-base/manual.xml:53:0)
 </book>
^
 could not load /home/mumumu/work/phpdoc/doc-base/manual.xml, and no fallback
 was found

ERROR (/home/mumumu/work/phpdoc/doc-base/manual.xml:58:0)
  &install.unix.index;
^
 XPointer evaluation failed: #xmlns(db=http://docbook.org/ns/docbook)
 xpointer(id('class.domdocumentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])

ERROR (/home/mumumu/work/phpdoc/doc-base/manual.xml:69:0)
  <title>&LanguageReference;</title>
^
 XPointer evaluation failed: #xmlns(db=http://docbook.org/ns/docbook)
 xpointer(id('class.domentityreference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])

ERROR (/home/mumumu/work/phpdoc/doc-base/manual.xml:69:0)
  <title>&LanguageReference;</title>
^
 could not load /home/mumumu/work/phpdoc/doc-base/manual.xml, and no fallback
 was found

ERROR (/home/mumumu/work/phpdoc/doc-base/manual.xml:53:0)
 </book>
^
 XPointer evaluation failed: #xmlns(db=http://docbook.org/ns/docbook)
 xpointer(id('class.domimplementation')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])

ERROR (/home/mumumu/work/phpdoc/doc-base/manual.xml:58:0)
  &install.unix.index;
^
 XPointer evaluation failed: #xmlns(db=http://docbook.org/ns/docbook)
 xpointer(id('class.domnamednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])

ERROR (/home/mumumu/work/phpdoc/doc-base/manual.xml:130:0)
      <simpara>
^
 XPointer evaluation failed: #xmlns(db=http://docbook.org/ns/docbook)
 xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])

ERROR (/home/mumumu/work/phpdoc/doc-base/manual.xml:58:0)
  &install.unix.index;
^
 XPointer evaluation failed: #xmlns(db=http://docbook.org/ns/docbook)
 xpointer(id('class.domnodelist')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])

ERROR (/home/mumumu/work/phpdoc/doc-base/manual.xml:65:0)
  &install.ini;
^
 XPointer evaluation failed: #xmlns(db=http://docbook.org/ns/docbook)
 xpointer(id('class.domprocessinginstruction')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])

ERROR (/home/mumumu/work/phpdoc/doc-base/manual.xml:65:0)
  &install.ini;
^
 could not load /home/mumumu/work/phpdoc/doc-base/manual.xml, and no fallback
 was found
done.

All good. Saving .manual.xml... done.
All you have to do now is run 'phd -d /home/mumumu/work/phpdoc/doc-base/.manual.xml'
If the script hangs here, you can abort with ^C.
         _ _..._ __
        \)`    (` /
         /      `\
        |  d  b   |
        =\  Y    =/--..-="````"-.
          '.=__.-'               `\
             o/                 /\ \
              |                 | \ \   / )
               \    .--""`\    <   \ '-' /
              //   |      ||    \   '---'
         jgs ((,,_/      ((,,___/

 (Run `nice php configure.php` next time!)
```