### PR TITLE
fix return type of array_change_key_case error

### DIFF
--- a/reference/array/functions/array-change-key-case.xml
+++ b/reference/array/functions/array-change-key-case.xml
@@ -50,7 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an array with its keys lower or uppercased, or &false; if
+   Returns an array with its keys lower or uppercased, or &null; if
    <parameter>array</parameter> is not an array.
   </para>
  </refsect1>


### PR DESCRIPTION
Fix return type of `array_change_key_case` in case of parameter wrong type that changed from false to null starting PHP 5.3 ~11.5 years ago
This can be checked here: https://3v4l.org/23Zcf