### PR TITLE
Remove references to `mysql` extension and to versions below 7.0

### DIFF
--- a/reference/mysqlinfo/concepts.xml
+++ b/reference/mysqlinfo/concepts.xml
@@ -70,6 +70,7 @@ if ($uresult) {
    }
 }
 $uresult->close();
+?>
 ]]>
    </programlisting>
   </example>
@@ -88,6 +89,7 @@ if ($uresult) {
        echo $row['Name'] . PHP_EOL;
    }
 }
+?>
 ]]>
    </programlisting>
   </example>
@@ -134,6 +136,7 @@ $mysqli->set_charset('utf8mb4');
 
 // But, this will NOT affect it (UTF-8 vs utf8mb4) -- don't use dashes here
 $mysqli->set_charset('UTF-8');
+?>
 ]]>
    </programlisting>
   </example>
@@ -167,6 +170,7 @@ if (!$mysqli->set_charset('utf8mb4')) {
 }
 
 echo 'Your current character set is: ' . $mysqli->character_set_name() . "\n";
+?>
 ]]>
    </programlisting>
   </example>
@@ -177,6 +181,7 @@ echo 'Your current character set is: ' . $mysqli->character_set_name() . "\n";
 <![CDATA[
 <?php
 $pdo = new PDO("mysql:host=localhost;dbname=world;charset=utf8mb4", 'my_user', 'my_pass');
+?>
 ]]>
    </programlisting>
   </example>

--- a/reference/mysqlinfo/concepts.xml
+++ b/reference/mysqlinfo/concepts.xml
@@ -181,24 +181,6 @@ $pdo = new PDO("mysql:host=localhost;dbname=world;charset=utf8mb4", 'my_user', '
    </programlisting>
   </example>
 
-  <example>
-   <title>Setting the character set example: mysqli</title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-$mysqli = mysqli_connect("localhost", "my_user", "my_pass", "world");
-
-echo 'Initial character set: ' . $mysqli->character_set_name() . "\n";
-
-if (!$mysqli->set_charset('utf8mb4')) {
-    echo "Error: Unable to set the character set.\n";
-    exit;
-}
-
-echo 'Your current character set is: ' . $mysqli->character_set_name() . "\n";
-]]>
-   </programlisting>
-  </example>  
  </section>
 
 </chapter>

--- a/reference/mysqlinfo/concepts.xml
+++ b/reference/mysqlinfo/concepts.xml
@@ -61,7 +61,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$mysqli  = new mysqli("localhost", "my_user", "my_pass", "world");
+$mysqli  = new mysqli("localhost", "my_user", "my_password", "world");
 $uresult = $mysqli->query("SELECT Name FROM City", MYSQLI_USE_RESULT);
 
 if ($uresult) {
@@ -120,7 +120,8 @@ if ($uresult) {
    <programlisting role="php">
 <![CDATA[
 <?php
-$mysqli = new mysqli("localhost", "my_user", "my_pass", "world");
+
+$mysqli = new mysqli("localhost", "my_user", "my_password", "world");
 
 // Will NOT affect $mysqli->real_escape_string();
 $mysqli->query("SET NAMES utf8mb4");
@@ -156,7 +157,7 @@ $mysqli->set_charset('UTF-8');
    <programlisting role="php">
 <![CDATA[
 <?php
-$mysqli = new mysqli("localhost", "my_user", "my_pass", "world");
+$mysqli = new mysqli("localhost", "my_user", "my_password", "world");
 
 printf("Initial character set: %s\n", $mysqli->character_set_name());
 

--- a/reference/mysqlinfo/concepts.xml
+++ b/reference/mysqlinfo/concepts.xml
@@ -61,7 +61,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$mysqli  = new mysqli("localhost", "my_user", "my_password", "world");
+$mysqli  = new mysqli("localhost", "my_user", "my_pass", "world");
 $uresult = $mysqli->query("SELECT Name FROM City", MYSQLI_USE_RESULT);
 
 if ($uresult) {
@@ -70,7 +70,6 @@ if ($uresult) {
    }
 }
 $uresult->close();
-?>
 ]]>
    </programlisting>
   </example>
@@ -89,26 +88,6 @@ if ($uresult) {
        echo $row['Name'] . PHP_EOL;
    }
 }
-?>
-]]>
-   </programlisting>
-  </example>
-
-  <example>
-   <title>Unbuffered query example: mysql</title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-$conn = mysql_connect("localhost", "my_user", "my_pass");
-$db   = mysql_select_db("world");
-
-$uresult = mysql_unbuffered_query("SELECT Name FROM City");
-if ($uresult) {
-   while ($row = mysql_fetch_assoc($uresult)) {
-       echo $row['Name'] . PHP_EOL;
-   }
-}
-?>
 ]]>
    </programlisting>
   </example>
@@ -129,8 +108,7 @@ if ($uresult) {
    <para>
     The character set should be understood and defined, as it has an affect on every
     action, and includes security implications. For example, the escaping mechanism
-    (e.g., <function>mysqli_real_escape_string</function> for mysqli, <function>mysql_real_escape_string</function>
-    for mysql, and <methodname>PDO::quote</methodname> for PDO_MySQL) will adhere to
+    (e.g., <function>mysqli_real_escape_string</function> for mysqli and <methodname>PDO::quote</methodname> for PDO_MySQL) will adhere to
     this setting. It is important to realize that these functions will not use the character
     set that is defined with a query, so for example the following will not have an effect
     on them:
@@ -142,8 +120,7 @@ if ($uresult) {
    <programlisting role="php">
 <![CDATA[
 <?php
-
-$mysqli = new mysqli("localhost", "my_user", "my_password", "world");
+$mysqli = new mysqli("localhost", "my_user", "my_pass", "world");
 
 // Will NOT affect $mysqli->real_escape_string();
 $mysqli->query("SET NAMES utf8mb4");
@@ -156,8 +133,6 @@ $mysqli->set_charset('utf8mb4');
 
 // But, this will NOT affect it (UTF-8 vs utf8mb4) -- don't use dashes here
 $mysqli->set_charset('UTF-8');
-
-?>
 ]]>
    </programlisting>
   </example>
@@ -181,7 +156,7 @@ $mysqli->set_charset('UTF-8');
    <programlisting role="php">
 <![CDATA[
 <?php
-$mysqli = new mysqli("localhost", "my_user", "my_password", "world");
+$mysqli = new mysqli("localhost", "my_user", "my_pass", "world");
 
 printf("Initial character set: %s\n", $mysqli->character_set_name());
 
@@ -192,43 +167,35 @@ if (!$mysqli->set_charset('utf8mb4')) {
 
 echo "New character set information:\n";
 print_r( $mysqli->get_charset() );
-
-?>
 ]]>
    </programlisting>
   </example>
 
   <example>
    <title>Setting the character set example: <link linkend="ref.pdo-mysql.connection">pdo_mysql</link></title>
-   <para>
-    Note: This only works as of PHP 5.3.6.
-   </para>
    <programlisting role="php">
 <![CDATA[
 <?php
 $pdo = new PDO("mysql:host=localhost;dbname=world;charset=utf8mb4", 'my_user', 'my_pass');
-?>
 ]]>
    </programlisting>
   </example>
 
   <example>
-   <title>Setting the character set example: mysql</title>
+   <title>Setting the character set example: mysqli</title>
    <programlisting role="php">
 <![CDATA[
 <?php
-$conn = mysql_connect("localhost", "my_user", "my_pass");
-$db   = mysql_select_db("world");
+$mysqli = mysqli_connect("localhost", "my_user", "my_pass", "world");
 
-echo 'Initial character set: ' .  mysql_client_encoding($conn) . "\n";
+echo 'Initial character set: ' . $mysqli->character_set_name() . "\n";
 
-if (!mysql_set_charset('utf8mb4', $conn)) {
+if (!$mysqli->set_charset('utf8mb4')) {
     echo "Error: Unable to set the character set.\n";
     exit;
 }
 
-echo 'Your current character set is: ' .  mysql_client_encoding($conn);
-?>
+echo 'Your current character set is: ' . $mysqli->character_set_name() . "\n";
 ]]>
    </programlisting>
   </example>  

--- a/reference/mysqlinfo/concepts.xml
+++ b/reference/mysqlinfo/concepts.xml
@@ -69,7 +69,6 @@ if ($uresult) {
        echo $row['Name'] . PHP_EOL;
    }
 }
-$uresult->close();
 ?>
 ]]>
    </programlisting>

--- a/reference/mysqlinfo/concepts.xml
+++ b/reference/mysqlinfo/concepts.xml
@@ -159,15 +159,14 @@ $mysqli->set_charset('UTF-8');
 <?php
 $mysqli = new mysqli("localhost", "my_user", "my_password", "world");
 
-printf("Initial character set: %s\n", $mysqli->character_set_name());
+echo 'Initial character set: ' . $mysqli->character_set_name() . "\n";
 
 if (!$mysqli->set_charset('utf8mb4')) {
     printf("Error loading character set utf8mb4: %s\n", $mysqli->error);
     exit;
 }
 
-echo "New character set information:\n";
-print_r( $mysqli->get_charset() );
+echo 'Your current character set is: ' . $mysqli->character_set_name() . "\n";
 ]]>
    </programlisting>
   </example>

--- a/reference/mysqlinfo/set.xml
+++ b/reference/mysqlinfo/set.xml
@@ -199,7 +199,7 @@ echo htmlentities($row['_message']);
     as low as 0.1%.
    </para>
    <informaltable>
-    <tgroup cols="4">
+    <tgroup cols="3">
      <thead>
       <row>
        <entry></entry>
@@ -474,6 +474,7 @@ $ ./configure --with-mysqli=/path/to/mysql_config --with-pdo-mysql=/path/to/mysq
 
  &reference.mysqli.book;
  &reference.mysql-xdevapi.book;
+ &reference.mysql.book;
  &reference.mysqlnd.book;
  &reference.mysqlnd-ms.book;
  &reference.mysqlnd-qc.book;

--- a/reference/mysqlinfo/set.xml
+++ b/reference/mysqlinfo/set.xml
@@ -25,12 +25,10 @@
    <title>Introduction</title>
    <abstract>
     <para>
-     Depending on the version of PHP, there are either two or three PHP APIs
-     for accessing the MySQL database. PHP 5 users can choose between the
-     deprecated <link linkend="book.mysql">mysql</link> extension,
-     <link linkend="book.mysqli">mysqli</link>, or
-     <link linkend="ref.pdo-mysql">PDO_MySQL</link>. PHP 7 removes the mysql
-     extension, leaving only the latter two options.
+     There are several PHP APIs
+     for accessing the MySQL database. Users can choose between the
+     <link linkend="book.mysqli">mysqli</link> or
+     <link linkend="ref.pdo-mysql">PDO_MySQL</link> extensions.
     </para>
     <para>
      This guide explains the
@@ -68,7 +66,7 @@
     APIs can be procedural or object-oriented. With a procedural API you
     call functions to carry out tasks, with the object-oriented API you
     instantiate classes and then call methods on the resulting objects.
-    Of the two the latter is usually the preferred interface, as it is
+    Of the two, the latter is usually the preferred interface, as it is
     more modern and leads to better organized code.
    </para>
 
@@ -134,11 +132,10 @@
    </para>
 
    <para>
-    In the PHP documentation you will come across another term -
+    In the PHP documentation, you will come across another term -
     <emphasis>extension</emphasis>. The PHP code consists of a core,
     with optional extensions to the core functionality. PHP's
-    MySQL-related extensions, such as the <literal>mysqli</literal>
-    extension, and the <literal>mysql</literal> extension, are
+    MySQL-related extension, <literal>mysqli</literal>, is
     implemented using the PHP extension framework.
    </para>
 
@@ -165,15 +162,15 @@
   <chapter xml:id="mysqlinfo.api.choosing" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
    <title>Choosing an API</title>
    <para>
-    PHP offers three different APIs to connect to MySQL. Below we show
-    the APIs provided by the mysql, mysqli, and PDO extensions. Each code snippet
+    PHP offers different APIs to connect to MySQL. Below we show
+    the APIs provided by the mysqli and PDO extensions. Each code snippet
     creates a connection to a MySQL server running on "example.com" using
     the username "user" and the password "password". And a query is run to
     greet the user.
    </para>
    <para>
     <example>
-     <title>Comparing the three MySQL APIs</title>
+     <title>Comparing the MySQL APIs</title>
      <programlisting role="php">
 <![CDATA[
 <?php
@@ -188,34 +185,18 @@ $pdo = new PDO('mysql:host=example.com;dbname=database', 'user', 'password');
 $statement = $pdo->query("SELECT 'Hello, dear MySQL user!' AS _message FROM DUAL");
 $row = $statement->fetch(PDO::FETCH_ASSOC);
 echo htmlentities($row['_message']);
-
-// mysql
-$c = mysql_connect("example.com", "user", "password");
-mysql_select_db("database");
-$result = mysql_query("SELECT 'Hello, dear MySQL user!' AS _message FROM DUAL");
-$row = mysql_fetch_assoc($result);
-echo htmlentities($row['_message']);
-?>
 ]]>
      </programlisting>
     </example>
    </para>
    <para>
-    <emphasis role="bold">Recommended API</emphasis>
+    <emphasis role="bold">Feature comparison</emphasis>
    </para>
    <para>
-    It is recommended to use either the <link linkend="book.mysqli">mysqli</link>
-    or <link linkend="ref.pdo-mysql">PDO_MySQL</link> extensions.
-    It is not recommended to use the old <link linkend="ref.mysql">mysql</link>
-    extension for new development, as it was deprecated in PHP 5.5.0 and was
-    removed in PHP 7. A detailed feature comparison matrix is provided below.
-    The overall performance of all three extensions is considered to be about
+    The overall performance of both extensions is considered to be about
     the same. Although the performance of the extension contributes only a
     fraction of the total run time of a PHP web request.  Often, the impact is
     as low as 0.1%.
-   </para>
-   <para>
-    <emphasis role="bold">Feature comparison</emphasis>
    </para>
    <informaltable>
     <tgroup cols="4">
@@ -224,7 +205,6 @@ echo htmlentities($row['_message']);
        <entry></entry>
        <entry>ext/mysqli</entry>
        <entry>PDO_MySQL</entry>
-       <entry>ext/mysql</entry>
       </row>
      </thead>
      <tbody>
@@ -232,59 +212,44 @@ echo htmlentities($row['_message']);
        <entry>PHP version introduced</entry>
        <entry>5.0</entry>
        <entry>5.1</entry>
-       <entry>2.0</entry>
-      </row>
-      <row>
-       <entry>Included with PHP 5.x</entry>
-       <entry>Yes</entry>
-       <entry>Yes</entry>
-       <entry>Yes</entry>
       </row>
       <row>
        <entry>Included with PHP 7.x</entry>
        <entry>Yes</entry>
        <entry>Yes</entry>
-       <entry>No</entry>
       </row>
       <row>
        <entry>Development status</entry>
        <entry>Active</entry>
        <entry>Active</entry>
-       <entry>Maintenance only in 5.x; removed in 7.x</entry>
       </row>
       <row>
        <entry>Lifecycle</entry>
        <entry>Active</entry>
        <entry>Active</entry>
-       <entry>Deprecated in 5.x; removed in 7.x</entry>
       </row>
       <row>
        <entry>Recommended for new projects</entry>
        <entry>Yes</entry>
        <entry>Yes</entry>
-       <entry>No</entry>
       </row>
       <row>
        <entry>OOP Interface</entry>
        <entry>Yes</entry>
        <entry>Yes</entry>
-       <entry>No</entry>
       </row>
       <row>
        <entry>Procedural Interface</entry>
        <entry>Yes</entry>
        <entry>No</entry>
-       <entry>Yes</entry>
       </row>
       <row>
        <entry>API supports non-blocking, asynchronous queries with mysqlnd</entry>
        <entry>Yes</entry>
        <entry>No</entry>
-       <entry>No</entry>
       </row>
       <row>
        <entry>Persistent Connections</entry>
-       <entry>Yes</entry>
        <entry>Yes</entry>
        <entry>Yes</entry>
       </row>
@@ -292,41 +257,34 @@ echo htmlentities($row['_message']);
        <entry>API supports Charsets</entry>
        <entry>Yes</entry>
        <entry>Yes</entry>
-       <entry>Yes</entry>
       </row>
       <row>
        <entry>API supports server-side Prepared Statements</entry>
        <entry>Yes</entry>
        <entry>Yes</entry>
-       <entry>No</entry>
       </row>
       <row>
        <entry>API supports client-side Prepared Statements</entry>
        <entry>No</entry>
        <entry>Yes</entry>
-       <entry>No</entry>
       </row>
       <row>
        <entry>API supports Stored Procedures</entry>
        <entry>Yes</entry>
        <entry>Yes</entry>
-       <entry>No</entry>
       </row>
       <row>
        <entry>API supports Multiple Statements</entry>
        <entry>Yes</entry>
        <entry>Most</entry>
-       <entry>No</entry>
       </row>
       <row>
        <entry>API supports Transactions</entry>
        <entry>Yes</entry>
        <entry>Yes</entry>
-       <entry>No</entry>
       </row>
       <row>
        <entry>Transactions can be controlled with SQL</entry>
-       <entry>Yes</entry>
        <entry>Yes</entry>
        <entry>Yes</entry>
       </row>
@@ -334,7 +292,6 @@ echo htmlentities($row['_message']);
        <entry>Supports all MySQL 5.1+ functionality</entry>
        <entry>Yes</entry>
        <entry>Most</entry>
-       <entry>No</entry>
       </row>
      </tbody>
     </tgroup>
@@ -344,13 +301,13 @@ echo htmlentities($row['_message']);
   <chapter xml:id="mysqlinfo.library.choosing" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
    <title>Choosing a library</title>
    <para>
-    The mysqli, PDO_MySQL and mysql PHP extensions are lightweight wrappers on
+    The mysqli and PDO_MySQL PHP extensions are lightweight wrappers on
     top of a C client library. The extensions can either use the
     <link linkend="book.mysqlnd">mysqlnd</link> library or the <literal>libmysqlclient</literal>
     library. Choosing a library is a compile time decision.
    </para>
    <para>
-    The mysqlnd library is part of the PHP distribution since 5.3.0. It offers
+    The mysqlnd library is part of the PHP distribution. It offers
     features like lazy connections and query caching, features that are not available
     with libmysqlclient, so using the built-in mysqlnd library is highly recommended.
     See the <link linkend="book.mysqlnd">mysqlnd documentation</link> for
@@ -362,13 +319,13 @@ echo htmlentities($row['_message']);
      <programlisting role="shell">
 <![CDATA[
 // Recommended, compiles with mysqlnd
-$ ./configure --with-mysqli=mysqlnd --with-pdo-mysql=mysqlnd --with-mysql=mysqlnd
+$ ./configure --with-mysqli=mysqlnd --with-pdo-mysql=mysqlnd
 
-// Alternatively recommended, compiles with mysqlnd as of PHP 5.4
-$ ./configure --with-mysqli --with-pdo-mysql --with-mysql
+// Alternatively recommended, compiles with mysqlnd
+$ ./configure --with-mysqli --with-pdo-mysql
 
 // Not recommended, compiles with libmysqlclient
-$ ./configure --with-mysqli=/path/to/mysql_config --with-pdo-mysql=/path/to/mysql_config --with-mysql=/path/to/mysql_config
+$ ./configure --with-mysqli=/path/to/mysql_config --with-pdo-mysql=/path/to/mysql_config
 ]]>
      </programlisting>
     </example>
@@ -417,28 +374,23 @@ $ ./configure --with-mysqli=/path/to/mysql_config --with-pdo-mysql=/path/to/mysq
        <entry>No end announced</entry>
       </row>
       <row>
-       <entry>PHP 5.4 and above; compile default (for all MySQL extensions)</entry>
+       <entry>Compile default (for all MySQL extensions)</entry>
        <entry>Yes</entry>
        <entry>No</entry>
-      </row>
-      <row>
-       <entry>PHP 5.3; compile default (for all MySQL extensions)</entry>
-       <entry>No</entry>
-       <entry>Yes</entry>
       </row>
       <row>
        <entry>Compression protocol support</entry>
-       <entry>Yes (5.3.1+)</entry>
+       <entry>Yes</entry>
        <entry>Yes</entry>
       </row>
       <row>
        <entry>SSL support</entry>
-       <entry>Yes (5.3.3+)</entry>
+       <entry>Yes</entry>
        <entry>Yes</entry>
       </row>
       <row>
        <entry>Named pipe support</entry>
-       <entry>Yes (5.3.4+)</entry>
+       <entry>Yes</entry>
        <entry>Yes</entry>
       </row>
       <row>
@@ -522,7 +474,6 @@ $ ./configure --with-mysqli=/path/to/mysql_config --with-pdo-mysql=/path/to/mysq
 
  &reference.mysqli.book;
  &reference.mysql-xdevapi.book;
- &reference.mysql.book;
  &reference.mysqlnd.book;
  &reference.mysqlnd-ms.book;
  &reference.mysqlnd-qc.book;


### PR DESCRIPTION
- Remove references to `mysql` extension and related examples.
- Unify and cleanup preserved examples.
- Add missing `mysqli` charset example.
- Remove link to `reference.mysql.book` so that we could eventually retire it.
- Remove references to old PHP versions, except where it made sense to keep it (I think it makes sense to keep "PHP version introduced" in case we add new extensions in the future).

Note: this PR only focuses on mysqlinfo pages in order to make this bug obsolete: https://bugs.php.net/bug.php?id=72158