### PR TITLE
Make class type declaration context independent

### DIFF
--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -43,7 +43,7 @@
       <entry><type>self</type></entry>
       <entry>
        The value must be an &instanceof; the same class as the one the
-       method is defined on.
+       in which the type declaration is used.
        Can only be used in classes.
       </entry>
       <entry/>
@@ -52,7 +52,7 @@
       <entry><type>parent</type></entry>
       <entry>
        The value must be an &instanceof; the parent of the class
-       in which the property is defined.
+       in which the type declaration is used.
        Can only be used in classes.
       </entry>
       <entry/>


### PR DESCRIPTION
Not exactly sure how to formulate this, but the current formulation is rather bad due to being context dependent (as it comes from a copy and paste)