### PR TITLE
Renamed 7.0 classes migration to new-classes (same as 7.4 new-classes migration)

### DIFF
--- a/appendices/migration70.xml
+++ b/appendices/migration70.xml
@@ -12,7 +12,7 @@
  &appendices.migration70.deprecated;
  &appendices.migration70.changed-functions;
  &appendices.migration70.new-functions;
- &appendices.migration70.classes;
+ &appendices.migration70.new-classes;
  &appendices.migration70.constants;
  &appendices.migration70.sapi-changes;
  &appendices.migration70.removed-exts-sapis;

--- a/appendices/migration70/new-classes.xml
+++ b/appendices/migration70/new-classes.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<sect1 xml:id="migration70.classes" xmlns:xlink="http://www.w3.org/1999/xlink">
+<sect1 xml:id="migration70.new-classes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>New Classes and Interfaces</title>
 
- <sect2 xml:id="migration70.classes.intl">
+ <sect2 xml:id="migration70.new-classes.intl">
   <title><link linkend="book.intl">Intl</link></title>
 
   <itemizedlist>
@@ -16,7 +16,7 @@
   </itemizedlist>
  </sect2>
 
- <sect2 xml:id="migration70.classes.reflection">
+ <sect2 xml:id="migration70.new-classes.reflection">
   <title><link linkend="book.reflection">Reflection</link></title>
 
   <itemizedlist>
@@ -35,7 +35,7 @@
   </itemizedlist>
  </sect2>
 
- <sect2 xml:id="migration70.classes.session">
+ <sect2 xml:id="migration70.new-classes.session">
   <title><link linkend="book.session">Session Handling</link></title>
 
   <itemizedlist>
@@ -47,7 +47,7 @@
   </itemizedlist>
  </sect2>
 
- <sect2 xml:id="migration70.classes.exception-hierarchy">
+ <sect2 xml:id="migration70.new-classes.exception-hierarchy">
   <title>Exception Hierarchy</title>
 
   <itemizedlist>


### PR DESCRIPTION
`New Features` and `New Functions` sections have the `new-` prefix. Also PHP 7.4 `New Classes and Interfaces` is `new-classes`.