### PR TITLE
Close bug #54863 by clarifying return values

### DIFF
--- a/reference/pgsql/functions/pg-fetch-array.xml
+++ b/reference/pgsql/functions/pg-fetch-array.xml
@@ -89,6 +89,7 @@
   <para>
    &false; is returned if <parameter>row</parameter> exceeds the number
    of rows in the set, there are no more rows, or on any other error.
+   Fetching from the result of a query other than SELECT will also return &false;.
   </para>
  </refsect1>
 


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=54863

The issue is really that the docs should be more clear that non-SELECT queries will not let you fetch from the results. That should close the ticket.

The last commenter confirmed this behavior on PostgreSQL 9.2 + PHP 5.4/5.5. I confirmed this on PostgreSQL 9.6/12.5 + PHP 7.4