### PR TITLE
Link to SplFileInfo from is_file()/file_exists() docs

### DIFF
--- a/reference/filesystem/functions/file-exists.xml
+++ b/reference/filesystem/functions/file-exists.xml
@@ -99,6 +99,7 @@ if (file_exists($filename)) {
     <member><function>is_writable</function></member>
     <member><function>is_file</function></member>
     <member><function>file</function></member>
+    <member><classname>SplFileInfo</classname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/filesystem/functions/is-file.xml
+++ b/reference/filesystem/functions/is-file.xml
@@ -83,6 +83,7 @@ bool(false)
    <simplelist>
     <member><function>is_dir</function></member>
     <member><function>is_link</function></member>
+    <member><classname>SplFileInfo</classname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/spl/splfileinfo/gettype.xml
+++ b/reference/spl/splfileinfo/gettype.xml
@@ -28,7 +28,8 @@
   <para>
    A <type>string</type> representing the type of the entry.
    May be one of <literal>file</literal>, <literal>link</literal>,
-   or <literal>dir</literal>
+   <literal>dir</literal>, <literal>block</literal>, <literal>fifo</literal>,
+   <literal>char</literal>, <literal>socket</literal>, or <literal>unknown</literal>
   </para>
  </refsect1>
  


### PR DESCRIPTION
And update the list of values that can be returned by getType based on
php 8.0 ext/standard/filestat.c

SplFileInfo is the only way to do some things, such as

1. Check for the existence of a file that may or may not be readable
   without emitting a notice
   that is caught by whatever error handler the project uses.

   (e.g. file_exists can return false for unix sockets)
2. Check for file types such as unix sockets
   (e.g. `$info->getType() === 'socket'`)

Recently, I was looking for how to check if a given path was a unix
socket and the filesystem functions didn't have any links to that
information.