### PR TITLE
Improvements to stat() - document other file types

### DIFF
--- a/reference/filesystem/functions/stat.xml
+++ b/reference/filesystem/functions/stat.xml
@@ -161,6 +161,10 @@
      </thead>
      <tbody>
       <row>
+       <entry><constant>0140000</constant></entry>
+       <entry>socket</entry>
+      </row>
+      <row>
        <entry><constant>0120000</constant></entry>
        <entry>link</entry>
       </row>
@@ -175,6 +179,10 @@
       <row>
        <entry><constant>0040000</constant></entry>
        <entry>directory</entry>
+      </row>
+      <row>
+       <entry><constant>0020000</constant></entry>
+       <entry>character device</entry>
       </row>
       <row>
        <entry><constant>0010000</constant></entry>
@@ -308,6 +316,7 @@ if (!$stat) {
     <member><function>fstat</function></member>
     <member><function>filemtime</function></member>
     <member><function>filegroup</function></member>
+    <member><classname>SplFileInfo</classname></member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
Document character device and sockets (this info is also seen in user-submitted notes)

Link to SplFileInfo.
Unlike stat(), SplFileInfo throws instead of emitting a notice,
which is convenient for avoiding the error handler.
(file_exists() returns files that exist but are unreadable)

Related to GH-319

The mode documentation was introduced in 3c8132d8240441503401c9e66ae23b15067ee2f1