### PR TITLE
Remove unnecessary try-catch statements from PDO manual

### DIFF
--- a/reference/pdo/pdo/construct.xml
+++ b/reference/pdo/pdo/construct.xml
@@ -118,7 +118,7 @@
   &reftitle.errors;
   <para>
    <function>PDO::__construct</function> throws a <classname>PDOException</classname> if the attempt
-   to connect to the requested database fails.
+   to connect to the requested database fails regardless of which <constant>PDO::ATTR_ERRMODE</constant> is currently set.
   </para>
  </refsect1>
 
@@ -134,11 +134,7 @@ $dsn = 'mysql:dbname=testdb;host=127.0.0.1';
 $user = 'dbuser';
 $password = 'dbpass';
 
-try {
-    $dbh = new PDO($dsn, $user, $password);
-} catch (PDOException $e) {
-    echo 'Connection failed: ' . $e->getMessage();
-}
+$dbh = new PDO($dsn, $user, $password);
 
 ?>
 ]]>
@@ -169,11 +165,7 @@ $dsn = 'uri:file:///usr/local/dbconnect';
 $user = '';
 $password = '';
 
-try {
-    $dbh = new PDO($dsn, $user, $password);
-} catch (PDOException $e) {
-    echo 'Connection failed: ' . $e->getMessage();
-}
+$dbh = new PDO($dsn, $user, $password);
 
 ?>
 ]]>
@@ -197,11 +189,7 @@ $dsn = 'mydb';
 $user = '';
 $password = '';
 
-try {
-    $dbh = new PDO($dsn, $user, $password);
-} catch (PDOException $e) {
-    echo 'Connection failed: ' . $e->getMessage();
-}
+$dbh = new PDO($dsn, $user, $password);
 
 ?>
 ]]>

--- a/reference/pdo/pdo/construct.xml
+++ b/reference/pdo/pdo/construct.xml
@@ -118,7 +118,7 @@
   &reftitle.errors;
   <para>
    <function>PDO::__construct</function> throws a <classname>PDOException</classname> if the attempt
-   to connect to the requested database fails regardless of which <constant>PDO::ATTR_ERRMODE</constant> is currently set.
+   to connect to the requested database fails, regardless of which <constant>PDO::ATTR_ERRMODE</constant> is currently set.
   </para>
  </refsect1>
 

--- a/reference/pdo/pdostatement/bindcolumn.xml
+++ b/reference/pdo/pdostatement/bindcolumn.xml
@@ -114,33 +114,22 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-function readData($dbh) {
-  $sql = 'SELECT name, colour, calories FROM fruit';
-  try {
-    $stmt = $dbh->prepare($sql);
-    $stmt->execute();
+$stmt = $dbh->prepare('SELECT name, colour, calories FROM fruit');
+$stmt->execute();
 
-    /* Bind by column number */
-    $stmt->bindColumn(1, $name);
-    $stmt->bindColumn(2, $colour);
-    
-    /* Bind by column name */
-    $stmt->bindColumn('calories', $cals);
+/* Bind by column number */
+$stmt->bindColumn(1, $name);
+$stmt->bindColumn(2, $colour);
 
-    while ($row = $stmt->fetch(PDO::FETCH_BOUND)) {
-      $data = $name . "\t" . $colour . "\t" . $cals . "\n";
-      print $data;
-    }
-  }
-  catch (PDOException $e) {
-    print $e->getMessage();
-  }
+/* Bind by column name */
+$stmt->bindColumn('calories', $cals);
+
+while ($stmt->fetch(PDO::FETCH_BOUND)) {
+    print $name . "\t" . $colour . "\t" . $cals . "\n";
 }
-readData($dbh);
-?>
-  ]]>
+]]>
     </programlisting>
-    &example.outputs;
+    &example.outputs.similar;
     <screen>
 <![CDATA[
 apple   red     150

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -215,35 +215,23 @@ kiwi
 <![CDATA[
 <?php
 function readDataForwards($dbh) {
-  $sql = 'SELECT hand, won, bet FROM mynumbers ORDER BY BET';
-  try {
+    $sql = 'SELECT hand, won, bet FROM mynumbers ORDER BY BET';
     $stmt = $dbh->prepare($sql, array(PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL));
     $stmt->execute();
     while ($row = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_NEXT)) {
-      $data = $row[0] . "\t" . $row[1] . "\t" . $row[2] . "\n";
-      print $data;
+        $data = $row[0] . "\t" . $row[1] . "\t" . $row[2] . "\n";
+        print $data;
     }
-    $stmt = null;
-  }
-  catch (PDOException $e) {
-    print $e->getMessage();
-  }
 }
 function readDataBackwards($dbh) {
-  $sql = 'SELECT hand, won, bet FROM mynumbers ORDER BY bet';
-  try {
+    $sql = 'SELECT hand, won, bet FROM mynumbers ORDER BY bet';
     $stmt = $dbh->prepare($sql, array(PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL));
     $stmt->execute();
     $row = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_LAST);
     do {
-      $data = $row[0] . "\t" . $row[1] . "\t" . $row[2] . "\n";
-      print $data;
+        $data = $row[0] . "\t" . $row[1] . "\t" . $row[2] . "\n";
+        print $data;
     } while ($row = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_PRIOR));
-    $stmt = null;
-  }
-  catch (PDOException $e) {
-    print $e->getMessage();
-  }
 }
 
 print "Reading forwards:\n";

--- a/reference/pdo/pdostatement/setfetchmode.xml
+++ b/reference/pdo/pdostatement/setfetchmode.xml
@@ -103,7 +103,7 @@
 <![CDATA[
 <?php
 $stmt = $dbh->query('SELECT name, colour, calories FROM fruit');
-$result = $stmt->setFetchMode(PDO::FETCH_NUM);
+$stmt->setFetchMode(PDO::FETCH_NUM);
 foreach ($stmt as $row) {
     print $row[0] . "\t" . $row[1] . "\t" . $row[2] . "\n";
 }

--- a/reference/pdo/pdostatement/setfetchmode.xml
+++ b/reference/pdo/pdostatement/setfetchmode.xml
@@ -102,21 +102,14 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$sql = 'SELECT name, colour, calories FROM fruit';
-try {
-  $stmt = $dbh->query($sql);
-  $result = $stmt->setFetchMode(PDO::FETCH_NUM);
-  while ($row = $stmt->fetch()) {
+$stmt = $dbh->query('SELECT name, colour, calories FROM fruit');
+$result = $stmt->setFetchMode(PDO::FETCH_NUM);
+foreach ($stmt as $row) {
     print $row[0] . "\t" . $row[1] . "\t" . $row[2] . "\n";
-  }
 }
-catch (PDOException $e) {
-  print $e->getMessage();
-}
-?>
 ]]>
     </programlisting>
-    &example.outputs;
+    &example.outputs.similar;
     <screen>
 <![CDATA[
 apple   red     150
@@ -125,7 +118,6 @@ orange  orange  300
 kiwi    brown   75
 lemon   yellow  25
 pear    green   150
-watermelon      pink    90
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
Since now PHP has exception mode set to default, the try-catch on the constructor page is useless. Previously, people have been catching these exceptions to silence them just like the rest of PDO functions. Now, there is no observable difference between the constructor or any other PDO function with default settings in terms of exception throwing. 

The idea is to make the examples simple and to the point without any unnecessary noise. The try-catch statements serve no visible purpose and without proper explanation they are just confusing to new developers. 

The information is not lost, as we have 2 dedicated pages in the manual for [connections](https://www.php.net/manual/en/pdo.connections.php) and [error handling](https://www.php.net/manual/en/pdo.error-handling.php). 

There were 3 other examples where the try-catch was unnecessarily used. These were even worse because there was no code to recover from the exceptional situation, there was only a print statement, and they were encompassing arbitrary code within a function. If code fails then it should be handled by the error handler if the code can't recover from it. A try-catch with no means to recover is just dirty code. 
The examples used 2 spaces for indentation, I changed it to 4. 
Now, the examples are clean and short, and they continue to demonstrate the idea behind them. 