### PR TITLE
mysqli_query can return a mysqli_result for other types

### DIFF
--- a/reference/mysqli/mysqli/query.xml
+++ b/reference/mysqli/mysqli/query.xml
@@ -111,9 +111,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &false; on failure. For successful <literal>SELECT, SHOW, DESCRIBE</literal> or
-   <literal>EXPLAIN</literal> queries <function>mysqli_query</function> will return
-   a <classname>mysqli_result</classname> object. For other successful queries <function>mysqli_query</function> will
+   Returns &false; on failure. For successful queries which produce a result set, such as <literal>SELECT, SHOW, DESCRIBE</literal> or
+   <literal>EXPLAIN</literal>, <function>mysqli_query</function> will return
+   a <classname>mysqli_result</classname> object. For other successful queries, <function>mysqli_query</function> will
    return &true;.
   </para>
  </refsect1>

--- a/reference/mysqli/mysqli/reap-async-query.xml
+++ b/reference/mysqli/mysqli/reap-async-query.xml
@@ -37,7 +37,10 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns <classname>mysqli_result</classname> in success, &false; otherwise.
+   Returns &false; on failure. For successful queries which produce a result set, such as <literal>SELECT, SHOW, DESCRIBE</literal> or
+   <literal>EXPLAIN</literal>, <function>mysqli_reap_async_query</function> will return
+   a <classname>mysqli_result</classname> object. For other successful queries, <function>mysqli_reap_async_query</function> will
+   return &true;.
   </para>
  </refsect1>
 

--- a/reference/mysqli/mysqli_stmt/get-result.xml
+++ b/reference/mysqli/mysqli_stmt/get-result.xml
@@ -40,7 +40,8 @@
    Returns &false; on failure. For successful queries which produce a result set, such as <literal>SELECT, SHOW, DESCRIBE</literal> or
    <literal>EXPLAIN</literal>, <function>mysqli_stmt_get_result</function> will return
    a <classname>mysqli_result</classname> object. For other successful queries, <function>mysqli_stmt_get_result</function> will
-   return &true;.
+   return &false;. The <function>mysqli_errno</function> function can be
+   used to distinguish between the two reasons for &false;.
   </para>
  </refsect1>
 

--- a/reference/mysqli/mysqli_stmt/get-result.xml
+++ b/reference/mysqli/mysqli_stmt/get-result.xml
@@ -37,9 +37,10 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a resultset for successful SELECT queries, or &false; for other DML
-   queries or on failure. The <function>mysqli_errno</function> function can be
-   used to distinguish between the two types of failure.
+   Returns &false; on failure. For successful queries which produce a result set, such as <literal>SELECT, SHOW, DESCRIBE</literal> or
+   <literal>EXPLAIN</literal>, <function>mysqli_stmt_get_result</function> will return
+   a <classname>mysqli_result</classname> object. For other successful queries, <function>mysqli_stmt_get_result</function> will
+   return &true;.
   </para>
  </refsect1>
 


### PR DESCRIPTION
From the mailing list:

> Under 'Return Values,' it says:
> 
> >Returns false on failure. For successful SELECT, SHOW, DESCRIBE or EXPLAIN queries mysqli_query() will return a mysqli_result object. For other successful queries mysqli_query() will return true
> 
> This is not correct. I can provide one counterexample, which is when you run an optimize query:
> 
> OPTIMIZE TABLE my_table;
> 
> This query will return a result set with two records whether the table exists or not.

I have confirmed this behavior using this code:

```php
$mysqli = mysqli_connect("localhost", "my_user", "my_password", "world");
print_r($mysqli->query('optimize table City'));
print_r($mysqli->query('optimize table Invalid'));
```

Both returned a `mysqli_result` object showing two rows. I therefore updated the doc as per the recommendation.