### PR TITLE
Fixed param name LDAP_OPT_X_TLS_KEYILE

### DIFF
--- a/reference/ldap/functions/ldap-get-option.xml
+++ b/reference/ldap/functions/ldap-get-option.xml
@@ -182,7 +182,7 @@
            <entry>7.1</entry>
           </row>
           <row>
-           <entry><constant>LDAP_OPT_X_TLS_KEYILE</constant></entry>
+           <entry><constant>LDAP_OPT_X_TLS_KEYFILE</constant></entry>
            <entry><type>string</type></entry>
            <entry>7.1</entry>
           </row>


### PR DESCRIPTION
The param name is not ok in https://www.php.net/manual/en/function.ldap-get-option.php