### PR TITLE
Added PHP 8 into versions.xml for strings functions

### DIFF
--- a/reference/strings/versions.xml
+++ b/reference/strings/versions.xml
@@ -4,107 +4,107 @@
   Do NOT translate this file
 -->
 <versions>
- <function name="addcslashes" from="PHP 4, PHP 5, PHP 7"/>
- <function name="addslashes" from="PHP 4, PHP 5, PHP 7"/>
- <function name="bin2hex" from="PHP 4, PHP 5, PHP 7"/>
- <function name="chop" from="PHP 4, PHP 5, PHP 7"/>
- <function name="chr" from="PHP 4, PHP 5, PHP 7"/>
- <function name="chunk_split" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="addcslashes" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="addslashes" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="bin2hex" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="chop" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="chr" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="chunk_split" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="convert_cyr_string" from="PHP 4, PHP 5, PHP 7" deprecated='PHP 7.4.0'/>
- <function name="convert_uudecode" from="PHP 5, PHP 7"/>
- <function name="convert_uuencode" from="PHP 5, PHP 7"/>
- <function name="count_chars" from="PHP 4, PHP 5, PHP 7"/>
- <function name="crc32" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7"/>
- <function name="crypt" from="PHP 4, PHP 5, PHP 7"/>
- <function name="echo" from="PHP 4, PHP 5, PHP 7"/>
- <function name="explode" from="PHP 4, PHP 5, PHP 7"/>
- <function name="fprintf" from="PHP 5, PHP 7"/>
- <function name="get_html_translation_table" from="PHP 4, PHP 5, PHP 7"/>
- <function name="hebrev" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="convert_uudecode" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="convert_uuencode" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="count_chars" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="crc32" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
+ <function name="crypt" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="echo" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="explode" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="fprintf" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="get_html_translation_table" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="hebrev" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="hebrevc" from="PHP 4, PHP 5, PHP 7" deprecated='PHP 7.4.0'/>
- <function name="hex2bin" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="html_entity_decode" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="htmlentities" from="PHP 4, PHP 5, PHP 7"/>
- <function name="htmlspecialchars" from="PHP 4, PHP 5, PHP 7"/>
- <function name="htmlspecialchars_decode" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="implode" from="PHP 4, PHP 5, PHP 7"/>
- <function name="join" from="PHP 4, PHP 5, PHP 7"/>
- <function name="lcfirst" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="levenshtein" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7"/>
- <function name="localeconv" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7"/>
- <function name="ltrim" from="PHP 4, PHP 5, PHP 7"/>
- <function name="md5" from="PHP 4, PHP 5, PHP 7"/>
- <function name="md5_file" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="metaphone" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="hex2bin" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="html_entity_decode" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="htmlentities" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="htmlspecialchars" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="htmlspecialchars_decode" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="implode" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="join" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="lcfirst" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="levenshtein" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
+ <function name="localeconv" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PHP 8"/>
+ <function name="ltrim" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="md5" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="md5_file" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="metaphone" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="money_format" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="nl2br" from="PHP 4, PHP 5, PHP 7"/>
- <function name="nl_langinfo" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7"/>
- <function name="number_format" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ord" from="PHP 4, PHP 5, PHP 7"/>
- <function name="parse_str" from="PHP 4, PHP 5, PHP 7"/>
- <function name="print" from="PHP 4, PHP 5, PHP 7"/>
- <function name="printf" from="PHP 4, PHP 5, PHP 7"/>
- <function name="quoted_printable_decode" from="PHP 4, PHP 5, PHP 7"/>
- <function name="quoted_printable_encode" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="quotemeta" from="PHP 4, PHP 5, PHP 7"/>
- <function name="rtrim" from="PHP 4, PHP 5, PHP 7"/>
- <function name="setlocale" from="PHP 4, PHP 5, PHP 7"/>
- <function name="sha1" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="sha1_file" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="similar_text" from="PHP 4, PHP 5, PHP 7"/>
- <function name="soundex" from="PHP 4, PHP 5, PHP 7"/>
- <function name="sprintf" from="PHP 4, PHP 5, PHP 7"/>
- <function name="sscanf" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7"/>
+ <function name="nl2br" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="nl_langinfo" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="number_format" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ord" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="parse_str" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="print" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="printf" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="quoted_printable_decode" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="quoted_printable_encode" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="quotemeta" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="rtrim" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="setlocale" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="sha1" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="sha1_file" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="similar_text" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="soundex" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="sprintf" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="sscanf" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
  <function name="str_contains" from="PHP 8"/>
  <function name="str_ends_with" from="PHP 8"/>
- <function name="str_getcsv" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="str_ireplace" from="PHP 5, PHP 7"/>
- <function name="str_pad" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7"/>
- <function name="str_repeat" from="PHP 4, PHP 5, PHP 7"/>
- <function name="str_replace" from="PHP 4, PHP 5, PHP 7"/>
- <function name="str_rot13" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="str_shuffle" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="str_split" from="PHP 5, PHP 7"/>
+ <function name="str_getcsv" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="str_ireplace" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="str_pad" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
+ <function name="str_repeat" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="str_replace" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="str_rot13" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="str_shuffle" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="str_split" from="PHP 5, PHP 7, PHP 8"/>
  <function name="str_starts_with" from="PHP 8"/>
- <function name="str_word_count" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="strcasecmp" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strchr" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strcmp" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strcoll" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7"/>
- <function name="strcspn" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strip_tags" from="PHP 4, PHP 5, PHP 7"/>
- <function name="stripcslashes" from="PHP 4, PHP 5, PHP 7"/>
- <function name="stripos" from="PHP 5, PHP 7"/>
- <function name="stripslashes" from="PHP 4, PHP 5, PHP 7"/>
- <function name="stristr" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strlen" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strnatcasecmp" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strnatcmp" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strncasecmp" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7"/>
- <function name="strncmp" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strpbrk" from="PHP 5, PHP 7"/>
- <function name="strpos" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strrchr" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strrev" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strripos" from="PHP 5, PHP 7"/>
- <function name="strrpos" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strspn" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strstr" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strtok" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strtolower" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strtoupper" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strtr" from="PHP 4, PHP 5, PHP 7"/>
- <function name="substr" from="PHP 4, PHP 5, PHP 7"/>
- <function name="substr_compare" from="PHP 5, PHP 7"/>
- <function name="substr_count" from="PHP 4, PHP 5, PHP 7"/>
- <function name="substr_replace" from="PHP 4, PHP 5, PHP 7"/>
- <function name="trim" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ucfirst" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ucwords" from="PHP 4, PHP 5, PHP 7"/>
- <function name="vfprintf" from="PHP 5, PHP 7"/>
- <function name="vprintf" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7"/>
- <function name="vsprintf" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7"/>
- <function name="wordwrap" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7"/>
+ <function name="str_word_count" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="strcasecmp" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strchr" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strcmp" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strcoll" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PHP 8"/>
+ <function name="strcspn" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strip_tags" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="stripcslashes" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="stripos" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="stripslashes" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="stristr" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strlen" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strnatcasecmp" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strnatcmp" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strncasecmp" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="strncmp" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strpbrk" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="strpos" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strrchr" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strrev" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strripos" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="strrpos" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strspn" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strstr" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strtok" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strtolower" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strtoupper" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strtr" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="substr" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="substr_compare" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="substr_count" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="substr_replace" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="trim" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ucfirst" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ucwords" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="vfprintf" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="vprintf" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="vsprintf" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="wordwrap" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
I noticed by #333, that `PHP 8` version is not added in most of versions.xml.

Old versions.xml leads to some confusion for PHP newbie, because It seems most of these functions cannot be used in PHP 8.

For fixing this issue, I created PR for ext/standard/strings functions for starting point.
