### PR TITLE
Added version 'PHP 8' to array functions' pages

### DIFF
--- a/reference/array/functions/array-walk.xml
+++ b/reference/array/functions/array-walk.xml
@@ -65,7 +65,7 @@
        Only the values of the <parameter>array</parameter> may potentially be
        changed; its structure cannot be altered, i.e., the programmer cannot
        add, unset or reorder elements. If the callback does not respect this
-       requirement, the behavior of this function is undefined, and      
+       requirement, the behavior of this function is undefined, and
        unpredictable.
       </para>
      </listitem>
@@ -92,10 +92,10 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   As of PHP 7.1.0, an <classname>ArgumentCountError</classname> will be thrown if the <parameter>callback</parameter> function 
+   As of PHP 7.1.0, an <classname>ArgumentCountError</classname> will be thrown if the <parameter>callback</parameter> function
    requires more than 2 parameters (the value and key of the array member).
-   Previously, if the <parameter>callback</parameter> function required more than 2 parameters, 
-   an error of level <link linkend="errorfunc.constants">E_WARNING</link> would be generated each time 
+   Previously, if the <parameter>callback</parameter> function required more than 2 parameters,
+   an error of level <link linkend="errorfunc.constants">E_WARNING</link> would be generated each time
    <function>array_walk</function> calls <parameter>callback</parameter>.
   </para>
  </refsect1>
@@ -116,7 +116,7 @@ function test_alter(&$item1, $key, $prefix)
 
 function test_print($item2, $key)
 {
-    echo "$key. $item2<br />\n";
+    echo "$key. $item2\n";
 }
 
 echo "Before ...:\n";

--- a/reference/array/functions/each.xml
+++ b/reference/array/functions/each.xml
@@ -7,7 +7,7 @@
  </refnamediv>
 
  <refsynopsisdiv>
-   &warn.deprecated.function-7-2-0;
+   &warn.deprecated.function-7-2-0.removed-8-0-0;
  </refsynopsisdiv>
 
  <refsect1 role="description">
@@ -157,8 +157,8 @@ c => cranberry
   </caution>
   <warning>
    <para>
-    <function>each</function> will also accept objects, but may return unexpected 
-    results. It's therefore not recommended to iterate though object properties 
+    <function>each</function> will also accept objects, but may return unexpected
+    results. It's therefore not recommended to iterate though object properties
     with <function>each</function>.
    </para>
   </warning>

--- a/reference/array/functions/key.xml
+++ b/reference/array/functions/key.xml
@@ -38,7 +38,7 @@
    The <function>key</function> function simply returns the
    key of the array element that's currently being pointed to by the
    internal pointer.  It does not move the pointer in any way.  If the
-   internal pointer points beyond the end of the elements list or the array is 
+   internal pointer points beyond the end of the elements list or the array is
    empty, <function>key</function> returns &null;.
   </para>
  </refsect1>
@@ -86,7 +86,7 @@ $array = array(
 // key where value equals "apple"
 while ($fruit_name = current($array)) {
     if ($fruit_name == 'apple') {
-        echo key($array).'<br />';
+        echo key($array), "\n";
     }
     next($array);
 }

--- a/reference/array/functions/range.xml
+++ b/reference/array/functions/range.xml
@@ -72,17 +72,26 @@ foreach (range(0, 12) as $number) {
     echo $number;
 }
 
+echo "\n";
+
 // The step parameter
 // array(0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100)
-foreach (range(0, 100, 10) as $number) {
+foreach (range(0, 100, 10) as $k => $number) {
     echo $number;
+    if ($k === count(range(0, 100, 10)) - 1) {
+        echo "\n";
+    }
 }
 
 // Usage of character sequences
 // array('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i');
-foreach (range('a', 'i') as $letter) {
+foreach ($arr = range('a', 'i') as $k => $letter) {
     echo $letter;
+    if ($k === array_key_last($arr)) {
+        echo "\n";
+    }
 }
+
 // array('c', 'b', 'a');
 foreach (range('c', 'a') as $letter) {
     echo $letter;

--- a/reference/array/functions/range.xml
+++ b/reference/array/functions/range.xml
@@ -76,21 +76,19 @@ echo "\n";
 
 // The step parameter
 // array(0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100)
-foreach (range(0, 100, 10) as $k => $number) {
+foreach (range(0, 100, 10) as $number) {
     echo $number;
-    if ($k === count(range(0, 100, 10)) - 1) {
-        echo "\n";
-    }
 }
+
+echo "\n";
 
 // Usage of character sequences
 // array('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i');
-foreach ($arr = range('a', 'i') as $k => $letter) {
+foreach (range('a', 'i') as $letter) {
     echo $letter;
-    if ($k === array_key_last($arr)) {
-        echo "\n";
-    }
 }
+
+echo "\n";
 
 // array('c', 'b', 'a');
 foreach (range('c', 'a') as $letter) {

--- a/reference/array/versions.xml
+++ b/reference/array/versions.xml
@@ -4,87 +4,87 @@
   Do NOT translate this file
 -->
 <versions>
- <function name='array' from='PHP 4, PHP 5, PHP 7'/>
- <function name='array_change_key_case' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='array_chunk' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='array_column' from='PHP 5 &gt;= 5.5.0, PHP 7'/>
- <function name='array_combine' from='PHP 5, PHP 7'/>
- <function name='array_count_values' from='PHP 4, PHP 5, PHP 7'/>
- <function name='array_diff' from='PHP 4 &gt;= 4.0.1, PHP 5, PHP 7'/>
- <function name='array_diff_assoc' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='array_diff_key' from='PHP 5 &gt;= 5.1.0, PHP 7'/>
- <function name='array_diff_uassoc' from='PHP 5, PHP 7'/>
- <function name='array_diff_ukey' from='PHP 5 &gt;= 5.1.0, PHP 7'/>
- <function name='array_fill' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='array_fill_keys' from='PHP 5 &gt;= 5.2.0, PHP 7'/>
- <function name='array_filter' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='array_flip' from='PHP 4, PHP 5, PHP 7'/>
- <function name='array_intersect' from='PHP 4 &gt;= 4.0.1, PHP 5, PHP 7'/>
- <function name='array_intersect_assoc' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='array_intersect_key' from='PHP 5 &gt;= 5.1.0, PHP 7'/>
- <function name='array_intersect_uassoc' from='PHP 5, PHP 7'/>
- <function name='array_intersect_ukey' from='PHP 5 &gt;= 5.1.0, PHP 7'/>
- <function name='array_key_exists' from='PHP 4 &gt;= 4.0.7, PHP 5, PHP 7'/>
- <function name='array_key_first' from='PHP 7 &gt;= 7.3.0'/>
- <function name='array_key_last' from='PHP 7 &gt;= 7.3.0'/>
- <function name='array_keys' from='PHP 4, PHP 5, PHP 7'/>
- <function name='array_map' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='array_merge' from='PHP 4, PHP 5, PHP 7'/>
- <function name='array_merge_recursive' from='PHP 4 &gt;= 4.0.1, PHP 5, PHP 7'/>
- <function name='array_multisort' from='PHP 4, PHP 5, PHP 7'/>
- <function name='array_pad' from='PHP 4, PHP 5, PHP 7'/>
- <function name='array_pop' from='PHP 4, PHP 5, PHP 7'/>
- <function name='array_product' from='PHP 5 &gt;= 5.1.0, PHP 7'/>
- <function name='array_push' from='PHP 4, PHP 5, PHP 7'/>
- <function name='array_rand' from='PHP 4, PHP 5, PHP 7'/>
- <function name='array_reduce' from='PHP 4 &gt;= 4.0.5, PHP 5, PHP 7'/>
- <function name='array_replace' from='PHP 5 &gt;= 5.3.0, PHP 7'/>
- <function name='array_replace_recursive' from='PHP 5 &gt;= 5.3.0, PHP 7'/>
- <function name='array_reverse' from='PHP 4, PHP 5, PHP 7'/>
- <function name='array_search' from='PHP 4 &gt;= 4.0.5, PHP 5, PHP 7'/>
- <function name='array_shift' from='PHP 4, PHP 5, PHP 7'/>
- <function name='array_slice' from='PHP 4, PHP 5, PHP 7'/>
- <function name='array_splice' from='PHP 4, PHP 5, PHP 7'/>
- <function name='array_sum' from='PHP 4 &gt;= 4.0.4, PHP 5, PHP 7'/>
- <function name='array_udiff' from='PHP 5, PHP 7'/>
- <function name='array_udiff_assoc' from='PHP 5, PHP 7'/>
- <function name='array_udiff_uassoc' from='PHP 5, PHP 7'/>
- <function name='array_uintersect' from='PHP 5, PHP 7'/>
- <function name='array_uintersect_assoc' from='PHP 5, PHP 7'/>
- <function name='array_uintersect_uassoc' from='PHP 5, PHP 7'/>
- <function name='array_unique' from='PHP 4 &gt;= 4.0.1, PHP 5, PHP 7'/>
- <function name='array_unshift' from='PHP 4, PHP 5, PHP 7'/>
- <function name='array_values' from='PHP 4, PHP 5, PHP 7'/>
- <function name='array_walk' from='PHP 4, PHP 5, PHP 7'/>
- <function name='array_walk_recursive' from='PHP 5, PHP 7'/>
- <function name='arsort' from='PHP 4, PHP 5, PHP 7'/>
- <function name='asort' from='PHP 4, PHP 5, PHP 7'/>
- <function name='compact' from='PHP 4, PHP 5, PHP 7'/>
- <function name='count' from='PHP 4, PHP 5, PHP 7'/>
- <function name='current' from='PHP 4, PHP 5, PHP 7'/>
+ <function name='array' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_change_key_case' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_chunk' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_column' from='PHP 5 &gt;= 5.5.0, PHP 7, PHP 8'/>
+ <function name='array_combine' from='PHP 5, PHP 7, PHP 8'/>
+ <function name='array_count_values' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_diff' from='PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_diff_assoc' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_diff_key' from='PHP 5 &gt;= 5.1.0, PHP 7, PHP 8'/>
+ <function name='array_diff_uassoc' from='PHP 5, PHP 7, PHP 8'/>
+ <function name='array_diff_ukey' from='PHP 5 &gt;= 5.1.0, PHP 7, PHP 8'/>
+ <function name='array_fill' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_fill_keys' from='PHP 5 &gt;= 5.2.0, PHP 7, PHP 8'/>
+ <function name='array_filter' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_flip' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_intersect' from='PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_intersect_assoc' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_intersect_key' from='PHP 5 &gt;= 5.1.0, PHP 7, PHP 8'/>
+ <function name='array_intersect_uassoc' from='PHP 5, PHP 7, PHP 8'/>
+ <function name='array_intersect_ukey' from='PHP 5 &gt;= 5.1.0, PHP 7, PHP 8'/>
+ <function name='array_key_exists' from='PHP 4 &gt;= 4.0.7, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_key_first' from='PHP 7 &gt;= 7.3.0, PHP 8'/>
+ <function name='array_key_last' from='PHP 7 &gt;= 7.3.0, PHP 8'/>
+ <function name='array_keys' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_map' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_merge' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_merge_recursive' from='PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_multisort' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_pad' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_pop' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_product' from='PHP 5 &gt;= 5.1.0, PHP 7, PHP 8'/>
+ <function name='array_push' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_rand' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_reduce' from='PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_replace' from='PHP 5 &gt;= 5.3.0, PHP 7, PHP 8'/>
+ <function name='array_replace_recursive' from='PHP 5 &gt;= 5.3.0, PHP 7, PHP 8'/>
+ <function name='array_reverse' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_search' from='PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_shift' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_slice' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_splice' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_sum' from='PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_udiff' from='PHP 5, PHP 7, PHP 8'/>
+ <function name='array_udiff_assoc' from='PHP 5, PHP 7, PHP 8'/>
+ <function name='array_udiff_uassoc' from='PHP 5, PHP 7, PHP 8'/>
+ <function name='array_uintersect' from='PHP 5, PHP 7, PHP 8'/>
+ <function name='array_uintersect_assoc' from='PHP 5, PHP 7, PHP 8'/>
+ <function name='array_uintersect_uassoc' from='PHP 5, PHP 7, PHP 8'/>
+ <function name='array_unique' from='PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_unshift' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_values' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_walk' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_walk_recursive' from='PHP 5, PHP 7, PHP 8'/>
+ <function name='arsort' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='asort' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='compact' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='count' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='current' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
  <function name='each' from='PHP 4, PHP 5, PHP 7' deprecated='PHP 7.2.0'/>
- <function name='end' from='PHP 4, PHP 5, PHP 7'/>
- <function name='extract' from='PHP 4, PHP 5, PHP 7'/>
- <function name='in_array' from='PHP 4, PHP 5, PHP 7'/>
- <function name='key' from='PHP 4, PHP 5, PHP 7'/>
- <function name='key_exists' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7'/>
- <function name='krsort' from='PHP 4, PHP 5, PHP 7'/>
- <function name='ksort' from='PHP 4, PHP 5, PHP 7'/>
- <function name='list' from='PHP 4, PHP 5, PHP 7'/>
- <function name='natcasesort' from='PHP 4, PHP 5, PHP 7'/>
- <function name='natsort' from='PHP 4, PHP 5, PHP 7'/>
- <function name='next' from='PHP 4, PHP 5, PHP 7'/>
- <function name='pos' from='PHP 4, PHP 5, PHP 7'/>
- <function name='prev' from='PHP 4, PHP 5, PHP 7'/>
- <function name='range' from='PHP 4, PHP 5, PHP 7'/>
- <function name='reset' from='PHP 4, PHP 5, PHP 7'/>
- <function name='rsort' from='PHP 4, PHP 5, PHP 7'/>
- <function name='shuffle' from='PHP 4, PHP 5, PHP 7'/>
- <function name='sizeof' from='PHP 4, PHP 5, PHP 7'/>
- <function name='sort' from='PHP 4, PHP 5, PHP 7'/>
- <function name='uasort' from='PHP 4, PHP 5, PHP 7'/>
- <function name='uksort' from='PHP 4, PHP 5, PHP 7'/>
- <function name='usort' from='PHP 4, PHP 5, PHP 7'/>
+ <function name='end' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='extract' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='in_array' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='key' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='key_exists' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8'/>
+ <function name='krsort' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='ksort' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='list' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='natcasesort' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='natsort' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='next' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='pos' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='prev' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='range' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='reset' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='rsort' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='shuffle' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='sizeof' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='sort' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='uasort' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='uksort' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='usort' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
 </versions>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Also fixed and improved some of examples on pages:

https://www.php.net/manual/en/function.array-walk.php
  - removed <br> tag from print function

https://www.php.net/manual/en/function.key.php
  - removed '<br>' tag and add "\n" in echo

https://www.php.net/manual/en/function.range.php
  - improved examples' readability

What is left there that I can see:

https://www.php.net/manual/en/function.array-fill.php
  - different behavior in PHP 8

https://www.php.net/manual/en/function.array-udiff-assoc.php
  - different behavior for PHP 5, PHP 7, PHP 8

https://www.php.net/manual/en/function.array-udiff-uassoc.php
  - different behavior for PHP 7, PHP 8

https://www.php.net/manual/en/function.count.php
  - different behavior for PHP 7, PHP 8

Changelog section would be appropriate similarly to 
https://www.php.net/manual/en/function.array-unique.php
