### PR TITLE
Updating mysqli: prepared statements

### DIFF
--- a/reference/mysqli/mysqli/prepare.xml
+++ b/reference/mysqli/mysqli/prepare.xml
@@ -47,22 +47,20 @@
        question mark (<literal>?</literal>) characters at the appropriate positions.
       </para>
       <note>
+<!-- Copied from https://dev.mysql.com/doc/c-api/8.0/en/mysql-stmt-prepare.html -->
        <para>
         The markers are legal only in certain places in SQL statements.
-        For example, they are allowed in the <literal>VALUES()</literal>
+        For example, they are permitted in the <literal>VALUES()</literal>
         list of an <literal>INSERT</literal> statement (to specify column
         values for a row), or in a comparison with a column in a
         <literal>WHERE</literal> clause to specify a comparison value.
        </para>
        <para>
-        However, they are not allowed for identifiers (such as table or
-        column names), in the select list that names the columns to be
-        returned by a <literal>SELECT</literal> statement, or to specify both
+        However, they are not permitted for identifiers (such as table or
+        column names), or to specify both
         operands of a binary operator such as the <literal>=</literal> equal
         sign. The latter restriction is necessary because it would be
-        impossible to determine the parameter type. It's not allowed to
-        compare marker with <literal>NULL</literal> by 
-        <literal>? IS NULL</literal> too. In general, parameters are legal
+        impossible to determine the parameter type. In general, parameters are legal
         only in Data Manipulation Language (DML) statements, and not in Data
         Definition Language (DDL) statements.
        </para>

--- a/reference/mysqli/mysqli/prepare.xml
+++ b/reference/mysqli/mysqli/prepare.xml
@@ -25,7 +25,7 @@
    operations on the statement. The query must consist of a single SQL statement.
   </para>
   <para>
-   The statement template can contain zero or more question mark (?) parameter markers⁠—also called 
+   The statement template can contain zero or more question mark (<literal>?</literal>) parameter markers⁠—also called 
    placeholders. The parameter markers must be bound to application variables using
    <function>mysqli_stmt_bind_param</function> before executing the statement.
   </para>

--- a/reference/mysqli/mysqli/prepare.xml
+++ b/reference/mysqli/mysqli/prepare.xml
@@ -25,8 +25,9 @@
    operations on the statement. The query must consist of a single SQL statement.
   </para>
   <para>
-   The statement template can contain zero or more question mark (<literal>?</literal>) parameter markers⁠—also called 
-   placeholders. The parameter markers must be bound to application variables using
+   The statement template can contain zero or more question mark
+   (<literal>?</literal>) parameter markers⁠—also called placeholders.
+   The parameter markers must be bound to application variables using
    <function>mysqli_stmt_bind_param</function> before executing the statement.
   </para>
  </refsect1>
@@ -43,8 +44,9 @@
        The query, as a string. It must consist of a single SQL statement.
       </para>
       <para>
-       The SQL statement may contain zero or more parameter markers represented by 
-       question mark (<literal>?</literal>) characters at the appropriate positions.
+       The SQL statement may contain zero or more parameter markers
+       represented by question mark (<literal>?</literal>) characters
+       at the appropriate positions.
       </para>
       <note>
 <!-- Copied from https://dev.mysql.com/doc/c-api/8.0/en/mysql-stmt-prepare.html -->
@@ -60,9 +62,9 @@
         column names), or to specify both
         operands of a binary operator such as the <literal>=</literal> equal
         sign. The latter restriction is necessary because it would be
-        impossible to determine the parameter type. In general, parameters are legal
-        only in Data Manipulation Language (DML) statements, and not in Data
-        Definition Language (DDL) statements.
+        impossible to determine the parameter type. In general, parameters are
+        legal only in Data Manipulation Language (DML) statements, and not in
+        Data Definition Language (DDL) statements.
        </para>
       </note>
      </listitem>

--- a/reference/mysqli/mysqli/prepare.xml
+++ b/reference/mysqli/mysqli/prepare.xml
@@ -42,12 +42,6 @@
       <para>
        The query, as a string.
       </para>
-      <note>
-       <para>
-        You should not add a terminating semicolon or <literal>\g</literal>
-        to the statement.
-       </para>
-      </note>
       <para>
        The SQL statement may contain zero or more parameter markers represented by 
        question mark (<literal>?</literal>) characters at the appropriate positions.

--- a/reference/mysqli/mysqli/prepare.xml
+++ b/reference/mysqli/mysqli/prepare.xml
@@ -86,80 +86,56 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$mysqli = new mysqli("localhost", "my_user", "my_password", "world");
 
-/* check connection */
-if (mysqli_connect_errno()) {
-    printf("Connect failed: %s\n", mysqli_connect_error());
-    exit();
-}
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = new mysqli("localhost", "my_user", "my_password", "world");
 
 $city = "Amersfoort";
 
 /* create a prepared statement */
-if ($stmt = $mysqli->prepare("SELECT District FROM City WHERE Name=?")) {
+$stmt = $mysqli->prepare("SELECT District FROM City WHERE Name=?");
 
-    /* bind parameters for markers */
-    $stmt->bind_param("s", $city);
+/* bind parameters for markers */
+$stmt->bind_param("s", $city);
 
-    /* execute query */
-    $stmt->execute();
+/* execute query */
+$stmt->execute();
 
-    /* bind result variables */
-    $stmt->bind_result($district);
+/* bind result variables */
+$stmt->bind_result($district);
 
-    /* fetch value */
-    $stmt->fetch();
+/* fetch value */
+$stmt->fetch();
 
-    printf("%s is in district %s\n", $city, $district);
-
-    /* close statement */
-    $stmt->close();
-}
-
-/* close connection */
-$mysqli->close();
-?>
+printf("%s is in district %s\n", $city, $district);
 ]]>
    </programlisting>
    <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
-$link = mysqli_connect("localhost", "my_user", "my_password", "world");
 
-/* check connection */
-if (mysqli_connect_errno()) {
-    printf("Connect failed: %s\n", mysqli_connect_error());
-    exit();
-}
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$link = mysqli_connect("localhost", "my_user", "my_password", "world");
 
 $city = "Amersfoort";
 
 /* create a prepared statement */
-if ($stmt = mysqli_prepare($link, "SELECT District FROM City WHERE Name=?")) {
+$stmt = mysqli_prepare($link, "SELECT District FROM City WHERE Name=?");
 
-    /* bind parameters for markers */
-    mysqli_stmt_bind_param($stmt, "s", $city);
+/* bind parameters for markers */
+mysqli_stmt_bind_param($stmt, "s", $city);
 
-    /* execute query */
-    mysqli_stmt_execute($stmt);
+/* execute query */
+mysqli_stmt_execute($stmt);
 
-    /* bind result variables */
-    mysqli_stmt_bind_result($stmt, $district);
+/* bind result variables */
+mysqli_stmt_bind_result($stmt, $district);
 
-    /* fetch value */
-    mysqli_stmt_fetch($stmt);
+/* fetch value */
+mysqli_stmt_fetch($stmt);
 
-    printf("%s is in district %s\n", $city, $district);
-
-    /* close statement */
-    mysqli_stmt_close($stmt);
-}
-
-/* close connection */
-mysqli_close($link);
-?>
+printf("%s is in district %s\n", $city, $district);
 ]]>
    </programlisting>
    &examples.outputs;
@@ -179,6 +155,7 @@ Amersfoort is in district Utrecht
     <member><function>mysqli_stmt_fetch</function></member>
     <member><function>mysqli_stmt_bind_param</function></member>
     <member><function>mysqli_stmt_bind_result</function></member>
+    <member><function>mysqli_stmt_get_result</function></member>
     <member><function>mysqli_stmt_close</function></member>
    </simplelist>
   </para>

--- a/reference/mysqli/mysqli/prepare.xml
+++ b/reference/mysqli/mysqli/prepare.xml
@@ -4,7 +4,7 @@
  <refnamediv>
   <refname>mysqli::prepare</refname>
   <refname>mysqli_prepare</refname>
-  <refpurpose>Prepare an SQL statement for execution</refpurpose>
+  <refpurpose>Prepares an SQL statement for execution</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -25,10 +25,9 @@
    operations on the statement. The query must consist of a single SQL statement.
   </para>
   <para>
-   The parameter markers must be bound to application variables using
-   <function>mysqli_stmt_bind_param</function> and/or 
-   <function>mysqli_stmt_bind_result</function> before executing the
-   statement or fetching rows.
+   The statement template can contain zero or more question mark (?) parameter markers⁠—also called 
+   placeholders. The parameter markers must be bound to application variables using
+   <function>mysqli_stmt_bind_param</function> before executing the statement.
   </para>
  </refsect1>
 

--- a/reference/mysqli/mysqli/prepare.xml
+++ b/reference/mysqli/mysqli/prepare.xml
@@ -49,9 +49,8 @@
        </para>
       </note>
       <para>
-       This parameter can include one or more parameter markers in the SQL
-       statement by embedding question mark (<literal>?</literal>) characters
-       at the appropriate positions.
+       The SQL statement may contain zero or more parameter markers represented by 
+       question mark (<literal>?</literal>) characters at the appropriate positions.
       </para>
       <note>
        <para>

--- a/reference/mysqli/mysqli/prepare.xml
+++ b/reference/mysqli/mysqli/prepare.xml
@@ -40,7 +40,7 @@
      <term><parameter>query</parameter></term>
      <listitem>
       <para>
-       The query, as a string.
+       The query, as a string. It must consist of a single SQL statement.
       </para>
       <para>
        The SQL statement may contain zero or more parameter markers represented by 

--- a/reference/mysqli/mysqli_stmt/construct.xml
+++ b/reference/mysqli/mysqli_stmt/construct.xml
@@ -23,7 +23,14 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &mysqli.link.description;
+    <varlistentry>
+     <term><parameter>link</parameter></term>
+     <listitem>
+      <para>
+       A valid <classname>mysqli</classname> object.
+      </para>
+     </listitem>
+    </varlistentry>
     <varlistentry>
      <term><parameter>query</parameter></term>
      <listitem>

--- a/reference/mysqli/mysqli_stmt/execute.xml
+++ b/reference/mysqli/mysqli_stmt/execute.xml
@@ -52,24 +52,21 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>&style.oop;</title>
+   <title><methodname>mysqli_stmt::execute</methodname> example</title>
+   <para>&style.oop;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
-$mysqli = new mysqli("localhost", "my_user", "my_password", "world");
 
-/* check connection */
-if (mysqli_connect_errno()) {
-    printf("Connect failed: %s\n", mysqli_connect_error());
-    exit();
-}
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = new mysqli("localhost", "my_user", "my_password", "world");
 
 $mysqli->query("CREATE TABLE myCity LIKE City");
 
 /* Prepare an insert statement */
-$query = "INSERT INTO myCity (Name, CountryCode, District) VALUES (?,?,?)";
-$stmt = $mysqli->prepare($query);
+$stmt = $mysqli->prepare("INSERT INTO myCity (Name, CountryCode, District) VALUES (?,?,?)");
 
+/* Bind variables to parameters */
 $stmt->bind_param("sss", $val1, $val2, $val3);
 
 $val1 = 'Stuttgart';
@@ -86,47 +83,31 @@ $val3 = 'Aquitaine';
 /* Execute the statement */
 $stmt->execute();
 
-/* close statement */
-$stmt->close();
-
 /* retrieve all rows from myCity */
 $query = "SELECT Name, CountryCode, District FROM myCity";
-if ($result = $mysqli->query($query)) {
-    while ($row = $result->fetch_row()) {
-        printf("%s (%s,%s)\n", $row[0], $row[1], $row[2]);
-    }
-    /* free result set */
-    $result->close();
+$result = $mysqli->query($query);
+while ($row = $result->fetch_row()) {
+    printf("%s (%s,%s)\n", $row[0], $row[1], $row[2]);
 }
 
 /* remove table */
 $mysqli->query("DROP TABLE myCity");
-
-/* close connection */
-$mysqli->close();
-?>
 ]]>
    </programlisting>
-  </example>
-  <example>
-   <title>&style.procedural;</title>
+   <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
-$link = mysqli_connect("localhost", "my_user", "my_password", "world");
 
-/* check connection */
-if (mysqli_connect_errno()) {
-    printf("Connect failed: %s\n", mysqli_connect_error());
-    exit();
-}
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$link = mysqli_connect("localhost", "my_user", "my_password", "world");
 
 mysqli_query($link, "CREATE TABLE myCity LIKE City");
 
 /* Prepare an insert statement */
-$query = "INSERT INTO myCity (Name, CountryCode, District) VALUES (?,?,?)";
-$stmt = mysqli_prepare($link, $query);
+$stmt = mysqli_prepare($link, "INSERT INTO myCity (Name, CountryCode, District) VALUES (?,?,?)");
 
+/* Bind variables to parameters */
 mysqli_stmt_bind_param($stmt, "sss", $val1, $val2, $val3);
 
 $val1 = 'Stuttgart';
@@ -143,25 +124,15 @@ $val3 = 'Aquitaine';
 /* Execute the statement */
 mysqli_stmt_execute($stmt);
 
-/* close statement */
-mysqli_stmt_close($stmt);
-
 /* retrieve all rows from myCity */
 $query = "SELECT Name, CountryCode, District FROM myCity";
-if ($result = mysqli_query($link, $query)) {
-    while ($row = mysqli_fetch_row($result)) {
-        printf("%s (%s,%s)\n", $row[0], $row[1], $row[2]);
-    }
-    /* free result set */
-    mysqli_free_result($result);
+$result = mysqli_query($link, $query);
+while ($row = mysqli_fetch_row($result)) {
+    printf("%s (%s,%s)\n", $row[0], $row[1], $row[2]);
 }
 
 /* remove table */
 mysqli_query($link, "DROP TABLE myCity");
-
-/* close connection */
-mysqli_close($link);
-?>
 ]]>
      </programlisting>
      &examples.outputs;

--- a/reference/mysqli/mysqli_stmt/execute.xml
+++ b/reference/mysqli/mysqli_stmt/execute.xml
@@ -20,9 +20,11 @@
    <methodparam><type>mysqli_stmt</type><parameter>stmt</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Executes previously prepared statement. The statement must be successfully prepared prior to execution,
-   using either the <function>mysqli_prepare</function> or <function>mysqli_stmt_prepare</function>
-   function, or by passing the second argument to <methodname>mysqli_stmt::__construct</methodname>. 
+   Executes previously prepared statement. The statement must be successfully 
+   prepared prior to execution, using either
+   the <function>mysqli_prepare</function> or
+   <function>mysqli_stmt_prepare</function> function, or by passing the second
+   argument to <methodname>mysqli_stmt::__construct</methodname>. 
   </para>
   <para>
    If the statement is <literal>UPDATE</literal>, <literal>DELETE</literal>,

--- a/reference/mysqli/mysqli_stmt/execute.xml
+++ b/reference/mysqli/mysqli_stmt/execute.xml
@@ -4,7 +4,7 @@
  <refnamediv>
   <refname>mysqli_stmt::execute</refname>
   <refname>mysqli_stmt_execute</refname>
-  <refpurpose>Executes a prepared Query</refpurpose>
+  <refpurpose>Executes a prepared statement</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -20,8 +20,9 @@
    <methodparam><type>mysqli_stmt</type><parameter>stmt</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Executes a query that has been previously prepared using the
-   <function>mysqli_prepare</function> function. 
+   Executes previously prepared statement. The statement must be successfully prepared prior to execution,
+   using either the <function>mysqli_prepare</function> or <function>mysqli_stmt_prepare</function>
+   function, or by passing the second argument to <methodname>mysqli_stmt::__construct</methodname>. 
   </para>
   <para>
    If the statement is <literal>UPDATE</literal>, <literal>DELETE</literal>,

--- a/reference/mysqli/mysqli_stmt/execute.xml
+++ b/reference/mysqli/mysqli_stmt/execute.xml
@@ -21,9 +21,7 @@
   </methodsynopsis>
   <para>
    Executes a query that has been previously prepared using the
-   <function>mysqli_prepare</function> function. When executed any
-   parameter markers which exist will automatically be replaced with the
-   appropriate data.
+   <function>mysqli_prepare</function> function. 
   </para>
   <para>
    If the statement is <literal>UPDATE</literal>, <literal>DELETE</literal>,
@@ -32,13 +30,6 @@
    function. Likewise, if the query yields a result set the 
    <function>mysqli_stmt_fetch</function> function is used.
   </para>
-  <note>
-   <para>
-    When using <function>mysqli_stmt_execute</function>, the 
-    <function>mysqli_stmt_fetch</function> function must be used to fetch the
-    data prior to performing any additional queries.
-   </para>
-  </note>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli_stmt/prepare.xml
+++ b/reference/mysqli/mysqli_stmt/prepare.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <modifier>public</modifier> <type>mixed</type><methodname>mysqli_stmt::prepare</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli_stmt::prepare</methodname>
    <methodparam><type>string</type><parameter>query</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/mysqli_stmt/prepare.xml
+++ b/reference/mysqli/mysqli_stmt/prepare.xml
@@ -78,20 +78,22 @@
        question mark (<literal>?</literal>) characters at the appropriate positions.
       </para>
       <note>
+<!-- Copied from https://dev.mysql.com/doc/c-api/8.0/en/mysql-stmt-prepare.html -->
        <para>
         The markers are legal only in certain places in SQL statements.
-        For example, they are allowed in the VALUES() list of an INSERT statement
-        (to specify column values for a row), or in a comparison with a column in
-        a WHERE clause to specify a comparison value.
+        For example, they are permitted in the <literal>VALUES()</literal>
+        list of an <literal>INSERT</literal> statement (to specify column
+        values for a row), or in a comparison with a column in a
+        <literal>WHERE</literal> clause to specify a comparison value.
        </para>
        <para>
-        However, they are not allowed for identifiers (such as table or column names),
-        in the select list that names the columns to be returned by a SELECT statement),
-        or to specify both operands of a binary operator such as the <literal>=</literal>
-        equal sign. The latter restriction is necessary because it would be impossible
-        to determine the parameter type. In general, parameters are legal only in Data
-        Manipulation Language (DML) statements, and not in Data Definition Language
-        (DDL) statements.
+        However, they are not permitted for identifiers (such as table or
+        column names), or to specify both
+        operands of a binary operator such as the <literal>=</literal> equal
+        sign. The latter restriction is necessary because it would be
+        impossible to determine the parameter type. In general, parameters are legal
+        only in Data Manipulation Language (DML) statements, and not in Data
+        Definition Language (DDL) statements.
        </para>
       </note>
      </listitem>

--- a/reference/mysqli/mysqli_stmt/prepare.xml
+++ b/reference/mysqli/mysqli_stmt/prepare.xml
@@ -24,7 +24,7 @@
    Prepares a statement for execution. The query must consist of a single SQL statement.
   </para>
   <para>
-   The statement template can contain zero or more question mark (?) parameter markers⁠—also called 
+   The statement template can contain zero or more question mark (<literal>?</literal>) parameter markers⁠—also called 
    placeholders. The parameter markers must be bound to application variables using
    <function>mysqli_stmt_bind_param</function> before executing the statement.
   </para>

--- a/reference/mysqli/mysqli_stmt/prepare.xml
+++ b/reference/mysqli/mysqli_stmt/prepare.xml
@@ -74,9 +74,8 @@
        The query, as a string. It must consist of a single SQL statement.
       </para>
       <para>
-       You can include one or more parameter markers in the SQL statement by
-       embedding question mark (<literal>?</literal>) characters at the
-       appropriate positions.
+       The SQL statement may contain zero or more parameter markers represented by 
+       question mark (<literal>?</literal>) characters at the appropriate positions.
       </para>
       <note>
        <para>

--- a/reference/mysqli/mysqli_stmt/prepare.xml
+++ b/reference/mysqli/mysqli_stmt/prepare.xml
@@ -112,88 +112,63 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>&style.oop;</title>
+   <title><methodname>mysqli_stmt::prepare</methodname> example</title>
+   <para>&style.oop;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
-$mysqli = new mysqli("localhost", "my_user", "my_password", "world");
 
-/* check connection */
-if (mysqli_connect_errno()) {
-    printf("Connect failed: %s\n", mysqli_connect_error());
-    exit();
-}
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = new mysqli("localhost", "my_user", "my_password", "world");
 
 $city = "Amersfoort";
 
 /* create a prepared statement */
-$stmt =  $mysqli->stmt_init();
-if ($stmt->prepare("SELECT District FROM City WHERE Name=?")) {
+$stmt = $mysqli->stmt_init();
+$stmt->prepare("SELECT District FROM City WHERE Name=?");
 
-    /* bind parameters for markers */
-    $stmt->bind_param("s", $city);
+/* bind parameters for markers */
+$stmt->bind_param("s", $city);
 
-    /* execute query */
-    $stmt->execute();
+/* execute query */
+$stmt->execute();
 
-    /* bind result variables */
-    $stmt->bind_result($district);
+/* bind result variables */
+$stmt->bind_result($district);
 
-    /* fetch value */
-    $stmt->fetch();
+/* fetch value */
+$stmt->fetch();
 
-    printf("%s is in district %s\n", $city, $district);
-
-    /* close statement */
-    $stmt->close();
-}
-
-/* close connection */
-$mysqli->close();
-?>
+printf("%s is in district %s\n", $city, $district);
 ]]>
    </programlisting>
-  </example>
-  <example>
-   <title>&style.procedural;</title>
+   <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
-$link = mysqli_connect("localhost", "my_user", "my_password", "world");
 
-/* check connection */
-if (mysqli_connect_errno()) {
-    printf("Connect failed: %s\n", mysqli_connect_error());
-    exit();
-}
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$link = mysqli_connect("localhost", "my_user", "my_password", "world");
 
 $city = "Amersfoort";
 
 /* create a prepared statement */
 $stmt = mysqli_stmt_init($link);
-if (mysqli_stmt_prepare($stmt, 'SELECT District FROM City WHERE Name=?')) {
+mysqli_stmt_prepare($stmt, "SELECT District FROM City WHERE Name=?");
 
-    /* bind parameters for markers */
-    mysqli_stmt_bind_param($stmt, "s", $city);
+/* bind parameters for markers */
+mysqli_stmt_bind_param($stmt, "s", $city);
 
-    /* execute query */
-    mysqli_stmt_execute($stmt);
+/* execute query */
+mysqli_stmt_execute($stmt);
 
-    /* bind result variables */
-    mysqli_stmt_bind_result($stmt, $district);
+/* bind result variables */
+mysqli_stmt_bind_result($stmt, $district);
 
-    /* fetch value */
-    mysqli_stmt_fetch($stmt);
+/* fetch value */
+mysqli_stmt_fetch($stmt);
 
-    printf("%s is in district %s\n", $city, $district);
-
-    /* close statement */
-    mysqli_stmt_close($stmt);
-}
-
-/* close connection */
-mysqli_close($link);
-?>
+printf("%s is in district %s\n", $city, $district);
 ]]>
    </programlisting>
    &examples.outputs;

--- a/reference/mysqli/mysqli_stmt/prepare.xml
+++ b/reference/mysqli/mysqli_stmt/prepare.xml
@@ -79,12 +79,6 @@
       </para>
       <note>
        <para>
-        You should not add a terminating semicolon or <literal>\g</literal>
-        to the statement.
-       </para>
-      </note>
-      <note>
-       <para>
         The markers are legal only in certain places in SQL statements.
         For example, they are allowed in the VALUES() list of an INSERT statement
         (to specify column values for a row), or in a comparison with a column in

--- a/reference/mysqli/mysqli_stmt/prepare.xml
+++ b/reference/mysqli/mysqli_stmt/prepare.xml
@@ -4,7 +4,7 @@
  <refnamediv>
   <refname>mysqli_stmt::prepare</refname>
   <refname>mysqli_stmt_prepare</refname>
-  <refpurpose>Prepare an SQL statement for execution</refpurpose>
+  <refpurpose>Prepares an SQL statement for execution</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -21,13 +21,12 @@
    <methodparam><type>string</type><parameter>query</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Prepares the SQL query pointed to by the null-terminated string query. 
+   Prepares a statement for execution. The query must consist of a single SQL statement.
   </para>
   <para>
-   The parameter markers must be bound to application variables using
-   <function>mysqli_stmt_bind_param</function> and/or 
-   <function>mysqli_stmt_bind_result</function> before executing the
-   statement or fetching rows.
+   The statement template can contain zero or more question mark (?) parameter markers⁠—also called 
+   placeholders. The parameter markers must be bound to application variables using
+   <function>mysqli_stmt_bind_param</function> before executing the statement.
   </para>
   <note>
    <para>

--- a/reference/mysqli/mysqli_stmt/prepare.xml
+++ b/reference/mysqli/mysqli_stmt/prepare.xml
@@ -21,11 +21,13 @@
    <methodparam><type>string</type><parameter>query</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Prepares a statement for execution. The query must consist of a single SQL statement.
+   Prepares a statement for execution.
+   The query must consist of a single SQL statement.
   </para>
   <para>
-   The statement template can contain zero or more question mark (<literal>?</literal>) parameter markers⁠—also called 
-   placeholders. The parameter markers must be bound to application variables using
+   The statement template can contain zero or more question mark
+   (<literal>?</literal>) parameter markers⁠—also called placeholders.
+   The parameter markers must be bound to application variables using
    <function>mysqli_stmt_bind_param</function> before executing the statement.
   </para>
   <note>
@@ -74,8 +76,9 @@
        The query, as a string. It must consist of a single SQL statement.
       </para>
       <para>
-       The SQL statement may contain zero or more parameter markers represented by 
-       question mark (<literal>?</literal>) characters at the appropriate positions.
+       The SQL statement may contain zero or more parameter markers
+       represented by question mark (<literal>?</literal>) characters
+       at the appropriate positions.
       </para>
       <note>
 <!-- Copied from https://dev.mysql.com/doc/c-api/8.0/en/mysql-stmt-prepare.html -->
@@ -91,9 +94,9 @@
         column names), or to specify both
         operands of a binary operator such as the <literal>=</literal> equal
         sign. The latter restriction is necessary because it would be
-        impossible to determine the parameter type. In general, parameters are legal
-        only in Data Manipulation Language (DML) statements, and not in Data
-        Definition Language (DDL) statements.
+        impossible to determine the parameter type. In general, parameters are
+        legal only in Data Manipulation Language (DML) statements, and not in
+        Data Definition Language (DDL) statements.
        </para>
       </note>
      </listitem>


### PR DESCRIPTION
Another PR aiming to improve mysqli docs by removing lies and deception. In this episode:
- `mysqli_stmt_bind_result()` cannot be used to bind variables to placeholders
- There is no such thing as *"null-terminated string query"*.
- A prepared statement doesn't have to have any parameter markers. The parameter binding can be skipped. This means that the SQL can contain zero or more markers.
- The trailing semicolon is ignored. The Go command (i.e. `\g`) is not allowed in any application layer client API. No idea why that note was there, but it has been throwing a lot of people off.
- The note which was copied from MySQL docs has been altered. Not only the English language was broken, but incorrect information was added. I am not aware of any limitations in regards to `? IS NULL`. The two pages in the manual had a slightly different version of the note. If it was copied from MySQL then let's bring it up to date. 
- `mysqli_stmt::prepare` can return only a boolean as far as I know
- `mysqli_stmt::execute` contained some strange notes, which I removed. Parameter markers are never replaced into the SQL by neither client nor server. They are sent separately and are used in the execution. `mysqli_stmt_fetch` doesn't have to be used. It might be used in situations where a result set is bound to variables and needs to be fetched, but it is in no way a requirement. That sentence made no sense, but I assume it was meant to inform users that `execute` doesn't return the result set. If that was the intention then there are better ways to communicate it. 
- A copy-paste of a snippet made for some strange information in `mysqli_stmt::__construct`. The first parameter is mandatory and there is no procedural version. The object needs to be a valid mysqli connection to MySQL. 
- Improved code examples and some wording. 