### PR TITLE
Added PHP 8 into versions.xml for mbstring based on stubs.

### DIFF
--- a/reference/mbstring/versions.xml
+++ b/reference/mbstring/versions.xml
@@ -4,67 +4,67 @@
   Do NOT translate this file
 -->
 <versions>
- <function name="mb_check_encoding" from="PHP 4 &gt;= 4.4.3, PHP 5 &gt;= 5.1.3, PHP 7"/>
- <function name="mb_chr" from="PHP 7 &gt;= 7.2.0"/>
- <function name="mb_convert_case" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="mb_convert_encoding" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_convert_kana" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_convert_variables" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_decode_mimeheader" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_decode_numericentity" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_detect_encoding" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_detect_order" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_encode_mimeheader" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_encode_numericentity" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_encoding_aliases" from="PHP 5 &gt;= 5.3.0, PHP 7"/> 
- <function name="mb_ereg" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="mb_ereg_match" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="mb_ereg_replace" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="mb_ereg_replace_callback" from="PHP 5 &gt;= 5.4.1, PHP 7"/>
- <function name="mb_ereg_search" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="mb_ereg_search_getpos" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="mb_ereg_search_getregs" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="mb_ereg_search_init" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="mb_ereg_search_pos" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="mb_ereg_search_regs" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="mb_ereg_search_setpos" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="mb_eregi" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="mb_eregi_replace" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="mb_get_info" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="mb_http_input" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_http_output" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_internal_encoding" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_language" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_list_encodings" from="PHP 5, PHP 7"/>
+ <function name="mb_check_encoding" from="PHP 4 &gt;= 4.4.3, PHP 5 &gt;= 5.1.3, PHP 7, PHP 8"/>
+ <function name="mb_chr" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="mb_convert_case" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_convert_encoding" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_convert_kana" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_convert_variables" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_decode_mimeheader" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_decode_numericentity" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_detect_encoding" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_detect_order" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_encode_mimeheader" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_encode_numericentity" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_encoding_aliases" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="mb_ereg" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_ereg_match" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_ereg_replace" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_ereg_replace_callback" from="PHP 5 &gt;= 5.4.1, PHP 7, PHP 8"/>
+ <function name="mb_ereg_search" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_ereg_search_getpos" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_ereg_search_getregs" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_ereg_search_init" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_ereg_search_pos" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_ereg_search_regs" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_ereg_search_setpos" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_eregi" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_eregi_replace" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_get_info" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_http_input" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_http_output" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_internal_encoding" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_language" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_list_encodings" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mb_list_encodings_alias_names" from="PHP 5 &gt;= 5.2.0 &lt; 5.2.7"/>
  <function name="mb_list_mime_names" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="mb_ord" from="PHP 7 &gt;= 7.2.0"/>
- <function name="mb_output_handler" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_parse_str" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_preferred_mime_name" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_regex_encoding" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="mb_regex_set_options" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="mb_scrub" from="PHP 7 &gt;= 7.2.0"/>
- <function name="mb_send_mail" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_split" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="mb_strcut" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_strimwidth" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_stripos" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="mb_stristr" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="mb_strlen" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_strpos" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_strrchr" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="mb_strrichr" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="mb_strripos" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="mb_strrpos" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_strstr" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="mb_strtolower" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="mb_strtoupper" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="mb_strwidth" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_substitute_character" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_substr" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="mb_substr_count" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="mb_str_split" from="PHP 7 &gt;= 7.4.0"/>
+ <function name="mb_ord" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="mb_output_handler" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_parse_str" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_preferred_mime_name" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_regex_encoding" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_regex_set_options" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_scrub" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="mb_send_mail" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_split" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_strcut" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_strimwidth" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_stripos" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="mb_stristr" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="mb_strlen" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_strpos" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_strrchr" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="mb_strrichr" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="mb_strripos" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="mb_strrpos" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_strstr" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="mb_strtolower" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_strtoupper" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_strwidth" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_substitute_character" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_substr" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_substr_count" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="mb_str_split" from="PHP 7 &gt;= 7.4.0, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Generated verions.xml based on the folloing stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/mbstring/mbstring.stub.php
- deleted function from PHP 8
  * these deleted functions are undocumented on appendices/migration80*
    - mb_list_encodings_alias_names
    - mb_list_mime_names

Note: generate script https://gist.github.com/mumumu/b087d6c3ce2716db83a9aef8ffad1656