### PR TITLE
Added PHP 8 into versions.xml for zip based on stubs.

### DIFF
--- a/reference/zip/versions.xml
+++ b/reference/zip/versions.xml
@@ -5,68 +5,68 @@
 -->
 <versions>
 
- <function name="ZipArchive" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.1.0"/>
- <function name="ZipArchive::addEmptyDir" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.8.0"/>
- <function name="ZipArchive::addFile" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.1.0"/>
- <function name="ZipArchive::addFromString" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.1.0"/>
- <function name="ZipArchive::addGlob" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL zip &gt;= 1.9.0"/>
- <function name="ZipArchive::addPattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL zip &gt;= 1.9.0"/>
- <function name="ZipArchive::close" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.1.0"/>
- <function name="ZipArchive::count" from="PHP 7 &gt;= 7.2.0, PECL zip &gt;= 1.15.0"/>
+ <function name="ZipArchive" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.1.0"/>
+ <function name="ZipArchive::addEmptyDir" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.8.0"/>
+ <function name="ZipArchive::addFile" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.1.0"/>
+ <function name="ZipArchive::addFromString" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.1.0"/>
+ <function name="ZipArchive::addGlob" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL zip &gt;= 1.9.0"/>
+ <function name="ZipArchive::addPattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL zip &gt;= 1.9.0"/>
+ <function name="ZipArchive::close" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.1.0"/>
+ <function name="ZipArchive::count" from="PHP 7 &gt;= 7.2.0, PHP 8, PECL zip &gt;= 1.15.0"/>
  <function name="ZipArchive::delete" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &lt; 1.5.0"/>
- <function name="ZipArchive::deleteIndex" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.5.0"/>
- <function name="ZipArchive::deleteName" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.5.0"/>
- <function name="ZipArchive::extractTo" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.1.0"/>
- <function name="ZipArchive::getArchiveComment" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.1.0"/>
- <function name="ZipArchive::getCommentIndex" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.4.0"/>
- <function name="ZipArchive::getCommentName" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.4.0"/>
- <function name="ZipArchive::getExternalAttributesIndex" from="PHP 5 &gt;= 5.6.0, PHP 7, PECL zip &gt;= 1.12.4"/>
- <function name="ZipArchive::getExternalAttributesName" from="PHP 5 &gt;= 5.6.0, PHP 7, PECL zip &gt;= 1.12.4"/>
- <function name="ZipArchive::getFromIndex" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.1.0"/>
- <function name="ZipArchive::getFromName" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.1.0"/>
- <function name="ZipArchive::getNameIndex" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.5.0"/>
- <function name="ZipArchive::getStream" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.1.0"/>
- <function name="ZipArchive::getStatusString" from="PHP 5 &gt;= 5.2.7, PHP 7"/>
+ <function name="ZipArchive::deleteIndex" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.5.0"/>
+ <function name="ZipArchive::deleteName" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.5.0"/>
+ <function name="ZipArchive::extractTo" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.1.0"/>
+ <function name="ZipArchive::getArchiveComment" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.1.0"/>
+ <function name="ZipArchive::getCommentIndex" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.4.0"/>
+ <function name="ZipArchive::getCommentName" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.4.0"/>
+ <function name="ZipArchive::getExternalAttributesIndex" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8, PECL zip &gt;= 1.12.4"/>
+ <function name="ZipArchive::getExternalAttributesName" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8, PECL zip &gt;= 1.12.4"/>
+ <function name="ZipArchive::getFromIndex" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.1.0"/>
+ <function name="ZipArchive::getFromName" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.1.0"/>
+ <function name="ZipArchive::getNameIndex" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.5.0"/>
+ <function name="ZipArchive::getStream" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.1.0"/>
+ <function name="ZipArchive::getStatusString" from="PHP 5 &gt;= 5.2.7, PHP 7, PHP 8"/>
  <function name="ZipArchive::isCompressionMethodSupported" from="PHP &gt;= 8.0.0, PECL zip &gt;= 1.19.0"/>
  <function name="ZipArchive::isEncryptionMethodSupported" from="PHP &gt;= 8.0.0, PECL zip &gt;= 1.19.0"/>
- <function name="ZipArchive::locateName" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.5.0"/>
- <function name="ZipArchive::open" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.1.0"/>
+ <function name="ZipArchive::locateName" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.5.0"/>
+ <function name="ZipArchive::open" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.1.0"/>
  <function name="ZipArchive::rename" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &lt; 1.5.0"/>
- <function name="ZipArchive::renameIndex" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.5.0"/>
- <function name="ZipArchive::renameName" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.5.0"/>
+ <function name="ZipArchive::renameIndex" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.5.0"/>
+ <function name="ZipArchive::renameName" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.5.0"/>
  <function name="ZipArchive::replaceFile" from="PHP &gt;= 8.0.0, PECL zip &gt;= 1.18.0"/>
  <function name="ZipArchive::registerProgressCallback" from="PHP &gt;= 8.0.0, PECL zip &gt;= 1.17.0"/>
  <function name="ZipArchive::registerCancelCallback" from="PHP &gt;= 8.0.0, PECL zip &gt;= 1.17.0"/>
- <function name="ZipArchive::setArchiveComment" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.4.0"/>
- <function name="ZipArchive::setCommentIndex" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.4.0"/>
- <function name="ZipArchive::setCommentName" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.4.0"/>
- <function name="ZipArchive::setCompressionIndex" from="PHP 7, PECL zip &gt;= 1.13.0"/>
- <function name="ZipArchive::setCompressionName" from="PHP 7, PECL zip &gt;= 1.13.0"/>
- <function name="ZipArchive::setEncryptionIndex" from="PHP &gt;= 7.2.0, PECL zip &gt;= 1.14.0"/>
- <function name="ZipArchive::setEncryptionName" from="PHP &gt;= 7.2.0, PECL zip &gt;= 1.14.0"/>
+ <function name="ZipArchive::setArchiveComment" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.4.0"/>
+ <function name="ZipArchive::setCommentIndex" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.4.0"/>
+ <function name="ZipArchive::setCommentName" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.4.0"/>
+ <function name="ZipArchive::setCompressionIndex" from="PHP 7, PHP 8, PECL zip &gt;= 1.13.0"/>
+ <function name="ZipArchive::setCompressionName" from="PHP 7, PHP 8, PECL zip &gt;= 1.13.0"/>
+ <function name="ZipArchive::setEncryptionIndex" from="PHP &gt;= 7.2.0, PHP 8, PECL zip &gt;= 1.14.0"/>
+ <function name="ZipArchive::setEncryptionName" from="PHP &gt;= 7.2.0, PHP 8, PECL zip &gt;= 1.14.0"/>
  <function name="ZipArchive::setMtimeIndex" from="PHP &gt;= 8.0.0, PECL zip &gt;= 1.16.0"/>
  <function name="ZipArchive::setMtimeName" from="PHP &gt;= 8.0.0, PECL zip &gt;= 1.16.0"/>
- <function name="ZipArchive::setExternalAttributesIndex" from="PHP 5 &gt;= 5.6.0, PHP 7, PECL zip &gt;= 1.12.4"/>
- <function name="ZipArchive::setExternalAttributesName" from="PHP 5 &gt;= 5.6.0, PHP 7, PECL zip &gt;= 1.12.4"/>
- <function name="ZipArchive::setPassword" from="PHP 5 &gt;= 5.6.0, PHP 7, PECL zip &gt;= 1.12.4"/>
+ <function name="ZipArchive::setExternalAttributesIndex" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8, PECL zip &gt;= 1.12.4"/>
+ <function name="ZipArchive::setExternalAttributesName" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8, PECL zip &gt;= 1.12.4"/>
+ <function name="ZipArchive::setPassword" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8, PECL zip &gt;= 1.12.4"/>
  <function name="ZipArchive::stat" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &lt; 1.5.0"/>
- <function name="ZipArchive::statIndex" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.1.0"/>
- <function name="ZipArchive::statName" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.5.0"/>
- <function name="ZipArchive::unchangeAll" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.1.0"/>
- <function name="ZipArchive::unchangeArchive" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.1.0"/>
- <function name="ZipArchive::unchangeIndex" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.1.0"/>
- <function name="ZipArchive::unchangeName" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.5.0"/>
+ <function name="ZipArchive::statIndex" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.1.0"/>
+ <function name="ZipArchive::statName" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.5.0"/>
+ <function name="ZipArchive::unchangeAll" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.1.0"/>
+ <function name="ZipArchive::unchangeArchive" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.1.0"/>
+ <function name="ZipArchive::unchangeIndex" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.1.0"/>
+ <function name="ZipArchive::unchangeName" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.5.0"/>
 
- <function name="zip_close" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
- <function name="zip_entry_close" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
- <function name="zip_entry_compressedsize" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
- <function name="zip_entry_compressionmethod" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
- <function name="zip_entry_filesize" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
- <function name="zip_entry_name" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
- <function name="zip_entry_open" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
- <function name="zip_entry_read" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
- <function name="zip_open" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
- <function name="zip_read" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
+ <function name="zip_close" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
+ <function name="zip_entry_close" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
+ <function name="zip_entry_compressedsize" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
+ <function name="zip_entry_compressionmethod" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
+ <function name="zip_entry_filesize" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
+ <function name="zip_entry_name" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
+ <function name="zip_entry_open" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
+ <function name="zip_entry_read" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
+ <function name="zip_open" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
+ <function name="zip_read" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Generated verions.xml based on the folloing stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/zip/php_zip.stub.php
- the following functions were not found in stub file, but undocumented in appendices/migration80*
  * ZipArchive::delete
  * ZipArchive::stat

Note: generate script https://gist.github.com/mumumu/b087d6c3ce2716db83a9aef8ffad1656