### PR TITLE
Added PHP 8 into versions.xml for phar based on stubs.

### DIFF
--- a/reference/phar/versions.xml
+++ b/reference/phar/versions.xml
@@ -5,110 +5,110 @@
 -->
 <versions>
 
- <function name='phar' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::__construct' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::addemptydir' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::addfile' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::addfromstring' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::apiversion' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::buildfromdirectory' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::buildfromiterator' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::cancompress' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::canwrite' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::compress' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::compressfiles' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::converttodata' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::converttotar' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::converttozip' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::converttophar' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::converttoexecutable' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::copy' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::count' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::createdefaultstub' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::decompress' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::decompressfiles' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::delete' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::delmetadata' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.2.0'/>
- <function name='phar::extractto' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::getalias' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.2.1'/>
- <function name='phar::getmetadata' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::getmodified' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::getpath' from='PHP 5 &gt;= 5.3.0, PHP 7'/>
- <function name='phar::getsignature' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::getstub' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::getsupportedcompression' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.2.0'/>
- <function name='phar::getsupportedsignatures' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.1.0'/>
- <function name='phar::getversion' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::hasmetadata' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.2.0'/>
- <function name='phar::interceptfilefuncs' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::iscompressed' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::isphar' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::istar' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::iszip' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::isfileformat' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::iswritable' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::isbuffering' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::isvalidpharfilename' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.2.0'/>
- <function name='phar::loadphar' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::mapphar' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::mount' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::mungserver' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::offsetexists' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::offsetget' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::offsetset' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::offsetunset' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::running' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::setalias' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.2.1'/>
- <function name='phar::setdefaultstub' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::setmetadata' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::setsignaturealgorithm' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.1.0'/>
- <function name='phar::setstub' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::startbuffering' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::stopbuffering' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='phar::unlinkarchive' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phar::webphar' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
+ <function name="phar" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::addemptydir" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::addfile" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::addfromstring" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::apiversion" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::buildfromdirectory" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::buildfromiterator" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::cancompress" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::canwrite" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::compress" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::compressfiles" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::converttodata" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::converttotar" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::converttozip" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::converttophar" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::converttoexecutable" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::copy" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::count" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::createdefaultstub" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::decompress" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::decompressfiles" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::delete" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::delmetadata" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.2.0"/>
+ <function name="phar::extractto" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::getalias" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.2.1"/>
+ <function name="phar::getmetadata" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::getmodified" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::getpath" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="phar::getsignature" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::getstub" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::getsupportedcompression" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.2.0"/>
+ <function name="phar::getsupportedsignatures" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.1.0"/>
+ <function name="phar::getversion" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::hasmetadata" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.2.0"/>
+ <function name="phar::interceptfilefuncs" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::iscompressed" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::isphar" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::istar" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::iszip" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::isfileformat" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::iswritable" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::isbuffering" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::isvalidpharfilename" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.2.0"/>
+ <function name="phar::loadphar" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::mapphar" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::mount" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::mungserver" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::offsetexists" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::offsetget" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::offsetset" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::offsetunset" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::running" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::setalias" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.2.1"/>
+ <function name="phar::setdefaultstub" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::setmetadata" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::setsignaturealgorithm" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.1.0"/>
+ <function name="phar::setstub" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::startbuffering" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::stopbuffering" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="phar::unlinkarchive" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phar::webphar" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
 
- <function name='phardata' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::addemptydir' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::addfile' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::addfromstring' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::buildfromdirectory' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::buildfromiterator' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::compress' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::compressfiles' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::_construct' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::converttodata' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::converttoexecutable' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::copy' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::decompress' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::decompressfiles' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::delmetadata' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::delete' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::extractto' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::iswritable' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::offsetset' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::offsetunset' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::setalias' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::setdefaultstub' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='phardata::setstub' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
+ <function name="phardata" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::addemptydir" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::addfile" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::addfromstring" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::buildfromdirectory" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::buildfromiterator" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::compress" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::compressfiles" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::_construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::converttodata" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::converttoexecutable" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::copy" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::decompress" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::decompressfiles" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::delmetadata" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::delete" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::extractto" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::iswritable" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::offsetset" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::offsetunset" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::setalias" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::setdefaultstub" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::setstub" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
 
- <function name='pharexception' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
+ <function name="pharexception" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
 
- <function name='pharfileinfo' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='pharfileinfo::__construct' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='pharfileinfo::chmod' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='pharfileinfo_compress' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='pharfileinfo_decompress' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0'/>
- <function name='pharfileinfo::delmetadata' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.2.0'/>
- <function name='pharfileinfo::getcompressedsize' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='pharfileinfo::getcontent' from='PHP 5 &gt;= 5.3.0, PHP 7'/>
- <function name='pharfileinfo::getcrc32' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='pharfileinfo::getmetadata' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='pharfileinfo::getpharflags' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='pharfileinfo::hasmetadata' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.2.0'/>
- <function name='pharfileinfo::iscompressed' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='pharfileinfo::iscrcchecked' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
- <function name='pharfileinfo::setmetadata' from='PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 1.0.0'/>
+ <function name="pharfileinfo" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="pharfileinfo::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="pharfileinfo::chmod" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="pharfileinfo_compress" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
+ <function name="pharfileinfo_decompress" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
+ <function name="pharfileinfo::delmetadata" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.2.0"/>
+ <function name="pharfileinfo::getcompressedsize" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="pharfileinfo::getcontent" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="pharfileinfo::getcrc32" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="pharfileinfo::getmetadata" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="pharfileinfo::getpharflags" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="pharfileinfo::hasmetadata" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.2.0"/>
+ <function name="pharfileinfo::iscompressed" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="pharfileinfo::iscrcchecked" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
+ <function name="pharfileinfo::setmetadata" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
 </versions>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Generated verions.xml based on the folloing stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/phar/phar_object.stub.php
- the following functions were not found in stub file, but undocumented in appendices/migration80*
  * Phar::convertToTar
  * Phar::convertToZip
  * Phar::convertToPhar
  * Phar::isPhar
  * Phar::isTar
  * Phar::isZip
  * pharfileinfo_decompress
  * pharfileinfo_compress

Note: generate script https://gist.github.com/mumumu/b087d6c3ce2716db83a9aef8ffad1656