### PR TITLE
Added PHP 8 into versions.xml for pgsql based on stubs.

### DIFF
--- a/reference/pgsql/versions.xml
+++ b/reference/pgsql/versions.xml
@@ -4,97 +4,97 @@
   Do NOT translate this file
 -->
 <versions>
- <function name="pg_affected_rows" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_cancel_query" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_client_encoding" from="PHP 4 &gt;= 4.0.3, PHP 5, PHP 7"/>
- <function name="pg_close" from="PHP 4, PHP 5, PHP 7"/>
- <function name="pg_connect" from="PHP 4, PHP 5, PHP 7"/>
- <function name="pg_connect_poll" from="PHP 5 &gt;= 5.6.0, PHP 7"/>
- <function name="pg_connection_busy" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_connection_reset" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_connection_status" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_consume_input" from="PHP 5 &gt;= 5.6.0, PHP 7"/>
- <function name="pg_convert" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="pg_copy_from" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_copy_to" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_dbname" from="PHP 4, PHP 5, PHP 7"/>
- <function name="pg_delete" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="pg_end_copy" from="PHP 4 &gt;= 4.0.3, PHP 5, PHP 7"/>
- <function name="pg_escape_bytea" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_escape_identifier" from="PHP 5 &gt;= 5.4.4, PHP 7"/>
- <function name="pg_escape_literal" from="PHP 5 &gt;= 5.4.4, PHP 7"/>
- <function name="pg_escape_string" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_exec" from="PHP 4, PHP 5, PHP 7"/>
- <function name="pg_execute" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="pg_fetch_all" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="pg_fetch_all_columns" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="pg_fetch_array" from="PHP 4, PHP 5, PHP 7"/>
- <function name="pg_fetch_assoc" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="pg_fetch_object" from="PHP 4, PHP 5, PHP 7"/>
- <function name="pg_fetch_result" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_fetch_row" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="pg_affected_rows" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_cancel_query" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_client_encoding" from="PHP 4 &gt;= 4.0.3, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_close" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_connect" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_connect_poll" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
+ <function name="pg_connection_busy" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_connection_reset" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_connection_status" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_consume_input" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
+ <function name="pg_convert" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_copy_from" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_copy_to" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_dbname" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_delete" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_end_copy" from="PHP 4 &gt;= 4.0.3, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_escape_bytea" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_escape_identifier" from="PHP 5 &gt;= 5.4.4, PHP 7, PHP 8"/>
+ <function name="pg_escape_literal" from="PHP 5 &gt;= 5.4.4, PHP 7, PHP 8"/>
+ <function name="pg_escape_string" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_exec" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_execute" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="pg_fetch_all" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_fetch_all_columns" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="pg_fetch_array" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_fetch_assoc" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_fetch_object" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_fetch_result" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_fetch_row" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="pg_fetchrow" from="PHP 4"/>
- <function name="pg_field_is_null" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_field_name" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_field_num" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_field_prtlen" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_field_size" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_field_table" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="pg_field_type" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_field_type_oid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="pg_flush" from="PHP 5 &gt;= 5.6.0, PHP 7"/>
- <function name="pg_free_result" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_get_notify" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="pg_get_pid" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="pg_get_result" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_host" from="PHP 4, PHP 5, PHP 7"/>
- <function name="pg_insert" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="pg_last_error" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_last_notice" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="pg_last_oid" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_lo_close" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_lo_create" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_lo_export" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_lo_import" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_lo_open" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_lo_read" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_lo_read_all" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_lo_seek" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_lo_tell" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_lo_truncate" from="PHP 5 &gt;= 5.6.0, PHP 7"/>
- <function name="pg_lo_unlink" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_lo_write" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_meta_data" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="pg_num_fields" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_num_rows" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_options" from="PHP 4, PHP 5, PHP 7"/>
- <function name="pg_parameter_status" from="PHP 5, PHP 7"/>
- <function name="pg_pconnect" from="PHP 4, PHP 5, PHP 7"/>
- <function name="pg_ping" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="pg_port" from="PHP 4, PHP 5, PHP 7"/>
- <function name="pg_prepare" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="pg_put_line" from="PHP 4 &gt;= 4.0.3, PHP 5, PHP 7"/>
- <function name="pg_query" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_query_params" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="pg_result_error" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_result_error_field" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="pg_result_seek" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="pg_result_status" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_select" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="pg_send_execute" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="pg_send_prepare" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="pg_send_query" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="pg_send_query_params" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="pg_set_client_encoding" from="PHP 4 &gt;= 4.0.3, PHP 5, PHP 7"/>
- <function name="pg_set_error_verbosity" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="pg_socket" from="PHP 5 &gt;= 5.6.0, PHP 7"/>
- <function name="pg_trace" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7"/>
- <function name="pg_transaction_status" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="pg_tty" from="PHP 4, PHP 5, PHP 7"/>
- <function name="pg_unescape_bytea" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="pg_untrace" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7"/>
- <function name="pg_update" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="pg_version" from="PHP 5, PHP 7"/>
+ <function name="pg_field_is_null" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_field_name" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_field_num" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_field_prtlen" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_field_size" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_field_table" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="pg_field_type" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_field_type_oid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="pg_flush" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
+ <function name="pg_free_result" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_get_notify" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_get_pid" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_get_result" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_host" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_insert" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_last_error" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_last_notice" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_last_oid" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_lo_close" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_lo_create" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_lo_export" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_lo_import" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_lo_open" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_lo_read" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_lo_read_all" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_lo_seek" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_lo_tell" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_lo_truncate" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
+ <function name="pg_lo_unlink" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_lo_write" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_meta_data" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_num_fields" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_num_rows" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_options" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_parameter_status" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_pconnect" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_ping" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_port" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_prepare" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="pg_put_line" from="PHP 4 &gt;= 4.0.3, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_query" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_query_params" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="pg_result_error" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_result_error_field" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="pg_result_seek" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_result_status" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_select" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_send_execute" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="pg_send_prepare" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="pg_send_query" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_send_query_params" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="pg_set_client_encoding" from="PHP 4 &gt;= 4.0.3, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_set_error_verbosity" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="pg_socket" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
+ <function name="pg_trace" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_transaction_status" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="pg_tty" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_unescape_bytea" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_untrace" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_update" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_version" from="PHP 5, PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Generated verions.xml based on the folloing stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/pgsql/pgsql.stub.php
- `pg_fetchrow` function is too obsolete!!!!

Note: generate script https://gist.github.com/mumumu/b087d6c3ce2716db83a9aef8ffad1656