### PR TITLE
Added PHP 8 into versions.xml for stream based on stubs.

### DIFF
--- a/reference/stream/versions.xml
+++ b/reference/stream/versions.xml
@@ -4,84 +4,84 @@
   Do NOT translate this file
 -->
 <versions>
- <function name="stream_bucket_append" from="PHP 5, PHP 7"/>
- <function name="stream_bucket_make_writeable" from="PHP 5, PHP 7"/>
- <function name="stream_bucket_new" from="PHP 5, PHP 7"/>
- <function name="stream_bucket_prepend" from="PHP 5, PHP 7"/>
- <function name="stream_context_create" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="stream_context_get_default" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="stream_context_get_options" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="stream_context_get_params" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="stream_context_set_default" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="stream_context_set_option" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="stream_context_set_params" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="stream_copy_to_stream" from="PHP 5, PHP 7"/>
- <function name="stream_filter_append" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="stream_filter_prepend" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="stream_filter_register" from="PHP 5, PHP 7"/>
- <function name="stream_filter_remove" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="stream_get_contents" from="PHP 5, PHP 7"/>
- <function name="stream_get_filters" from="PHP 5, PHP 7"/>
- <function name="stream_get_line" from="PHP 5, PHP 7"/>
- <function name="stream_get_meta_data" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="stream_get_transports" from="PHP 5, PHP 7"/>
- <function name="stream_get_wrappers" from="PHP 5, PHP 7"/>
- <function name="stream_is_local" from="PHP 5 &gt;= 5.2.4, PHP 7"/>
- <function name="stream_isatty" from="PHP 7 &gt;= 7.2.0"/>
+ <function name="stream_bucket_append" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_bucket_make_writeable" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_bucket_new" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_bucket_prepend" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_context_create" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_context_get_default" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="stream_context_get_options" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_context_get_params" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="stream_context_set_default" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="stream_context_set_option" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_context_set_params" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_copy_to_stream" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_filter_append" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_filter_prepend" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_filter_register" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_filter_remove" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="stream_get_contents" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_get_filters" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_get_line" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_get_meta_data" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_get_transports" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_get_wrappers" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_is_local" from="PHP 5 &gt;= 5.2.4, PHP 7, PHP 8"/>
+ <function name="stream_isatty" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
  <function name="stream_notification_callback" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="stream_register_wrapper" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="stream_resolve_include_path" from="PHP 5 &gt;= 5.3.2, PHP 7"/>
- <function name="stream_select" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="stream_set_blocking" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="stream_set_chunk_size" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="stream_set_timeout" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="stream_set_write_buffer" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="stream_set_read_buffer" from="PHP 5 &gt;= 5.3.3, PHP 7"/>
- <function name="stream_socket_accept" from="PHP 5, PHP 7"/>
- <function name="stream_socket_client" from="PHP 5, PHP 7"/>
- <function name="stream_socket_enable_crypto" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="stream_socket_get_name" from="PHP 5, PHP 7"/>
- <function name="stream_socket_pair" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="stream_socket_recvfrom" from="PHP 5, PHP 7"/>
- <function name="stream_socket_sendto" from="PHP 5, PHP 7"/>
- <function name="stream_socket_server" from="PHP 5, PHP 7"/>
- <function name="stream_socket_shutdown" from="PHP 5 &gt;= 5.2.1, PHP 7"/>
- <function name="stream_supports_lock" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="stream_wrapper_register" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="stream_wrapper_restore" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="stream_wrapper_unregister" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="stream_register_wrapper" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_resolve_include_path" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8"/>
+ <function name="stream_select" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_set_blocking" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_set_chunk_size" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="stream_set_timeout" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_set_write_buffer" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_set_read_buffer" from="PHP 5 &gt;= 5.3.3, PHP 7, PHP 8"/>
+ <function name="stream_socket_accept" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_socket_client" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_socket_enable_crypto" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="stream_socket_get_name" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_socket_pair" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="stream_socket_recvfrom" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_socket_sendto" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_socket_server" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_socket_shutdown" from="PHP 5 &gt;= 5.2.1, PHP 7, PHP 8"/>
+ <function name="stream_supports_lock" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="stream_wrapper_register" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="stream_wrapper_restore" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="stream_wrapper_unregister" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="php_user_filter" from="PHP 5, PHP 7"/>
- <function name="php_user_filter::filter" from="PHP 5, PHP 7"/>
- <function name="php_user_filter::onclose" from="PHP 5, PHP 7"/>
- <function name="php_user_filter::oncreate" from="PHP 5, PHP 7"/>
+ <function name="php_user_filter" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="php_user_filter::filter" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="php_user_filter::onclose" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="php_user_filter::oncreate" from="PHP 5, PHP 7, PHP 8"/>
  
- <function name="streamwrapper" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="streamwrapper::__construct" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="streamwrapper::__destruct" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="streamwrapper::dir_closedir" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="streamwrapper::dir_opendir" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="streamwrapper::dir_readdir" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="streamwrapper::dir_rewinddir" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="streamwrapper::mkdir" from="PHP 5, PHP 7"/>
- <function name="streamwrapper::rename" from="PHP 5, PHP 7"/>
- <function name="streamwrapper::rmdir" from="PHP 5, PHP 7"/>
- <function name="streamwrapper::stream_cast" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="streamwrapper::stream_close" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="streamwrapper::stream_eof" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="streamwrapper::stream_flush" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="streamwrapper::stream_lock" from="PHP 5, PHP 7"/>
- <function name="streamwrapper::stream_metadata" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="streamwrapper::stream_open" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="streamwrapper::stream_read" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="streamwrapper::stream_seek" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="streamwrapper::stream_set_option" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="streamwrapper::stream_stat" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="streamwrapper::stream_tell" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="streamwrapper::stream_truncate" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="streamwrapper::stream_write" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="streamwrapper::unlink" from="PHP 5, PHP 7"/>
- <function name="streamwrapper::url_stat" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
+ <function name="streamwrapper" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::__construct" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::__destruct" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::dir_closedir" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::dir_opendir" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::dir_readdir" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::dir_rewinddir" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::mkdir" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::rename" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::rmdir" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::stream_cast" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="streamwrapper::stream_close" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::stream_eof" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::stream_flush" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::stream_lock" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::stream_metadata" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="streamwrapper::stream_open" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::stream_read" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::stream_seek" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::stream_set_option" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="streamwrapper::stream_stat" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::stream_tell" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::stream_truncate" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="streamwrapper::stream_write" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::unlink" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="streamwrapper::url_stat" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Generated verions.xml based on the folloing stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/standard/user_filters.stub.php
- https://github.com/php/php-src/blob/PHP-8.0/ext/standard/basic_functions.stub.php
- Notable changes
  * `stream_notification_callback` function seems to be deleted, but undocumented in appendices/migration80*
  * `streamWrapper` class is not a real class, but exists in manual, so I added "PHP 8" manually.
    - https://www.php.net/manual/en/class.streamwrapper.php

Note: generate script https://gist.github.com/mumumu/b087d6c3ce2716db83a9aef8ffad1656