### PR TITLE
Added PHP 8 into versions.xml for info based on stubs.

### DIFF
--- a/reference/info/versions.xml
+++ b/reference/info/versions.xml
@@ -4,61 +4,61 @@
   Do NOT translate this file
 -->
 <versions>
- <function name='assert' from='PHP 4, PHP 5, PHP 7'/>
- <function name='assert_options' from='PHP 4, PHP 5, PHP 7'/>
- <function name='cli_get_process_title' from='PHP 5 &gt;= 5.5.0, PHP 7'/>
- <function name='cli_set_process_title' from='PHP 5 &gt;= 5.5.0, PHP 7'/>
- <function name='dl' from='PHP 4, PHP 5, PHP 7'/>
- <function name='extension_loaded' from='PHP 4, PHP 5, PHP 7'/>
- <function name='gc_collect_cycles' from='PHP 5 &gt;= 5.3.0, PHP 7'/>
- <function name='gc_disable' from='PHP 5 &gt;= 5.3.0, PHP 7'/>
- <function name='gc_enable' from='PHP 5 &gt;= 5.3.0, PHP 7'/>
- <function name='gc_enabled' from='PHP 5 &gt;= 5.3.0, PHP 7'/>
- <function name='gc_mem_caches' from='PHP 7'/>
- <function name='gc_status' from='PHP 7 &gt;= 7.3.0'/>
- <function name='get_cfg_var' from='PHP 4, PHP 5, PHP 7'/>
- <function name='get_current_user' from='PHP 4, PHP 5, PHP 7'/>
- <function name='get_defined_constants' from='PHP 4 &gt;= 4.1.0, PHP 5, PHP 7'/>
- <function name='get_defined_functions' from='PHP 4 &gt;= 4.0.4, PHP 5, PHP 7'/>
- <function name='get_extension_funcs' from='PHP 4, PHP 5, PHP 7'/>
- <function name='get_include_path' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='get_included_files' from='PHP 4, PHP 5, PHP 7'/>
- <function name='get_required_files' from='PHP 4, PHP 5, PHP 7'/>
- <function name='get_resources' from='PHP 7'/>
- <function name='get_loaded_extensions' from='PHP 4, PHP 5, PHP 7'/>
- <function name='get_magic_quotes_gpc' from='PHP 4, PHP 5, PHP 7'/>
- <function name='get_magic_quotes_runtime' from='PHP 4, PHP 5, PHP 7'/>
- <function name='get_required_files' from='PHP 4, PHP 5, PHP 7'/>
- <function name='getenv' from='PHP 4, PHP 5, PHP 7'/>
- <function name='getlastmod' from='PHP 4, PHP 5, PHP 7'/>
- <function name='getmygid' from='PHP 4 &gt;= 4.1.0, PHP 5, PHP 7'/>
- <function name='getmyinode' from='PHP 4, PHP 5, PHP 7'/>
- <function name='getmypid' from='PHP 4, PHP 5, PHP 7'/>
- <function name='getmyuid' from='PHP 4, PHP 5, PHP 7'/>
- <function name='getopt' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='getrusage' from='PHP 4, PHP 5, PHP 7'/>
- <function name='ini_alter' from='PHP 4, PHP 5, PHP 7'/>
- <function name='ini_get' from='PHP 4, PHP 5, PHP 7'/>
- <function name='ini_get_all' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='ini_restore' from='PHP 4, PHP 5, PHP 7'/>
- <function name='ini_set' from='PHP 4, PHP 5, PHP 7'/>
- <function name='memory_get_peak_usage' from='PHP 5 &gt;= 5.2.0, PHP 7'/>
- <function name='memory_get_usage' from='PHP 4 &gt;= 4.3.2, PHP 5, PHP 7'/>
- <function name='php_ini_loaded_file' from='PHP 5 &gt;= 5.2.4, PHP 7'/>
- <function name='php_ini_scanned_files' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='php_sapi_name' from='PHP 4 &gt;= 4.0.1, PHP 5, PHP 7'/>
- <function name='php_uname' from='PHP 4 &gt;= 4.0.2, PHP 5, PHP 7'/>
- <function name='phpcredits' from='PHP 4, PHP 5, PHP 7'/>
- <function name='phpinfo' from='PHP 4, PHP 5, PHP 7'/>
- <function name='phpversion' from='PHP 4, PHP 5, PHP 7'/>
- <function name='putenv' from='PHP 4, PHP 5, PHP 7'/>
- <function name='restore_include_path' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7' deprecated='PHP 7.4.0'/>
- <function name='set_include_path' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='set_time_limit' from='PHP 4, PHP 5, PHP 7'/>
- <function name='sys_get_temp_dir' from='PHP 5 &gt;= 5.2.1, PHP 7'/>
- <function name='version_compare' from='PHP 4 &gt;= 4.1.0, PHP 5, PHP 7'/>
- <function name='zend_thread_id' from='PHP 5, PHP 7'/>
- <function name='zend_version' from='PHP 4, PHP 5, PHP 7'/>
+ <function name="assert" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="assert_options" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="cli_get_process_title" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="cli_set_process_title" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="dl" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="extension_loaded" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gc_collect_cycles" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="gc_disable" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="gc_enable" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="gc_enabled" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="gc_mem_caches" from="PHP 7, PHP 8"/>
+ <function name="gc_status" from="PHP 7 &gt;= 7.3.0, PHP 8"/>
+ <function name="get_cfg_var" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="get_current_user" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="get_defined_constants" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="get_defined_functions" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
+ <function name="get_extension_funcs" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="get_include_path" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="get_included_files" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="get_required_files" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="get_resources" from="PHP 7, PHP 8"/>
+ <function name="get_loaded_extensions" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="get_magic_quotes_gpc" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="get_magic_quotes_runtime" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="get_required_files" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="getenv" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="getlastmod" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="getmygid" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="getmyinode" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="getmypid" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="getmyuid" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="getopt" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="getrusage" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ini_alter" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ini_get" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ini_get_all" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="ini_restore" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ini_set" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="memory_get_peak_usage" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="memory_get_usage" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="php_ini_loaded_file" from="PHP 5 &gt;= 5.2.4, PHP 7, PHP 8"/>
+ <function name="php_ini_scanned_files" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="php_sapi_name" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
+ <function name="php_uname" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="phpcredits" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="phpinfo" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="phpversion" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="putenv" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="restore_include_path" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7" deprecated="PHP 7.4.0"/>
+ <function name="set_include_path" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="set_time_limit" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="sys_get_temp_dir" from="PHP 5 &gt;= 5.2.1, PHP 7, PHP 8"/>
+ <function name="version_compare" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="zend_thread_id" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="zend_version" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 </versions>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Generated verions.xml based on the folloing stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/standard/dl.stub.php
- https://github.com/php/php-src/blob/PHP-8.0/ext/standard/basic_functions.stub.php
- https://github.com/php/php-src/blob/PHP-8.0/sapi/cli/php_cli_process_title.stub.php
- Notable changes
  * deleted functions
    - get_magic_quotes_gpc
    - get_magic_quotes_runtime
    - restore_include_path

Note: generate script https://gist.github.com/mumumu/b087d6c3ce2716db83a9aef8ffad1656