### PR TITLE
Added PHP 8 into versions.xml for session based on stubs.

### DIFF
--- a/reference/session/versions.xml
+++ b/reference/session/versions.xml
@@ -4,56 +4,56 @@
   Do NOT translate this file
 -->
 <versions>
- <function name="session_cache_expire" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="session_cache_limiter" from="PHP 4 &gt;= 4.0.3, PHP 5, PHP 7"/>
- <function name="session_commit" from="PHP 4 &gt;= 4.4.0, PHP 5, PHP 7"/>
- <function name="session_create_id" from="PHP 7 &gt;= 7.1.0"/>
- <function name="session_decode" from="PHP 4, PHP 5, PHP 7"/>
- <function name="session_destroy" from="PHP 4, PHP 5, PHP 7"/>
- <function name="session_encode" from="PHP 4, PHP 5, PHP 7"/>
- <function name="session_gc" from="PHP 7 &gt;= 7.1.0"/>
- <function name="session_get_cookie_params" from="PHP 4, PHP 5, PHP 7"/>
- <function name="session_id" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="session_cache_expire" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="session_cache_limiter" from="PHP 4 &gt;= 4.0.3, PHP 5, PHP 7, PHP 8"/>
+ <function name="session_commit" from="PHP 4 &gt;= 4.4.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="session_create_id" from="PHP 7 &gt;= 7.1.0, PHP 8"/>
+ <function name="session_decode" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="session_destroy" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="session_encode" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="session_gc" from="PHP 7 &gt;= 7.1.0, PHP 8"/>
+ <function name="session_get_cookie_params" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="session_id" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="session_is_registered" from="PHP 4, PHP 5 &lt; 5.4.0" deprecated="PHP 5.3.0"/>
- <function name="session_module_name" from="PHP 4, PHP 5, PHP 7"/>
- <function name="session_name" from="PHP 4, PHP 5, PHP 7"/>
- <function name="session_regenerate_id" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
+ <function name="session_module_name" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="session_name" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="session_regenerate_id" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
  <function name="session_register" from="PHP 4, PHP 5 &lt; 5.4.0" deprecated="PHP 5.3.0"/>
- <function name="session_register_shutdown" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="session_save_path" from="PHP 4, PHP 5, PHP 7"/>
- <function name="session_set_cookie_params" from="PHP 4, PHP 5, PHP 7"/>
- <function name="session_set_save_handler" from="PHP 4, PHP 5, PHP 7"/>
- <function name="session_start" from="PHP 4, PHP 5, PHP 7"/>
- <function name="session_status" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
+ <function name="session_register_shutdown" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="session_save_path" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="session_set_cookie_params" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="session_set_save_handler" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="session_start" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="session_status" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
  <function name="session_unregister" from="PHP 4, PHP 5 &lt; 5.4.0" deprecated="PHP 5.3.0"/>
- <function name="session_unset" from="PHP 4, PHP 5, PHP 7"/>
- <function name="session_write_close" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7"/>
- <function name="session_abort" from="PHP 5 &gt;= 5.6.0, PHP 7"/>
- <function name="session_reset" from="PHP 5 &gt;= 5.6.0, PHP 7"/>
- <function name="sessionhandler" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="sessionhandler::close" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="sessionhandler::create_sid" from="PHP 5 &gt;= 5.5.1, PHP 7"/>
- <function name="sessionhandler::destroy" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="sessionhandler::gc" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="sessionhandler::open" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="sessionhandler::read" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
+ <function name="session_unset" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="session_write_close" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
+ <function name="session_abort" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
+ <function name="session_reset" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
+ <function name="sessionhandler" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="sessionhandler::close" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="sessionhandler::create_sid" from="PHP 5 &gt;= 5.5.1, PHP 7, PHP 8"/>
+ <function name="sessionhandler::destroy" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="sessionhandler::gc" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="sessionhandler::open" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="sessionhandler::read" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
  <function name="sessionhandler::updatetimestamp" from="PHP 7"/>
  <function name="sessionhandler::validateid" from="PHP 7"/>
- <function name="sessionhandler::write" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="sessionhandlerinterface" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="sessionhandlerinterface::close" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="sessionhandlerinterface::destroy" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="sessionhandlerinterface::gc" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="sessionhandlerinterface::open" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="sessionhandlerinterface::read" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="sessionhandlerinterface::write" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
+ <function name="sessionhandler::write" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="sessionhandlerinterface" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="sessionhandlerinterface::close" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="sessionhandlerinterface::destroy" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="sessionhandlerinterface::gc" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="sessionhandlerinterface::open" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="sessionhandlerinterface::read" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="sessionhandlerinterface::write" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
  
- <function name="SessionIdInterface" from="PHP 5 &gt;= 5.5.1, PHP 7"/>
- <function name="SessionIdInterface::create_sid" from="PHP 5 &gt;= 5.5.1, PHP 7"/>
+ <function name="SessionIdInterface" from="PHP 5 &gt;= 5.5.1, PHP 7, PHP 8"/>
+ <function name="SessionIdInterface::create_sid" from="PHP 5 &gt;= 5.5.1, PHP 7, PHP 8"/>
  
- <function name="sessionupdatetimestamphandlerinterface" from="PHP 7"/>
- <function name="sessionupdatetimestamphandlerinterface::updatetimestamp" from="PHP 7"/>
- <function name="sessionupdatetimestamphandlerinterface::validateid" from="PHP 7"/>
+ <function name="sessionupdatetimestamphandlerinterface" from="PHP 7, PHP 8"/>
+ <function name="sessionupdatetimestamphandlerinterface::updatetimestamp" from="PHP 7, PHP 8"/>
+ <function name="sessionupdatetimestamphandlerinterface::validateid" from="PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Generated verions.xml based on the folloing stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/session/session.stub.php
- Notable changes
  * already deleted in ancient times.
    - session_is_registered
    - session_register
    - session_unregister
  * Maybe, the following function is mistake, because these definitions does not exist in manual nor stub file.
    - sessionhandler::updatetimestamp
    - sessionhandler::validateid

Note: generate script https://gist.github.com/mumumu/b087d6c3ce2716db83a9aef8ffad1656