### PR TITLE
Added PHP 8 into versions.xml for fileinfo based on stubs.

### DIFF
--- a/reference/fileinfo/versions.xml
+++ b/reference/fileinfo/versions.xml
@@ -4,19 +4,19 @@
   Do NOT translate this file
 -->
 <versions> 
- <function name="finfo_buffer" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL fileinfo &gt;= 0.1.0"/>
- <function name="finfo_close" from="PHP &gt;= 5.3.0, PECL fileinfo &gt;= 0.1.0"/>
- <function name="finfo_file" from="PHP &gt;= 5.3.0, PECL fileinfo &gt;= 0.1.0"/>
- <function name="finfo_open" from="PHP &gt;= 5.3.0, PECL fileinfo &gt;= 0.1.0"/>
- <function name="finfo_set_flags" from="PHP &gt;= 5.3.0, PECL fileinfo &gt;= 0.1.0"/>
+ <function name="finfo_buffer" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL fileinfo &gt;= 0.1.0"/>
+ <function name="finfo_close" from="PHP &gt;= 5.3.0, PHP 7, PHP 8, PECL fileinfo &gt;= 0.1.0"/>
+ <function name="finfo_file" from="PHP &gt;= 5.3.0, PHP 7, PHP 8, PECL fileinfo &gt;= 0.1.0"/>
+ <function name="finfo_open" from="PHP &gt;= 5.3.0, PHP 7, PHP 8, PECL fileinfo &gt;= 0.1.0"/>
+ <function name="finfo_set_flags" from="PHP &gt;= 5.3.0, PHP 7, PHP 8, PECL fileinfo &gt;= 0.1.0"/>
 
- <function name="finfo" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL fileinfo &gt;= 0.1.0"/>
- <function name="finfo::__construct" from="PHP &gt;= 5.3.0, PECL fileinfo &gt;= 0.1.0"/>
- <function name="finfo::buffer" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL fileinfo &gt;= 0.1.0"/>
- <function name="finfo::file" from="PHP &gt;= 5.3.0, PECL fileinfo &gt;= 0.1.0"/>
- <function name="finfo::set_flags" from="PHP &gt;= 5.3.0, PECL fileinfo &gt;= 0.1.0"/>
+ <function name="finfo" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL fileinfo &gt;= 0.1.0"/>
+ <function name="finfo::__construct" from="PHP &gt;= 5.3.0, PHP 7, PHP 8, PECL fileinfo &gt;= 0.1.0"/>
+ <function name="finfo::buffer" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL fileinfo &gt;= 0.1.0"/>
+ <function name="finfo::file" from="PHP &gt;= 5.3.0, PHP 7, PHP 8, PECL fileinfo &gt;= 0.1.0"/>
+ <function name="finfo::set_flags" from="PHP &gt;= 5.3.0, PHP 7, PHP 8, PECL fileinfo &gt;= 0.1.0"/>
 
- <function name="mime_content_type" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
+ <function name="mime_content_type" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Generated verions.xml based on the folloing stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/fileinfo/fileinfo.stub.php
- Note
  * `PHP 7` was omitted somehow  in most functions, but they were already implemented in PHP 7.
    - https://github.com/php/php-src/blob/php-7.0.0/ext/fileinfo/fileinfo.c#L165-L171
    - https://github.com/php/php-src/blob/php-7.0.0/ext/fileinfo/fileinfo.c#L199-L207

Note: generate script https://gist.github.com/mumumu/b087d6c3ce2716db83a9aef8ffad1656




