### PR TITLE
Added PHP 8 into versions.xml for zlib based on stubs.

### DIFF
--- a/reference/zlib/versions.xml
+++ b/reference/zlib/versions.xml
@@ -4,36 +4,36 @@
   Do NOT translate this file
 -->
 <versions>
- <function name="deflate_add" from="PHP 7"/>
- <function name="deflate_init" from="PHP 7"/>
- <function name="gzclose" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gzcompress" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7"/>
- <function name="gzdeflate" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7"/>
- <function name="gzdecode" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="gzencode" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7"/>
- <function name="gzeof" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gzfile" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gzgetc" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gzgets" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="deflate_add" from="PHP 7, PHP 8"/>
+ <function name="deflate_init" from="PHP 7, PHP 8"/>
+ <function name="gzclose" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gzcompress" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
+ <function name="gzdeflate" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gzdecode" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="gzencode" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gzeof" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gzfile" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gzgetc" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gzgets" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="gzgetss" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gzinflate" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7"/>
- <function name="gzopen" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gzpassthru" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gzputs" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gzread" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gzrewind" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gzseek" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gztell" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gzuncompress" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7"/>
- <function name="gzwrite" from="PHP 4, PHP 5, PHP 7"/>
- <function name="inflate_add" from="PHP 7"/>
- <function name="inflate_get_read_len" from="PHP 7 &gt;= 7.2.0"/>
- <function name="inflate_get_status" from="PHP 7 &gt;= 7.2.0"/>
- <function name="inflate_init" from="PHP 7"/>
- <function name="readgzfile" from="PHP 4, PHP 5, PHP 7"/>
- <function name="zlib_get_coding_type" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="zlib_encode" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="zlib_decode" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
+ <function name="gzinflate" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gzopen" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gzpassthru" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gzputs" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gzread" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gzrewind" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gzseek" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gztell" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gzuncompress" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
+ <function name="gzwrite" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="inflate_add" from="PHP 7, PHP 8"/>
+ <function name="inflate_get_read_len" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="inflate_get_status" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="inflate_init" from="PHP 7, PHP 8"/>
+ <function name="readgzfile" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="zlib_get_coding_type" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="zlib_encode" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="zlib_decode" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
 
  <function name="deflatecontext" from="PHP 8"/>
  <function name="inflatecontext" from="PHP 8"/>


### PR DESCRIPTION
Generated verions.xml based on the folloing stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/zlib/zlib.stub.php
- Notable changes.
  * `gzgetss` was deleted in PHP 8.0.0.
    - but it is still valid entry because it is alive in PHP 7.

Note: generate script https://gist.github.com/mumumu/b087d6c3ce2716db83a9aef8ffad1656