### PR TITLE
Added PHP 8 into versions.xml for bcmath based on stubs.

### DIFF
--- a/reference/bc/versions.xml
+++ b/reference/bc/versions.xml
@@ -4,16 +4,16 @@
   Do NOT translate this file
 -->
 <versions> 
- <function name='bcadd' from='PHP 4, PHP 5, PHP 7'/>
- <function name='bccomp' from='PHP 4, PHP 5, PHP 7'/>
- <function name='bcdiv' from='PHP 4, PHP 5, PHP 7'/>
- <function name='bcmod' from='PHP 4, PHP 5, PHP 7'/>
- <function name='bcmul' from='PHP 4, PHP 5, PHP 7'/>
- <function name='bcpow' from='PHP 4, PHP 5, PHP 7'/>
- <function name='bcpowmod' from='PHP 5, PHP 7'/>
- <function name='bcscale' from='PHP 4, PHP 5, PHP 7'/>
- <function name='bcsqrt' from='PHP 4, PHP 5, PHP 7'/>
- <function name='bcsub' from='PHP 4, PHP 5, PHP 7'/>
+ <function name="bcadd" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="bccomp" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="bcdiv" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="bcmod" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="bcmul" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="bcpow" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="bcpowmod" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="bcscale" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="bcsqrt" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="bcsub" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 </versions>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/bcmath/bcmath.stub.php
- Notable changes were not found.

Note: generate script https://gist.github.com/mumumu/b087d6c3ce2716db83a9aef8ffad1656