### PR TITLE
Use 'ENT_QUOTES|ENT_SUBSTITUTE' for HTML encoding and decoding functions

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -660,7 +660,7 @@ array_fill(value: 50, num: 100, start_index: 0);
 <?php
 htmlspecialchars($string, double_encode: false);
 // Same as
-htmlspecialchars($string, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8', false);
 ?>
 ]]>
      </programlisting>

--- a/reference/strings/functions/get-html-translation-table.xml
+++ b/reference/strings/functions/get-html-translation-table.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>array</type><methodname>get_html_translation_table</methodname>
    <methodparam choice="opt"><type>int</type><parameter>table</parameter><initializer><constant>HTML_SPECIALCHARS</constant></initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>ENT_COMPAT</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>ENT_QUOTES</constant> | <constant>ENT_SUBSTITUTE</constant></initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>encoding</parameter><initializer>"UTF-8"</initializer></methodparam>
   </methodsynopsis>
   <para>
@@ -51,7 +51,7 @@
       <para>
        A bitmask of one or more of the following flags, which specify which quotes the
        table will contain as well as which document type the table is for. The default is
-       <literal>ENT_COMPAT | ENT_HTML401</literal>.
+       <literal>ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401</literal>.
        <table>
         <title>Available <parameter>flags</parameter> constants</title>
         <tgroup cols="2">
@@ -116,6 +116,28 @@
    Returns the translation table as an array, with the original characters
    as keys and entities as values.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       <parameter>flags</parameter> changed from <constant>ENT_COMPAT</constant> to <constant>ENT_QUOTES</constant> | <constant>ENT_SUBSTITUTE</constant>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/strings/functions/html-entity-decode.xml
+++ b/reference/strings/functions/html-entity-decode.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>string</type><methodname>html_entity_decode</methodname>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>ENT_COMPAT</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>ENT_QUOTES</constant> | <constant>ENT_SUBSTITUTE</constant></initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>encoding</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
@@ -46,7 +46,7 @@
      <listitem>
       <para>
        A bitmask of one or more of the following flags, which specify how to handle quotes and
-       which document type to use. The default is <literal>ENT_COMPAT | ENT_HTML401</literal>.
+       which document type to use. The default is <literal>ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401</literal>.
        <table>
         <title>Available <parameter>flags</parameter> constants</title>
         <tgroup cols="2">
@@ -128,6 +128,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       <parameter>flags</parameter> changed from <constant>ENT_COMPAT</constant> to <constant>ENT_QUOTES</constant> | <constant>ENT_SUBSTITUTE</constant>.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/strings/functions/htmlentities.xml
+++ b/reference/strings/functions/htmlentities.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>string</type><methodname>htmlentities</methodname>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>ENT_COMPAT</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>ENT_QUOTES</constant> | <constant>ENT_SUBSTITUTE</constant></initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>encoding</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>double_encode</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
@@ -44,7 +44,7 @@
       <para>
        A bitmask of one or more of the following flags, which specify how to handle quotes,
        invalid code unit sequences and the used document type. The default is
-       <literal>ENT_COMPAT | ENT_HTML401</literal>.
+       <literal>ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401</literal>.
        <table>
         <title>Available <parameter>flags</parameter> constants</title>
         <tgroup cols="2">
@@ -166,6 +166,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       <parameter>flags</parameter> changed from <constant>ENT_COMPAT</constant> to <constant>ENT_QUOTES</constant> | <constant>ENT_SUBSTITUTE</constant>.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/strings/functions/htmlspecialchars-decode.xml
+++ b/reference/strings/functions/htmlspecialchars-decode.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <type>string</type><methodname>htmlspecialchars_decode</methodname>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>ENT_COMPAT</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>ENT_QUOTES</constant> | <constant>ENT_SUBSTITUTE</constant></initializer></methodparam>
   </methodsynopsis>
 
   <para>
@@ -44,7 +44,7 @@
      <listitem>
       <para>
        A bitmask of one or more of the following flags, which specify how to handle quotes and
-       which document type to use. The default is <literal>ENT_COMPAT | ENT_HTML401</literal>.
+       which document type to use. The default is <literal>ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401</literal>.
        <table>
         <title>Available <parameter>flags</parameter> constants</title>
         <tgroup cols="2">
@@ -106,6 +106,28 @@
   <para>
    Returns the decoded string.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       <parameter>flags</parameter> changed from <constant>ENT_COMPAT</constant> to <constant>ENT_QUOTES</constant> | <constant>ENT_SUBSTITUTE</constant>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/strings/functions/htmlspecialchars.xml
+++ b/reference/strings/functions/htmlspecialchars.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>string</type><methodname>htmlspecialchars</methodname>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>ENT_COMPAT</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>ENT_QUOTES</constant> | <constant>ENT_SUBSTITUTE</constant></initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>encoding</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>double_encode</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
@@ -93,7 +93,7 @@
       <para>
        A bitmask of one or more of the following flags, which specify how to handle quotes,
        invalid code unit sequences and the used document type. The default is
-       <literal>ENT_COMPAT | ENT_HTML401</literal>.
+       <literal>ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401</literal>.
        <table>
         <title>Available <parameter>flags</parameter> constants</title>
         <tgroup cols="2">
@@ -212,6 +212,28 @@
    will be returned, unless either the <constant>ENT_IGNORE</constant> or
    <constant>ENT_SUBSTITUTE</constant> flags are set.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       <parameter>flags</parameter> changed from <constant>ENT_COMPAT</constant> to <constant>ENT_QUOTES</constant> | <constant>ENT_SUBSTITUTE</constant>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
I'm not familiar with the PHP development process, but it looks like [PR 6583](https://github.com/php/php-src/pull/6583) has been accepted in [50eca61](https://github.com/php/php-src/commit/50eca61f68815005f3b0f808578cc1ce3b4297f0), and will be in PHP 8.1.

These should update the documentation to reflect this change.