### PR TITLE
Added PHP 8 into versions.xml for ldap based on stubs.

### DIFF
--- a/reference/ldap/versions.xml
+++ b/reference/ldap/versions.xml
@@ -4,65 +4,65 @@
   Do NOT translate this file
 -->
 <versions>
- <function name="ldap_8859_to_t61" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7"/>
- <function name="ldap_add" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_add_ext" from="PHP 7 &gt;= 7.3.0"/>
- <function name="ldap_bind" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_bind_ext" from="PHP 7 &gt;= 7.3.0"/>
- <function name="ldap_close" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_compare" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7"/>
- <function name="ldap_connect" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="ldap_8859_to_t61" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_add" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_add_ext" from="PHP 7 &gt;= 7.3.0, PHP 8"/>
+ <function name="ldap_bind" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_bind_ext" from="PHP 7 &gt;= 7.3.0, PHP 8"/>
+ <function name="ldap_close" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_compare" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_connect" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="ldap_control_paged_result" from="PHP 5 &gt;= 5.4.0, PHP 7" deprecated="PHP 7.4.0"/>
  <function name="ldap_control_paged_result_response" from="PHP 5 &gt;= 5.4.0, PHP 7" deprecated="PHP 7.4.0"/>
- <function name="ldap_count_entries" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_delete" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_delete_ext" from="PHP 7 &gt;= 7.3.0"/>
- <function name="ldap_dn2ufn" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_err2str" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_errno" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_error" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_escape" from="PHP 5 &gt;= 5.6.0, PHP 7"/>
- <function name="ldap_exop" from="PHP 7 &gt;= 7.2.0"/>
- <function name="ldap_exop_passwd" from="PHP 7 &gt;= 7.2.0"/>
- <function name="ldap_exop_refresh" from="PHP 7 &gt;= 7.3.0"/>
- <function name="ldap_exop_whoami" from="PHP 7 &gt;= 7.2.0"/>
- <function name="ldap_explode_dn" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_first_attribute" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_first_entry" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_first_reference" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7"/>
- <function name="ldap_free_result" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_get_attributes" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_get_dn" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_get_entries" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_get_option" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7"/>
- <function name="ldap_get_values" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_get_values_len" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_list" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_mod_add" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_mod_add_ext" from="PHP 7 &gt;= 7.3.0"/>
- <function name="ldap_mod_del" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_mod_del_ext" from="PHP 7 &gt;= 7.3.0"/>
- <function name="ldap_mod_replace" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_mod_replace_ext" from="PHP 7 &gt;= 7.3.0"/>
- <function name="ldap_modify" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_modify_batch" from="PHP 5.4 &gt;= 5.4.26, PHP 5.5 &gt;= 5.5.10, PHP 5.6 &gt;= 5.6.0, PHP 7"/>
- <function name="ldap_next_attribute" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_next_entry" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_next_reference" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7"/>
- <function name="ldap_parse_exop" from="PHP 7 &gt;= 7.2.0"/>
- <function name="ldap_parse_reference" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7"/>
- <function name="ldap_parse_result" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7"/>
- <function name="ldap_read" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_rename" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7"/>
- <function name="ldap_rename_ext" from="PHP 7 &gt;= 7.3.0"/>
- <function name="ldap_sasl_bind" from="PHP 5, PHP 7"/>
- <function name="ldap_search" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ldap_set_option" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7"/>
- <function name="ldap_set_rebind_proc" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
+ <function name="ldap_count_entries" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_delete" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_delete_ext" from="PHP 7 &gt;= 7.3.0, PHP 8"/>
+ <function name="ldap_dn2ufn" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_err2str" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_errno" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_error" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_escape" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
+ <function name="ldap_exop" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="ldap_exop_passwd" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="ldap_exop_refresh" from="PHP 7 &gt;= 7.3.0, PHP 8"/>
+ <function name="ldap_exop_whoami" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="ldap_explode_dn" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_first_attribute" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_first_entry" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_first_reference" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_free_result" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_get_attributes" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_get_dn" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_get_entries" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_get_option" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_get_values" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_get_values_len" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_list" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_mod_add" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_mod_add_ext" from="PHP 7 &gt;= 7.3.0, PHP 8"/>
+ <function name="ldap_mod_del" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_mod_del_ext" from="PHP 7 &gt;= 7.3.0, PHP 8"/>
+ <function name="ldap_mod_replace" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_mod_replace_ext" from="PHP 7 &gt;= 7.3.0, PHP 8"/>
+ <function name="ldap_modify" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_modify_batch" from="PHP 5.4 &gt;= 5.4.26, PHP 5.5 &gt;= 5.5.10, PHP 5.6 &gt;= 5.6.0, PHP 7, PHP 8"/>
+ <function name="ldap_next_attribute" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_next_entry" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_next_reference" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_parse_exop" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="ldap_parse_reference" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_parse_result" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_read" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_rename" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_rename_ext" from="PHP 7 &gt;= 7.3.0, PHP 8"/>
+ <function name="ldap_sasl_bind" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_search" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_set_option" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_set_rebind_proc" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
  <function name="ldap_sort" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="ldap_start_tls" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="ldap_t61_to_8859" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7"/>
- <function name="ldap_unbind" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="ldap_start_tls" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_t61_to_8859" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="ldap_unbind" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/ldap/ldap.stub.php
- Deleted functions from PHP8. These functions were already documented in migration guide.
  * ldap_sort
  * ldap_control_paged_result
  * ldap_control_paged_result_response

Note: generate script https://gist.github.com/mumumu/b087d6c3ce2716db83a9aef8ffad1656