### PR TITLE
Added PHP 8 into versions.xml for sodium based on stubs.

### DIFF
--- a/reference/sodium/versions.xml
+++ b/reference/sodium/versions.xml
@@ -6,105 +6,105 @@
 
 <versions>
  <!-- Functions -->
- <function name='sodium_base642bin' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_bin2base64' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_aead_aes256gcm_is_available' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_aead_aes256gcm_decrypt' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_aead_aes256gcm_encrypt' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_aead_aes256gcm_keygen' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_aead_chacha20poly1305_decrypt' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_aead_chacha20poly1305_encrypt' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_aead_chacha20poly1305_keygen' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_aead_chacha20poly1305_ietf_decrypt' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_aead_chacha20poly1305_ietf_encrypt' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_aead_chacha20poly1305_ietf_keygen' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_aead_xchacha20poly1305_ietf_decrypt' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_aead_xchacha20poly1305_ietf_encrypt' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_aead_xchacha20poly1305_ietf_keygen' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_auth' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_auth_keygen' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_auth_verify' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_box' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_box_keypair' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_box_seed_keypair' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_box_keypair_from_secretkey_and_publickey' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_box_open' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_box_publickey' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_box_publickey_from_secretkey' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_box_seal' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_box_seal_open' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_box_secretkey' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_kx_keypair' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_kx_publickey' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_kx_secretkey' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_kx_seed_keypair' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_kx_client_session_keys' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_kx_server_session_keys' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_generichash' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_generichash_keygen' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_generichash_init' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_generichash_update' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_generichash_final' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_kdf_derive_from_key' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_kdf_keygen' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_pwhash' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_pwhash_str' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_pwhash_str_needs_rehash' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_pwhash_str_verify' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_pwhash_scryptsalsa208sha256' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_pwhash_scryptsalsa208sha256_str' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_pwhash_scryptsalsa208sha256_str_verify' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_scalarmult' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_secretbox' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_secretbox_keygen' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_secretbox_open' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_secretstream_xchacha20poly1305_init_pull' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_secretstream_xchacha20poly1305_init_push' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_secretstream_xchacha20poly1305_keygen' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_secretstream_xchacha20poly1305_pull' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_secretstream_xchacha20poly1305_push' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_secretstream_xchacha20poly1305_rekey' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_shorthash' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_shorthash_keygen' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_sign' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_sign_detached' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_sign_ed25519_pk_to_curve25519' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_sign_ed25519_sk_to_curve25519' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_sign_keypair' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_sign_keypair_from_secretkey_and_publickey' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_sign_open' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_sign_publickey' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_sign_secretkey' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_sign_publickey_from_secretkey' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_sign_seed_keypair' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_sign_verify_detached' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_stream' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_stream_keygen' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_stream_xor' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_add' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_compare' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_increment' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_memcmp' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_memzero' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_pad' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_unpad' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_bin2hex' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_hex2bin' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodium_crypto_scalarmult_base' from='PHP 7 &gt;= 7.2.0'/>
+ <function name="sodium_base642bin" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_bin2base64" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_aead_aes256gcm_is_available" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_aead_aes256gcm_decrypt" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_aead_aes256gcm_encrypt" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_aead_aes256gcm_keygen" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_aead_chacha20poly1305_decrypt" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_aead_chacha20poly1305_encrypt" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_aead_chacha20poly1305_keygen" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_aead_chacha20poly1305_ietf_decrypt" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_aead_chacha20poly1305_ietf_encrypt" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_aead_chacha20poly1305_ietf_keygen" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_aead_xchacha20poly1305_ietf_decrypt" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_aead_xchacha20poly1305_ietf_encrypt" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_aead_xchacha20poly1305_ietf_keygen" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_auth" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_auth_keygen" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_auth_verify" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_box" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_box_keypair" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_box_seed_keypair" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_box_keypair_from_secretkey_and_publickey" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_box_open" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_box_publickey" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_box_publickey_from_secretkey" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_box_seal" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_box_seal_open" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_box_secretkey" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_kx_keypair" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_kx_publickey" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_kx_secretkey" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_kx_seed_keypair" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_kx_client_session_keys" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_kx_server_session_keys" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_generichash" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_generichash_keygen" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_generichash_init" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_generichash_update" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_generichash_final" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_kdf_derive_from_key" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_kdf_keygen" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_pwhash" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_pwhash_str" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_pwhash_str_needs_rehash" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_pwhash_str_verify" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_pwhash_scryptsalsa208sha256" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_pwhash_scryptsalsa208sha256_str" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_pwhash_scryptsalsa208sha256_str_verify" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_scalarmult" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_secretbox" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_secretbox_keygen" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_secretbox_open" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_secretstream_xchacha20poly1305_init_pull" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_secretstream_xchacha20poly1305_init_push" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_secretstream_xchacha20poly1305_keygen" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_secretstream_xchacha20poly1305_pull" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_secretstream_xchacha20poly1305_push" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_secretstream_xchacha20poly1305_rekey" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_shorthash" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_shorthash_keygen" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_sign" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_sign_detached" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_sign_ed25519_pk_to_curve25519" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_sign_ed25519_sk_to_curve25519" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_sign_keypair" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_sign_keypair_from_secretkey_and_publickey" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_sign_open" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_sign_publickey" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_sign_secretkey" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_sign_publickey_from_secretkey" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_sign_seed_keypair" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_sign_verify_detached" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_stream" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_stream_keygen" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_stream_xor" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_add" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_compare" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_increment" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_memcmp" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_memzero" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_pad" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_unpad" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_bin2hex" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_hex2bin" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_scalarmult_base" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
  <!-- Classes and Methods -->
 
- <function name='sodiumexception' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodiumexception::__clone' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodiumexception::__construct' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodiumexception::__wakeup' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodiumexception::getmessage' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodiumexception::getcode' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodiumexception::getfile' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodiumexception::getline' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodiumexception::gettrace' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodiumexception::getprevious' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodiumexception::gettraceasstring' from='PHP 7 &gt;= 7.2.0'/>
- <function name='sodiumexception::__tostring' from='PHP 7 &gt;= 7.2.0'/>
+ <function name="sodiumexception" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodiumexception::__clone" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodiumexception::__construct" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodiumexception::__wakeup" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodiumexception::getmessage" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodiumexception::getcode" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodiumexception::getfile" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodiumexception::getline" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodiumexception::gettrace" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodiumexception::getprevious" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodiumexception::gettraceasstring" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodiumexception::__tostring" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
 </versions>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/bcmath/bcmath.stub.php
- Note
  * sodiumexception were not found in manual, nor stub
    - but we could run the following script, so I added `PHP 8` entry to sodiumexception.
 
```php
<?php

$e = new SodiumException();
$e->__wakeup();
$e->getmessage();
$e->getcode();
$e->getfile();
$e->getline();
$e->gettrace();
$e->getprevious();
$e->gettraceasstring();
$e->__tostring();
```

Note: generate script https://gist.github.com/mumumu/b087d6c3ce2716db83a9aef8ffad1656