### PR TITLE
Replace with include expression instead of statement

### DIFF
--- a/language/control-structures/include.xml
+++ b/language/control-structures/include.xml
@@ -5,7 +5,7 @@
  <title>include</title>
  <?phpdoc print-version-for="include"?>
  <simpara>
-  The <literal>include</literal> statement includes and evaluates
+  The <literal>include</literal> expression includes and evaluates
   the specified file.
  </simpara>
  <simpara>

--- a/language/control-structures/require-once.xml
+++ b/language/control-structures/require-once.xml
@@ -5,7 +5,7 @@
  <title>require_once</title>
  <?phpdoc print-version-for="require_once"?>
  <para>
-  The <literal>require_once</literal> statement is identical to
+  The <literal>require_once</literal> expression is identical to
   <function>require</function> except PHP will check if the file has
   already been included, and if so, not include (require) it again.
  </para>


### PR DESCRIPTION
[Expressions](https://github.com/php/php-langspec/blob/master/spec/10-expressions.md) and [Statements](https://github.com/php/php-langspec/blob/master/spec/11-statements.md) are strictly distinguished by the PHP language specification.

In all PHP versions, "require" and "include" are expressions that returns a value, not statements.

```php
<?php

if (false) {
   $v = include __FILE__;
   $v = require __FILE__;
   $v = include_once __FILE__;
   $v = require_once __FILE__;
}
```

https://3v4l.org/hHYEF