### PR TITLE
Small grammar fix for the Attributes docs

### DIFF
--- a/language/attributes.xml
+++ b/language/attributes.xml
@@ -109,10 +109,10 @@ executeAction($copyAction);
 
    <para>
     There are several parts to the attributes syntax. First, attribute
-    declaration are always enclosed with a starting
+    declaration is always enclosed with a starting
     <literal>#[</literal> and a corresponding ending
     <literal>]</literal>. Inside, one or many attributes are listed,
-    seperated by comma. The attribute name is an unqualified, qualified
+    separated by comma. The attribute name is an unqualified, qualified
     or fully-qualified name as described in <link linkend="language.namespaces.basics">Using Namespaces Basics</link>.
     Arguments to the attribute are optional, but are enclosed in the usual parenthesis <literal>()</literal>.
     Arguments to attributes can only be literal values or constant expressions. Both positional and


### PR DESCRIPTION
- using `is` instead of `are` with a singular noun
- typo fix in word `separated`