### PR TITLE
Fix `CURLOPT_MAXREDIRS`/`FOLLOWLOCATION` descriptions

### DIFF
--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -203,9 +203,8 @@
            <entry valign="top">
             &true; to follow any
             <literal>"Location: "</literal> header that the server sends as
-            part of the HTTP header (note this is recursive, PHP will follow as
-            many <literal>"Location: "</literal> headers that it is sent,
-            unless <constant>CURLOPT_MAXREDIRS</constant> is set).
+            part of the HTTP header.
+            See also <constant>CURLOPT_MAXREDIRS</constant>.
            </entry>
            <entry valign="top">
            </entry>
@@ -831,6 +830,9 @@
            <entry valign="top">
             The maximum amount of HTTP redirections to follow. Use this option
             alongside <constant>CURLOPT_FOLLOWLOCATION</constant>.
+            Default value of <literal>20</literal> is set to prevent infinite redirects.
+            Setting to <literal>-1</literal> allows inifinite redirects, and <literal>0</literal>
+            refuses all redirects.
            </entry>
            <entry valign="top">
            </entry>


### PR DESCRIPTION
Currently, the description for `CURLOPT_FOLLOWLOCATION` and `CURLOPT_MAXREDIRS` indicates that unless a `CURLOPT_MAXREDIRS` value is set, Curl will do an infinite loop.

However, this is not the case, because PHP internally sets a default value of 20. Please see:
 - [`ext/curl/interface.c`](https://github.com/php/php-src/blob/d0e3fb495ff77ec0aa8bc052c15a3899e9da7899/ext/curl/interface.c#L1806)
 - [PHP Curl Security Hardening: Infinite loops](https://php.watch/articles/php-curl-security-hardening#infinite-redirects)
 - [Libcurl: CURLOPT_MAXREDIRS.html](https://curl.se/libcurl/c/CURLOPT_MAXREDIRS.html)

The default libcurl behavior is indeed to not limit the number of redirects, which enables infinite loops, but I think we probably should keep the PHP's sane default of 20, and update the documentation instead.