### PR TITLE
explode: update reference to implode param order

### DIFF
--- a/reference/strings/functions/explode.xml
+++ b/reference/strings/functions/explode.xml
@@ -62,9 +62,8 @@
   </para>
   <note>
    <para>
-    Although <function>implode</function> can, for historical reasons,
-    accept its parameters in either order,
-    <function>explode</function> cannot. You must ensure that the
+    Prior to PHP 8.0, <function>implode</function> accepted its parameters in either order.
+    <function>explode</function> has never supported this: you must ensure that the
     <parameter>separator</parameter> argument comes before the
     <parameter>string</parameter> argument.
    </para>


### PR DESCRIPTION
The legacy order was deprecated in 7.4 and removed in 8.0.