### PR TITLE
Added PHP 8 into versions.xml for oci8 based on stubs.

### DIFF
--- a/reference/oci8/versions.xml
+++ b/reference/oci8/versions.xml
@@ -4,145 +4,145 @@
   Do NOT translate this file
 -->
 <versions>
- <function name="oci_bind_array_by_name" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL OCI8 &gt;= 1.2.0"/>
- <function name="oci_bind_by_name" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_cancel" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_client_version" from="PHP 5 &gt;= 5.3.7, PHP 7, PECL OCI8 &gt;= 1.4.6"/>
- <function name="oci_close" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="OCICollection" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocicollection_append" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocicollection_assign" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocicollection_assignelem" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_collection_element_assign" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_collection_element_get" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocicollection_free" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocicollection_getelem" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocicollection_max" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocicollection_size" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocicollection_trim" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_commit" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_connect" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_define_by_name" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_error" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_execute" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_fetch" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_fetch_all" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_fetch_array" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_fetch_assoc" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_fetch_object" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_fetch_row" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_field_is_null" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_field_name" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_field_precision" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_field_scale" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_field_size" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_field_type" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_field_type_raw" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_free_collection" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_free_cursor" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_free_descriptor" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_free_statement" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_get_implicit_resultset" from="PHP 5 &gt;= 5.6.0, PHP 7, PECL OCI8 &gt;= 2.0.0"/>
+ <function name="oci_bind_array_by_name" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8, PECL OCI8 &gt;= 1.2.0"/>
+ <function name="oci_bind_by_name" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_cancel" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_client_version" from="PHP 5 &gt;= 5.3.7, PHP 7, PHP 8, PECL OCI8 &gt;= 1.4.6"/>
+ <function name="oci_close" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="OCICollection" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocicollection::append" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocicollection::assign" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocicollection::assignelem" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_collection_element_assign" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_collection_element_get" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocicollection::free" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocicollection::getelem" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocicollection::max" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocicollection::size" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocicollection::trim" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_commit" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_connect" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_define_by_name" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_error" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_execute" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_fetch" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_fetch_all" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_fetch_array" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_fetch_assoc" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_fetch_object" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_fetch_row" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_field_is_null" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_field_name" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_field_precision" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_field_scale" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_field_size" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_field_type" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_field_type_raw" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_free_collection" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_free_cursor" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_free_descriptor" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_free_statement" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_get_implicit_resultset" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8, PECL OCI8 &gt;= 2.0.0"/>
  <function name="oci_internal_debug" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0, PECL OCI8 &lt;= 2.2.0"/>
- <function name="OCILob" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_append" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_close" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_lob_copy" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_eof" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_erase" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_export" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_flush" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_free" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_getbuffering" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_import" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_lob_is_equal" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_load" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_read" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_rewind" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_save" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_savefile" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_seek" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_setbuffering" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_size" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_tell" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_truncate" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_write" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_writetemporary" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocilob_writetofile" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_new_collection" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_new_connect" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_new_cursor" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_new_descriptor" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_num_fields" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_num_rows" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_parse" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_password_change" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_pconnect" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_result" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_rollback" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_server_version" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_set_action" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL OCI8 &gt;= 1.4.0"/>
- <function name="oci_set_call_timeout" from="PHP 7.2 &gt;= 7.2.14, PHP 7 &gt;= 7.3.1, PECL OCI8 &gt;= 2.2.0"/>
- <function name="oci_set_client_info" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL OCI8 &gt;= 1.4.0"/>
- <function name="oci_set_client_identifier" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL OCI8 &gt;= 1.4.0"/>
- <function name="oci_set_db_operation" from="PHP 7 &gt;= 7.2.14, PHP 7 &gt;= 7.3.1, PECL OCI8 &gt;= 2.2.0"/>
- <function name="oci_set_edition" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL OCI8 &gt;= 1.4.0"/>
- <function name="oci_set_module_name" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL OCI8 &gt;= 1.4.0"/>
- <function name="oci_set_prefetch" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_statement_type" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="oci_unregister_taf_callback" from="PHP 7.0 &gt;= 7.0.23, PHP 7 &gt;= 7.1.9, PECL OCI8 &gt;= 2.1.7"/>
- <function name="oci_register_taf_callback" from="PHP 7.0 &gt;= 7.0.21, PHP 7 &gt;= 7.1.7, PECL OCI8 &gt;= 2.1.7"/>
- <function name="ocibindbyname" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocicancel" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="OCILob" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::append" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::close" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_lob_copy" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::eof" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::erase" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::export" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::flush" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::free" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::getbuffering" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::import" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_lob_is_equal" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::load" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::read" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::rewind" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::save" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::savefile" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::seek" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::setbuffering" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::size" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::tell" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::truncate" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::write" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::writetemporary" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocilob::writetofile" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_new_collection" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_new_connect" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_new_cursor" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_new_descriptor" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_num_fields" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_num_rows" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_parse" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_password_change" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_pconnect" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_result" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_rollback" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_server_version" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_set_action" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8, PECL OCI8 &gt;= 1.4.0"/>
+ <function name="oci_set_call_timeout" from="PHP 7.2 &gt;= 7.2.14, PHP 8, PHP 7 &gt;= 7.3.1, PHP 8, PECL OCI8 &gt;= 2.2.0"/>
+ <function name="oci_set_client_info" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8, PECL OCI8 &gt;= 1.4.0"/>
+ <function name="oci_set_client_identifier" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8, PECL OCI8 &gt;= 1.4.0"/>
+ <function name="oci_set_db_operation" from="PHP 7 &gt;= 7.2.14, PHP 8, PHP 7 &gt;= 7.3.1, PHP 8, PECL OCI8 &gt;= 2.2.0"/>
+ <function name="oci_set_edition" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8, PECL OCI8 &gt;= 1.4.0"/>
+ <function name="oci_set_module_name" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8, PECL OCI8 &gt;= 1.4.0"/>
+ <function name="oci_set_prefetch" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_statement_type" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="oci_unregister_taf_callback" from="PHP 7.0 &gt;= 7.0.23, PHP 8, PHP 7 &gt;= 7.1.9, PHP 8, PECL OCI8 &gt;= 2.1.7"/>
+ <function name="oci_register_taf_callback" from="PHP 7.0 &gt;= 7.0.21, PHP 8, PHP 7 &gt;= 7.1.7, PHP 8, PECL OCI8 &gt;= 2.1.7"/>
+ <function name="ocibindbyname" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocicancel" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
  <function name="ocicloselob" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PECL OCI8 1.0"/>
- <function name="ocicollappend" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocicollappend" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
  <function name="ocicollassign" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocicollassignelem" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocicollgetelem" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocicollmax" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocicollsize" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocicolltrim" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocicolumnisnull" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocicolumnname" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocicolumnprecision" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocicolumnscale" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocicolumnsize" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocicolumntype" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocicolumntyperaw" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocicommit" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocidefinebyname" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocierror" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ociexecute" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocifetch" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocifetchinto" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocifetchstatement" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocifreecollection" from="PHP 4 &gt;= 4.0.7, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocifreecursor" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocifreedesc" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocifreestatement" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocigetbufferinglob" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocicollassignelem" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocicollgetelem" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocicollmax" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocicollsize" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocicolltrim" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocicolumnisnull" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocicolumnname" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocicolumnprecision" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocicolumnscale" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocicolumnsize" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocicolumntype" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocicolumntyperaw" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocicommit" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocidefinebyname" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocierror" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ociexecute" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocifetch" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocifetchinto" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocifetchstatement" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocifreecollection" from="PHP 4 &gt;= 4.0.7, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocifreecursor" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocifreedesc" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocifreestatement" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocigetbufferinglob" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
  <function name="ociinternaldebug" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0, PECL OCI8 &lt;= 2.2.0"/>
- <function name="ociloadlob" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocilogoff" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocilogon" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocinewcollection" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocinewcursor" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocinewdescriptor" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocinlogon" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocinumcols" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ociparse" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocipasswordchange" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ociplogon" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ociresult" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocirollback" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocirowcount" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocisavelob" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocisavelobfile" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ociserverversion" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocisetbufferinglob" from="PHP 5, PHP 7, PECL OCI8 &gt;= 1.1.0"/>
- <function name="ocisetprefetch" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ocistatementtype" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
- <function name="ociwritelobtofile" from="PHP 4, PHP 5, PHP 7, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ociloadlob" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocilogoff" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocilogon" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocinewcollection" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocinewcursor" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocinewdescriptor" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocinlogon" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocinumcols" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ociparse" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocipasswordchange" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ociplogon" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ociresult" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocirollback" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocirowcount" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocisavelob" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocisavelobfile" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ociserverversion" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocisetbufferinglob" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
+ <function name="ocisetprefetch" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ocistatementtype" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
+ <function name="ociwritelobtofile" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
  <function name="ociwritetemporarylob" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PECL OCI8 1.0"/>
 </versions>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/oci8/oci8.stub.php
- Note
  * OCICollection, OCILob related functions are migrated from procedural to oop.
  * non-existent [function|alias] on PHP 8
    - oci_internal_debug
    - ocicloselob
    - ocicollassign
    - ociwritetemporarylob