### PR TITLE
Added PHP 8 into versions.xml for soap based on stubs.

### DIFF
--- a/reference/soap/versions.xml
+++ b/reference/soap/versions.xml
@@ -5,62 +5,62 @@
 -->
 <versions>
  <!-- Functions -->
- <function name="use_soap_error_handler" from="PHP 5, PHP 7"/>
- <function name="is_soap_fault" from="PHP 5, PHP 7"/>
+ <function name="use_soap_error_handler" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="is_soap_fault" from="PHP 5, PHP 7, PHP 8"/>
  <!-- Methods -->
 
- <function name="soapclient" from="PHP 5, PHP 7"/>
- <function name="soapclient::__construct" from="PHP 5, PHP 7"/>
- <function name="soapclient::__call" from="PHP 5, PHP 7"/>
- <function name="soapclient::__soapcall" from="PHP 5, PHP 7"/>
- <function name="soapclient::__getcookies" from="PHP 5 &gt;= 5.4.30, PHP 7"/>
- <function name="soapclient::__getlastrequest" from="PHP 5, PHP 7"/>
- <function name="soapclient::__getlastresponse" from="PHP 5, PHP 7"/>
- <function name="soapclient::__getlastrequestheaders" from="PHP 5, PHP 7"/>
- <function name="soapclient::__getlastresponseheaders" from="PHP 5, PHP 7"/>
- <function name="soapclient::__getfunctions" from="PHP 5, PHP 7"/>
- <function name="soapclient::__gettypes" from="PHP 5, PHP 7"/>
- <function name="soapclient::__dorequest" from="PHP 5, PHP 7"/>
- <function name="soapclient::__setcookie" from="PHP 5 &gt;= 5.0.4, PHP 7"/>
- <function name="soapclient::__setlocation" from="PHP 5 &gt;= 5.0.4, PHP 7"/>
- <function name="soapclient::__setsoapheaders" from="PHP 5 &gt;= 5.0.5, PHP 7"/>
+ <function name="soapclient" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapclient::__construct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapclient::__call" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapclient::__soapcall" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapclient::__getcookies" from="PHP 5 &gt;= 5.4.30, PHP 7, PHP 8"/>
+ <function name="soapclient::__getlastrequest" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapclient::__getlastresponse" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapclient::__getlastrequestheaders" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapclient::__getlastresponseheaders" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapclient::__getfunctions" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapclient::__gettypes" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapclient::__dorequest" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapclient::__setcookie" from="PHP 5 &gt;= 5.0.4, PHP 7, PHP 8"/>
+ <function name="soapclient::__setlocation" from="PHP 5 &gt;= 5.0.4, PHP 7, PHP 8"/>
+ <function name="soapclient::__setsoapheaders" from="PHP 5 &gt;= 5.0.5, PHP 7, PHP 8"/>
  <function name="soapclient::soapclient" from="PHP 5, PHP 7"/>
 
- <function name="soapserver" from="PHP 5, PHP 7"/>
- <function name="soapserver::__construct" from="PHP 5, PHP 7"/>
+ <function name="soapserver" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapserver::__construct" from="PHP 5, PHP 7, PHP 8"/>
  <function name="soapserver::soapserver" from="PHP 5, PHP 7"/>
- <function name="soapserver::setpersistence" from="PHP 5, PHP 7"/>
- <function name="soapserver::setclass" from="PHP 5, PHP 7"/>
- <function name="soapserver::setobject" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="soapserver::addfunction" from="PHP 5, PHP 7"/>
- <function name="soapserver::getfunctions" from="PHP 5, PHP 7"/>
- <function name="soapserver::handle" from="PHP 5, PHP 7"/>
- <function name="soapserver::fault" from="PHP 5, PHP 7"/>
- <function name="soapserver::addsoapheader" from="PHP 5 &gt;= 5.1.3, PHP 7"/>
+ <function name="soapserver::setpersistence" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapserver::setclass" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapserver::setobject" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="soapserver::addfunction" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapserver::getfunctions" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapserver::handle" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapserver::fault" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapserver::addsoapheader" from="PHP 5 &gt;= 5.1.3, PHP 7, PHP 8"/>
 
- <function name="soapfault" from="PHP 5, PHP 7"/>
+ <function name="soapfault" from="PHP 5, PHP 7, PHP 8"/>
  <function name="soapfault::soapfault" from="PHP 5, PHP 7"/>
- <function name="soapfault::__tostring" from="PHP 5, PHP 7"/>
- <function name="soapfault::__clone" from="PHP 5, PHP 7"/>
- <function name="soapfault::__construct" from="PHP 5, PHP 7"/>
- <function name="soapfault::getmessage" from="PHP 5, PHP 7"/>
- <function name="soapfault::getcode" from="PHP 5, PHP 7"/>
- <function name="soapfault::getfile" from="PHP 5, PHP 7"/>
- <function name="soapfault::getline" from="PHP 5, PHP 7"/>
- <function name="soapfault::gettrace" from="PHP 5, PHP 7"/>
- <function name="soapfault::getprevious" from="PHP 5, PHP 7"/>
- <function name="soapfault::gettraceasstring" from="PHP 5, PHP 7"/>
+ <function name="soapfault::__tostring" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapfault::__clone" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapfault::__construct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapfault::getmessage" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapfault::getcode" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapfault::getfile" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapfault::getline" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapfault::gettrace" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapfault::getprevious" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapfault::gettraceasstring" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="soapparam" from="PHP 5, PHP 7"/>
- <function name="soapparam::__construct" from="PHP 5, PHP 7"/>
+ <function name="soapparam" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapparam::__construct" from="PHP 5, PHP 7, PHP 8"/>
  <function name="soapparam::soapparam" from="PHP 5, PHP 7"/>
 
- <function name="soapheader" from="PHP 5, PHP 7"/>
- <function name="soapheader::__construct" from="PHP 5, PHP 7"/>
+ <function name="soapheader" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapheader::__construct" from="PHP 5, PHP 7, PHP 8"/>
  <function name="soapheader::soapheader" from="PHP 5, PHP 7"/>
 
- <function name="soapvar" from="PHP 5, PHP 7"/>
- <function name="soapvar::__construct" from="PHP 5, PHP 7"/>
+ <function name="soapvar" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="soapvar::__construct" from="PHP 5, PHP 7, PHP 8"/>
  <function name="soapvar::soapvar" from="PHP 5, PHP 7"/>
 </versions>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/soap/soap.stub.php
- Note
  * `soapfault::*` methods could not be generated from stub, because inherited from Exception