### PR TITLE
Added PHP 8 into versions.xml for simplexml based on stubs.

### DIFF
--- a/reference/simplexml/versions.xml
+++ b/reference/simplexml/versions.xml
@@ -4,35 +4,35 @@
   Do NOT translate this file
 -->
 <versions>
- <function name="simplexml_import_dom" from="PHP 5, PHP 7"/>
- <function name="simplexml_load_file" from="PHP 5, PHP 7"/>
- <function name="simplexml_load_string" from="PHP 5, PHP 7"/>
+ <function name="simplexml_import_dom" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="simplexml_load_file" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="simplexml_load_string" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="simplexmlelement" from="PHP 5, PHP 7"/>
- <function name="simplexmlelement::__construct" from="PHP 5, PHP 7"/>
- <function name="simplexmlelement::__tostring" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="simplexmlelement::addattribute" from="PHP 5 &gt;= 5.1.3, PHP 7"/>
- <function name="simplexmlelement::addchild" from="PHP 5 &gt;= 5.1.3, PHP 7"/>
- <function name="simplexmlelement::asxml" from="PHP 5, PHP 7"/>
- <function name="simplexmlelement::attributes" from="PHP 5, PHP 7"/>
- <function name="simplexmlelement::children" from="PHP 5, PHP 7"/>
- <function name="simplexmlelement::count" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="simplexmlelement::getdocnamespaces" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="simplexmlelement::getname" from="PHP 5 &gt;= 5.1.3, PHP 7"/>
- <function name="simplexmlelement::getnamespaces" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="simplexmlelement::registerxpathnamespace" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="simplexmlelement::savexml" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="simplexmlelement::xpath" from="PHP 5, PHP 7"/>
+ <function name="simplexmlelement" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="simplexmlelement::__construct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="simplexmlelement::__tostring" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="simplexmlelement::addattribute" from="PHP 5 &gt;= 5.1.3, PHP 7, PHP 8"/>
+ <function name="simplexmlelement::addchild" from="PHP 5 &gt;= 5.1.3, PHP 7, PHP 8"/>
+ <function name="simplexmlelement::asxml" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="simplexmlelement::attributes" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="simplexmlelement::children" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="simplexmlelement::count" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="simplexmlelement::getdocnamespaces" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="simplexmlelement::getname" from="PHP 5 &gt;= 5.1.3, PHP 7, PHP 8"/>
+ <function name="simplexmlelement::getnamespaces" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="simplexmlelement::registerxpathnamespace" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="simplexmlelement::savexml" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="simplexmlelement::xpath" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="simplexmliterator" from="PHP 5 &gt;= 5.1.3, PHP 7"/>
- <function name="simplexmliterator::count" from="PHP 5, PHP 7"/>
- <function name="simplexmliterator::current" from="PHP 5, PHP 7"/>
- <function name="simplexmliterator::getchildren" from="PHP 5, PHP 7"/>
- <function name="simplexmliterator::haschildren" from="PHP 5, PHP 7"/>
- <function name="simplexmliterator::key" from="PHP 5, PHP 7"/>
- <function name="simplexmliterator::next" from="PHP 5, PHP 7"/>
- <function name="simplexmliterator::rewind" from="PHP 5, PHP 7"/>
- <function name="simplexmliterator::valid" from="PHP 5, PHP 7"/>
+ <function name="simplexmliterator" from="PHP 5 &gt;= 5.1.3, PHP 7, PHP 8"/>
+ <function name="simplexmliterator::count" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="simplexmliterator::current" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="simplexmliterator::getchildren" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="simplexmliterator::haschildren" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="simplexmliterator::key" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="simplexmliterator::next" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="simplexmliterator::rewind" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="simplexmliterator::valid" from="PHP 5, PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/simplexml/simplexml.stub.php
- Note
  * `simplexmliterator::*` methods could not be generated from stub, because inherited from SimpleXMLElement
  *  but works on my PHP 8.0.1 environment.
