### PR TITLE
Added PHP 8 into versions.xml for date based on stubs.

### DIFF
--- a/reference/datetime/versions.xml
+++ b/reference/datetime/versions.xml
@@ -5,103 +5,103 @@
 -->
 <versions>
  <!-- Methods -->
- <function name="datetime" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="datetime::__construct" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="datetime::__set_state" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="datetime::__wakeup" from="PHP 5 >= 5.3.0, PHP 7"/>
- <function name="datetime::add" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="datetime::createfromformat" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="datetime::createfromimmutable" from="PHP 7 &gt;= 7.3.0"/>
+ <function name="datetime" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="datetime::__construct" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="datetime::__set_state" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="datetime::__wakeup" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="datetime::add" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="datetime::createfromformat" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="datetime::createfromimmutable" from="PHP 7 &gt;= 7.3.0, PHP 8"/>
  <function name="datetime::createfrominterface" from="PHP 8"/>
- <function name="datetime::diff" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="datetime::format" from="PHP 5 &gt;= 5.2.1, PHP 7"/>
- <function name="datetime::getlasterrors" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="datetime::getoffset" from="PHP 5 &gt;= 5.2.1, PHP 7"/>
- <function name="datetime::gettimestamp" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="datetime::gettimezone" from="PHP 5 &gt;= 5.2.1, PHP 7"/>
- <function name="datetime::modify" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="datetime::setdate" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="datetime::setisodate" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="datetime::settime" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="datetime::settimezone" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="datetime::settimestamp" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="datetime::sub" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="datetime::diff" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="datetime::format" from="PHP 5 &gt;= 5.2.1, PHP 7, PHP 8"/>
+ <function name="datetime::getlasterrors" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="datetime::getoffset" from="PHP 5 &gt;= 5.2.1, PHP 7, PHP 8"/>
+ <function name="datetime::gettimestamp" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="datetime::gettimezone" from="PHP 5 &gt;= 5.2.1, PHP 7, PHP 8"/>
+ <function name="datetime::modify" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="datetime::setdate" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="datetime::setisodate" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="datetime::settime" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="datetime::settimezone" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="datetime::settimestamp" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="datetime::sub" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
- <function name="datetimeinterface" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeinterface::__wakeup" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="datetimeinterface::diff" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="datetimeinterface::format" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="datetimeinterface::getoffset" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="datetimeinterface::gettimestamp" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="datetimeinterface::gettimezone" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
+ <function name="datetimeinterface" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeinterface::__wakeup" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="datetimeinterface::diff" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="datetimeinterface::format" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="datetimeinterface::getoffset" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="datetimeinterface::gettimestamp" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="datetimeinterface::gettimezone" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  
- <function name="datetimeimmutable" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeimmutable::__construct" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeimmutable::__set_state" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeimmutable::__wakeup" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeimmutable::createfromformat" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeimmutable::createfrommutable" from="PHP 5 &gt;= 5.6.0, PHP 7"/>
+ <function name="datetimeimmutable" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::__construct" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::__set_state" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::__wakeup" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::createfromformat" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::createfrommutable" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
  <function name="datetimeimmutable::createfrominterface" from="PHP 8"/>
- <function name="datetimeimmutable::diff" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeimmutable::format" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeimmutable::getlasterrors" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeimmutable::gettimezone" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeimmutable::getoffset" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeimmutable::gettimestamp" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeimmutable::modify" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeimmutable::add" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeimmutable::sub" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeimmutable::settimezone" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeimmutable::settime" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeimmutable::setdate" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeimmutable::setisodate" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimeimmutable::settimestamp" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
+ <function name="datetimeimmutable::diff" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::format" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::getlasterrors" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::gettimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::getoffset" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::gettimestamp" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::modify" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::add" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::sub" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::settimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::settime" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::setdate" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::setisodate" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::settimestamp" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  
- <function name="datetimezone" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="datetimezone::__construct" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="datetimezone::__wakeup" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimezone::__set_state" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datetimezone::getlocation" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="datetimezone::getname" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="datetimezone::getoffset" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="datetimezone::gettransitions" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="datetimezone::listabbreviations" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="datetimezone::listidentifiers" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
+ <function name="datetimezone" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="datetimezone::__construct" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="datetimezone::__wakeup" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimezone::__set_state" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimezone::getlocation" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="datetimezone::getname" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="datetimezone::getoffset" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="datetimezone::gettransitions" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="datetimezone::listabbreviations" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="datetimezone::listidentifiers" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
 
- <function name="dateinterval" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="dateinterval::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="dateinterval::createfromdatestring" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="dateinterval::format" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="dateinterval" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="dateinterval::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="dateinterval::createfromdatestring" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="dateinterval::format" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
- <function name="dateperiod" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="dateperiod::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="dateperiod::__wakeup" from="PHP 5 &gt;= 5.3.27, PHP 7"/>
- <function name="dateperiod::__set_state" from="PHP 5 &gt;= 5.3.27, PHP 7"/>
- <function name="dateperiod::getstartdate" from="PHP 5 &gt;= 5.6.5, PHP 7"/>
- <function name="dateperiod::getenddate" from="PHP 5 &gt;= 5.6.5, PHP 7"/>
- <function name="dateperiod::getdateinterval" from="PHP 5 &gt;= 5.6.5, PHP 7"/>
- <function name="dateperiod::getrecurrences" from="PHP 7 &gt;= 7.2.17/7.3.4"/>
+ <function name="dateperiod" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="dateperiod::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="dateperiod::__wakeup" from="PHP 5 &gt;= 5.3.27, PHP 7, PHP 8"/>
+ <function name="dateperiod::__set_state" from="PHP 5 &gt;= 5.3.27, PHP 7, PHP 8"/>
+ <function name="dateperiod::getstartdate" from="PHP 5 &gt;= 5.6.5, PHP 7, PHP 8"/>
+ <function name="dateperiod::getenddate" from="PHP 5 &gt;= 5.6.5, PHP 7, PHP 8"/>
+ <function name="dateperiod::getdateinterval" from="PHP 5 &gt;= 5.6.5, PHP 7, PHP 8"/>
+ <function name="dateperiod::getrecurrences" from="PHP 7 &gt;= 7.2.17/7.3.4, PHP 8"/>
  
  <!-- Functions -->
- <function name="checkdate" from="PHP 4, PHP 5, PHP 7"/>
- <function name="date" from="PHP 4, PHP 5, PHP 7"/>
- <function name="date_add" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="checkdate" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="date" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="date_add" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="date_add_days" from="PECL date_time:0.1"/>
  <function name="date_add_months" from="PECL date_time:0.1"/>
  <function name="date_add_weeks" from="PECL date_time:0.1"/>
  <function name="date_add_years" from="PECL date_time:0.1"/>
  <function name="date_clamp" from="PECL date_time:0.1"/>
  <function name="date_compare" from="PECL date_time:0.1"/>
- <function name="date_create" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="date_create_from_format" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="date_create_immutable" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="date_create_immutable_from_format" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="date_date_set" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
+ <function name="date_create" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="date_create_from_format" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="date_create_immutable" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="date_create_immutable_from_format" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="date_date_set" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="date_days_between" from="PECL date_time:0.1"/>
- <function name="date_default_timezone_get" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="date_default_timezone_set" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="date_diff" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="date_format" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
+ <function name="date_default_timezone_get" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="date_default_timezone_set" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="date_diff" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="date_format" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="date_free" from="PECL date_time:0.1"/>
  <function name="date_get_array" from="PECL date_time:0.1"/>
  <function name="date_get_day" from="PECL date_time:0.1"/>
@@ -112,7 +112,7 @@
  <function name="date_get_isoweek_of_year" from="PECL date_time:0.1"/>
  <function name="date_get_julian" from="PECL date_time:0.1"/>
  <function name="date_get_last_dow" from="PECL date_time:0.1"/>
- <function name="date_get_last_errors" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="date_get_last_errors" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="date_get_month" from="PECL date_time:0.1"/>
  <function name="date_get_to_last_month_day" from="PECL date_time:0.1"/>
  <function name="date_get_to_next_weekday" from="PECL date_time:0.1"/>
@@ -124,19 +124,19 @@
  <function name="date_get_weekday" from="PECL date_time:0.1"/>
  <function name="date_get_weeks_of_year" from="PECL date_time:0.1"/>
  <function name="date_get_year" from="PECL date_time:0.1"/>
- <function name="date_interval_create_from_date_string" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="date_interval_format" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="date_interval_create_from_date_string" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="date_interval_format" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="date_is_leap_year" from="PECL date_time:0.1"/>
- <function name="date_isodate_set" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="date_modify" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
+ <function name="date_isodate_set" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="date_modify" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="date_new" from="PECL date_time:0.1"/>
  <function name="date_new_dmy" from="PECL date_time:0.1"/>
  <function name="date_new_julian" from="PECL date_time:0.1"/>
  <function name="date_new_now" from="PECL date_time:0.1"/>
- <function name="date_offset_get" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
+ <function name="date_offset_get" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="date_order" from="PECL date_time:0.1"/>
- <function name="date_parse" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="date_parse_from_format" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="date_parse" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="date_parse_from_format" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="date_set_day" from="PECL date_time:0.1"/>
  <function name="date_set_dmy" from="PECL date_time:0.1"/>
  <function name="date_set_first_dow" from="PECL date_time:0.1"/>
@@ -151,44 +151,44 @@
  <function name="date_set_to_weekday_in_same_week" from="PECL date_time:0.1"/>
  <function name="date_set_year" from="PECL date_time:0.1"/>
  <function name="date_strftime" from="PECL date_time:0.1"/>
- <function name="date_sub" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="date_sub" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="date_sub_days" from="PECL date_time:0.1"/>
  <function name="date_sub_months" from="PECL date_time:0.1"/>
  <function name="date_sub_weeks" from="PECL date_time:0.1"/>
  <function name="date_sub_years" from="PECL date_time:0.1"/>
- <function name="date_sun_info" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="date_sunrise" from="PHP 5, PHP 7"/>
- <function name="date_sunset" from="PHP 5, PHP 7"/>
- <function name="date_time_set" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="date_timestamp_get" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="date_timestamp_set" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="date_timezone_get" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="date_timezone_set" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
+ <function name="date_sun_info" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="date_sunrise" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="date_sunset" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="date_time_set" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="date_timestamp_get" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="date_timestamp_set" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="date_timezone_get" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="date_timezone_set" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="date_valid" from="PECL date_time:0.1"/>
  <function name="date_valid_dmy" from="PECL date_time:0.1"/>
  <function name="date_valid_julian" from="PECL date_time:0.1"/>
- <function name="getdate" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="getdate" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="gettimeofday" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gmdate" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gmmktime" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gmstrftime" from="PHP 4, PHP 5, PHP 7"/>
- <function name="idate" from="PHP 5, PHP 7"/>
- <function name="localtime" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="gmdate" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gmmktime" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gmstrftime" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="idate" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="localtime" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="microtime" from="PHP 4, PHP 5, PHP 7"/>
- <function name="mktime" from="PHP 4, PHP 5, PHP 7"/>
- <function name="strftime" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="mktime" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="strftime" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="strptime" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="strtotime" from="PHP 4, PHP 5, PHP 7"/>
- <function name="time" from="PHP 4, PHP 5, PHP 7"/>
- <function name="timezone_abbreviations_list" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="timezone_identifiers_list" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="timezone_location_get" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="timezone_name_from_abbr" from="PHP 5 &gt;= 5.1.3, PHP 7"/>
- <function name="timezone_name_get" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="timezone_offset_get" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="timezone_open" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="timezone_transitions_get" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="timezone_version_get" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="strtotime" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="time" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="timezone_abbreviations_list" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="timezone_identifiers_list" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="timezone_location_get" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="timezone_name_from_abbr" from="PHP 5 &gt;= 5.1.3, PHP 7, PHP 8"/>
+ <function name="timezone_name_get" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="timezone_offset_get" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="timezone_open" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="timezone_transitions_get" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="timezone_version_get" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/date/php_date.stub.php
- Note
  * functions derived from `PECL date_time:0.1` were not found in php-src.
  * the following functions were not found on stub, but works on my environment.
    - gettimeofday
    - microtime
    - strptime
