### PR TITLE
$this is not a **reference** to the called object.

### DIFF
--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -47,7 +47,7 @@ class SimpleClass
    <para>
     The pseudo-variable <varname>$this</varname> is available when a
     method is called from within an object context.
-    <varname>$this</varname> is a reference to the calling object.
+    <varname>$this</varname> is the value of the calling object.
    </para>
    <warning>
     <para>

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -40,7 +40,7 @@
   <para>
    The pseudo-variable <varname>$this</varname> is available inside
    any class method when that method is called from within an object
-   context. <varname>$this</varname> is a reference to the calling
+   context. <varname>$this</varname> is the value of the calling
    object (usually the object to which the method belongs, but
    possibly another object, if the method is called
    <link linkend="language.oop5.static">statically</link> from the context

--- a/language/references.xml
+++ b/language/references.xml
@@ -529,14 +529,6 @@ $var =& $GLOBALS["var"];
      won't unset the global variable.
     </simpara>
    </sect2>
-
-   <sect2 xml:id="references.this">
-    <title><literal>$this</literal></title>
-    <simpara>
-     In an object method, <varname>$this</varname> is always a reference
-     to the called object.
-    </simpara>
-   </sect2>
   </sect1>
 
  </chapter>


### PR DESCRIPTION
It's the value of the called object.

Additionally, in php 7.1, it was no longer possible to reassign $this
indirectly through a reference.
https://wiki.php.net/rfc/this_var#disable_ability_to_re-assign_this_indirectly_through

Even in php 7.0, I'd think it would initially be more like a value
(that references can be created from) than
a reference, but I may be misunderstanding what this means or what $this
did in php 5 or older.

(The manual dropped support for documenting php 5's behavior months ago, anyway)