### PR TITLE
Update note on print_r() and var_export() using output buffering

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -115,6 +115,10 @@ all scopes throughout a script. There is no need to do
 is used, this function uses internal output buffering so it cannot be used inside an
 <function>ob_start</function> callback function.</para></note>'>
 
+<!ENTITY note.uses-ob-php70 '<note xmlns="http://docbook.org/ns/docbook"><para>When the <parameter>return</parameter> parameter
+is used, this function uses internal output buffering in PHP 7.0 and older so it cannot be used inside an
+<function>ob_start</function> callback function.</para></note>'>
+
 <!ENTITY note.filesystem-time-res '<note xmlns="http://docbook.org/ns/docbook"><para>Note that time resolution may differ
 from one file system to another.</para></note>'>
 

--- a/reference/var/functions/print-r.xml
+++ b/reference/var/functions/print-r.xml
@@ -69,7 +69,7 @@
 
  <refsect1 role="notes">
   &reftitle.notes;
-  &note.uses-ob;
+  &note.uses-ob-php70;
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/var/functions/var-export.xml
+++ b/reference/var/functions/var-export.xml
@@ -57,7 +57,6 @@
 
  <refsect1 role="notes">
   &reftitle.notes;
-  &note.uses-ob;
  </refsect1>
 
  <refsect1 role="changelog">


### PR DESCRIPTION
var_export stopped using output buffering to convert output to a string
long before php 7.0. See
https://github.com/php/php-src/blob/PHP-7.0/ext/standard/var.c#L564-L582
(I confirmed print_r(x, true) works in 7.1.0+)

highlight_string/highlight_file are still using output buffering so the documentation for those is correct.

```php
<?php
function my_buffer($value) {
    fprintf(STDERR, "var_export output: %s\n", var_export(array(), true));
    fprintf(STDERR, "print_r output: %s\n", print_r(array(), true));
    //fprintf(STDERR, "highlight_string output: %s\n", highlight_string('2+2', true));
    return $value;
}
ob_start('my_buffer');
echo "test";
$result = ob_get_clean();
echo "Result: $result\n";
```

Noticed while working on https://wiki.php.net/rfc/readable_var_representation