### PR TITLE
Added PHP 8 into versions.xml for xmlreader based on stubs.

### DIFF
--- a/reference/xmlreader/versions.xml
+++ b/reference/xmlreader/versions.xml
@@ -5,33 +5,33 @@
 -->
 <versions>
 
- <function name="xmlreader" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::close" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::expand" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::getattribute" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::getattributeno" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::getattributens" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::getparserproperty" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::isvalid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::lookupnamespace" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::movetoattribute" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::movetoattributeno" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::movetoattributens" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::movetoelement" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::movetofirstattribute" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::movetonextattribute" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::next" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::open" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::read" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::readinnerxml" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="xmlreader::readouterxml" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="xmlreader::readstring" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
+ <function name="xmlreader" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::close" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::expand" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::getattribute" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::getattributeno" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::getattributens" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::getparserproperty" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::isvalid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::lookupnamespace" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::movetoattribute" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::movetoattributeno" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::movetoattributens" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::movetoelement" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::movetofirstattribute" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::movetonextattribute" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::next" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::open" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::read" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::readinnerxml" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::readouterxml" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::readstring" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="xmlreader::resetstate" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::setparserproperty" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::setrelaxngschema" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::setrelaxngschemasource" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="xmlreader::setschema" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="xmlreader::xml" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="xmlreader::setparserproperty" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::setrelaxngschema" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::setrelaxngschemasource" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::setschema" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="xmlreader::xml" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/xmlreader/php_xmlreader.stub.php
- Note
  * `xmlreader::resetstate` is not Yet Implemented in libxml, but is supposed to be alive.
    - https://github.com/php/php-src/blob/PHP-8.0/ext/xmlreader/php_xmlreader.c#L890-L895
    - This function does not exist in stub, so I do not add `PHP8` entry.