### PR TITLE
Added PHP 8 into versions.xml for uodbc based on stubs.

### DIFF
--- a/reference/uodbc/versions.xml
+++ b/reference/uodbc/versions.xml
@@ -4,52 +4,52 @@
   Do NOT translate this file
 -->
 <versions>
- <function name="odbc_autocommit" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_binmode" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_close" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_close_all" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_columnprivileges" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_columns" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_commit" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_connect" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_cursor" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_data_source" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="odbc_do" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_error" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7"/>
- <function name="odbc_errormsg" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7"/>
- <function name="odbc_exec" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_execute" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_fetch_array" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7"/>
- <function name="odbc_fetch_into" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_fetch_object" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7"/>
- <function name="odbc_fetch_row" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_field_len" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_field_name" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_field_num" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_field_precision" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_field_scale" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_field_type" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_foreignkeys" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_free_result" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_gettypeinfo" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_longreadlen" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_next_result" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7"/>
- <function name="odbc_num_fields" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_num_rows" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_pconnect" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_prepare" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_primarykeys" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_procedurecolumns" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_procedures" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_result" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_result_all" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_rollback" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_setoption" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_specialcolumns" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_statistics" from="PHP 4, PHP 5, PHP 7"/>
- <function name="odbc_tableprivileges" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="odbc_autocommit" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_binmode" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_close" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_close_all" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_columnprivileges" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_columns" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_commit" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_connect" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_cursor" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_data_source" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_do" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_error" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_errormsg" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_exec" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_execute" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_fetch_array" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_fetch_into" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_fetch_object" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_fetch_row" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_field_len" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_field_name" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_field_num" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_field_precision" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_field_scale" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_field_type" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_foreignkeys" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_free_result" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_gettypeinfo" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_longreadlen" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_next_result" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_num_fields" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_num_rows" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_pconnect" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_prepare" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_primarykeys" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_procedurecolumns" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_procedures" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_result" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_result_all" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_rollback" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_setoption" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_specialcolumns" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_statistics" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="odbc_tableprivileges" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="odbc_tableprivilegess" from="PHP 4"/>
- <function name="odbc_tables" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="odbc_tables" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/odbc/odbc.stub.php
- Note
  * `odbc_tableprivilegess` does not exist from ancient times.