### PR TITLE
Added PHP 8 into versions.xml for libxml based on stubs.

### DIFF
--- a/reference/libxml/versions.xml
+++ b/reference/libxml/versions.xml
@@ -4,15 +4,15 @@
   Do NOT translate this file
 -->
 <versions>
- <function name="libxml_clear_errors" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="libxml_get_errors" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="libxml_get_last_error" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="libxml_set_streams_context" from="PHP 5, PHP 7"/>
- <function name="libxml_use_internal_errors" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="libxml_disable_entity_loader" from="PHP 5 &gt;= 5.2.11, PHP 7"/>
- <function name="libxml_set_external_entity_loader" from="PHP 5 &gt;= 5.4.0, PHP 7" deprecated="PHP 8.0.0"/>
+ <function name="libxml_clear_errors" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="libxml_get_errors" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="libxml_get_last_error" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="libxml_set_streams_context" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="libxml_use_internal_errors" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="libxml_disable_entity_loader" from="PHP 5 &gt;= 5.2.11, PHP 7, PHP 8"/>
+ <function name="libxml_set_external_entity_loader" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8" deprecated="PHP 8.0.0"/>
  
- <function name="libxmlerror" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="libxmlerror" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/libxml/libxml.stub.php
- Note
  * `LibXMLError` class could not be found in stub, but already implemented apparently.
  * added its definition to stub.
    - https://github.com/php/php-src/pull/6637