### PR TITLE
Added PHP 8 into versions.xml for xsl based on stubs.

### DIFF
--- a/reference/xsl/versions.xml
+++ b/reference/xsl/versions.xml
@@ -5,20 +5,20 @@
 -->
 <versions>
 
- <function name="XSLTProcessor" from="PHP 5, PHP 7"/>
- <function name="XSLTProcessor::__construct" from="PHP 5, PHP 7"/>
- <function name="XSLTProcessor::getParameter" from="PHP 5, PHP 7"/>
- <function name="XSLTProcessor::hasExsltSupport" from="PHP 5 &gt;= 5.0.4, PHP 7"/>
- <function name="XSLTProcessor::importStylesheet" from="PHP 5, PHP 7"/>
- <function name="XSLTProcessor::registerPhpFunctions" from="PHP 5 &gt;= 5.0.4, PHP 7"/>
- <function name="XSLTProcessor::removeParameter" from="PHP 5, PHP 7"/>
- <function name="XSLTProcessor::setParameter" from="PHP 5, PHP 7"/>
- <function name="XSLTProcessor::setProfiling" from="PHP &gt;= 5.3.0"/>
- <function name="XSLTProcessor::transformToDoc" from="PHP 5, PHP 7"/>
- <function name="XSLTProcessor::transformToUri" from="PHP 5, PHP 7"/>
- <function name="XSLTProcessor::transformToXml" from="PHP 5, PHP 7"/>
- <function name="XSLTProcessor::setSecurityPrefs" from="PHP &gt;= 5.4.0"/>
- <function name="XSLTProcessor::getSecurityPrefs" from="PHP &gt;= 5.4.0"/>
+ <function name="XSLTProcessor" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="XSLTProcessor::__construct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="XSLTProcessor::getParameter" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="XSLTProcessor::hasExsltSupport" from="PHP 5 &gt;= 5.0.4, PHP 7, PHP 8"/>
+ <function name="XSLTProcessor::importStylesheet" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="XSLTProcessor::registerPhpFunctions" from="PHP 5 &gt;= 5.0.4, PHP 7, PHP 8"/>
+ <function name="XSLTProcessor::removeParameter" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="XSLTProcessor::setParameter" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="XSLTProcessor::setProfiling" from="PHP &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="XSLTProcessor::transformToDoc" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="XSLTProcessor::transformToUri" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="XSLTProcessor::transformToXml" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="XSLTProcessor::setSecurityPrefs" from="PHP &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="XSLTProcessor::getSecurityPrefs" from="PHP &gt;= 5.4.0, PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/xsl/php_xsl.stub.php
- Note
  * the following methods did not have `PHP 7` entry, but already implemented apparently.
    - XSLTProcessor::setProfiling
    - XSLTProcessor::setSecurityPrefs
    - XSLTProcessor::getSecurityPrefs
  * https://github.com/php/php-src/blob/php-7.0.0/ext/xsl/xsltprocessor.c#L100-L102
    