### PR TITLE
Added PHP 8 into versions.xml for com_dotnet based on stubs.

### DIFF
--- a/reference/com/versions.xml
+++ b/reference/com/versions.xml
@@ -4,58 +4,58 @@
   Do NOT translate this file
 -->
 <versions> 
- <function name='com' from='PHP 4 &gt;= 4.1.0, PHP 5, PHP 7'/>
- <function name='com::__construct' from='PHP 4 &gt; 4.1.0, PHP 5, PHP 7'/>
- <function name='com_create_guid' from='PHP 5, PHP 7'/>
- <function name='com_event_sink' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='com_get_active_object' from='PHP 5, PHP 7'/>
- <function name='com_load_typelib' from='PHP 4 &gt;= 4.1.0, PHP 5, PHP 7'/>
- <function name='com_message_pump' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='com_print_typeinfo' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
+ <function name="com" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="com::__construct" from="PHP 4 &gt; 4.1.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="com_create_guid" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="com_event_sink" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="com_get_active_object" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="com_load_typelib" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="com_message_pump" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="com_print_typeinfo" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
 
- <function name='com_exception' from="PHP 5, PHP 7" />
+ <function name="com_exception" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name='compersisthelper' from="PHP 5, PHP 7" />
- <function name='compersisthelper::__construct' from="PHP 5, PHP 7" />
- <function name='compersisthelper::getcurfilename' from="PHP 5, PHP 7" />
- <function name='compersisthelper::getmaxstreamsize' from="PHP 5, PHP 7" />
- <function name='compersisthelper::initnew' from="PHP 5, PHP 7" />
- <function name='compersisthelper::loadfromfile' from="PHP 5, PHP 7" />
- <function name='compersisthelper::loadfromstream' from="PHP 5, PHP 7" />
- <function name='compersisthelper::savetofile' from="PHP 5, PHP 7" />
- <function name='compersisthelper::savetostream' from="PHP 5, PHP 7" />
+ <function name="compersisthelper" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="compersisthelper::__construct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="compersisthelper::getcurfilename" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="compersisthelper::getmaxstreamsize" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="compersisthelper::initnew" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="compersisthelper::loadfromfile" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="compersisthelper::loadfromstream" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="compersisthelper::savetofile" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="compersisthelper::savetostream" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name='dotnet' from='PHP 4 &gt;= 4.1.0, PHP 5, PHP 7'/>
- <function name='dotnet::__construct' from='PHP 4 &gt;= 4.1.0, PHP 5, PHP 7'/>
+ <function name="dotnet" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="dotnet::__construct" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
 
- <function name='variant' from='PHP 4 &gt;= 4.1.0, PHP 5, PHP 7'/>
- <function name='variant::__construct' from='PHP 4 &gt;= 4.1.0, PHP 5, PHP 7'/>
- <function name='variant_abs' from='PHP 5, PHP 7'/>
- <function name='variant_add' from='PHP 5, PHP 7'/>
- <function name='variant_and' from='PHP 5, PHP 7'/>
- <function name='variant_cast' from='PHP 5, PHP 7'/>
- <function name='variant_cat' from='PHP 5, PHP 7'/>
- <function name='variant_cmp' from='PHP 5, PHP 7'/>
- <function name='variant_date_from_timestamp' from='PHP 5, PHP 7'/>
- <function name='variant_date_to_timestamp' from='PHP 5, PHP 7'/>
- <function name='variant_div' from='PHP 5, PHP 7'/>
- <function name='variant_eqv' from='PHP 5, PHP 7'/>
- <function name='variant_fix' from='PHP 5, PHP 7'/>
- <function name='variant_get_type' from='PHP 5, PHP 7'/>
- <function name='variant_idiv' from='PHP 5, PHP 7'/>
- <function name='variant_imp' from='PHP 5, PHP 7'/>
- <function name='variant_int' from='PHP 5, PHP 7'/>
- <function name='variant_mod' from='PHP 5, PHP 7'/>
- <function name='variant_mul' from='PHP 5, PHP 7'/>
- <function name='variant_neg' from='PHP 5, PHP 7'/>
- <function name='variant_not' from='PHP 5, PHP 7'/>
- <function name='variant_or' from='PHP 5, PHP 7'/>
- <function name='variant_pow' from='PHP 5, PHP 7'/>
- <function name='variant_round' from='PHP 5, PHP 7'/>
- <function name='variant_set_type' from='PHP 5, PHP 7'/>
- <function name='variant_set' from='PHP 5, PHP 7'/>
- <function name='variant_sub' from='PHP 5, PHP 7'/>
- <function name='variant_xor' from='PHP 5, PHP 7'/>
+ <function name="variant" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="variant::__construct" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_abs" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_add" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_and" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_cast" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_cat" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_cmp" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_date_from_timestamp" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_date_to_timestamp" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_div" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_eqv" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_fix" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_get_type" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_idiv" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_imp" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_int" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_mod" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_mul" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_neg" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_not" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_or" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_pow" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_round" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_set_type" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_set" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_sub" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="variant_xor" from="PHP 5, PHP 7, PHP 8"/>
 </versions>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
- Generated verions.xml based on the following stubs.
  * https://github.com/php/php-src/blob/PHP-8.0/ext/com_dotnet/com_extension.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/com_dotnet/com_persist.stub.php
- Note
  * `com_exception` did not exist in stub file, but implemented apparently in PHP 8, too.
    - https://github.com/php/php-src/blob/PHP-8.0/ext/com_dotnet/com_extension.c#L167-L170
    