### PR TITLE
Added PHP 8 into versions.xml for classobj based on stubs.

### DIFF
--- a/reference/classobj/versions.xml
+++ b/reference/classobj/versions.xml
@@ -5,24 +5,24 @@
 -->
 
 <versions>
- <function name='__autoload' from='PHP 5, PHP 7' deprecated='PHP 7.2.0'/>
- <function name='class_alias' from='PHP 5 &gt;= 5.3.0, PHP 7'/>
- <function name='class_exists' from='PHP 4, PHP 5, PHP 7'/>
- <function name='get_called_class' from='PHP 5 &gt;= 5.3.0, PHP 7'/>
- <function name='get_class_methods' from='PHP 4, PHP 5, PHP 7'/>
- <function name='get_class_vars' from='PHP 4, PHP 5, PHP 7'/>
- <function name='get_class' from='PHP 4, PHP 5, PHP 7'/>
- <function name='get_declared_classes' from='PHP 4, PHP 5, PHP 7'/>
- <function name='get_declared_interfaces' from='PHP 5, PHP 7'/>
- <function name='get_declared_traits' from='PHP 5 &gt;= 5.4.0, PHP 7'/>
- <function name='get_object_vars' from='PHP 4, PHP 5, PHP 7'/>
- <function name='get_parent_class' from='PHP 4, PHP 5, PHP 7'/>
- <function name='interface_exists' from='PHP 5 &gt;= 5.0.2, PHP 7'/>
- <function name='is_a' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='is_subclass_of' from='PHP 4, PHP 5, PHP 7'/>
- <function name='method_exists' from='PHP 4, PHP 5, PHP 7'/>
- <function name='property_exists' from='PHP 5 &gt;= 5.1.0, PHP 7'/>
- <function name='trait_exists' from='PHP 5 &gt;= 5.4.0, PHP 7'/>
+ <function name="__autoload" from="PHP 5, PHP 7" deprecated="PHP 7.2.0"/>
+ <function name="class_alias" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="class_exists" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="get_called_class" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="get_class_methods" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="get_class_vars" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="get_class" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="get_declared_classes" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="get_declared_interfaces" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="get_declared_traits" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="get_object_vars" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="get_parent_class" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="interface_exists" from="PHP 5 &gt;= 5.0.2, PHP 7, PHP 8"/>
+ <function name="is_a" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="is_subclass_of" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="method_exists" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="property_exists" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="trait_exists" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
 </versions>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/Zend/zend_builtin_functions.stub.php
- Note
  * `__autoload` was deleted in PHP 8.0.0, but its entry still alive.