### PR TITLE
Added PHP 8 into versions.xml for snmp based on stubs.

### DIFF
--- a/reference/snmp/versions.xml
+++ b/reference/snmp/versions.xml
@@ -4,46 +4,46 @@
   Do NOT translate this file
 -->
 <versions>
- <function name="snmp_get_quick_print" from="PHP 4, PHP 5, PHP 7"/>
- <function name="snmp_get_valueretrieval" from="PHP 4 &gt;= 4.3.3, PHP 5, PHP 7"/>
- <function name="snmp_read_mib" from="PHP 5, PHP 7"/>
- <function name="snmp_set_enum_print" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="snmp_set_oid_numeric_print" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="snmp_set_oid_output_format" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="snmp_set_quick_print" from="PHP 4, PHP 5, PHP 7"/>
- <function name="snmp_set_valueretrieval" from="PHP 4 &gt;= 4.3.3, PHP 5, PHP 7"/>
+ <function name="snmp_get_quick_print" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="snmp_get_valueretrieval" from="PHP 4 &gt;= 4.3.3, PHP 5, PHP 7, PHP 8"/>
+ <function name="snmp_read_mib" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="snmp_set_enum_print" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="snmp_set_oid_numeric_print" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="snmp_set_oid_output_format" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="snmp_set_quick_print" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="snmp_set_valueretrieval" from="PHP 4 &gt;= 4.3.3, PHP 5, PHP 7, PHP 8"/>
 
- <function name="snmpget" from="PHP 4, PHP 5, PHP 7"/>
- <function name="snmpgetnext" from="PHP 5, PHP 7"/>
- <function name="snmprealwalk" from="PHP 4, PHP 5, PHP 7"/>
- <function name="snmpset" from="PHP 4, PHP 5, PHP 7"/>
- <function name="snmpwalk" from="PHP 4, PHP 5, PHP 7"/>
- <function name="snmpwalkoid" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="snmpget" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="snmpgetnext" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="snmprealwalk" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="snmpset" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="snmpwalk" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="snmpwalkoid" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 
- <function name="snmp2_get" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="snmp2_getnext" from="PHP &gt;= 5.2.0"/>
- <function name="snmp2_real_walk" from="PHP &gt;= 5.2.0"/>
- <function name="snmp2_set" from="PHP &gt;= 5.2.0"/>
- <function name="snmp2_walk" from="PHP &gt;= 5.2.0"/>
+ <function name="snmp2_get" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="snmp2_getnext" from="PHP &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="snmp2_real_walk" from="PHP &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="snmp2_set" from="PHP &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="snmp2_walk" from="PHP &gt;= 5.2.0, PHP 7, PHP 8"/>
 
- <function name="snmp3_get" from="PHP 4, PHP 5, PHP 7"/>
- <function name="snmp3_getnext" from="PHP 5, PHP 7"/>
- <function name="snmp3_real_walk" from="PHP 4, PHP 5, PHP 7"/>
- <function name="snmp3_set" from="PHP 4, PHP 5, PHP 7"/>
- <function name="snmp3_walk" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="snmp3_get" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="snmp3_getnext" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="snmp3_real_walk" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="snmp3_set" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="snmp3_walk" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 
- <function name="snmp" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="snmp::__construct" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="snmp::close" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="snmp::setSecurity" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="snmp::get" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="snmp::getnext" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="snmp::walk" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="snmp::set" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="snmp::getErrno" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="snmp::getError" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
+ <function name="snmp" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="snmp::__construct" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="snmp::close" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="snmp::setSecurity" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="snmp::get" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="snmp::getnext" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="snmp::walk" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="snmp::set" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="snmp::getErrno" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="snmp::getError" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
 
- <function name="snmpexception" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
+ <function name="snmpexception" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
  
 </versions>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/snmp/snmp.stub.php
- Note
  * the following methods did not have `PHP 7` entry, but already implemented apparently.
    - https://github.com/php/php-src/blob/php-7.0.0/ext/snmp/snmp.c#L403-L406
      * snmp2_getnext
      * snmp2_real_walk
      * snmp2_set
      * snmp2_walk
  * `snmpexception` does not exist in stub, but implemented in PHP 8.0.0 apparently.
    - https://github.com/php/php-src/blob/PHP-8.0/ext/snmp/snmp.c#L2037-L2039
    