### PR TITLE
Added PHP 8 into versions.xml for enchant based on stubs.

### DIFF
--- a/reference/enchant/versions.xml
+++ b/reference/enchant/versions.xml
@@ -4,29 +4,29 @@
   Do NOT translate this file
 -->
 <versions> 
- <function name="enchant_broker_describe" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant &gt;= 0.1.0"/>
- <function name="enchant_broker_dict_exists" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant &gt;= 0.1.0 "/>
- <function name="enchant_broker_free" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant &gt;= 0.1.0 "/>
- <function name="enchant_broker_free_dict" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant &gt;= 0.1.0 "/>
- <function name="enchant_broker_get_dict_path" from="PHP 5 &gt;= 5.3.1, PHP 7, PECL enchant &gt;= 1.0.1" deprecated="PHP 8.0.0"/>
- <function name="enchant_broker_get_error" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant &gt;= 0.1.0 "/>
- <function name="enchant_broker_init" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant &gt;= 0.1.0 "/>
- <function name="enchant_broker_list_dicts" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant &gt;= 1.0.1"/>
- <function name="enchant_broker_request_dict" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant &gt;= 0.1.0 "/>
- <function name="enchant_broker_request_pwl_dict" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant &gt;= 0.1.0 "/>
- <function name="enchant_broker_set_dict_path" from="PHP 5 &gt;= 5.3.1, PHP 7, PECL enchant &gt;= 1.0.1" deprecated="PHP 8.0.0"/>
- <function name="enchant_broker_set_ordering" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant &gt;= 0.1.0 "/>
- <function name="enchant_dict_add_to_personal" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant &gt;= 0.1.0 " deprecated="PHP 8.0.0"/>
+ <function name="enchant_broker_describe" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0"/>
+ <function name="enchant_broker_dict_exists" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>
+ <function name="enchant_broker_free" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>
+ <function name="enchant_broker_free_dict" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>
+ <function name="enchant_broker_get_dict_path" from="PHP 5 &gt;= 5.3.1, PHP 7, PHP 8, PECL enchant &gt;= 1.0.1" deprecated="PHP 8.0.0"/>
+ <function name="enchant_broker_get_error" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>
+ <function name="enchant_broker_init" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>
+ <function name="enchant_broker_list_dicts" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 1.0.1"/>
+ <function name="enchant_broker_request_dict" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>
+ <function name="enchant_broker_request_pwl_dict" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>
+ <function name="enchant_broker_set_dict_path" from="PHP 5 &gt;= 5.3.1, PHP 7, PHP 8, PECL enchant &gt;= 1.0.1" deprecated="PHP 8.0.0"/>
+ <function name="enchant_broker_set_ordering" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>
+ <function name="enchant_dict_add_to_personal" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 " deprecated="PHP 8.0.0"/>
  <function name="enchant_dict_add" from="PHP 8"/>
- <function name="enchant_dict_add_to_session" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant &gt;= 0.1.0 "/>
- <function name="enchant_dict_check" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant &gt;= 0.1.0 "/>
- <function name="enchant_dict_describe" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant &gt;= 0.1.0 "/>
- <function name="enchant_dict_get_error" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant &gt;= 0.1.0 "/>
+ <function name="enchant_dict_add_to_session" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>
+ <function name="enchant_dict_check" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>
+ <function name="enchant_dict_describe" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>
+ <function name="enchant_dict_get_error" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>
  <function name="enchant_dict_is_added" from="PHP 8"/>
- <function name="enchant_dict_is_in_session" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant &gt;= 0.1.0 " deprecated="PHP 8.0.0"/>
- <function name="enchant_dict_quick_check" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant:0.2.0-1.0.1"/>
- <function name="enchant_dict_store_replacement" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant &gt;= 0.1.0 "/>
- <function name="enchant_dict_suggest" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant &gt;= 0.1.0 "/>
+ <function name="enchant_dict_is_in_session" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 " deprecated="PHP 8.0.0"/>
+ <function name="enchant_dict_quick_check" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant:0.2.0-1.0.1"/>
+ <function name="enchant_dict_store_replacement" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>
+ <function name="enchant_dict_suggest" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>
  <function name="enchant_free" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant 0.1-1.0"/>
  <function name="enchant_new" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant 0.1"/>
  <function name="enchant_new_dmy" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL enchant 0.1"/>


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/enchant/enchant.stub.php
- Note
  * the following functions were not implemented even in PHP 7.0.0, so maybe wrong entries.
    - enchant_free
    - enchant_new
    - enchant_new_dmy