### PR TITLE
Added PHP 8 into versions.xml for funchand based on stubs.

### DIFF
--- a/reference/funchand/versions.xml
+++ b/reference/funchand/versions.xml
@@ -5,19 +5,19 @@
 -->
 
 <versions>
- <function name='call_user_func_array' from='PHP 4 &gt;= 4.0.4, PHP 5, PHP 7'/>
- <function name='call_user_func' from='PHP 4, PHP 5, PHP 7'/>
- <function name='create_function' from='PHP 4 &gt;= 4.0.1, PHP 5, PHP 7' deprecated='PHP 7.2.0'/>
- <function name='forward_static_call' from='PHP 5 &gt;= 5.3.0, PHP 7'/>
- <function name='forward_static_call_array' from='PHP 5 &gt;= 5.3.0, PHP 7'/>
- <function name='func_get_arg' from='PHP 4, PHP 5, PHP 7'/>
- <function name='func_get_args' from='PHP 4, PHP 5, PHP 7'/>
- <function name='func_num_args' from='PHP 4, PHP 5, PHP 7'/>
- <function name='function_exists' from='PHP 4, PHP 5, PHP 7'/>
- <function name='get_defined_functions' from='PHP 4 &gt;= 4.0.4, PHP 5, PHP 7'/>
- <function name='register_shutdown_function' from='PHP 4, PHP 5, PHP 7'/>
- <function name='register_tick_function' from='PHP 4 &gt;= 4.0.3, PHP 5, PHP 7'/>
- <function name='unregister_tick_function' from='PHP 4 &gt;= 4.0.3, PHP 5, PHP 7'/>
+ <function name="call_user_func_array" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
+ <function name="call_user_func" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="create_function" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7" deprecated="PHP 7.2.0"/>
+ <function name="forward_static_call" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="forward_static_call_array" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="func_get_arg" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="func_get_args" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="func_num_args" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="function_exists" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="get_defined_functions" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
+ <function name="register_shutdown_function" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="register_tick_function" from="PHP 4 &gt;= 4.0.3, PHP 5, PHP 7, PHP 8"/>
+ <function name="unregister_tick_function" from="PHP 4 &gt;= 4.0.3, PHP 5, PHP 7, PHP 8"/>
 </versions>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
- Generated verions.xml based on the following stubs.
  * https://github.com/php/php-src/blob/PHP-8.0/ext/standard/basic_functions.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/Zend/zend_builtin_functions.stub.php
- Note
  * `create_function` was deleted as of PHP 8.0.0, but still alive entry.