### PR TITLE
Added PHP 8 into versions.xml for outcontrol based on stubs.

### DIFF
--- a/reference/outcontrol/versions.xml
+++ b/reference/outcontrol/versions.xml
@@ -4,25 +4,25 @@
   Do NOT translate this file
 -->
 <versions>
- <function name="flush" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ob_clean" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="ob_end_clean" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ob_end_flush" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ob_flush" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="ob_get_clean" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="ob_get_contents" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ob_get_flush" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="ob_get_length" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7"/>
- <function name="ob_get_level" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="ob_get_status" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="ob_gzhandler" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7"/>
- <function name="ob_iconv_handler" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7"/>
- <function name="ob_implicit_flush" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ob_list_handlers" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="ob_start" from="PHP 4, PHP 5, PHP 7"/>
- <function name="ob_tidyhandler" from="PHP 5, PHP 7"/>
- <function name="output_add_rewrite_var" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="output_reset_rewrite_vars" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
+ <function name="flush" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ob_clean" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="ob_end_clean" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ob_end_flush" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ob_flush" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="ob_get_clean" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="ob_get_contents" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ob_get_flush" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="ob_get_length" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="ob_get_level" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="ob_get_status" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="ob_gzhandler" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ob_iconv_handler" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PHP 8"/>
+ <function name="ob_implicit_flush" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ob_list_handlers" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="ob_start" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="ob_tidyhandler" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="output_add_rewrite_var" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="output_reset_rewrite_vars" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
- Generated verions.xml based on the following stubs.
  * https://github.com/php/php-src/blob/PHP-8.0/ext/standard/basic_functions.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/zlib/zlib.stub.php
- Note
  * `ob_iconv_handler` does not exist in stub file, but already implemented in PHP8, too
    - https://github.com/php/php-src/blob/PHP-8.0/ext/iconv/iconv.c#L220-L221
    - https://github.com/php/php-src/blob/PHP-8.0/ext/iconv/iconv.c#L292-L345
  * `ob_tidyhandler` does not exist in stub file, but already implemented in PHP8, too
    - https://github.com/php/php-src/blob/PHP-8.0/ext/tidy/tidy.c#L851
    - https://github.com/php/php-src/blob/PHP-8.0/ext/tidy/tidy.c#L961-L1001