### PR TITLE
Added PHP 8 into versions.xml for mail based on stubs.

### DIFF
--- a/reference/mail/versions.xml
+++ b/reference/mail/versions.xml
@@ -5,7 +5,7 @@
 -->
 <versions>
  <function name="ezmlm_hash" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7"/>
- <function name="mail" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="mail" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/standard/basic_functions.stub.php
- Note
  * `ezmlm_hash` was deleted as of PHP 8.0.0.