### PR TITLE
Added PHP 8 into versions.xml for shmop based on stubs.

### DIFF
--- a/reference/shmop/versions.xml
+++ b/reference/shmop/versions.xml
@@ -4,12 +4,12 @@
   Do NOT translate this file
 -->
 <versions>
- <function name="shmop_close" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7"/>
- <function name="shmop_delete" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7"/>
- <function name="shmop_open" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7"/>
- <function name="shmop_read" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7"/>
- <function name="shmop_size" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7"/>
- <function name="shmop_write" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7"/>
+ <function name="shmop_close" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
+ <function name="shmop_delete" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
+ <function name="shmop_open" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
+ <function name="shmop_read" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
+ <function name="shmop_size" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
+ <function name="shmop_write" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
 
  <function name="shmop" from="PHP 8"/>
 </versions>


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/shmop/shmop.stub.php
- Notable changes were not found.