### PR TITLE
Added PHP 8 into versions.xml for misc based on stubs.

### DIFF
--- a/reference/misc/versions.xml
+++ b/reference/misc/versions.xml
@@ -4,37 +4,37 @@
   Do NOT translate this file
 -->
 <versions>
- <function name="__halt_compiler" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="connection_aborted" from="PHP 4, PHP 5, PHP 7"/>
- <function name="connection_status" from="PHP 4, PHP 5, PHP 7"/>
- <function name="constant" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7"/>
- <function name="define" from="PHP 4, PHP 5, PHP 7"/>
- <function name="defined" from="PHP 4, PHP 5, PHP 7"/>
- <function name="die" from="PHP 4, PHP 5, PHP 7"/>
- <function name="eval" from="PHP 4, PHP 5, PHP 7"/>
- <function name="exit" from="PHP 4, PHP 5, PHP 7"/>
- <function name="get_browser" from="PHP 4, PHP 5, PHP 7"/>
- <function name="highlight_file" from="PHP 4, PHP 5, PHP 7"/>
- <function name="highlight_string" from="PHP 4, PHP 5, PHP 7"/>
- <function name="hrtime" from="PHP 7 &gt;= 7.3.0"/>
- <function name="ignore_user_abort" from="PHP 4, PHP 5, PHP 7"/>
- <function name="pack" from="PHP 4, PHP 5, PHP 7"/>
- <function name="php_strip_whitespace" from="PHP 5, PHP 7"/>
- <function name="sapi_windows_cp_conv" from="PHP 7 &gt;= 7.1.0"/>
- <function name="sapi_windows_cp_get" from="PHP 7 &gt;= 7.1.0"/>
- <function name="sapi_windows_cp_is_utf8" from="PHP 7 &gt;= 7.1.0"/>
- <function name="sapi_windows_cp_set" from="PHP 7 &gt;= 7.1.0"/>
- <function name="sapi_windows_generate_ctrl_event" from="PHP 7 &gt;= 7.4.0"/>
- <function name="sapi_windows_set_ctrl_handler" from="PHP 7 &gt;= 7.4.0"/>
- <function name="sapi_windows_vt100_support" from="PHP 7 &gt;= 7.2.0"/>
- <function name="show_source" from="PHP 4, PHP 5, PHP 7"/>
- <function name="sleep" from="PHP 4, PHP 5, PHP 7"/>
- <function name="sys_getloadavg" from="PHP 5 &gt;= 5.1.3, PHP 7"/>
- <function name="time_nanosleep" from="PHP 5, PHP 7"/>
- <function name="time_sleep_until" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="uniqid" from="PHP 4, PHP 5, PHP 7"/>
- <function name="unpack" from="PHP 4, PHP 5, PHP 7"/>
- <function name="usleep" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="__halt_compiler" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="connection_aborted" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="connection_status" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="constant" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
+ <function name="define" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="defined" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="die" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="eval" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="exit" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="get_browser" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="highlight_file" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="highlight_string" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="hrtime" from="PHP 7 &gt;= 7.3.0, PHP 8"/>
+ <function name="ignore_user_abort" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="pack" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="php_strip_whitespace" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="sapi_windows_cp_conv" from="PHP 7 &gt;= 7.1.0, PHP 8"/>
+ <function name="sapi_windows_cp_get" from="PHP 7 &gt;= 7.1.0, PHP 8"/>
+ <function name="sapi_windows_cp_is_utf8" from="PHP 7 &gt;= 7.1.0, PHP 8"/>
+ <function name="sapi_windows_cp_set" from="PHP 7 &gt;= 7.1.0, PHP 8"/>
+ <function name="sapi_windows_generate_ctrl_event" from="PHP 7 &gt;= 7.4.0, PHP 8"/>
+ <function name="sapi_windows_set_ctrl_handler" from="PHP 7 &gt;= 7.4.0, PHP 8"/>
+ <function name="sapi_windows_vt100_support" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="show_source" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="sleep" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="sys_getloadavg" from="PHP 5 &gt;= 5.1.3, PHP 7, PHP 8"/>
+ <function name="time_nanosleep" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="time_sleep_until" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="uniqid" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="unpack" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="usleep" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
- Generated verions.xml based on the following stubs.
  * https://github.com/php/php-src/blob/PHP-8.0/ext/standard/basic_functions.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/Zend/zend_builtin_functions.stub.php
- Note
  * the followings are language construct. these can be found in `Zend/zend_language_scanner.l`.
    - [__halt_compiler](https://github.com/php/php-src/blob/PHP-8.0/Zend/zend_language_scanner.l#L1697-L1699)
    - [die](https://github.com/php/php-src/blob/PHP-8.0/Zend/zend_language_scanner.l#L1389-L1391)
    - [eval](https://github.com/php/php-src/blob/PHP-8.0/Zend/zend_language_scanner.l#L1653-L1655)
    - [exit](https://github.com/php/php-src/blob/PHP-8.0/Zend/zend_language_scanner.l#L1385-L1387)