### PR TITLE
Added PHP 8 into versions.xml for tidy based on stubs.

### DIFF
--- a/reference/tidy/versions.xml
+++ b/reference/tidy/versions.xml
@@ -5,48 +5,48 @@
 -->
 <versions>
 
- <function name="tidy" from="PHP 5, PHP 7, PECL tidy &gt;= 0.5.2"/>
- <function name="tidy::__construct" from="PHP 5, PHP 7, PECL tidy &gt;= 0.5.2"/>
+ <function name="tidy" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
+ <function name="tidy::__construct" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
 
- <function name="tidy_access_count" from="PHP 5, PHP 7, PECL tidy &gt;= 0.5.2"/>
- <function name="tidy_clean_repair" from="PHP 5, PHP 7, PECL tidy &gt;= 0.5.2"/>
- <function name="tidy_config_count" from="PHP 5, PHP 7, PECL tidy &gt;= 0.5.2"/>
- <function name="tidy_diagnose" from="PHP 5, PHP 7, PECL tidy &gt;= 0.5.2"/>
- <function name="tidy_error_count" from="PHP 5, PHP 7, PECL tidy &gt;= 0.5.2"/>
- <function name="tidy_get_body" from="PHP 5, PHP 7, PECL tidy 0.5.2-1.0"/>
- <function name="tidy_get_config" from="PHP 5, PHP 7, PECL tidy &gt;= 0.7.0"/>
- <function name="tidy_get_error_buffer" from="PHP 5, PHP 7, PECL tidy &gt;= 0.5.2"/>
- <function name="tidy_get_head" from="PHP 5, PHP 7, PECL tidy 0.5.2-1.0.0"/>
- <function name="tidy_get_html" from="PHP 5, PHP 7, PECL tidy 0.5.2-1.0.0"/>
- <function name="tidy_get_html_ver" from="PHP 5, PHP 7, PECL tidy &gt;= 0.5.2"/>
- <function name="tidy_get_opt_doc" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="tidy_get_output" from="PHP 5, PHP 7, PECL tidy &gt;= 0.5.2"/>
- <function name="tidy_get_release" from="PHP 5, PHP 7, PECL tidy &gt;= 0.5.2"/>
- <function name="tidy_get_root" from="PHP 5, PHP 7, PECL tidy 0.5.2-1.0.0"/>
- <function name="tidy_get_status" from="PHP 5, PHP 7, PECL tidy &gt;= 0.5.2"/>
- <function name="tidy_getopt" from="PHP 5, PHP 7, PECL tidy &gt;= 0.5.2"/>
- <function name="tidy_is_xhtml" from="PHP 5, PHP 7, PECL tidy &gt;= 0.5.2"/>
- <function name="tidy_is_xml" from="PHP 5, PHP 7, PECL tidy &gt;= 0.5.2"/>
+ <function name="tidy_access_count" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
+ <function name="tidy_clean_repair" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
+ <function name="tidy_config_count" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
+ <function name="tidy_diagnose" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
+ <function name="tidy_error_count" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
+ <function name="tidy_get_body" from="PHP 5, PHP 7, PHP 8, PECL tidy 0.5.2-1.0"/>
+ <function name="tidy_get_config" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.7.0"/>
+ <function name="tidy_get_error_buffer" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
+ <function name="tidy_get_head" from="PHP 5, PHP 7, PHP 8, PECL tidy 0.5.2-1.0.0"/>
+ <function name="tidy_get_html" from="PHP 5, PHP 7, PHP 8, PECL tidy 0.5.2-1.0.0"/>
+ <function name="tidy_get_html_ver" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
+ <function name="tidy_get_opt_doc" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="tidy_get_output" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
+ <function name="tidy_get_release" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
+ <function name="tidy_get_root" from="PHP 5, PHP 7, PHP 8, PECL tidy 0.5.2-1.0.0"/>
+ <function name="tidy_get_status" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
+ <function name="tidy_getopt" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
+ <function name="tidy_is_xhtml" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
+ <function name="tidy_is_xml" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
 
  <!-- From PHP 4 and early PECL Tidy days -->
 
- <function name="tidy_parse_file" from="PHP 5, PHP 7, PECL tidy &gt;= 0.5.2"/>
- <function name="tidy_parse_string" from="PHP 5, PHP 7, PECL tidy &gt;= 0.5.2"/>
- <function name="tidy_repair_file" from="PHP 5, PHP 7, PECL tidy &gt;= 0.7.0"/>
- <function name="tidy_repair_string" from="PHP 5, PHP 7, PECL tidy &gt;= 0.7.0"/>
- <function name="tidy_warning_count" from="PHP 5, PHP 7, PECL tidy &gt;= 0.5.2"/>
+ <function name="tidy_parse_file" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
+ <function name="tidy_parse_string" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
+ <function name="tidy_repair_file" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.7.0"/>
+ <function name="tidy_repair_string" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.7.0"/>
+ <function name="tidy_warning_count" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
 
- <function name="tidynode" from="PHP 5, PHP 7"/>
- <function name="tidynode::__construct" from="PHP 5, PHP 7"/>
- <function name="tidynode::getparent" from="PHP 5 &gt;= 5.2.2, PHP 7"/>
- <function name="tidynode::haschildren" from="PHP 5, PHP 7"/>
- <function name="tidynode::hassiblings" from="PHP 5, PHP 7"/>
- <function name="tidynode::isasp" from="PHP 5, PHP 7"/>
- <function name="tidynode::iscomment" from="PHP 5, PHP 7"/>
- <function name="tidynode::ishtml" from="PHP 5, PHP 7"/>
- <function name="tidynode::isjste" from="PHP 5, PHP 7"/>
- <function name="tidynode::isphp" from="PHP 5, PHP 7"/>
- <function name="tidynode::istext" from="PHP 5, PHP 7"/>
+ <function name="tidynode" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="tidynode::__construct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="tidynode::getparent" from="PHP 5 &gt;= 5.2.2, PHP 7, PHP 8"/>
+ <function name="tidynode::haschildren" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="tidynode::hassiblings" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="tidynode::isasp" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="tidynode::iscomment" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="tidynode::ishtml" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="tidynode::isjste" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="tidynode::isphp" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="tidynode::istext" from="PHP 5, PHP 7, PHP 8"/>
  <function name="tidynode::isxhtml" from="PHP 5, PHP 7"/>
  <function name="tidynode::isxml" from="PHP 5, PHP 7"/>
 </versions>


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/tidy/tidy.stub.php
- Note
  * the following methods were not implemented in PHP 7.0.0, even if PHP 5.6, so maybe mistake.
    - `tidynode::isxhtml`
    - `tidynode::isxml`