### PR TITLE
Added PHP 8 into versions.xml for network based on stubs.

### DIFF
--- a/reference/network/versions.xml
+++ b/reference/network/versions.xml
@@ -4,40 +4,40 @@
   Do NOT translate this file
 -->
 <versions>
- <function name="checkdnsrr" from="PHP 4, PHP 5, PHP 7"/>
- <function name="closelog" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="checkdnsrr" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="closelog" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="define_syslog_variables" from="PHP 4, PHP 5 &lt; 5.4.0" deprecated="PHP 5.3.0"/>
- <function name="dns_check_record" from="PHP 5, PHP 7"/>
- <function name="dns_get_mx" from="PHP 5, PHP 7"/>
- <function name="dns_get_record" from="PHP 5, PHP 7"/>
- <function name="fsockopen" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gethostbyaddr" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gethostbyname" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gethostbynamel" from="PHP 4, PHP 5, PHP 7"/>
- <function name="gethostname" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="getmxrr" from="PHP 4, PHP 5, PHP 7"/>
- <function name="getprotobyname" from="PHP 4, PHP 5, PHP 7"/>
- <function name="getprotobynumber" from="PHP 4, PHP 5, PHP 7"/>
- <function name="getservbyname" from="PHP 4, PHP 5, PHP 7"/>
- <function name="getservbyport" from="PHP 4, PHP 5, PHP 7"/>
- <function name="header" from="PHP 4, PHP 5, PHP 7"/>
- <function name="header_register_callback" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="header_remove" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="headers_list" from="PHP 5, PHP 7"/>
- <function name="headers_sent" from="PHP 4, PHP 5, PHP 7"/>
- <function name="http_response_code" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="inet_ntop" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="inet_pton" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="ip2long" from="PHP 4, PHP 5, PHP 7"/>
- <function name="long2ip" from="PHP 4, PHP 5, PHP 7"/>
- <function name="openlog" from="PHP 4, PHP 5, PHP 7"/>
- <function name="pfsockopen" from="PHP 4, PHP 5, PHP 7"/>
- <function name="setcookie" from="PHP 4, PHP 5, PHP 7"/>
- <function name="setrawcookie" from="PHP 5, PHP 7"/>
- <function name="socket_get_status" from="PHP 4, PHP 5, PHP 7"/>
- <function name="socket_set_blocking" from="PHP 4, PHP 5, PHP 7"/>
- <function name="socket_set_timeout" from="PHP 4, PHP 5, PHP 7"/>
- <function name="syslog" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="dns_check_record" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="dns_get_mx" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="dns_get_record" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="fsockopen" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gethostbyaddr" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gethostbyname" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gethostbynamel" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="gethostname" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="getmxrr" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="getprotobyname" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="getprotobynumber" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="getservbyname" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="getservbyport" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="header" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="header_register_callback" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="header_remove" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="headers_list" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="headers_sent" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="http_response_code" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="inet_ntop" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="inet_pton" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="ip2long" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="long2ip" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="openlog" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="pfsockopen" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="setcookie" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="setrawcookie" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="socket_get_status" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="socket_set_blocking" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="socket_set_timeout" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="syslog" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/standard/basic_functions.stub.php
- Note
  * `define_syslog_variables` was deleted as of PHP 5.4.0. We can safely delete it.