### PR TITLE
Added PHP 8 into versions.xml for apache based on stubs.

### DIFF
--- a/reference/apache/versions.xml
+++ b/reference/apache/versions.xml
@@ -4,18 +4,18 @@
   Do NOT translate this file
 -->
 <versions> 
- <function name="apache_child_terminate" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7"/>
- <function name="apache_get_modules" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="apache_get_version" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="apache_getenv" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="apache_lookup_uri" from="PHP 4, PHP 5, PHP 7"/>
- <function name="apache_note" from="PHP 4, PHP 5, PHP 7"/>
- <function name="apache_request_headers" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
+ <function name="apache_child_terminate" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PHP 8"/>
+ <function name="apache_get_modules" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="apache_get_version" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="apache_getenv" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="apache_lookup_uri" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="apache_note" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="apache_request_headers" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
  <function name="apache_reset_timeout" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="apache_response_headers" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="apache_setenv" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7"/>
- <function name="getallheaders" from="PHP 4, PHP 5, PHP 7"/>
- <function name="virtual" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="apache_response_headers" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="apache_setenv" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="getallheaders" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="virtual" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/sapi/cgi/cgi_main.stub.php
- https://github.com/php/php-src/blob/PHP-8.0/sapi/apache2handler/php_functions.stub.php
- Note
  * `apache_reset_timeout` is function for Apache1 which reached EOL in ancient times.
    - We cannot find its implementation in even PHP 7.0.0, so can safely delete it.