### PR TITLE
Add missing modifier

### DIFF
--- a/reference/zmq/zmqsocket/construct.xml
+++ b/reference/zmq/zmqsocket/construct.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <methodname>ZMQSocket::__construct</methodname>
+   <modifier>public</modifier> <methodname>ZMQSocket::__construct</methodname>
    <methodparam><type>ZMQContext</type><parameter>context</parameter></methodparam>
    <methodparam><type>int</type><parameter>type</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>persistent_id</parameter><initializer>&null;</initializer></methodparam>


### PR DESCRIPTION
*ZMQSocket::__construct()* is public.

See: https://github.com/zeromq/php-zmq