### PR TITLE
Added PHP 8 into versions.xml for image based on stubs.

### DIFF
--- a/reference/image/versions.xml
+++ b/reference/image/versions.xml
@@ -4,118 +4,118 @@
   Do NOT translate this file
 -->
 <versions> 
- <function name="gd_info" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="getimagesize" from="PHP 4, PHP 5, PHP 7"/>
- <function name="getimagesizefromstring" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
+ <function name="gd_info" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="getimagesize" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="getimagesizefromstring" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
  <function name="image2wbmp" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7"/>
- <function name="image_type_to_extension" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="image_type_to_mime_type" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="imageaffine" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="imageaffinematrixconcat" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="imageaffinematrixget" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="imagealphablending" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="imageantialias" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="imagearc" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagebmp" from="PHP 7 &gt;= 7.2.0"/>
- <function name="imagechar" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagecharup" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagecolorallocate" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagecolorallocatealpha" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="imagecolorat" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagecolorclosest" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagecolorclosestalpha" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="imagecolorclosesthwb" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7"/>
- <function name="imagecolordeallocate" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagecolorexact" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagecolorexactalpha" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="imagecolormatch" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="imagecolorresolve" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagecolorresolvealpha" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="imagecolorset" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagecolorsforindex" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagecolorstotal" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagecolortransparent" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imageconvolution" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="imagecopy" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagecopymerge" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7"/>
- <function name="imagecopymergegray" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="imagecopyresampled" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="imagecopyresized" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagecreate" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagecreatefrombmp" from="PHP 7 &gt;= 7.2.0"/>
- <function name="imagecreatefromgd" from="PHP 4 &gt;= 4.0.7, PHP 5, PHP 7"/>
- <function name="imagecreatefromgd2" from="PHP 4 &gt;= 4.0.7, PHP 5, PHP 7"/>
- <function name="imagecreatefromgd2part" from="PHP 4 &gt;= 4.0.7, PHP 5, PHP 7"/>
- <function name="imagecreatefromgif" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagecreatefromjpeg" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagecreatefrompng" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagecreatefromstring" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7"/>
- <function name="imagecreatefromwbmp" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7"/>
- <function name="imagecreatefromwebp" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="imagecreatefromxbm" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7"/>
- <function name="imagecreatefromxpm" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7"/>
- <function name="imagecreatetruecolor" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="imagecrop" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="imagecropauto" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="imagedashedline" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagedestroy" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imageellipse" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="imagefill" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagefilledarc" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="imagefilledellipse" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="imagefilledpolygon" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagefilledrectangle" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagefilltoborder" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagefilter" from="PHP 5, PHP 7"/>
- <function name="imageflip" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="imagefontheight" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagefontwidth" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imageftbbox" from="PHP 4 &gt;= 4.0.7, PHP 5, PHP 7"/>
- <function name="imagefttext" from="PHP 4 &gt;= 4.0.7, PHP 5, PHP 7"/>
- <function name="imagegammacorrect" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagegd" from="PHP 4 &gt;= 4.0.7, PHP 5, PHP 7"/>
- <function name="imagegd2" from="PHP 4 &gt;= 4.0.7, PHP 5, PHP 7"/>
- <function name="imagegetclip" from="PHP 7 &gt;= 7.2.0"/>
+ <function name="image_type_to_extension" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="image_type_to_mime_type" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="imageaffine" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="imageaffinematrixconcat" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="imageaffinematrixget" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="imagealphablending" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="imageantialias" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagearc" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagebmp" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="imagechar" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecharup" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecolorallocate" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecolorallocatealpha" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecolorat" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecolorclosest" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecolorclosestalpha" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecolorclosesthwb" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecolordeallocate" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecolorexact" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecolorexactalpha" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecolormatch" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecolorresolve" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecolorresolvealpha" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecolorset" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecolorsforindex" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecolorstotal" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecolortransparent" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imageconvolution" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="imagecopy" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecopymerge" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecopymergegray" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecopyresampled" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecopyresized" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecreate" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecreatefrombmp" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="imagecreatefromgd" from="PHP 4 &gt;= 4.0.7, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecreatefromgd2" from="PHP 4 &gt;= 4.0.7, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecreatefromgd2part" from="PHP 4 &gt;= 4.0.7, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecreatefromgif" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecreatefromjpeg" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecreatefrompng" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecreatefromstring" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecreatefromwbmp" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecreatefromwebp" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="imagecreatefromxbm" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecreatefromxpm" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecreatetruecolor" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecrop" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="imagecropauto" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="imagedashedline" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagedestroy" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imageellipse" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagefill" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagefilledarc" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagefilledellipse" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagefilledpolygon" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagefilledrectangle" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagefilltoborder" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagefilter" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="imageflip" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="imagefontheight" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagefontwidth" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imageftbbox" from="PHP 4 &gt;= 4.0.7, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagefttext" from="PHP 4 &gt;= 4.0.7, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagegammacorrect" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagegd" from="PHP 4 &gt;= 4.0.7, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagegd2" from="PHP 4 &gt;= 4.0.7, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagegetclip" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
  <function name="imagegetinterpolation" from="PHP 8"/>
- <function name="imagegif" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagegrabscreen" from="PHP 5 &gt;= 5.2.2, PHP 7"/>
- <function name="imagegrabwindow" from="PHP 5 &gt;= 5.2.2, PHP 7"/>
- <function name="imageinterlace" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imageistruecolor" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="imagejpeg" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagelayereffect" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="imageline" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imageloadfont" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imageopenpolygon" from="PHP 7 &gt;= 7.2.0"/>
- <function name="imagepalettecopy" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7"/>
- <function name="imagepalettetotruecolor" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="imagepng" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagepolygon" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagerectangle" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imageresolution" from="PHP 7 &gt;= 7.2.0"/>
- <function name="imagerotate" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7"/>
- <function name="imagesavealpha" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7"/>
- <function name="imagescale" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="imagesetbrush" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="imagesetclip" from="PHP 7 &gt;= 7.2.0"/>
- <function name="imagesetinterpolation" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="imagesetpixel" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagesetstyle" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="imagesetthickness" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="imagesettile" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="imagestring" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagestringup" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagesx" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagesy" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagetruecolortopalette" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7"/>
- <function name="imagettfbbox" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagettftext" from="PHP 4, PHP 5, PHP 7"/>
- <function name="imagetypes" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7"/>
- <function name="imagewbmp" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7"/>
- <function name="imagewebp" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="imagexbm" from="PHP 5, PHP 7"/>
- <function name="iptcembed" from="PHP 4, PHP 5, PHP 7"/>
- <function name="iptcparse" from="PHP 4, PHP 5, PHP 7"/>
+ <function name="imagegif" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagegrabscreen" from="PHP 5 &gt;= 5.2.2, PHP 7, PHP 8"/>
+ <function name="imagegrabwindow" from="PHP 5 &gt;= 5.2.2, PHP 7, PHP 8"/>
+ <function name="imageinterlace" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imageistruecolor" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagejpeg" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagelayereffect" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="imageline" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imageloadfont" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imageopenpolygon" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="imagepalettecopy" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagepalettetotruecolor" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="imagepng" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagepolygon" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagerectangle" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imageresolution" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="imagerotate" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagesavealpha" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagescale" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="imagesetbrush" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagesetclip" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="imagesetinterpolation" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="imagesetpixel" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagesetstyle" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagesetthickness" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagesettile" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagestring" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagestringup" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagesx" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagesy" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagetruecolortopalette" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagettfbbox" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagettftext" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagetypes" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagewbmp" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagewebp" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="imagexbm" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="iptcembed" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="iptcparse" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="jpeg2wbmp" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7"/>
  <function name="png2wbmp" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7"/>
 


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/gd/gd.stub.php
- https://github.com/php/php-src/blob/PHP-8.0/ext/standard/basic_functions.stub.php
- Note
  * the following functions were deleted as of PHP 8.0.0
    - image2wbmp
    - jpeg2wbmp
    - png2wbmp