### PR TITLE
Added PHP 8 into versions.xml for exif based on stubs.

### DIFF
--- a/reference/exif/versions.xml
+++ b/reference/exif/versions.xml
@@ -4,11 +4,11 @@
   Do NOT translate this file
 -->
 <versions> 
- <function name='exif_imagetype' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='exif_read_data' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='exif_tagname' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='exif_thumbnail' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7'/>
- <function name='read_exif_data' from='PHP 4 &gt;= 4.0.1, PHP 5, PHP 7'/>
+ <function name="exif_imagetype" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="exif_read_data" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="exif_tagname" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="exif_thumbnail" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="read_exif_data" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7"/>
 </versions>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/exif/exif.stub.php
- Note
  * `read_exif_data` was deleted as of PHP 8.0.0