### PR TITLE
Added PHP 8 into versions.xml for errorfunc based on stubs.

### DIFF
--- a/reference/errorfunc/versions.xml
+++ b/reference/errorfunc/versions.xml
@@ -5,18 +5,18 @@
 -->
 
 <versions>
- <function name='debug_backtrace' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7'/>
- <function name='debug_print_backtrace' from='PHP 5, PHP 7'/>
- <function name='error_get_last' from='PHP 5 &gt;= 5.2.0, PHP 7'/>
- <function name='error_clear_last' from='PHP 7'/>
- <function name='error_log' from='PHP 4, PHP 5, PHP 7'/>
- <function name='error_reporting' from='PHP 4, PHP 5, PHP 7'/>
- <function name='restore_error_handler' from='PHP 4 &gt;= 4.0.1, PHP 5, PHP 7'/>
- <function name='restore_exception_handler' from='PHP 5, PHP 7'/>
- <function name='set_error_handler' from='PHP 4 &gt;= 4.0.1, PHP 5, PHP 7'/>
- <function name='set_exception_handler' from='PHP 5, PHP 7'/>
- <function name='trigger_error' from='PHP 4 &gt;= 4.0.1, PHP 5, PHP 7'/>
- <function name='user_error' from='PHP 4, PHP 5, PHP 7'/>
+ <function name="debug_backtrace" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="debug_print_backtrace" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="error_get_last" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="error_clear_last" from="PHP 7, PHP 8"/>
+ <function name="error_log" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="error_reporting" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="restore_error_handler" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
+ <function name="restore_exception_handler" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="set_error_handler" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
+ <function name="set_exception_handler" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="trigger_error" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
+ <function name="user_error" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 </versions>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/standard/basic_functions.stub.php
- https://github.com/php/php-src/blob/PHP-8.0/Zend/zend_builtin_functions.stub.php
- Notable changes were not found.