### PR TITLE
Added PHP 8 into versions.xml for mysqli based on stubs.

### DIFF
--- a/reference/mysqli/versions.xml
+++ b/reference/mysqli/versions.xml
@@ -4,73 +4,73 @@
   Do NOT translate this file
 -->
 <versions>
- <function name="mysqli_affected_rows" from="PHP 5, PHP 7"/>
- <function name="mysqli_autocommit" from="PHP 5, PHP 7"/>
- <function name="mysqli_begin_transaction" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="mysqli_change_user" from="PHP 5, PHP 7"/>
- <function name="mysqli_character_set_name" from="PHP 5, PHP 7"/>
- <function name="mysqli_close" from="PHP 5, PHP 7"/>
- <function name="mysqli_commit" from="PHP 5, PHP 7"/>
- <function name="mysqli_connect" from="PHP 5, PHP 7"/>
- <function name="mysqli_connect_errno" from="PHP 5, PHP 7"/>
- <function name="mysqli_connect_error" from="PHP 5, PHP 7"/>
- <function name="mysqli_data_seek" from="PHP 5, PHP 7"/>
- <function name="mysqli_debug" from="PHP 5, PHP 7"/>
- <function name="mysqli_dump_debug_info" from="PHP 5, PHP 7"/>
+ <function name="mysqli_affected_rows" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_autocommit" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_begin_transaction" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="mysqli_change_user" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_character_set_name" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_close" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_commit" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_connect" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_connect_errno" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_connect_error" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_data_seek" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_debug" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_dump_debug_info" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_embedded_server_end" from="PHP 5 &gt;= 5.1.0, PHP 7 &lt; 7.4.0"/>
  <function name="mysqli_embedded_server_start" from="PHP 5 &gt;= 5.1.0, PHP 7 &lt; 7.4.0"/>
- <function name="mysqli_errno" from="PHP 5, PHP 7"/>
- <function name="mysqli_error" from="PHP 5, PHP 7"/>
- <function name="mysqli_error_list" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="mysqli_escape_string" from="PHP 5, PHP 7"/>
- <function name="mysqli_execute" from="PHP 5, PHP 7"/>
- <function name="mysqli_fetch_all" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="mysqli_fetch_array" from="PHP 5, PHP 7"/>
- <function name="mysqli_fetch_assoc" from="PHP 5, PHP 7"/>
- <function name="mysqli_fetch_field" from="PHP 5, PHP 7"/>
- <function name="mysqli_fetch_field_direct" from="PHP 5, PHP 7"/>
- <function name="mysqli_fetch_fields" from="PHP 5, PHP 7"/>
- <function name="mysqli_fetch_lengths" from="PHP 5, PHP 7"/>
- <function name="mysqli_fetch_object" from="PHP 5, PHP 7"/>
- <function name="mysqli_fetch_row" from="PHP 5, PHP 7"/>
- <function name="mysqli_field_count" from="PHP 5, PHP 7"/>
- <function name="mysqli_field_seek" from="PHP 5, PHP 7"/>
- <function name="mysqli_field_tell" from="PHP 5, PHP 7"/>
- <function name="mysqli_free_result" from="PHP 5, PHP 7"/>
- <function name="mysqli_get_charset" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="mysqli_get_client_info" from="PHP 5, PHP 7"/>
- <function name="mysqli_get_client_stats" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="mysqli_get_client_version" from="PHP 5, PHP 7"/>
- <function name="mysqli_get_connection_stats" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="mysqli_get_host_info" from="PHP 5, PHP 7"/>
- <function name="mysqli_get_links_stats" from="PHP 5 &gt;= 5.6.0, PHP 7"/>
- <function name="mysqli_get_proto_info" from="PHP 5, PHP 7"/>
- <function name="mysqli_get_server_info" from="PHP 5, PHP 7"/>
- <function name="mysqli_get_server_version" from="PHP 5, PHP 7"/>
- <function name="mysqli_get_warnings" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="mysqli_errno" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_error" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_error_list" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="mysqli_escape_string" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_execute" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_fetch_all" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="mysqli_fetch_array" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_fetch_assoc" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_fetch_field" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_fetch_field_direct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_fetch_fields" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_fetch_lengths" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_fetch_object" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_fetch_row" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_field_count" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_field_seek" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_field_tell" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_free_result" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_get_charset" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="mysqli_get_client_info" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_get_client_stats" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="mysqli_get_client_version" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_get_connection_stats" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="mysqli_get_host_info" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_get_links_stats" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
+ <function name="mysqli_get_proto_info" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_get_server_info" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_get_server_version" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_get_warnings" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
  <function name="mysqli_host_info" from="PHP 5, PHP 7"/>
- <function name="mysqli_info" from="PHP 5, PHP 7"/>
- <function name="mysqli_init" from="PHP 5, PHP 7"/>
- <function name="mysqli_insert_id" from="PHP 5, PHP 7"/>
- <function name="mysqli_kill" from="PHP 5, PHP 7"/>
- <function name="mysqli_more_results" from="PHP 5, PHP 7"/>
- <function name="mysqli_multi_query" from="PHP 5, PHP 7"/>
- <function name="mysqli_next_result" from="PHP 5, PHP 7"/>
- <function name="mysqli_num_fields" from="PHP 5, PHP 7"/>
- <function name="mysqli_num_rows" from="PHP 5, PHP 7"/>
- <function name="mysqli_options" from="PHP 5, PHP 7"/>
- <function name="mysqli_ping" from="PHP 5, PHP 7"/>
- <function name="mysqli_poll" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="mysqli_prepare" from="PHP 5, PHP 7"/>
- <function name="mysqli_query" from="PHP 5, PHP 7"/>
+ <function name="mysqli_info" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_init" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_insert_id" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_kill" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_more_results" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_multi_query" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_next_result" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_num_fields" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_num_rows" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_options" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_ping" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_poll" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="mysqli_prepare" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_query" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_read_query_result" from="PHP 5, PHP 7"/>
- <function name="mysqli_real_connect" from="PHP 5, PHP 7"/>
- <function name="mysqli_real_escape_string" from="PHP 5, PHP 7"/>
- <function name="mysqli_real_query" from="PHP 5, PHP 7"/>
- <function name="mysqli_reap_async_query" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="mysqli_refresh" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="mysqli_release_savepoint" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="mysqli_report" from="PHP 5, PHP 7"/>
+ <function name="mysqli_real_connect" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_real_escape_string" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_real_query" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_reap_async_query" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="mysqli_refresh" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="mysqli_release_savepoint" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="mysqli_report" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_result_current_field" from="PHP 5, PHP 7"/>
  <function name="mysqli_result_data_seek" from="PHP 5, PHP 7"/>
  <function name="mysqli_result_fetch_all" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
@@ -86,140 +86,140 @@
  <function name="mysqli_result_free" from="PHP 5, PHP 7"/>
  <function name="mysqli_result_lengths" from="PHP 5, PHP 7"/>
  <function name="mysqli_result_num_rows" from="PHP 5, PHP 7"/>
- <function name="mysqli_rollback" from="PHP 5, PHP 7"/>
+ <function name="mysqli_rollback" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_row_seek" from="PHP 5, PHP 7"/>
- <function name="mysqli_savepoint" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="mysqli_select_db" from="PHP 5, PHP 7"/>
- <function name="mysqli_set_charset" from="PHP 5 &gt;= 5.0.5, PHP 7"/>
- <function name="mysqli_set_opt" from="PHP 5, PHP 7"/>
- <function name="mysqli_sqlstate" from="PHP 5, PHP 7"/>
- <function name="mysqli_ssl_set" from="PHP 5, PHP 7"/>
- <function name="mysqli_stat" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_affected_rows" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_attr_get" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_attr_set" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_bind_param" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_bind_result" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_close" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_data_seek" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_errno" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_error" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_error_list" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="mysqli_stmt_execute" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_fetch" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_field_count" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_free_result" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_get_result" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="mysqli_stmt_get_warnings" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="mysqli_stmt_init" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_insert_id" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_more_results" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="mysqli_stmt_next_result" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="mysqli_stmt_num_rows" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_param_count" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_prepare" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_reset" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_result_metadata" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_send_long_data" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_sqlstate" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt_store_result" from="PHP 5, PHP 7"/>
- <function name="mysqli_store_result" from="PHP 5, PHP 7"/>
- <function name="mysqli_thread_id" from="PHP 5, PHP 7"/>
- <function name="mysqli_thread_safe" from="PHP 5, PHP 7"/>
- <function name="mysqli_use_result" from="PHP 5, PHP 7"/>
- <function name="mysqli_warning_count" from="PHP 5, PHP 7"/>
+ <function name="mysqli_savepoint" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="mysqli_select_db" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_set_charset" from="PHP 5 &gt;= 5.0.5, PHP 7, PHP 8"/>
+ <function name="mysqli_set_opt" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_sqlstate" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_ssl_set" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stat" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_affected_rows" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_attr_get" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_attr_set" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_bind_param" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_bind_result" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_close" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_data_seek" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_errno" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_error" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_error_list" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_execute" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_fetch" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_field_count" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_free_result" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_get_result" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_get_warnings" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_init" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_insert_id" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_more_results" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_next_result" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_num_rows" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_param_count" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_prepare" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_reset" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_result_metadata" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_send_long_data" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_sqlstate" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt_store_result" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_store_result" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_thread_id" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_thread_safe" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_use_result" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_warning_count" from="PHP 5, PHP 7, PHP 8"/>
 
  <!-- Classes -->
- <function name="mysqli" from="PHP 5, PHP 7"/>
- <function name="mysqli::__construct" from="PHP 5, PHP 7"/>
- <function name="mysqli::autocommit" from="PHP 5, PHP 7"/>
- <function name="mysqli::begin_transaction" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="mysqli::change_user" from="PHP 5, PHP 7"/>
- <function name="mysqli::character_set_name" from="PHP 5, PHP 7"/>
- <function name="mysqli::close" from="PHP 5, PHP 7"/>
- <function name="mysqli::commit" from="PHP 5, PHP 7"/>
- <function name="mysqli::connect" from="PHP 5, PHP 7"/>
- <function name="mysqli::debug" from="PHP 5, PHP 7"/>
- <function name="mysqli::dump_debug_info" from="PHP 5, PHP 7"/>
- <function name="mysqli::escape_string" from="PHP 5, PHP 7"/>
- <function name="mysqli::get_charset" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="mysqli::get_client_info" from="PHP 5, PHP 7"/>
- <function name="mysqli::get_connection_stats" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="mysqli::get_server_info" from="PHP 5, PHP 7"/>
- <function name="mysqli::get_warnings" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="mysqli::init" from="PHP 5, PHP 7"/>
- <function name="mysqli::kill" from="PHP 5, PHP 7"/>
- <function name="mysqli::more_results" from="PHP 5, PHP 7"/>
- <function name="mysqli::multi_query" from="PHP 5, PHP 7"/>
- <function name="mysqli::next_result" from="PHP 5, PHP 7"/>
- <function name="mysqli::options" from="PHP 5, PHP 7"/>
- <function name="mysqli::ping" from="PHP 5, PHP 7"/>
- <function name="mysqli::poll" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="mysqli::prepare" from="PHP 5, PHP 7"/>
- <function name="mysqli::query" from="PHP 5, PHP 7"/>
- <function name="mysqli::real_connect" from="PHP 5, PHP 7"/>
- <function name="mysqli::real_escape_string" from="PHP 5, PHP 7"/>
- <function name="mysqli::real_query" from="PHP 5, PHP 7"/>
- <function name="mysqli::reap_async_query" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="mysqli::refresh" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="mysqli::release_savepoint" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="mysqli::rollback" from="PHP 5, PHP 7"/>
- <function name="mysqli::savepoint" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="mysqli::select_db" from="PHP 5, PHP 7"/>
- <function name="mysqli::set_charset" from="PHP 5 &gt;= 5.0.5, PHP 7"/>
- <function name="mysqli::set_opt" from="PHP 5, PHP 7"/>
- <function name="mysqli::ssl_set" from="PHP 5, PHP 7"/>
- <function name="mysqli::stat" from="PHP 5, PHP 7"/>
- <function name="mysqli::stmt_init" from="PHP 5, PHP 7"/>
- <function name="mysqli::store_result" from="PHP 5, PHP 7"/>
- <function name="mysqli::thread_safe" from="PHP 5, PHP 7"/>
- <function name="mysqli::use_result" from="PHP 5, PHP 7"/>
+ <function name="mysqli" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::__construct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::autocommit" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::begin_transaction" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="mysqli::change_user" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::character_set_name" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::close" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::commit" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::connect" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::debug" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::dump_debug_info" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::escape_string" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::get_charset" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="mysqli::get_client_info" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::get_connection_stats" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="mysqli::get_server_info" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::get_warnings" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="mysqli::init" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::kill" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::more_results" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::multi_query" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::next_result" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::options" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::ping" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::poll" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="mysqli::prepare" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::query" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::real_connect" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::real_escape_string" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::real_query" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::reap_async_query" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="mysqli::refresh" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="mysqli::release_savepoint" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="mysqli::rollback" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::savepoint" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="mysqli::select_db" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::set_charset" from="PHP 5 &gt;= 5.0.5, PHP 7, PHP 8"/>
+ <function name="mysqli::set_opt" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::ssl_set" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::stat" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::stmt_init" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::store_result" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::thread_safe" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli::use_result" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="mysqli_stmt" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt::__construct" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt::attr_get" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt::attr_set" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt::bind_param" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt::bind_result" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt::close" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt::data_seek" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt::execute" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt::fetch" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt::free_result" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt::get_result" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="mysqli_stmt::get_warnings" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="mysqli_stmt::more_results" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="mysqli_stmt::next_result" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="mysqli_stmt::num_rows" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt::prepare" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt::reset" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt::result_metadata" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt::send_long_data" from="PHP 5, PHP 7"/>
- <function name="mysqli_stmt::store_result" from="PHP 5, PHP 7"/>
+ <function name="mysqli_stmt" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::__construct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::attr_get" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::attr_set" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::bind_param" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::bind_result" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::close" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::data_seek" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::execute" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::fetch" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::free_result" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::get_result" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::get_warnings" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::more_results" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::next_result" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::num_rows" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::prepare" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::reset" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::result_metadata" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::send_long_data" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_stmt::store_result" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="mysqli_result" from="PHP 5, PHP 7"/>
- <function name="mysqli_result::close" from="PHP 5, PHP 7"/>
- <function name="mysqli_result::data_seek" from="PHP 5, PHP 7"/>
- <function name="mysqli_result::fetch_all" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="mysqli_result::fetch_array" from="PHP 5, PHP 7"/>
- <function name="mysqli_result::fetch_assoc" from="PHP 5, PHP 7"/>
- <function name="mysqli_result::fetch_field_direct" from="PHP 5, PHP 7"/>
- <function name="mysqli_result::fetch_field" from="PHP 5, PHP 7"/>
- <function name="mysqli_result::fetch_fields" from="PHP 5, PHP 7"/>
- <function name="mysqli_result::fetch_object" from="PHP 5, PHP 7"/>
- <function name="mysqli_result::fetch_row" from="PHP 5, PHP 7"/>
- <function name="mysqli_result::field_seek" from="PHP 5, PHP 7"/>
- <function name="mysqli_result::free" from="PHP 5, PHP 7"/>
- <function name="mysqli_result::free_result" from="PHP 5, PHP 7"/>
+ <function name="mysqli_result" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_result::close" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_result::data_seek" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_result::fetch_all" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="mysqli_result::fetch_array" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_result::fetch_assoc" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_result::fetch_field_direct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_result::fetch_field" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_result::fetch_fields" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_result::fetch_object" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_result::fetch_row" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_result::field_seek" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_result::free" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_result::free_result" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="mysqli_driver" from="PHP 5, PHP 7"/>
+ <function name="mysqli_driver" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_driver::embedded_server_end" from="PHP 5 &gt;= 5.1.0, PHP 7 &lt; 7.4.0"/>
  <function name="mysqli_driver::embedded_server_start" from="PHP 5 &gt;= 5.1.0, PHP 7 &lt; 7.4.0"/>
 
- <function name="mysqli_warning" from="PHP 5, PHP 7"/>
- <function name="mysqli_warning::next" from="PHP 5, PHP 7"/>
+ <function name="mysqli_warning" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="mysqli_warning::next" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="mysqli_sql_exception" from="PHP 5, PHP 7"/>
+ <function name="mysqli_sql_exception" from="PHP 5, PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/mysqli/mysqli.stub.php
- Notable changes
  * deleted functions as of PHP 8
    - `mysqli_embedded_server_start`
    - `mysqli_embedded_server_end`
    - `mysqli_driver::embedded_server_end`
    - `mysqli_driver::embedded_server_start`
  * not exist in manual nor PHP 5, PHP 7, PHP 8 source.
    - `mysqli_result_*` function, for example, `mysqli_result_current_field`
    - `mysqli_host_info`
  * exists in PHP5, PHP 7 source, but not exist in manual.
    - `mysqli_row_seek`
    - `mysqli_read_query_result`