### PR TITLE
password_hash(): Fix for incorrect return type #77218

### DIFF
--- a/reference/password/functions/password-hash.xml
+++ b/reference/password/functions/password-hash.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type class="union"><type>string</type><type>false</type></type><methodname>password_hash</methodname>
+   <type class="union"><type>string</type><type>null</type></type><methodname>password_hash</methodname>
    <methodparam><type>string</type><parameter>password</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>algo</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter></methodparam>
@@ -162,7 +162,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the hashed password, &return.falseforfailure;.
+   Returns the hashed password, or &null; on failure (with a warning) prior to 8.0.
   </para>
   <para>
    The used algorithm, cost and salt are returned as part of the hash. Therefore,
@@ -184,6 +184,12 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Throws an Error instead of returning &null; with a warning on errors.
+       </entry>
+      </row>
       <row>
        <entry>7.4.0</entry>
        <entry>


### PR DESCRIPTION
Fix the return type (null instead of false on failure) and add a changelog entry for 8.0 error handling changes.