### PR TITLE
Added PHP 8 into versions.xml for pdo based on stubs.

### DIFF
--- a/reference/pdo/versions.xml
+++ b/reference/pdo/versions.xml
@@ -7,70 +7,70 @@
  FIXME: Discuss how/where to keep PDO version info...
 -->
 <versions>
- <function name="pdo" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
- <function name="pdo::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
+ <function name="pdo" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
+ <function name="pdo::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
  <function name="pdo::__sleep" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 1.0.0"/>
  <function name="pdo::__wakeup" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 1.0.0"/>
- <function name="pdo::begintransaction" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
- <function name="pdo::commit" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
+ <function name="pdo::begintransaction" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
+ <function name="pdo::commit" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
  <function name="pdo::cubrid_schema" from="PECL PDO_CUBRID &gt;= 8.3.0.0001"/>
- <function name="pdo::errorcode" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
- <function name="pdo::errorinfo" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
- <function name="pdo::exec" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
- <function name="pdo::getattribute" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.2.0"/>
- <function name="pdo::getavailabledrivers" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 1.0.3"/>
- <function name="pdo::intransaction" from="PHP 5 &gt;= 5.3.3, Bundled pdo_pgsql, PHP 7"/>
- <function name="pdo::lastinsertid" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
- <function name="pdo::pgsqlcopyfromarray" from="PHP 5 &gt;= 5.3.3, PHP 7"/>
- <function name="pdo::pgsqlcopyfromfile" from="PHP 5 &gt;= 5.3.3, PHP 7"/>
- <function name="pdo::pgsqlcopytoarray" from="PHP 5 &gt;= 5.3.3, PHP 7"/>
- <function name="pdo::pgsqlcopytofile" from="PHP 5 &gt;= 5.3.3, PHP 7"/>
- <function name="pdo::pgsqlgetnotify" from="PHP 5 &gt;= 5.6.0, PHP 7"/>
- <function name="pdo::pgsqlgetpid" from="PHP 5 &gt;= 5.6.0, PHP 7"/>
- <function name="pdo::pgsqllobcreate" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL pdo_pgsql &gt;= 1.0.2"/>
- <function name="pdo::pgsqllobopen" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL pdo_pgsql &gt;= 1.0.2"/>
- <function name="pdo::pgsqllobunlink" from="PHP 5 &gt;= 5.1.2, PHP 7, PECL pdo_pgsql &gt;= 1.0.2"/>
- <function name="pdo::prepare" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
- <function name="pdo::query" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.2.0"/>
- <function name="pdo::quote" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.2.1"/>
- <function name="pdo::rollback" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
- <function name="pdo::setattribute" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
- <function name="pdo::sqlitecreateaggregate" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo_sqlite &gt;= 1.0.0"/>
- <function name="pdo::sqlitecreatefunction" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo_sqlite &gt;= 1.0.0"/>
- <function name="pdo::sqlitecreatecollation" from="PHP 5 &gt;= 5.3.11, PHP 7"/>
+ <function name="pdo::errorcode" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
+ <function name="pdo::errorinfo" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
+ <function name="pdo::exec" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
+ <function name="pdo::getattribute" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.2.0"/>
+ <function name="pdo::getavailabledrivers" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 1.0.3"/>
+ <function name="pdo::intransaction" from="PHP 5 &gt;= 5.3.3, Bundled pdo_pgsql, PHP 7, PHP 8"/>
+ <function name="pdo::lastinsertid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
+ <function name="pdo::pgsqlcopyfromarray" from="PHP 5 &gt;= 5.3.3, PHP 7, PHP 8"/>
+ <function name="pdo::pgsqlcopyfromfile" from="PHP 5 &gt;= 5.3.3, PHP 7, PHP 8"/>
+ <function name="pdo::pgsqlcopytoarray" from="PHP 5 &gt;= 5.3.3, PHP 7, PHP 8"/>
+ <function name="pdo::pgsqlcopytofile" from="PHP 5 &gt;= 5.3.3, PHP 7, PHP 8"/>
+ <function name="pdo::pgsqlgetnotify" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
+ <function name="pdo::pgsqlgetpid" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
+ <function name="pdo::pgsqllobcreate" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8, PECL pdo_pgsql &gt;= 1.0.2"/>
+ <function name="pdo::pgsqllobopen" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8, PECL pdo_pgsql &gt;= 1.0.2"/>
+ <function name="pdo::pgsqllobunlink" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8, PECL pdo_pgsql &gt;= 1.0.2"/>
+ <function name="pdo::prepare" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PHP 8,PECL pdo &gt;= 0.1.0"/>
+ <function name="pdo::query" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.2.0"/>
+ <function name="pdo::quote" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.2.1"/>
+ <function name="pdo::rollback" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
+ <function name="pdo::setattribute" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
+ <function name="pdo::sqlitecreateaggregate" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo_sqlite &gt;= 1.0.0"/>
+ <function name="pdo::sqlitecreatefunction" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo_sqlite &gt;= 1.0.0"/>
+ <function name="pdo::sqlitecreatecollation" from="PHP 5 &gt;= 5.3.11, PHP 7, PHP 8"/>
 
- <function name="pdo_drivers" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.9.0"/>
+ <function name="pdo_drivers" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.9.0"/>
 
  <function name="pdo_user" from="PECL pdo_user &gt;= 0.2.0"/>
  <function name="pdo_user::parsesql" from="PECL pdo_user &gt;= 0.2.0"/>
  <function name="pdo_user::tokenizesql" from="PECL pdo_user &gt;= 0.2.0"/>
  <function name="pdo_user::tokenname" from="PECL pdo_user &gt;= 0.2.0"/>
 
- <function name="pdostatement" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 1.0.0"/>
+ <function name="pdostatement" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 1.0.0"/>
  <function name="pdostatement::__sleep" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 1.0.0"/>
  <function name="pdostatement::__wakeup" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 1.0.0"/>
- <function name="pdostatement::bindcolumn" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
- <function name="pdostatement::bindparam" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
- <function name="pdostatement::bindvalue" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 1.0.0"/>
- <function name="pdostatement::closecursor" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.9.0"/>
- <function name="pdostatement::columncount" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.2.0"/>
- <function name="pdostatement::debugdumpparams" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.9.0"/>
- <function name="pdostatement::errorcode" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
- <function name="pdostatement::errorinfo" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
- <function name="pdostatement::execute" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
- <function name="pdostatement::fetch" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
- <function name="pdostatement::fetchall" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
- <function name="pdostatement::fetchcolumn" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.9.0"/>
- <function name="pdostatement::fetchobject" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.2.4"/>
+ <function name="pdostatement::bindcolumn" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
+ <function name="pdostatement::bindparam" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
+ <function name="pdostatement::bindvalue" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 1.0.0"/>
+ <function name="pdostatement::closecursor" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.9.0"/>
+ <function name="pdostatement::columncount" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.2.0"/>
+ <function name="pdostatement::debugdumpparams" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.9.0"/>
+ <function name="pdostatement::errorcode" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
+ <function name="pdostatement::errorinfo" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
+ <function name="pdostatement::execute" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
+ <function name="pdostatement::fetch" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
+ <function name="pdostatement::fetchall" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
+ <function name="pdostatement::fetchcolumn" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.9.0"/>
+ <function name="pdostatement::fetchobject" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.2.4"/>
  <function name="pdostatement::fetchsingle" from="PECL pdo 0.1-0.3"/>
- <function name="pdostatement::getattribute" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.2.0"/>
- <function name="pdostatement::getcolumnmeta" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.2.0"/>
- <function name="pdostatement::nextrowset" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.2.0"/>
- <function name="pdostatement::rowcount" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0"/>
- <function name="pdostatement::setattribute" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.2.0"/>
- <function name="pdostatement::setfetchmode" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.2.0"/>
+ <function name="pdostatement::getattribute" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.2.0"/>
+ <function name="pdostatement::getcolumnmeta" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.2.0"/>
+ <function name="pdostatement::nextrowset" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.2.0"/>
+ <function name="pdostatement::rowcount" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
+ <function name="pdostatement::setattribute" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.2.0"/>
+ <function name="pdostatement::setfetchmode" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.2.0"/>
 
- <function name="pdoexception" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="pdoexception" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
  <function name="pdo_cubrid dsn" from="PECL PDO_CUBRID &gt;= 8.3.0.0001"/>
  <function name="pdo_dblib dsn" from="PECL PDO_DBLIB &gt;= 0.9.0"/>


### PR DESCRIPTION
- Generated verions.xml based on the following stubs.
  * https://github.com/php/php-src/blob/PHP-8.0/ext/pdo/pdo.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/pdo/pdo_stmt.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/pdo/pdo_dbh.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/pdo_pgsql/pgsql_driver.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/pdo_sqlite/sqlite_driver.stub.php
- Note
  * I did not change PECL specific function and methods.
    - `pdo::cubrid_schema`
    - `pdo_user*`
    - `pdo_* dsn`
    - `pdostatement::fetchsingle`
   * Not unsure the following is implemented in PHP 8.
     - `pdo::__sleep`
     - `pdo::__wakeup`
     - `pdostatement::__sleep`
     - `pdostatement::__wakeup`