### PR TITLE
Added PHP 8 into versions.xml for intl based on stubs.

### DIFF
--- a/reference/intl/versions.xml
+++ b/reference/intl/versions.xml
@@ -4,437 +4,439 @@
   Do NOT translate this file
 -->
 <versions>
- <function name="intlexception" from="PHP 5 &gt; 5.5.0, PHP 7, PECL intl &gt; 3.0.0a1"/>
+ <function name="intlexception" from="PHP 5 &gt; 5.5.0, PHP 7, PHP 8, PECL intl &gt; 3.0.0a1"/>
  <!-- Methods -->
- <function name="collator" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator::create" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator::compare" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator::sort" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator::sortwithsortkeys" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator::asort" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator::getattribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator::getsortkey" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL intl &gt;= 1.0.3"/>
- <function name="collator::setattribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator::getstrength" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator::setstrength" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator::getlocale" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator::geterrorcode" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator::geterrormessage" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
+ <function name="collator" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator::create" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator::compare" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator::sort" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator::sortwithsortkeys" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator::asort" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator::getattribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator::getsortkey" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8, PECL intl &gt;= 1.0.3"/>
+ <function name="collator::setattribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator::getstrength" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator::setstrength" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator::getlocale" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator::geterrorcode" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator::geterrormessage" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
 
- <function name="intlcalendar" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::__construct" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::createinstance" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::getkeywordvaluesforlocale" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::getnow" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::getavailablelocales" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::get" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::gettime" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::settime" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::add" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::settimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::after" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::before" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::set" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::roll" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::clear" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::fielddifference" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::getactualmaximum" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::getactualminimum" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::getdayofweektype" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::getfirstdayofweek" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::getgreatestminimum" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::getleastmaximum" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::getlocale" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::getmaximum" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::getminimaldaysinfirstweek" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::getminimum" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::gettimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::gettype" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::getweekendtransition" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::indaylighttime" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::isequivalentto" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::islenient" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::isset" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::isweekend" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::setfirstdayofweek" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::setlenient" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::equals" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::getrepeatedwalltimeoption" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::getskippedwalltimeoption" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::setrepeatedwalltimeoption" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::setskippedwalltimeoption" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::setminimaldaysinfirstweek" from="PHP 5 &gt;= 5.5.1, PHP 7"/>
- <function name="intlcalendar::fromdatetime" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a2"/>
- <function name="intlcalendar::todatetime" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a2"/>
- <function name="intlcalendar::geterrorcode" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intlcalendar::geterrormessage" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::__construct" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::createinstance" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::getkeywordvaluesforlocale" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::getnow" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::getavailablelocales" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::get" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::gettime" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::settime" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::add" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::settimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::after" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::before" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::set" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::roll" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::clear" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::fielddifference" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::getactualmaximum" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::getactualminimum" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::getdayofweektype" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::getfirstdayofweek" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::getgreatestminimum" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::getleastmaximum" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::getlocale" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::getmaximum" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::getminimaldaysinfirstweek" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::getminimum" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::gettimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::gettype" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::getweekendtransition" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::indaylighttime" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::isequivalentto" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::islenient" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::isset" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::isweekend" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::setfirstdayofweek" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::setlenient" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::equals" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::getrepeatedwalltimeoption" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::getskippedwalltimeoption" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::setrepeatedwalltimeoption" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::setskippedwalltimeoption" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::setminimaldaysinfirstweek" from="PHP 5 &gt;= 5.5.1, PHP 7, PHP 8"/>
+ <function name="intlcalendar::fromdatetime" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a2"/>
+ <function name="intlcalendar::todatetime" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a2"/>
+ <function name="intlcalendar::geterrorcode" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intlcalendar::geterrormessage" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
 
- <function name="intlchar" from="PHP 7"/>
- <function name="intlchar::charage" from="PHP 7"/>
- <function name="intlchar::chardigitvalue" from="PHP 7"/>
- <function name="intlchar::chardirection" from="PHP 7"/>
- <function name="intlchar::charfromname" from="PHP 7"/>
- <function name="intlchar::charmirror" from="PHP 7"/>
- <function name="intlchar::charname" from="PHP 7"/>
- <function name="intlchar::chartype" from="PHP 7"/>
- <function name="intlchar::chr" from="PHP 7"/>
- <function name="intlchar::digit" from="PHP 7"/>
- <function name="intlchar::enumcharnames" from="PHP 7"/>
- <function name="intlchar::enumchartypes" from="PHP 7"/>
- <function name="intlchar::foldcase" from="PHP 7"/>
- <function name="intlchar::fordigit" from="PHP 7"/>
- <function name="intlchar::getbidipairedbracket" from="PHP 7"/>
- <function name="intlchar::getblockcode" from="PHP 7"/>
- <function name="intlchar::getcombiningclass" from="PHP 7"/>
- <function name="intlchar::getfc-nfkc-closure" from="PHP 7"/>
- <function name="intlchar::getintpropertymaxvalue" from="PHP 7"/>
- <function name="intlchar::getintpropertyminvalue" from="PHP 7"/>
- <function name="intlchar::getintpropertyvalue" from="PHP 7"/>
- <function name="intlchar::getnumericvalue" from="PHP 7"/>
- <function name="intlchar::getpropertyenum" from="PHP 7"/>
- <function name="intlchar::getpropertyname" from="PHP 7"/>
- <function name="intlchar::getpropertyvalueenum" from="PHP 7"/>
- <function name="intlchar::getpropertyvaluename" from="PHP 7"/>
- <function name="intlchar::getunicodeversion" from="PHP 7"/>
- <function name="intlchar::hasbinaryproperty" from="PHP 7"/>
- <function name="intlchar::isalnum" from="PHP 7"/>
- <function name="intlchar::isalpha" from="PHP 7"/>
- <function name="intlchar::isbase" from="PHP 7"/>
- <function name="intlchar::isblank" from="PHP 7"/>
- <function name="intlchar::iscntrl" from="PHP 7"/>
- <function name="intlchar::isdefined" from="PHP 7"/>
- <function name="intlchar::isdigit" from="PHP 7"/>
- <function name="intlchar::isgraph" from="PHP 7"/>
- <function name="intlchar::isidignorable" from="PHP 7"/>
- <function name="intlchar::isidpart" from="PHP 7"/>
- <function name="intlchar::isidstart" from="PHP 7"/>
- <function name="intlchar::isisocontrol" from="PHP 7"/>
- <function name="intlchar::isjavaidpart" from="PHP 7"/>
- <function name="intlchar::isjavaidstart" from="PHP 7"/>
- <function name="intlchar::isjavaspacechar" from="PHP 7"/>
- <function name="intlchar::islower" from="PHP 7"/>
- <function name="intlchar::ismirrored" from="PHP 7"/>
- <function name="intlchar::isprint" from="PHP 7"/>
- <function name="intlchar::ispunct" from="PHP 7"/>
- <function name="intlchar::isspace" from="PHP 7"/>
- <function name="intlchar::istitle" from="PHP 7"/>
- <function name="intlchar::isualphabetic" from="PHP 7"/>
- <function name="intlchar::isulowercase" from="PHP 7"/>
- <function name="intlchar::isupper" from="PHP 7"/>
- <function name="intlchar::isuuppercase" from="PHP 7"/>
- <function name="intlchar::isuwhitespace" from="PHP 7"/>
- <function name="intlchar::iswhitespace" from="PHP 7"/>
- <function name="intlchar::isxdigit" from="PHP 7"/>
- <function name="intlchar::ord" from="PHP 7"/>
- <function name="intlchar::tolower" from="PHP 7"/>
- <function name="intlchar::totitle" from="PHP 7"/>
- <function name="intlchar::toupper" from="PHP 7"/>
+ <function name="intlchar" from="PHP 7, PHP 8"/>
+ <function name="intlchar::charage" from="PHP 7, PHP 8"/>
+ <function name="intlchar::chardigitvalue" from="PHP 7, PHP 8"/>
+ <function name="intlchar::chardirection" from="PHP 7, PHP 8"/>
+ <function name="intlchar::charfromname" from="PHP 7, PHP 8"/>
+ <function name="intlchar::charmirror" from="PHP 7, PHP 8"/>
+ <function name="intlchar::charname" from="PHP 7, PHP 8"/>
+ <function name="intlchar::chartype" from="PHP 7, PHP 8"/>
+ <function name="intlchar::chr" from="PHP 7, PHP 8"/>
+ <function name="intlchar::digit" from="PHP 7, PHP 8"/>
+ <function name="intlchar::enumcharnames" from="PHP 7, PHP 8"/>
+ <function name="intlchar::enumchartypes" from="PHP 7, PHP 8"/>
+ <function name="intlchar::foldcase" from="PHP 7, PHP 8"/>
+ <function name="intlchar::fordigit" from="PHP 7, PHP 8"/>
+ <function name="intlchar::getbidipairedbracket" from="PHP 7, PHP 8"/>
+ <function name="intlchar::getblockcode" from="PHP 7, PHP 8"/>
+ <function name="intlchar::getcombiningclass" from="PHP 7, PHP 8"/>
+ <function name="intlchar::getfc-nfkc-closure" from="PHP 7, PHP 8"/>
+ <function name="intlchar::getintpropertymaxvalue" from="PHP 7, PHP 8"/>
+ <function name="intlchar::getintpropertyminvalue" from="PHP 7, PHP 8"/>
+ <function name="intlchar::getintpropertyvalue" from="PHP 7, PHP 8"/>
+ <function name="intlchar::getnumericvalue" from="PHP 7, PHP 8"/>
+ <function name="intlchar::getpropertyenum" from="PHP 7, PHP 8"/>
+ <function name="intlchar::getpropertyname" from="PHP 7, PHP 8"/>
+ <function name="intlchar::getpropertyvalueenum" from="PHP 7, PHP 8"/>
+ <function name="intlchar::getpropertyvaluename" from="PHP 7, PHP 8"/>
+ <function name="intlchar::getunicodeversion" from="PHP 7, PHP 8"/>
+ <function name="intlchar::hasbinaryproperty" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isalnum" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isalpha" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isbase" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isblank" from="PHP 7, PHP 8"/>
+ <function name="intlchar::iscntrl" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isdefined" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isdigit" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isgraph" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isidignorable" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isidpart" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isidstart" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isisocontrol" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isjavaidpart" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isjavaidstart" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isjavaspacechar" from="PHP 7, PHP 8"/>
+ <function name="intlchar::islower" from="PHP 7, PHP 8"/>
+ <function name="intlchar::ismirrored" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isprint" from="PHP 7, PHP 8"/>
+ <function name="intlchar::ispunct" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isspace" from="PHP 7, PHP 8"/>
+ <function name="intlchar::istitle" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isualphabetic" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isulowercase" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isupper" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isuuppercase" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isuwhitespace" from="PHP 7, PHP 8"/>
+ <function name="intlchar::iswhitespace" from="PHP 7, PHP 8"/>
+ <function name="intlchar::isxdigit" from="PHP 7, PHP 8"/>
+ <function name="intlchar::ord" from="PHP 7, PHP 8"/>
+ <function name="intlchar::tolower" from="PHP 7, PHP 8"/>
+ <function name="intlchar::totitle" from="PHP 7, PHP 8"/>
+ <function name="intlchar::toupper" from="PHP 7, PHP 8"/>
 
- <function name="intltimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::__construct" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::createtimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::fromdatetimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::createdefault" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::getgmt" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::createenumeration" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::createtimezoneidenumeration" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intltimezone::countequivalentids" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::getcanonicalid" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::gettzdataversion" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::getequivalentid" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::getid" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::getidforwindowsid" from="PHP 7 &gt;= 7.1.0"/>
- <function name="intltimezone::getregion" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intltimezone::getunknown" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intltimezone::usedaylighttime" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::getoffset" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::getrawoffset" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::hassamerules" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::getdisplayname" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::getdstsavings" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::todatetimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::geterrorcode" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::geterrormessage" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="intltimezone::getwindowsid" from="PHP 7 &gt;= 7.1.0"/>
+ <function name="intltimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::__construct" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::createtimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::fromdatetimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::createdefault" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::getgmt" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::createenumeration" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::createtimezoneidenumeration" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intltimezone::countequivalentids" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::getcanonicalid" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::gettzdataversion" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::getequivalentid" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::getid" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::getidforwindowsid" from="PHP 7 &gt;= 7.1.0, PHP 8"/>
+ <function name="intltimezone::getregion" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intltimezone::getunknown" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intltimezone::usedaylighttime" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::getoffset" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::getrawoffset" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::hassamerules" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::getdisplayname" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::getdstsavings" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::todatetimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::geterrorcode" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::geterrormessage" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="intltimezone::getwindowsid" from="PHP 7 &gt;= 7.1.0, PHP 8"/>
 
- <function name="intldateformatter" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intldateformatter::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intldateformatter::create" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intldateformatter::getdatetype" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intldateformatter::gettimetype" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intldateformatter::getcalendar" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intldateformatter::getcalendarobject" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL intl &gt;= 3.0.0"/>
- <function name="intldateformatter::setcalendar" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intldateformatter::gettimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL intl &gt;= 3.0.0"/>
- <function name="intldateformatter::settimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL intl &gt;= 3.0.0"/>
- <function name="intldateformatter::gettimezoneid" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intldateformatter::setpattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intldateformatter::getpattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intldateformatter::getlocale" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intldateformatter::setlenient" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intldateformatter::islenient" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intldateformatter::format" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intldateformatter::formatobject" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL intl &gt;= 3.0.0"/>
- <function name="intldateformatter::parse" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intldateformatter::localtime" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intldateformatter::geterrorcode" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intldateformatter::geterrormessage" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter::create" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter::getdatetype" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter::gettimetype" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter::getcalendar" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter::getcalendarobject" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL intl &gt;= 3.0.0"/>
+ <function name="intldateformatter::setcalendar" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter::gettimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL intl &gt;= 3.0.0"/>
+ <function name="intldateformatter::settimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL intl &gt;= 3.0.0"/>
+ <function name="intldateformatter::gettimezoneid" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter::settimezoneid" from="PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0" deprecated="PHP 5 &gt;= 5.5.0"/>
+ <function name="intldateformatter::setpattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter::getpattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter::getlocale" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter::setlenient" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter::islenient" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter::format" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter::formatobject" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL intl &gt;= 3.0.0"/>
+ <function name="intldateformatter::parse" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter::localtime" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter::geterrorcode" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter::geterrormessage" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
 
- <function name="locale" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale::getdefault" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale::setdefault" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale::getprimarylanguage" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale::getscript" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale::getregion" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale::getkeywords" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale::getdisplayscript" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale::getdisplayregion" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale::getdisplayname" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale::getdisplaylanguage" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale::getdisplayvariant" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale::composelocale" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale::parselocale" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale::getallvariants" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale::filtermatches" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale::lookup" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale::canonicalize" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale::acceptfromhttp" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
+ <function name="locale" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale::getdefault" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale::setdefault" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale::getprimarylanguage" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale::getscript" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale::getregion" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale::getkeywords" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale::getdisplayscript" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale::getdisplayregion" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale::getdisplayname" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale::getdisplaylanguage" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale::getdisplayvariant" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale::composelocale" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale::parselocale" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale::getallvariants" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale::filtermatches" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale::lookup" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale::canonicalize" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale::acceptfromhttp" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
 
- <function name="messageformatter" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="messageformatter::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="messageformatter::create" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="messageformatter::format" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="messageformatter::formatmessage" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="messageformatter::parse" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="messageformatter::parsemessage" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="messageformatter::setpattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="messageformatter::getpattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="messageformatter::getlocale" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="messageformatter::geterrorcode" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="messageformatter::geterrormessage" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
+ <function name="messageformatter" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="messageformatter::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="messageformatter::create" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="messageformatter::format" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="messageformatter::formatmessage" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="messageformatter::parse" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="messageformatter::parsemessage" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="messageformatter::setpattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="messageformatter::getpattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="messageformatter::getlocale" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="messageformatter::geterrorcode" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="messageformatter::geterrormessage" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
 
- <function name="normalizer" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="normalizer::normalize" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="normalizer::isnormalized" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="normalizer::getrawdecomposition" from="PHP 7 &gt;= 7.3"/>
+ <function name="normalizer" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="normalizer::normalize" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="normalizer::isnormalized" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="normalizer::getrawdecomposition" from="PHP 7 &gt;= 7.3, PHP 8"/>
 
- <function name="numberformatter" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numberformatter::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numberformatter::create" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numberformatter::format" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numberformatter::parse" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numberformatter::formatcurrency" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numberformatter::parsecurrency" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numberformatter::setattribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numberformatter::getattribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numberformatter::settextattribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numberformatter::gettextattribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numberformatter::setsymbol" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numberformatter::getsymbol" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numberformatter::setpattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numberformatter::getpattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numberformatter::getlocale" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numberformatter::geterrorcode" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numberformatter::geterrormessage" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
+ <function name="numberformatter" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numberformatter::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numberformatter::create" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numberformatter::format" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numberformatter::parse" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numberformatter::formatcurrency" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numberformatter::parsecurrency" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numberformatter::setattribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numberformatter::getattribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numberformatter::settextattribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numberformatter::gettextattribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numberformatter::setsymbol" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numberformatter::getsymbol" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numberformatter::setpattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numberformatter::getpattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numberformatter::getlocale" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numberformatter::geterrorcode" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numberformatter::geterrormessage" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
 
- <function name="intlbreakiterator" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::__construct" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::createwordinstance" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::createlineinstance" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::createcharacterinstance" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::createsentenceinstance" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::createtitleinstance" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::createcodepointinstance" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::gettext" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::settext" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::first" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::last" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::previous" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::next" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::current" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::following" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::preceding" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::isboundary" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::getlocale" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::getpartsiterator" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::geterrorcode" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlbreakiterator::geterrormessage" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
+ <function name="intlbreakiterator" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::__construct" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::createwordinstance" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::createlineinstance" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::createcharacterinstance" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::createsentenceinstance" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::createtitleinstance" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::createcodepointinstance" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::gettext" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::settext" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::first" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::last" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::previous" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::next" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::current" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::following" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::preceding" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::isboundary" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::getlocale" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::getpartsiterator" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::geterrorcode" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlbreakiterator::geterrormessage" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  
- <function name="intlcodepointbreakiterator" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlcodepointbreakiterator::getlastcodepoint" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
+ <function name="intlcodepointbreakiterator" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlcodepointbreakiterator::getlastcodepoint" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
 
- <function name="intlpartsiterator" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlpartsiterator::getbreakiterator" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
+ <function name="intlpartsiterator" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlpartsiterator::getbreakiterator" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
 
- <function name="intlrulebasedbreakiterator" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlrulebasedbreakiterator::__construct" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlrulebasedbreakiterator::getrules" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlrulebasedbreakiterator::getrulestatus" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlrulebasedbreakiterator::getrulestatusvec" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlrulebasedbreakiterator::getbinaryrules" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
+ <function name="intlrulebasedbreakiterator" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlrulebasedbreakiterator::__construct" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlrulebasedbreakiterator::getrules" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlrulebasedbreakiterator::getrulestatus" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlrulebasedbreakiterator::getrulestatusvec" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlrulebasedbreakiterator::getbinaryrules" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  
- <function name="intlgregoriancalendar" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlgregoriancalendar::__construct" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlgregoriancalendar::setgregorianchange" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlgregoriancalendar::getgregorianchange" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intlgregoriancalendar::isleapyear" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
+ <function name="intlgregoriancalendar" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlgregoriancalendar::__construct" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlgregoriancalendar::setgregorianchange" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlgregoriancalendar::getgregorianchange" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intlgregoriancalendar::isleapyear" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  
- <function name="intliterator" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="intliterator::current" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="IntlIterator::key" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="IntlIterator::next" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="IntlIterator::rewind" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="IntlIterator::valid" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
+ <function name="intliterator" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="intliterator::current" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="IntlIterator::key" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="IntlIterator::next" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="IntlIterator::rewind" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="IntlIterator::valid" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
 
- <function name="resourcebundle" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="resourcebundle-count" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="resourcebundle-create" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="resourcebundle--construct" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="resourcebundle-geterrorcode" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="resourcebundle-get-error-code" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="resourcebundle-geterrormessage" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="resourcebundle-get-error-message" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="resourcebundle-get" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="resourcebundle-getlocales" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="resourcebundle-locales" from="PHP 5 &gt;= 5.3.2, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="spoofchecker" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="spoofchecker-areconfusable" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="spoofchecker--construct" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="spoofchecker-issuspicious" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="spoofchecker-setallowedlocales" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="spoofchecker-setchecks" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="transliterator" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="transliterator--construct" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="transliterator-create" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="transliterator-createfromrules" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="transliterator-create-from-rules" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="transliterator-createinverse" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="transliterator-create-inverse" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="transliterator-geterrorcode" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="transliterator-get-error-code" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="transliterator-geterrormessage" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="transliterator-get-error-message" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="transliterator-listids" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="transliterator-list-ids" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
- <function name="transliterator-transliterate" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
+ <function name="resourcebundle" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="resourcebundle::count" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="resourcebundle::create" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="resourcebundle::__construct" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="resourcebundle::geterrorcode" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="resourcebundle_get_error_code" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="resourcebundle::geterrormessage" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="resourcebundle_get_error_message" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="resourcebundle::get" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="resourcebundle::getlocales" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="resourcebundle_locales" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="spoofchecker" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="spoofchecker::areconfusable" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="spoofchecker::construct" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
+ <function name="spoofchecker::issuspicious" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="spoofchecker::setallowedlocales" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="spoofchecker::setchecks" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="transliterator" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="transliterator::__construct" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="transliterator::create" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="transliterator::createfromrules" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="transliterator::create-from-rules" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
+ <function name="transliterator::createinverse" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="transliterator::create-inverse" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
+ <function name="transliterator::geterrorcode" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="transliterator::get-error-code" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
+ <function name="transliterator::geterrormessage" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="transliterator::get-error-message" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
+ <function name="transliterator::listids" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="transliterator::list-ids" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
+ <function name="transliterator::transliterate" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
 
- <function name="uconverter" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::__construct" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::setsourceencoding" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::setdestinationencoding" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::getsourceencoding" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::getdestinationencoding" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::getsourcetype" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::getdestinationtype" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::getsubstchars" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::setsubstchars" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::toucallback" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::fromucallback" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::convert" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::transcode" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::geterrorcode" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::geterrormessage" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::reasontext" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::getavailable" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::getaliases" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
- <function name="uconverter::getstandards" from="PHP 5 &gt;= 5.5.0, PHP 7, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::__construct" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::setsourceencoding" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::setdestinationencoding" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::getsourceencoding" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::getdestinationencoding" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::getsourcetype" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::getdestinationtype" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::getsubstchars" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::setsubstchars" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::toucallback" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::fromucallback" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::convert" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::transcode" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::geterrorcode" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::geterrormessage" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::reasontext" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::getavailable" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::getaliases" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
+ <function name="uconverter::getstandards" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
 
  <!-- Functions -->
- <function name="collator_create" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator_compare" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator_get_attribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator_set_attribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator_get_sort_key" from="PHP 5 &gt;= 5.3.2, PHP 7"/>
- <function name="collator_get_strength" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator_set_strength" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator_sort" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator_sort_with_sort_keys" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator_asort" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator_get_locale" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator_get_error_code" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="collator_get_error_message" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="datefmt_create" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="datefmt_get_datetype" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="datefmt_get_timetype" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="datefmt_get_calendar" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="datefmt_set_calendar" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="datefmt_get_locale" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="datefmt_get_timezone_id" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="datefmt_get_pattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="datefmt_set_pattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="datefmt_is_lenient" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="datefmt_set_lenient" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="datefmt_format" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="datefmt_parse" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="datefmt_localtime" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="datefmt_get_error_code" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="datefmt_get_error_message" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="datefmt_format_object" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datefmt_get_calendar_object" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datefmt_get_timezone" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="datefmt_set_timezone" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="grapheme_strlen" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="grapheme_strpos" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="grapheme_stripos" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="grapheme_strrpos" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="grapheme_strripos" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="grapheme_substr" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="grapheme_strstr" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="grapheme_stristr" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="grapheme_extract" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intl_get_error_code" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intl_get_error_message" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intl_is_failure" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="intl_error_name" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="idn_to_ascii" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.2, PECL idn &gt;= 0.1"/>
- <function name="idn_to_utf8" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.2, PECL idn &gt;= 0.1"/>
- <function name="locale_get_default" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale_set_default" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale_get_primary_language" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale_get_script" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale_get_region" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale_get_keywords" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale_get_display_script" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale_get_display_region" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale_get_display_name" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale_get_display_language" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale_get_display_variant" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale_compose" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale_parse" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale_get_all_variants" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale_filter_matches" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale_canonicalize" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale_lookup" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="locale_accept_from_http" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="msgfmt_create" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="msgfmt_format" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="msgfmt_format_message" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="msgfmt_parse" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="msgfmt_parse_message" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="msgfmt_set_pattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="msgfmt_get_pattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="msgfmt_get_locale" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="msgfmt_get_error_code" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="msgfmt_get_error_message" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="normalizer_normalize" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="normalizer_is_normalized" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numfmt_create" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numfmt_format" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numfmt_parse" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numfmt_format_currency" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numfmt_parse_currency" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numfmt_set_attribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numfmt_get_attribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numfmt_set_text_attribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numfmt_get_text_attribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numfmt_set_symbol" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numfmt_get_symbol" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numfmt_set_pattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numfmt_get_pattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numfmt_get_locale" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numfmt_get_error_code" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
- <function name="numfmt_get_error_message" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.0"/>
+ <function name="collator_create" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator_compare" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator_get_attribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator_set_attribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator_get_sort_key" from="PHP 5 &gt;= 5.3.2, PHP 7, PHP 8"/>
+ <function name="collator_get_strength" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator_set_strength" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator_sort" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator_sort_with_sort_keys" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator_asort" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator_get_locale" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator_get_error_code" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="collator_get_error_message" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="datefmt_create" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="datefmt_get_datetype" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="datefmt_get_timetype" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="datefmt_get_calendar" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="datefmt_set_calendar" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="datefmt_get_locale" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="datefmt_get_timezone_id" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="datefmt_set_timezone_id" from="PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0"/>
+ <function name="datefmt_get_pattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="datefmt_set_pattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="datefmt_is_lenient" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="datefmt_set_lenient" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="datefmt_format" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="datefmt_parse" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="datefmt_localtime" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="datefmt_get_error_code" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="datefmt_get_error_message" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="datefmt_format_object" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datefmt_get_calendar_object" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datefmt_get_timezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datefmt_set_timezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="grapheme_strlen" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="grapheme_strpos" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="grapheme_stripos" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="grapheme_strrpos" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="grapheme_strripos" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="grapheme_substr" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="grapheme_strstr" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="grapheme_stristr" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="grapheme_extract" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intl_get_error_code" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intl_get_error_message" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intl_is_failure" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intl_error_name" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="idn_to_ascii" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.2, PECL idn &gt;= 0.1"/>
+ <function name="idn_to_utf8" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.2, PECL idn &gt;= 0.1"/>
+ <function name="locale_get_default" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale_set_default" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale_get_primary_language" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale_get_script" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale_get_region" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale_get_keywords" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale_get_display_script" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale_get_display_region" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale_get_display_name" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale_get_display_language" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale_get_display_variant" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale_compose" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale_parse" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale_get_all_variants" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale_filter_matches" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale_canonicalize" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale_lookup" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="locale_accept_from_http" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="msgfmt_create" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="msgfmt_format" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="msgfmt_format_message" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="msgfmt_parse" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="msgfmt_parse_message" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="msgfmt_set_pattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="msgfmt_get_pattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="msgfmt_get_locale" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="msgfmt_get_error_code" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="msgfmt_get_error_message" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="normalizer_normalize" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="normalizer_is_normalized" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numfmt_create" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numfmt_format" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numfmt_parse" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numfmt_format_currency" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numfmt_parse_currency" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numfmt_set_attribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numfmt_get_attribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numfmt_set_text_attribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numfmt_get_text_attribute" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numfmt_set_symbol" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numfmt_get_symbol" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numfmt_set_pattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numfmt_get_pattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numfmt_get_locale" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numfmt_get_error_code" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="numfmt_get_error_message" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
- Generated verions.xml based on the following stubs.
  * https://github.com/php/php-src/blob/PHP-8.0/ext/intl/formatter/formatter.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/intl/normalizer/normalizer.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/intl/php_intl.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/intl/spoofchecker/spoofchecker.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/intl/breakiterator/breakiterator.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/intl/timezone/timezone.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/intl/transliterator/transliterator.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/intl/msgformat/msgformat.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/intl/common/common.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/intl/resourcebundle/resourcebundle.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/intl/converter/converter.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/intl/uchar/uchar.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/intl/locale/locale.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/intl/calendar/calendar.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/intl/dateformat/dateformat.stub.php
- Note
  * `intlchar::getfc-nfkc-closure` does not exist in php-src, but exists in manual. why?
    - https://www.php.net/manual/en/intlchar.getfc-nfkc-closure.php
  * deleted function in PHP 7.0.0
    - `IntlDateFormatter::setTimeZoneId`
    - `datefmt_set_timezone_id`
  * replaced function name with class, because stub file defines them in class.
    - `resourcebundle_*`
    - `spoofchecker_*`
    - `transliterator_*`