### PR TITLE
Added PHP 8 into versions.xml for dom based on stubs.

### DIFF
--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -4,159 +4,159 @@
   Do NOT translate this file
 -->
 <versions> 
- <function name="domattr" from="PHP 5, PHP 7"/>
- <function name="domattr::__construct" from="PHP 5, PHP 7"/>
- <function name="domattr::isid" from="PHP 5, PHP 7"/>
+ <function name="domattr" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domattr::__construct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domattr::isid" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="domcdatasection" from="PHP 5, PHP 7"/>
- <function name="domcdatasection::__construct" from="PHP 5, PHP 7"/>
+ <function name="domcdatasection" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domcdatasection::__construct" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="domcharacterdata" from="PHP 5, PHP 7"/>
- <function name="domcharacterdata::appenddata" from="PHP 5, PHP 7"/>
- <function name="domcharacterdata::deletedata" from="PHP 5, PHP 7"/>
- <function name="domcharacterdata::insertdata" from="PHP 5, PHP 7"/>
- <function name="domcharacterdata::replacedata" from="PHP 5, PHP 7"/>
- <function name="domcharacterdata::substringdata" from="PHP 5, PHP 7"/>
+ <function name="domcharacterdata" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domcharacterdata::appenddata" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domcharacterdata::deletedata" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domcharacterdata::insertdata" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domcharacterdata::replacedata" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domcharacterdata::substringdata" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="domcomment" from="PHP 5, PHP 7"/>
- <function name="domcomment::__construct" from="PHP 5, PHP 7"/>
+ <function name="domcomment" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domcomment::__construct" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="domdocument" from="PHP 5, PHP 7"/>
- <function name="domdocument::__construct" from="PHP 5, PHP 7"/>
- <function name="domdocument::registernodeclass" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="domdocument::adoptnode" from="PHP 5, PHP 7"/>
- <function name="domdocument::createattribute" from="PHP 5, PHP 7"/>
- <function name="domdocument::createattributens" from="PHP 5, PHP 7"/>
- <function name="domdocument::createcdatasection" from="PHP 5, PHP 7"/>
- <function name="domdocument::createcomment" from="PHP 5, PHP 7"/>
- <function name="domdocument::createdocumentfragment" from="PHP 5, PHP 7"/>
- <function name="domdocument::createelement" from="PHP 5, PHP 7"/>
- <function name="domdocument::createelementns" from="PHP 5, PHP 7"/>
- <function name="domdocument::createentityreference" from="PHP 5, PHP 7"/>
- <function name="domdocument::createprocessinginstruction" from="PHP 5, PHP 7"/>
- <function name="domdocument::createtextnode" from="PHP 5, PHP 7"/>
- <function name="domdocument::getelementbyid" from="PHP 5, PHP 7"/>
- <function name="domdocument::getelementsbytagname" from="PHP 5, PHP 7"/>
- <function name="domdocument::getelementsbytagnamens" from="PHP 5, PHP 7"/>
- <function name="domdocument::importnode" from="PHP 5, PHP 7"/>
- <function name="domdocument::load" from="PHP 5, PHP 7"/>
- <function name="domdocument::loadhtml" from="PHP 5, PHP 7"/>
- <function name="domdocument::loadhtmlfile" from="PHP 5, PHP 7"/>
- <function name="domdocument::loadxml" from="PHP 5, PHP 7"/>
- <function name="domdocument::normalizedocument" from="PHP 5, PHP 7"/>
- <function name="domdocument::relaxngvalidate" from="PHP 5, PHP 7"/>
- <function name="domdocument::relaxngvalidatesource" from="PHP 5, PHP 7"/>
+ <function name="domdocument" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::__construct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::registernodeclass" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="domdocument::adoptnode" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::createattribute" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::createattributens" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::createcdatasection" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::createcomment" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::createdocumentfragment" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::createelement" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::createelementns" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::createentityreference" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::createprocessinginstruction" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::createtextnode" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::getelementbyid" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::getelementsbytagname" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::getelementsbytagnamens" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::importnode" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::load" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::loadhtml" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::loadhtmlfile" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::loadxml" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::normalizedocument" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::relaxngvalidate" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::relaxngvalidatesource" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domdocument::renamenode" from="PHP 5, PHP 7"/>
- <function name="domdocument::save" from="PHP 5, PHP 7"/>
- <function name="domdocument::savehtml" from="PHP 5, PHP 7"/>
- <function name="domdocument::savehtmlfile" from="PHP 5, PHP 7"/>
- <function name="domdocument::savexml" from="PHP 5, PHP 7"/>
- <function name="domdocument::schemavalidatesource" from="PHP 5, PHP 7"/>
- <function name="domdocument::schemavalidate" from="PHP 5, PHP 7"/>
- <function name="domdocument::validate" from="PHP 5, PHP 7"/>
- <function name="domdocument::xinclude" from="PHP 5, PHP 7"/>
+ <function name="domdocument::save" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::savehtml" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::savehtmlfile" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::savexml" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::schemavalidatesource" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::schemavalidate" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::validate" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocument::xinclude" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="domdocumentfragment" from="PHP 5, PHP 7"/>
- <function name="domdocumentfragment::__construct" from="PHP 5, PHP 7"/>
- <function name="domdocumentfragment::appendxml" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="domdocumentfragment" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocumentfragment::__construct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domdocumentfragment::appendxml" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="domdocumenttype" from="PHP 5, PHP 7"/>
+ <function name="domdocumenttype" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="domelement" from="PHP 5, PHP 7"/>
- <function name="domelement::__construct" from="PHP 5, PHP 7"/>
- <function name="domelement::getattribute" from="PHP 5, PHP 7"/>
- <function name="domelement::getattributenode" from="PHP 5, PHP 7"/>
- <function name="domelement::getattributenodens" from="PHP 5, PHP 7"/>
- <function name="domelement::getattributens" from="PHP 5, PHP 7"/>
- <function name="domelement::getelementsbytagname" from="PHP 5, PHP 7"/>
- <function name="domelement::getelementsbytagnamens" from="PHP 5, PHP 7"/>
- <function name="domelement::hasattribute" from="PHP 5, PHP 7"/>
- <function name="domelement::hasattributens" from="PHP 5, PHP 7"/>
- <function name="domelement::removeattribute" from="PHP 5, PHP 7"/>
- <function name="domelement::removeattributenode" from="PHP 5, PHP 7"/>
- <function name="domelement::removeattributens" from="PHP 5, PHP 7"/>
- <function name="domelement::setattribute" from="PHP 5, PHP 7"/>
- <function name="domelement::setattributenode" from="PHP 5, PHP 7"/>
- <function name="domelement::setattributenodens" from="PHP 5, PHP 7"/>
- <function name="domelement::setattributens" from="PHP 5, PHP 7"/>
- <function name="domelement::setidattribute" from="PHP 5, PHP 7"/>
- <function name="domelement::setidattributenode" from="PHP 5, PHP 7"/>
- <function name="domelement::setidattributens" from="PHP 5, PHP 7"/>
+ <function name="domelement" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::__construct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::getattribute" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::getattributenode" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::getattributenodens" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::getattributens" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::getelementsbytagname" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::getelementsbytagnamens" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::hasattribute" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::hasattributens" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::removeattribute" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::removeattributenode" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::removeattributens" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::setattribute" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::setattributenode" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::setattributenodens" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::setattributens" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::setidattribute" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::setidattributenode" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domelement::setidattributens" from="PHP 5, PHP 7, PHP 8"/>
  
-  <function name="domentity" from="PHP 5, PHP 7"/>
+  <function name="domentity" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="domentityreference" from="PHP 5, PHP 7"/>
- <function name="domentityreference::__construct" from="PHP 5, PHP 7"/>
+ <function name="domentityreference" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domentityreference::__construct" from="PHP 5, PHP 7, PHP 8"/>
  
-  <function name="domexception" from="PHP 5, PHP 7"/>
+  <function name="domexception" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="domimplementation" from="PHP 5, PHP 7"/>
+ <function name="domimplementation" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domimplementation::__construct" from="PHP 5, PHP 7"/>
- <function name="domimplementation::createdocument" from="PHP 5, PHP 7"/>
- <function name="domimplementation::createdocumenttype" from="PHP 5, PHP 7"/>
- <function name="domimplementation::getfeature" from="PHP 5, PHP 7"/>
- <function name="domimplementation::hasfeature" from="PHP 5, PHP 7"/>
+ <function name="domimplementation::createdocument" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domimplementation::createdocumenttype" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domimplementation::getfeature" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domimplementation::hasfeature" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domimplementation::listitem" from="PHP 5, PHP 7"/>
  <function name="domimplementation::source_get_domimplementation" from="PHP 5, PHP 7"/>
  <function name="domimplementation::source_get_domimplementations" from="PHP 5, PHP 7"/>
 
- <function name="domnamednodemap" from="PHP 5, PHP 7"/>
- <function name="domnamednodemap::count" from="PHP 7 &gt;= 7.2.0"/>
- <function name="domnamednodemap::getnameditem" from="PHP 5, PHP 7"/>
- <function name="domnamednodemap::getnameditemns" from="PHP 5, PHP 7"/>
- <function name="domnamednodemap::item" from="PHP 5, PHP 7"/>
+ <function name="domnamednodemap" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domnamednodemap::count" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="domnamednodemap::getnameditem" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domnamednodemap::getnameditemns" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domnamednodemap::item" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domnamednodemap::removenameditem" from="PHP 5, PHP 7"/>
  <function name="domnamednodemap::removenameditemns" from="PHP 5, PHP 7"/>
  <function name="domnamednodemap::setnameditem" from="PHP 5, PHP 7"/>
  <function name="domnamednodemap::setnameditemns" from="PHP 5, PHP 7"/>
 
- <function name="domnode" from="PHP 5, PHP 7"/>
- <function name="domnode::appendchild" from="PHP 5, PHP 7"/>
- <function name="domnode::c14n" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="domnode::c14nfile" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="domnode::clonenode" from="PHP 5, PHP 7"/>
+ <function name="domnode" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domnode::appendchild" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domnode::c14n" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="domnode::c14nfile" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="domnode::clonenode" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domnode::comparedocumentposition" from="PHP 5, PHP 7"/>
  <function name="domnode::getfeature" from="PHP 5, PHP 7"/>
- <function name="domnode::getlineno" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="domnode::getnodepath" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
+ <function name="domnode::getlineno" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="domnode::getnodepath" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="domnode::getuserdata" from="PHP 5, PHP 7"/>
- <function name="domnode::hasattributes" from="PHP 5, PHP 7"/>
- <function name="domnode::haschildnodes" from="PHP 5, PHP 7"/>
- <function name="domnode::insertbefore" from="PHP 5, PHP 7"/>
- <function name="domnode::isdefaultnamespace" from="PHP 5, PHP 7"/>
+ <function name="domnode::hasattributes" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domnode::haschildnodes" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domnode::insertbefore" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domnode::isdefaultnamespace" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domnode::isequalnode" from="PHP 5, PHP 7"/>
- <function name="domnode::issamenode" from="PHP 5, PHP 7"/>
- <function name="domnode::issupported" from="PHP 5, PHP 7"/>
- <function name="domnode::lookupnamespaceuri" from="PHP 5, PHP 7"/>
- <function name="domnode::lookupprefix" from="PHP 5, PHP 7"/>
- <function name="domnode::normalize" from="PHP 5, PHP 7"/>
- <function name="domnode::removechild" from="PHP 5, PHP 7"/>
- <function name="domnode::replacechild" from="PHP 5, PHP 7"/>
+ <function name="domnode::issamenode" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domnode::issupported" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domnode::lookupnamespaceuri" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domnode::lookupprefix" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domnode::normalize" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domnode::removechild" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domnode::replacechild" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domnode::setuserdata" from="PHP 5, PHP 7"/>
 
- <function name="domnodelist" from="PHP 5, PHP 7"/>
- <function name="domnodelist::count" from="PHP 7 &gt;= 7.2.0"/>
- <function name="domnodelist::item" from="PHP 5, PHP 7"/>
+ <function name="domnodelist" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domnodelist::count" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="domnodelist::item" from="PHP 5, PHP 7, PHP 8"/>
  
- <function name="domnotation" from="PHP 5, PHP 7"/>
+ <function name="domnotation" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="domprocessinginstruction" from="PHP 5, PHP 7"/>
- <function name="domprocessinginstruction::__construct" from="PHP 5, PHP 7"/>
+ <function name="domprocessinginstruction" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domprocessinginstruction::__construct" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="domtext" from="PHP 5, PHP 7"/>
- <function name="domtext::__construct" from="PHP 5, PHP 7"/>
- <function name="domtext::iswhitespaceinelementcontent" from="PHP 5, PHP 7"/>
+ <function name="domtext" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domtext::__construct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domtext::iswhitespaceinelementcontent" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domtext::replacewholetext" from="PHP 5, PHP 7"/>
- <function name="domtext::splittext" from="PHP 5, PHP 7"/>
+ <function name="domtext::splittext" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="domxpath" from="PHP 5, PHP 7"/>
- <function name="domxpath::__construct" from="PHP 5, PHP 7"/>
- <function name="domxpath::evaluate" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="domxpath::query" from="PHP 5, PHP 7"/>
- <function name="domxpath::registernamespace" from="PHP 5, PHP 7"/>
- <function name="domxpath::registerphpfunctions" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="domxpath" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domxpath::__construct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domxpath::evaluate" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="domxpath::query" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domxpath::registernamespace" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domxpath::registerphpfunctions" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
- <function name="dom_import_simplexml" from="PHP 5, PHP 7"/>
+ <function name="dom_import_simplexml" from="PHP 5, PHP 7, PHP 8"/>
 
  <!-- Unsure -->
  <function name="dom_domconfigurationcansetparameter" from="PHP 5, PHP 7"/>


### PR DESCRIPTION
Generated verions.xml based on the following stubs.

- https://github.com/php/php-src/blob/PHP-8.0/ext/dom/php_dom.stub.php
- Note
  * the following methods not implemented in PHP-8.0.
    - domdocument
      * `domdocument::renamenode`
    - domimplementation
      * `domimplementation::source_get_domimplementations`
      * `domimplementation::source_get_domimplementation`
      * `domimplementation::listitem`
    - domnamednodemap
      * `domnamednodemap::removenameditem`
      * `domnamednodemap::removenameditemns`
      * `domnamednodemap::setnameditem`
      * `domnamednodemap::setnameditemns`
    - domnode
      * `domnode::getfeature`
      *  `domnode::comparedocumentposition`
      *  `domnode::getuserdata`
      * `domnode::isequalnode`
      *  `domnode::setuserdata`
      * `domtext::replacewholetext`
  * not exist in stub file, but [exists in manual](https://www.php.net/manual/en/domimplementation.construct.php), and can be used in PHP 8.0
    - `domimplementation::__construct`