### PR TITLE
Added PHP 8 into versions.xml for spl based on stubs.

### DIFF
--- a/reference/spl/versions.xml
+++ b/reference/spl/versions.xml
@@ -5,1023 +5,1023 @@
 -->
 <versions>
  <!-- Functions -->
- <function name="class_parents" from="PHP 5, PHP 7"/>
- <function name="class_implements" from="PHP 5, PHP 7"/>
- <function name="class_uses" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="iterator_to_array" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="iterator_count" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="iterator_apply" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="spl_autoload" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="spl_autoload_call" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="spl_autoload_extensions" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="spl_autoload_functions" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="spl_autoload_register" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="spl_autoload_unregister" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="spl_classes" from="PHP 5, PHP 7"/>
- <function name="spl_object_hash" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="spl_object_id" from="PHP 7 &gt;= 7.2.0"/>
+ <function name="class_parents" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="class_implements" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="class_uses" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="iterator_to_array" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="iterator_count" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="iterator_apply" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="spl_autoload" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="spl_autoload_call" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="spl_autoload_extensions" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="spl_autoload_functions" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="spl_autoload_register" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="spl_autoload_unregister" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="spl_classes" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="spl_object_hash" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="spl_object_id" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
 
  <!-- Methods -->
- <function name="logicexception" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="logicexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="logicexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="logicexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="logicexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="logicexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="logicexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="logicexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="logicexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="logicexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="logicexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="logicexception" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="logicexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="logicexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="logicexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="logicexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="logicexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="logicexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="logicexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="logicexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="logicexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="logicexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="badfunctioncallexception" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badfunctioncallexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badfunctioncallexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badfunctioncallexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badfunctioncallexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badfunctioncallexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badfunctioncallexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badfunctioncallexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badfunctioncallexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badfunctioncallexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badfunctioncallexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="badfunctioncallexception" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badfunctioncallexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badfunctioncallexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badfunctioncallexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badfunctioncallexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badfunctioncallexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badfunctioncallexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badfunctioncallexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badfunctioncallexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badfunctioncallexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badfunctioncallexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="badmethodcallexception" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badmethodcallexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badmethodcallexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badmethodcallexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badmethodcallexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badmethodcallexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badmethodcallexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badmethodcallexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badmethodcallexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badmethodcallexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="badmethodcallexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="badmethodcallexception" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badmethodcallexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badmethodcallexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badmethodcallexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badmethodcallexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badmethodcallexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badmethodcallexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badmethodcallexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badmethodcallexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badmethodcallexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="badmethodcallexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="domainexception" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="domainexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="domainexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="domainexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="domainexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="domainexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="domainexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="domainexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="domainexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="domainexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="domainexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="domainexception" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="domainexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="domainexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="domainexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="domainexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="domainexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="domainexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="domainexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="domainexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="domainexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="domainexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="invalidargumentexception" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="invalidargumentexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="invalidargumentexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="invalidargumentexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="invalidargumentexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="invalidargumentexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="invalidargumentexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="invalidargumentexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="invalidargumentexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="invalidargumentexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="invalidargumentexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="invalidargumentexception" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="invalidargumentexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="invalidargumentexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="invalidargumentexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="invalidargumentexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="invalidargumentexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="invalidargumentexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="invalidargumentexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="invalidargumentexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="invalidargumentexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="invalidargumentexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="lengthexception" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="lengthexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="lengthexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="lengthexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="lengthexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="lengthexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="lengthexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="lengthexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="lengthexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="lengthexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="lengthexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="lengthexception" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="lengthexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="lengthexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="lengthexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="lengthexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="lengthexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="lengthexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="lengthexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="lengthexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="lengthexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="lengthexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="outofrangeexception" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofrangeexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofrangeexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofrangeexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofrangeexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofrangeexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofrangeexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofrangeexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofrangeexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofrangeexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofrangeexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="outofrangeexception" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofrangeexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofrangeexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofrangeexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofrangeexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofrangeexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofrangeexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofrangeexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofrangeexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofrangeexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofrangeexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="runtimeexception" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="runtimeexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="runtimeexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="runtimeexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="runtimeexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="runtimeexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="runtimeexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="runtimeexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="runtimeexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="runtimeexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="runtimeexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="runtimeexception" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="runtimeexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="runtimeexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="runtimeexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="runtimeexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="runtimeexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="runtimeexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="runtimeexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="runtimeexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="runtimeexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="runtimeexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="outofboundsexception" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofboundsexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofboundsexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofboundsexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofboundsexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofboundsexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofboundsexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofboundsexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofboundsexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofboundsexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outofboundsexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="outofboundsexception" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofboundsexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofboundsexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofboundsexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofboundsexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofboundsexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofboundsexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofboundsexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofboundsexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofboundsexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outofboundsexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="overflowexception" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="overflowexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="overflowexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="overflowexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="overflowexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="overflowexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="overflowexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="overflowexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="overflowexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="overflowexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="overflowexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="overflowexception" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="overflowexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="overflowexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="overflowexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="overflowexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="overflowexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="overflowexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="overflowexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="overflowexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="overflowexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="overflowexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="rangeexception" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="rangeexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="rangeexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="rangeexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="rangeexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="rangeexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="rangeexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="rangeexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="rangeexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="rangeexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="rangeexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="rangeexception" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="rangeexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="rangeexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="rangeexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="rangeexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="rangeexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="rangeexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="rangeexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="rangeexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="rangeexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="rangeexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="underflowexception" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="underflowexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="underflowexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="underflowexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="underflowexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="underflowexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="underflowexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="underflowexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="underflowexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="underflowexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="underflowexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="underflowexception" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="underflowexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="underflowexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="underflowexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="underflowexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="underflowexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="underflowexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="underflowexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="underflowexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="underflowexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="underflowexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="unexpectedvalueexception" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="unexpectedvalueexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="unexpectedvalueexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="unexpectedvalueexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="unexpectedvalueexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="unexpectedvalueexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="unexpectedvalueexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="unexpectedvalueexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="unexpectedvalueexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="unexpectedvalueexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="unexpectedvalueexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="unexpectedvalueexception" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="unexpectedvalueexception::__clone" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="unexpectedvalueexception::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="unexpectedvalueexception::getmessage" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="unexpectedvalueexception::getcode" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="unexpectedvalueexception::getfile" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="unexpectedvalueexception::getline" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="unexpectedvalueexception::gettrace" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="unexpectedvalueexception::getprevious" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="unexpectedvalueexception::gettraceasstring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="unexpectedvalueexception::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="recursiveiterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursiveiterator::haschildren" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursiveiterator::getchildren" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursiveiterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursiveiterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursiveiterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursiveiterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursiveiterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="recursiveiterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursiveiterator::haschildren" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursiveiterator::getchildren" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursiveiterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursiveiterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursiveiterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursiveiterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursiveiterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="recursiveiteratoriterator" from="PHP 5, PHP 7"/>
- <function name="recursiveiteratoriterator::__construct" from="PHP 5 &gt;= 5.1.3, PHP 7"/>
- <function name="recursiveiteratoriterator::beginchildren" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursiveiteratoriterator::beginiteration" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursiveiteratoriterator::callgetchildren" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursiveiteratoriterator::callhaschildren" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursiveiteratoriterator::current" from="PHP 5, PHP 7"/>
- <function name="recursiveiteratoriterator::endchildren" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursiveiteratoriterator::enditeration" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursiveiteratoriterator::getdepth" from="PHP 5, PHP 7"/>
- <function name="recursiveiteratoriterator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursiveiteratoriterator::getmaxdepth" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursiveiteratoriterator::getsubiterator" from="PHP 5, PHP 7"/>
- <function name="recursiveiteratoriterator::key" from="PHP 5, PHP 7"/>
- <function name="recursiveiteratoriterator::next" from="PHP 5, PHP 7"/>
- <function name="recursiveiteratoriterator::nextelement" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursiveiteratoriterator::rewind" from="PHP 5, PHP 7"/>
- <function name="recursiveiteratoriterator::setmaxdepth" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursiveiteratoriterator::valid" from="PHP 5, PHP 7"/>
+ <function name="recursiveiteratoriterator" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="recursiveiteratoriterator::__construct" from="PHP 5 &gt;= 5.1.3, PHP 7, PHP 8"/>
+ <function name="recursiveiteratoriterator::beginchildren" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursiveiteratoriterator::beginiteration" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursiveiteratoriterator::callgetchildren" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursiveiteratoriterator::callhaschildren" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursiveiteratoriterator::current" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="recursiveiteratoriterator::endchildren" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursiveiteratoriterator::enditeration" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursiveiteratoriterator::getdepth" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="recursiveiteratoriterator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursiveiteratoriterator::getmaxdepth" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursiveiteratoriterator::getsubiterator" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="recursiveiteratoriterator::key" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="recursiveiteratoriterator::next" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="recursiveiteratoriterator::nextelement" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursiveiteratoriterator::rewind" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="recursiveiteratoriterator::setmaxdepth" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursiveiteratoriterator::valid" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="outeriterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outeriterator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outeriterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outeriterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outeriterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outeriterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="outeriterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="outeriterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outeriterator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outeriterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outeriterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outeriterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outeriterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="outeriterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="iteratoriterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="iteratoriterator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="iteratoriterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="iteratoriterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="iteratoriterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="iteratoriterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="iteratoriterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="iteratoriterator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="iteratoriterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="iteratoriterator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="iteratoriterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="iteratoriterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="iteratoriterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="iteratoriterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="iteratoriterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="iteratoriterator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="filteriterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="filteriterator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="filteriterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="filteriterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="filteriterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="filteriterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="filteriterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="filteriterator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="filteriterator::accept" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="filteriterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="filteriterator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="filteriterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="filteriterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="filteriterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="filteriterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="filteriterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="filteriterator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="filteriterator::accept" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="recursivefilteriterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivefilteriterator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivefilteriterator::getchildren" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivefilteriterator::haschildren" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivefilteriterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivefilteriterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivefilteriterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivefilteriterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivefilteriterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivefilteriterator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivefilteriterator::accept" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="recursivefilteriterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivefilteriterator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivefilteriterator::getchildren" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivefilteriterator::haschildren" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivefilteriterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivefilteriterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivefilteriterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivefilteriterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivefilteriterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivefilteriterator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivefilteriterator::accept" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="parentiterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="parentiterator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="parentiterator::accept" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="parentiterator::haschildren" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="parentiterator::getchildren" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="parentiterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="parentiterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="parentiterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="parentiterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="parentiterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="parentiterator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="parentiterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="parentiterator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="parentiterator::accept" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="parentiterator::haschildren" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="parentiterator::getchildren" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="parentiterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="parentiterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="parentiterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="parentiterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="parentiterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="parentiterator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="countable" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="countable::count" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="countable" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="countable::count" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="seekableiterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="seekableiterator::seek" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="seekableiterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="seekableiterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="seekableiterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="seekableiterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="seekableiterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="seekableiterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="seekableiterator::seek" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="seekableiterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="seekableiterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="seekableiterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="seekableiterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="seekableiterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="limititerator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="limititerator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="limititerator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="limititerator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="limititerator::key" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="limititerator::current" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="limititerator::next" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="limititerator::seek" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="limititerator::getposition" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="limititerator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="limititerator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="limititerator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="limititerator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="limititerator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="limititerator::key" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="limititerator::current" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="limititerator::next" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="limititerator::seek" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="limititerator::getposition" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="limititerator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="cachingiterator" from="PHP 5, PHP 7"/>
- <function name="cachingiterator::__construct" from="PHP 5, PHP 7"/>
- <function name="cachingiterator::__tostring" from="PHP 5, PHP 7"/>
- <function name="cachingiterator::count" from="PHP 5 &gt;= 5.2.2, PHP 7"/>
- <function name="cachingiterator::current" from="PHP 5, PHP 7"/>
- <function name="cachingiterator::getcache" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="cachingiterator::getflags" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="cachingiterator::getinneriterator" from="PHP 5, PHP 7"/>
- <function name="cachingiterator::hasnext" from="PHP 5, PHP 7"/>
- <function name="cachingiterator::key" from="PHP 5, PHP 7"/>
- <function name="cachingiterator::next" from="PHP 5, PHP 7"/>
- <function name="cachingiterator::offsetexists" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="cachingiterator::offsetget" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="cachingiterator::offsetset" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="cachingiterator::offsetunset" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="cachingiterator::rewind" from="PHP 5, PHP 7"/>
- <function name="cachingiterator::setflags" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="cachingiterator::valid" from="PHP 5, PHP 7"/>
+ <function name="cachingiterator" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="cachingiterator::__construct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="cachingiterator::__tostring" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="cachingiterator::count" from="PHP 5 &gt;= 5.2.2, PHP 7, PHP 8"/>
+ <function name="cachingiterator::current" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="cachingiterator::getcache" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="cachingiterator::getflags" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="cachingiterator::getinneriterator" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="cachingiterator::hasnext" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="cachingiterator::key" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="cachingiterator::next" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="cachingiterator::offsetexists" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="cachingiterator::offsetget" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="cachingiterator::offsetset" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="cachingiterator::offsetunset" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="cachingiterator::rewind" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="cachingiterator::setflags" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="cachingiterator::valid" from="PHP 5, PHP 7, PHP 8"/>
 
  <function name="cachingrecursiveiterator" from="PHP 5 &lt; 5.1.0"/>
  <function name="cachingrecursiveiterator::getchildren" from="PHP 5 &lt; 5.1.0"/>
  <function name="cachingrecursiveiterator::haschildren" from="PHP 5 &lt; 5.1.0"/>
 
- <function name="recursivecachingiterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::haschildren" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::getchildren" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::hasnext" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::getflags" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::setflags" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::offsetget" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::offsetset" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::offsetunset" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::offsetexists" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::getcache" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivecachingiterator::count" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="recursivecachingiterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::haschildren" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::getchildren" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::hasnext" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::getflags" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::setflags" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::offsetget" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::offsetset" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::offsetunset" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::offsetexists" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::getcache" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivecachingiterator::count" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="norewinditerator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="norewinditerator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="norewinditerator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="norewinditerator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="norewinditerator::key" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="norewinditerator::current" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="norewinditerator::next" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="norewinditerator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="norewinditerator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="norewinditerator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="norewinditerator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="norewinditerator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="norewinditerator::key" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="norewinditerator::current" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="norewinditerator::next" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="norewinditerator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="appenditerator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="appenditerator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="appenditerator::append" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="appenditerator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="appenditerator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="appenditerator::key" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="appenditerator::current" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="appenditerator::next" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="appenditerator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="appenditerator::getiteratorindex" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="appenditerator::getarrayiterator" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
+ <function name="appenditerator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="appenditerator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="appenditerator::append" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="appenditerator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="appenditerator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="appenditerator::key" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="appenditerator::current" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="appenditerator::next" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="appenditerator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="appenditerator::getiteratorindex" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="appenditerator::getarrayiterator" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
 
- <function name="infiniteiterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="infiniteiterator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="infiniteiterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="infiniteiterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="infiniteiterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="infiniteiterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="infiniteiterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="infiniteiterator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="infiniteiterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="infiniteiterator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="infiniteiterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="infiniteiterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="infiniteiterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="infiniteiterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="infiniteiterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="infiniteiterator::getinneriterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="regexiterator" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="regexiterator::__construct" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="regexiterator::accept" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="regexiterator::getmode" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="regexiterator::setmode" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="regexiterator::getflags" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="regexiterator::setflags" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="regexiterator::getpregflags" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="regexiterator::setpregflags" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="regexiterator::rewind" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="regexiterator::valid" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="regexiterator::key" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="regexiterator::current" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="regexiterator::next" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="regexiterator::getinneriterator" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="regexiterator::getregex" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
+ <function name="regexiterator" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="regexiterator::__construct" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="regexiterator::accept" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="regexiterator::getmode" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="regexiterator::setmode" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="regexiterator::getflags" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="regexiterator::setflags" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="regexiterator::getpregflags" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="regexiterator::setpregflags" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="regexiterator::rewind" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="regexiterator::valid" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="regexiterator::key" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="regexiterator::current" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="regexiterator::next" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="regexiterator::getinneriterator" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="regexiterator::getregex" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
 
- <function name="recursiveregexiterator" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursiveregexiterator::__construct" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursiveregexiterator::haschildren" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursiveregexiterator::getchildren" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursiveregexiterator::accept" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursiveregexiterator::getmode" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursiveregexiterator::setmode" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursiveregexiterator::getflags" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursiveregexiterator::setflags" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursiveregexiterator::getpregflags" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursiveregexiterator::setpregflags" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursiveregexiterator::rewind" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursiveregexiterator::valid" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursiveregexiterator::key" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursiveregexiterator::current" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursiveregexiterator::next" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursiveregexiterator::getinneriterator" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
+ <function name="recursiveregexiterator" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursiveregexiterator::__construct" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursiveregexiterator::haschildren" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursiveregexiterator::getchildren" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursiveregexiterator::accept" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursiveregexiterator::getmode" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursiveregexiterator::setmode" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursiveregexiterator::getflags" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursiveregexiterator::setflags" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursiveregexiterator::getpregflags" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursiveregexiterator::setpregflags" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursiveregexiterator::rewind" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursiveregexiterator::valid" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursiveregexiterator::key" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursiveregexiterator::current" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursiveregexiterator::next" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursiveregexiterator::getinneriterator" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
 
- <function name="emptyiterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="emptyiterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="emptyiterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="emptyiterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="emptyiterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="emptyiterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="emptyiterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="emptyiterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="emptyiterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="emptyiterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="emptyiterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="emptyiterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="recursivetreeiterator" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::valid" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::key" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::current" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::next" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::beginiteration" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::enditeration" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::callhaschildren" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::callgetchildren" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::beginchildren" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::endchildren" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::nextelement" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::getprefix" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::setprefixpart" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::getentry" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::getpostfix" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::setpostfix" from="PHP 5 &gt;= 5.5.3, PHP 7"/>
- <function name="recursivetreeiterator::getdepth" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::getsubiterator" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::getinneriterator" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::setmaxdepth" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivetreeiterator::getmaxdepth" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="recursivetreeiterator" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::valid" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::key" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::current" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::next" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::beginiteration" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::enditeration" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::callhaschildren" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::callgetchildren" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::beginchildren" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::endchildren" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::nextelement" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::getprefix" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::setprefixpart" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::getentry" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::getpostfix" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::setpostfix" from="PHP 5 &gt;= 5.5.3, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::getdepth" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::getsubiterator" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::getinneriterator" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::setmaxdepth" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivetreeiterator::getmaxdepth" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
- <function name="arrayobject" from="PHP 5, PHP 7"/>
- <function name="arrayobject::__construct" from="PHP 5, PHP 7"/>
- <function name="arrayobject::offsetexists" from="PHP 5, PHP 7"/>
- <function name="arrayobject::offsetget" from="PHP 5, PHP 7"/>
- <function name="arrayobject::offsetset" from="PHP 5, PHP 7"/>
- <function name="arrayobject::offsetunset" from="PHP 5, PHP 7"/>
- <function name="arrayobject::append" from="PHP 5, PHP 7"/>
- <function name="arrayobject::getarraycopy" from="PHP 5, PHP 7"/>
- <function name="arrayobject::count" from="PHP 5, PHP 7"/>
- <function name="arrayobject::getiterator" from="PHP 5, PHP 7"/>
- <function name="arrayobject::getflags" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="arrayobject::setflags" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="arrayobject::exchangearray" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="arrayobject::setiteratorclass" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="arrayobject::getiteratorclass" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="arrayobject::asort" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="arrayobject::ksort" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="arrayobject::uasort" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="arrayobject::uksort" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="arrayobject::natsort" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="arrayobject::natcasesort" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="arrayobject::unserialize" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="arrayobject::serialize" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="arrayobject" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayobject::__construct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayobject::offsetexists" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayobject::offsetget" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayobject::offsetset" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayobject::offsetunset" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayobject::append" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayobject::getarraycopy" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayobject::count" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayobject::getiterator" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayobject::getflags" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="arrayobject::setflags" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="arrayobject::exchangearray" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="arrayobject::setiteratorclass" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="arrayobject::getiteratorclass" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="arrayobject::asort" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="arrayobject::ksort" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="arrayobject::uasort" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="arrayobject::uksort" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="arrayobject::natsort" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="arrayobject::natcasesort" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="arrayobject::unserialize" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="arrayobject::serialize" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
- <function name="arrayiterator" from="PHP 5, PHP 7"/>
- <function name="arrayiterator::__construct" from="PHP 5, PHP 7"/>
- <function name="arrayiterator::offsetexists" from="PHP 5, PHP 7"/>
- <function name="arrayiterator::offsetget" from="PHP 5, PHP 7"/>
- <function name="arrayiterator::offsetset" from="PHP 5, PHP 7"/>
- <function name="arrayiterator::offsetunset" from="PHP 5, PHP 7"/>
- <function name="arrayiterator::append" from="PHP 5, PHP 7"/>
- <function name="arrayiterator::getarraycopy" from="PHP 5, PHP 7"/>
- <function name="arrayiterator::count" from="PHP 5, PHP 7"/>
- <function name="arrayiterator::rewind" from="PHP 5, PHP 7"/>
- <function name="arrayiterator::current" from="PHP 5, PHP 7"/>
- <function name="arrayiterator::key" from="PHP 5, PHP 7"/>
- <function name="arrayiterator::next" from="PHP 5, PHP 7"/>
- <function name="arrayiterator::valid" from="PHP 5, PHP 7"/>
- <function name="arrayiterator::seek" from="PHP 5, PHP 7"/>
- <function name="arrayiterator::getflags" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="arrayiterator::setflags" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="arrayiterator::asort" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="arrayiterator::ksort" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="arrayiterator::uasort" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="arrayiterator::uksort" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="arrayiterator::natsort" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="arrayiterator::natcasesort" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="arrayiterator::unserialize" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="arrayiterator::serialize" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="arrayiterator" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayiterator::__construct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayiterator::offsetexists" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayiterator::offsetget" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayiterator::offsetset" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayiterator::offsetunset" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayiterator::append" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayiterator::getarraycopy" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayiterator::count" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayiterator::rewind" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayiterator::current" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayiterator::key" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayiterator::next" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayiterator::valid" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayiterator::seek" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="arrayiterator::getflags" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="arrayiterator::setflags" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="arrayiterator::asort" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="arrayiterator::ksort" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="arrayiterator::uasort" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="arrayiterator::uksort" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="arrayiterator::natsort" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="arrayiterator::natcasesort" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="arrayiterator::unserialize" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="arrayiterator::serialize" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
- <function name="recursivearrayiterator" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::haschildren" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::getchildren" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::offsetexists" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::offsetget" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::offsetset" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::offsetunset" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::append" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::getarraycopy" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::count" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::getflags" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::setflags" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::seek" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivearrayiterator::asort" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursivearrayiterator::ksort" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursivearrayiterator::uasort" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursivearrayiterator::uksort" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursivearrayiterator::natsort" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursivearrayiterator::natcasesort" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="recursivearrayiterator::unserialize" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivearrayiterator::serialize" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="recursivearrayiterator" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::haschildren" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::getchildren" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::offsetexists" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::offsetget" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::offsetset" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::offsetunset" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::append" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::getarraycopy" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::count" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::getflags" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::setflags" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::current" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::key" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::next" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::seek" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::asort" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::ksort" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::uasort" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::uksort" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::natsort" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::natcasesort" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::unserialize" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivearrayiterator::serialize" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
- <function name="splfileinfo" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::__construct" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::__tostring" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::getatime" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::getbasename" from="PHP 5 &gt;= 5.2.2, PHP 7"/>
- <function name="splfileinfo::getctime" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::getextension" from="PHP 5 &gt;= 5.3.6, PHP 7"/>
- <function name="splfileinfo::getfileinfo" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::getfilename" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::getgroup" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::getinode" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::getlinktarget" from="PHP 5 &gt;= 5.2.2, PHP 7"/>
- <function name="splfileinfo::getmtime" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::getowner" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::getpath" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::getpathinfo" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::getpathname" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::getperms" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::getrealpath" from="PHP 5 &gt;= 5.2.2, PHP 7"/>
- <function name="splfileinfo::getsize" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::gettype" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::isdir" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::isexecutable" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::isfile" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::islink" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::isreadable" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::iswritable" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::openfile" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::setfileclass" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileinfo::setinfoclass" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
+ <function name="splfileinfo" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::__construct" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::__tostring" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::getatime" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::getbasename" from="PHP 5 &gt;= 5.2.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::getctime" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::getextension" from="PHP 5 &gt;= 5.3.6, PHP 7, PHP 8"/>
+ <function name="splfileinfo::getfileinfo" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::getfilename" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::getgroup" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::getinode" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::getlinktarget" from="PHP 5 &gt;= 5.2.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::getmtime" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::getowner" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::getpath" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::getpathinfo" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::getpathname" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::getperms" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::getrealpath" from="PHP 5 &gt;= 5.2.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::getsize" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::gettype" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::isdir" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::isexecutable" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::isfile" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::islink" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::isreadable" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::iswritable" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::openfile" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::setfileclass" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileinfo::setinfoclass" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
 
- <function name="directoryiterator" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::__construct" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::__tostring" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::current" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::getatime" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::getbasename" from="PHP 5 &gt;= 5.2.2, PHP 7"/>
- <function name="directoryiterator::getctime" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::getextension" from="PHP 5 &gt;= 5.3.6, PHP 7"/>
- <function name="directoryiterator::getfilename" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::getgroup" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::getinode" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::getmtime" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::getowner" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::getpath" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::getpathname" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::getperms" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::getsize" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::gettype" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::getlinktarget" from="PHP 5 &gt;= 5.2.2, PHP 7"/>
- <function name="directoryiterator::getrealpath" from="PHP 5 &gt;= 5.2.2, PHP 7"/>
- <function name="directoryiterator::getfileinfo" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="directoryiterator::getpathinfo" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="directoryiterator::isdir" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::isdot" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::isexecutable" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::isfile" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::islink" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::isreadable" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::iswritable" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::key" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::next" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::openfile" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="directoryiterator::rewind" from="PHP 5, PHP 7"/>
- <function name="directoryiterator::seek" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="directoryiterator::setfileclass" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="directoryiterator::setinfoclass" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="directoryiterator::valid" from="PHP 5, PHP 7"/>
+ <function name="directoryiterator" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::__construct" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::__tostring" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::current" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::getatime" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::getbasename" from="PHP 5 &gt;= 5.2.2, PHP 7, PHP 8"/>
+ <function name="directoryiterator::getctime" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::getextension" from="PHP 5 &gt;= 5.3.6, PHP 7, PHP 8"/>
+ <function name="directoryiterator::getfilename" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::getgroup" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::getinode" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::getmtime" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::getowner" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::getpath" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::getpathname" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::getperms" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::getsize" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::gettype" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::getlinktarget" from="PHP 5 &gt;= 5.2.2, PHP 7, PHP 8"/>
+ <function name="directoryiterator::getrealpath" from="PHP 5 &gt;= 5.2.2, PHP 7, PHP 8"/>
+ <function name="directoryiterator::getfileinfo" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="directoryiterator::getpathinfo" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="directoryiterator::isdir" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::isdot" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::isexecutable" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::isfile" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::islink" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::isreadable" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::iswritable" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::key" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::next" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::openfile" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="directoryiterator::rewind" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="directoryiterator::seek" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="directoryiterator::setfileclass" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="directoryiterator::setinfoclass" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="directoryiterator::valid" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="filesystemiterator" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::next" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::key" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::current" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::getflags" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::setflags" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::getfilename" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::getbasename" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::isdot" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::valid" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::seek" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::__tostring" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::getpath" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::getpathname" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::getperms" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::getinode" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::getsize" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::getowner" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::getgroup" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::getatime" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::getmtime" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::getctime" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::gettype" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::iswritable" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::isreadable" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::isexecutable" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::isfile" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::isdir" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::islink" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::getlinktarget" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::getrealpath" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::getfileinfo" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::getpathinfo" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::openfile" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::setfileclass" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="filesystemiterator::setinfoclass" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="filesystemiterator" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::next" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::key" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::current" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::getflags" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::setflags" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::getfilename" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::getbasename" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::isdot" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::valid" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::seek" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::__tostring" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::getpath" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::getpathname" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::getperms" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::getinode" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::getsize" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::getowner" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::getgroup" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::getatime" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::getmtime" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::getctime" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::gettype" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::iswritable" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::isreadable" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::isexecutable" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::isfile" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::isdir" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::islink" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::getlinktarget" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::getrealpath" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::getfileinfo" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::getpathinfo" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::openfile" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::setfileclass" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="filesystemiterator::setinfoclass" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
 
- <function name="recursivedirectoryiterator" from="PHP 5, PHP 7"/>
- <function name="recursivedirectoryiterator::__construct" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="recursivedirectoryiterator::__tostring" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="recursivedirectoryiterator::haschildren" from="PHP 5, PHP 7"/>PHP 5 &gt;= 5.1.0
- <function name="recursivedirectoryiterator::getchildren" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::getsubpath" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::getsubpathname" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::rewind" from="PHP 5, PHP 7"/>
- <function name="recursivedirectoryiterator::key" from="PHP 5, PHP 7"/>
- <function name="recursivedirectoryiterator::next" from="PHP 5, PHP 7"/>
- <function name="recursivedirectoryiterator::current" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="recursivedirectoryiterator::getflags" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivedirectoryiterator::setflags" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="recursivedirectoryiterator::getsubpath" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="recursivedirectoryiterator" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::__construct" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::__tostring" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::haschildren" from="PHP 5, PHP 7, PHP 8"/>PHP 5 &gt;= 5.1.0
+ <function name="recursivedirectoryiterator::getchildren" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getsubpath" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getsubpathname" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::rewind" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::key" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::next" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::current" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getflags" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::setflags" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getsubpath" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
  <function name="recursivedirectoryiterator::getsubpathinfo" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="recursivedirectoryiterator::getsubpathname" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::getfilename" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::getbasename" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::isdot" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::seek" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::getpath" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::getpathname" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::getperms" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::getinode" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::getsize" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::getowner" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::getgroup" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::getatime" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::getmtime" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::getctime" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::gettype" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::iswritable" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::isreadable" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::isexecutable" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::isfile" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::isdir" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::islink" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::getlinktarget" from="PHP 5 &gt;= 5.2.2, PHP 7"/>
- <function name="recursivedirectoryiterator::getrealpath" from="PHP 5 &gt;= 5.2.2, PHP 7"/>
- <function name="recursivedirectoryiterator::getfileinfo" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="recursivedirectoryiterator::getpathinfo" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="recursivedirectoryiterator::openfile" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::setfileclass" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="recursivedirectoryiterator::setinfoclass" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="recursivedirectoryiterator::getsubpathname" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getfilename" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getbasename" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::isdot" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::valid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::seek" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getpath" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getpathname" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getperms" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getinode" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getsize" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getowner" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getgroup" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getatime" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getmtime" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getctime" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::gettype" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::iswritable" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::isreadable" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::isexecutable" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::isfile" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::isdir" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::islink" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getlinktarget" from="PHP 5 &gt;= 5.2.2, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getrealpath" from="PHP 5 &gt;= 5.2.2, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getfileinfo" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::getpathinfo" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::openfile" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::setfileclass" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="recursivedirectoryiterator::setinfoclass" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="globiterator" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::__tostring" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::count" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::next" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::key" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::current" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::getflags" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::setflags" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::getfilename" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::getbasename" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::isdot" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::valid" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::seek" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::getpath" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::getpathname" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::getperms" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::getinode" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::getsize" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::getowner" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::getgroup" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::getatime" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::getmtime" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::getctime" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::gettype" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::iswritable" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::isreadable" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::isexecutable" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::isfile" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::isdir" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::islink" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::getlinktarget" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::getrealpath" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::getfileinfo" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::getpathinfo" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::openfile" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::setfileclass" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="globiterator::setinfoclass" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="globiterator" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::__tostring" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::count" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::next" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::key" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::current" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::getflags" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::setflags" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::getfilename" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::getbasename" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::isdot" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::valid" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::seek" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::getpath" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::getpathname" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::getperms" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::getinode" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::getsize" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::getowner" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::getgroup" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::getatime" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::getmtime" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::getctime" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::gettype" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::iswritable" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::isreadable" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::isexecutable" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::isfile" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::isdir" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::islink" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::getlinktarget" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::getrealpath" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::getfileinfo" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::getpathinfo" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::openfile" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::setfileclass" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="globiterator::setinfoclass" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
- <function name="splfileobject" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::current" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::eof" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::fflush" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::fgetc" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::fgetcsv" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::fgets" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="splfileobject" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::__tostring" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::current" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::eof" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::fflush" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::fgetc" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::fgetcsv" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::fgets" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
  <function name="splfileobject::fgetss" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::flock" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::fpassthru" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::fputcsv" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="splfileobject::fread" from="PHP 5 &gt;= 5.5.11, PHP 7"/>
- <function name="splfileobject::fscanf" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::fseek" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::fstat" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::ftell" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::ftruncate" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::fwrite" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::getchildren" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::getcsvcontrol" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="splfileobject::getfilename" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::getflags" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::getmaxlinelen" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::getcurrentline" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::getpath" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::getfilename" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::getbasename" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::getpathname" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::getperms" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::getinode" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::getsize" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::getowner" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::getgroup" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::getatime" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::getmtime" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::getctime" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::gettype" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::getlinktarget" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::getrealpath" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::getfileinfo" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::getpathinfo" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::haschildren" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::iswritable" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::isreadable" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::isexecutable" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::isfile" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::isdir" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::islink" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::key" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::next" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::openfile" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::seek" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::setcsvcontrol" from="PHP 5 &gt;= 5.2.0, PHP 7"/>
- <function name="splfileobject::setfileclass" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::setflags" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::setinfoclass" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="splfileobject::setmaxlinelen" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splfileobject::valid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="splfileobject::flock" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::fpassthru" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::fputcsv" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::fread" from="PHP 5 &gt;= 5.5.11, PHP 7, PHP 8"/>
+ <function name="splfileobject::fscanf" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::fseek" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::fstat" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::ftell" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::ftruncate" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::fwrite" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::getchildren" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::getcsvcontrol" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::getfilename" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::getflags" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::getmaxlinelen" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::getcurrentline" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::getpath" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::getfilename" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::getbasename" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::getpathname" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::getperms" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::getinode" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::getsize" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::getowner" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::getgroup" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::getatime" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::getmtime" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::getctime" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::gettype" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::getlinktarget" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::getrealpath" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::getfileinfo" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::getpathinfo" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::haschildren" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::iswritable" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::isreadable" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::isexecutable" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::isfile" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::isdir" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::islink" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::key" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::next" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::openfile" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::seek" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::setcsvcontrol" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::setfileclass" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::setflags" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::setinfoclass" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="splfileobject::setmaxlinelen" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splfileobject::valid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="spltempfileobject" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::__construct" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::rewind" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::eof" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::valid" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::fgets" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::fgetcsv" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::setcsvcontrol" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getcsvcontrol" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::flock" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::fflush" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::ftell" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::fseek" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::fgetc" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::fpassthru" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
+ <function name="spltempfileobject" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::__construct" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::rewind" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::eof" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::valid" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::fgets" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::fgetcsv" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::setcsvcontrol" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getcsvcontrol" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::flock" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::fflush" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::ftell" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::fseek" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::fgetc" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::fpassthru" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
  <function name="spltempfileobject::fgetss" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::fscanf" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::fwrite" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::fstat" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::ftruncate" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::current" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::key" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::next" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::setflags" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getflags" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::setmaxlinelen" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getmaxlinelen" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::haschildren" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getchildren" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::seek" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getcurrentline" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::__tostring" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getpath" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getfilename" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getbasename" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getpathname" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getperms" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getinode" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getsize" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getowner" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getgroup" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getatime" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getmtime" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getctime" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::gettype" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::iswritable" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::isreadable" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::isexecutable" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::isfile" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::isdir" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::islink" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getlinktarget" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getrealpath" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getfileinfo" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::getpathinfo" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::openfile" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::setfileclass" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
- <function name="spltempfileobject::setinfoclass" from="PHP 5 &gt;= 5.1.2, PHP 7"/>
+ <function name="spltempfileobject::fscanf" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::fwrite" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::fstat" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::ftruncate" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::current" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::key" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::next" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::setflags" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getflags" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::setmaxlinelen" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getmaxlinelen" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::haschildren" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getchildren" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::seek" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getcurrentline" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::__tostring" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getpath" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getfilename" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getbasename" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getpathname" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getperms" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getinode" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getsize" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getowner" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getgroup" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getatime" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getmtime" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getctime" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::gettype" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::iswritable" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::isreadable" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::isexecutable" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::isfile" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::isdir" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::islink" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getlinktarget" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getrealpath" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getfileinfo" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::getpathinfo" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::openfile" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::setfileclass" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
+ <function name="spltempfileobject::setinfoclass" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8"/>
 
- <function name="spldoublylinkedlist" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="spldoublylinkedlist" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="spldoublylinkedlist::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::pop" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::add" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="spldoublylinkedlist::shift" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::push" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::unshift" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::top" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::bottom" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::count" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::isempty" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::setiteratormode" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::getiteratormode" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::offsetexists" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::offsetget" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::offsetset" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::offsetunset" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::current" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::key" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::next" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::valid" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::prev" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="spldoublylinkedlist::serialize" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="spldoublylinkedlist::unserialize" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
+ <function name="spldoublylinkedlist::pop" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::add" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::shift" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::push" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::unshift" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::top" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::bottom" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::count" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::isempty" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::setiteratormode" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::getiteratormode" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::offsetexists" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::offsetget" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::offsetset" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::offsetunset" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::current" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::key" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::next" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::valid" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::prev" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::serialize" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="spldoublylinkedlist::unserialize" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
 
- <function name="splqueue" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="splqueue" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="splqueue::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::add" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="splqueue::enqueue" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::dequeue" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::pop" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::shift" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::push" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::unshift" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::top" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::bottom" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::count" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::isempty" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::setiteratormode" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::getiteratormode" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::offsetexists" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::offsetget" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::offsetset" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::offsetunset" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::current" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::key" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::next" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splqueue::valid" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="splqueue::add" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="splqueue::enqueue" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::dequeue" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::pop" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::shift" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::push" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::unshift" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::top" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::bottom" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::count" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::isempty" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::setiteratormode" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::getiteratormode" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::offsetexists" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::offsetget" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::offsetset" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::offsetunset" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::current" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::key" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::next" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splqueue::valid" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
- <function name="splstack" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="splstack" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="splstack::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::add" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="splstack::pop" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::shift" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::push" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::unshift" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::top" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::bottom" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::count" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::isempty" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::setiteratormode" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::getiteratormode" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::offsetexists" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::offsetget" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::offsetset" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::offsetunset" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::current" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::key" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::next" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splstack::valid" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="splstack::add" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="splstack::pop" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splstack::shift" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splstack::push" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splstack::unshift" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splstack::top" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splstack::bottom" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splstack::count" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splstack::isempty" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splstack::setiteratormode" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splstack::getiteratormode" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splstack::offsetexists" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splstack::offsetget" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splstack::offsetset" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splstack::offsetunset" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splstack::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splstack::current" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splstack::key" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splstack::next" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splstack::valid" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
- <function name="splheap" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="splheap" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="splheap::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splheap::extract" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splheap::insert" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splheap::iscorrupted" from="PHP 7"/>
- <function name="splheap::top" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splheap::count" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splheap::isempty" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splheap::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splheap::current" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splheap::key" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splheap::next" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splheap::valid" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splheap::recoverfromcorruption" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splheap::compare" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="splheap::extract" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splheap::insert" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splheap::iscorrupted" from="PHP 7, PHP 8"/>
+ <function name="splheap::top" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splheap::count" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splheap::isempty" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splheap::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splheap::current" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splheap::key" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splheap::next" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splheap::valid" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splheap::recoverfromcorruption" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splheap::compare" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
- <function name="splminheap" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splminheap::compare" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splminheap::extract" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splminheap::insert" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splminheap::top" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splminheap::count" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splminheap::isempty" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splminheap::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splminheap::current" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splminheap::key" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splminheap::next" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splminheap::valid" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splminheap::recoverfromcorruption" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="splminheap" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splminheap::compare" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splminheap::extract" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splminheap::insert" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splminheap::top" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splminheap::count" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splminheap::isempty" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splminheap::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splminheap::current" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splminheap::key" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splminheap::next" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splminheap::valid" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splminheap::recoverfromcorruption" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
- <function name="splmaxheap" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splmaxheap::compare" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splmaxheap::extract" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splmaxheap::insert" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splmaxheap::top" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splmaxheap::count" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splmaxheap::isempty" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splmaxheap::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splmaxheap::current" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splmaxheap::key" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splmaxheap::next" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splmaxheap::valid" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splmaxheap::recoverfromcorruption" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="splmaxheap" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splmaxheap::compare" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splmaxheap::extract" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splmaxheap::insert" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splmaxheap::top" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splmaxheap::count" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splmaxheap::isempty" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splmaxheap::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splmaxheap::current" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splmaxheap::key" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splmaxheap::next" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splmaxheap::valid" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splmaxheap::recoverfromcorruption" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
- <function name="splpriorityqueue" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="splpriorityqueue" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="splpriorityqueue::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splpriorityqueue::compare" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splpriorityqueue::insert" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splpriorityqueue::getextractflags" from="PHP 7"/>
- <function name="splpriorityqueue::setextractflags" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splpriorityqueue::top" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splpriorityqueue::extract" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splpriorityqueue::count" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splpriorityqueue::iscorrupted" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splpriorityqueue::isempty" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splpriorityqueue::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splpriorityqueue::current" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splpriorityqueue::key" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splpriorityqueue::next" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splpriorityqueue::valid" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splpriorityqueue::recoverfromcorruption" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="splpriorityqueue::compare" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splpriorityqueue::insert" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splpriorityqueue::getextractflags" from="PHP 7, PHP 8"/>
+ <function name="splpriorityqueue::setextractflags" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splpriorityqueue::top" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splpriorityqueue::extract" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splpriorityqueue::count" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splpriorityqueue::iscorrupted" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splpriorityqueue::isempty" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splpriorityqueue::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splpriorityqueue::current" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splpriorityqueue::key" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splpriorityqueue::next" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splpriorityqueue::valid" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splpriorityqueue::recoverfromcorruption" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
- <function name="splfixedarray" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splfixedarray::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splfixedarray::__wakeup" from="PHP 5 &gt;= 5.5.0, PHP 7"/>
- <function name="splfixedarray::count" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splfixedarray::toarray" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splfixedarray::fromarray" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splfixedarray::getsize" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splfixedarray::setsize" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splfixedarray::offsetexists" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splfixedarray::offsetget" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splfixedarray::offsetset" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splfixedarray::offsetunset" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="splfixedarray" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splfixedarray::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splfixedarray::__wakeup" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="splfixedarray::count" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splfixedarray::toarray" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splfixedarray::fromarray" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splfixedarray::getsize" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splfixedarray::setsize" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splfixedarray::offsetexists" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splfixedarray::offsetget" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splfixedarray::offsetset" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splfixedarray::offsetunset" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="splfixedarray::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
  <function name="splfixedarray::current" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
  <function name="splfixedarray::key" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
  <function name="splfixedarray::next" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
  <function name="splfixedarray::valid" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
 
- <function name="splobserver" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splobserver::update" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="splobserver" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splobserver::update" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="splsubject" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splsubject::attach" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splsubject::detach" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splsubject::notify" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="splsubject" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splsubject::attach" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splsubject::detach" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splsubject::notify" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="splobjectstorage" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splobjectstorage::addall" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splobjectstorage::attach" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splobjectstorage::contains" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splobjectstorage::count" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splobjectstorage::current" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splobjectstorage::detach" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splobjectstorage::gethash" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="splobjectstorage::getinfo" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splobjectstorage::key" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splobjectstorage::next" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splobjectstorage::offsetexists" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splobjectstorage::offsetget" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splobjectstorage::offsetset" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splobjectstorage::offsetunset" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splobjectstorage::removeall" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splobjectstorage::removeallexcept" from="PHP 5 &gt;= 5.3.6, PHP 7"/>
- <function name="splobjectstorage::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
- <function name="splobjectstorage::serialize" from="PHP 5 &gt;= 5.2.2, PHP 7"/>
- <function name="splobjectstorage::setinfo" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="splobjectstorage::unserialize" from="PHP 5 &gt;= 5.2.2, PHP 7"/>
- <function name="splobjectstorage::valid" from="PHP 5 &gt;= 5.1.0, PHP 7"/>
+ <function name="splobjectstorage" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::addall" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::attach" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::contains" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::count" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::current" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::detach" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::gethash" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::getinfo" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::key" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::next" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::offsetexists" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::offsetget" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::offsetset" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::offsetunset" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::removeall" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::removeallexcept" from="PHP 5 &gt;= 5.3.6, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::rewind" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::serialize" from="PHP 5 &gt;= 5.2.2, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::setinfo" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::unserialize" from="PHP 5 &gt;= 5.2.2, PHP 7, PHP 8"/>
+ <function name="splobjectstorage::valid" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 
- <function name="multipleiterator" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="multipleiterator::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="multipleiterator::getflags" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="multipleiterator::setflags" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="multipleiterator::attachiterator" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="multipleiterator::detachiterator" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="multipleiterator::containsiterator" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="multipleiterator::countiterators" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="multipleiterator::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="multipleiterator::valid" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="multipleiterator::key" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="multipleiterator::current" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="multipleiterator::next" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
+ <function name="multipleiterator" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="multipleiterator::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="multipleiterator::getflags" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="multipleiterator::setflags" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="multipleiterator::attachiterator" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="multipleiterator::detachiterator" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="multipleiterator::containsiterator" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="multipleiterator::countiterators" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="multipleiterator::rewind" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="multipleiterator::valid" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="multipleiterator::key" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="multipleiterator::current" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="multipleiterator::next" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
- <function name="callbackfilteriterator" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="callbackfilteriterator::__construct" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="callbackfilteriterator::accept" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
+ <function name="callbackfilteriterator" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="callbackfilteriterator::__construct" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="callbackfilteriterator::accept" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
 
- <function name="recursivecallbackfilteriterator" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="recursivecallbackfilteriterator::__construct" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="recursivecallbackfilteriterator::getchildren" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
- <function name="recursivecallbackfilteriterator::haschildren" from="PHP 5 &gt;= 5.4.0, PHP 7"/>
+ <function name="recursivecallbackfilteriterator" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="recursivecallbackfilteriterator::__construct" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="recursivecallbackfilteriterator::getchildren" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="recursivecallbackfilteriterator::haschildren" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
 
 </versions>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
- Generated verions.xml based on the following stubs.
  * https://github.com/php/php-src/blob/PHP-8.0/Zend/zend_interfaces.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/Zend/zend_exceptions.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/spl/spl_observer.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/spl/spl_directory.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/spl/spl_array.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/spl/php_spl.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/spl/spl_heap.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/spl/spl_dllist.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/spl/spl_iterators.stub.php
  * https://github.com/php/php-src/blob/PHP-8.0/ext/spl/spl_fixedarray.stub.php
- Note
  * deleted methods as of PHP 8.0
    - splfileobject
      * `splfileobject::fgetss`
      * `spltempfileobject::fgetss`
    - splfixedarray
      * `splfixedarray::rewind`
      * `splfixedarray::current`
      * `splfixedarray::key`
      * `splfixedarray::next`
      * `splfixedarray::valid`
  * `cachingrecursiveiterator` was deleted in ancient times
  * `recursivedirectoryiterator::getsubpathinfo` not implemented in PHP 8.0
  * unsure if the following constructors is implemeneted
    - `spldoublylinkedlist::__construct`
    - `splqueue::__construct`
    - `splstack::__construct`
    - `splheap::__construct`
    - `splpriorityqueue::__construct`
  * [NOTICE] spl exceptions stub does not exist!!
    - we should add it like the following [based on its implementation](https://github.com/php/php-src/blob/PHP-8.0/ext/spl/spl_exceptions.c#L48-L67).

```php
<?php

class LogicException extends Exception {};
class BadFunctionCallException extends LogicException {};
class BadMethodCallException extends BadFunctionCallException {};
class DomainException extends LogicException {};
class InvalidArgumentException extends LogicException {};
class LengthException extends LogicException {};
class OutOfRangeException extends LogicException {};
class RuntimeException extends Exception {};
class OutOfBoundsException extends RuntimeException {};
class OverflowException extends RuntimeException {};
class RangeException extends RuntimeException {};
class UnderflowException extends RuntimeException {};
class UnexpectedValueException extends RuntimeException {};
```