### PR TITLE
Update for function.getopt parameters description.

### DIFF
--- a/reference/info/functions/getopt.xml
+++ b/reference/info/functions/getopt.xml
@@ -81,6 +81,14 @@
     </simpara>
    </note>
   </para>
+  <para>
+    The <parameter>long_options</parameter> array values may contain:
+    <simplelist>
+      <member>String (parameter does not accept any value)</member>
+      <member>String followed by a colon (parameter requires value)</member>
+      <member>String followed by two colons (optional value)</member>
+    </simplelist>
+  </para>
   <note>
    <para>
     The format for the <parameter>short_options</parameter> and


### PR DESCRIPTION
It's somewhat confusing on what's the right formatting for the **long_options** parameter .
The current docs clearly describes how the **short_options** should be described but leaves most of the long_options ones to the imagination. There's a brief note below but does not shed much light about it. 

This is an attempt to clearly describe what the format should be for the **long_options** param on the getopt() function.