### PR TITLE
Added missing documentation for openssl_pkey_derive

### DIFF
--- a/reference/openssl/functions/openssl-pkey-derive.xml
+++ b/reference/openssl/functions/openssl-pkey-derive.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<refentry xml:id="function.openssl-pkey-derive" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>openssl_pkey_derive</refname>
+  <refpurpose>Computes shared secret for public value of remote and local DH or ECDH key</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>openssl_pkey_derive</methodname>
+   <methodparam><type class="union"><type>OpenSSLAsymmetricKey</type><type>OpenSSLCertificate</type><type>array</type><type>string</type></type><parameter>public_key</parameter></methodparam>
+   <methodparam><type class="union"><type>OpenSSLAsymmetricKey</type><type>OpenSSLCertificate</type><type>array</type><type>string</type></type><parameter>private_key</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>key_length</parameter><initializer>NULL</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>openssl_pkey_derive</function> takes a set of a <parameter>public_key</parameter>
+   and <parameter>private_key</parameter> and derives a shared secret, for either DH or EC keys.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>public_key</parameter></term>
+    <listitem>
+     <para>
+      <parameter>public_key</parameter> is the public key for the derivation.
+      See <link linkend="openssl.certparams">Public/Private Key parameters</link> for a list of valid values.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>private_key</parameter></term>
+    <listitem>
+     <para>
+      <parameter>private_key</parameter> is the private key for the derivation.
+      See <link linkend="openssl.certparams">Public/Private Key parameters</link> for a list of valid values.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>key_length</parameter></term>
+    <listitem>
+     <para>
+      If specified, will set the desired length of the derived secret.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   The derived secret on success&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>openssl_pkey_derive</function> example</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// Load in private key
+$priv = openssl_pkey_get_private("-----BEGIN PRIVATE KEY-----
+MIICJgIBADCCARcGCSqGSIb3DQEDATCCAQgCggEBAJLxRCaZ933uW+AXmabHFDDy
+upojBIRlbmQLJZfigDaSA1f9YOTsIv+WwVFTX/J1mtCyx9uBcz0Nt2kmVwxWuc2f
+VtCEMPsmLsVXX7xRUFLpyX1Y1IYGBVXQOoOvLWYQjpZgnx47Pkh1Ok1+smffztfC
+0DCNt4KorWrbsPcmqBejXHN79KvWFjZmXOksRiNu/Bn76RiqvofC4z8Ri3kHXQG2
+197JGZzzFXHadGC3xbkg8UxsNbYhVMKbm0iANfafUH7/hoS9UjAVQYtvwe7YNiW/
+HnyfVCrKwcc7sadd8Iphh+3lf5P1AhaQEAMytanrzq9RDXKBxuvpSJifRYasZYsC
+AQIEggEEAoIBAGwAYC2E81Y1U2Aox0U7u1+vBcbht/OO87tutMvc4NTLf6NLPHsW
+cPqBixs+3rSn4fADzAIvdLBmogjtiIZoB6qyHrllF/2xwTVGEeYaZIupQH3bMK2b
+6eUvnpuu4Ytksiz6VpXBBRMrIsj3frM+zUtnq8vKUr+TbjV2qyKR8l3eNDwzqz30
+dlbKh9kIhZafclHfRVfyp+fVSKPfgrRAcLUgAbsVjOjPeJ90xQ4DTMZ6vjiv6tHM
+hkSjJIcGhRtSBzVF/cT38GyCeTmiIA/dRz2d70lWrqDQCdp9ArijgnpjNKAAulSY
+CirnMsGZTDGmLOHg4xOZ5FEAzZI2sFNLlcw=
+-----END PRIVATE KEY-----
+");
+
+// Load in public key
+$pub = openssl_pkey_get_public("-----BEGIN PUBLIC KEY-----
+MIICJDCCARcGCSqGSIb3DQEDATCCAQgCggEBAJLxRCaZ933uW+AXmabHFDDyupoj
+BIRlbmQLJZfigDaSA1f9YOTsIv+WwVFTX/J1mtCyx9uBcz0Nt2kmVwxWuc2fVtCE
+MPsmLsVXX7xRUFLpyX1Y1IYGBVXQOoOvLWYQjpZgnx47Pkh1Ok1+smffztfC0DCN
+t4KorWrbsPcmqBejXHN79KvWFjZmXOksRiNu/Bn76RiqvofC4z8Ri3kHXQG2197J
+GZzzFXHadGC3xbkg8UxsNbYhVMKbm0iANfafUH7/hoS9UjAVQYtvwe7YNiW/Hnyf
+VCrKwcc7sadd8Iphh+3lf5P1AhaQEAMytanrzq9RDXKBxuvpSJifRYasZYsCAQID
+ggEFAAKCAQAiCSBpxvGgsTorxAWtcAlSmzAJnJxFgSPef0g7OjhESytnc8G2QYmx
+ovMt5KVergcitztWh08hZQUdAYm4rI+zMlAFDdN8LWwBT/mGKSzRkWeprd8E7mvy
+ucqC1YXCMqmIwPySvLQUB/Dl8kgau7BLAnIJm8VP+MVrn8g9gghD0qRCgPgtEaDV
+vocfgnOU43rhKnIgO0cHOKtw2qybSFB8QuZrYugq4j8Bwkrzh6rdMMeyMl/ej5Aj
+c0wamOzuBDtXt0T9+Fx3khHaowjCc7xJZRgZCxg43SbqMWJ9lUg94I7+LTX61Gyv
+dtlkbGbtoDOnxeNnN93gwQZngGYZYciu
+-----END PUBLIC KEY-----
+");
+
+// Outputs the hex version of the derived key
+echo bin2hex(openssl_pkey_derive($pub,$priv));
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/openssl/versions.xml
+++ b/reference/openssl/versions.xml
@@ -38,6 +38,7 @@
  <function name="openssl_pkcs7_read" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
  <function name="openssl_pkcs7_sign" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
  <function name="openssl_pkcs7_verify" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
+ <function name="openssl_pkey_derive" from="PHP 7 &gt;= 7.3.0, PHP 8"/>
  <function name="openssl_pkey_export" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
  <function name="openssl_pkey_export_to_file" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
  <function name="openssl_pkey_free" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>


### PR DESCRIPTION
Adding documentation for `openssl_pkey_derive`.

Was introduced here: https://github.com/php/php-src/pull/3197
As a result of: https://bugs.php.net/bug.php?id=76026

