### PR TITLE
Add the standard PECL installation instructions to APCu

### DIFF
--- a/reference/apcu/setup.xml
+++ b/reference/apcu/setup.xml
@@ -12,6 +12,10 @@
  <section xml:id="apcu.installation">
   &reftitle.install;
   <para>
+   &pecl.info;
+   <link xlink:href="&url.pecl.package;apcu">&url.pecl.package;apcu</link>.
+  </para>
+  <para>
    If backward compatibility with the applicable parts of APC is required,
    APCu must be configured with the option --enable-apcu-bc.
   </para>


### PR DESCRIPTION
https://www.php.net/manual/en/apcu.installation.php would be confusing
to new users. A recent user note coincidentally mentions this.
(noticed while looking for how installation instructions are written in general)

This starts the installation section with the following message:

> Information for installing this PECL extension may be found in the manual chapter titled [Installation of PECL extensions](https://www.php.net/manual/en/install.pecl.php). Additional information such as new releases, downloads, source files, maintainer information, and a CHANGELOG, can be located here: » https://pecl.php.net/package/apcu. 