### PR TITLE
Allow Throwable for $previous param

### DIFF
--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -25,7 +25,7 @@ class Exception extends Throwable
     private   $trace;                           // backtrace
     private   $previous;                        // previous exception if nested exception
 
-    public function __construct($message = null, $code = 0, Exception $previous = null);
+    public function __construct($message = null, $code = 0, Throwable $previous = null);
 
     final private function __clone();           // Inhibits cloning of exceptions.
 
@@ -71,7 +71,7 @@ class Exception extends Throwable
 class MyException extends Exception
 {
     // Redefine the exception so message isn't optional
-    public function __construct($message, $code = 0, Exception $previous = null) {
+    public function __construct($message, $code = 0, Throwable $previous = null) {
         // some code
     
         // make sure everything is assigned properly


### PR DESCRIPTION
In current PHP versions the Exception-class seems to allow all Throwable values for its constructor's $previous param instead of only values of type Exception.