### PR TITLE
Remove incorrect note about autoloading in interactive CLI

### DIFF
--- a/language/oop5/autoload.xml
+++ b/language/oop5/autoload.xml
@@ -27,12 +27,6 @@
   </tip>
   <note>
    <para>
-    Autoloading is not available if using PHP in CLI
-    <link linkend="features.commandline">interactive mode</link>.
-   </para>
-  </note>
-  <note>
-   <para>
     If the class name is used e.g. in <function>call_user_func</function> then
     it can contain some dangerous characters such as <literal>../</literal>.
     It is recommended to not use the user-input in such functions or at least


### PR DESCRIPTION
This was apparently added in response to a bug report against PHP
5.2 [https://bugs.php.net/bug.php?id=40775]. Testing suggests the
limitation was removed at least as long ago as 5.6, and probably
earlier.