### PR TITLE
Fixed simplexml_import_dom return type

### DIFF
--- a/reference/simplexml/functions/simplexml-import-dom.xml
+++ b/reference/simplexml/functions/simplexml-import-dom.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type class="union"><type>SimpleXMLElement</type><type>false</type></type><methodname>simplexml_import_dom</methodname>
+   <type class="union"><type>SimpleXMLElement</type><type>null</type></type><methodname>simplexml_import_dom</methodname>
    <methodparam><type>DOMNode</type><parameter>node</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>class_name</parameter><initializer>"SimpleXMLElement"</initializer></methodparam>
   </methodsynopsis>
@@ -49,9 +49,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a <type>SimpleXMLElement</type>&return.falseforfailure;.
+   Returns a <type>SimpleXMLElement</type> or &null; on failure.
   </para>
-  &return.falseproblem;
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
The PHP 8 stubs say that `simplexml_import_dom` returns `null` on failure. I verified that: https://3v4l.org/9fVRO