### PR TITLE
In OpenSSL extension, configargs parameter name was renamed to options.

### DIFF
--- a/reference/openssl/configure.xml
+++ b/reference/openssl/configure.xml
@@ -65,7 +65,7 @@
    whether to install it someplace else and use environmental variables
    (possibly on a per-virtual-host basis) to locate the configuration file.
    Note that it is possible to override the default path from the script using
-   the <parameter>configargs</parameter> of the functions that require a
+   the <parameter>options</parameter> of the functions that require a
    configuration file.
   </simpara>
   <caution>


### PR DESCRIPTION
Maybe, should we replace this `configargs` too?