### PR TITLE
Updated actual functions using in examples of get_resource_type

### DIFF
--- a/reference/var/functions/get-resource-type.xml
+++ b/reference/var/functions/get-resource-type.xml
@@ -58,8 +58,8 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// prints: mysql link
-$c = mysql_connect();
+// prints: pgsql link persistent
+$c = pg_pconnect();
 echo get_resource_type($c) . "\n";
 
 // prints: stream

--- a/reference/var/functions/get-resource-type.xml
+++ b/reference/var/functions/get-resource-type.xml
@@ -58,13 +58,13 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// prints: curl
-$c = curl_init ();
-echo get_resource_type($c) . "\n";
-
 // prints: stream
 $fp = fopen("foo", "w");
 echo get_resource_type($fp) . "\n";
+
+// prints: curl
+$c = curl_init ();
+echo get_resource_type($c) . "\n"; // works prior to PHP 8.0.0 as since 8.0 curl_init returns a CurlHandle object
 ?>
 ]]>
     </programlisting>

--- a/reference/var/functions/get-resource-type.xml
+++ b/reference/var/functions/get-resource-type.xml
@@ -58,17 +58,13 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// prints: pgsql link persistent
-$c = pg_pconnect();
+// prints: curl
+$c = curl_init ();
 echo get_resource_type($c) . "\n";
 
 // prints: stream
 $fp = fopen("foo", "w");
 echo get_resource_type($fp) . "\n";
-
-// prints: domxml document
-$doc = new_xmldoc("1.0");
-echo get_resource_type($doc->doc) . "\n";
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
mysql_connect is used in the example for get_resource_type which is deprecated since PHP 5.5.0. As it is better to use actual functions in examples -  it was replaced by pg_pconnect with similar example output 