### PR TITLE
Fix operator associativity of null coalescing operator

### DIFF
--- a/language/operators.xml
+++ b/language/operators.xml
@@ -216,7 +216,7 @@
         </entry>
        </row>
        <row>
-        <entry>right</entry>
+        <entry>left</entry>
         <entry><literal>??</literal></entry>
         <entry>
          <link linkend="language.operators.comparison.coalesce">null coalescing</link>


### PR DESCRIPTION
The operator associativity of the null coalescing operator should be left instead of right.
Here an example from the documentation. It is solved from left to right...

<?php
$foo = null;
$bar = null;
$baz = 1;
$qux = 2;

echo $foo ?? $bar ?? $baz ?? $qux; // outputs 1
?>