### PR TITLE
Update index_key handling in array_column for php8

### DIFF
--- a/reference/array/functions/array-column.xml
+++ b/reference/array/functions/array-column.xml
@@ -58,8 +58,8 @@
        The column to use as the index/keys for the returned array. This value
        may be the integer key of the column, or it may be the string key name.
        The value is <link linkend="language.types.array.key-casts">cast</link>
-       as usual for array keys (however, objects supporting conversion to string
-       are also allowed).
+       as usual for array keys (however, prior to PHP 8, objects supporting
+       conversion to string were also allowed).
       </para>
      </listitem>
     </varlistentry>
@@ -84,6 +84,13 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Objects in columns indicated by <parameter>index_key</parameter> parameter
+        will no longer be cast to string and will now throw a TypeError instead.
+       </entry>
+      </row>
       <row>
        <entry>7.0.0</entry>
        <entry>


### PR DESCRIPTION
As per PR https://github.com/php/php-src/pull/5487, the `array_column()` now uses standard type handling for keys. As a result, if an object is used for the key, it will no longer be cast to string.

Example of the behavior change: https://3v4l.org/1qoLQ