### PR TITLE
add ob_implicit_flush.flag-param change log for php 8.0

### DIFF
--- a/reference/outcontrol/functions/ob-implicit-flush.xml
+++ b/reference/outcontrol/functions/ob-implicit-flush.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>void</type><methodname>ob_implicit_flush</methodname>
-   <methodparam choice="opt"><type>int</type><parameter>flag</parameter><initializer>1</initializer></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>flag</parameter><initializer>true</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>ob_implicit_flush</function> will turn implicit flushing on or
@@ -28,7 +28,7 @@
      <term><parameter>flag</parameter></term>
      <listitem>
       <para>
-       <literal>1</literal> to turn implicit flushing on, <literal>0</literal> otherwise.
+       <literal>true</literal> to turn implicit flushing on, <literal>false</literal> otherwise.
       </para>
      </listitem>
     </varlistentry>
@@ -41,6 +41,29 @@
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       The <parameter>flag</parameter> expects a <type>bool</type> value now;
+       previously, an <type>int</type> was expected.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
- update the documentation of [`ob_implicit_flush`](https://www.php.net/manual/en/function.ob-implicit-flush.php) to reflect changes of https://github.com/php/php-src/commit/46d22e435f43529aa55b54460dd265c4bd22409f
- add a changelog section for php 8.0

code: https://github.com/php/php-src/blob/23afc62080588f612fa6c5d0ea217564930dab3d/main/output.c#L1514-L1525

test: https://3v4l.org/aVgk6