### PR TITLE
Clarify that Exception::getPrevious may return a Throwable

### DIFF
--- a/language/predefined/exception/getprevious.xml
+++ b/language/predefined/exception/getprevious.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="exception.getprevious" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Exception::getPrevious</refname>
-  <refpurpose>Returns previous Exception</refpurpose>
+  <refpurpose>Returns previous Throwable</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Returns previous exception (the third parameter of <methodname>Exception::__construct</methodname>).
+   Returns previous throwable (which may be an exception or error, passed as the third parameter of <methodname>Exception::__construct</methodname>).
   </para>
  </refsect1>
  


### PR DESCRIPTION
Spotted this when using PhpStorm's documentation (which copies the PHP docs) which incorrectly typehints an Exception - use of this as Exception could cause a TypeError if a non-Exception Throwable is returned. The definitions here for return params of this method are correct so its just the top line description that needs to change.