### PR TITLE
Fixed Ticks usage example

### DIFF
--- a/language/control-structures/declare.xml
+++ b/language/control-structures/declare.xml
@@ -122,13 +122,13 @@ function tick_handler()
     echo "tick_handler() called\n";
 }
 
-register_tick_function('tick_handler');
+register_tick_function('tick_handler'); // this is a tick event
 
-$a = 1;
+$a = 1; // this is a tick event
 
 if ($a > 0) {
-    $a += 2;
-    print($a);
+    $a += 2; // this is a tick event
+    print($a); // this is a tick event
 }
 
 ?>
@@ -157,7 +157,6 @@ if ($a > 0) {
     print($a);
     tick_handler();
 }
-tick_handler();
 
 ?>
 ]]>

--- a/language/control-structures/declare.xml
+++ b/language/control-structures/declare.xml
@@ -122,40 +122,13 @@ function tick_handler()
     echo "tick_handler() called\n";
 }
 
-register_tick_function('tick_handler'); // this is a tick event
+register_tick_function('tick_handler'); // the register_tick_function execution causes a tick event
 
-$a = 1; // this is a tick event
-
-if ($a > 0) {
-    $a += 2; // this is a tick event
-    print($a); // this is a tick event
-}
-
-?>
-]]>
-   </programlisting>
-  </example>
- </para>
- <para>
-  <example>
-   <title>Ticks usage example</title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-
-function tick_handler()
-{
-  echo "tick_handler() called\n";
-}
-
-$a = 1;
-tick_handler();
+$a = 1; // it causes a tick event
 
 if ($a > 0) {
-    $a += 2;
-    tick_handler();
-    print($a);
-    tick_handler();
+    $a += 2; // it causes a tick event
+    print($a); // it causes a tick event
 }
 
 ?>


### PR DESCRIPTION
There is a mistake in Tick usage example. There is `tick_handler();` after if clause - but it should not. The last tick event in the example is `print($a);`