### PR TITLE
Move iterable variance section to OOP section

### DIFF
--- a/language/oop5/variance.xml
+++ b/language/oop5/variance.xml
@@ -31,6 +31,11 @@
      <type>float</type> is changed to <type>int</type>
     </simpara>
    </listitem>
+   <listitem>
+    <simpara>
+     <type>iterable</type> is changed to <type>array</type> or <classname>Traversable</classname>
+    </simpara>
+   </listitem>
   </itemizedlist>
 
   A type class is considered less specific if the opposite is true.

--- a/language/types/iterable.xml
+++ b/language/types/iterable.xml
@@ -120,42 +120,6 @@ function gen(): iterable {
   </para>
  </sect2>
 
- <sect2 xml:id="language.types.iterable.variance">
-  <title>Iterable Type Variance</title>
-
-  <para>
-   Classes extending/implementing may broaden methods using &array; or
-   <classname>Traversable</classname> as parameter types to
-   <type>iterable</type> or narrow return types from <type>iterable</type> to
-   &array; or <classname>Traversable</classname>.
-  </para>
-
-  <para>
-   <example>
-    <title>
-     Iterable type variance example
-    </title>
-    <programlisting role="php">
-<![CDATA[
-<?php
-
-interface Example {
-    public function method(array $array): iterable;
-}
-
-class ExampleImplementation implements Example {
-    public function method(iterable $iterable): array {
-        // Parameter broadened and return type narrowed.
-    }
-}
-
-?>
-]]>
-    </programlisting>
-   </example>
-  </para>
- </sect2>
-
 </sect1>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Makes more sense to group it together but we lose the example.