### PR TITLE
Fix ternary precedence

### DIFF
--- a/language/operators.xml
+++ b/language/operators.xml
@@ -223,7 +223,7 @@
         </entry>
        </row>
        <row>
-        <entry>left</entry>
+        <entry>right</entry>
         <entry><literal>? :</literal></entry>
         <entry>
          <link linkend="language.operators.comparison.ternary">ternary</link>


### PR DESCRIPTION
it is right associative since PHP 7.4, see https://wiki.php.net/rfc/ternary_associativity