### PR TITLE
Update for LuaSandbox 4.0.0

### DIFF
--- a/reference/luasandbox/book.xml
+++ b/reference/luasandbox/book.xml
@@ -8,7 +8,7 @@
  <preface xml:id="intro.luasandbox">
   &reftitle.intro;
   <para>
-   LuaSandbox is an extension for PHP 5, PHP 7, and HHVM to allow safely
+   LuaSandbox is an extension for PHP 7 and PHP 8 to allow safely
    running untrusted Lua 5.1 code from within PHP.
   </para>
   <para>

--- a/reference/luasandbox/setup.xml
+++ b/reference/luasandbox/setup.xml
@@ -34,7 +34,7 @@
    <link xlink:href="&url.pecl.package;luasandbox">&url.pecl.package;luasandbox</link>.
   </para>
   <para>
-   If the operating system is Debian 9 or later, or Ubuntu 18.04 or later, then
+   If the operating system is Debian 10 or later, or Ubuntu 18.04 or later, then
    LuaSandbox should typically be installed from the package
    <literal>php-luasandbox</literal>:
    <screen>
@@ -42,15 +42,6 @@
 sudo apt-get install php-luasandbox
 ]]>
    </screen>
-  </para>
-  <para>
-   Debian 9 users may need to add
-   <screen>
-<![CDATA[
-deb http://ftp.debian.org/debian stretch-backports main
-]]>
-   </screen>
-   to their <link xlink:href="https://manpages.debian.org/stretch/apt/sources.list.5.en.html">sources.list</link>.
   </para>
  </section>
 


### PR DESCRIPTION
Copies changes made in <https://gerrit.wikimedia.org/g/mediawiki/php/luasandbox>:
* Drop support for PHP 5 & HHVM, add PHP 8 support
* Remove stretch-backports instructions (no longer functional)