### PR TITLE
[67034] Document warning when trying to compare DatePeriod objects

### DIFF
--- a/reference/datetime/dateperiod.xml
+++ b/reference/datetime/dateperiod.xml
@@ -181,6 +181,12 @@
       </thead>
       <tbody>
        <row>
+        <entry>7.4.0</entry>
+        <entry>
+         <classname>DatePeriod</classname> comparison with operator <code>==</code> will now emit a warning.
+        </entry>
+       </row>
+       <row>
         <entry>5.3.27, 5.4.17</entry>
         <entry>
          The public properties <varname>recurrences</varname>,


### PR DESCRIPTION
Add changelog note about DatePeriod comparison as reported in https://bugs.php.net/bug.php?id=67034