### PR TITLE
[80766] Add changelog about defining custom assert

### DIFF
--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -225,7 +225,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>8.0</entry>
+       <entry>8.0.0</entry>
        <entry>Defining a custom <function>assert</function> function will now raise a fatal error.</entry>
       </row>
       <row>

--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -225,6 +225,14 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.0</entry>
+       <entry>Defining a custom <function>assert</function> function will now raise a fatal error.</entry>
+      </row>
+      <row>
+       <entry>7.3.0</entry>
+       <entry>Defining a custom <function>assert</function> function will now emit an <constant>E_DEPRECATED</constant>.</entry>
+      </row>
+      <row>
        <entry>7.2.0</entry>
        <entry>
         Usage of a <type>string</type> as the <parameter>assertion</parameter>


### PR DESCRIPTION
Added changelog notes to `assert` about it no longer being possible to declare a custom function.