### PR TITLE
Note that all visibilities of trait abstract methods are supported.

### DIFF
--- a/language/oop5/traits.xml
+++ b/language/oop5/traits.xml
@@ -325,7 +325,7 @@ Hello World!
    <title>Abstract Trait Members</title>
    <para>
     Traits support the use of abstract methods in order to impose requirements
-    upon the exhibiting class.
+    upon the exhibiting class. Public, protected, and private methods are supported.
    </para>
    <caution>
     <simpara>

--- a/language/oop5/traits.xml
+++ b/language/oop5/traits.xml
@@ -326,6 +326,7 @@ Hello World!
    <para>
     Traits support the use of abstract methods in order to impose requirements
     upon the exhibiting class. Public, protected, and private methods are supported.
+    Prior to PHP 8.0.0, only protected and private abstract methods were supported.
    </para>
    <caution>
     <simpara>


### PR DESCRIPTION
The docs didn't specify before, so I just clarified that it does now work on all of them.