### PR TITLE
[80538] Shorthand syntax for array destruction

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -744,7 +744,7 @@ function small_numbers()
 // Array destruction will collect each member of the array individually
 [$zero, $one, $two] = small_numbers();
 
-// Equivalent to array destruction using list() construct
+// Prior to 7.1.0, the only equivalent alternative is using list() construct
 list($zero, $one, $two) = small_numbers();
 
 ?>

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -741,7 +741,7 @@ function small_numbers()
 {
     return [0, 1, 2];
 }
-// Array destruction will collect each member of the array individually
+// Array destructuring will collect each member of the array individually
 [$zero, $one, $two] = small_numbers();
 
 // Prior to 7.1.0, the only equivalent alternative is using list() construct

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -741,9 +741,10 @@ function small_numbers()
 {
     return [0, 1, 2];
 }
+// Array destruction will collect each member of the array individually
 [$zero, $one, $two] = small_numbers();
 
-// For PHP 7.0 or lower
+// Equivalent to array destruction using list() construct
 list($zero, $one, $two) = small_numbers();
 
 ?>

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -739,9 +739,13 @@ echo square(4);   // outputs '16'.
 <?php
 function small_numbers()
 {
-    return array (0, 1, 2);
+    return [0, 1, 2];
 }
-list ($zero, $one, $two) = small_numbers();
+[$zero, $one, $two] = small_numbers();
+
+// For PHP 7.0 or lower
+list($zero, $one, $two) = small_numbers();
+
 ?>
 ]]>
       </programlisting>


### PR DESCRIPTION
This pull request updates the return value documentation for functions to reflect newer syntax provided by PHP as reported in https://bugs.php.net/bug.php?id=80538