### PR TITLE
[80502] Document 0 < (empty string)

### DIFF
--- a/language/operators.xml
+++ b/language/operators.xml
@@ -1486,7 +1486,7 @@ Expression: 0 = -4 << 62
     <para>
      Prior to PHP 8.0.0, if a <type>string</type> is compared to a number
      or a numeric string then the <type>string</type> was converted to a
-     number before performing the comparison. This can lead to surprising
+     number before performing the comparison. This could lead to surprising
      results as can be seen with the following example:
      <informalexample>
       <programlisting role="php">
@@ -1496,6 +1496,7 @@ var_dump(0 == "a"); // 0 == 0 -> true
 var_dump("1" == "01"); // 1 == 1 -> true
 var_dump("10" == "1e1"); // 10 == 10 -> true
 var_dump(100 == "1e2"); // 100 == 100 -> true
+var_dump("" < 0);  // 0 < 0 -> false
 
 switch ("a") {
 case 0:
@@ -1503,6 +1504,29 @@ case 0:
     break;
 case "a": // never reached because "a" is already matched with 0
     echo "a";
+    break;
+}
+?>
+]]>
+      </programlisting>
+     </informalexample>
+     As of PHP 8.0.0:
+     <informalexample>
+      <programlisting role="php">
+       <![CDATA[
+<?php
+var_dump(0 == "a"); // "0" == "a" -> false
+var_dump("1" == "01"); // 1 == 1 -> true
+var_dump("10" == "1e1"); // 10 == 10 -> true
+var_dump(100 == "1e2"); // 100 == 100 -> true
+var_dump("" < 0);  // "" < "0" -> true
+
+switch ("a") {
+case 0:
+    echo "0";
+    break;
+case "a":
+    echo "a"; // output: "a"
     break;
 }
 ?>


### PR DESCRIPTION
As mentioned in https://bugs.php.net/bug.php?id=80502 the comparison between `0 < ''` has changed in PHP 8.0.0 due to saner string comparison RFC.