### PR TITLE
Fix infinite loop possibility in fwrite example

### DIFF
--- a/reference/filesystem/functions/fwrite.xml
+++ b/reference/filesystem/functions/fwrite.xml
@@ -65,7 +65,8 @@
   &reftitle.returnvalues;
   <simpara>
    <function>fwrite</function> returns the number of bytes
-   written, or &false; on error.
+   written, or &false; on some errors.  Note that some error conditions
+   may cause 0 to be returned.
   </simpara>
  </refsect1>
 
@@ -81,7 +82,10 @@
 function fwrite_stream($fp, $string) {
     for ($written = 0; $written < strlen($string); $written += $fwrite) {
         $fwrite = fwrite($fp, substr($string, $written));
-        if ($fwrite === false) {
+        // since fwrite can return either false or 0 on error
+        // (depending on the nature of the error)
+        // we need to do a loose test (or multiple checks)
+        if (!$fwrite) {
             return $written;
         }
     }


### PR DESCRIPTION
One of the proposed changes from bug #51006 is incorrect.  Because some error conditions cause fwrite to return 0 (bytes written), this can create a condition where on each iteration, it fails to write without updating `$written`.  In those situations, the code as written loops forever.  

Switching back to the loose check causes it to return when that happens, breaking the loop.  

https://bugs.php.net/bug.php?id=51006
https://www.php.net/manual/en/function.fwrite.php#96951

If this is the wrong protocol for reporting/fixing this, please advise on how to go about proposing this change.  