### PR TITLE
Expand XSL Documentation Example

### DIFF
--- a/reference/xsl/examples.xml
+++ b/reference/xsl/examples.xml
@@ -38,7 +38,7 @@
  <xsl:param name="owner" select="'Nicolas Eliaszewicz'"/>
  <xsl:output method="html" encoding="iso-8859-1" indent="no"/>
  <xsl:template match="collection">
-  Hey! Welcome to <xsl:value-of select="$owner"/>'s sweet CD collection! 
+  Hey! Welcome to <xsl:value-of select="$owner"/>'s sweet CD collection!
   <xsl:apply-templates/>
  </xsl:template>
  <xsl:template match="cd">
@@ -47,6 +47,48 @@
   <hr />
  </xsl:template>
 </xsl:stylesheet>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   To transform the content of the <filename>collection.xml</filename> we
+   use <methodname>XSLTProcessor::importStyleSheet</methodname> to load our
+   <filename>collection.xsl</filename>. We then transform the XML document
+   using <methodname>XSLTProcessor::transformToXML</methodname>.
+  </para>
+  <para>
+   <example>
+    <title>index.php</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+    $xslDoc = new DOMDocument();
+    $xslDoc->load("collection.xsl");
+
+    $xmlDoc = new DOMDocument();
+    $xmlDoc->load("collection.xml");
+
+    $proc = new XSLTProcessor();
+    $proc->importStylesheet($xslDoc);
+    echo $proc->transformToXML($xmlDoc);
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   Applying this transformation yields the following Output:
+  </para>
+  <para>
+   <example>
+    <title>Output of <filename>index.php</filename></title>
+    <programlisting role="html">
+<![CDATA[
+Hey! Welcome to Nicolas Eliaszewicz's sweet CD collection!
+
+<h1>Fight for your mind</h1><h2>by Ben Harper - 1995</h2><hr>
+<h1>Electric Ladyland</h1><h2>by Jimi Hendrix - 1997</h2><hr>
 ]]>
     </programlisting>
    </example>


### PR DESCRIPTION
The current XSL documentation has two examples, the [first](https://www.php.net/manual/en/xsl.examples-collection.php) being very brief. It currently only contains an XML and an XSLT file.

This PR expands the example by adding the code posted as a _User Contributed Note_ on the main [Examples](https://www.php.net/manual/en/xsl.examples.php) page and also adds the HTML output.