### PR TITLE
Add union type to streamWrapper::stream_stat

### DIFF
--- a/reference/stream/streamwrapper/stream-stat.xml
+++ b/reference/stream/streamwrapper/stream-stat.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>array</type><methodname>streamWrapper::stream_stat</methodname>
+   <modifier>public</modifier><type class="union"><type>array</type><type>false</type></type><methodname>streamWrapper::stream_stat</methodname>
    <void />
   </methodsynopsis>
   <para>


### PR DESCRIPTION
Add a union here to keep the same signature of `stat()` and to document a valid behavior.