### PR TITLE
Add example of a float string as an array key

### DIFF
--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -280,13 +280,14 @@ $array = array(
     "1"  => "b", // the value "a" will be overwritten by "b"
     1.5  => "c", // the value "b" will be overwritten by "c"
     -1 => 'd',
-    "01"  => "e",
+    "01"  => "e", // as this is not an integer string it will NOT override the key for 1
     true => "f", // the value "c" will be overwritten by "f"
     false => 'g',
     '' => 'h',
     null => 'i', // the value "h" will be overwritten by "i"
     'j', // value "j" is assigned the key 2. This is because the largest integer key before that was 1
     2 => 'k', // the value "j" will be overwritten by "k"
+    '1.5' => 'l', // as this is not an integer string it will NOT override the key for 1
 );
 
 var_dump($array);
@@ -296,7 +297,7 @@ var_dump($array);
     &example.outputs;
     <screen>
 <![CDATA[
-array(6) {
+array(7) {
   [1]=>
   string(1) "f"
   [-1]=>
@@ -309,6 +310,8 @@ array(6) {
   string(1) "i"
   [2]=>
   string(1) "k"
+  ["1.5"]=>
+  string(1) "l"
 }
 ]]>
     </screen>


### PR DESCRIPTION
The behaviour is different from a float key

Don't know if I should reorder the key values to move it next to the key `"01"`.

(Also should we fix the mixing of double quotes and single quote string keys?)