### PR TITLE
Correct Closure::bindTo failure return value

### DIFF
--- a/language/predefined/closure/bindto.xml
+++ b/language/predefined/closure/bindto.xml
@@ -87,7 +87,7 @@
   &reftitle.returnvalues;
   <para>
    Returns the newly created <classname>Closure</classname> object
-   &return.nullforfailure;
+   or &.null on failure.
   </para>
  </refsect1>
 

--- a/language/predefined/closure/bindto.xml
+++ b/language/predefined/closure/bindto.xml
@@ -87,7 +87,7 @@
   &reftitle.returnvalues;
   <para>
    Returns the newly created <classname>Closure</classname> object
-   or &.null on failure.
+   or &null; on failure.
   </para>
  </refsect1>
 

--- a/language/predefined/closure/bindto.xml
+++ b/language/predefined/closure/bindto.xml
@@ -12,7 +12,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type class="union"><type>Closure</type><type>false</type></type><methodname>Closure::bindTo</methodname>
+   <modifier>public</modifier> <type class="union"><type>Closure</type><type>null</type></type><methodname>Closure::bindTo</methodname>
    <methodparam><type>object</type><parameter>newthis</parameter></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>newscope</parameter>
    <initializer>"static"</initializer></methodparam>
@@ -87,7 +87,7 @@
   &reftitle.returnvalues;
   <para>
    Returns the newly created <classname>Closure</classname> object
-   &return.falseforfailure;
+   &return.nullforfailure;
   </para>
  </refsect1>
 


### PR DESCRIPTION
`Closure::bindTo()` appears to return `null` on failure, not the documented `false`. This corrects the documentation to match the exhibited behavior.

Context: https://github.com/phpstan/phpstan/issues/4716 and repro script: https://3v4l.org/no5qG

Internals: https://github.com/php/php-src/blob/dcac654fd56a2cecec0c187ba061ecc82bbc9031/Zend/zend_closures.c#L219-L221

Also, reflection shows `?Closure`:

```
$ php --rc Closure
Class [ <internal:Core> final class Closure ] {

  ...

  - Methods [3] {
  ...
    Method [ <internal:Core> public method bindTo ] {

      - Parameters [2] {
        Parameter #0 [ <required> ?object $newThis ]
        Parameter #1 [ <optional> object|string|null $newScope = "static" ]
      }
      - Return [ ?Closure ]
    }
  ...
  }
}
```