### PR TITLE
Match fgetcsv parameter names to values in reflection

### DIFF
--- a/reference/filesystem/functions/fgetcsv.xml
+++ b/reference/filesystem/functions/fgetcsv.xml
@@ -10,9 +10,9 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>fgetcsv</methodname>
-   <methodparam><type>resource</type><parameter>handle</parameter></methodparam>
+   <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer>0</initializer></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>delimiter</parameter><initializer>","</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>separator</parameter><initializer>","</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>enclosure</parameter><initializer>'"'</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>escape</parameter><initializer>"\\"</initializer></methodparam>
   </methodsynopsis>
@@ -36,7 +36,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>handle</parameter></term>
+     <term><parameter>stream</parameter></term>
      <listitem>
       <para>
        A valid file pointer to a file successfully opened by
@@ -62,10 +62,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>delimiter</parameter></term>
+     <term><parameter>separator</parameter></term>
      <listitem>
       <para>
-       The optional <parameter>delimiter</parameter> parameter sets the field delimiter (one character only).
+       The optional <parameter>separator</parameter> parameter sets the field separator (one character only).
       </para>
      </listitem>
     </varlistentry>
@@ -117,7 +117,7 @@
   &note.line-endings;
   <para>
    <function>fgetcsv</function> returns &null; if an invalid
-   <parameter>handle</parameter> is supplied or &false; on other errors,
+   <parameter>stream</parameter> is supplied or &false; on other errors,
    including end of file.
   </para>
  </refsect1>


### PR DESCRIPTION
The documented parameters differ from the names exposed in reflection/source code. Now that named parameters are supported in PHP 8, this discrepancy is confusing and impactful.

```
 $ php --rf fgetcsv
Function [ <internal:standard> function fgetcsv ] {

  - Parameters [5] {
    Parameter #0 [ <required> $stream ]
    Parameter #1 [ <optional> ?int $length = null ]
    Parameter #2 [ <optional> string $separator = "," ]
    Parameter #3 [ <optional> string $enclosure = "\"" ]
    Parameter #4 [ <optional> string $escape = "\\" ]
  }
  - Return [ array|false ]
}
```