### PR TITLE
Update swoole-async-readfile.xml

### DIFF
--- a/reference/swoole/functions/swoole-async-readfile.xml
+++ b/reference/swoole/functions/swoole-async-readfile.xml
@@ -52,7 +52,7 @@
         <term><parameter>content</parameter></term>
         <listitem>
          <para>
-          The content readed from the file.
+          The content read from the file.
          </para>
         </listitem>
        </varlistentry>


### PR DESCRIPTION
Grammar correction, "read" is the correct past tense.