### PR TITLE
Language Ref/Traits: fix incorrect information about abstract methods

### DIFF
--- a/language/oop5/traits.xml
+++ b/language/oop5/traits.xml
@@ -326,7 +326,7 @@ Hello World!
    <para>
     Traits support the use of abstract methods in order to impose requirements
     upon the exhibiting class. Public, protected, and private methods are supported.
-    Prior to PHP 8.0.0, only protected and private abstract methods were supported.
+    Prior to PHP 8.0.0, only public and protected abstract methods were supported.
    </para>
    <caution>
     <simpara>


### PR DESCRIPTION
As of PHP 8.0, `abstract private` methods are allowed in `trait`s. `abstract public` method were previously already supported.

Also see: https://3v4l.org/eQY8v and https://3v4l.org/HKLcI