### PR TITLE
Updating mysqli: bind_param

### DIFF
--- a/reference/mysqli/mysqli_stmt/bind-param.xml
+++ b/reference/mysqli/mysqli_stmt/bind-param.xml
@@ -185,11 +185,9 @@ printf("%d row deleted.\n", mysqli_affected_rows($link));
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli('localhost', 'my_user', 'my_password', 'world');
 
-$array = ['DEU', 'POL'];
-
 $stmt = $mysqli->prepare("SELECT Language FROM CountryLanguage WHERE CountryCode IN (?, ?)");
 /* Using ... to provide arguments */
-$stmt->bind_param(str_repeat('s', count($array)), ...$array);
+$stmt->bind_param('ss', ...['DEU', 'POL']);
 $stmt->execute();
 $stmt->store_result();
 

--- a/reference/mysqli/mysqli_stmt/bind-param.xml
+++ b/reference/mysqli/mysqli_stmt/bind-param.xml
@@ -122,13 +122,14 @@
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli('localhost', 'my_user', 'my_password', 'world');
 
+$stmt = $mysqli->prepare("INSERT INTO CountryLanguage VALUES (?, ?, ?, ?)");
+$stmt->bind_param('sssd', $code, $language, $official, $percent);
+
 $code = 'DEU';
 $language = 'Bavarian';
 $official = "F";
 $percent = 11.2;
 
-$stmt = $mysqli->prepare("INSERT INTO CountryLanguage VALUES (?, ?, ?, ?)");
-$stmt->bind_param('sssd', $code, $language, $official, $percent);
 $stmt->execute();
 
 printf("%d row inserted.\n", $stmt->affected_rows);
@@ -146,13 +147,14 @@ printf("%d row deleted.\n", $mysqli->affected_rows);
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $link = mysqli_connect('localhost', 'my_user', 'my_password', 'world');
 
+$stmt = mysqli_prepare($link, "INSERT INTO CountryLanguage VALUES (?, ?, ?, ?)");
+mysqli_stmt_bind_param($stmt, 'sssd', $code, $language, $official, $percent);
+
 $code = 'DEU';
 $language = 'Bavarian';
 $official = "F";
 $percent = 11.2;
 
-$stmt = mysqli_prepare($link, "INSERT INTO CountryLanguage VALUES (?, ?, ?, ?)");
-mysqli_stmt_bind_param($stmt, 'sssd', $code, $language, $official, $percent);
 mysqli_stmt_execute($stmt);
 
 printf("%d row inserted.\n", mysqli_stmt_affected_rows($stmt));

--- a/reference/mysqli/mysqli_stmt/bind-param.xml
+++ b/reference/mysqli/mysqli_stmt/bind-param.xml
@@ -25,8 +25,8 @@
    <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Bind variables for the parameter markers in the SQL statement that was
-   passed to <function>mysqli_prepare</function>.
+   Bind variables for the parameter markers in the SQL statement prepared by
+   <function>mysqli_prepare</function> or <function>mysqli_stmt_prepare</function>.
   </para>
   <note>
    <para>

--- a/reference/mysqli/mysqli_stmt/bind-param.xml
+++ b/reference/mysqli/mysqli_stmt/bind-param.xml
@@ -117,37 +117,24 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli('localhost', 'my_user', 'my_password', 'world');
-
-/* check connection */
-if (mysqli_connect_errno()) {
-    printf("Connect failed: %s\n", mysqli_connect_error());
-    exit();
-}
-
-$stmt = $mysqli->prepare("INSERT INTO CountryLanguage VALUES (?, ?, ?, ?)");
-$stmt->bind_param('sssd', $code, $language, $official, $percent);
 
 $code = 'DEU';
 $language = 'Bavarian';
 $official = "F";
 $percent = 11.2;
 
-/* execute prepared statement */
+$stmt = $mysqli->prepare("INSERT INTO CountryLanguage VALUES (?, ?, ?, ?)");
+$stmt->bind_param('sssd', $code, $language, $official, $percent);
 $stmt->execute();
 
 printf("%d Row inserted.\n", $stmt->affected_rows);
 
-/* close statement and connection */
-$stmt->close();
-
 /* Clean up table CountryLanguage */
 $mysqli->query("DELETE FROM CountryLanguage WHERE Language='Bavarian'");
 printf("%d Row deleted.\n", $mysqli->affected_rows);
-
-/* close connection */
-$mysqli->close();
-?>
 ]]>
    </programlisting>
   </example>
@@ -156,37 +143,24 @@ $mysqli->close();
    <programlisting role="php">
 <![CDATA[
 <?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $link = mysqli_connect('localhost', 'my_user', 'my_password', 'world');
-
-/* check connection */
-if (!$link) {
-    printf("Connect failed: %s\n", mysqli_connect_error());
-    exit();
-}
-
-$stmt = mysqli_prepare($link, "INSERT INTO CountryLanguage VALUES (?, ?, ?, ?)");
-mysqli_stmt_bind_param($stmt, 'sssd', $code, $language, $official, $percent);
 
 $code = 'DEU';
 $language = 'Bavarian';
 $official = "F";
 $percent = 11.2;
 
-/* execute prepared statement */
+$stmt = mysqli_prepare($link, "INSERT INTO CountryLanguage VALUES (?, ?, ?, ?)");
+mysqli_stmt_bind_param($stmt, 'sssd', $code, $language, $official, $percent);
 mysqli_stmt_execute($stmt);
 
 printf("%d Row inserted.\n", mysqli_stmt_affected_rows($stmt));
 
-/* close statement and connection */
-mysqli_stmt_close($stmt);
-
 /* Clean up table CountryLanguage */
 mysqli_query($link, "DELETE FROM CountryLanguage WHERE Language='Bavarian'");
 printf("%d Row deleted.\n", mysqli_affected_rows($link));
-
-/* close connection */
-mysqli_close($link);
-?>
 ]]>
    </programlisting>
    &examples.outputs;

--- a/reference/mysqli/mysqli_stmt/bind-param.xml
+++ b/reference/mysqli/mysqli_stmt/bind-param.xml
@@ -113,7 +113,8 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>&style.oop;</title>
+   <title><methodname>mysqli_stmt::bind_param</methodname> example</title>
+   <para>&style.oop;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -137,9 +138,7 @@ $mysqli->query("DELETE FROM CountryLanguage WHERE Language='Bavarian'");
 printf("%d Row deleted.\n", $mysqli->affected_rows);
 ]]>
    </programlisting>
-  </example>
-  <example>
-   <title>&style.procedural;</title>
+   <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/mysqli/mysqli_stmt/bind-param.xml
+++ b/reference/mysqli/mysqli_stmt/bind-param.xml
@@ -183,9 +183,11 @@ printf("%d row deleted.\n", mysqli_affected_rows($link));
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli('localhost', 'my_user', 'my_password', 'world');
 
+$array = ['DEU', 'POL'];
+
 $stmt = $mysqli->prepare("SELECT Language FROM CountryLanguage WHERE CountryCode IN (?, ?)");
 /* Using ... to provide arguments */
-$stmt->bind_param('ss', ...['DEU', 'POL']);
+$stmt->bind_param(str_repeat('s', count($array)), ...$array);
 $stmt->execute();
 $stmt->store_result();
 

--- a/reference/mysqli/mysqli_stmt/bind-param.xml
+++ b/reference/mysqli/mysqli_stmt/bind-param.xml
@@ -131,11 +131,11 @@ $stmt = $mysqli->prepare("INSERT INTO CountryLanguage VALUES (?, ?, ?, ?)");
 $stmt->bind_param('sssd', $code, $language, $official, $percent);
 $stmt->execute();
 
-printf("%d Row inserted.\n", $stmt->affected_rows);
+printf("%d row inserted.\n", $stmt->affected_rows);
 
 /* Clean up table CountryLanguage */
 $mysqli->query("DELETE FROM CountryLanguage WHERE Language='Bavarian'");
-printf("%d Row deleted.\n", $mysqli->affected_rows);
+printf("%d row deleted.\n", $mysqli->affected_rows);
 ]]>
    </programlisting>
    <para>&style.procedural;</para>
@@ -155,18 +155,47 @@ $stmt = mysqli_prepare($link, "INSERT INTO CountryLanguage VALUES (?, ?, ?, ?)")
 mysqli_stmt_bind_param($stmt, 'sssd', $code, $language, $official, $percent);
 mysqli_stmt_execute($stmt);
 
-printf("%d Row inserted.\n", mysqli_stmt_affected_rows($stmt));
+printf("%d row inserted.\n", mysqli_stmt_affected_rows($stmt));
 
 /* Clean up table CountryLanguage */
 mysqli_query($link, "DELETE FROM CountryLanguage WHERE Language='Bavarian'");
-printf("%d Row deleted.\n", mysqli_affected_rows($link));
+printf("%d row deleted.\n", mysqli_affected_rows($link));
 ]]>
    </programlisting>
    &examples.outputs;
    <screen>
 <![CDATA[
-1 Row inserted.
-1 Row deleted.
+1 row inserted.
+1 row deleted.
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>Using <literal>...</literal> to provide arguments</title>
+   <para>
+    The <literal>...</literal> operator can be used to provide variable-length
+    argument list, e.g. in a <literal>WHERE IN</literal> clause.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = new mysqli('localhost', 'my_user', 'my_password', 'world');
+
+$stmt = $mysqli->prepare("SELECT Language FROM CountryLanguage WHERE CountryCode IN (?, ?)");
+/* Using ... to provide arguments */
+$stmt->bind_param('ss', ...['DEU', 'POL']);
+$stmt->execute();
+$stmt->store_result();
+
+printf("%d rows found.\n", $stmt->num_rows());
+]]>
+   </programlisting>
+   &examples.outputs;
+   <screen>
+<![CDATA[
+10 rows found.
 ]]>
    </screen>
   </example>


### PR DESCRIPTION
This PR aims to improve examples for parameter binding. The existing examples were simplified to show only the important bits, and a new example was added to show how to bind values from arrays. 

I moved variable assignment before prepare() but I am having second thoughts now. Some people are unaware of how binding by reference works, so creating them after bind_param() in the example makes sense. 

I am not sure about the second-last commit cebb442e040d063cbb8af572a36ca23e91c17159. If the PR is better without it, then we can drop it. 