### PR TITLE
Updating mysqli: fetch_all

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1656,8 +1656,8 @@ returned by <function>fbsql_query</function> or
 <!-- MySQLi Notes -->
 <!ENTITY mysqli.result.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>
 result</parameter></term><listitem><para>Procedural style only: A result set
-identifier returned by <function>mysqli_query</function>, <function>mysqli_store_result</function>
-or <function>mysqli_use_result</function>.</para></listitem></varlistentry>'>
+identifier returned by <function>mysqli_query</function>, <function>mysqli_store_result</function>,
+<function>mysqli_use_result</function> or <function>mysqli_stmt_get_result</function>.</para></listitem></varlistentry>'>
 <!ENTITY mysqli.link.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>
 link</parameter></term><listitem><para>Procedural style only: A link identifier
 returned by <function>mysqli_connect</function> or <function>mysqli_init</function>

--- a/reference/mysqli/mysqli_result/fetch-all.xml
+++ b/reference/mysqli/mysqli_result/fetch-all.xml
@@ -59,18 +59,6 @@
   <para>
    &mysqli.available.mysqlnd;
   </para>
-
-  <para>
-    As <function>mysqli_fetch_all</function> returns all the rows as an
-    array in a single step, it may consume more memory than some similar
-    functions such as <function>mysqli_fetch_array</function>, which
-    only returns one row at a time from the result set. Further, if you
-    need to iterate over the result set, you will need a looping
-    construct that will further impact performance. For these reasons
-    <function>mysqli_fetch_all</function> should only be used in those
-    situations where the fetched result set will be sent to another
-    layer for processing.
-  </para>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mysqli/mysqli_result/fetch-all.xml
+++ b/reference/mysqli/mysqli_result/fetch-all.xml
@@ -61,6 +61,53 @@
   </para>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>mysqli_result::fetch_all</methodname> example</title>
+   <para>&style.oop;</para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = new mysqli("localhost", "my_user", "my_password", "world");
+
+$result = $mysqli->query("SELECT Name, CountryCode FROM City ORDER BY ID LIMIT 3");
+
+$rows = $result->fetch_all(MYSQLI_ASSOC);
+foreach ($rows as $row) {
+    printf("%s (%s)\n", $row["Name"], $row["CountryCode"]);
+}
+]]>
+   </programlisting>
+   <para>&style.procedural;</para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = mysqli_connect("localhost", "my_user", "my_password", "world");
+
+$result = mysqli_query($mysqli, "SELECT Name, CountryCode FROM City ORDER BY ID LIMIT 3");
+
+$rows = mysqli_fetch_all($result, MYSQLI_ASSOC);
+foreach ($rows as $row) {
+    printf("%s (%s)\n", $row["Name"], $row["CountryCode"]);
+}
+]]>
+   </programlisting>
+   &examples.outputs;
+   <screen>
+<![CDATA[
+Kabul (AFG)
+Qandahar (AFG)
+Herat (AFG)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/mysqli/mysqli_result/fetch-all.xml
+++ b/reference/mysqli/mysqli_result/fetch-all.xml
@@ -4,7 +4,7 @@
  <refnamediv>
   <refname>mysqli_result::fetch_all</refname>
   <refname>mysqli_fetch_all</refname>
-  <refpurpose>Fetches all result rows as an associative array, a numeric array, or both</refpurpose>
+  <refpurpose>Fetch all result rows as an associative array, a numeric array, or both</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -21,8 +21,8 @@
    <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>MYSQLI_NUM</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>mysqli_fetch_all</function> fetches all result rows and returns the result 
-   set as an associative array, a numeric array, or both.
+   Returns a two-dimensional array of all result rows 
+   as an associative array, a numeric array, or both.
   </para>
  </refsect1>
 


### PR DESCRIPTION
This page was missing an example. I have created a simple example with a single fetch mode. 

While I was at it I read the note about mysqlnd. I have spent more time than I care to admit trying to understand what it said. As a result, I decided to remove it. It might be technically correct; processing the data row by row will use less memory as long as you discard the previous row every iteration. This is a no-brainer. But people looking at fetch_all are interested in fetching all of the data into an array, in which case fetch_all is a perfect choice. I removed the note because it was comparing apples to oranges and I couldn't find any sensible way to rewrite it and still make sense. If we compare apples to apples, then fetch_all consumes the same amount of memory and is faster. 

The procedural parameter snippet was expanded to cover `get_result()`

P.S. After PHP 8.1 release we should remember to add a changelog and then we can remove the mysqlnd section.