### PR TITLE
Fix half-deleted sentence about "new" and reference assignment

### DIFF
--- a/language/references.xml
+++ b/language/references.xml
@@ -95,10 +95,13 @@ $foo =& find_var($bar);
 ]]>
       </programlisting>
      </informalexample>
-     <link linkend="language.oop5.basic.new">new</link>
-     returns a reference automatically, thus it is syntactically invalid.
-     For more information, see <link linkend="language.oop5.references">Objects
-     and references</link>.)
+    </para>
+    <para>
+     Using the same syntax with a function that does <emphasis>not</emphasis>
+     return by reference will give an error, as will using it with the result
+     of the <link linkend="language.oop5.basic.new">new</link> operator.
+     Although objects are passed around as pointers, these are not the same as references,
+     as explained under <link linkend="language.oop5.references">Objects and references</link>.
     </para>
     <warning>
      <para>


### PR DESCRIPTION
This had a stray ")", and was left with a misleading half-sentence
about "new" returning a reference, which it doesn't.