### PR TITLE
Fix attributes overview example emitting E_WARNING

### DIFF
--- a/language/attributes.xml
+++ b/language/attributes.xml
@@ -71,7 +71,7 @@ class CopyFile implements ActionHandler
         if (!file_exists($this->targetDirectory)) {
             mkdir($this->targetDirectory);
         } elseif (!is_dir($this->targetDirectory)) {
-            throw new RuntimeException("A file already exists with the name $this->targetDirectory");
+            throw new RuntimeException("Target directory $this->targetDirectory is not a directory");
         }
     }
 

--- a/language/attributes.xml
+++ b/language/attributes.xml
@@ -68,8 +68,10 @@ class CopyFile implements ActionHandler
     #[SetUp]
     public function targetDirectoryExists()
     {
-        if (!is_dir($this->targetDirectory)) {
+        if (!file_exists($this->targetDirectory)) {
             mkdir($this->targetDirectory);
+        } elseif (!is_dir($this->targetDirectory)) {
+            throw new RuntimeException("A file already exists with the name $this->targetDirectory");
         }
     }
 

--- a/language/attributes.xml
+++ b/language/attributes.xml
@@ -68,7 +68,9 @@ class CopyFile implements ActionHandler
     #[SetUp]
     public function targetDirectoryExists()
     {
-        mkdir($this->targetDirectory);
+        if (!is_dir($this->targetDirectory)) {
+            mkdir($this->targetDirectory);
+        }
     }
 
     public function execute()


### PR DESCRIPTION
The method `targetDirectoryExists` in the attributes overview example emits **E_WARNING** if `$targetDirectory` already exists. This PR fixes this issue by wrapping the `mkdir` call in an `is_dir` check. 

### File exists warning.

![Example code ran showing the file exists warning](https://user-images.githubusercontent.com/2221746/114440484-7f842d80-9bca-11eb-8d53-43514a8b8e38.png)

### Cause of the warning.

https://github.com/php/doc-en/blob/68a416eeb74a6df5b7e31b77cfa5e91a4c368844/language/attributes.xml#L69-L72
