### PR TITLE
Remove or rewrite examples using implode("", file(...))

### DIFF
--- a/reference/filesystem/functions/file.xml
+++ b/reference/filesystem/functions/file.xml
@@ -137,9 +137,6 @@ foreach ($lines as $line_num => $line) {
     echo "Line #<b>{$line_num}</b> : " . htmlspecialchars($line) . "<br />\n";
 }
 
-// Another example, let's get a web page into a string.  See also file_get_contents().
-$html = implode('', file('http://www.example.com/'));
-
 // Using the optional flags parameter since PHP 5
 $trimmed = file('somefile.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
 ?>
@@ -158,11 +155,11 @@ $trimmed = file('somefile.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
   &reftitle.seealso;
   <para>
    <simplelist>
+    <member><function>file_get_contents</function></member>
     <member><function>readfile</function></member>
     <member><function>fopen</function></member>
     <member><function>fsockopen</function></member>
     <member><function>popen</function></member>
-    <member><function>file_get_contents</function></member>
     <member><function>include</function></member>
     <member><function>stream_context_create</function></member>
    </simplelist>

--- a/reference/xml/functions/xml-parse-into-struct.xml
+++ b/reference/xml/functions/xml-parse-into-struct.xml
@@ -168,7 +168,7 @@ Array
    Event-driven parsing (based on the expat library) can get
    complicated when you have an XML document that is complex.
    This function does not produce a DOM style object, but it
-   generates structures amenable of being transversed in a tree
+   generates structures amenable of being traversed in a tree
    fashion. Thus, we can create objects representing the data
    in the XML file easily. Let's consider the following XML file
    representing a small database of aminoacids information:
@@ -224,7 +224,7 @@ class AminoAcid {
 function readDatabase($filename) 
 {
     // read the XML database of aminoacids
-    $data = implode("", file($filename));
+    $data = file_get_contents($filename);
     $parser = xml_parser_create();
     xml_parser_set_option($parser, XML_OPTION_CASE_FOLDING, 0);
     xml_parser_set_option($parser, XML_OPTION_SKIP_WHITE, 1);

--- a/reference/zlib/functions/gzencode.xml
+++ b/reference/zlib/functions/gzencode.xml
@@ -88,11 +88,9 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$data = implode("", file("bigfile.txt"));
+$data = file_get_contents("bigfile.txt");
 $gzdata = gzencode($data, 9);
-$fp = fopen("bigfile.txt.gz", "w");
-fwrite($fp, $gzdata);
-fclose($fp);
+file_put_contents("bigfile.txt.gz", $gzdata);
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
This is a weirdly inefficient way of getting a file's content into
a string, and I'm not sure why anyone would think it was a good
idea.