### PR TITLE
PHP 8.0 migration/deprecated: expand on libxml_disable_entity_loader()

### DIFF
--- a/appendices/migration80/deprecated.xml
+++ b/appendices/migration80/deprecated.xml
@@ -95,7 +95,10 @@ function test(?A $a, $b) {}       // Recommended
   <para>
    <function>libxml_disable_entity_loader</function> has been deprecated. As libxml 2.9.0 is now
    required, external entity loading is guaranteed to be disabled by default, and this function is
-   no longer needed to protect against XXE attacks.
+   no longer needed to protect against XXE attacks, unless the (still vulnerable).
+   <constant>LIBXML_NOENT</constant> is used.
+   In that case, it is recommended to refactor the code using
+   <function>libxml_set_external_entity_loader</function> to suppress loading of external entities.
   </para>
  </sect2>
 

--- a/reference/libxml/functions/libxml-disable-entity-loader.xml
+++ b/reference/libxml/functions/libxml-disable-entity-loader.xml
@@ -99,7 +99,7 @@
    <simplelist>
     <member><function>libxml_use_internal_errors</function></member>
     <member><function>libxml_set_external_entity_loader</function></member>
-    <member><link linkend="libxml.constants">The <constant>LIBXML_NONET</constant> constant</link></member>
+    <member><link linkend="libxml.constants">The <constant>LIBXML_NOENT</constant> constant</link></member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
The current text in the migration guide about the deprecation of `libxml_disable_entity_loader()` is misleading and can easily lead to the introduction of XXE vulnerable code.

In select circumstances, when `LIBXML_NOENT` is used, code can still be vulnerable to XXE attacks, even on PHP 8.0.
So I'm proposing to add an appropriate warning and mention the upgrade path in the migration guide.

Includes fixing a typo on the `libxml_disable_entity_loader()` page.