### PR TITLE
Undocumented behavior in FILTER_SANITIZE_STRING

### DIFF
--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -335,7 +335,7 @@
          <constant>FILTER_FLAG_ENCODE_HIGH</constant>,
          <constant>FILTER_FLAG_ENCODE_AMP</constant>
         </entry>
-        <entry>Strip tags and encode "', optionally strip or encode special characters.</entry>
+        <entry>Strip tags and encode <literal>"'</literal>, optionally strip or encode special characters.</entry>
        </row>
        <row>
         <entry><constant>FILTER_SANITIZE_STRIPPED</constant></entry>

--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -335,7 +335,7 @@
          <constant>FILTER_FLAG_ENCODE_HIGH</constant>,
          <constant>FILTER_FLAG_ENCODE_AMP</constant>
         </entry>
-        <entry>Strip tags, optionally strip or encode special characters.</entry>
+        <entry>Strip tags and encode "', optionally strip or encode special characters.</entry>
        </row>
        <row>
         <entry><constant>FILTER_SANITIZE_STRIPPED</constant></entry>

--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -335,7 +335,7 @@
          <constant>FILTER_FLAG_ENCODE_HIGH</constant>,
          <constant>FILTER_FLAG_ENCODE_AMP</constant>
         </entry>
-        <entry>Strip tags and encode <literal>"'</literal>, optionally strip or encode special characters.</entry>
+        <entry>Strip tags and encode <literal>"'</literal>, optionally strip or encode special characters. Encoding quotes can be disabled by setting <constant>FILTER_FLAG_NO_ENCODE_QUOTES</constant>.</entry>
        </row>
        <row>
         <entry><constant>FILTER_SANITIZE_STRIPPED</constant></entry>

--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -335,7 +335,10 @@
          <constant>FILTER_FLAG_ENCODE_HIGH</constant>,
          <constant>FILTER_FLAG_ENCODE_AMP</constant>
         </entry>
-        <entry>Strip tags and encode double and single quotes, optionally strip or encode special characters. Encoding quotes can be disabled by setting <constant>FILTER_FLAG_NO_ENCODE_QUOTES</constant>.</entry>
+        <entry>
+         Strip tags and encode double and single quotes, optionally strip or encode special characters. Encoding quotes can be
+         disabled by setting <constant>FILTER_FLAG_NO_ENCODE_QUOTES</constant>.
+        </entry>
        </row>
        <row>
         <entry><constant>FILTER_SANITIZE_STRIPPED</constant></entry>

--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -336,7 +336,8 @@
          <constant>FILTER_FLAG_ENCODE_AMP</constant>
         </entry>
         <entry>
-         Strip tags and encode double and single quotes, optionally strip or encode special characters. Encoding quotes can be
+         Strip tags and HTML-encode double and single quotes, optionally strip
+         or encode special characters. Encoding quotes can be
          disabled by setting <constant>FILTER_FLAG_NO_ENCODE_QUOTES</constant>.
         </entry>
        </row>

--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -335,7 +335,7 @@
          <constant>FILTER_FLAG_ENCODE_HIGH</constant>,
          <constant>FILTER_FLAG_ENCODE_AMP</constant>
         </entry>
-        <entry>Strip tags and encode <literal>"'</literal>, optionally strip or encode special characters. Encoding quotes can be disabled by setting <constant>FILTER_FLAG_NO_ENCODE_QUOTES</constant>.</entry>
+        <entry>Strip tags and encode double and single quotes, optionally strip or encode special characters. Encoding quotes can be disabled by setting <constant>FILTER_FLAG_NO_ENCODE_QUOTES</constant>.</entry>
        </row>
        <row>
         <entry><constant>FILTER_SANITIZE_STRIPPED</constant></entry>


### PR DESCRIPTION
We found the description for the filter `FILTER_SANITIZE_STRING` misleading. It says in https://www.php.net/manual/en/filter.filters.sanitize.php:

> Strip tags, optionally strip or encode special characters.

But apart from removing tags, this filter also encodes quotes.

Example: 
``` php
<?php
echo filter_var("'\"", FILTER_SANITIZE_STRING);
// >> &#39;&#34;
```

This seems to be the result of the following line in the sourcecode: 
https://github.com/php/php-src/blob/0236bbc777e8ef1c72a5bb6b88bfc5f843627eab/ext/filter/sanitizing_filters.c#L194

As this behavior is undocumented and led to some confusion, we propose to modify the documentation to better reflect this behavior.