### PR TITLE
Fix double "language"

### DIFF
--- a/reference/strings/functions/echo.xml
+++ b/reference/strings/functions/echo.xml
@@ -16,7 +16,7 @@
    Outputs one or more expressions, with no additional newlines or spaces.
   </simpara>
   <para>
-   <literal>echo</literal> is not a function but a language language construct.
+   <literal>echo</literal> is not a function but a language construct.
    Its arguments are a list of expressions following the <literal>echo</literal>
    keyword, separated by commas, and not delimited by parentheses.
    Unlike some other language constructs, <literal>echo</literal> does not have

--- a/reference/strings/functions/print.xml
+++ b/reference/strings/functions/print.xml
@@ -16,7 +16,7 @@
    Outputs <parameter>expression</parameter>.
   </para>
   <para>
-   <literal>print</literal> is not a function but a language language construct.
+   <literal>print</literal> is not a function but a language construct.
    Its argument is the expression following the <literal>print</literal> keyword,
    and is not delimited by parentheses.
   </para>


### PR DESCRIPTION
Replaced two instances of

> .. not a function but a language language construct.

To

> .. not a function but a language construct.