### PR TITLE
Clarify that array sorting functions are unstable only before PHP 8.0.0

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -137,7 +137,10 @@ from one file system to another.</para></note>'>
 
 <!ENTITY note.sort-unstable '<note xmlns="http://docbook.org/ns/docbook">
  <para>
-  If two members compare as equal, their relative order in the sorted array is undefined.
+  Prior to PHP 8.0.0, if two members compare as equal, their relative order in the sorted array is undefined.
+ </para>
+ <para>
+  As of PHP 8.0.0 all array sorting functions are stable.
  </para>
 </note>
 '>


### PR DESCRIPTION
Right now there's no info on documentation pages for array sorting functions, that would indicate that since PHP 8.0.0 they are stable not unstable.