### PR TITLE
Updated string & array curly brace access with support notice

### DIFF
--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -358,9 +358,10 @@ string(3) "foo"
    
    <note>
     <para>
-     Both square brackets and curly braces can be used interchangeably
-     for accessing array elements (e.g. <literal>$array[42]</literal> and <literal>$array{42}</literal> will
-     both do the same thing in the example above).
+     Prior to PHP 8.0.0, square brackets and curly braces could be used interchangeably
+     for accessing array elements (e.g. <literal>$array[42]</literal> and <literal>$array{42}</literal>
+     would both do the same thing in the example above).
+     The curly brace syntax was deprecated as of PHP 7.4.0 and no longer supported as of PHP 8.0.0.
     </para>
    </note>
 

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -808,8 +808,9 @@ echo "I'd like an {${beers::$ale}}\n";
 
    <note>
     <simpara>
-     <type>String</type>s may also be accessed using braces, as in
+     Prior to PHP 8.0.0, <type>string</type>s could also be accessed using braces, as in
      <varname>$str{42}</varname>, for the same purpose.
+     This curly brace syntax was deprecated as of PHP 7.4.0 and no longer supported as of PHP 8.0.0.
     </simpara>
    </note>
 


### PR DESCRIPTION
The documentation still states that array/string curly brace access is possible but this was deprecated as of PHP 7.4 as per this RFC: https://wiki.php.net/rfc/deprecate_curly_braces_array_access

As of PHP 8.0.0 this syntax is no longer supported. This PR specifies the changes in support for this syntax. I did think about removing these notes altogether but thought they'd still have value for people working with, or migrating, older code.

By the way, this is my first time contributing to any official PHP project so please let me know if there's a different process I should be following or if any actions need to be taken before contributing. 