### PR TITLE
Add note for passing references to invoke methods.

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2160,6 +2160,10 @@ as opposed to emitting it. Setting to &false; (the default) will do the opposite
 <!ENTITY reflection.invoke.reference 'If the function has arguments that need
 to be references, then they must be references in the passed argument list.'>
 
+<!ENTITY reflectionmethod.invoke.reference.5_4 'As call-time pass-by-reference has been removed since PHP 5.4, use <methodname xmlns="http://docbook.org/ns/docbook">ReflectionMethod::invokeArgs</methodname> instead.'>
+
+<!ENTITY reflectionfunction.invoke.reference.5_4 'As call-time pass-by-reference has been removed since PHP 5.4, use <methodname xmlns="http://docbook.org/ns/docbook">ReflectionFunction::invokeArgs</methodname> instead.'>
+
 <!ENTITY reflection.export.param.name 'The reflection to export.'>
 
 <!-- SPL -->

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2160,10 +2160,6 @@ as opposed to emitting it. Setting to &false; (the default) will do the opposite
 <!ENTITY reflection.invoke.reference 'If the function has arguments that need
 to be references, then they must be references in the passed argument list.'>
 
-<!ENTITY reflectionmethod.invoke.reference.5_4 'As call-time pass-by-reference has been removed since PHP 5.4, use <methodname xmlns="http://docbook.org/ns/docbook">ReflectionMethod::invokeArgs</methodname> instead.'>
-
-<!ENTITY reflectionfunction.invoke.reference.5_4 'As call-time pass-by-reference has been removed since PHP 5.4, use <methodname xmlns="http://docbook.org/ns/docbook">ReflectionFunction::invokeArgs</methodname> instead.'>
-
 <!ENTITY reflection.export.param.name 'The reflection to export.'>
 
 <!-- SPL -->

--- a/reference/reflection/reflectionfunction/invoke.xml
+++ b/reference/reflection/reflectionfunction/invoke.xml
@@ -76,12 +76,12 @@ Dr. Phil
   &reftitle.notes;
   <note>
    <para>
-    &reflection.invoke.reference;
+    <methodname xmlns="http://docbook.org/ns/docbook">::invoke</methodname> can't be used at all when reference parameters are expected
    </para>
   </note>
   <note>
    <para>
-    &reflectionfunction.invoke.reference.5_4;
+    <methodname xmlns="http://docbook.org/ns/docbook">::invokeArgs</methodname> has to be used instead (passing references in the argument list)
    </para>
   </note>
  </refsect1>

--- a/reference/reflection/reflectionfunction/invoke.xml
+++ b/reference/reflection/reflectionfunction/invoke.xml
@@ -79,6 +79,11 @@ Dr. Phil
     &reflection.invoke.reference;
    </para>
   </note>
+  <note>
+   <para>
+    &reflectionfunction.invoke.reference.5_4;
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/reflection/reflectionmethod/invoke.xml
+++ b/reference/reflection/reflectionmethod/invoke.xml
@@ -101,6 +101,11 @@ Hello Mike
     &reflection.invoke.reference;
    </para>
   </note>
+  <note>
+   <para>
+    &reflectionmethod.invoke.reference.5_4;
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/reflection/reflectionmethod/invoke.xml
+++ b/reference/reflection/reflectionmethod/invoke.xml
@@ -98,12 +98,12 @@ Hello Mike
   &reftitle.notes;
   <note>
    <para>
-    &reflection.invoke.reference;
+    <methodname xmlns="http://docbook.org/ns/docbook">::invoke</methodname> can't be used at all when reference parameters are expected
    </para>
   </note>
   <note>
    <para>
-    &reflectionmethod.invoke.reference.5_4;
+    <methodname xmlns="http://docbook.org/ns/docbook">::invokeArgs</methodname> has to be used instead (passing references in the argument list)
    </para>
   </note>
  </refsect1>


### PR DESCRIPTION
During running unit tests for a private method I faced the lack of
documentation about how to pass arguments by references through `invoke`
method. (See https://bugs.php.net/bug.php?id=80991) I'd like to add
notes to clarify the workaround to make it easier for others.