### PR TITLE
Fix missing space between `public` and `getPrevious` in Exception class synopsis

### DIFF
--- a/language/predefined/exception/getprevious.xml
+++ b/language/predefined/exception/getprevious.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier><type class="union"><type>Throwable</type><type>null</type></type><methodname>Exception::getPrevious</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>Throwable</type><type>null</type></type> <methodname>Exception::getPrevious</methodname>
    <void />
   </methodsynopsis>
   <para>


### PR DESCRIPTION
Screenshots: [Exception](https://user-images.githubusercontent.com/7404452/116270481-6a3d0080-a77f-11eb-84ab-9526a25b8f35.png) vs [Error](https://user-images.githubusercontent.com/7404452/116270556-7e80fd80-a77f-11eb-91ce-caed714e7128.png)

