### PR TITLE
Cleanup after PHP 5 mention removal

### DIFF
--- a/reference/fileinfo/configure.xml
+++ b/reference/fileinfo/configure.xml
@@ -14,32 +14,6 @@
   A patch against libmagic named <filename>libmagic.patch</filename> is maintained
   and may be found within the PHP fileinfo extensions source.
  </para>
- <para>
-  <table>
-   <title>Upgrade history of the bundled libmagic library</title>
-   <tgroup cols="3">
-    <thead>
-     <row>
-      <entry>PHP &Version;</entry>
-      <entry>Updated libmagic &Version;</entry>
-      <entry>Notes</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>5.3.2</entry>
-      <entry>5.03</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry>5.3.0</entry>
-      <entry>5.02</entry>
-      <entry></entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </table>
- </para>
 </section>
 
 <!-- Keep this comment at the end of the file

--- a/reference/fileinfo/setup.xml
+++ b/reference/fileinfo/setup.xml
@@ -7,9 +7,7 @@
  <!-- {{{ Requirements -->
  <section xml:id="fileinfo.requirements">
   &reftitle.required;
-  <para>
-   
-  </para>
+  &no.requirement;
  </section>
  <!-- }}} -->
 

--- a/reference/sphinx/setup.xml
+++ b/reference/sphinx/setup.xml
@@ -6,9 +6,7 @@
 
  <section xml:id="sphinx.requirements">
   &reftitle.required;
-  <para>
-
-  </para>
+  &no.requirement;
  </section>
 
  <!-- {{{ Installation -->


### PR DESCRIPTION
Basic fixes that I saw when updating the FR translation.

There are still many pages which still have references to PHP 5 although said file has been touched.
I might do another pass on the whole documentation when I'm caught up with the updating the French version.