### PR TITLE
[80999] Fix count TypeError not documented

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -521,6 +521,8 @@ currently not documented; only its argument list is available.
 
 <!ENTITY example.outputs.71 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 7.1:</para>'>
 
+<!ENTITY example.outputs.72 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 7.2:</para>'>
+
 <!ENTITY example.outputs.73 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 7.3:</para>'>
 
 <!ENTITY example.outputs.8 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8:</para>'>

--- a/reference/array/functions/count.xml
+++ b/reference/array/functions/count.xml
@@ -91,6 +91,28 @@ $b[0]  = 7;
 $b[5]  = 9;
 $b[10] = 11;
 var_dump(count($b));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen role="php">
+<![CDATA[
+int(3)
+int(3)
+]]>
+    </screen>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title><function>count</function> non Countable|array example (bad example - don't do this)</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$b[0]  = 7;
+$b[5]  = 9;
+$b[10] = 11;
+var_dump(count($b));
 
 var_dump(count(null));
 
@@ -102,7 +124,6 @@ var_dump(count(false));
     <screen role="php">
 <![CDATA[
 int(3)
-int(3)
 int(0)
 int(1)
 ]]>
@@ -110,7 +131,6 @@ int(1)
     &example.outputs.72;
     <screen role="php">
 <![CDATA[
-int(3)
 int(3)
 
 Warning: count(): Parameter must be an array or an object that implements Countable in … on line 12
@@ -123,7 +143,6 @@ int(1)
     &example.outputs.8;
     <screen role="php">
 <![CDATA[
-int(3)
 int(3)
 
 Fatal error: Uncaught TypeError: count(): Argument #1 ($var) must be of type Countable .. on line 12

--- a/reference/array/functions/count.xml
+++ b/reference/array/functions/count.xml
@@ -103,14 +103,30 @@ var_dump(count(false));
 <![CDATA[
 int(3)
 int(3)
-
-Fatal error: Uncaught TypeError: count(): Argument #1 ($var) must be of type Countable .. on line 12 // as of PHP 8.0
+int(0)
+int(1)
+]]>
+    </screen>
+    &example.outputs.72;
+    <screen role="php">
+<![CDATA[
+int(3)
+int(3)
 
 Warning: count(): Parameter must be an array or an object that implements Countable in … on line 12 // as of PHP 7.2
 int(0)
 
 Warning: count(): Parameter must be an array or an object that implements Countable in … on line 14 // as of PHP 7.2
 int(1)
+]]>
+    </screen>
+    &example.outputs.8;
+    <screen role="php">
+<![CDATA[
+int(3)
+int(3)
+
+Fatal error: Uncaught TypeError: count(): Argument #1 ($var) must be of type Countable .. on line 12 // as of PHP 8.0
 ]]>
     </screen>
    </example>

--- a/reference/array/functions/count.xml
+++ b/reference/array/functions/count.xml
@@ -104,6 +104,8 @@ var_dump(count(false));
 int(3)
 int(3)
 
+Fatal error: Uncaught TypeError: count(): Argument #1 ($var) must be of type Countable .. on line 12 // as of PHP 8.0
+
 Warning: count(): Parameter must be an array or an object that implements Countable in … on line 12 // as of PHP 7.2
 int(0)
 

--- a/reference/array/functions/count.xml
+++ b/reference/array/functions/count.xml
@@ -146,6 +146,13 @@ echo count($food); // output 2
     </thead>
     <tbody>
      <row>
+      <entry>8.0.0</entry>
+      <entry>
+       <function>count</function> will now throw <classname>TypeError</classname> on 
+       invalid countable types passed to the <parameter>value</parameter> parameter.
+      </entry>
+     </row>
+     <row>
       <entry>7.2.0</entry>
       <entry>
        <function>count</function> will now yield a warning on invalid countable types 

--- a/reference/array/functions/count.xml
+++ b/reference/array/functions/count.xml
@@ -113,10 +113,10 @@ int(1)
 int(3)
 int(3)
 
-Warning: count(): Parameter must be an array or an object that implements Countable in … on line 12 // as of PHP 7.2
+Warning: count(): Parameter must be an array or an object that implements Countable in … on line 12
 int(0)
 
-Warning: count(): Parameter must be an array or an object that implements Countable in … on line 14 // as of PHP 7.2
+Warning: count(): Parameter must be an array or an object that implements Countable in … on line 14
 int(1)
 ]]>
     </screen>
@@ -126,7 +126,7 @@ int(1)
 int(3)
 int(3)
 
-Fatal error: Uncaught TypeError: count(): Argument #1 ($var) must be of type Countable .. on line 12 // as of PHP 8.0
+Fatal error: Uncaught TypeError: count(): Argument #1 ($var) must be of type Countable .. on line 12
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
This PR adds the **TypeError** `count()` now throws to the changelog, and also updates the example showing that PHP 8.0 throws a **TypeError** instead of emitting and **E_WARNING**.

First time adding to a changelog, so not 100% sure if the versions are displayed in descending order or ascending. 🤔&nbsp; Will change if requested.