### PR TITLE
[80975] Fix: Doc incomplete - explode

### DIFF
--- a/reference/strings/functions/explode.xml
+++ b/reference/strings/functions/explode.xml
@@ -6,7 +6,7 @@
   <refpurpose>Split a string by a string</refpurpose>
  </refnamediv>
  
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>explode</methodname>
@@ -19,9 +19,9 @@
    <parameter>string</parameter> formed by splitting it on
    boundaries formed by the string <parameter>separator</parameter>.
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="parameters"><!-- {{{ -->
+ <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
    <variablelist>
@@ -68,9 +68,9 @@
     <parameter>string</parameter> argument.
    </para>
   </note>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="returnvalues"><!-- {{{ -->
+ <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    Returns an <type>array</type> of <type>string</type>s
@@ -89,9 +89,9 @@
    will be added as an empty <type>array</type> value either in the first or last 
    position of the returned <type>array</type> respectively.
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="changelog"><!-- {{{ -->
+ <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
     <tgroup cols="2">
@@ -112,9 +112,9 @@
       </tbody>
     </tgroup>
   </informaltable>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
   <para>
    <example>
@@ -214,14 +214,14 @@ Array
     </screen>
    </example>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="notes"><!-- {{{ -->
+ <refsect1 role="notes">
   &reftitle.notes;
   &note.bin-safe;
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
    <simplelist>
@@ -233,7 +233,7 @@ Array
     <member><function>implode</function></member>
    </simplelist>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/strings/functions/explode.xml
+++ b/reference/strings/functions/explode.xml
@@ -84,7 +84,10 @@
    contained in <parameter>string</parameter> and a negative
    <parameter>limit</parameter> is used, then an empty <type>array</type> will be
    returned, otherwise an <type>array</type> containing
-   <parameter>string</parameter> will be returned.
+   <parameter>string</parameter> will be returned. If <parameter>separator</parameter> 
+   values appear at the start or end of <parameter>string</parameter>, said values 
+   will be added as an empty <type>array</type> value either in the first or last 
+   position of the returned <type>array</type> respectively.
   </para>
  </refsect1>
 

--- a/reference/strings/functions/explode.xml
+++ b/reference/strings/functions/explode.xml
@@ -91,6 +91,29 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+    <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>8.0.0</entry>
+        <entry>
+          <function>explode</function> will now throw <classname>TypeError</classname> 
+          when <parameter>separator</parameter> parameter is given an empty string ("").
+        </entry>
+       </row>
+      </tbody>
+    </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -192,29 +215,6 @@ Array
    </example>
   </para>
  </refsect1>
-
-<refsect1 role="changelog">
- &reftitle.changelog;
- <informaltable>
-  <tgroup cols="2">
-   <thead>
-    <row>
-     <entry>&Version;</entry>
-     <entry>&Description;</entry>
-    </row>
-   </thead>
-   <tbody>
-    <row>
-     <entry>8.0.0</entry>
-     <entry>
-      <function>explode</function> will now throw <classname>TypeError</classname> 
-      when <parameter>separator</parameter> parameter is given an empty string ("").
-     </entry>
-    </row>
-   </tbody>
-  </tgroup>
- </informaltable>
-</refsect1>
 
  <refsect1 role="notes">
   &reftitle.notes;

--- a/reference/strings/functions/explode.xml
+++ b/reference/strings/functions/explode.xml
@@ -6,7 +6,7 @@
   <refpurpose>Split a string by a string</refpurpose>
  </refnamediv>
  
- <refsect1 role="description">
+ <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>explode</methodname>
@@ -19,9 +19,9 @@
    <parameter>string</parameter> formed by splitting it on
    boundaries formed by the string <parameter>separator</parameter>.
   </para>
- </refsect1>
+ </refsect1><!-- }}} -->
 
- <refsect1 role="parameters">
+ <refsect1 role="parameters"><!-- {{{ -->
   &reftitle.parameters;
   <para>
    <variablelist>
@@ -68,9 +68,9 @@
     <parameter>string</parameter> argument.
    </para>
   </note>
- </refsect1>
+ </refsect1><!-- }}} -->
 
- <refsect1 role="returnvalues">
+ <refsect1 role="returnvalues"><!-- {{{ -->
   &reftitle.returnvalues;
   <para>
    Returns an <type>array</type> of <type>string</type>s
@@ -89,9 +89,9 @@
    will be added as an empty <type>array</type> value either in the first or last 
    position of the returned <type>array</type> respectively.
   </para>
- </refsect1>
+ </refsect1><!-- }}} -->
 
- <refsect1 role="changelog">
+ <refsect1 role="changelog"><!-- {{{ -->
   &reftitle.changelog;
   <informaltable>
     <tgroup cols="2">
@@ -112,9 +112,9 @@
       </tbody>
     </tgroup>
   </informaltable>
- </refsect1>
+ </refsect1><!-- }}} -->
 
- <refsect1 role="examples">
+ <refsect1 role="examples"><!-- {{{ -->
   &reftitle.examples;
   <para>
    <example>
@@ -214,14 +214,14 @@ Array
     </screen>
    </example>
   </para>
- </refsect1>
+ </refsect1><!-- }}} -->
 
- <refsect1 role="notes">
+ <refsect1 role="notes"><!-- {{{ -->
   &reftitle.notes;
   &note.bin-safe;
- </refsect1>
+ </refsect1><!-- }}} -->
 
- <refsect1 role="seealso">
+ <refsect1 role="seealso"><!-- {{{ -->
   &reftitle.seealso;
   <para>
    <simplelist>
@@ -233,7 +233,7 @@ Array
     <member><function>implode</function></member>
    </simplelist>
   </para>
- </refsect1>
+ </refsect1><!-- }}} -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/strings/functions/explode.xml
+++ b/reference/strings/functions/explode.xml
@@ -190,6 +190,29 @@ Array
   </para>
  </refsect1>
 
+<refsect1 role="changelog">
+ &reftitle.changelog;
+ <informaltable>
+  <tgroup cols="2">
+   <thead>
+    <row>
+     <entry>&Version;</entry>
+     <entry>&Description;</entry>
+    </row>
+   </thead>
+   <tbody>
+    <row>
+     <entry>8.0.0</entry>
+     <entry>
+      <function>explode</function> will now throw <classname>TypeError</classname> 
+      when <parameter>separator</parameter> parameter is given an empty argument.
+     </entry>
+    </row>
+   </tbody>
+  </tgroup>
+ </informaltable>
+</refsect1>
+
  <refsect1 role="notes">
   &reftitle.notes;
   &note.bin-safe;

--- a/reference/strings/functions/explode.xml
+++ b/reference/strings/functions/explode.xml
@@ -205,7 +205,7 @@ Array
      <entry>8.0.0</entry>
      <entry>
       <function>explode</function> will now throw <classname>TypeError</classname> 
-      when <parameter>separator</parameter> parameter is given an empty argument.
+      when <parameter>separator</parameter> parameter is given an empty string ("").
      </entry>
     </row>
    </tbody>


### PR DESCRIPTION
This PR updates the `<note>` about return values if the start or end of `$string` contains a **separator** value. Also updated the changelog since `explode` now throws a `TypeError` when `$separator` is an empty string.

Personally don't think adding an example regarding the return value would be necessary here. `explode` already has *3* examples, *2* with outputs - and a `<note>` about it being binary-safe, so it would be a bit much IMHO. Therefore I opted to update the return values `<note>` instead.

Also, should the **changelog** be added before **notes** or after? I know it's usually after **examples** and before **seealso**, but not sure where the position should be in regards to **notes**.