### PR TITLE
Fix `count` changelog being in wrong section.

### DIFF
--- a/reference/array/functions/count.xml
+++ b/reference/array/functions/count.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
+
 <refentry xml:id="function.count" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>count</refname>
   <refpurpose>Count all elements in an array, or something in an object</refpurpose>
  </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -29,6 +31,7 @@
    are implemented and used in PHP.
   </para>
  </refsect1>
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -63,6 +66,7 @@
    </variablelist>
   </para>
  </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
@@ -74,6 +78,37 @@
    <literal>0</literal> will be returned.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       <function>count</function> will now throw <classname>TypeError</classname> on 
+       invalid countable types passed to the <parameter>value</parameter> parameter.
+      </entry>
+     </row>
+     <row>
+      <entry>7.2.0</entry>
+      <entry>
+       <function>count</function> will now yield a warning on invalid countable types 
+       passed to the <parameter>value</parameter> parameter.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -171,35 +206,7 @@ echo count($food); // output 2
    </example>
   </para>
  </refsect1>
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <informaltable>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>&Version;</entry>
-      <entry>&Description;</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>8.0.0</entry>
-      <entry>
-       <function>count</function> will now throw <classname>TypeError</classname> on 
-       invalid countable types passed to the <parameter>value</parameter> parameter.
-      </entry>
-     </row>
-     <row>
-      <entry>7.2.0</entry>
-      <entry>
-       <function>count</function> will now yield a warning on invalid countable types 
-       passed to the <parameter>value</parameter> parameter.
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </informaltable>
- </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -212,7 +219,9 @@ echo count($food); // output 2
    </simplelist>
   </para>
  </refsect1>
+
 </refentry>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
After the discussion in #558 about the **changelog** location, I noticed the **changelog** for `count` function was in the wrong section, currently located *below* the **examples**. This PR moves the **changelog** to the correct place above the **examples**.