### PR TITLE
Add missing sections to zookeeper documentation

### DIFF
--- a/reference/zookeeper/functions/zookeeper_dispatch.xml
+++ b/reference/zookeeper/functions/zookeeper_dispatch.xml
@@ -5,6 +5,7 @@
   <refname>zookeeper_dispatch</refname>
   <refpurpose>Calls callbacks for pending operations</refpurpose>
  </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -26,6 +27,18 @@
    After PHP 7.1, you can ignore this function. This extension uses EG(vm_interrupt) to implement async dispatch.
   </para>
 
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/zookeeper/zookeeper/close.xml
+++ b/reference/zookeeper/zookeeper/close.xml
@@ -16,6 +16,18 @@
   </methodsynopsis>
  </refsect1>
 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
  <refsect1 role="errors">
   &reftitle.errors;
   <para>

--- a/reference/zookeeper/zookeeper/connect.xml
+++ b/reference/zookeeper/zookeeper/connect.xml
@@ -52,6 +52,13 @@
   </variablelist>
  </refsect1>
 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
  <refsect1 role="errors">
   &reftitle.errors;
   <para>

--- a/reference/zookeeper/zookeeper/construct.xml
+++ b/reference/zookeeper/zookeeper/construct.xml
@@ -51,6 +51,13 @@
   </variablelist>
  </refsect1>
 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
  <refsect1 role="errors">
   &reftitle.errors;
   <para>

--- a/reference/zookeeper/zookeeper/getclientid.xml
+++ b/reference/zookeeper/zookeeper/getclientid.xml
@@ -16,6 +16,11 @@
   </methodsynopsis>
  </refsect1>
 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/zookeeper/zookeeper/getconfig.xml
+++ b/reference/zookeeper/zookeeper/getconfig.xml
@@ -16,6 +16,11 @@
   </methodsynopsis>
  </refsect1>
 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/zookeeper/zookeeper/getrecvtimeout.xml
+++ b/reference/zookeeper/zookeeper/getrecvtimeout.xml
@@ -16,6 +16,11 @@
   </methodsynopsis>
  </refsect1>
 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/zookeeper/zookeeper/getstate.xml
+++ b/reference/zookeeper/zookeeper/getstate.xml
@@ -16,6 +16,11 @@
   </methodsynopsis>
  </refsect1>
 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/zookeeper/zookeeper/isrecoverable.xml
+++ b/reference/zookeeper/zookeeper/isrecoverable.xml
@@ -19,6 +19,11 @@
   </para>
  </refsect1>
 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/zookeeper/zookeeperconfig/add.xml
+++ b/reference/zookeeper/zookeeperconfig/add.xml
@@ -49,6 +49,13 @@
   </variablelist>
  </refsect1>
 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
  <refsect1 role="errors">
   &reftitle.errors;
   <para>

--- a/reference/zookeeper/zookeeperconfig/remove.xml
+++ b/reference/zookeeper/zookeeperconfig/remove.xml
@@ -48,6 +48,13 @@
   </variablelist>
  </refsect1>
 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
  <refsect1 role="errors">
   &reftitle.errors;
   <para>

--- a/reference/zookeeper/zookeeperconfig/set.xml
+++ b/reference/zookeeper/zookeeperconfig/set.xml
@@ -48,6 +48,13 @@
   </variablelist>
  </refsect1>
 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
  <refsect1 role="errors">
   &reftitle.errors;
   <para>


### PR DESCRIPTION
This PR adds missing `parameters` and `returnvalues` sections to [zookeeper](https://github.com/php/doc-en/tree/HEAD/reference/zookeeper) documentation. Default **no parameter** and **void return** sections have been added.