### PR TITLE
Cleanup reference/zmq documentation.

### DIFF
--- a/reference/zmq/zmqcontext/construct.xml
+++ b/reference/zmq/zmqcontext/construct.xml
@@ -45,13 +45,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns a <classname>ZMQContext</classname> object on success.
-  </para>
- </refsect1>
-
  <refsect1 role="errors">
   &reftitle.errors;
   <para>

--- a/reference/zmq/zmqcontext/construct.xml
+++ b/reference/zmq/zmqcontext/construct.xml
@@ -48,6 +48,13 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
+   Returns a <classname>ZMQContext</classname> object on success.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
    Throws ZMQContextException if context initialization fails.
   </para>
  </refsect1>

--- a/reference/zmq/zmqcontext/construct.xml
+++ b/reference/zmq/zmqcontext/construct.xml
@@ -55,7 +55,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Throws ZMQContextException if context initialization fails.
+   Throws <classname>ZMQContextException</classname> if context initialization fails.
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqcontext/construct.xml
+++ b/reference/zmq/zmqcontext/construct.xml
@@ -44,7 +44,14 @@
    </variablelist>
   </para>
  </refsect1>
- 
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Throws ZMQContextException if context initialization fails.
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
  &reftitle.examples;
   <para>
@@ -74,13 +81,6 @@ $message = $socket->recv();
 ]]>
     </programlisting>
    </example>
-  </para>
- </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Throws ZMQContextException if context initialization fails.
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqcontext/getsocket.xml
+++ b/reference/zmq/zmqcontext/getsocket.xml
@@ -58,7 +58,14 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a ZMQSocket object on success. Throws ZMQSocketException on error.
+   Returns a <classname>ZMQSocket</classname> object on success.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Throws ZMQSocketException on error.
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqcontext/getsocket.xml
+++ b/reference/zmq/zmqcontext/getsocket.xml
@@ -65,7 +65,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Throws ZMQSocketException on error.
+   Throws <classname>ZMQSocketException</classname> on error.
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqcontext/getsocket.xml
+++ b/reference/zmq/zmqcontext/getsocket.xml
@@ -54,7 +54,14 @@
    </variablelist>
   </para>
  </refsect1>
- 
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns a ZMQSocket object on success. Throws ZMQSocketException on error.
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
  &reftitle.examples;
   <para>
@@ -87,14 +94,6 @@ echo "Received message: {$message}\n";
    </example>
   </para>
  </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns a ZMQSocket object on success. Throws ZMQSocketException on error.
-  </para>
- </refsect1>
-
 
 </refentry>
 

--- a/reference/zmq/zmqcontext/getsocket.xml
+++ b/reference/zmq/zmqcontext/getsocket.xml
@@ -58,7 +58,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a <classname>ZMQSocket</classname> object on success.
+   Returns a <classname>ZMQSocket</classname> object.
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqdevice/getidletimeout.xml
+++ b/reference/zmq/zmqdevice/getidletimeout.xml
@@ -18,13 +18,17 @@
   </para>
  </refsect1>
 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    This method returns the idle callback timeout value.
   </para>
  </refsect1>
-
 
 </refentry>
 

--- a/reference/zmq/zmqdevice/gettimertimeout.xml
+++ b/reference/zmq/zmqdevice/gettimertimeout.xml
@@ -18,13 +18,17 @@
   </para>
  </refsect1>
 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    This method returns the timer timeout value.
   </para>
  </refsect1>
-
 
 </refentry>
 

--- a/reference/zmq/zmqpoll/poll.xml
+++ b/reference/zmq/zmqpoll/poll.xml
@@ -69,7 +69,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Throws ZMQPollException on error.
+   Throws <classname>ZMQPollException</classname> on error.
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqpoll/poll.xml
+++ b/reference/zmq/zmqpoll/poll.xml
@@ -58,7 +58,14 @@
    </variablelist>
   </para>
  </refsect1>
- 
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns an integer representing amount of items with activity. Throws ZMQPollException on error.
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
  &reftitle.examples;
   <para>
@@ -133,14 +140,6 @@ while (true) {
    </example>
   </para>
  </refsect1> 
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns an integer representing amount of items with activity. Throws ZMQPollException on error.
-  </para>
- </refsect1>
-
 
 </refentry>
 

--- a/reference/zmq/zmqpoll/poll.xml
+++ b/reference/zmq/zmqpoll/poll.xml
@@ -62,7 +62,14 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an integer representing amount of items with activity. Throws ZMQPollException on error.
+   Returns an integer representing amount of items with activity.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Throws ZMQPollException on error.
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqpoll/poll.xml
+++ b/reference/zmq/zmqpoll/poll.xml
@@ -62,7 +62,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an integer representing amount of items with activity.
+   Returns an integer representing the amount of items with activity.
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqsocket/connect.xml
+++ b/reference/zmq/zmqsocket/connect.xml
@@ -47,7 +47,14 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the current object. Throws ZMQSocketException on error.
+   Returns the current object.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Throws <classname>ZMQSocketException</classname> on error.
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqsocket/connect.xml
+++ b/reference/zmq/zmqsocket/connect.xml
@@ -43,7 +43,14 @@
    </variablelist>
   </para>
  </refsect1>
- 
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the current object. Throws ZMQSocketException on error.
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
  &reftitle.examples;
   <para>
@@ -83,14 +90,6 @@ echo "<p>Server said: {$message}</p>";
    </example>
   </para>
  </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns the current object. Throws ZMQSocketException on error.
-  </para>
- </refsect1>
-
 
 </refentry>
 

--- a/reference/zmq/zmqsocket/construct.xml
+++ b/reference/zmq/zmqsocket/construct.xml
@@ -65,30 +65,37 @@
    </variablelist>
   </para>
  </refsect1>
- 
-  <refsect1 role="examples">
-  &reftitle.examples;
-   <para>
-    <example>
-     <title>A <function>ZMQSocket</function> example</title>
-     <para>
-      Using callback the bind/connect socket
-     </para>
-     <programlisting role="php">
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Throws ZMQSocketException on error.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+ &reftitle.examples;
+  <para>
+   <example>
+    <title>A <function>ZMQSocket</function> example</title>
+    <para>
+     Using callback the bind/connect socket
+    </para>
+    <programlisting role="php">
 <![CDATA[
 <?php
 
 /*
-  The socket is persistent so this function is called only on the 
-  first request to the script.
+ The socket is persistent so this function is called only on the 
+ first request to the script.
 */
 function on_new_socket_cb(ZMQSocket $socket, $persistent_id = null)
 {
-    if ($persistent_id === 'server') {
-        $socket->bind("tcp://localhost:12122");
-    } else {
-        $socket->connect("tcp://localhost:12122");
-    }
+   if ($persistent_id === 'server') {
+       $socket->bind("tcp://localhost:12122");
+   } else {
+       $socket->connect("tcp://localhost:12122");
+   }
 }
 
 /* Allocate a new context */
@@ -101,29 +108,21 @@ $message = $socket->recv();
 echo "Received message: {$message}\n";
 ?>
 ]]>
-     </programlisting>
-    </example>
-   </para>
-  </refsect1> 
- 
-  <refsect1 role="notes">
-   <para>
-    The callback signature
-    <note>
-     <para>
-      function on_new_socket_cb(ZMQSocket $socket, string $persistent_id = null);
-     </para>
-    </note>
-   </para>
-  </refsect1> 
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Throws ZMQSocketException on error.
+    </programlisting>
+   </example>
   </para>
- </refsect1>
+ </refsect1> 
 
+ <refsect1 role="notes">
+  <para>
+   The callback signature
+   <note>
+    <para>
+     function on_new_socket_cb(ZMQSocket $socket, string $persistent_id = null);
+    </para>
+   </note>
+  </para>
+ </refsect1> 
 
 </refentry>
 

--- a/reference/zmq/zmqsocket/construct.xml
+++ b/reference/zmq/zmqsocket/construct.xml
@@ -69,7 +69,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Throws ZMQSocketException on error.
+   Throws <classname>ZMQSocketException</classname> on error.
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqsocket/construct.xml
+++ b/reference/zmq/zmqsocket/construct.xml
@@ -86,16 +86,16 @@
 <?php
 
 /*
- The socket is persistent so this function is called only on the 
- first request to the script.
+  The socket is persistent so this function is called only on the 
+  first request to the script.
 */
 function on_new_socket_cb(ZMQSocket $socket, $persistent_id = null)
 {
-   if ($persistent_id === 'server') {
-       $socket->bind("tcp://localhost:12122");
-   } else {
-       $socket->connect("tcp://localhost:12122");
-   }
+    if ($persistent_id === 'server') {
+        $socket->bind("tcp://localhost:12122");
+    } else {
+        $socket->connect("tcp://localhost:12122");
+    }
 }
 
 /* Allocate a new context */

--- a/reference/zmq/zmqsocket/construct.xml
+++ b/reference/zmq/zmqsocket/construct.xml
@@ -60,6 +60,11 @@
        Callback function, which is executed when a new socket structure is created. This function does not get invoked
        if the underlying persistent connection is re-used.
       </para>
+      <methodsynopsis>
+       <methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>ZMQSocket</type><parameter>socket</parameter></methodparam>
+       <methodparam choice="opt"><type>string</type><parameter>persistent_id</parameter><initializer>&null;</initializer></methodparam>
+      </methodsynopsis>
      </listitem>
     </varlistentry>    
    </variablelist>
@@ -110,17 +115,6 @@ echo "Received message: {$message}\n";
 ]]>
     </programlisting>
    </example>
-  </para>
- </refsect1> 
-
- <refsect1 role="notes">
-  <para>
-   The callback signature
-   <note>
-    <para>
-     function on_new_socket_cb(ZMQSocket $socket, string $persistent_id = null);
-    </para>
-   </note>
   </para>
  </refsect1> 
 

--- a/reference/zmq/zmqsocket/recv.xml
+++ b/reference/zmq/zmqsocket/recv.xml
@@ -41,9 +41,15 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the message. Throws ZMQSocketException in error. 
-   If <constant>ZMQ::MODE_DONTWAIT</constant> is used and the operation would 
-   block &boolean; false shall be returned.
+   Returns the message. If <constant>ZMQ::MODE_DONTWAIT</constant> 
+   is used and the operation would block &boolean; false shall be returned.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Throws <classname>ZMQSocketException</classname> in error. 
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqsocket/recv.xml
+++ b/reference/zmq/zmqsocket/recv.xml
@@ -37,7 +37,16 @@
    </variablelist>
   </para>
  </refsect1>
- 
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the message. Throws ZMQSocketException in error. 
+   If <constant>ZMQ::MODE_DONTWAIT</constant> is used and the operation would 
+   block &boolean; false shall be returned.
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
  &reftitle.examples;
   <para>
@@ -95,16 +104,6 @@ Got response: This is a message
    </example>
   </para>
  </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns the message. Throws ZMQSocketException in error. 
-   If <constant>ZMQ::MODE_DONTWAIT</constant> is used and the operation would 
-   block &boolean; false shall be returned.
-  </para>
- </refsect1>
-
 
 </refentry>
 

--- a/reference/zmq/zmqsocket/recv.xml
+++ b/reference/zmq/zmqsocket/recv.xml
@@ -49,7 +49,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Throws <classname>ZMQSocketException</classname> in error. 
+   Throws <classname>ZMQSocketException</classname> on error. 
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqsocket/recv.xml
+++ b/reference/zmq/zmqsocket/recv.xml
@@ -42,7 +42,7 @@
   &reftitle.returnvalues;
   <para>
    Returns the message. If <constant>ZMQ::MODE_DONTWAIT</constant> 
-   is used and the operation would block &boolean; false shall be returned.
+   is used and the operation would block &false; shall be returned.
   </para>
  </refsect1>
 


### PR DESCRIPTION
This PR cleans up [reference/zmq](https://github.com/php/doc-en/tree/master/reference/zmq) by re-ordering the `returnvalues` section into the proper place and also adding default `parameters` sections to documents that don't have it. 

The given issues this pull request fixes were found by the following script: [section-order.php](https://gist.github.com/Girgias/885fa1622511fc72afec3dd026748e5b).