### PR TITLE
Add missing parameters section to zlib-get-coding-type.xml

### DIFF
--- a/reference/zlib/functions/zlib-get-coding-type.xml
+++ b/reference/zlib/functions/zlib-get-coding-type.xml
@@ -5,6 +5,7 @@
   <refname>zlib_get_coding_type</refname>
   <refpurpose>Returns the coding type used for output compression</refpurpose>
  </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -15,6 +16,12 @@
    Returns the coding type used for output compression.  
   </para>
  </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
@@ -22,6 +29,7 @@
    or &false;.
   </para>
  </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -34,6 +42,7 @@
    </simplelist>
   </para>
  </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
The given issue this pull request fixes were found by the following script: [section-order.php](https://gist.github.com/Girgias/885fa1622511fc72afec3dd026748e5b).