### PR TITLE
Fix notes section being in wrong order for reference/zip

### DIFF
--- a/reference/zip/ziparchive/registercancelcallback.xml
+++ b/reference/zip/ziparchive/registercancelcallback.xml
@@ -6,6 +6,7 @@
   <refname>ZipArchive::registerCancelCallback</refname>
   <refpurpose>Register a callback to allow cancellation during archive close.</refpurpose>
  </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -17,6 +18,7 @@
    Register a <parameter>callback</parameter> function to allow cancellation during archive close. 
   </para>
  </refsect1>
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -32,20 +34,12 @@
    </variablelist>
   </para>
  </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.success;
   </para>
- </refsect1>
-
- <refsect1 role="notes">
-  &reftitle.notes;
-  <note>
-   <para>
-    This function is only available if built against libzip ≥ 1.6.0.
-   </para>
-  </note>
  </refsect1>
 
  <refsect1 role="examples">
@@ -73,6 +67,15 @@ if ($zip->open('php.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
     </example>
  </refsect1>
 
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <para>
+    This function is only available if built against libzip ≥ 1.6.0.
+   </para>
+  </note>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -81,6 +84,7 @@ if ($zip->open('php.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
    </simplelist>
   </para>
  </refsect1>
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/registerprogresscallback.xml
+++ b/reference/zip/ziparchive/registerprogresscallback.xml
@@ -6,6 +6,7 @@
   <refname>ZipArchive::registerProgressCallback</refname>
   <refpurpose>Register a callback to provide updates during archive close.</refpurpose>
  </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -18,6 +19,7 @@
    Register a <parameter>callback</parameter> function to provide updates during archive close. 
   </para>
  </refsect1>
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -41,20 +43,12 @@
    </variablelist>
   </para>
  </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.success;
   </para>
- </refsect1>
-
- <refsect1 role="notes">
-  &reftitle.notes;
-  <note>
-   <para>
-    This function is only available if built against libzip ≥ 1.3.0.
-   </para>
-  </note>
  </refsect1>
 
  <refsect1 role="examples">
@@ -81,6 +75,15 @@ if ($zip->open('php.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
     </example>
  </refsect1>
 
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <para>
+    This function is only available if built against libzip ≥ 1.3.0.
+   </para>
+  </note>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -89,6 +92,7 @@ if ($zip->open('php.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
    </simplelist>
   </para>
  </refsect1>
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/setencryptionindex.xml
+++ b/reference/zip/ziparchive/setencryptionindex.xml
@@ -5,6 +5,7 @@
   <refname>ZipArchive::setEncryptionIndex</refname>
   <refpurpose>Set the encryption method of an entry defined by its index</refpurpose>
  </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -17,6 +18,7 @@
    Set the encryption method of an entry defined by its index.
   </para>
  </refsect1>
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -48,20 +50,12 @@
    </variablelist>
   </para>
  </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.success;
   </para>
- </refsect1>
-
- <refsect1 role="notes">
-  &reftitle.notes;
-  <note>
-   <para>
-    This function is only available if built against libzip ≥ 1.2.0.
-   </para>
-  </note>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -86,6 +80,15 @@
   </informaltable>
  </refsect1>
 
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <para>
+    This function is only available if built against libzip ≥ 1.2.0.
+   </para>
+  </note>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -95,6 +98,7 @@
    </simplelist>
   </para>
  </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
This PR fixes `notes` being in the wrong order for reference/zip, with them being before `examples` and or `changelog` sections.

The given issues this pull request fixes were found by the following script: [section-order.php](https://gist.github.com/Girgias/885fa1622511fc72afec3dd026748e5b).