### PR TITLE
Clean up reference/yaf documentation.

### DIFF
--- a/reference/yaf/yaf_controller_abstract/forward.xml
+++ b/reference/yaf/yaf_controller_abstract/forward.xml
@@ -80,7 +80,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    return FALSE on failure
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_controller_abstract/forward.xml
+++ b/reference/yaf/yaf_controller_abstract/forward.xml
@@ -10,18 +10,18 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>void</type><methodname>Yaf_Controller_Abstract::forward</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>Yaf_Controller_Abstract::forward</methodname>
    <methodparam><type>string</type><parameter>action</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>paramters</parameter></methodparam>
   </methodsynopsis>
   <methodsynopsis>
-   <modifier>public</modifier> <type>void</type><methodname>Yaf_Controller_Abstract::forward</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>Yaf_Controller_Abstract::forward</methodname>
    <methodparam><type>string</type><parameter>controller</parameter></methodparam>
    <methodparam><type>string</type><parameter>action</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>paramters</parameter></methodparam>
   </methodsynopsis>
   <methodsynopsis>
-   <modifier>public</modifier> <type>void</type><methodname>Yaf_Controller_Abstract::forward</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>Yaf_Controller_Abstract::forward</methodname>
    <methodparam><type>string</type><parameter>module</parameter></methodparam>
    <methodparam><type>string</type><parameter>controller</parameter></methodparam>
    <methodparam><type>string</type><parameter>action</parameter></methodparam>

--- a/reference/yaf/yaf_controller_abstract/forward.xml
+++ b/reference/yaf/yaf_controller_abstract/forward.xml
@@ -77,6 +77,13 @@
   </variablelist>
  </refsect1>
 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+    return FALSE on failure
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
@@ -111,14 +118,6 @@ class IndexController extends Yaf_Controller_Abstract
 ]]>
    </screen>
   </example>
- </refsect1>
-
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-    return FALSE on failure
-  </para>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/yaf/yaf_response_abstract/appendbody.xml
+++ b/reference/yaf/yaf_response_abstract/appendbody.xml
@@ -82,19 +82,12 @@ Hello World
   &reftitle.seealso;
   <simplelist>
    <member><classname>Yaf_Config_Ini</classname></member>
-  </simplelist>
- </refsect1>
-
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <simplelist>
    <member><methodname>Yaf_Response_Abstract::getBody</methodname></member>
    <member><methodname>Yaf_Response_Abstract::setBody</methodname></member>
    <member><methodname>Yaf_Response_Abstract::prependBody</methodname></member>
    <member><methodname>Yaf_Response_Abstract::clearBody</methodname></member>
   </simplelist>
  </refsect1>
-
 
 </refentry>
 

--- a/reference/yaf/yaf_route_map/assemble.xml
+++ b/reference/yaf/yaf_route_map/assemble.xml
@@ -44,7 +44,14 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &string; on success.
+   Returns &string; on success or &null; on failure.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   May throw <classname>Yaf_Exception_TypeError</classname>.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_route_map/assemble.xml
+++ b/reference/yaf/yaf_route_map/assemble.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns string on success.
+   Returns &string; on success.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_route_map/assemble.xml
+++ b/reference/yaf/yaf_route_map/assemble.xml
@@ -41,6 +41,13 @@
   </variablelist>
  </refsect1>
 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns string on success.
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
@@ -89,13 +96,6 @@ string(%d) "/foo/bar/_/tkey1/tval1/tkey2/tval2"
 ]]>
    </screen>
   </example>
- </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-  
-  </para>
  </refsect1>
 
 </refentry>

--- a/reference/yaf/yaf_route_regex/assemble.xml
+++ b/reference/yaf/yaf_route_regex/assemble.xml
@@ -41,6 +41,13 @@
   </variablelist>
  </refsect1>
 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns string on success.
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
@@ -85,13 +92,6 @@ string(49) "/module/controller/action?tkey1=tval1&tkey2=tval2"
 ]]>
    </screen>
   </example>
- </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-  
-  </para>
  </refsect1>
 
 </refentry>

--- a/reference/yaf/yaf_route_regex/assemble.xml
+++ b/reference/yaf/yaf_route_regex/assemble.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns string on success.
+   Returns &string; on success.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_route_regex/assemble.xml
+++ b/reference/yaf/yaf_route_regex/assemble.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>string</type><methodname>Yaf_Route_Regex::assemble</methodname>
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Yaf_Route_Regex::assemble</methodname>
    <methodparam><type>array</type><parameter>info</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>query</parameter></methodparam>
   </methodsynopsis>
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &string; on success.
+   Returns &string; on success or &null; on failure.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_route_rewrite/assemble.xml
+++ b/reference/yaf/yaf_route_rewrite/assemble.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns string on success.
+   Returns &string; on success.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_route_rewrite/assemble.xml
+++ b/reference/yaf/yaf_route_rewrite/assemble.xml
@@ -41,6 +41,13 @@
   </variablelist>
  </refsect1>
 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns string on success.
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
@@ -81,13 +88,6 @@ string(57) "/product/foo/bar/tmpkey1/tmpval1/?tkey1=tval1&tkey2=tval2"
 ]]>
    </screen>
   </example>
- </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-
-  </para>
  </refsect1>
 
 </refentry>

--- a/reference/yaf/yaf_route_rewrite/assemble.xml
+++ b/reference/yaf/yaf_route_rewrite/assemble.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &string; on success.
+   Returns &string;.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_route_simple/assemble.xml
+++ b/reference/yaf/yaf_route_simple/assemble.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns string on success.
+   Returns &string; on success.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_route_simple/assemble.xml
+++ b/reference/yaf/yaf_route_simple/assemble.xml
@@ -44,7 +44,15 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &string; on success.
+   Returns a &string;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Throws <classname>Yaf_Exception_TypeError</classname> if <parameter>info</parameter> 
+   keys <literal>':c'</literal> or <literal>':a'</literal> are not set.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_route_simple/assemble.xml
+++ b/reference/yaf/yaf_route_simple/assemble.xml
@@ -41,6 +41,13 @@
   </variablelist>
  </refsect1>
 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns string on success.
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
@@ -76,13 +83,6 @@ string(64) "?m=yafmodule&c=yafcontroller&a=yafaction&tkey1=tval1&tkey2=tval2"
 ]]>
    </screen>
   </example>
- </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-
-  </para>
  </refsect1>
 
 </refentry>

--- a/reference/yaf/yaf_route_static/assemble.xml
+++ b/reference/yaf/yaf_route_static/assemble.xml
@@ -44,7 +44,15 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &string; on success.
+   Returns a &string;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Throws <classname>Yaf_Exception_TypeError</classname> if <parameter>info</parameter> 
+   keys <literal>':c'</literal> and <literal>':a'</literal> are not set.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_route_static/assemble.xml
+++ b/reference/yaf/yaf_route_static/assemble.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns string on success.
+   Returns &string; on success.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_route_static/assemble.xml
+++ b/reference/yaf/yaf_route_static/assemble.xml
@@ -41,6 +41,13 @@
   </variablelist>
  </refsect1>
 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns string on success.
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
@@ -89,13 +96,6 @@ string(%d) "/yafmodule/yafcontroller/yafaction?tkey1=tval1&tkey2=tval2"
 ]]>
    </screen>
   </example>
- </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-
-  </para>
  </refsect1>
 
 </refentry>

--- a/reference/yaf/yaf_route_supervar/assemble.xml
+++ b/reference/yaf/yaf_route_supervar/assemble.xml
@@ -44,15 +44,15 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &string; on success.
+   Returns a &string;.
   </para>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Throws <classname>Exception</classname> when <parameter>info</parameter> 
-   key <literal>':c'</literal> is not set.
+   Throws <classname>Yaf_Exception_TypeError</classname> if <parameter>info</parameter> 
+   keys <literal>':c'</literal> and <literal>':a'</literal> are not set.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_route_supervar/assemble.xml
+++ b/reference/yaf/yaf_route_supervar/assemble.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns string on success.
+   Returns &string; on success.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_route_supervar/assemble.xml
+++ b/reference/yaf/yaf_route_supervar/assemble.xml
@@ -41,10 +41,24 @@
   </variablelist>
  </refsect1>
 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns string on success.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Throws <classname>Exception</classname> when <parameter>$info</parameter> key ':c' is not set.
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>Yaf_Route_Supervar::assemble</function>example</title>
+   <title><function>Yaf_Route_Supervar::assemble</function> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -94,13 +108,6 @@ string(%d) "You need to specify the controller by ':c'"
 ]]>
    </screen>
   </example>
- </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-
-  </para>
  </refsect1>
 
 </refentry>

--- a/reference/yaf/yaf_route_supervar/assemble.xml
+++ b/reference/yaf/yaf_route_supervar/assemble.xml
@@ -51,7 +51,8 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Throws <classname>Exception</classname> when <parameter>$info</parameter> key ':c' is not set.
+   Throws <classname>Exception</classname> when <parameter>info</parameter> 
+   key <literal>':c'</literal> is not set.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_view_simple/construct.xml
+++ b/reference/yaf/yaf_view_simple/construct.xml
@@ -47,6 +47,13 @@
   </variablelist>
  </refsect1>
 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
@@ -63,14 +70,6 @@
    </programlisting>
   </example>
  </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-
-  </para>
- </refsect1>
-
 
 </refentry>
 

--- a/reference/yaf/yaf_view_simple/construct.xml
+++ b/reference/yaf/yaf_view_simple/construct.xml
@@ -47,12 +47,16 @@
   </variablelist>
  </refsect1>
 
+ <!-- Return values commented out, as constructors generally don't return a
+      value. Uncomment this if you do need a return values section (for
+      example, because there's also a procedural version of the method).
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
 
   </para>
  </refsect1>
+ -->
 
  <refsect1 role="examples">
   &reftitle.examples;


### PR DESCRIPTION
This PR fixes some small issues on **reference/yaf** documentation, some `return values` sections were out-of-order or had completely blank `<para>`s. Fixed to the best of my knowledge after reading up and peeking at the `yaf` source. Also combined a duplicate `seealso` into a single.

Is there a warnings section or something that can be added warning about documentation possibly being out-of-date? Looking at the [repository](https://github.com/laruence/yaf) for `yaf` the current version is `3.3.2`, docs target everything from `1.0.0` to `2.2.0`.

The given issues this pull request fixes were found by the following script: [section-order.php](https://gist.github.com/Girgias/885fa1622511fc72afec3dd026748e5b).