### PR TITLE
Fix Yac::__construct documentation.

### DIFF
--- a/reference/yac/yac/construct.xml
+++ b/reference/yac/yac/construct.xml
@@ -33,18 +33,21 @@
   </variablelist>
  </refsect1>
 
- <!-- Return values commented out, as constructors generally don't return a
-      value. Uncomment this if you do need a return values section (for
-      example, because there's also a procedural version of the method).
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    
   </para>
  </refsect1>
- -->
 
-
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Throws a <classname>Exception</classname> if Yac is not enabled. Throws 
+   <classname>Exception</classname> if <parameter>$prefix</parameter> exceeds 
+   max key length of 48 (<constant>YAC_MAX_KEY_LEN</constant>) bytes.
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/construct.xml
+++ b/reference/yac/yac/construct.xml
@@ -44,7 +44,7 @@
   &reftitle.errors;
   <para>
    Throws a <classname>Exception</classname> if Yac is not enabled. Throws 
-   <classname>Exception</classname> if <parameter>$prefix</parameter> exceeds 
+   <classname>Exception</classname> if <parameter>prefix</parameter> exceeds 
    max key length of 48 (<constant>YAC_MAX_KEY_LEN</constant>) bytes.
   </para>
  </refsect1>

--- a/reference/yac/yac/construct.xml
+++ b/reference/yac/yac/construct.xml
@@ -33,12 +33,16 @@
   </variablelist>
  </refsect1>
 
+ <!-- Return values commented out, as constructors generally don't return a
+      value. Uncomment this if you do need a return values section (for
+      example, because there's also a procedural version of the method).
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    
   </para>
  </refsect1>
+ -->
 
  <refsect1 role="errors">
   &reftitle.errors;

--- a/reference/yac/yac/construct.xml
+++ b/reference/yac/yac/construct.xml
@@ -47,7 +47,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Throws a <classname>Exception</classname> if Yac is not enabled. Throws 
+   Throws an <classname>Exception</classname> if Yac is not enabled. Throws 
    <classname>Exception</classname> if <parameter>prefix</parameter> exceeds 
    max key length of 48 (<constant>YAC_MAX_KEY_LEN</constant>) bytes.
   </para>


### PR DESCRIPTION
This PR adds back the missing `returnvalues` section and adds a new `errors` section indicating what causes the constructor to throw an exception. @laruence could possibly confirm if this PR and the #569 PR are correct in terms of return values and expectations.

Note: Not sure if `<constant>` is a valid way to target constants in a package, see line 48 in PR.

The given issues this pull request fixes were found by the following script: [section-order.php](https://gist.github.com/Girgias/885fa1622511fc72afec3dd026748e5b).