### PR TITLE
Add missing parameters section to XSLTProcessor::hasExsltSupport

### DIFF
--- a/reference/xsl/xsltprocessor/hasexsltsupport.xml
+++ b/reference/xsl/xsltprocessor/hasexsltsupport.xml
@@ -5,6 +5,7 @@
   <refname>XSLTProcessor::hasExsltSupport</refname>
   <refpurpose>Determine if PHP has EXSLT support</refpurpose>
  </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -16,12 +17,19 @@
    xlink:href="&url.exsltlib;">EXSLT library</link>.
   </para>
  </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.success;
   </para>
  </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -44,6 +52,7 @@ if (!$proc->hasExsltSupport()) {
    </example>
   </para>
  </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
This PR adds missing `parameters` section to `XSLTProcessor::hasExsltSupport`.

The given issues this pull request fixes were found by the following script: [section-order.php](https://gist.github.com/Girgias/885fa1622511fc72afec3dd026748e5b).