### PR TITLE
Fix xmlrpc_set_type errors section being out-of-order

### DIFF
--- a/reference/xmlrpc/functions/xmlrpc-set-type.xml
+++ b/reference/xmlrpc/functions/xmlrpc-set-type.xml
@@ -50,6 +50,13 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Issues E_WARNING with type unsupported by XMLRPC.
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -82,13 +89,6 @@ echo xmlrpc_encode($params);
 ]]>
     </screen>
    </example>
-  </para>
- </refsect1>
-
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   Issues E_WARNING with type unsupported by XMLRPC.
   </para>
  </refsect1>
 


### PR DESCRIPTION
This PR moves `xmlrpc_set_type` errors section to it's correct place.

The given issues this pull request fixes were found by the following script: [section-order.php](https://gist.github.com/Girgias/885fa1622511fc72afec3dd026748e5b).
