### PR TITLE
Add missing parameter sections to XMLReader methods

### DIFF
--- a/reference/xmlreader/xmlreader/close.xml
+++ b/reference/xmlreader/xmlreader/close.xml
@@ -15,6 +15,10 @@
    Closes the input the XMLReader object is currently parsing.
   </para>
  </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/xmlreader/xmlreader/isvalid.xml
+++ b/reference/xmlreader/xmlreader/isvalid.xml
@@ -15,6 +15,10 @@
    Returns a boolean indicating if the document being parsed is currently valid.
   </para>
  </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/xmlreader/xmlreader/movetoelement.xml
+++ b/reference/xmlreader/xmlreader/movetoelement.xml
@@ -15,6 +15,10 @@
    Moves cursor to the parent Element of current Attribute. 
   </para>
  </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/xmlreader/xmlreader/movetofirstattribute.xml
+++ b/reference/xmlreader/xmlreader/movetofirstattribute.xml
@@ -15,6 +15,10 @@
    Moves cursor to the first Attribute.
   </para>
  </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/xmlreader/xmlreader/movetonextattribute.xml
+++ b/reference/xmlreader/xmlreader/movetonextattribute.xml
@@ -16,6 +16,10 @@
    moves to first attribute if positioned on an Element.
   </para>
  </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/xmlreader/xmlreader/read.xml
+++ b/reference/xmlreader/xmlreader/read.xml
@@ -15,6 +15,10 @@
    Moves cursor to the next node in the document.
   </para>
  </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>


### PR DESCRIPTION
This PR solves the issues of some `XMLReader` methods not having any parameter sections. While they don't accept any arguments, this fact should still be documented correctly, similar to other methods and functions.

The given issues this pull request fixes were found by the following script: [section-order.php](https://gist.github.com/Girgias/885fa1622511fc72afec3dd026748e5b).