### PR TITLE
Fix two `xml` functions having section out-of-order.

### DIFF
--- a/reference/xml/functions/xml-get-current-byte-index.xml
+++ b/reference/xml/functions/xml-get-current-byte-index.xml
@@ -42,16 +42,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="notes">
-  &reftitle.notes;
-  <warning>
-   <para>
-    This function returns byte index according to UTF-8 encoded text
-    disregarding if input is in another encoding.
-   </para>
-  </warning>
- </refsect1>
-
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -67,6 +57,16 @@
     </tbody>
    </tgroup>
   </informaltable>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <warning>
+   <para>
+    This function returns byte index according to UTF-8 encoded text
+    disregarding if input is in another encoding.
+   </para>
+  </warning>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/xml/functions/xml-set-default-handler.xml
+++ b/reference/xml/functions/xml-set-default-handler.xml
@@ -85,6 +85,13 @@
   </para>
  </refsect1>
 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -100,13 +107,6 @@
     </tbody>
    </tgroup>
   </informaltable>
- </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.success;
-  </para>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
This PR fixes `xml_set_default_handler` and `xml_get_current_byte_index` having sections out-of-order.

The given issues this pull request fixes were found by the following script: [section-order.php](https://gist.github.com/Girgias/885fa1622511fc72afec3dd026748e5b).