### PR TITLE
Fix multiple `wincache_*` functions having missing parameter sections

### DIFF
--- a/reference/wincache/functions/wincache-fcache-meminfo.xml
+++ b/reference/wincache/functions/wincache-fcache-meminfo.xml
@@ -17,6 +17,12 @@
    Retrieves information about memory usage by file cache.
   </para>
  </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/wincache/functions/wincache-ocache-meminfo.xml
+++ b/reference/wincache/functions/wincache-ocache-meminfo.xml
@@ -17,6 +17,12 @@
    Retrieves information about memory usage by opcode cache.
   </para>
  </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/wincache/functions/wincache-rplist-fileinfo.xml
+++ b/reference/wincache/functions/wincache-rplist-fileinfo.xml
@@ -18,6 +18,23 @@
    and corresponding absolute file paths.
   </para>
  </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>summaryonly</parameter></term>
+     <listitem>
+      <para>
+
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
@@ -53,6 +70,7 @@
    </itemizedlist>
   </para>
  </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/wincache/functions/wincache-rplist-meminfo.xml
+++ b/reference/wincache/functions/wincache-rplist-meminfo.xml
@@ -17,6 +17,12 @@
    Retrieves information about memory usage by resolve file path cache.
   </para>
  </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/wincache/functions/wincache-scache-meminfo.xml
+++ b/reference/wincache/functions/wincache-scache-meminfo.xml
@@ -17,6 +17,12 @@
    Retrieves information about memory usage by session cache.
   </para>
  </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/wincache/functions/wincache-ucache-clear.xml
+++ b/reference/wincache/functions/wincache-ucache-clear.xml
@@ -17,12 +17,19 @@
    Clears/deletes all the values stored in the user cache.
   </para>
  </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.success;
   </para>
  </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/wincache/functions/wincache-ucache-meminfo.xml
+++ b/reference/wincache/functions/wincache-ucache-meminfo.xml
@@ -17,6 +17,12 @@
    Retrieves information about memory usage by user cache.
   </para>
  </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>


### PR DESCRIPTION
This PR fixes multiple `wincache_*` functions not having parameter sections, most missing non-argument ones. 

`wincache_rplist_fileinfo` was missing its `$summaryonly` parameter section and description. Copied `wincache_fcache_fileinfo` parameter section and description for the latter since its name is the same. I will update the description once I know what the argument does. 🤷‍♂️

The given issues this pull request fixes were found by the following script: [section-order.php](https://gist.github.com/Girgias/885fa1622511fc72afec3dd026748e5b).