### PR TITLE
Cleanup four `win32service` functions

### DIFF
--- a/reference/win32service/functions/win32-create-service.xml
+++ b/reference/win32service/functions/win32-create-service.xml
@@ -6,6 +6,7 @@
   <refname>win32_create_service</refname>
   <refpurpose>Creates a new service entry in the SCM database</refpurpose>
  </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -18,6 +19,7 @@
    privileges are required for this to succeed.
   </para>
  </refsect1>
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -300,7 +302,7 @@
   </para>
  </refsect1>
 
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    A <classname>ValueError</classname> is thrown if the; 
@@ -351,9 +353,57 @@
   <para>
    A <classname>Win32ServiceException</classname> is thrown on error.
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
-
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL win32service 1.0.0</entry>
+       <entry>
+        Throws a <classname>ValueError</classname> on invalid data in parameters,
+        previously &false; was returned.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL win32service 1.0.0</entry>
+       <entry>
+        Throws a <classname>Win32ServiceException</classname> on error,
+        previously a 
+        <link xmlns="http://docbook.org/ns/docbook" linkend="win32service.constants.errors">Win32 Error Code</link>
+        was returned.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL win32service 1.0.0</entry>
+       <entry>
+        The return type is now <type>void</type>, previously it was <type>mixed</type>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL win32service 0.4.0</entry>
+       <entry>
+        The <parameter>dependencies</parameter>, <parameter>recovery_delay</parameter>,
+        <parameter>recovery_action_1</parameter>, <parameter>recovery_action_2</parameter>,
+        <parameter>recovery_action_3</parameter>, <parameter>recovery_reset_period</parameter>,
+        <parameter>recovery_enabled</parameter>, <parameter>recovery_reboot_msg</parameter>
+        and <parameter>recovery_command</parameter> parameters have been added.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
@@ -430,57 +480,6 @@ debug_zval_dump($x);
    </example>
   </para>
  </refsect1>
-
-
- <refsect1 role="changelog"><!-- {{{ -->
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL win32service 1.0.0</entry>
-       <entry>
-        Throws a <classname>ValueError</classname> on invalid data in parameters,
-        previously &false; was returned.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL win32service 1.0.0</entry>
-       <entry>
-        Throws a <classname>Win32ServiceException</classname> on error,
-        previously a 
-        <link xmlns="http://docbook.org/ns/docbook" linkend="win32service.constants.errors">Win32 Error Code</link>
-        was returned.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL win32service 1.0.0</entry>
-       <entry>
-        The return type is now <type>void</type>, previously it was <type>mixed</type>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL win32service 0.4.0</entry>
-       <entry>
-        The <parameter>dependencies</parameter>, <parameter>recovery_delay</parameter>,
-        <parameter>recovery_action_1</parameter>, <parameter>recovery_action_2</parameter>,
-        <parameter>recovery_action_3</parameter>, <parameter>recovery_reset_period</parameter>,
-        <parameter>recovery_enabled</parameter>, <parameter>recovery_reboot_msg</parameter>
-        and <parameter>recovery_command</parameter> parameters have been added.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1><!-- }}} -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/win32service/functions/win32-delete-service.xml
+++ b/reference/win32service/functions/win32-delete-service.xml
@@ -27,6 +27,7 @@
   </para>
 
  </refsect1>
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -61,8 +62,7 @@
   </para>
  </refsect1>
 
-
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
     A <classname>ValueError</classname> is thrown if the; 
@@ -72,28 +72,9 @@
    <para>
     A <classname>Win32ServiceException</classname> is thrown on error.
    </para>
- </refsect1><!-- }}} -->
-
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>win32_delete_service</function> example</title>
-    <para>
-     Deletes the dummyphp service.
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-win32_delete_service('dummyphp');
-?>
-]]>
-    </programlisting>
-   </example>
-  </para>
  </refsect1>
 
- <refsect1 role="changelog"><!-- {{{ -->
+ <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
    <informaltable>
@@ -131,7 +112,26 @@ win32_delete_service('dummyphp');
     </tgroup>
    </informaltable>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>A <function>win32_delete_service</function> example</title>
+    <para>
+     Deletes the dummyphp service.
+    </para>
+    <programlisting role="php">
+<![CDATA[
+<?php
+win32_delete_service('dummyphp');
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/win32service/functions/win32-get-last-control-message.xml
+++ b/reference/win32service/functions/win32-get-last-control-message.xml
@@ -26,6 +26,12 @@
   </caution>
   
  </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
@@ -52,7 +58,7 @@
   </para>
  </refsect1>
 
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    Prior to version 1.0.0, if the SAPI is not <literal>"cli"</literal>, this function emits an 
@@ -63,9 +69,9 @@
     <classname>Win32ServiceException</classname> if SAPI is not 
     <literal>"cli"</literal>
    </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
- <refsect1 role="changelog"><!-- {{{ -->
+ <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
    <informaltable>
@@ -103,7 +109,7 @@
     </tgroup>
    </informaltable>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/win32service/functions/win32-start-service-ctrl-dispatcher.xml
+++ b/reference/win32service/functions/win32-start-service-ctrl-dispatcher.xml
@@ -41,6 +41,7 @@
    </para>
   </caution>
  </refsect1>
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -77,7 +78,7 @@
   </para>
  </refsect1>
 
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    Prior to version 1.0.0, if the SAPI is not <literal>"cli"</literal>, this function emits an 
@@ -88,41 +89,9 @@
     <classname>Win32ServiceException</classname> if SAPI is not 
     <literal>"cli"</literal>
    </para>
- </refsect1><!-- }}} -->
-
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>win32_start_service_ctrl_dispatcher</function> example</title>
-    <para>
-     Check if the service is runnig under the SCM.
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if (!win32_start_service_ctrl_dispatcher('dummyphp')) {
-  die("I'm probably not running under the service control manager");
-}
-
-win32_set_service_status(WIN32_SERVICE_START_PENDING);
-
-// Some lengthy process to get this service up and running.
-
-win32_set_service_status(WIN32_SERVICE_RUNNING);
-
-while (WIN32_SERVICE_CONTROL_STOP != win32_get_last_control_message()) {
-  # do some work here, trying not to take more than around 30 seconds
-  # before coming back into the loop again
-}
-?>
-]]>
-    </programlisting>
-   </example>
-  </para>
  </refsect1>
 
- <refsect1 role="changelog"><!-- {{{ -->
+ <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
    <informaltable>
@@ -172,7 +141,39 @@ while (WIN32_SERVICE_CONTROL_STOP != win32_get_last_control_message()) {
     </tgroup>
    </informaltable>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>A <function>win32_start_service_ctrl_dispatcher</function> example</title>
+    <para>
+     Check if the service is runnig under the SCM.
+    </para>
+    <programlisting role="php">
+<![CDATA[
+<?php
+if (!win32_start_service_ctrl_dispatcher('dummyphp')) {
+  die("I'm probably not running under the service control manager");
+}
+
+win32_set_service_status(WIN32_SERVICE_START_PENDING);
+
+// Some lengthy process to get this service up and running.
+
+win32_set_service_status(WIN32_SERVICE_RUNNING);
+
+while (WIN32_SERVICE_CONTROL_STOP != win32_get_last_control_message()) {
+  # do some work here, trying not to take more than around 30 seconds
+  # before coming back into the loop again
+}
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
  
  <refsect1 role="seealso">
   &reftitle.seealso;


### PR DESCRIPTION
This PR fixes issues in four `win32service` functions. `win32_get_last_control_message` was missing a parameters section.

`win32_create_service`, `win32_delete_service` and `win32_start_service_ctrl_dispatcher`  had their `changelog` located after their `examples` section.

These issues have now been fixed. Also removed some straggling fold marks that were left from older changes.

The given issues this pull request fixes were found by the following script: [section-order.php](https://gist.github.com/Girgias/885fa1622511fc72afec3dd026748e5b).



