### PR TITLE
Reflection deprecation

### DIFF
--- a/reference/reflection/reflectionfunctionabstract/getparameters.xml
+++ b/reference/reflection/reflectionfunctionabstract/getparameters.xml
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Get the parameters as an array of <type>ReflectionParameter</type>.
+   Get the parameters as an array of <type>ReflectionParameter</type>, in the order in which they are defined in the source.
   </para>
 
   &warn.undocumented.func;

--- a/reference/reflection/reflectionfunctionabstract/getparameters.xml
+++ b/reference/reflection/reflectionfunctionabstract/getparameters.xml
@@ -14,7 +14,8 @@
    <void />
   </methodsynopsis>
   <para>
-   Get the parameters as an array of <type>ReflectionParameter</type>, in the order in which they are defined in the source.
+  Get the parameters as an array of <type>ReflectionParameter</type>,
+  in the order in which they are defined in the source.
   </para>
 
   &warn.undocumented.func;

--- a/reference/reflection/reflectionfunctionabstract/getparameters.xml
+++ b/reference/reflection/reflectionfunctionabstract/getparameters.xml
@@ -14,8 +14,8 @@
    <void />
   </methodsynopsis>
   <para>
-  Get the parameters as an array of <type>ReflectionParameter</type>,
-  in the order in which they are defined in the source.
+   Get the parameters as an array of <type>ReflectionParameter</type>,
+   in the order in which they are defined in the source.
   </para>
 
   &warn.undocumented.func;

--- a/reference/reflection/reflectionnamedtype/isbuiltin.xml
+++ b/reference/reflection/reflectionnamedtype/isbuiltin.xml
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Checks if the type is a built-in type in PHP.
+   Checks if the type is a built-in type in PHP. A built-in type is any type that is not a class.
   </para>
  </refsect1>
 

--- a/reference/reflection/reflectionnamedtype/isbuiltin.xml
+++ b/reference/reflection/reflectionnamedtype/isbuiltin.xml
@@ -14,7 +14,8 @@
    <void />
   </methodsynopsis>
   <para>
-   Checks if the type is a built-in type in PHP. A built-in type is any type that is not a class.
+   Checks if the type is a built-in type in PHP. A built-in type is any type that
+   is not a class, interface, or trait.
   </para>
  </refsect1>
 

--- a/reference/reflection/reflectionparameter/getclass.xml
+++ b/reference/reflection/reflectionparameter/getclass.xml
@@ -21,7 +21,7 @@
   </para>
   <para>
    As of PHP 8.0.0 this function is deprecated and not recommended. Instead, use
-   <methodname>ReflectionParameter::getType</methodname> to get the <class>ReflectionType</class>
+   <methodname>ReflectionParameter::getType</methodname> to get the <classname>ReflectionType</classname>
    of the parameter, then interrogate that object to determine the parameter type.
   </para>
 

--- a/reference/reflection/reflectionparameter/getclass.xml
+++ b/reference/reflection/reflectionparameter/getclass.xml
@@ -36,7 +36,13 @@
    or the declared type is not a class or interface.
   </para>
  </refsect1>
- 
+
+ <section>
+  As of PHP 8.0.0 this function is deprecated and not recommended. Instead, use
+  <methodname>ReflectionParameter::getType</methodname> to get the <class>ReflectionType</class>
+  of the parameter, then interrogate that object to determine the parameter type.
+ </section>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/reflection/reflectionparameter/getclass.xml
+++ b/reference/reflection/reflectionparameter/getclass.xml
@@ -19,6 +19,11 @@
   <para>
    Gets the class type hinted for the parameter as a <classname>ReflectionClass</classname> object.
   </para>
+  <para>
+   As of PHP 8.0.0 this function is deprecated and not recommended. Instead, use
+   <methodname>ReflectionParameter::getType</methodname> to get the <class>ReflectionType</class>
+   of the parameter, then interrogate that object to determine the parameter type.
+  </para>
 
   &warn.undocumented.func;
 
@@ -36,12 +41,6 @@
    or the declared type is not a class or interface.
   </para>
  </refsect1>
-
- <section>
-  As of PHP 8.0.0 this function is deprecated and not recommended. Instead, use
-  <methodname>ReflectionParameter::getType</methodname> to get the <class>ReflectionType</class>
-  of the parameter, then interrogate that object to determine the parameter type.
- </section>
 
  <refsect1 role="examples">
   &reftitle.examples;
@@ -61,12 +60,6 @@ echo $aParameter->getClass()->name;
 ?>
 ]]>
     </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Exception
-]]>
-    </screen>
    </example>
   </para>
  </refsect1>

--- a/reference/reflection/reflectionparameter/gettype.xml
+++ b/reference/reflection/reflectionparameter/gettype.xml
@@ -86,12 +86,37 @@ var_dump($reflectionType2);
     </programlisting>
     &example.outputs.70;
     <screen>
-<![CDATA[
+     <![CDATA[
 int
 NULL
 ]]>
     </screen>
    </example>
+   <example>
+   <title><methodname>ReflectionParameter::getType</methodname> Usage in PHP 8.0.0 and later</title>
+    <para>
+     As of PHP 8.0.0, this method may return a <classname>ReflectionNamedType</classname> instance or
+     a <classname>ReflectionUnionType</classname> instance.  The latter is a collection of the former.
+     To analyze a type, it is often convenient to normalize it to an array of <classname>ReflectionNamedType</classname>
+     objects.  The following function will return an array of 0 or more <classname>ReflectionNamedType</classname>
+     instances.
+    </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+function getAllTypes(ReflectionParameter $reflectionParameter): bool {
+    $reflectionType = $reflectionParameter->getType();
+
+    if (!$reflectionType) return [];
+
+    return $reflectionType instanceof ReflectionUnionType
+        ? $reflectionType->getTypes()
+        : [$reflectionType];
+}
+?>
+]]>
+   </programlisting>
+  </example>
   </para>
  </refsect1>
 

--- a/reference/reflection/reflectionparameter/gettype.xml
+++ b/reference/reflection/reflectionparameter/gettype.xml
@@ -98,7 +98,7 @@ NULL
      As of PHP 8.0.0, this method may return a <classname>ReflectionNamedType</classname> instance or
      a <classname>ReflectionUnionType</classname> instance.  The latter is a collection of the former.
      To analyze a type, it is often convenient to normalize it to an array of <classname>ReflectionNamedType</classname>
-     objects.  The following function will return an array of 0 or more <classname>ReflectionNamedType</classname>
+     objects.  The following function will return an array of <literal>0</literal> or more <classname>ReflectionNamedType</classname>
      instances.
     </para>
    <programlisting role="php">

--- a/reference/reflection/reflectionparameter/gettype.xml
+++ b/reference/reflection/reflectionparameter/gettype.xml
@@ -86,7 +86,7 @@ var_dump($reflectionType2);
     </programlisting>
     &example.outputs.70;
     <screen>
-     <![CDATA[
+<![CDATA[
 int
 NULL
 ]]>

--- a/reference/reflection/reflectionparameter/gettype.xml
+++ b/reference/reflection/reflectionparameter/gettype.xml
@@ -104,7 +104,7 @@ NULL
    <programlisting role="php">
 <![CDATA[
 <?php
-function getAllTypes(ReflectionParameter $reflectionParameter): bool {
+function getAllTypes(ReflectionParameter $reflectionParameter): array {
     $reflectionType = $reflectionParameter->getType();
 
     if (!$reflectionType) return [];

--- a/reference/reflection/reflectionparameter/gettype.xml
+++ b/reference/reflection/reflectionparameter/gettype.xml
@@ -104,7 +104,8 @@ NULL
    <programlisting role="php">
 <![CDATA[
 <?php
-function getAllTypes(ReflectionParameter $reflectionParameter): array {
+function getAllTypes(ReflectionParameter $reflectionParameter): array
+{
     $reflectionType = $reflectionParameter->getType();
 
     if (!$reflectionType) return [];

--- a/reference/reflection/reflectionparameter/isarray.xml
+++ b/reference/reflection/reflectionparameter/isarray.xml
@@ -34,6 +34,32 @@
   </para>
  </refsect1>
 
+ <section>
+  As of PHP 8.0.0, the following code will report if a type supports arrays,
+  including as part of a union.
+ </section>
+
+ <example>
+  <title>PHP 8.0.0 equivalent</title>
+  <programlisting role="php">
+<![CDATA[
+<?php
+function allowsArray(ReflectionParameter $reflectionParameter): bool {
+    $reflectionType = $reflectionParameter->getType();
+
+    if (!$reflectionType) return false;
+
+    $types = $reflectionType instanceof ReflectionUnionType
+        ? $reflectionType->getTypes()
+        : [$reflectionType];
+
+   return in_array('array', array_map(fn(ReflectionNamedType $t) => $t->getName(), $types));
+}
+?>
+]]>
+  </programlisting>
+ </example>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/reflection/reflectionparameter/isarray.xml
+++ b/reference/reflection/reflectionparameter/isarray.xml
@@ -9,6 +9,7 @@
 
  <refsynopsisdiv>
    &warn.deprecated.function-8-0-0;
+  <para>See the example below for an alternative way to derive this information.</para>
  </refsynopsisdiv>
 
  <refsect1 role="description">
@@ -34,17 +35,20 @@
   </para>
  </refsect1>
 
- <section>
-  As of PHP 8.0.0, the following code will report if a type supports arrays,
-  including as part of a union.
- </section>
-
- <example>
-  <title>PHP 8.0.0 equivalent</title>
-  <programlisting role="php">
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>PHP 8.0.0 equivalent</title>
+    <para>
+     As of PHP 8.0.0, the following code will report if a type declares arrays,
+     including as part of a union.
+    </para>
+    <programlisting role="php">
 <![CDATA[
 <?php
-function allowsArray(ReflectionParameter $reflectionParameter): bool {
+function declaresArray(ReflectionParameter $reflectionParameter): bool
+{
     $reflectionType = $reflectionParameter->getType();
 
     if (!$reflectionType) return false;
@@ -57,8 +61,10 @@ function allowsArray(ReflectionParameter $reflectionParameter): bool {
 }
 ?>
 ]]>
-  </programlisting>
- </example>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/reflection/reflectionparameter/iscallable.xml
+++ b/reference/reflection/reflectionparameter/iscallable.xml
@@ -38,6 +38,31 @@
   </para>
  </refsect1>
 
+ <section>
+  As of PHP 8.0.0, the following code will report if a type supports callables,
+  including as part of a union.
+ </section>
+
+ <example>
+  <title>PHP 8.0.0 equivalent</title>
+  <programlisting role="php">
+<![CDATA[
+<?php
+function allowsCallable(ReflectionParameter $reflectionParameter): bool {
+    $reflectionType = $reflectionParameter->getType();
+
+    if (!$reflectionType) return false;
+
+    $types = $reflectionType instanceof ReflectionUnionType
+        ? $reflectionType->getTypes()
+        : [$reflectionType];
+
+   return in_array('callable', array_map(fn(ReflectionNamedType $t) => $t->getName(), $types));
+}
+?>
+]]>
+  </programlisting>
+ </example>
 
 </refentry>
 

--- a/reference/reflection/reflectionparameter/iscallable.xml
+++ b/reference/reflection/reflectionparameter/iscallable.xml
@@ -9,6 +9,7 @@
 
  <refsynopsisdiv>
    &warn.deprecated.function-8-0-0;
+  <para>See the example below for an alternative way to derive this information.</para>
  </refsynopsisdiv>
 
  <refsect1 role="description">
@@ -38,17 +39,20 @@
   </para>
  </refsect1>
 
- <section>
-  As of PHP 8.0.0, the following code will report if a type supports callables,
-  including as part of a union.
- </section>
-
- <example>
-  <title>PHP 8.0.0 equivalent</title>
-  <programlisting role="php">
+ <refsect1 role="examples">
+ &reftitle.examples;
+ <para>
+  <example>
+   <title>PHP 8.0.0 equivalent</title>
+   <para>
+    As of PHP 8.0.0, the following code will report if a type supports callables,
+    including as part of a union.
+   </para>
+   <programlisting role="php">
 <![CDATA[
 <?php
-function allowsCallable(ReflectionParameter $reflectionParameter): bool {
+function declaresCallable(ReflectionParameter $reflectionParameter): bool
+{
     $reflectionType = $reflectionParameter->getType();
 
     if (!$reflectionType) return false;
@@ -61,8 +65,10 @@ function allowsCallable(ReflectionParameter $reflectionParameter): bool {
 }
 ?>
 ]]>
-  </programlisting>
- </example>
+   </programlisting>
+  </example>
+ </para>
+ </refsect1>
 
 </refentry>
 


### PR DESCRIPTION
Considerable chunks of the ReflectionParameter class are marked as deprecated with no indication of what to do instead.  After some experimentation (while trying to remove the deprecated stuff from TYPO3), I offer the following "do this instead" options.  And some other commentary and improvement along the way.

I'm not 100% sure my XML structuring is right.  Let me know what I should do instead and I'll adjust accordingly.