### PR TITLE
Clean up various variable handling functions.

### DIFF
--- a/reference/var/functions/get-defined-vars.xml
+++ b/reference/var/functions/get-defined-vars.xml
@@ -20,6 +20,10 @@
    called. 
   </para>
  </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/var/functions/gettype.xml
+++ b/reference/var/functions/gettype.xml
@@ -75,6 +75,31 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>7.2.0</entry>
+       <entry>
+        Closed resources are now reported as <literal>'resource (closed)'</literal>. 
+        Previously the returned value for closed resources were <literal>'unknown type'</literal>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -104,31 +129,6 @@ string
 ]]>
     </screen>
    </example>
-  </para>
- </refsect1>
-
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>7.2.0</entry>
-       <entry>
-        Closed resources are now reported as <literal>'resource (closed)'</literal>. 
-        Previously the returned value for closed resources were <literal>'unknown type'</literal>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
   </para>
  </refsect1>
 

--- a/reference/var/functions/is-object.xml
+++ b/reference/var/functions/is-object.xml
@@ -41,6 +41,32 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>7.2.0</entry>
+       <entry>
+        <function>is_object</function> now returns &true; for unserialized objects without 
+        a class definition (class of <classname>__PHP_Incomplete_Class</classname>). Previously 
+        &false; was returned.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -71,32 +97,6 @@ var_dump(get_students($obj));
 ]]>
     </programlisting>
    </example>
-  </para>
- </refsect1>
-
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>7.2.0</entry>
-       <entry>
-        <function>is_object</function> now returns &true; for unserialized objects without 
-        a class definition (class of <classname>__PHP_Incomplete_Class</classname>). Previously 
-        &false; was returned.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
   </para>
  </refsect1>
 

--- a/reference/var/functions/print-r.xml
+++ b/reference/var/functions/print-r.xml
@@ -67,11 +67,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="notes">
-  &reftitle.notes;
-  &note.uses-ob-php70;
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -120,6 +115,11 @@ $results = print_r($b, true); // $results now contains output from print_r
     </programlisting>
    </example>
   </para>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  &note.uses-ob-php70;
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
This PR fixes some issues found in `reference/var`. Mainly sections out-of-order, and `get_defined_var` not having a parameters section.

The given issues this pull request fixes were found by the following script: [section-order.php](https://gist.github.com/Girgias/885fa1622511fc72afec3dd026748e5b).