### PR TITLE
Fix two uopz functions having no returnvalues sections

### DIFF
--- a/reference/uopz/functions/uopz-set-mock.xml
+++ b/reference/uopz/functions/uopz-set-mock.xml
@@ -51,6 +51,13 @@
   </variablelist>
  </refsect1>
 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -178,13 +185,13 @@ mockA
   </example>
  </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><function>uopz_get_mock</function></member>
    <member><function>uopz_unset_mock</function></member>
   </simplelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 

--- a/reference/uopz/functions/uopz-unset-mock.xml
+++ b/reference/uopz/functions/uopz-unset-mock.xml
@@ -32,13 +32,20 @@
   </variablelist>
  </refsect1>
 
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    A <classname>RuntimeException</classname> is thrown, if no mock was previously
    set for <parameter>class</parameter>.
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
@@ -74,13 +81,13 @@ A
   </example>
  </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><function>uopz_set_mock</function></member>
    <member><function>uopz_get_mock</function></member>
   </simplelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 


### PR DESCRIPTION
Fix `uopz_unset_mock`, `uopz_set_mock` No returnvalues sections, both was missing void return values sections.

The given issues this pull request fixes were found by the following script: [section-order.php](https://gist.github.com/Girgias/885fa1622511fc72afec3dd026748e5b).