### PR TITLE
Fix `fontFamilies` No returnvalues sections

### DIFF
--- a/reference/ui/functions/ui.draw.text.font.fontfamilies.xml
+++ b/reference/ui/functions/ui.draw.text.font.fontfamilies.xml
@@ -24,6 +24,13 @@
   &no.function.parameters;
  </refsect1>
 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns an array of valid font families for the current system
+  </para>
+ </refsect1>
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/ui/functions/ui.draw.text.font.fontfamilies.xml
+++ b/reference/ui/functions/ui.draw.text.font.fontfamilies.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an array of valid font families for the current system
+   Returns an &array; of valid font families for the current system.
   </para>
  </refsect1>
 


### PR DESCRIPTION
This PR is frankly a little unnecessary since `description` section already says what's returned, but technically should be in the missing `returnvalues` section. 🤷‍♂️

The given issues this pull request fixes were found by the following script: [section-order.php](https://gist.github.com/Girgias/885fa1622511fc72afec3dd026748e5b).