### PR TITLE
[80671] Update `mb_convert_encoding`.

### DIFF
--- a/reference/mbstring/functions/mb-convert-encoding.xml
+++ b/reference/mbstring/functions/mb-convert-encoding.xml
@@ -73,13 +73,10 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   A <classname>ValueError</classname> is thrown if the; value of 
-   <parameter>to_encoding</parameter> or <parameter>from_encoding</parameter> 
-   is an invalid encoding, as of PHP 8.0.0.
-  </para>
-  <para>
-   Emits E_WARNING if the; value of <parameter>to_encoding</parameter> and 
-   or <parameter>from_encoding</parameter> is an invalid encoding.
+   As of PHP 8.0.0, a <classname>ValueError</classname> is thrown if the; 
+   value of <parameter>to_encoding</parameter> and or 
+   <parameter>from_encoding</parameter> is an invalid encoding.
+   Prior to PHP 8.0.0, a <constant>E_WARNING</constant> was emitted instead.
   </para>
  </refsect1>
 

--- a/reference/mbstring/functions/mb-convert-encoding.xml
+++ b/reference/mbstring/functions/mb-convert-encoding.xml
@@ -84,6 +84,20 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
+       <function>mb_convert_encoding</function> will now throw <classname>ValueError</classname> 
+       when <parameter>to_encoding</parameter> is passed an invalid encoding.
+      </entry>
+     </row>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       <function>mb_convert_encoding</function> will now throw <classname>ValueError</classname> 
+       when <parameter>from_encoding</parameter> is passed an invalid encoding.
+      </entry>
+     </row>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
        <parameter>from_encoding</parameter> is nullable now.
       </entry>
      </row>

--- a/reference/mbstring/functions/mb-convert-encoding.xml
+++ b/reference/mbstring/functions/mb-convert-encoding.xml
@@ -74,7 +74,7 @@
   &reftitle.errors;
   <para>
    A <classname>ValueError</classname> is thrown if the; value of 
-   <parameter>to_encoding</parameter> and or <parameter>from_encoding</parameter> 
+   <parameter>to_encoding</parameter> or <parameter>from_encoding</parameter> 
    is an invalid encoding, as of PHP 8.0.0.
   </para>
   <para>

--- a/reference/mbstring/functions/mb-convert-encoding.xml
+++ b/reference/mbstring/functions/mb-convert-encoding.xml
@@ -94,15 +94,17 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <function>mb_convert_encoding</function> will now throw <classname>ValueError</classname> 
-       when <parameter>to_encoding</parameter> is passed an invalid encoding.
+       <function>mb_convert_encoding</function> will now throw 
+       <classname>ValueError</classname> when 
+       <parameter>to_encoding</parameter> is passed an invalid encoding.
       </entry>
      </row>
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <function>mb_convert_encoding</function> will now throw <classname>ValueError</classname> 
-       when <parameter>from_encoding</parameter> is passed an invalid encoding.
+       <function>mb_convert_encoding</function> will now throw 
+       <classname>ValueError</classname> when 
+       <parameter>from_encoding</parameter> is passed an invalid encoding.
       </entry>
      </row>
      <row>

--- a/reference/mbstring/functions/mb-convert-encoding.xml
+++ b/reference/mbstring/functions/mb-convert-encoding.xml
@@ -74,7 +74,7 @@
   &reftitle.errors;
   <para>
    As of PHP 8.0.0, a <classname>ValueError</classname> is thrown if the; 
-   value of <parameter>to_encoding</parameter> and or 
+   value of <parameter>to_encoding</parameter> or 
    <parameter>from_encoding</parameter> is an invalid encoding.
    Prior to PHP 8.0.0, a <constant>E_WARNING</constant> was emitted instead.
   </para>

--- a/reference/mbstring/functions/mb-convert-encoding.xml
+++ b/reference/mbstring/functions/mb-convert-encoding.xml
@@ -73,7 +73,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   As of PHP 8.0.0, a <classname>ValueError</classname> is thrown if the; 
+   As of PHP 8.0.0, a <classname>ValueError</classname> is thrown if the
    value of <parameter>to_encoding</parameter> or 
    <parameter>from_encoding</parameter> is an invalid encoding.
    Prior to PHP 8.0.0, a <constant>E_WARNING</constant> was emitted instead.
@@ -94,7 +94,7 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <function>mb_convert_encoding</function> will now throw 
+       <function>mb_convert_encoding</function> will now throw a
        <classname>ValueError</classname> when 
        <parameter>to_encoding</parameter> is passed an invalid encoding.
       </entry>
@@ -102,7 +102,7 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <function>mb_convert_encoding</function> will now throw 
+       <function>mb_convert_encoding</function> will now throw a
        <classname>ValueError</classname> when 
        <parameter>from_encoding</parameter> is passed an invalid encoding.
       </entry>

--- a/reference/mbstring/functions/mb-convert-encoding.xml
+++ b/reference/mbstring/functions/mb-convert-encoding.xml
@@ -70,6 +70,19 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   A <classname>ValueError</classname> is thrown if the; value of 
+   <parameter>to_encoding</parameter> and or <parameter>from_encoding</parameter> 
+   is an invalid encoding, as of PHP 8.0.0.
+  </para>
+  <para>
+   Emits E_WARNING if the; value of <parameter>to_encoding</parameter> and 
+   or <parameter>from_encoding</parameter> is an invalid encoding.
+  </para>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>


### PR DESCRIPTION
`mb_convert_encoding` now throws `ValueError` if either `$to_encoding` or `$from_encoding` are passed an invalid encoding. Looking at other changelogs, I'm guessing this is the correct way to add multiple changes to one version?

Added an `errors` section to indicate the old and new behavior - since previous to PHP 8.0, this function did emit a warning when supplied invalid encoding types, as demonstrated in this [3v4l demo](https://3v4l.org/5cErI).