### PR TITLE
Document Memcached::OPT_NOREPLY

### DIFF
--- a/reference/memcached/constants.xml
+++ b/reference/memcached/constants.xml
@@ -225,7 +225,7 @@
      Storage commands will be sent without spending time waiting for a reply 
      (there would be no reply).
      Retrieval commands such as <function>Memcached::get</function> are unaffected by this setting.</para>
-    <para>Type: <type>bool</type>, default: &false;.</para>
+    <para>Type: &boolean;, default: &false;.</para>
    </listitem>
   </varlistentry>
 

--- a/reference/memcached/constants.xml
+++ b/reference/memcached/constants.xml
@@ -216,6 +216,19 @@
    </listitem>
   </varlistentry>
 
+  <varlistentry xml:id="memcached.constants.opt-noreply">
+   <term><constant>Memcached::OPT_NOREPLY</constant></term>
+   <listitem>
+    <para>
+     Enable this to ignore the result of storage commands 
+     (set, add, replace, append, prepend, delete, increment, decrement, etc.). 
+     Storage commands will be sent without spending time waiting for a reply 
+     (there would be no reply).
+     Retrieval commands such as <function>Memcached::get</function> are unaffected by this setting.</para>
+    <para>Type: <type>bool</type>, default: &false;.</para>
+   </listitem>
+  </varlistentry>
+
   <varlistentry xml:id="memcached.constants.opt-tcp-nodelay">
    <term><constant>Memcached::OPT_TCP_NODELAY</constant></term>
    <listitem>


### PR DESCRIPTION
This was added in 2009.
A lot of other constants were also added.
See http://docs.libmemcached.org/memcached_behavior.html