### PR TITLE
Improve openssl-pkcs7-read - fix arguments

### DIFF
--- a/reference/openssl/functions/openssl-pkcs7-read.xml
+++ b/reference/openssl/functions/openssl-pkcs7-read.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>openssl_pkcs7_read</methodname>
-   <methodparam><type>string</type><parameter>input_filename</parameter></methodparam>
+   <methodparam><type>string</type><parameter>data</parameter></methodparam>
    <methodparam><type>array</type><parameter role="reference">certificates</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -25,7 +25,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>input_filename</parameter></term>
+    <term><parameter>data</parameter></term>
     <listitem>
      <para>
       The string of data you wish to parse (p7b format).


### PR DESCRIPTION
The input shall be a string data.

Basic example along with the error cases.

Fix: related to, https://github.com/php/php-src/commit/bb0107b63dec8de5b0f3c3f535d3c52c2decda28