### PR TITLE
Remove extra full stop

### DIFF
--- a/appendices/migration80/deprecated.xml
+++ b/appendices/migration80/deprecated.xml
@@ -95,7 +95,7 @@ function test(?A $a, $b) {}       // Recommended
   <para>
    <function>libxml_disable_entity_loader</function> has been deprecated. As libxml 2.9.0 is now
    required, external entity loading is guaranteed to be disabled by default, and this function is
-   no longer needed to protect against XXE attacks, unless the (still vulnerable).
+   no longer needed to protect against XXE attacks, unless the (still vulnerable)
    <constant>LIBXML_NOENT</constant> is used.
    In that case, it is recommended to refactor the code using
    <function>libxml_set_external_entity_loader</function> to suppress loading of external entities.


### PR DESCRIPTION
Just removing an extra full stop before a constant name.

Follow-up to f3b5475 / #528.