### PR TITLE
Documenting the changes to syslog.filter

### DIFF
--- a/appendices/migration73/other-changes.xml
+++ b/appendices/migration73/other-changes.xml
@@ -46,9 +46,12 @@
       <term><link linkend="ini.syslog.filter">syslog.filter</link></term>
       <listitem>
        <simpara>
-        Specifies the filter type to filter the logged messages. There are three
+        Specifies the filter type to filter the logged messages, with the
         supported filter types - <literal>all</literal>,
         <literal>no-ctrl</literal> and <literal>ascii</literal>.
+        Starting with PHP 7.3.8, <literal>raw</literal> is also available, 
+        restoring the way syslog behaved in previous PHP versions.
+        This filter will also affect calls to <function>syslog</function>.
        </simpara>
       </listitem>
      </varlistentry>

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -526,8 +526,7 @@
      <para>
       Specifies the filter type to filter the logged messages. Allowed
       characters are passed unmodified; all others are written in their
-      hexadecimal representation prefixed with <literal>\x</literal>. There are
-      four supported filter types:
+      hexadecimal representation prefixed with <literal>\x</literal>. 
       <itemizedlist>
        <listitem>
         <simpara><literal>all</literal> – the logged string will be split 

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -538,6 +538,9 @@
        <listitem>
         <simpara><literal>ascii</literal> – all printable ASCII characters and <literal>NL</literal></simpara>
        </listitem>
+       <listitem>
+        <simpara><literal>raw</literal> – all characters, newlines will not trigger additional log lines (identical behaviour prior to PHP 7.3)</simpara>
+       </listitem>
       </itemizedlist>
       Only effective if <link linkend="ini.error-log">error_log</link> is set to "syslog".
      </para>

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -527,23 +527,36 @@
       Specifies the filter type to filter the logged messages. Allowed
       characters are passed unmodified; all others are written in their
       hexadecimal representation prefixed with <literal>\x</literal>. There are
-      three supported filter types:
+      four supported filter types:
       <itemizedlist>
        <listitem>
-        <simpara><literal>all</literal> – all characters</simpara>
+        <simpara><literal>all</literal> – the logged string will be split 
+         at newline characters, and all characters are passed unaltered
+        </simpara>
        </listitem>
        <listitem>
-        <simpara><literal>no-ctrl</literal> – all characters except control characters</simpara>
+        <simpara><literal>ascii</literal> – the logged string will be split 
+         at newline characters, and any non-printable 7-bit ASCII characters will be escaped
+        </simpara>
        </listitem>
        <listitem>
-        <simpara><literal>ascii</literal> – all printable ASCII characters and <literal>NL</literal></simpara>
+        <simpara><literal>no-ctrl</literal> – the logged string will be split 
+         at newline characters, and any non-printable characters will be escaped
+        </simpara>
        </listitem>
        <listitem>
-        <simpara><literal>raw</literal> – all characters, newlines will not trigger additional log lines (identical behaviour prior to PHP 7.3)</simpara>
+        <simpara><literal>raw</literal> – all characters are passed to the system 
+         logger unaltered, without splitting at newlines (identical to PHP before 7.3)
+        </simpara>
        </listitem>
       </itemizedlist>
-      Only effective if <link linkend="ini.error-log">error_log</link> is set to "syslog".
+      This setting will affect logging via <link linkend="ini.error-log">error_log</link> set to "syslog" and calls to <function>syslog</function>.
      </para>
+     <note>
+      <para>
+       The <literal>raw</literal> filter type is available as of PHP 7.3.8 and PHP 7.4.0.
+      </para>
+     </note>
     </listitem>
    </varlistentry>
 

--- a/reference/network/functions/syslog.xml
+++ b/reference/network/functions/syslog.xml
@@ -161,6 +161,7 @@ closelog();
    <simplelist>
     <member><function>openlog</function></member>
     <member><function>closelog</function></member>
+    <member><link linkend="ini.syslog.filter">syslog.filter</link> INI setting (starting with PHP 7.3)</member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
https://github.com/php/php-src/pull/4265 restored the previous handling of multi-line log messages by adding `syslog.filter=raw`.

Relates to https://bugs.php.net/bug.php?id=77913