### PR TITLE
file_get_contents methodsynopsis

### DIFF
--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -14,13 +14,13 @@
    <methodparam choice="opt"><type>bool</type><parameter>use_include_path</parameter><initializer>&false;</initializer></methodparam>
    <methodparam choice="opt"><type>resource</type><parameter>context</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>offset</parameter><initializer>0</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>maxlen</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>length</parameter></methodparam>
   </methodsynopsis>
   <para> 
    This function is similar to <function>file</function>, except that
    <function>file_get_contents</function> returns the file in a 
    <type>string</type>, starting at the specified <parameter>offset</parameter> 
-   up to <parameter>maxlen</parameter> bytes. On failure, 
+   up to <parameter>length</parameter> bytes. On failure, 
    <function>file_get_contents</function> will return &false;.
   </para>
   <para>
@@ -89,7 +89,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>maxlen</parameter></term>
+     <term><parameter>length</parameter></term>
      <listitem>
       <para>
        Maximum length of data read. The default is to read until end

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -113,7 +113,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   An <constant>E_WARNING</constant> level error is generated if <parameter>filename</parameter> cannot be found, <parameter>maxlength</parameter>
+   An <constant>E_WARNING</constant> level error is generated if <parameter>filename</parameter> cannot be found, <parameter>length</parameter>
    is less than zero, or if seeking to the specified <parameter>offset</parameter> in the stream fails.
   </para>
   <para>


### PR DESCRIPTION
Rename `maxlen` parameter to `length`.

Bug [#81018](https://bugs.php.net/bug.php?id=81018)
[basic_functions.stub.php](https://github.com/php/php-src/blob/e8ef923dd6f6377c28c58fb64f632d2d4f3e8857/ext/standard/basic_functions.stub.php#L861)