### PR TITLE
fixed SQLite3::setAuthorizer parameter order description.

### DIFF
--- a/reference/sqlite3/sqlite3/setauthorizer.xml
+++ b/reference/sqlite3/sqlite3/setauthorizer.xml
@@ -82,11 +82,11 @@
    </table>
   </para>
   <para>
-   The 5th parameter will be the name of the database (<literal>"main"</literal>,
+   The 4th parameter will be the name of the database (<literal>"main"</literal>,
    <literal>"temp"</literal>, etc.) if applicable.
   </para>
   <para>
-   The 6th parameter to the authorizer callback is the name of the inner-most trigger or
+   The 5th parameter to the authorizer callback is the name of the inner-most trigger or
    view that is responsible for the access attempt or &null; if this access attempt is
    directly from top-level SQL code.
   </para>


### PR DESCRIPTION
5th and 6th parameter description is wrong, because they are copy-and-pasted from the following C interface manual page[*1].
In PHP world, we use only 5 parameters as an Authorizer callback[*2].

[*1] https://www.sqlite.org/c3ref/c_alter_table.html
[*2] https://github.com/php/php-src/blob/php-8.0.0/ext/sqlite3/sqlite3.c#L2077-L2126