### PR TITLE
Fold in comments for get_object_vars()

### DIFF
--- a/reference/classobj/functions/get-object-vars.xml
+++ b/reference/classobj/functions/get-object-vars.xml
@@ -13,7 +13,8 @@
   </methodsynopsis>
   <para>
    Gets the accessible non-static properties of the given 
-   <parameter>object</parameter> according to scope.
+   <parameter>object</parameter> according to scope.  Note that it will only return
+   parameters defined on that object's class, not on its parent class.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -90,6 +91,11 @@ array(4) {
     </screen>
    </example>
   </para>
+  <note>
+   <para>
+    Uninitialized properties are considered inaccessible, and thus will not be included in the array.
+   </para>
+  </note>
  </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;


### PR DESCRIPTION
These were the only comments I thought worth folding in.  The rest were for PHP 4 and didn't even make sense then...

Another 37-ish comments exterminated.