### PR TITLE
Redesign parameter list for PDO_Statement::fetchAll

### DIFF
--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -65,32 +65,25 @@
       </para>
      </listitem>
     </varlistentry>
+   </variablelist>
+   The following are dynamic parameters that are depending on the fetch mode.
+   They can't be used with named parameters.
+   <variablelist>
     <varlistentry>
-     <term><parameter>args</parameter></term>
+     <term><parameter>column</parameter></term>
      <listitem>
       <para>
-       This argument has a different meaning depending on the value of 
-       the <parameter>mode</parameter> parameter:
-       <itemizedlist>
-        <listitem>
-         <para>
-          <constant>PDO::FETCH_COLUMN</constant>: Returns the indicated 0-indexed 
-           column.
-         </para>
-        </listitem>
-        <listitem>
-         <para>
-          <constant>PDO::FETCH_CLASS</constant>: Returns instances of the specified
-          class, mapping the columns of each row to named properties in the class.
-         </para>
-        </listitem>
-        <listitem>
-         <para>
-          <constant>PDO::FETCH_FUNC</constant>: Returns the results of calling the
-          specified function, using each row's columns as parameters in the call.
-         </para>
-        </listitem>
-       </itemizedlist>
+       Used with <constant>PDO::FETCH_COLUMN</constant>. Returns the indicated
+       0-indexed column.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>class</parameter></term>
+     <listitem>
+      <para>
+       Used with <constant>PDO::FETCH_CLASS</constant>. Returns instances of the specified
+       class, mapping the columns of each row to named properties in the class.
       </para>
      </listitem>
     </varlistentry>
@@ -100,6 +93,15 @@
       <para>
        Arguments of custom class constructor when the <parameter>mode</parameter> 
        parameter is <constant>PDO::FETCH_CLASS</constant>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>callback</parameter></term>
+     <listitem>
+      <para>
+       Used with <constant>PDO::FETCH_FUNC</constant>. Returns the results of calling the
+       specified function, using each row's columns as parameters in the call.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
This was missed in review. The overloaded signature is not identical to `setFetchMode`. 
Additionally, specified that these parameters do not work with named parameters. 