### PR TITLE
Add outputs to show differences between PHP 8 and previous versions

### DIFF
--- a/language/operators.xml
+++ b/language/operators.xml
@@ -1574,29 +1574,29 @@ case "a": // never reached because "a" is already matched with 0
     echo "a";
     break;
 }
-
-/**
- * Output for PHP >= 8.0
- */
-
-//    bool(false)
-//    bool(true)
-//    bool(true)
-//    bool(true)
-//    a
-
-/**
- * Output for PHP < 8.0
- */
-
-//    bool(true)
-//    bool(true)
-//    bool(true)
-//    bool(true)
-//    0
 ?>
 ]]>
       </programlisting>
+      &example.outputs.7;
+      <screen>
+<![CDATA[
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+0
+]]>
+      </screen>
+      &example.outputs.8;
+      <screen>
+<![CDATA[
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+a
+]]>
+      </screen>      
      </informalexample>
     </para>
    </warning>

--- a/language/operators.xml
+++ b/language/operators.xml
@@ -1561,16 +1561,16 @@ Expression: 0 = -4 << 62
       <programlisting role="php">
 <![CDATA[
 <?php
-var_dump(0 == "a"); // 0 == 0 -> true
-var_dump("1" == "01"); // 1 == 1 -> true
-var_dump("10" == "1e1"); // 10 == 10 -> true
-var_dump(100 == "1e2"); // 100 == 100 -> true
+var_dump(0 == "a");
+var_dump("1" == "01");
+var_dump("10" == "1e1");
+var_dump(100 == "1e2");
 
 switch ("a") {
 case 0:
     echo "0";
     break;
-case "a": // never reached because "a" is already matched with 0
+case "a":
     echo "a";
     break;
 }

--- a/language/operators.xml
+++ b/language/operators.xml
@@ -1574,6 +1574,26 @@ case "a": // never reached because "a" is already matched with 0
     echo "a";
     break;
 }
+
+/**
+ * Output for PHP >= 8.0
+ */
+
+//    bool(false)
+//    bool(true)
+//    bool(true)
+//    bool(true)
+//    a
+
+/**
+ * Output for PHP < 8.0
+ */
+
+//    bool(true)
+//    bool(true)
+//    bool(true)
+//    bool(true)
+//    0
 ?>
 ]]>
       </programlisting>


### PR DESCRIPTION
The current warning https://www.php.net/manual/en/language.operators.comparison.php is correct: 

> Prior to PHP 8.0.0, if a string is compared to a number or a numeric string then the string was converted to a number before performing the comparison. This can lead to surprising results as can be seen with the following example:

However, without showing outputs for the current example, it's hard to see the subtle differences between PHP 8.0 and PHP < 8.0. That's why I am adding these outputs. 

The output is captured from here https://3v4l.org/SHpi4

Relevant links:

- https://wiki.php.net/rfc/string_to_number_comparison
- https://www.php.net/manual/en/migration80.incompatible.php