### PR TITLE
Fix fputcsv for php 8 to separator

### DIFF
--- a/reference/filesystem/functions/fputcsv.xml
+++ b/reference/filesystem/functions/fputcsv.xml
@@ -12,7 +12,7 @@
    <type class="union"><type>int</type><type>false</type></type><methodname>fputcsv</methodname>
    <methodparam><type>resource</type><parameter>handle</parameter></methodparam>
    <methodparam><type>array</type><parameter>fields</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>delimiter</parameter><initializer>","</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>separator</parameter><initializer>","</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>enclosure</parameter><initializer>'"'</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>escape_char</parameter><initializer>"\\"</initializer></methodparam>
   </methodsynopsis>


### PR DESCRIPTION
As pointed out in https://github.com/php/doc-en/pull/606#issuecomment-843098871 by @cmb69 

fputcsv is now seperator not delimiter: https://3v4l.org/BBCBF