### PR TITLE
Clean up Classname::Method refs

### DIFF
--- a/reference/solr/solrobject/construct.xml
+++ b/reference/solr/solrobject/construct.xml
@@ -53,15 +53,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><methodname>Classname::Method</methodname></member>
-   </simplelist>
-  </para>
- </refsect1>
-
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/solr/solrobject/offsetunset.xml
+++ b/reference/solr/solrobject/offsetunset.xml
@@ -64,15 +64,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><methodname>Classname::Method</methodname></member>
-   </simplelist>
-  </para>
- </refsect1>
-
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/tokyo_tyrant/tokyotyrant/setmaster.xml
+++ b/reference/tokyo_tyrant/tokyotyrant/setmaster.xml
@@ -93,15 +93,6 @@ $tt->setMaster(NULL, 0, 0);
   </para>
  </refsect1>
 
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><methodname>Classname::Method</methodname></member>
-   </simplelist>
-  </para>
- </refsect1>
-
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/tokyo_tyrant/tokyotyrant/stat.xml
+++ b/reference/tokyo_tyrant/tokyotyrant/stat.xml
@@ -93,15 +93,6 @@ array(19) {
   </para>
  </refsect1>
 
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><methodname>Classname::Method</methodname></member>
-   </simplelist>
-  </para>
- </refsect1>
-
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/tokyo_tyrant/tokyotyrantquery/addcond.xml
+++ b/reference/tokyo_tyrant/tokyotyrantquery/addcond.xml
@@ -115,15 +115,6 @@ array(2) {
   </para>
  </refsect1>
 
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><methodname>Classname::Method</methodname></member>
-   </simplelist>
-  </para>
- </refsect1>
-
 </refentry>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Removed unnecessary `<methodname>Classname::Method</methodname>` refs