### PR TITLE
Fix the default value of `mysqli.rollback-on-cached-plink`

### DIFF
--- a/reference/mysqli/ini.xml
+++ b/reference/mysqli/ini.xml
@@ -84,7 +84,7 @@
      </row>
      <row>
       <entry><link linkend="ini.mysqli.rollback-on-cached-plink">mysqli.rollback_on_cached_plink</link></entry>
-      <entry>TRUE</entry>
+      <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
       <entry></entry>
      </row>


### PR DESCRIPTION
This PR fixes the default value of `mysqli.rollback-on-cached-plink`. It's is `"0"` as set here. 
https://github.com/php/php-src/blob/php-8.0.6/ext/mysqli/mysqli.c#L490