### PR TITLE
Clarify that \Q and \E don't affect delimiters

### DIFF
--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -600,7 +600,7 @@
    regexp metacharacters in the pattern. For example:
    <literal>\w+\Q.$.\E$</literal> will match one or more word characters,
    followed by literals <literal>.$.</literal> and anchored at the end of
-   the string. Note that this does not change the behaviour of 
+   the string. Note that this does not change the behavior of 
    delimiters; for instance the pattern <literal>#\Q#\E#$</literal>
    is not valid, because the second <literal>#</literal> marks the end
    of the pattern, and the <literal>\E#</literal> is interpreted as invalid

--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -602,7 +602,7 @@
    followed by literals <literal>.$.</literal> and anchored at the end of
    the string. Note that this does not change the behaviour of 
    delimiters; for instance the pattern <literal>#\Q#\E#$</literal>
-   is in not valid, because the second <literal>#</literal> marks the end
+   is not valid, because the second <literal>#</literal> marks the end
    of the pattern, and the <literal>\E#</literal> is interpreted as invalid
    modifiers.
   </para>

--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -600,7 +600,11 @@
    regexp metacharacters in the pattern. For example:
    <literal>\w+\Q.$.\E$</literal> will match one or more word characters,
    followed by literals <literal>.$.</literal> and anchored at the end of
-   the string.
+   the string. Note that this does not change the behaviour of 
+   delimiters; for instance the pattern <literal>#\Q#\E#$</literal>
+   is in not valid, because the second <literal>#</literal> marks the end
+   of the pattern, and the <literal>\E#</literal> is interpreted as invalid
+   modifiers.
   </para>
 
   <para>


### PR DESCRIPTION
Inspired by https://bugs.php.net/bug.php?id=81060