### PR TITLE
Fix parameter names for the `mkdir` function

### DIFF
--- a/reference/filesystem/functions/mkdir.xml
+++ b/reference/filesystem/functions/mkdir.xml
@@ -10,13 +10,13 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>mkdir</methodname>
-   <methodparam><type>string</type><parameter>pathname</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer>0777</initializer></methodparam>
+   <methodparam><type>string</type><parameter>directory</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>permissions</parameter><initializer>0777</initializer></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>recursive</parameter><initializer>&false;</initializer></methodparam>
    <methodparam choice="opt"><type>resource</type><parameter>context</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Attempts to create the directory specified by pathname. 
+   Attempts to create the directory specified by directory.
   </para>
  </refsect1>
 
@@ -25,7 +25,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>pathname</parameter></term>
+     <term><parameter>directory</parameter></term>
      <listitem>
       <para>
        The directory path.
@@ -33,16 +33,16 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>mode</parameter></term>
+     <term><parameter>permissions</parameter></term>
      <listitem>
       <para>
-       The mode is 0777 by default, which means the widest possible
+       The permissions are 0777 by default, which means the widest possible
        access. For more information on modes, read the details
        on the <function>chmod</function> page.
       </para>
       <note>
        <para>
-        <parameter>mode</parameter> is ignored on Windows.
+        <parameter>permissions</parameter> is ignored on Windows.
        </para>
       </note>
       <para>
@@ -58,7 +58,7 @@
      <listitem>
       <para>
        Allows the creation of nested directories specified in the 
-       <parameter>pathname</parameter>.
+       <parameter>directory</parameter>.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Thankfully PHP 8 provides us with [named arguments][1].
Unfortunately the current [documentation for the `mkdir` function][2] does not specify the correct parameter names.
As per the current documentation, the first parameter is named `pathname` and the second parameter `mode`.

This is not correct and can be verified with
```
$ php -v
PHP 8.0.3 (cli) (built: Apr  1 2021 15:33:29) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.3, Copyright (c) Zend Technologies

$ php -a
Interactive shell

php > mkdir(pathname: '/tmp/test', recursive: true);

Warning: Uncaught Error: Unknown named parameter $pathname in php shell code:1
Stack trace:
#0 {main}
  thrown in php shell code on line 1
php > $r = new \ReflectionFunction('mkdir');
php > var_dump($r->getParameters());
array(4) {
  [0]=>
  object(ReflectionParameter)#2 (1) {
    ["name"]=>
    string(9) "directory"
  }
  [1]=>
  object(ReflectionParameter)#3 (1) {
    ["name"]=>
    string(11) "permissions"
  }
  [2]=>
  object(ReflectionParameter)#4 (1) {
    ["name"]=>
    string(9) "recursive"
  }
  [3]=>
  object(ReflectionParameter)#5 (1) {
    ["name"]=>
    string(7) "context"
  }
}

```

  [1]: https://wiki.php.net/rfc/named_params
  [2]: https://archive.is/C1RiR