### PR TITLE
Fix parameter names for the `rmdir` function

### DIFF
--- a/reference/filesystem/functions/rmdir.xml
+++ b/reference/filesystem/functions/rmdir.xml
@@ -10,11 +10,11 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>rmdir</methodname>
-   <methodparam><type>string</type><parameter>dirname</parameter></methodparam>
+   <methodparam><type>string</type><parameter>directory</parameter></methodparam>
    <methodparam choice="opt"><type>resource</type><parameter>context</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Attempts to remove the directory named by <parameter>dirname</parameter>.
+   Attempts to remove the directory named by <parameter>directory</parameter>.
    The directory must be empty, and the relevant permissions must permit this.
    A <constant>E_WARNING</constant> level error will be generated on failure.
   </para>
@@ -25,7 +25,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>dirname</parameter></term>
+     <term><parameter>directory</parameter></term>
      <listitem>
       <para>
        Path to the directory.


### PR DESCRIPTION
Basically the same as #614.
I looked around a bit more and noticed, that the parameter names in the [documentation of the `rmdir` function][1]
also differ from the implementation.

```
$ php -v
PHP 8.0.3 (cli) (built: Apr  1 2021 15:33:29) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.3, Copyright (c) Zend Technologies
$ php -a
Interactive shell

php > print_r((new \ReflectionFunction('rmdir'))->getParameters());
Array
(
    [0] => ReflectionParameter Object
        (
            [name] => directory
        )

    [1] => ReflectionParameter Object
        (
            [name] => context
        )

)
```

If I find some more bugs of this kind in the future, should I continue to create a PR per function or collect all changes in a single PR?

  [1]: https://archive.is/2l650