### PR TITLE
Fix the examples for character_set_name

### DIFF
--- a/reference/mysqli/mysqli/character-set-name.xml
+++ b/reference/mysqli/mysqli/character-set-name.xml
@@ -4,7 +4,7 @@
  <refnamediv>
   <refname>mysqli::character_set_name</refname>
   <refname>mysqli_character_set_name</refname>
-  <refpurpose>Returns the default character set for the database connection</refpurpose>
+  <refpurpose>Returns the current character set of the database connection</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -20,7 +20,7 @@
    <methodparam><type>mysqli</type><parameter>mysql</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Returns the current character set for the database connection.
+   Returns the current character set of the database connection.
   </para>
  </refsect1>
 
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>The default character set for the current connection</para>
+  <para>The current character set of the connection</para>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mysqli/mysqli/character-set-name.xml
+++ b/reference/mysqli/mysqli/character-set-name.xml
@@ -50,7 +50,7 @@
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("localhost", "my_user", "my_password", "world");
 
-/* Set a default character set */
+/* Set the default character set */
 $mysqli->set_charset('utf8mb4');
 
 /* Print current character set */
@@ -66,7 +66,7 @@ printf("Current character set is %s\n", $charset);
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = mysqli_connect("localhost", "my_user", "my_password", "world");
 
-/* Set a default character set */
+/* Set the default character set */
 mysqli_set_charset($mysqli, 'utf8mb4');
 
 /* Print current character set */

--- a/reference/mysqli/mysqli/character-set-name.xml
+++ b/reference/mysqli/mysqli/character-set-name.xml
@@ -46,49 +46,38 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-/* Open a connection */
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli("localhost", "my_user", "my_password", "world");
 
-/* check connection */
-if (mysqli_connect_errno()) {
-    printf("Connect failed: %s\n", mysqli_connect_error());
-    exit();
-}
+/* Set a default character set */
+$mysqli->set_charset('utf8mb4');
 
 /* Print current character set */
 $charset = $mysqli->character_set_name();
-printf ("Current character set is %s\n", $charset);
-
-$mysqli->close();
-?>
+printf("Current character set is %s\n", $charset);
 ]]>
    </programlisting>
    <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
-/* Open a connection */
-$link = mysqli_connect("localhost", "my_user", "my_password", "world");
 
-/* check connection */
-if (!$link) {
-    printf("Connect failed: %s\n", mysqli_connect_error());
-    exit();
-}
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = mysqli_connect("localhost", "my_user", "my_password", "world");
+
+/* Set a default character set */
+mysqli_set_charset($mysqli, 'utf8mb4');
 
 /* Print current character set */
-$charset = mysqli_character_set_name($link);
-printf ("Current character set is %s\n",$charset);
-
-/* close connection */
-mysqli_close($link);
-?>
+$charset = mysqli_character_set_name($mysqli);
+printf("Current character set is %s\n", $charset);
 ]]>
    </programlisting>
    &examples.outputs;
    <screen>
 <![CDATA[
-Current character set is latin1_swedish_ci
+Current character set is utf8mb4
 ]]>
    </screen>
   </example>


### PR DESCRIPTION
The example had incorrect return value. It does not return current collation, but the charset. Fixed the example, which now set the charset before reading to show the behaviour more clearly. 