### PR TITLE
Updating mysqli: connect_error & connect_errno

### DIFF
--- a/reference/mysqli/mysqli/connect-errno.xml
+++ b/reference/mysqli/mysqli/connect-errno.xml
@@ -17,16 +17,15 @@
    <void />
   </methodsynopsis>
   <para>
-   Returns the last error code number from the last call to 
-   <function>mysqli_connect</function>.
+   Returns the last error code from the last connection attempt.
   </para>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An error code value for the last call to <function>mysqli_connect</function>, if it failed.
-   zero means no error occurred.
+   An error code for the last connection attempt, if it failed.
+   Zero means no error occurred.
   </para>
  </refsect1>
 

--- a/reference/mysqli/mysqli/connect-errno.xml
+++ b/reference/mysqli/mysqli/connect-errno.xml
@@ -20,15 +20,6 @@
    Returns the last error code number from the last call to 
    <function>mysqli_connect</function>.
   </para>
-  <note>
-   <para>
-    Client error message numbers are listed in the MySQL 
-    <filename>errmsg.h</filename> header file, server error message numbers
-    are listed in <filename>mysqld_error.h</filename>. In the MySQL source
-    distribution you can find a complete list of error messages and error
-    numbers in the file <filename>Docs/mysqld_error.txt</filename>.
-   </para>
-  </note>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/mysqli/mysqli/connect-errno.xml
+++ b/reference/mysqli/mysqli/connect-errno.xml
@@ -37,30 +37,32 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+/* @ is used to suppress default error messages */
 $mysqli = @new mysqli('localhost', 'fake_user', 'my_password', 'my_db');
 
 if ($mysqli->connect_errno) {
-    die('Connect Error: ' . $mysqli->connect_errno);
+    /* Use your preferred error logging method here */
+    error_log('Connection error: ' . $mysqli->connect_errno);
 }
-?>
 ]]>
    </programlisting>
    <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
+/* @ is used to suppress default error messages */
 $link = @mysqli_connect('localhost', 'fake_user', 'my_password', 'my_db');
 
 if (!$link) {
-    die('Connect Error: ' . mysqli_connect_errno());
+    /* Use your preferred error logging method here */
+    error_log('Connection error: ' . mysqli_connect_errno());
 }
-?>
 ]]>
    </programlisting>
    &examples.outputs;
    <screen>
 <![CDATA[
-Connect Error: 1045
+Connection error: 1045
 ]]>
    </screen>
   </example>

--- a/reference/mysqli/mysqli/connect-error.xml
+++ b/reference/mysqli/mysqli/connect-error.xml
@@ -36,30 +36,32 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+/* @ is used to suppress default error messages */
 $mysqli = @new mysqli('localhost', 'fake_user', 'my_password', 'my_db');
 
 if ($mysqli->connect_error) {
-    die('Connect Error: ' . $mysqli->connect_error);
+    /* Use your preferred error logging method here */
+    error_log('Connection error: ' . $mysqli->connect_error);
 }
-?>
 ]]>
    </programlisting>
    <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
+/* @ is used to suppress default error messages */
 $link = @mysqli_connect('localhost', 'fake_user', 'my_password', 'my_db');
 
 if (!$link) {
-    die('Connect Error: ' . mysqli_connect_error());
+    /* Use your preferred error logging method here */
+    error_log('Connection error: ' . mysqli_connect_error());
 }
-?>
 ]]>
    </programlisting>
    &examples.outputs;
    <screen>
 <![CDATA[
-Connect Error: Access denied for user 'fake_user'@'localhost' (using password: YES)
+Connection error: Access denied for user 'fake_user'@'localhost' (using password: YES)
 ]]>
    </screen>
   </example>

--- a/reference/mysqli/mysqli/connect-error.xml
+++ b/reference/mysqli/mysqli/connect-error.xml
@@ -4,7 +4,7 @@
  <refnamediv>
   <refname>mysqli::$connect_error</refname>
   <refname>mysqli_connect_error</refname>
-  <refpurpose>Returns a string description of the last connect error</refpurpose>
+  <refpurpose>Returns a description of the last connection error</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,8 +17,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Returns the last error message string from the last call to 
-   <function>mysqli_connect</function>.
+   Returns the error message from the last failed connection attempt.
   </para>
  </refsect1>
  

--- a/reference/mysqli/mysqli/errno.xml
+++ b/reference/mysqli/mysqli/errno.xml
@@ -20,14 +20,6 @@
    Returns the last error code for the most recent MySQLi function call that
    can succeed or fail.
   </para>
-  <para>
-   Client error message numbers are listed in the MySQL 
-   <filename>errmsg.h</filename> header file, server error message numbers
-   are listed in <filename>mysqld_error.h</filename>.
-   In the MySQL source distribution you can find a complete list of error
-   messages and error numbers in the file 
-   <filename>Docs/mysqld_error.txt</filename>.
-  </para>
  </refsect1>
  
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli_stmt/errno.xml
+++ b/reference/mysqli/mysqli_stmt/errno.xml
@@ -20,15 +20,6 @@
    Returns the error code for the most recently invoked statement function
    that can succeed or fail.
   </para>
-  <para>
-   Client error message numbers are listed in the MySQL
-   <filename>errmsg.h</filename> header file,
-   server error message numbers are listed in
-   <filename>mysqld_error.h</filename>.
-   In the MySQL source distribution you can find a complete list of error
-   messages and error numbers in the file 
-   <filename>Docs/mysqld_error.txt</filename>.
-  </para>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
 - Removed unhelpful notes
 - Replaced `die()` with `error_log()` - if default error reporting is disabled then the errors should probably be logged to a file
 - Removed mention of `mysqli_connect`. The connection error can come from all connection attempts except `change_user`
 - Added explanatory comments in the code examples