### PR TITLE
Doc Bug #81073 Fixed example titles in PDOStatement::execute

### DIFF
--- a/reference/pdo/pdostatement/execute.xml
+++ b/reference/pdo/pdostatement/execute.xml
@@ -85,7 +85,7 @@ $sth->execute();
    </programlisting>
   </example>
 
-  <example><title>Execute a prepared statement with an array of insert values (named parameters)</title>
+  <example><title>Execute a prepared statement with an array of named values</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -101,7 +101,7 @@ $sth->execute(array(':calories' => $calories, ':colour' => $colour));
    </programlisting>
   </example>
 
-  <example><title>Execute a prepared statement with an array of insert values (placeholders)</title>
+  <example><title>Execute a prepared statement with an array of positional values</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -117,7 +117,7 @@ $sth->execute(array($calories, $colour));
    </programlisting>
   </example>
 
-  <example><title>Execute a prepared statement with question mark placeholders</title>
+  <example><title>Execute a prepared statement with variables bound to positional placeholders</title>
    <programlisting role="php">
 <![CDATA[
 <?php


### PR DESCRIPTION
Similar to what was proposed in the bug report but used the word "positional" for question mark placeholder values. Fixed the third title too.