### PR TITLE
Update `spl_autoload_register` parameter section.

### DIFF
--- a/reference/spl/functions/spl-autoload-register.xml
+++ b/reference/spl/functions/spl-autoload-register.xml
@@ -45,6 +45,10 @@
        If no parameter is provided, then the default implementation of
        <function>spl_autoload</function> will be registered.      
       </para>
+      <methodsynopsis>
+       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>string</type><parameter>class_name</parameter></methodparam>
+      </methodsynopsis>
      </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
This PR might not be necessary but noticed `spl_autoload_register` didn't have a signature for its callback parameter, so I decided to add it.

Choose to base it on the signature of `spl_autoload` which is the default method called if the callback is *null*. Hence the `string $class_name` parameter and `void` return type.

Feel this will be quicker for end-users to see the signature here instead of scrolling down to the examples section to see the implementation.