### PR TITLE
[80738] Update MB string functions

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1061,6 +1061,13 @@ encoding value will be used.</para>'>
  </entry>
 </row>'>
 
+<!ENTITY mbstring.changelog.needle-empty '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.0.0</entry>
+ <entry>
+  <parameter>needle</parameter> now accepts empty string.
+ </entry>
+</row>'>
+
 <!-- mcrypt notes -->
 
 <!ENTITY mcrypt.parameter.cipher '<para xmlns="http://docbook.org/ns/docbook">One of the <constant>MCRYPT_ciphername</constant> constants, or the name of the algorithm as string.</para>'>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1064,7 +1064,7 @@ encoding value will be used.</para>'>
 <!ENTITY mbstring.changelog.needle-empty '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
-  <parameter>needle</parameter> now accepts empty string.
+  <parameter>needle</parameter> now accepts an empty string.
  </entry>
 </row>'>
 

--- a/reference/mbstring/functions/mb-stripos.xml
+++ b/reference/mbstring/functions/mb-stripos.xml
@@ -87,6 +87,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       <parameter>needle</parameter> now accepts <literal>""</literal> (empty string).
+      </entry>
+     </row>
      &mbstring.changelog.encoding-nullable;
      <row>
       <entry>7.1.0</entry>

--- a/reference/mbstring/functions/mb-stripos.xml
+++ b/reference/mbstring/functions/mb-stripos.xml
@@ -90,7 +90,7 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <parameter>needle</parameter> now accepts <literal>""</literal> (empty string).
+       <parameter>needle</parameter> now accepts empty string.
       </entry>
      </row>
      &mbstring.changelog.encoding-nullable;

--- a/reference/mbstring/functions/mb-stripos.xml
+++ b/reference/mbstring/functions/mb-stripos.xml
@@ -87,12 +87,7 @@
      </row>
     </thead>
     <tbody>
-     <row>
-      <entry>8.0.0</entry>
-      <entry>
-       <parameter>needle</parameter> now accepts empty string.
-      </entry>
-     </row>
+     &mbstring.changelog.needle-empty;
      &mbstring.changelog.encoding-nullable;
      <row>
       <entry>7.1.0</entry>

--- a/reference/mbstring/functions/mb-stristr.xml
+++ b/reference/mbstring/functions/mb-stristr.xml
@@ -98,6 +98,7 @@
      </row>
     </thead>
     <tbody>
+     &mbstring.changelog.needle-empty;
      &mbstring.changelog.encoding-nullable;
     </tbody>
    </tgroup>

--- a/reference/mbstring/functions/mb-strpos.xml
+++ b/reference/mbstring/functions/mb-strpos.xml
@@ -88,6 +88,7 @@
      </row>
     </thead>
     <tbody>
+     &mbstring.changelog.needle-empty;
      &mbstring.changelog.encoding-nullable;
      <row>
       <entry>7.1.0</entry>

--- a/reference/mbstring/functions/mb-strrchr.xml
+++ b/reference/mbstring/functions/mb-strrchr.xml
@@ -87,6 +87,7 @@
      </row>
     </thead>
     <tbody>
+     &mbstring.changelog.needle-empty;
      &mbstring.changelog.encoding-nullable;
     </tbody>
    </tgroup>

--- a/reference/mbstring/functions/mb-strrichr.xml
+++ b/reference/mbstring/functions/mb-strrichr.xml
@@ -98,6 +98,7 @@
      </row>
     </thead>
     <tbody>
+     &mbstring.changelog.needle-empty;
      &mbstring.changelog.encoding-nullable;
     </tbody>
    </tgroup>

--- a/reference/mbstring/functions/mb-strripos.xml
+++ b/reference/mbstring/functions/mb-strripos.xml
@@ -98,6 +98,7 @@
      </row>
     </thead>
     <tbody>
+     &mbstring.changelog.needle-empty;
      &mbstring.changelog.encoding-nullable;
     </tbody>
    </tgroup>

--- a/reference/mbstring/functions/mb-strrpos.xml
+++ b/reference/mbstring/functions/mb-strrpos.xml
@@ -87,6 +87,7 @@
      </row>
     </thead>
     <tbody>
+     &mbstring.changelog.needle-empty;
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/mbstring/functions/mb-strstr.xml
+++ b/reference/mbstring/functions/mb-strstr.xml
@@ -96,6 +96,7 @@
      </row>
     </thead>
     <tbody>
+     &mbstring.changelog.needle-empty;
      &mbstring.changelog.encoding-nullable;
     </tbody>
    </tgroup>


### PR DESCRIPTION
This PR aims to fix the currently missing "_`needle` argument can now be empty_" changelogs in some `mb_*` functions.

If the wording in the changelog is acceptable, it will be added to the rest of the function, namely `mb_strpos`, `mb_strrpos`, `mb_strstr`, `mb_stristr`, `mb_strchr` and `mb_strichr`. Those are the function listed in the [migration](https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.mbstring).

Potentially by creating a new entity `&mbstring.changelog.needle-empty;` to avoid duplication.