### PR TITLE
Remove obsolete opcache.fast_shutdown config recommendation

### DIFF
--- a/reference/opcache/configure.xml
+++ b/reference/opcache/configure.xml
@@ -43,7 +43,6 @@ opcache.memory_consumption=128
 opcache.interned_strings_buffer=8
 opcache.max_accelerated_files=4000
 opcache.revalidate_freq=60
-opcache.fast_shutdown=1
 opcache.enable_cli=1
 ]]>
    </programlisting>


### PR DESCRIPTION
`opcache.fast_shutdown` was removed in PHP 7.2