### PR TITLE
Fix function description

### DIFF
--- a/reference/image/functions/imageresolution.xml
+++ b/reference/image/functions/imageresolution.xml
@@ -18,7 +18,7 @@
    <function>imageresolution</function> allows to set and get the resolution of
    an image in DPI (dots per inch). If the optional parameters are &null;,
    the current resolution is returned as an indexed array. If only
-   <parameter>resolution_x</parameter> is &null;, the horizontal and vertical resolution
+   <parameter>resolution_x</parameter> is not &null;, the horizontal and vertical resolution
    are set to this value. If none of the optional parameters are &null;, the horizontal
    and vertical resolution are set to these values, respectively.
   </para>


### PR DESCRIPTION
Seems that `not` is missed.

The previous description was:
```
If only <parameter>res_x</parameter> is given, the horizontal and vertical resolution  are set to this value.
```