### PR TITLE
Update stream_bucket_make_writeable return types

### DIFF
--- a/reference/stream/functions/stream-bucket-make-writeable.xml
+++ b/reference/stream/functions/stream-bucket-make-writeable.xml
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>object</type><methodname>stream_bucket_make_writeable</methodname>
+   <type class="union"><type>object</type><type>null</type></type><methodname>stream_bucket_make_writeable</methodname>
    <methodparam><type>resource</type><parameter>brigade</parameter></methodparam>
   </methodsynopsis>
 


### PR DESCRIPTION
The current documentation states `stream_bucket_make_writeable` returns `object`. 

This is incorrect, it returns `object|null`: 
* https://github.com/php/php-src/blob/dd83ced6bd600e0dd5b09cf26fe4302344521e97/ext/standard/user_filters.c#L382
* https://github.com/php/php-src/blob/dd83ced6bd600e0dd5b09cf26fe4302344521e97/ext/standard/basic_functions.stub.php#L1456