### PR TITLE
Fix Extension membership, and rebuild extension list file from automated script

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -39,5 +39,8 @@ jobs:
           path: "doc-base"
           repository: "php/doc-base"
 
+      - name: "Quality Assurance scripts"
+        run: "php8.0 doc-base/scripts/qa/extensions.xml.php --check"
+
       - name: "Build documentation for ${{ matrix.language }}"
         run: "php8.0 doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}"

--- a/appendices/extensions.xml
+++ b/appendices/extensions.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!--
   DO NOT TRANSLATE THIS FILE! All the content that is displayed
   on the extension categorization page in your translated manual
@@ -19,7 +18,9 @@
    <listitem><simpara><xref linkend="book.bzip2"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.calendar"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.classobj"/></simpara></listitem>
+   <listitem><simpara><xref linkend="book.cmark"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.com"/></simpara></listitem>
+   <listitem><simpara><xref linkend="book.componere"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.csprng"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.ctype"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.cubrid"/></simpara></listitem>
@@ -40,9 +41,9 @@
    <listitem><simpara><xref linkend="book.exif"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.expect"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.fann"/></simpara></listitem>
-   <listitem><simpara><xref linkend="book.fann"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.fbsql"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.fdf"/></simpara></listitem>
+   <listitem><simpara><xref linkend="book.ffi"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.fileinfo"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.filesystem"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.filter"/></simpara></listitem>
@@ -71,6 +72,7 @@
    <listitem><simpara><xref linkend="book.ldap"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.libxml"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.lua"/></simpara></listitem>
+   <listitem><simpara><xref linkend="book.luasandbox"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.lzf"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.mail"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.mailparse"/></simpara></listitem>
@@ -81,10 +83,9 @@
    <listitem><simpara><xref linkend="book.memcached"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.mhash"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.misc"/></simpara></listitem>
-   <listitem><simpara><xref linkend="book.bson"/></simpara></listitem>
-   <listitem><simpara><xref linkend="book.mongodb"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.mqseries"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.mysql"/></simpara></listitem>
+   <listitem><simpara><xref linkend="book.mysql-xdevapi"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.mysqli"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.mysqlnd"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.network"/></simpara></listitem>
@@ -94,6 +95,7 @@
    <listitem><simpara><xref linkend="book.openal"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.openssl"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.outcontrol"/></simpara></listitem>
+   <listitem><simpara><xref linkend="book.parallel"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.parle"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.password"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.pcntl"/></simpara></listitem>
@@ -112,6 +114,8 @@
    <listitem><simpara><xref linkend="ref.pdo-sqlsrv"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.pgsql"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.phar"/></simpara></listitem>
+   <listitem><simpara><xref linkend="book.phpdbg"/></simpara></listitem>
+   <listitem><simpara><xref linkend="book.pht"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.posix"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.ps"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.pspell"/></simpara></listitem>
@@ -121,7 +125,9 @@
    <listitem><simpara><xref linkend="book.readline"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.recode"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.reflection"/></simpara></listitem>
+   <listitem><simpara><xref linkend="book.rpminfo"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.rrd"/></simpara></listitem>
+   <listitem><simpara><xref linkend="book.runkit7"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.scoutapm"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.seaslog"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.sem"/></simpara></listitem>
@@ -164,12 +170,14 @@
    <listitem><simpara><xref linkend="book.xattr"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.xdiff"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.xhprof"/></simpara></listitem>
+   <listitem><simpara><xref linkend="book.xlswriter"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.xml"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.xmldiff"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.xmlreader"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.xmlrpc"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.xmlwriter"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.xsl"/></simpara></listitem>
+   <listitem><simpara><xref linkend="book.yac"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.yaconf"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.yaf"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.yaml"/></simpara></listitem>
@@ -196,24 +204,27 @@
     <listitem><para><xref linkend="book.dir"/></para></listitem>
     <listitem><para><xref linkend="book.errorfunc"/></para></listitem>
     <listitem><para><xref linkend="book.exec"/></para></listitem>
+    <listitem><para><xref linkend="book.ffi"/></para></listitem>
     <listitem><para><xref linkend="book.filesystem"/></para></listitem>
-    <listitem><para><xref linkend="book.filter"/></para></listitem>
+    <listitem><para><xref linkend="book.fpm"/></para></listitem>
     <listitem><para><xref linkend="book.funchand"/></para></listitem>
     <listitem><para><xref linkend="book.hash"/></para></listitem>
+    <listitem><para><xref linkend="book.hrtime"/></para></listitem>
     <listitem><para><xref linkend="book.info"/></para></listitem>
+    <listitem><para><xref linkend="book.json"/></para></listitem>
     <listitem><para><xref linkend="book.mail"/></para></listitem>
     <listitem><para><xref linkend="book.math"/></para></listitem>
+    <listitem><para><xref linkend="book.mhash"/></para></listitem>
     <listitem><para><xref linkend="book.misc"/></para></listitem>
     <listitem><para><xref linkend="book.network"/></para></listitem>
+    <listitem><para><xref linkend="book.opcache"/></para></listitem>
     <listitem><para><xref linkend="book.outcontrol"/></para></listitem>
     <listitem><para><xref linkend="book.password"/></para></listitem>
-    <listitem><para><xref linkend="book.phar"/></para></listitem>
+    <listitem><para><xref linkend="book.pcre"/></para></listitem>
     <listitem><para><xref linkend="book.reflection"/></para></listitem>
-    <listitem><para><xref linkend="book.session"/></para></listitem>
     <listitem><para><xref linkend="book.spl"/></para></listitem>
     <listitem><para><xref linkend="book.stream"/></para></listitem>
     <listitem><para><xref linkend="book.strings"/></para></listitem>
-    <listitem><para><xref linkend="book.tokenizer"/></para></listitem>
     <listitem><para><xref linkend="book.url"/></para></listitem>
     <listitem><para><xref linkend="book.var"/></para></listitem>
    </itemizedlist>
@@ -231,22 +242,23 @@
     <listitem><para><xref linkend="book.dba"/></para></listitem>
     <listitem><para><xref linkend="book.exif"/></para></listitem>
     <listitem><para><xref linkend="book.fileinfo"/></para></listitem>
+    <listitem><para><xref linkend="book.filter"/></para></listitem>
     <listitem><para><xref linkend="book.ftp"/></para></listitem>
     <listitem><para><xref linkend="book.iconv"/></para></listitem>
     <listitem><para><xref linkend="book.image"/></para></listitem>
     <listitem><para><xref linkend="book.intl"/></para></listitem>
-    <listitem><para><xref linkend="book.json"/></para></listitem>
     <listitem><para><xref linkend="book.mbstring"/></para></listitem>
-    <listitem><para><xref linkend="book.opcache"/></para></listitem>
     <listitem><para><xref linkend="book.pcntl"/></para></listitem>
-    <listitem><para><xref linkend="book.pcre"/></para></listitem>
     <listitem><para><xref linkend="book.pdo"/></para></listitem>
+    <listitem><para><xref linkend="book.phar"/></para></listitem>
+    <listitem><para><xref linkend="book.phpdbg"/></para></listitem>
     <listitem><para><xref linkend="book.posix"/></para></listitem>
     <listitem><para><xref linkend="book.sem"/></para></listitem>
+    <listitem><para><xref linkend="book.session"/></para></listitem>
     <listitem><para><xref linkend="book.shmop"/></para></listitem>
     <listitem><para><xref linkend="book.sockets"/></para></listitem>
     <listitem><para><xref linkend="book.sqlite3"/></para></listitem>
-    <listitem><para><xref linkend="book.xmlrpc"/></para></listitem>
+    <listitem><para><xref linkend="book.tokenizer"/></para></listitem>
     <listitem><para><xref linkend="book.zlib"/></para></listitem>
    </itemizedlist>
   </section>
@@ -257,19 +269,14 @@
    <itemizedlist>
     <listitem><para><xref linkend="book.bzip2"/></para></listitem>
     <listitem><para><xref linkend="book.curl"/></para></listitem>
-    <listitem><para><xref linkend="book.dbase"/></para></listitem>
     <listitem><para><xref linkend="book.dom"/></para></listitem>
     <listitem><para><xref linkend="book.enchant"/></para></listitem>
     <listitem><para><xref linkend="book.fbsql"/></para></listitem>
     <listitem><para><xref linkend="book.gettext"/></para></listitem>
     <listitem><para><xref linkend="book.gmp"/></para></listitem>
-    <listitem><para><xref linkend="book.ibase"/></para></listitem>
     <listitem><para><xref linkend="book.imap"/></para></listitem>
     <listitem><para><xref linkend="book.ldap"/></para></listitem>
     <listitem><para><xref linkend="book.libxml"/></para></listitem>
-    <listitem><para><xref linkend="book.mcrypt"/></para></listitem>
-    <listitem><para><xref linkend="book.mhash"/></para></listitem>
-    <listitem><para><xref linkend="book.mysql"/></para></listitem>
     <listitem><para><xref linkend="book.mysqli"/></para></listitem>
     <listitem><para><xref linkend="book.mysqlnd"/></para></listitem>
     <listitem><para><xref linkend="book.oci8"/></para></listitem>
@@ -282,16 +289,15 @@
     <listitem><para><xref linkend="ref.pdo-pgsql"/></para></listitem>
     <listitem><para><xref linkend="ref.pdo-sqlite"/></para></listitem>
     <listitem><para><xref linkend="book.pgsql"/></para></listitem>
+    <listitem><para><xref linkend="book.pht"/></para></listitem>
     <listitem><para><xref linkend="book.pspell"/></para></listitem>
     <listitem><para><xref linkend="book.readline"/></para></listitem>
-    <listitem><para><xref linkend="book.recode"/></para></listitem>
     <listitem><para><xref linkend="book.simplexml"/></para></listitem>
     <listitem><para><xref linkend="book.snmp"/></para></listitem>
     <listitem><para><xref linkend="book.soap"/></para></listitem>
     <listitem><para><xref linkend="book.sodium"/></para></listitem>
     <listitem><para><xref linkend="book.tidy"/></para></listitem>
     <listitem><para><xref linkend="book.uodbc"/></para></listitem>
-    <listitem><para><xref linkend="book.wddx"/></para></listitem>
     <listitem><para><xref linkend="book.xml"/></para></listitem>
     <listitem><para><xref linkend="book.xmlreader"/></para></listitem>
     <listitem><para><xref linkend="book.xmlwriter"/></para></listitem>
@@ -304,18 +310,25 @@
    &extcat.membership.pecl;
 
    <itemizedlist>
+    <listitem><para><xref linkend="book.apcu"/></para></listitem>
+    <listitem><para><xref linkend="book.cmark"/></para></listitem>
+    <listitem><para><xref linkend="book.componere"/></para></listitem>
     <listitem><para><xref linkend="book.cubrid"/></para></listitem>
+    <listitem><para><xref linkend="book.dbase"/></para></listitem>
     <listitem><para><xref linkend="book.dio"/></para></listitem>
+    <listitem><para><xref linkend="book.ds"/></para></listitem>
     <listitem><para><xref linkend="book.eio"/></para></listitem>
     <listitem><para><xref linkend="book.ev"/></para></listitem>
     <listitem><para><xref linkend="book.event"/></para></listitem>
     <listitem><para><xref linkend="book.expect"/></para></listitem>
+    <listitem><para><xref linkend="book.fann"/></para></listitem>
     <listitem><para><xref linkend="book.fdf"/></para></listitem>
     <listitem><para><xref linkend="book.gearman"/></para></listitem>
     <listitem><para><xref linkend="book.gender"/></para></listitem>
     <listitem><para><xref linkend="book.geoip"/></para></listitem>
     <listitem><para><xref linkend="book.gmagick"/></para></listitem>
     <listitem><para><xref linkend="book.gnupg"/></para></listitem>
+    <listitem><para><xref linkend="book.ibase"/></para></listitem>
     <listitem><para><xref linkend="book.ibm-db2"/></para></listitem>
     <listitem><para><xref linkend="book.imagick"/></para></listitem>
     <listitem><para><xref linkend="book.inotify"/></para></listitem>
@@ -323,19 +336,27 @@
     <listitem><para><xref linkend="book.luasandbox"/></para></listitem>
     <listitem><para><xref linkend="book.lzf"/></para></listitem>
     <listitem><para><xref linkend="book.mailparse"/></para></listitem>
+    <listitem><para><xref linkend="book.mcrypt"/></para></listitem>
     <listitem><para><xref linkend="book.memcache"/></para></listitem>
     <listitem><para><xref linkend="book.memcached"/></para></listitem>
     <listitem><para><xref linkend="book.mqseries"/></para></listitem>
+    <listitem><para><xref linkend="book.mysql"/></para></listitem>
+    <listitem><para><xref linkend="book.mysql-xdevapi"/></para></listitem>
     <listitem><para><xref linkend="book.oauth"/></para></listitem>
     <listitem><para><xref linkend="book.openal"/></para></listitem>
+    <listitem><para><xref linkend="book.parallel"/></para></listitem>
+    <listitem><para><xref linkend="book.parle"/></para></listitem>
     <listitem><para><xref linkend="ref.pdo-cubrid"/></para></listitem>
     <listitem><para><xref linkend="ref.pdo-ibm"/></para></listitem>
     <listitem><para><xref linkend="ref.pdo-informix"/></para></listitem>
     <listitem><para><xref linkend="ref.pdo-sqlsrv"/></para></listitem>
+    <listitem><para><xref linkend="book.pht"/></para></listitem>
     <listitem><para><xref linkend="book.ps"/></para></listitem>
     <listitem><para><xref linkend="book.pthreads"/></para></listitem>
     <listitem><para><xref linkend="book.radius"/></para></listitem>
     <listitem><para><xref linkend="book.rar"/></para></listitem>
+    <listitem><para><xref linkend="book.recode"/></para></listitem>
+    <listitem><para><xref linkend="book.rpminfo"/></para></listitem>
     <listitem><para><xref linkend="book.rrd"/></para></listitem>
     <listitem><para><xref linkend="book.runkit7"/></para></listitem>
     <listitem><para><xref linkend="book.scoutapm"/></para></listitem>
@@ -345,22 +366,34 @@
     <listitem><para><xref linkend="book.ssdeep"/></para></listitem>
     <listitem><para><xref linkend="book.ssh2"/></para></listitem>
     <listitem><para><xref linkend="book.stomp"/></para></listitem>
-    <listitem><para><xref linkend="book.swoole"/></para></listitem>
     <listitem><para><xref linkend="book.svm"/></para></listitem>
     <listitem><para><xref linkend="book.svn"/></para></listitem>
+    <listitem><para><xref linkend="book.swoole"/></para></listitem>
+    <listitem><para><xref linkend="book.sync"/></para></listitem>
     <listitem><para><xref linkend="book.taint"/></para></listitem>
     <listitem><para><xref linkend="book.tcpwrap"/></para></listitem>
     <listitem><para><xref linkend="book.trader"/></para></listitem>
+    <listitem><para><xref linkend="book.ui"/></para></listitem>
+    <listitem><para><xref linkend="book.uopz"/></para></listitem>
     <listitem><para><xref linkend="book.v8js"/></para></listitem>
     <listitem><para><xref linkend="book.varnish"/></para></listitem>
+    <listitem><para><xref linkend="book.wddx"/></para></listitem>
     <listitem><para><xref linkend="book.win32service"/></para></listitem>
     <listitem><para><xref linkend="book.wincache"/></para></listitem>
+    <listitem><para><xref linkend="book.wkhtmltox"/></para></listitem>
     <listitem><para><xref linkend="book.xattr"/></para></listitem>
     <listitem><para><xref linkend="book.xdiff"/></para></listitem>
     <listitem><para><xref linkend="book.xhprof"/></para></listitem>
+    <listitem><para><xref linkend="book.xlswriter"/></para></listitem>
+    <listitem><para><xref linkend="book.xmldiff"/></para></listitem>
+    <listitem><para><xref linkend="book.xmlrpc"/></para></listitem>
+    <listitem><para><xref linkend="book.yac"/></para></listitem>
+    <listitem><para><xref linkend="book.yaconf"/></para></listitem>
     <listitem><para><xref linkend="book.yaf"/></para></listitem>
     <listitem><para><xref linkend="book.yaml"/></para></listitem>
+    <listitem><para><xref linkend="book.yar"/></para></listitem>
     <listitem><para><xref linkend="book.yaz"/></para></listitem>
+    <listitem><para><xref linkend="book.zmq"/></para></listitem>
     <listitem><para><xref linkend="book.zookeeper"/></para></listitem>
    </itemizedlist>
   </section>
@@ -368,15 +401,15 @@
 
  <section xml:id="extensions.state">
   &extcat.state;
-  <!--
+
   <section xml:id="extensions.state.deprecated">
    &extcat.state.deprecated;
 
    <itemizedlist>
-    <listitem><para></para></listitem>
+    <listitem><para/></listitem>
    </itemizedlist>
   </section>
- -->
+
   <section xml:id="extensions.state.experimental">
    &extcat.state.experimental;
 

--- a/reference/apcu/book.xml
+++ b/reference/apcu/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.apcu" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>APC User Cache</title>
  <titleabbrev>APCu</titleabbrev>
 

--- a/reference/cmark/book.xml
+++ b/reference/cmark/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.cmark" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <?phpdoc extension-membership="pecl" ?>
  <title>CommonMark</title>
  <titleabbrev>CommonMark</titleabbrev>
 

--- a/reference/componere/book.xml
+++ b/reference/componere/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.componere" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Componere</title>
  <titleabbrev>Componere</titleabbrev>
 

--- a/reference/cubrid/book.xml
+++ b/reference/cubrid/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.cubrid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>CUBRID</title>
  <titleabbrev>CUBRID</titleabbrev>
 

--- a/reference/dio/book.xml
+++ b/reference/dio/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.dio" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Direct IO</title>
  
  <!-- {{{ preface -->
@@ -17,11 +18,6 @@
    <link linkend="book.filesystem">filesystem</link> functions are more
    than adequate. 
   </para>
-  <note>
-   <para>
-    &pecl.moved-ver;5.1.0.
-   </para>
-  </note>
  </preface>
  <!-- }}} -->
  

--- a/reference/ds/book.xml
+++ b/reference/ds/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.ds" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Data Structures</title>
  <titleabbrev></titleabbrev>
 

--- a/reference/eio/book.xml
+++ b/reference/eio/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.eio" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Eio</title>
  <titleabbrev>Eio</titleabbrev>
 <!--{{{ preface -->

--- a/reference/ev/book.xml
+++ b/reference/ev/book.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <book xml:id="book.ev" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Ev</title>
  <titleabbrev>Ev</titleabbrev>
  <preface xml:id="intro.ev">

--- a/reference/event/book.xml
+++ b/reference/event/book.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <book xml:id="book.event" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Event</title>
  <titleabbrev>Event</titleabbrev>
  <preface xml:id="intro.event">

--- a/reference/expect/book.xml
+++ b/reference/expect/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.expect" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Expect</title>
  
  <!-- {{{ preface -->

--- a/reference/fann/book.xml
+++ b/reference/fann/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.fann" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>FANN (Fast Artificial Neural Network)</title>
  <titleabbrev>FANN</titleabbrev>
 

--- a/reference/fdf/book.xml
+++ b/reference/fdf/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.fdf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Forms Data Format</title>
  <titleabbrev>FDF</titleabbrev>
  

--- a/reference/ffi/book.xml
+++ b/reference/ffi/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.ffi" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="core" ?>
  <title>Foreign Function Interface</title>
  <titleabbrev>FFI</titleabbrev>
 

--- a/reference/gearman/book.xml
+++ b/reference/gearman/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.gearman" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Gearman</title>
  <titleabbrev>Gearman</titleabbrev>
 

--- a/reference/gender/book.xml
+++ b/reference/gender/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.gender" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Determine gender of firstnames</title>
  <titleabbrev>Gender</titleabbrev>
 

--- a/reference/geoip/book.xml
+++ b/reference/geoip/book.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-
 <book xml:id="book.geoip" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Geo IP Location</title>
  <titleabbrev>GeoIP</titleabbrev>
 
@@ -45,4 +44,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/gmagick/book.xml
+++ b/reference/gmagick/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.gmagick" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Gmagick</title>
  <titleabbrev>Gmagick</titleabbrev>
 

--- a/reference/gnupg/book.xml
+++ b/reference/gnupg/book.xml
@@ -3,6 +3,7 @@
 <!-- State: beta --> 
 
 <book xml:id="book.gnupg" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>GNU Privacy Guard</title>
  <titleabbrev>GnuPG</titleabbrev>
  

--- a/reference/hash/book.xml
+++ b/reference/hash/book.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- State: experimental -->
- 
 <book xml:id="book.hash" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="core" ?>
  <title>HASH Message Digest Framework</title>
@@ -23,7 +21,6 @@
  &reference.hash.reference;
 
 </book>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
@@ -44,4 +41,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/hrtime/book.xml
+++ b/reference/hrtime/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.hrtime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="core" ?>
  <title>High resolution timing</title>
  <titleabbrev>HRTime</titleabbrev>
 

--- a/reference/ibase/book.xml
+++ b/reference/ibase/book.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.ibase" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <?phpdoc extension-membership="bundledexternal" ?>
+ <?phpdoc extension-membership="pecl" ?>
  <title>Firebird/InterBase</title>
  
  <!-- {{{ preface -->

--- a/reference/ibm_db2/book.xml
+++ b/reference/ibm_db2/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.ibm-db2" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>IBM DB2, Cloudscape and Apache Derby</title>
  <titleabbrev>IBM DB2</titleabbrev>
  

--- a/reference/imagick/book.xml
+++ b/reference/imagick/book.xml
@@ -3,6 +3,7 @@
 <!-- State: experimental -->
  
 <book xml:id="book.imagick" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Image Processing (ImageMagick)</title>
  <titleabbrev>ImageMagick</titleabbrev>
  

--- a/reference/inotify/book.xml
+++ b/reference/inotify/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.inotify" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Inotify</title>
  
  <!-- {{{ preface -->

--- a/reference/json/book.xml
+++ b/reference/json/book.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.json" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <?phpdoc extension-membership="bundled" ?>
+ <?phpdoc extension-membership="core" ?>
  <title>JavaScript Object Notation</title>
  <titleabbrev>JSON</titleabbrev>
 

--- a/reference/lua/book.xml
+++ b/reference/lua/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.lua" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Lua</title>
  <titleabbrev>Lua</titleabbrev>
 

--- a/reference/luasandbox/book.xml
+++ b/reference/luasandbox/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.luasandbox" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>LuaSandbox</title>
  <titleabbrev>LuaSandbox</titleabbrev>
 

--- a/reference/lzf/book.xml
+++ b/reference/lzf/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.lzf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>LZF</title>
  <titleabbrev>LZF</titleabbrev>
  

--- a/reference/mailparse/book.xml
+++ b/reference/mailparse/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.mailparse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Mailparse</title>
  
  <!-- {{{ preface -->

--- a/reference/mcrypt/book.xml
+++ b/reference/mcrypt/book.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.mcrypt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <?phpdoc extension-membership="bundledexternal" ?>
+ <?phpdoc extension-membership="pecl" ?>
  <title>Mcrypt</title>
  
  <!-- {{{ preface -->

--- a/reference/memcache/book.xml
+++ b/reference/memcache/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.memcache" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Memcache</title>
  
  <!-- {{{ preface -->

--- a/reference/memcached/book.xml
+++ b/reference/memcached/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.memcached" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Memcached</title>
  <titleabbrev>Memcached</titleabbrev>
 

--- a/reference/mhash/book.xml
+++ b/reference/mhash/book.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.mhash" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <?phpdoc extension-membership="bundledexternal" ?>
+ <?phpdoc extension-membership="core" ?>
  <title>Mhash</title>
 
  <!-- {{{ preface -->

--- a/reference/mqseries/book.xml
+++ b/reference/mqseries/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.mqseries" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>mqseries</title>
 
  <!-- {{{ preface -->

--- a/reference/mysql/book.xml
+++ b/reference/mysql/book.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-
+<!-- State: deprecated -->
 <book xml:id="book.mysql" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <?phpdoc extension-membership="bundledexternal"?>
+ <?phpdoc extension-membership="pecl"?>
  <title>Original MySQL API</title>
  <titleabbrev>MySQL (Original)</titleabbrev>
 
@@ -36,7 +35,6 @@
  &reference.mysql.reference;
 
 </book>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/mysql_xdevapi/book.xml
+++ b/reference/mysql_xdevapi/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.mysql-xdevapi" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Mysql_xdevapi</title>
  <titleabbrev>Mysql_xdevapi</titleabbrev>
 

--- a/reference/oauth/book.xml
+++ b/reference/oauth/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.oauth" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>OAuth</title>
 
  <preface xml:id="intro.oauth">

--- a/reference/openal/book.xml
+++ b/reference/openal/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.openal" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>OpenAL Audio Bindings</title>
  <titleabbrev>OpenAL</titleabbrev>
  

--- a/reference/parallel/book.xml
+++ b/reference/parallel/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.parallel" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <?phpdoc extension-membership="pecl" ?>
  <title>parallel</title>
  <titleabbrev>parallel</titleabbrev>
 

--- a/reference/parle/book.xml
+++ b/reference/parle/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.parle" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Parsing and lexing</title>
  <titleabbrev>Parle</titleabbrev>
 

--- a/reference/pcre/book.xml
+++ b/reference/pcre/book.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.pcre" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <?phpdoc extension-membership="bundled" ?>
+ <?phpdoc extension-membership="core" ?>
  <title>Regular Expressions (Perl-Compatible)</title>
  <titleabbrev>PCRE</titleabbrev>   
 

--- a/reference/pdo_cubrid/reference.xml
+++ b/reference/pdo_cubrid/reference.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-
  <reference xml:id="ref.pdo-cubrid" xmlns="http://docbook.org/ns/docbook">
+ <?phpdoc extension-membership="pecl" ?>
   <title>CUBRID Functions (PDO_CUBRID)</title>
   <titleabbrev>CUBRID (PDO)</titleabbrev>
   <partintro>

--- a/reference/pdo_ibm/reference.xml
+++ b/reference/pdo_ibm/reference.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-
 <reference xml:id="ref.pdo-ibm" xmlns="http://docbook.org/ns/docbook">
+ <?phpdoc extension-membership="pecl" ?>
   <title>IBM Functions (PDO_IBM)</title>
   <titleabbrev>IBM (PDO)</titleabbrev>
   <partintro>

--- a/reference/pdo_informix/reference.xml
+++ b/reference/pdo_informix/reference.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-
  <reference xml:id="ref.pdo-informix" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
   <title>Informix Functions (PDO_INFORMIX)</title>
   <titleabbrev>Informix (PDO)</titleabbrev>
   <partintro>

--- a/reference/pdo_sqlsrv/reference.xml
+++ b/reference/pdo_sqlsrv/reference.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-
  <reference xml:id="ref.pdo-sqlsrv" xmlns="http://docbook.org/ns/docbook">
+ <?phpdoc extension-membership="pecl" ?>
   <title>Microsoft SQL Server Functions (PDO_SQLSRV)</title>
   <titleabbrev>MS SQL Server (PDO)</titleabbrev>
   <partintro>

--- a/reference/phpdbg/book.xml
+++ b/reference/phpdbg/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.phpdbg" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="bundled" ?>
  <title>Interactive PHP Debugger</title>
  <titleabbrev>phpdbg</titleabbrev>
 

--- a/reference/ps/book.xml
+++ b/reference/ps/book.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <!-- Author: Uwe Steinmann <steinm@php.net> -->
-<!-- State: experimental -->
  
 <book xml:id="book.ps" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>PostScript document creation</title>
  <titleabbrev>PS</titleabbrev>
  

--- a/reference/pthreads/book.xml
+++ b/reference/pthreads/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.pthreads" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>pthreads</title>
  <titleabbrev>pthreads</titleabbrev>
 

--- a/reference/radius/book.xml
+++ b/reference/radius/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.radius" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Radius</title>
  
  <!-- {{{ preface -->

--- a/reference/rar/book.xml
+++ b/reference/rar/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.rar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Rar Archiving</title>
  <titleabbrev>Rar</titleabbrev>
  

--- a/reference/recode/book.xml
+++ b/reference/recode/book.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.recode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <?phpdoc extension-membership="bundledexternal" ?>
+ <?phpdoc extension-membership="pecl" ?>
  <title>GNU Recode</title>
  <titleabbrev>Recode</titleabbrev>
 

--- a/reference/rpminfo/book.xml
+++ b/reference/rpminfo/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.rpminfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>RpmInfo</title>
  <titleabbrev>RpmInfo</titleabbrev>
 

--- a/reference/rrd/book.xml
+++ b/reference/rrd/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.rrd" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>RRDtool</title>
  <titleabbrev>RRD</titleabbrev>
 

--- a/reference/runkit7/book.xml
+++ b/reference/runkit7/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.runkit7" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>runkit7</title>
  <titleabbrev>runkit7</titleabbrev>
 

--- a/reference/scoutapm/book.xml
+++ b/reference/scoutapm/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.scoutapm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>ScoutAPM</title>
  <titleabbrev>ScoutAPM</titleabbrev>
 

--- a/reference/seaslog/book.xml
+++ b/reference/seaslog/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.seaslog" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Seaslog</title>
  <titleabbrev>Seaslog</titleabbrev>
 

--- a/reference/solr/book.xml
+++ b/reference/solr/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.solr" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Apache Solr</title>
  <titleabbrev>Solr</titleabbrev>
 

--- a/reference/sqlsrv/book.xml
+++ b/reference/sqlsrv/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.sqlsrv" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Microsoft SQL Server Driver for PHP</title>
  <titleabbrev>SQLSRV</titleabbrev>
  

--- a/reference/ssdeep/book.xml
+++ b/reference/ssdeep/book.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-
 <book xml:id="book.ssdeep" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>ssdeep Fuzzy Hashing</title>
  <titleabbrev>ssdeep</titleabbrev>
 
@@ -29,7 +28,6 @@
  &reference.ssdeep.reference;
 
 </book>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/ssh2/book.xml
+++ b/reference/ssh2/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.ssh2" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Secure Shell2</title>
  <titleabbrev>SSH2</titleabbrev>
  

--- a/reference/stomp/book.xml
+++ b/reference/stomp/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.stomp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Stomp Client</title>
  <titleabbrev>Stomp</titleabbrev>
 

--- a/reference/svm/book.xml
+++ b/reference/svm/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.svm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Support Vector Machine</title>
  <titleabbrev>SVM</titleabbrev>
 

--- a/reference/svn/book.xml
+++ b/reference/svn/book.xml
@@ -3,6 +3,7 @@
 <!-- State: new --> 
 
 <book xml:id="book.svn" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Subversion</title>
  <titleabbrev>SVN</titleabbrev>
  

--- a/reference/swoole/book.xml
+++ b/reference/swoole/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.swoole" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Swoole</title>
  
  <!-- {{{ preface -->

--- a/reference/sync/book.xml
+++ b/reference/sync/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.sync" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Sync</title>
  <titleabbrev>Sync</titleabbrev>
 

--- a/reference/taint/book.xml
+++ b/reference/taint/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ --> 
 
 <book xml:id="book.taint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Taint</title>
  <titleabbrev>Taint</titleabbrev>
 

--- a/reference/tcpwrap/book.xml
+++ b/reference/tcpwrap/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.tcpwrap" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>TCP Wrappers</title>
  <titleabbrev>TCP</titleabbrev>
  

--- a/reference/trader/book.xml
+++ b/reference/trader/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.trader" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Technical Analysis for Traders</title>
  <titleabbrev>Trader</titleabbrev>
 

--- a/reference/ui/book.xml
+++ b/reference/ui/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.ui" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>UI</title>
  <titleabbrev>UI</titleabbrev>
 

--- a/reference/uopz/book.xml
+++ b/reference/uopz/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.uopz" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>User Operations for Zend</title>
  <titleabbrev>uopz</titleabbrev>
 

--- a/reference/v8js/book.xml
+++ b/reference/v8js/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.v8js" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>V8 Javascript Engine Integration</title>
  <titleabbrev>V8js</titleabbrev>
 

--- a/reference/varnish/book.xml
+++ b/reference/varnish/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.varnish" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Varnish</title>
  <titleabbrev>Varnish</titleabbrev>
 

--- a/reference/wddx/book.xml
+++ b/reference/wddx/book.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
- 
+<!-- State: deprecated -->
 <book xml:id="book.wddx" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
  <title>WDDX</title>
@@ -36,7 +35,6 @@
  &reference.wddx.reference;
 
 </book>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/win32service/book.xml
+++ b/reference/win32service/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.win32service" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>win32service</title>
  
  <!-- {{{ preface -->

--- a/reference/wincache/book.xml
+++ b/reference/wincache/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.wincache" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Windows Cache for PHP</title>
  <titleabbrev>WinCache</titleabbrev>
 

--- a/reference/wkhtmltox/book.xml
+++ b/reference/wkhtmltox/book.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 
 <book xml:id="book.wkhtmltox" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <!-- This has an entry on PECL but no releases -->
+ <?phpdoc extension-membership="pecl" ?>
  <title>wkhtmltox</title>
  <titleabbrev>wkhtmltox</titleabbrev>
 
@@ -20,7 +21,6 @@
 
  &reference.wkhtmltox.wkhtmltox.image.converter;
 </book>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/xattr/book.xml
+++ b/reference/xattr/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.xattr" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>xattr</title>
  
  <!-- {{{ preface -->

--- a/reference/xdiff/book.xml
+++ b/reference/xdiff/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.xdiff" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>xdiff</title>
  
  <!-- {{{ preface -->

--- a/reference/xhprof/book.xml
+++ b/reference/xhprof/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.xhprof" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Hierarchical Profiler</title>
  <titleabbrev>Xhprof</titleabbrev>
 

--- a/reference/xlswriter/book.xml
+++ b/reference/xlswriter/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.xlswriter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>XLSWriter</title>
  
  <!-- {{{ preface -->

--- a/reference/xmldiff/book.xml
+++ b/reference/xmldiff/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.xmldiff" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>XML diff and merge</title>
  <titleabbrev>XMLDiff</titleabbrev>
 

--- a/reference/xmlrpc/book.xml
+++ b/reference/xmlrpc/book.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
+<!-- State: deprecated -->
 <!-- State: experimental -->
  
 <book xml:id="book.xmlrpc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <?phpdoc extension-membership="bundled" ?>
+ <?phpdoc extension-membership="pecl" ?>
  <title>XML-RPC</title>
  
  <!-- {{{ preface -->

--- a/reference/yac/book.xml
+++ b/reference/yac/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.yac" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Yac</title>
  <titleabbrev>Yac</titleabbrev>
 

--- a/reference/yaconf/book.xml
+++ b/reference/yaconf/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.yaconf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Yaconf</title>
  <titleabbrev>Yaconf</titleabbrev>
 

--- a/reference/yaf/book.xml
+++ b/reference/yaf/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.yaf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Yet Another Framework</title>
  <titleabbrev>Yaf</titleabbrev>
 

--- a/reference/yaml/book.xml
+++ b/reference/yaml/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.yaml" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>YAML Data Serialization</title>
  <titleabbrev>Yaml</titleabbrev>
 

--- a/reference/yar/book.xml
+++ b/reference/yar/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ --> 
 
 <book xml:id="book.yar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Yet Another RPC Framework</title>
  <titleabbrev>Yar</titleabbrev>
 

--- a/reference/yaz/book.xml
+++ b/reference/yaz/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.yaz" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>YAZ</title>
  
  <!-- {{{ preface -->

--- a/reference/zmq/book.xml
+++ b/reference/zmq/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.zmq" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>ZMQ</title>
  <titleabbrev>0MQ messaging</titleabbrev>
 

--- a/reference/zookeeper/book.xml
+++ b/reference/zookeeper/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
  
 <book xml:id="book.zookeeper" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>ZooKeeper</title>
  <titleabbrev>ZooKeeper</titleabbrev>
  


### PR DESCRIPTION
doc-base has a script to generate the extensions.xml file, so it makes to use and check for it in CI.

To do this I've added and/or adjusted the extension membership of all currently documented extensions, except `pht` as it is not available on PECL, @tpunt  is there any reason for it not being on PECL?

