### PR TITLE
Ini settings: upload_max_filesize: Add note regarding post_max_size

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -1629,6 +1629,9 @@ include_path = ".:${USER}/pear/php"
        <para>
         The maximum size of an uploaded file.
        </para>
+       <para>
+        <link linkend="ini.post-max-size">post_max_size</link> must be larger than this value.
+       </para>
        
        &ini.shorthandbytes;
        


### PR DESCRIPTION
Currently the upload_max_filesize entry makes no reference to post_max_size, which creates a gotcha when increasing its value. (There is a similar note under post_max_size, but users who don't know about this aren't likely to be looking there)