### PR TITLE
Improved ext/sodium [Introduction|Resource Types] documentation.

### DIFF
--- a/reference/sodium/book.xml
+++ b/reference/sodium/book.xml
@@ -9,7 +9,8 @@
  <preface xml:id="intro.sodium">
   &reftitle.intro;
   <para>
-
+   Sodium is a modern, easy-to-use software library for encryption, decryption, signatures, password hashing and more.
+   Its goal is to provide all of the core operations needed to build higher-level cryptographic tools.
   </para>
  </preface>
 

--- a/reference/sodium/setup.xml
+++ b/reference/sodium/setup.xml
@@ -53,9 +53,7 @@
 
  <section xml:id="sodium.resources">
   &reftitle.resources;
-  <para>
-
-  </para>
+  &no.resource;
  </section>
 
 </chapter>


### PR DESCRIPTION
Many great improvement of ext/sodium documentation was added in #592.
I added some more basic information about it.

- filled ext/sodium Introduction page contents
  * copied from https://doc.libsodium.org/
- filled Resouce type page, too.
  * ext/sodium uses sodium_init() internally and seems to use no resource.