### PR TITLE
Document Exception as implementing, not extending Throwable, + fix me…

### DIFF
--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -15,7 +15,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-class Exception extends Throwable
+class Exception implements Throwable
 {
     protected $message = 'Unknown exception';   // exception message
     private   $string;                          // __toString cache
@@ -25,7 +25,7 @@ class Exception extends Throwable
     private   $trace;                           // backtrace
     private   $previous;                        // previous exception if nested exception
 
-    public function __construct($message = null, $code = 0, Throwable $previous = null);
+    public function __construct($message = '', $code = 0, Throwable $previous = null);
 
     final private function __clone();           // Inhibits cloning of exceptions.
 


### PR DESCRIPTION
…ssage param type.

We were getting an Error trying to pass null to construct an exception, and found that "" works but null doesn't.

Also correcting the inheritance keyword since Throwable is an interface.

This brings these docs more into line with the PHPStorm stubs.