### PR TITLE
Clarify assert() behavior in PHP 8

### DIFF
--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -14,7 +14,7 @@
    <methodparam><type>mixed</type><parameter>assertion</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>description</parameter></methodparam>
   </methodsynopsis>
-  <para>PHP 7</para>
+  <para>PHP 7 and higher</para>
   <methodsynopsis>
    <type>bool</type><methodname>assert</methodname>
    <methodparam><type>mixed</type><parameter>assertion</parameter></methodparam>
@@ -80,7 +80,7 @@
    </para>
   </refsect2>
   <refsect2 xml:id="function.assert.expectations">
-   <title>Expectations (PHP 7 only)</title>
+   <title>Expectations (PHP 7 and higher)</title>
    <para>
     <function>assert</function> is a language construct in PHP 7, allowing for
     the definition of expectations: assertions that take effect in development


### PR DESCRIPTION
As far as I understand, the signature and behavior of `assert()` has changed in PHP 7 and remained the same in PHP 8.

The docs didn't yet mention PHP 8, leaving you guess whether PHP 8 behaves the same as PHP 7. I think it's worth making it clearer.