### PR TITLE
Add FILTER_VALIDATE_BOOL alias to docs

### DIFF
--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -150,6 +150,17 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.filter-validate-bool">
+   <term>
+    <constant>FILTER_VALIDATE_BOOL</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Alias of <constant>FILTER_VALIDATE_BOOLEAN</constant>.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.filter-validate-boolean">
    <term>
     <constant>FILTER_VALIDATE_BOOLEAN</constant>

--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -21,7 +21,10 @@
       </thead>
       <tbody>
        <row>
-        <entry><constant>FILTER_VALIDATE_BOOLEAN</constant></entry>
+        <entry>
+         <constant>FILTER_VALIDATE_BOOLEAN</constant>,
+         <constant>FILTER_VALIDATE_BOOL</constant>
+        </entry>
         <entry>"boolean"</entry>
         <entry>
          <parameter>default</parameter>
@@ -189,6 +192,13 @@
        </row>
       </thead>
       <tbody>
+       <row>
+        <entry>8.0.0</entry>
+        <entry>
+         Added <constant>FILTER_VALIDATE_BOOL</constant> as an alias for <constant>FILTER_VALIDATE_BOOLEAN</constant>.
+         Using <constant>FILTER_VALIDATE_BOOL</constant> is preferred.
+        </entry>
+       </row>
        <row>
         <entry>7.4.0</entry>
         <entry>
@@ -586,7 +596,8 @@ filter.default_flags = 0
       <row>
        <entry><constant>FILTER_NULL_ON_FAILURE</constant></entry>
        <entry>
-        <constant>FILTER_VALIDATE_BOOLEAN</constant>
+        <constant>FILTER_VALIDATE_BOOLEAN</constant>,
+        <constant>FILTER_VALIDATE_BOOL</constant>
        </entry>
        <entry>
         Returns &null; for unrecognized boolean values.


### PR DESCRIPTION
Hey there :vulcan_salute: 

this pull request will add documentation about the `FILTER_VALIDATE_BOOL` alias for `FILTER_VALIDATE_BOOLEAN` to the docs, see #674

Kind regards
Florian