### PR TITLE
Update FILTER_NULL_ON_FAILURE usage

### DIFF
--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -606,16 +606,7 @@ filter.default_flags = 0
       <row>
        <entry><constant>FILTER_NULL_ON_FAILURE</constant></entry>
        <entry>
-        <constant>FILTER_VALIDATE_BOOLEAN</constant>,
-        <constant>FILTER_VALIDATE_BOOL</constant>,
-        <constant>FILTER_VALIDATE_INT</constant>,
-        <constant>FILTER_VALIDATE_FLOAT</constant>,
-        <constant>FILTER_VALIDATE_DOMAIN</constant>,
-        <constant>FILTER_VALIDATE_EMAIL</constant>,
-        <constant>FILTER_VALIDATE_IP</constant>,
-        <constant>FILTER_VALIDATE_MAC</constant>,
-        <constant>FILTER_VALIDATE_REGEXP</constant>,
-        <constant>FILTER_VALIDATE_URL</constant>
+        any <link linkend="filter.filters.validate"><constant>FILTER_VALIDATE_*</constant></link>
        </entry>
        <entry>
         Returns &null; for unrecognized values.

--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -51,7 +51,8 @@
          <parameter>default</parameter>
         </entry>
         <entry>
-         <constant>FILTER_FLAG_HOSTNAME</constant>
+         <constant>FILTER_FLAG_HOSTNAME</constant>,
+         <constant>FILTER_NULL_ON_FAILURE</constant>
         </entry>
         <entry>
          <para>
@@ -74,7 +75,8 @@
          <parameter>default</parameter>
         </entry>
         <entry>
-         <constant>FILTER_FLAG_EMAIL_UNICODE</constant>
+         <constant>FILTER_FLAG_EMAIL_UNICODE</constant>,
+         <constant>FILTER_NULL_ON_FAILURE</constant>
         </entry>
         <entry>
          <para>
@@ -98,7 +100,8 @@
          <parameter>max_range</parameter>
         </entry>
         <entry>
-         <constant>FILTER_FLAG_ALLOW_THOUSAND</constant>
+         <constant>FILTER_FLAG_ALLOW_THOUSAND</constant>,
+         <constant>FILTER_NULL_ON_FAILURE</constant>
         </entry>
         <entry>Validates value as float, optionally from the specified range, and converts to float on success.</entry>
        </row>
@@ -112,7 +115,8 @@
         </entry>
         <entry>
          <constant>FILTER_FLAG_ALLOW_OCTAL</constant>,
-         <constant>FILTER_FLAG_ALLOW_HEX</constant>
+         <constant>FILTER_FLAG_ALLOW_HEX</constant>,
+         <constant>FILTER_NULL_ON_FAILURE</constant>
         </entry>
         <entry>Validates value as integer, optionally from the specified range, and converts to int on success.</entry>
        </row>
@@ -126,7 +130,8 @@
          <constant>FILTER_FLAG_IPV4</constant>,
          <constant>FILTER_FLAG_IPV6</constant>,
          <constant>FILTER_FLAG_NO_PRIV_RANGE</constant>,
-         <constant>FILTER_FLAG_NO_RES_RANGE</constant>
+         <constant>FILTER_FLAG_NO_RES_RANGE</constant>,
+         <constant>FILTER_NULL_ON_FAILURE</constant>
         </entry>
         <entry>
          Validates value as IP address, optionally only IPv4 or IPv6 or not
@@ -139,7 +144,9 @@
         <entry>
          <parameter>default</parameter>
         </entry>
-        <entry></entry>
+        <entry>
+         <constant>FILTER_NULL_ON_FAILURE</constant>
+        </entry>
         <entry>Validates value as MAC address.</entry>
        </row>
        <row>
@@ -149,7 +156,9 @@
          <parameter>default</parameter>,
          <parameter>regexp</parameter>
         </entry>
-        <entry></entry>
+        <entry>
+         <constant>FILTER_NULL_ON_FAILURE</constant>
+        </entry>
         <entry>
          Validates value against <parameter>regexp</parameter>, a
          <link linkend="book.pcre">Perl-compatible</link> regular expression.
@@ -165,7 +174,8 @@
          <constant>FILTER_FLAG_SCHEME_REQUIRED</constant>,
          <constant>FILTER_FLAG_HOST_REQUIRED</constant>,
          <constant>FILTER_FLAG_PATH_REQUIRED</constant>,
-         <constant>FILTER_FLAG_QUERY_REQUIRED</constant>
+         <constant>FILTER_FLAG_QUERY_REQUIRED</constant>,
+         <constant>FILTER_NULL_ON_FAILURE</constant>
         </entry>
         <entry>Validates value as URL (according to <link xlink:href="&url.rfc;2396">&url.rfc;2396</link>), optionally with required components. Beware a valid URL may not specify the HTTP protocol <literal>http://</literal> so further validation may be required to determine the URL uses an expected protocol, e.g. <literal>ssh://</literal> or <literal>mailto:</literal>. Note that the function will only find ASCII URLs to be valid; internationalized domain names (containing non-ASCII characters) will fail.</entry>
        </row>

--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -599,10 +599,16 @@ filter.default_flags = 0
         <constant>FILTER_VALIDATE_BOOLEAN</constant>,
         <constant>FILTER_VALIDATE_BOOL</constant>,
         <constant>FILTER_VALIDATE_INT</constant>,
-        <constant>FILTER_VALIDATE_FLOAT</constant>
+        <constant>FILTER_VALIDATE_FLOAT</constant>,
+        <constant>FILTER_VALIDATE_DOMAIN</constant>,
+        <constant>FILTER_VALIDATE_EMAIL</constant>,
+        <constant>FILTER_VALIDATE_IP</constant>,
+        <constant>FILTER_VALIDATE_MAC</constant>,
+        <constant>FILTER_VALIDATE_REGEXP</constant>,
+        <constant>FILTER_VALIDATE_URL</constant>
        </entry>
        <entry>
-        Returns &null; for unrecognized boolean, int or float values.
+        Returns &null; for unrecognized values.
        </entry>
       </row>
       <row>

--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -597,10 +597,12 @@ filter.default_flags = 0
        <entry><constant>FILTER_NULL_ON_FAILURE</constant></entry>
        <entry>
         <constant>FILTER_VALIDATE_BOOLEAN</constant>,
-        <constant>FILTER_VALIDATE_BOOL</constant>
+        <constant>FILTER_VALIDATE_BOOL</constant>,
+        <constant>FILTER_VALIDATE_INT</constant>,
+        <constant>FILTER_VALIDATE_FLOAT</constant>
        </entry>
        <entry>
-        Returns &null; for unrecognized boolean values.
+        Returns &null; for unrecognized boolean, int or float values.
        </entry>
       </row>
       <row>


### PR DESCRIPTION
Hey there :vulcan_salute: 

I found the following comment in the docs to be true https://www.php.net/manual/en/filter.filters.flags.php#125956
The `FILTER_NULL_ON_FAILURE` flag can not only be used with `FILTER_VALIDATE_BOOL`/`FILTER_VALIDATE_BOOLEAN` but also with other validating filters.

This PR updates the docs accordingly, see https://3v4l.org/raIiu

Kind regards