### PR TITLE
fixed localtime returnvalues description.

### DIFF
--- a/reference/datetime/functions/localtime.xml
+++ b/reference/datetime/functions/localtime.xml
@@ -47,9 +47,9 @@
    the array is returned as a regular, numerically indexed array.
    If <parameter>associative</parameter> is set to &true; then
    <function>localtime</function> returns an associative array containing
-   identical elements of the structure returned by the C
+   the elements of the structure returned by the C
    function call to localtime. 
-   The names of the associative array are as follows:
+   The keys of the associative array are as follows:
   </para>
   <para>
    <itemizedlist>

--- a/reference/datetime/functions/localtime.xml
+++ b/reference/datetime/functions/localtime.xml
@@ -47,9 +47,9 @@
    the array is returned as a regular, numerically indexed array.
    If <parameter>associative</parameter> is set to &true; then
    <function>localtime</function> returns an associative array containing
-   all the different elements of the structure returned by the C
+   identical elements of the structure returned by the C
    function call to localtime. 
-   The names of the different keys of the associative array are as follows:
+   The names of the associative array are as follows:
   </para>
   <para>
    <itemizedlist>


### PR DESCRIPTION
`localtime` function of PHP returns assosiative array which has  identical elements of the structure returned by the C [*1].
Also, it is inconsistent with [function description](https://github.com/php/doc-en/blob/d91e36266dddbe570789dbe218e5672fc0b85089/reference/datetime/functions/localtime.xml#L18).

[*1] https://linux.die.net/man/3/localtime