### PR TITLE
Fix issues in mysqli directory

### DIFF
--- a/reference/mysqli/functions/mysqli-get-client-stats.xml
+++ b/reference/mysqli/functions/mysqli-get-client-stats.xml
@@ -14,8 +14,12 @@
   </methodsynopsis>
   <para>
    Returns client per-process statistics.
-   &mysqli.available.mysqlnd;
   </para>
+  <note>
+   <para>
+    &mysqli.available.mysqlnd;
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli/get-connection-stats.xml
+++ b/reference/mysqli/mysqli/get-connection-stats.xml
@@ -21,8 +21,12 @@
   </methodsynopsis>
   <para>
    Returns statistics about the client connection.
-   &mysqli.available.mysqlnd;
   </para>
+  <note>
+   <para>
+    &mysqli.available.mysqlnd;
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli/poll.xml
+++ b/reference/mysqli/mysqli/poll.xml
@@ -29,10 +29,14 @@
   </methodsynopsis>
   <para>
    Poll connections.
-   &mysqli.available.mysqlnd;
    The method can be used as
    <link linkend="language.oop5.static">static</link>.
   </para>
+  <note>
+   <para>
+    &mysqli.available.mysqlnd;
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli/reap-async-query.xml
+++ b/reference/mysqli/mysqli/reap-async-query.xml
@@ -21,8 +21,12 @@
   </methodsynopsis>
   <para>
    Get result from async query.
-   &mysqli.available.mysqlnd;
   </para>
+  <note>
+   <para>
+    &mysqli.available.mysqlnd;
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli_result/fetch-all.xml
+++ b/reference/mysqli/mysqli_result/fetch-all.xml
@@ -24,6 +24,11 @@
    Returns a two-dimensional array of all result rows 
    as an associative array, a numeric array, or both.
   </para>
+  <note>
+   <para>
+    &mysqli.available.mysqlnd;
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -50,14 +55,6 @@
   &reftitle.returnvalues;
   <para>
    Returns an array of associative or numeric arrays holding result rows.
-  </para>
- </refsect1>
-
- <refsect1 role="mysqlnd">
-   &reftitle.mysqlnd;
-
-  <para>
-   &mysqli.available.mysqlnd;
   </para>
  </refsect1>
 

--- a/reference/mysqli/mysqli_stmt/get-result.xml
+++ b/reference/mysqli/mysqli_stmt/get-result.xml
@@ -22,6 +22,11 @@
   <para>
     Call to return a result set from a prepared statement query.
   </para>
+  <note>
+   <para>
+    &mysqli.available.mysqlnd;
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -42,14 +47,6 @@
    return &false;. The <function>mysqli_stmt_errno</function> function can be
    used to distinguish between the two reasons for &false;; due to a bug, prior to PHP 7.4.13,
    <function>mysqli_errno</function> had to be used for this purpose.
-  </para>
- </refsect1>
-
- <refsect1 role="mysqlnd">
-   &reftitle.mysqlnd;
-
-  <para>
-   &mysqli.available.mysqlnd;
   </para>
  </refsect1>
 

--- a/reference/mysqli/mysqli_stmt/more-results.xml
+++ b/reference/mysqli/mysqli_stmt/more-results.xml
@@ -22,6 +22,11 @@
   <para>
    Checks if there are more query results from a multiple query.
   </para>
+  <note>
+   <para>
+    &mysqli.available.mysqlnd;
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -37,14 +42,6 @@
   &reftitle.returnvalues;
   <para>
    Returns &true; if more results exist, otherwise &false;.
-  </para>
- </refsect1>
-
- <refsect1 role="mysqlnd">
-   &reftitle.mysqlnd;
-
-  <para>
-   &mysqli.available.mysqlnd;
   </para>
  </refsect1>
 

--- a/reference/mysqli/mysqli_stmt/next-result.xml
+++ b/reference/mysqli/mysqli_stmt/next-result.xml
@@ -22,6 +22,11 @@
   <para>
    Reads the next result from a multiple query.
   </para>
+  <note>
+   <para>
+    &mysqli.available.mysqlnd;
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -46,14 +51,6 @@
    Emits an <constant>E_STRICT</constant> level error if a result set does
    not exist, and suggests using <methodname>mysqli_stmt::more_results</methodname>
    in these cases, before calling <methodname>mysqli_stmt::next_result</methodname>.
-  </para>
- </refsect1>
-
- <refsect1 role="mysqlnd">
-   &reftitle.mysqlnd;
-
-  <para>
-   &mysqli.available.mysqlnd;
   </para>
  </refsect1>
 


### PR DESCRIPTION
I'm not sure about the `note` tag.

Some functions have this note as plain text (e.g. [`mysqli_get_client_stats`](https://www.php.net/function.mysqli-get-client-stats)).

If it should be a note, I'll wrap this in other functions, 
if not — replace it as plain text in these functions.