### PR TITLE
Update return type for SessionHandlerInterface::gc()

### DIFF
--- a/reference/session/sessionhandlerinterface/gc.xml
+++ b/reference/session/sessionhandlerinterface/gc.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>bool</type></type><methodname>SessionHandlerInterface::gc</methodname>
+   <modifier>abstract</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>SessionHandlerInterface::gc</methodname>
    <methodparam><type>int</type><parameter>max_lifetime</parameter></methodparam>
   </methodsynopsis>
   <para>


### PR DESCRIPTION
The type is `int|false` but documented as `int|bool`.

https://github.com/php/php-src/blob/PHP-8.0.8/ext/session/session.stub.php#L83