### PR TITLE
fix link from predefined to magic constants

### DIFF
--- a/language/constants.xml
+++ b/language/constants.xml
@@ -6,7 +6,7 @@
   <simpara>
    A constant is an identifier (name) for a simple value. As the name
    suggests, that value cannot change during the execution of the
-   script (except for <link linkend="language.constants.predefined">
+   script (except for <link linkend="language.constants.magic">
    magic constants</link>, which aren't actually constants).
    Constants are case-sensitive. By convention, constant
    identifiers are always uppercase.


### PR DESCRIPTION
Change link from predefined constants to magic constants on [Constants page](https://www.php.net/manual/en/language.constants.php).