### PR TITLE
Use a better example for using header() to set status code

### DIFF
--- a/reference/network/functions/header.xml
+++ b/reference/network/functions/header.xml
@@ -67,7 +67,12 @@ exit;
         <programlisting role="php">
 <![CDATA[
 <?php
-header("HTTP/1.0 404 Not Found");
+// This example illustrates the "HTTP/" special case
+// Better alternatives in typical use cases include:
+// 1. header($_SERVER["SERVER_PROTOCOL"] . " 404 Not Found");
+//    (to override http status messages for clients that are still using HTTP/1.0)
+// 2. http_response_code(404); (to use the default message)
+header("HTTP/1.1 404 Not Found");
 ?>
 ]]>
         </programlisting>


### PR DESCRIPTION
This may be the first thing users see when searching how to set the
response code - most will not be familiar with differences between
http/1.0 and 1.1

- HTTP/1.0 does not support connection keepalive
- http_response_code(404) is a shorter way to set a status code with the default
  status message

https://www.php.net/manual/en/function.header.php#92305 also mentions
that the wrong protocol can cause issues with (older?) web servers

https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#History http 1.1 was officially released in 1997