### PR TITLE
Fix example of datefmt_get_timezone_id

### DIFF
--- a/reference/intl/dateformatter/get-timezone-id.xml
+++ b/reference/intl/dateformatter/get-timezone-id.xml
@@ -65,9 +65,9 @@ $fmt = datefmt_create(
     'America/Los_Angeles',
     IntlDateFormatter::GREGORIAN
 );
-echo 'timezone_id of the formatter is : ' . datefmt_get_timezone_id($fmt);
-datefmt_set_timezone_id($fmt, 'CN');
-echo 'Now timezone_id of the formatter is : ' . datefmt_get_timezone_id($fmt);
+echo 'timezone_id of the formatter is: ' . datefmt_get_timezone_id($fmt) . "\n";
+datefmt_set_timezone($fmt, 'Europe/Madrid');
+echo 'Now timezone_id of the formatter is: ' . datefmt_get_timezone_id($fmt);
 
 ?>
 ]]>
@@ -85,9 +85,9 @@ $fmt = new IntlDateFormatter(
     'America/Los_Angeles',
     IntlDateFormatter::GREGORIAN
 );
-echo 'timezone_id of the formatter is : ' . $fmt->getTimezoneId();
-$fmt->setTimezoneId('CN');
-echo 'Now timezone_id of the formatter is : ' . $fmt->getTimezoneId();
+echo 'timezone_id of the formatter is: ' . $fmt->getTimezoneId() . "\n";
+$fmt->setTimezone('Europe/Madrid');
+echo 'Now timezone_id of the formatter is: ' . $fmt->getTimezoneId();
 
 ?>
 ]]>
@@ -96,8 +96,8 @@ echo 'Now timezone_id of the formatter is : ' . $fmt->getTimezoneId();
   &example.outputs;
   <screen>
 <![CDATA[
-timezone_id of the formatter is : America/Los_Angeles
-Now timezone_id of the formatter is : CN
+timezone_id of the formatter is: America/Los_Angeles
+Now timezone_id of the formatter is: Europe/Madrid
 ]]>
   </screen>
  </refsect1>
@@ -106,7 +106,7 @@ Now timezone_id of the formatter is : CN
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>datefmt_set_timezone_id</function></member>
+    <member><function>datefmt_set_timezone</function></member>
      <member><function>datefmt_create</function></member>
    </simplelist>
   </para>

--- a/reference/intl/versions.xml
+++ b/reference/intl/versions.xml
@@ -169,7 +169,6 @@
  <function name="intldateformatter::gettimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL intl &gt;= 3.0.0"/>
  <function name="intldateformatter::settimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL intl &gt;= 3.0.0"/>
  <function name="intldateformatter::gettimezoneid" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
- <function name="intldateformatter::settimezoneid" from="PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0" deprecated="PHP 5 &gt;= 5.5.0"/>
  <function name="intldateformatter::setpattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
  <function name="intldateformatter::getpattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
  <function name="intldateformatter::getlocale" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
@@ -362,7 +361,6 @@
  <function name="datefmt_set_calendar" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
  <function name="datefmt_get_locale" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
  <function name="datefmt_get_timezone_id" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
- <function name="datefmt_set_timezone_id" from="PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0"/>
  <function name="datefmt_get_pattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
  <function name="datefmt_set_pattern" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
  <function name="datefmt_is_lenient" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>


### PR DESCRIPTION
I am not sure what exactly CN was and I can't find out what the purpose of this example was, but I replaced it with a valid timezone name. 