### PR TITLE
Remove Magic quotes runtime

### DIFF
--- a/appendices/aliases.xml
+++ b/appendices/aliases.xml
@@ -222,11 +222,6 @@
       <entry><link linkend="ref.ldap">LDAP</link></entry>
      </row>
      <row>
-      <entry>magic_quotes_runtime</entry>
-      <entry><function>set_magic_quotes_runtime</function></entry>
-      <entry>Base syntax</entry>
-     </row>
-     <row>
       <entry>mbstrcut</entry>
       <entry><function>mb_strcut</function></entry>
       <entry><link linkend="ref.mbstring">Multi-bytes Strings</link></entry>

--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -975,12 +975,6 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
       
     </variablelist>
    </para>
-   <para>
-    See also: <link linkend="ini.magic-quotes-gpc">magic_quotes_gpc</link>,
-    <link linkend="ini.magic-quotes-runtime">magic_quotes_runtime</link>,
-    and
-    magic_quotes_sybase.
-   </para>
   </section>
   
   <section xml:id="ini.sect.path-directory">

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -370,12 +370,6 @@ to several possible vulnerabilities. Please read our
 <link linkend="security.cgi-bin">CGI security section</link> to learn how to
 defend yourself from such attacks.</para></warning>'>
 
-<!ENTITY note.magicquotes.gpc '<note xmlns="http://docbook.org/ns/docbook"><title>directive note: magic_quotes_gpc
-</title><para>The <link linkend="ini.magic-quotes-gpc">magic_quotes_gpc</link>
-directive defaults to <literal>on</literal>. It essentially runs
-<function>addslashes</function> on all GET, POST, and COOKIE data.
-<function>stripslashes</function> may be used to remove them.</para></note>'>
-
 <!ENTITY warn.passwordhashing '
 <warning xmlns="http://docbook.org/ns/docbook">
  <para>

--- a/reference/filesystem/functions/fwrite.xml
+++ b/reference/filesystem/functions/fwrite.xml
@@ -48,13 +48,6 @@
        the end of <parameter>string</parameter> is reached, whichever comes
        first.
       </para>
-      <para>
-       Note that if the <parameter>length</parameter> argument is given,
-       then the <link
-       linkend="ini.magic-quotes-runtime">magic_quotes_runtime</link>
-       configuration option will be ignored and no slashes will be
-       stripped from <parameter>string</parameter>.
-      </para>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/info/functions/get-magic-quotes-runtime.xml
+++ b/reference/info/functions/get-magic-quotes-runtime.xml
@@ -85,7 +85,6 @@ if(get_magic_quotes_runtime())
   <para>
    <simplelist>
     <member><function>get_magic_quotes_gpc</function></member>
-    <member><function>set_magic_quotes_runtime</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/info/ini.xml
+++ b/reference/info/ini.xml
@@ -83,18 +83,6 @@
      <entry>Available as of PHP 5.3.9.</entry>
     </row>
     <row>
-     <entry><link linkend="ini.magic-quotes-gpc">magic_quotes_gpc</link></entry>
-     <entry>"1"</entry>
-     <entry>PHP_INI_PERDIR</entry>
-     <entry>Removed in PHP 5.4.0.</entry>
-    </row>
-    <row>
-     <entry><link linkend="ini.magic-quotes-runtime">magic_quotes_runtime</link></entry>
-     <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
-     <entry>Removed in PHP 5.4.0.</entry>
-    </row>
-    <row>
      <entry><link linkend="ini.zend.enable-gc">zend.enable_gc</link></entry>
      <entry>"1"</entry>
      <entry>PHP_INI_ALL</entry>
@@ -282,91 +270,6 @@
       If there are more input variables than specified by this directive,
       an <constant>E_WARNING</constant> is issued, and further input
       variables are truncated from the request.
-     </para>
-    </listitem>
-   </varlistentry>
-   
-   <varlistentry xml:id="ini.magic-quotes-gpc">
-    <term>
-     <parameter>magic_quotes_gpc</parameter>
-     <type>bool</type>
-    </term>
-     <listitem>
-     &warn.deprecated.feature-5-3-0.removed-5-4-0;
-     <para>
-      Sets the magic_quotes state for GPC (Get/Post/Cookie)
-      operations.  When magic_quotes are on, all ' (single-quote),
-      &quot; (double quote), \ (backslash) and NUL's are escaped
-      with a backslash automatically.
-     </para>
-     <para>
-      See also <function>get_magic_quotes_gpc</function>
-     </para>
-    </listitem>
-   </varlistentry>
-
-   <varlistentry xml:id="ini.magic-quotes-runtime">
-    <term>
-     <parameter>magic_quotes_runtime</parameter>
-     <type>bool</type>
-    </term>
-    <listitem>
-     &warn.deprecated.feature-5-3-0.removed-5-4-0;
-     <para>
-      If <parameter>magic_quotes_runtime</parameter> is enabled,
-      most functions that return data from any sort of external
-      source including databases and text files will have quotes
-      escaped with a backslash.
-     </para>
-     <para>
-      Functions affected by <parameter>magic_quotes_runtime</parameter>
-      (does not include functions from PECL):
-      <simplelist>
-       <member><function>get_meta_tags</function></member>
-       <member><function>file_get_contents</function></member>
-       <member><function>file</function></member>
-       <member><function>fgets</function></member>
-       <member><function>fwrite</function></member>
-       <member><function>fread</function></member>
-       <member><function>fputcsv</function></member>
-       <member><function>stream_socket_recvfrom</function></member>
-       <member><function>exec</function></member>
-       <member><function>system</function></member>
-       <member><function>passthru</function></member>
-       <member><function>stream_get_contents</function></member>
-       <member><function>bzread</function></member>
-       <member><function>gzfile</function></member>
-       <member><function>gzgets</function></member>
-       <member><function>gzwrite</function></member>
-       <member><function>gzread</function></member>
-       <member><function>exif_read_data</function></member>
-       <member><function>dba_insert</function></member>
-       <member><function>dba_replace</function></member>
-       <member><function>dba_fetch</function></member>
-       <member><function>ibase_fetch_row</function></member>
-       <member><function>ibase_fetch_assoc</function></member>
-       <member><function>ibase_fetch_object</function></member>
-       <member><function>mssql_fetch_row</function></member>
-       <member><function>mssql_fetch_object</function></member>
-       <member><function>mssql_fetch_array</function></member>
-       <member><function>mssql_fetch_assoc</function></member>
-       <member><function>mysqli_fetch_row</function></member>
-       <member><function>mysqli_fetch_array</function></member>
-       <member><function>mysqli_fetch_assoc</function></member>
-       <member><function>mysqli_fetch_object</function></member>
-       <member><function>pg_fetch_row</function></member>
-       <member><function>pg_fetch_assoc</function></member>
-       <member><function>pg_fetch_array</function></member>
-       <member><function>pg_fetch_object</function></member>
-       <member><function>pg_fetch_all</function></member>
-       <member><function>pg_select</function></member>
-       <member><function>sybase_fetch_object</function></member>
-       <member><function>sybase_fetch_array</function></member>
-       <member><function>sybase_fetch_assoc</function></member>
-       <member><function>SplFileObject::fgets</function></member>
-       <member><function>SplFileObject::fgetcsv</function></member>
-       <member><function>SplFileObject::fwrite</function></member>
-      </simplelist>
      </para>
     </listitem>
    </varlistentry>

--- a/reference/info/ini.xml
+++ b/reference/info/ini.xml
@@ -83,6 +83,18 @@
      <entry>Available as of PHP 5.3.9.</entry>
     </row>
     <row>
+     <entry><link linkend="ini.magic-quotes-gpc">magic_quotes_gpc</link></entry>
+     <entry>"1"</entry>
+     <entry>PHP_INI_PERDIR</entry>
+     <entry>Removed in PHP 5.4.0.</entry>
+    </row>
+    <row>
+     <entry><link linkend="ini.magic-quotes-runtime">magic_quotes_runtime</link></entry>
+     <entry>"0"</entry>
+     <entry>PHP_INI_ALL</entry>
+     <entry>Removed in PHP 5.4.0.</entry>
+    </row>
+    <row>
      <entry><link linkend="ini.zend.enable-gc">zend.enable_gc</link></entry>
      <entry>"1"</entry>
      <entry>PHP_INI_ALL</entry>
@@ -270,6 +282,91 @@
       If there are more input variables than specified by this directive,
       an <constant>E_WARNING</constant> is issued, and further input
       variables are truncated from the request.
+     </para>
+    </listitem>
+   </varlistentry>
+   
+   <varlistentry xml:id="ini.magic-quotes-gpc">
+    <term>
+     <parameter>magic_quotes_gpc</parameter>
+     <type>bool</type>
+    </term>
+     <listitem>
+     &warn.deprecated.feature-5-3-0.removed-5-4-0;
+     <para>
+      Sets the magic_quotes state for GPC (Get/Post/Cookie)
+      operations.  When magic_quotes are on, all ' (single-quote),
+      &quot; (double quote), \ (backslash) and NUL's are escaped
+      with a backslash automatically.
+     </para>
+     <para>
+      See also <function>get_magic_quotes_gpc</function>
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="ini.magic-quotes-runtime">
+    <term>
+     <parameter>magic_quotes_runtime</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     &warn.deprecated.feature-5-3-0.removed-5-4-0;
+     <para>
+      If <parameter>magic_quotes_runtime</parameter> is enabled,
+      most functions that return data from any sort of external
+      source including databases and text files will have quotes
+      escaped with a backslash.
+     </para>
+     <para>
+      Functions affected by <parameter>magic_quotes_runtime</parameter>
+      (does not include functions from PECL):
+      <simplelist>
+       <member><function>get_meta_tags</function></member>
+       <member><function>file_get_contents</function></member>
+       <member><function>file</function></member>
+       <member><function>fgets</function></member>
+       <member><function>fwrite</function></member>
+       <member><function>fread</function></member>
+       <member><function>fputcsv</function></member>
+       <member><function>stream_socket_recvfrom</function></member>
+       <member><function>exec</function></member>
+       <member><function>system</function></member>
+       <member><function>passthru</function></member>
+       <member><function>stream_get_contents</function></member>
+       <member><function>bzread</function></member>
+       <member><function>gzfile</function></member>
+       <member><function>gzgets</function></member>
+       <member><function>gzwrite</function></member>
+       <member><function>gzread</function></member>
+       <member><function>exif_read_data</function></member>
+       <member><function>dba_insert</function></member>
+       <member><function>dba_replace</function></member>
+       <member><function>dba_fetch</function></member>
+       <member><function>ibase_fetch_row</function></member>
+       <member><function>ibase_fetch_assoc</function></member>
+       <member><function>ibase_fetch_object</function></member>
+       <member><function>mssql_fetch_row</function></member>
+       <member><function>mssql_fetch_object</function></member>
+       <member><function>mssql_fetch_array</function></member>
+       <member><function>mssql_fetch_assoc</function></member>
+       <member><function>mysqli_fetch_row</function></member>
+       <member><function>mysqli_fetch_array</function></member>
+       <member><function>mysqli_fetch_assoc</function></member>
+       <member><function>mysqli_fetch_object</function></member>
+       <member><function>pg_fetch_row</function></member>
+       <member><function>pg_fetch_assoc</function></member>
+       <member><function>pg_fetch_array</function></member>
+       <member><function>pg_fetch_object</function></member>
+       <member><function>pg_fetch_all</function></member>
+       <member><function>pg_select</function></member>
+       <member><function>sybase_fetch_object</function></member>
+       <member><function>sybase_fetch_array</function></member>
+       <member><function>sybase_fetch_assoc</function></member>
+       <member><function>SplFileObject::fgets</function></member>
+       <member><function>SplFileObject::fgetcsv</function></member>
+       <member><function>SplFileObject::fwrite</function></member>
+      </simplelist>
      </para>
     </listitem>
    </varlistentry>

--- a/reference/oci8/functions/oci-bind-by-name.xml
+++ b/reference/oci8/functions/oci-bind-by-name.xml
@@ -802,9 +802,7 @@ var_dump($output2);  // false
   &reftitle.notes;
   <warning>
    <para>
-    Do not use <link
-     linkend="ini.magic-quotes-gpc">magic_quotes_gpc</link> or
-    <function>addslashes</function>
+    Do not use <function>addslashes</function>
     and <function>oci_bind_by_name</function> simultaneously as no
     quoting is needed. Any magically applied quotes will be written
     into your database because <function>oci_bind_by_name</function>

--- a/reference/strings/functions/parse-str.xml
+++ b/reference/strings/functions/parse-str.xml
@@ -156,14 +156,6 @@ echo $output['My_Value']; // Something
     sources</link>.
    </para>
   </note>
-  <note>
-   <para>
-    The <link linkend="ini.magic-quotes-gpc">magic_quotes_gpc</link> setting
-    affects the output of this function, as <function>parse_str</function> uses
-    the same mechanism that PHP uses to populate the <varname>$_GET</varname>,
-    <varname>$_POST</varname>, etc. variables.
-   </para>
-  </note>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/zlib/functions/gzwrite.xml
+++ b/reference/zlib/functions/gzwrite.xml
@@ -48,15 +48,6 @@
        written or the end of <parameter>data</parameter> is reached,
        whichever comes first.
       </para>
-      <note>
-       <para>
-        Note that if the <parameter>length</parameter> argument is given,
-        then the <link
-        linkend="ini.magic-quotes-runtime">magic_quotes_runtime</link>
-        configuration option will be ignored and no slashes will be
-        stripped from <parameter>data</parameter>.
-       </para>
-      </note>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
This PR removes information related to magicquotes which has been removed in PHP 7.0. 
I did _**not**_ change:
https://www.php.net/manual/en/function.parse-ini-file
https://www.php.net/manual/en/function.get-magic-quotes-gpc
https://www.php.net/manual/en/function.get-magic-quotes-runtime.php
https://www.php.net/manual/en/function.mysql-escape-string
https://www.php.net/manual/en/function.mysql-real-escape-string.php
https://www.php.net/security.variables