### PR TITLE
Remove unneeded note

### DIFF
--- a/reference/stream/functions/stream-set-blocking.xml
+++ b/reference/stream/functions/stream-set-blocking.xml
@@ -63,13 +63,6 @@
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
-    This function was previously called as
-    <function>set_socket_blocking</function> and later
-    <function>socket_set_blocking</function> but this usage is deprecated.
-   </para>
-  </note>
-  <note>
    <para>On Windows, this has no affect on local files. Non-blocking IO for local files is not supported on Windows.
    </para>
   </note>


### PR DESCRIPTION
`set_socket_blocking` was removed in PHP 7.0. `socket_set_blocking` is still an alias and is not deprecated, but since we don't document aliases in notes, I removed the whole note. 