### PR TITLE
Revise wording for ucwords

### DIFF
--- a/reference/strings/functions/ucwords.xml
+++ b/reference/strings/functions/ucwords.xml
@@ -18,9 +18,10 @@
    <parameter>string</parameter> capitalized, if that character is alphabetic.
   </para>
   <para>
-   The definition of a word is any string of characters that is immediately
-   after any character listed in the <parameter>separators</parameter> parameter
-   (By default these are: space, form-feed, newline, carriage return, horizontal tab, and vertical tab).
+   A "word" is described as any string of characters that is segmented by any
+   character in the <parameter>separators</parameter> parameter. By default, 
+   these are: space, form-feed, newline, carriage return, horizontal tab and 
+   vertical tab.
   </para>
  </refsect1>
 

--- a/reference/strings/functions/ucwords.xml
+++ b/reference/strings/functions/ucwords.xml
@@ -18,7 +18,7 @@
    <parameter>string</parameter> capitalized, if that character is alphabetic.
   </para>
   <para>
-   A "word" is described as any string of characters that is segmented by any
+   A "word" is described as any string of characters that is delimited by any
    character in the <parameter>separators</parameter> parameter. By default, 
    these are: space, form-feed, newline, carriage return, horizontal tab and 
    vertical tab.


### PR DESCRIPTION
Revised the wording in the second paragraph of `ucwords`. I'm not entirely sure about the use of double quotes around "word", but I think the changes overall provide clearer meaning of intent.

Resolves https://github.com/php/doc-en/issues/720