### PR TITLE
Added PDO::FETCH_GROUP to the Description

### DIFF
--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -32,6 +32,12 @@
    <methodparam><type>int</type><parameter>mode</parameter><initializer>PDO::FETCH_INTO</initializer></methodparam>
    <methodparam><type>object</type><parameter>object</parameter></methodparam>
   </methodsynopsis>
+  
+   <methodsynopsis>
+   <modifier>public</modifier> <type>array</type><methodname>PDOStatement::fetchAll</methodname>
+   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer>PDO::FETCH_GROUP</initializer></methodparam>
+  </methodsynopsis>
+  
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
PDO::FETCH_COLUMN is illustrated in the description, but not PDO::FETCH_GROUP, so I added PDO::FETCH_GROUP as it is one of the most underrated / misunderstood functions in PDO, that can make an incredible difference in production speed if more developers discover it.

A net positive for the community.