### PR TITLE
Fix ldap functions description

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1021,6 +1021,8 @@ Passing untrusted data to this parameter is <emphasis>insecure</emphasis>, unles
 
 <!ENTITY ldap.parameter.ldap 'An LDAP resource, returned by <function xmlns="http://docbook.org/ns/docbook">ldap_connect</function>.'>
 
+<!ENTITY ldap.parameter.result 'An LDAP result resource, returned by <function xmlns="http://docbook.org/ns/docbook">ldap_list</function> or <function xmlns="http://docbook.org/ns/docbook">ldap_search</function>.'>
+
 <!ENTITY ldap.warn.control-paged '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
   This function has been <emphasis>DEPRECATED</emphasis> as of PHP 7.4.0, and <emphasis>REMOVED</emphasis> as of PHP 8.0.0.

--- a/reference/ldap/functions/ldap-count-entries.xml
+++ b/reference/ldap/functions/ldap-count-entries.xml
@@ -35,7 +35,7 @@
      <term><parameter>result</parameter></term>
      <listitem>
       <para>
-       The internal LDAP result.
+       &ldap.parameter.result;
       </para>
      </listitem>
     </varlistentry>
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns number of entries in the result or &false; on error.
+   Returns number of entries in the result,&return.falseforfailure;.
   </para>
  </refsect1>
 
@@ -55,7 +55,7 @@
   &reftitle.examples;
   <para>
    <example xml:id="ldap-count-entries.example.basic">
-    <title><function>ldap-count-entries</function> example</title>
+    <title><function>ldap_count_entries</function> example</title>
     <para>
      Retrieve number of entries in the result.
     </para>

--- a/reference/ldap/functions/ldap-count-references.xml
+++ b/reference/ldap/functions/ldap-count-references.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.ldap-count-references" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ldap_count_references</refname>
+  <refpurpose>Counts the number of references in a search result</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>ldap_count_references</methodname>
+   <methodparam><type>resource</type><parameter>ldap</parameter></methodparam>
+   <methodparam><type>resource</type><parameter>result</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Counts the number of references in a search result.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>ldap</parameter></term>
+    <listitem>
+     <para>
+      &ldap.parameter.ldap;
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>result</parameter></term>
+    <listitem>
+     <para>
+      &ldap.parameter.result;
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the number of references in a search result.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ldap_connect</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ldap/functions/ldap-first-entry.xml
+++ b/reference/ldap/functions/ldap-first-entry.xml
@@ -41,6 +41,7 @@
      <term><parameter>result</parameter></term>
      <listitem>
       <para>
+       &ldap.parameter.result;
       </para>
      </listitem>
     </varlistentry>
@@ -51,8 +52,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the result entry identifier for the first entry on success and
-   &false; on error.
+   Returns the result entry identifier for the first entry on success,&return.falseforfailure;.
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-free-result.xml
+++ b/reference/ldap/functions/ldap-free-result.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ldap_free_result</methodname>
-   <methodparam><type>resource</type><parameter>ldap</parameter></methodparam>
+   <methodparam><type>resource</type><parameter>result</parameter></methodparam>
   </methodsynopsis>
   <para>
    Frees up the memory allocated internally to store the result. All result
@@ -29,9 +29,10 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>ldap</parameter></term>
+     <term><parameter>result</parameter></term>
      <listitem>
       <para>
+       &ldap.parameter.result;
       </para>
      </listitem>
     </varlistentry>

--- a/reference/ldap/functions/ldap-get-entries.xml
+++ b/reference/ldap/functions/ldap-get-entries.xml
@@ -35,6 +35,7 @@
      <term><parameter>result</parameter></term>
      <listitem>
       <para>
+       &ldap.parameter.result;
       </para>
      </listitem>
     </varlistentry>
@@ -46,7 +47,7 @@
   &reftitle.returnvalues;
   <para>
    Returns a complete result information in a multi-dimensional array on
-   success and &false; on error.
+   success,&return.falseforfailure;.
   </para>
   <para>
    The structure of the array is as follows.

--- a/reference/ldap/functions/ldap-parse-result.xml
+++ b/reference/ldap/functions/ldap-parse-result.xml
@@ -36,11 +36,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>result_identifier</parameter></term>
+     <term><parameter>result</parameter></term>
      <listitem>
       <para>
-       An LDAP result resource, returned by <function>ldap_list</function> or
-       <function>ldap_search</function>.
+       &ldap.parameter.result;
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Fixed `result` parameter description, based on stubs for:

- [ldap_free_result](https://github.com/php/php-src/blob/master/ext/ldap/ldap.stub.php#L52)
- [ldap_count_entries](https://github.com/php/php-src/blob/master/ext/ldap/ldap.stub.php#L54)
- [ldap_first_entry](https://github.com/php/php-src/blob/master/ext/ldap/ldap.stub.php#L56)
- [ldap_get_entries](https://github.com/php/php-src/blob/master/ext/ldap/ldap.stub.php#L60)
- [ldap_count_references](https://github.com/php/php-src/blob/master/ext/ldap/ldap.stub.php#L125)
- [ldap_parse_result](https://github.com/php/php-src/blob/master/ext/ldap/ldap.stub.php#L144)

Added `ldap_count_references` function, ref #674