### PR TITLE
is_numeric: See also filter_var (specifically with validation_filters)

### DIFF
--- a/reference/var/functions/is-numeric.xml
+++ b/reference/var/functions/is-numeric.xml
@@ -119,6 +119,7 @@ NULL is NOT numeric
     <member><function>is_string</function></member>
     <member><function>is_object</function></member>
     <member><function>is_array</function></member>
+    <member><function>filter_var</function> with <link linkend="filter.filters.validate">validation filters</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/var/functions/is-numeric.xml
+++ b/reference/var/functions/is-numeric.xml
@@ -119,7 +119,7 @@ NULL is NOT numeric
     <member><function>is_string</function></member>
     <member><function>is_object</function></member>
     <member><function>is_array</function></member>
-    <member><function>filter_var</function> with <link linkend="filter.filters.validate">validation filters</member>
+    <member><link linkend="function.filter-var">filter_var</link> - Filters a variable with <link linkend="filter.filters.validate">validation filters</link></member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
filter_var validation filters provide for more specific filtering than is_numeric (such as "is integer").

I've avoided the `<function>` tag here to specifically link to validation filters. If you can think of a better alternative, let me know.

Edit: Fix hidden 'function' tag name