### PR TITLE
Documentation for the FPM status page and fpm_get_status()

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -487,8 +487,8 @@
       </term>
       <listitem>
        <para>
-        The URI to view the FPM status page. If this value is not set, no URI
-        will be recognized as a status page. Default value: none.
+        The URI to view the <link linkend="fpm.status">FPM status page</link>. This value must start with a leading
+        slash (/). If this value is not set, no URI will be recognized as a status page. Default value: none.
        </para>
       </listitem>
      </varlistentry>

--- a/reference/fpm/book.xml
+++ b/reference/fpm/book.xml
@@ -17,6 +17,7 @@
  </preface>
 
  &reference.fpm.setup;
+ &reference.fpm.status;
  &reference.fpm.reference;
 
 </book>

--- a/reference/fpm/functions/fpm_get_status.xml
+++ b/reference/fpm/functions/fpm_get_status.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<refentry xml:id="function.fpm-get-status" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>fpm_get_status</refname>
+  <refpurpose>Returns the current FPM pool status</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>array</type><methodname>fpm_get_status</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   This function returns the full current FPM pool status as an associative array. It always returns the full status,
+   including per-process status information. See the <link linkend="fpm.status">FPM status page guide</link> for further
+   details.
+  </para>
+  <para>
+   Note that this function will only be defined if FPM is being used to serve the script.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Associative array containing the full FPM pool status.
+  </para>
+ </refsect1>
+</refentry>
+
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/fpm/status.xml
+++ b/reference/fpm/status.xml
@@ -52,6 +52,7 @@
  <simplelist>
   <member>html</member>
   <member>json</member>
+  <member>openmetrics (PHP >= 8.1)</member>
   <member>xml</member>
  </simplelist>
 
@@ -76,6 +77,10 @@
 
  <para>
   Note: All values are specific to the pool and are reset when FPM is restarted.
+ </para>
+ <para>
+  Note: OpenMetrics format output uses different parameter types to better suit the OpenMetrics format.
+  The parameters and descriptions of their values are included in the OpenMetrics format output.
  </para>
  <para>
   Date/Time values use the unix timestamp format in JSON and XML output, otherwise they use the format '03/Jun/2021:07:21:46 +0100'.

--- a/reference/fpm/status.xml
+++ b/reference/fpm/status.xml
@@ -1,0 +1,250 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<chapter xml:id="fpm.status">
+ <title>Status Page</title>
+
+ <para>
+  This page provides information on the setup and contents of the FPM status page. See also
+  <function>fpm_get_status</function>.
+ </para>
+
+ <para xml:id="fpm.status.configuration">
+   <emphasis role="bold">Configuration</emphasis>
+ </para>
+
+ <para>
+  The FPM status page can be enabled by setting the <link linkend="pm.status-path">pm.status_path</link> configuration
+  parameter in the FPM pool configuration.
+ </para>
+
+ <para>
+  For security you must restrict the FPM status page to internal requests or known client IPs only as the page reveals
+  request URLs and information about available resources.
+ </para>
+
+ <para>
+  You will additionally need to configure your webserver to allow requests directly to this path, bypassing any PHP
+  scripts. An example configuration for Apache would look like:
+ </para>
+
+ <informalexample>
+  <programlisting role="apache-conf">
+<![CDATA[
+<LocationMatch "/fpm-status">
+    Order Allow,Deny
+    Allow from 127.0.0.1
+    ProxyPass "unix:/var/run/php-fpm.sock|fcgi://localhost/fpm-status"
+</LocationMatch>
+]]>
+  </programlisting>
+ </informalexample>
+
+ <para>
+  After restarting both FPM and your webserver the status page will now be accessible from your browser (as long as
+  the request comes from an allowed IP address).
+ </para>
+
+ <para>
+  The format of the status page output can be altered by specifying one of the following query parameters:
+ </para>
+
+ <simplelist>
+  <member>html</member>
+  <member>json</member>
+  <member>xml</member>
+ </simplelist>
+
+ <para>
+  Additional information can also be returned using the 'full' query parameter.
+ </para>
+
+ <para>
+  Example status page URLs:
+ </para>
+
+ <simplelist>
+  <member>https://localhost/fpm-status - Brief output in the default text format</member>
+  <member>https://localhost/fpm-status?full - Full output in the default text format</member>
+  <member>https://localhost/fpm-status?json - Brief output in JSON format</member>
+  <member>https://localhost/fpm-status?html&amp;full - Full output in HTML format</member>
+ </simplelist>
+
+ <para xml:id="fpm.status.contents">
+  <emphasis role="bold">Displayed Information</emphasis>
+ </para>
+
+ <para>
+  Note: All values are specific to the pool and are reset when FPM is restarted.
+ </para>
+
+ <table>
+  <title>Basic information - Always displayed on the status page</title>
+  <tgroup cols="2">
+   <thead>
+    <row>
+     <entry>Parameter</entry>
+     <entry>Description</entry>
+    </row>
+   </thead>
+   <tbody>
+    <row>
+     <entry>pool</entry>
+     <entry>The name of the FPM process pool.</entry>
+    </row>
+    <row>
+     <entry>proccess manager</entry>
+     <entry>The process manager type - static, dynamic or ondemand.</entry>
+    </row>
+    <row>
+     <entry>start time</entry>
+     <entry>The unix timestamp that the process pool was last started.</entry>
+    </row>
+    <row>
+     <entry>start since</entry>
+     <entry>The time in seconds since the process pool was last started.</entry>
+    </row>
+    <row>
+     <entry>accepted conn</entry>
+     <entry>The total number of accepted connections.</entry>
+    </row>
+    <row>
+     <entry>listen queue</entry>
+     <entry>The number of requests (backlog) currently waiting for a free process.</entry>
+    </row>
+    <row>
+     <entry>max listen queue</entry>
+     <entry>The maximum number of requests seen in the listen queue at any one time.</entry>
+    </row>
+    <row>
+     <entry>listen queue len</entry>
+     <entry>The maximum allowed size of the listen queue.</entry>
+    </row>
+    <row>
+     <entry>idle processes</entry>
+     <entry>The number of processes that are currently idle (waiting for requests).</entry>
+    </row>
+    <row>
+     <entry>active processes</entry>
+     <entry>The number of processes that are currently processing requests.</entry>
+    </row>
+    <row>
+     <entry>total processes</entry>
+     <entry>The current total number of processes.</entry>
+    </row>
+    <row>
+     <entry>max active processes</entry>
+     <entry>The maximum number of concurrently active processes.</entry>
+    </row>
+    <row>
+     <entry>max children reached</entry>
+     <entry>Has the maximum number of processes ever been reached? '1' if yes, '0' if no.</entry>
+    </row>
+    <row>
+     <entry>slow requests</entry>
+     <entry>The total number of requests that have hit the request_slowlog_timeout.</entry>
+    </row>
+   </tbody>
+  </tgroup>
+ </table>
+
+ <table>
+  <title>Per-process information - only displayed in 'full' output mode</title>
+  <tgroup cols="2">
+   <thead>
+    <row>
+     <entry>Parameter</entry>
+     <entry>Description</entry>
+    </row>
+   </thead>
+   <tbody>
+    <row>
+     <entry>pid</entry>
+     <entry>The system PID of the process.</entry>
+    </row>
+    <row>
+     <entry>state</entry>
+     <entry>The state of the process - Idle, Running, ...</entry>
+    </row>
+    <row>
+     <entry>start time</entry>
+     <entry>The unix timestamp at which the process started.</entry>
+    </row>
+    <row>
+     <entry>start since</entry>
+     <entry>The number of seconds since the process started.</entry>
+    </row>
+    <row>
+     <entry>requests</entry>
+     <entry>The total number of requests served.</entry>
+    </row>
+    <row>
+     <entry>request duration</entry>
+     <entry>The total time in seconds spent serving requests.</entry>
+    </row>
+    <row>
+     <entry>request method</entry>
+     <entry>The HTTP method of the last served request.</entry>
+    </row>
+    <row>
+     <entry>request uri</entry>
+     <entry>
+      The URI of the last served request (after webserver processing, so may always be "/index.php" if you use
+      a front controller pattern redirect).
+     </entry>
+    </row>
+    <row>
+     <entry>content length</entry>
+     <entry>The length of the request body, in bytes, of the last request.</entry>
+    </row>
+    <row>
+     <entry>user</entry>
+     <entry>The HTTP user (PHP_AUTH_USER) of the last request.</entry>
+    </row>
+    <row>
+     <entry>script</entry>
+     <entry>
+      The full path of the script executed by the last request. This will be '-' if not applicable
+      (eg. status page requests).
+     </entry>
+    </row>
+    <row>
+     <entry>last request cpu</entry>
+     <entry>
+      The %cpu of the last request. This will be 0 if the process is not Idle because the calculation is done when
+      the request processing is complete.
+     </entry>
+    </row>
+    <row>
+     <entry>last request memory</entry>
+     <entry>
+      The maximum amount of memory consumed by the last request. This will be 0 if the process is not Idle because
+      the calculation is done when the request processing is complete.
+     </entry>
+    </row>
+   </tbody>
+  </tgroup>
+ </table>
+
+</chapter>
+
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/fpm/status.xml
+++ b/reference/fpm/status.xml
@@ -77,6 +77,9 @@
  <para>
   Note: All values are specific to the pool and are reset when FPM is restarted.
  </para>
+ <para>
+  Date/Time values use the unix timestamp format in JSON and XML output, otherwise they use the format '03/Jun/2021:07:21:46 +0100'.
+ </para>
 
  <table>
   <title>Basic information - Always displayed on the status page</title>
@@ -98,7 +101,7 @@
     </row>
     <row>
      <entry>start time</entry>
-     <entry>The unix timestamp that the process pool was last started.</entry>
+     <entry>The date/time that the process pool was last started.</entry>
     </row>
     <row>
      <entry>start since</entry>
@@ -168,7 +171,7 @@
     </row>
     <row>
      <entry>start time</entry>
-     <entry>The unix timestamp at which the process started.</entry>
+     <entry>The date/time at which the process started.</entry>
     </row>
     <row>
      <entry>start since</entry>

--- a/reference/fpm/versions.xml
+++ b/reference/fpm/versions.xml
@@ -6,6 +6,7 @@
 
 <versions>
  <function name="fastcgi_finish_request" from="PHP 5 &gt;= 5.3.3, PHP 7, PHP 8"/>
+ <function name="fpm_get_status" from="PHP 7 &gt;= 7.3, PHP 8"/>
 </versions>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Relates to #663 
Resolves https://bugs.php.net/bug.php?id=72105

The vast majority of the information comes from the existing documentation in the FPM template configuration files, however some details have been added from my own knowledge and checking other sites. If you see anything amiss, please let me know.

I am not experienced enough with nginx to provide reliable configuration information for it. If you know the nginx equivalent for the example Apache configuration given, please let me know and I can add that.