### PR TITLE
Remove unsafe AddHandler example

### DIFF
--- a/install/windows/apache2.xml
+++ b/install/windows/apache2.xml
@@ -47,7 +47,9 @@
 <![CDATA[
 #
 LoadModule php8_module "c:/php/php8apache2_4.dll"
-AddHandler application/x-httpd-php .php
+<FilesMatch \.php$>
+    SetHandler application/x-httpd-php
+</FilesMatch>
 # configure the path to php.ini
 PHPIniDir "C:/php"
 ]]>
@@ -63,24 +65,6 @@ PHPIniDir "C:/php"
     for PHP 7, or <filename>php8apache2_4.dll</filename> for PHP 8.
    </simpara>
   </note>
-  <para>
-   The above configuration will enable PHP handling of any file that has a
-   .php extension, even if there are other file extensions. For example, a
-   file named <filename>example.php.txt</filename> will be executed by the
-   PHP handler. To ensure that only files that <emphasis>end in</emphasis>
-   <filename>.php</filename> are executed, use the following configuration
-   instead:
-  </para>
-
-  <example>
-   <programlisting role="apache-conf">
-<![CDATA[
-<FilesMatch \.php$>
-    SetHandler application/x-httpd-php
-</FilesMatch>
-]]>
-   </programlisting>
-  </example>
  </sect2>
 
  <sect2 xml:id="install.windows.apache2.cgi">

--- a/install/windows/apache2.xml
+++ b/install/windows/apache2.xml
@@ -124,7 +124,9 @@ PHPIniDir "C:/php"
 LoadModule fcgid_module modules/mod_fcgid.so
 # Where is your php.ini file?
 FcgidInitialEnv PHPRC        "c:/php"
-AddHandler fcgid-script .php
+<FilesMatch \.php$>
+    SetHandler fcgid-script
+</FilesMatch>
 FcgidWrapper "c:/php/php-cgi.exe" .php
 ]]>
     </programlisting>


### PR DESCRIPTION
The internet will always take your example code and repost it out of context. Googling shows plenty of installation guides that use `AddHandler application/x-httpd-php .php`, which potentially leads to parsing unsafe files like `evil.php.jpg`

I propose to totally remove the unsafe example and only show the correct version with `<FilesMatch \.php$>`, similar to https://www.php.net/manual/en/install.unix.apache2.php