### PR TITLE
New example for class_exists

### DIFF
--- a/reference/classobj/functions/class-exists.xml
+++ b/reference/classobj/functions/class-exists.xml
@@ -68,17 +68,16 @@ if (class_exists('MyClass')) {
     <programlisting role="php">
 <![CDATA[
 <?php
-function __autoload($class)
-{
-    include($class . '.php');
+spl_autoload_register(function ($class_name) {
+    include $class_name . '.php';
 
     // Check to see whether the include declared the class
-    if (!class_exists($class, false)) {
-        trigger_error("Unable to load class: $class", E_USER_WARNING);
+    if (!class_exists($class_name, false)) {
+        throw new LogicException("Unable to load class: $class_name");
     }
-}
+});
 
-if (class_exists('MyClass')) {
+if (class_exists(MyClass::class)) {
     $myclass = new MyClass();
 }
 


### PR DESCRIPTION
`__autoload` has been removed now, so the example using it should be changed too. 