### PR TITLE
ReflectionProperty: fix a few references to wrong class name(s)

### DIFF
--- a/reference/reflection/reflectionproperty/getdefaultvalue.xml
+++ b/reference/reflection/reflectionproperty/getdefaultvalue.xml
@@ -29,7 +29,7 @@
    The default value if the property has any default value (including &null;).
    If there is no default value, then &null; is returned. It is not possible to differentiate
    between a &null; default value and an unitialized typed property.
-   Use <methodname>ReflectionClass::hasDefaultValue</methodname> to detect the difference.
+   Use <methodname>ReflectionProperty::hasDefaultValue</methodname> to detect the difference.
   </para>
  </refsect1>
 
@@ -37,7 +37,7 @@
   &reftitle.examples;
   <para>
    <example>
- <title><methodname>ReflectionClass::getDefaultValue</methodname> example</title>
+ <title><methodname>ReflectionProperty::getDefaultValue</methodname> example</title>
  <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/reflection/reflectionproperty/hasdefaultvalue.xml
+++ b/reference/reflection/reflectionproperty/hasdefaultvalue.xml
@@ -37,7 +37,7 @@
   &reftitle.examples;
   <para>
    <example>
- <title><methodname>ReflectionClass::hasDefaultValue</methodname> example</title>
+ <title><methodname>ReflectionProperty::hasDefaultValue</methodname> example</title>
  <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/reflection/reflectionproperty/isdefault.xml
+++ b/reference/reflection/reflectionproperty/isdefault.xml
@@ -36,7 +36,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title><methodname>ReflectionClass::isDefault</methodname> example</title>
+    <title><methodname>ReflectionProperty::isDefault</methodname> example</title>
     <programlisting role="php">
 <![CDATA[
 <?php


### PR DESCRIPTION
These methods only exist on the `ReflectionProperty` class, not on `ReflectionClass`.