### PR TITLE
Fix remaining usages of __autoload

### DIFF
--- a/reference/classobj/functions/class-exists.xml
+++ b/reference/classobj/functions/class-exists.xml
@@ -32,7 +32,7 @@
      <term><parameter>autoload</parameter></term>
      <listitem>
       <para>
-       Whether or not to call &link.autoload; by default.
+       Whether to call &link.autoload; by default.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/classobj/versions.xml
+++ b/reference/classobj/versions.xml
@@ -5,7 +5,7 @@
 -->
 
 <versions>
- <function name="__autoload" from="PHP 5, PHP 7" deprecated="PHP 7.2.0"/>
+ <function name="__autoload" from="PHP 5, PHP 7" deprecated="PHP 7.2.0" removed="PHP 8"/>
  <function name="class_alias" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="class_exists" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="get_called_class" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>

--- a/reference/spl/functions/class-implements.xml
+++ b/reference/spl/functions/class-implements.xml
@@ -36,8 +36,7 @@
      <term><parameter>autoload</parameter></term>
      <listitem>
       <para>
-       Whether to allow this function to load the class automatically through
-       the <function>__autoload</function> magic method.
+       Whether or not to call &link.autoload; by default.
       </para>
      </listitem>
     </varlistentry>
@@ -70,12 +69,9 @@ print_r(class_implements(new bar));
 // you may also specify the parameter as a string
 print_r(class_implements('bar'));
 
+spl_autoload_register();
 
-function __autoload($class_name) {
-   require_once $class_name . '.php';
-}
-
-// use __autoload to load the 'not_loaded' class
+// use autoloading to load the 'not_loaded' class
 print_r(class_implements('not_loaded', true));
 
 ?>
@@ -88,7 +84,10 @@ Array
 (
     [foo] => foo
 )
-
+Array
+(
+    [foo] => foo
+)
 Array
 (
     [interface_of_not_loaded] => interface_of_not_loaded

--- a/reference/spl/functions/class-implements.xml
+++ b/reference/spl/functions/class-implements.xml
@@ -36,7 +36,7 @@
      <term><parameter>autoload</parameter></term>
      <listitem>
       <para>
-       Whether or not to call &link.autoload; by default.
+       Whether to call &link.autoload; by default.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/spl/functions/class-parents.xml
+++ b/reference/spl/functions/class-parents.xml
@@ -36,8 +36,7 @@
      <term><parameter>autoload</parameter></term>
      <listitem>
       <para>
-       Whether to allow this function to load the class automatically through
-       the <function>__autoload</function> magic method.
+       Whether to call &link.autoload; by default.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/spl/functions/class-parents.xml
+++ b/reference/spl/functions/class-parents.xml
@@ -68,13 +68,11 @@ print_r(class_parents(new bar));
 // you may also specify the parameter as a string
 print_r(class_parents('bar'));
 
-
-function __autoload($class_name) {
-   require_once $class_name . '.php';
-}
+spl_autoload_register();
 
 // use __autoload to load the 'not_loaded' class
 print_r(class_parents('not_loaded', true));
+
 ?>
 ]]>
     </programlisting>
@@ -85,7 +83,10 @@ Array
 (
     [foo] => foo
 )
-
+Array
+(
+    [foo] => foo
+)
 Array
 (
     [parent_of_not_loaded] => parent_of_not_loaded

--- a/reference/spl/functions/class-parents.xml
+++ b/reference/spl/functions/class-parents.xml
@@ -70,7 +70,7 @@ print_r(class_parents('bar'));
 
 spl_autoload_register();
 
-// use __autoload to load the 'not_loaded' class
+// use autoloading to load the 'not_loaded' class
 print_r(class_parents('not_loaded', true));
 
 ?>

--- a/reference/spl/functions/class-uses.xml
+++ b/reference/spl/functions/class-uses.xml
@@ -73,7 +73,7 @@ print_r(class_uses('bar'));
 
 spl_autoload_register();
 
-// use __autoload to load the 'not_loaded' class
+// use autoloading to load the 'not_loaded' class
 print_r(class_uses('not_loaded', true));
 
 ?>

--- a/reference/spl/functions/class-uses.xml
+++ b/reference/spl/functions/class-uses.xml
@@ -37,8 +37,7 @@
      <term><parameter>autoload</parameter></term>
      <listitem>
       <para>
-       Whether to allow this function to load the class automatically through
-       the <function>__autoload</function> magic method.
+       Whether to call &link.autoload; by default.
       </para>
      </listitem>
     </varlistentry>
@@ -72,9 +71,7 @@ print_r(class_uses(new bar));
 
 print_r(class_uses('bar'));
 
-function __autoload($class_name) {
-   require_once $class_name . '.php';
-}
+spl_autoload_register();
 
 // use __autoload to load the 'not_loaded' class
 print_r(class_uses('not_loaded', true));
@@ -89,12 +86,10 @@ Array
 (
     [foo] => foo
 )
-
 Array
 (
     [foo] => foo
 )
-
 Array
 (
     [trait_of_not_loaded] => trait_of_not_loaded


### PR DESCRIPTION
PHAR still uses `__autoload` in their documentation but I don't care that much about changing it right now. 