### PR TITLE
The opened_path paramater is only set when STREAM_USE_PATH is set

### DIFF
--- a/reference/stream/streamwrapper/stream-open.xml
+++ b/reference/stream/streamwrapper/stream-open.xml
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
    <methodparam><type>string</type><parameter>mode</parameter></methodparam>
    <methodparam><type>int</type><parameter>options</parameter></methodparam>
-   <methodparam><type>string</type><parameter role="reference">opened_path</parameter></methodparam>
+   <methodparam><type>?string</type><parameter role="reference">opened_path</parameter></methodparam>
   </methodsynopsis>
   <para>
    This method is called immediately after the wrapper is initialized (f.e. by


### PR DESCRIPTION
If you use the `string` typehint, you will get an error about null passed from `fopen()`.