### PR TITLE
Fix typos in setup.xml

### DIFF
--- a/reference/rar/setup.xml
+++ b/reference/rar/setup.xml
@@ -54,8 +54,8 @@ phpize
   &reftitle.resources;
   <para>
    This extension registers three internal classes:
-   The archive representations returned by <function>rar_open</function> –
-   <type>RarArchive</type> –, the entry representations returned by
+   the archive representations returned by <function>rar_open</function> –
+   <type>RarArchive</type>, the entry representations returned by
    <function>rar_list</function> and <function>rar_entry_get</function> –
    <type>RarEntry</type> and the exception type <type>RarException</type>.
   </para>


### PR DESCRIPTION
This fixes a couple of typos on https://www.php.net/manual/en/rar.resources.php