### PR TITLE
Add period and comma on Phar intro page

### DIFF
--- a/reference/phar/book.xml
+++ b/reference/phar/book.xml
@@ -30,7 +30,7 @@
   <para>
    Phar implements this functionality through a <link linkend="book.stream">Stream
    Wrapper</link>.  Normally, to use an external file within a PHP script, you
-   would use <function>include</function>
+   would use <function>include</function>:
   </para>
   <para>
    <example>
@@ -137,7 +137,7 @@
   </para>
   <para>
    If you are using phar applications, there are helpful tips in
-   <link linkend="phar.using">How to use Phar Archives</link>
+   <link linkend="phar.using">How to use Phar Archives</link>.
   </para>
   <para>
    The word <literal>phar</literal> is a portmanteau of <literal>PHP</literal> and


### PR DESCRIPTION
Added a couple of missing punctuation marks on https://www.php.net/manual/en/intro.phar.php