### PR TITLE
Reflect new default for `CURLOPT_TIMECONDITION` since cURL 7.46.0

### DIFF
--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -1802,7 +1802,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 5.5.0 and cURL 7.9.7
+
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -1805,11 +1805,6 @@
      Available since PHP 5.5.0 and cURL 7.9.7
     </simpara>
    </listitem>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.curl-timecond-ifmodsince">
    <term>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -1795,6 +1795,17 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curl-timecond-none">
+   <term>
+    <constant>CURL_TIMECOND_NONE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curl-timecond-ifmodsince">
    <term>
     <constant>CURL_TIMECOND_IFMODSINCE</constant>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -1802,6 +1802,11 @@
    </term>
    <listitem>
     <simpara>
+     Available since PHP 5.5.0 and cURL 7.9.7
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
 
     </simpara>
    </listitem>

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -1129,8 +1129,9 @@
             a <literal>"304 Not Modified"</literal> header will be returned
             assuming <constant>CURLOPT_HEADER</constant> is &true;.
             Use <constant>CURL_TIMECOND_IFUNMODSINCE</constant> for the reverse
-            effect. The default is <constant>CURL_TIMECOND_NONE</constant> which
-            ignores the <constant>CURLOPT_TIMEVALUE</constant>.
+            effect. Use <constant>CURL_TIMECOND_NONE</constant> to ignore
+            <constant>CURLOPT_TIMEVALUE</constant> and always return the page.
+            <constant>CURL_TIMECOND_NONE</constant> is the default.
            </entry>
            <entry valign="top">
             Before cURL 7.46.0 the default was

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -1129,10 +1129,12 @@
             a <literal>"304 Not Modified"</literal> header will be returned
             assuming <constant>CURLOPT_HEADER</constant> is &true;.
             Use <constant>CURL_TIMECOND_IFUNMODSINCE</constant> for the reverse
-            effect. <constant>CURL_TIMECOND_IFMODSINCE</constant> is the
-            default.
+            effect. The default is <constant>CURL_TIMECOND_NONE</constant> which
+            ignores the <constant>CURLOPT_TIMEVALUE</constant>.
            </entry>
            <entry valign="top">
+            Before cURL 7.46.0 the default was
+            <constant>CURL_TIMECOND_IFMODSINCE</constant>.
            </entry>
           </row>
           <row>
@@ -1161,8 +1163,7 @@
            <entry valign="top"><constant>CURLOPT_TIMEVALUE</constant></entry>
            <entry valign="top">
             The time in seconds since January 1st, 1970. The time will be used
-            by <constant>CURLOPT_TIMECONDITION</constant>. By default,
-            <constant>CURL_TIMECOND_IFMODSINCE</constant> is used.
+            by <constant>CURLOPT_TIMECONDITION</constant>.
            </entry>
            <entry valign="top">
            </entry>


### PR DESCRIPTION
In cURL 7.46.0 the default for `CURLOPT_TIMECONDITION` was changed from `CURL_TIMECOND_IFMODSINCE` to `CURL_TIMECOND_NONE`.

References:
- https://curl.se/libcurl/c/CURLOPT_TIMECONDITION.html
- https://curl.se/changes.html#7_46_0
- https://github.com/curl/curl/commit/cd2b73b3e