### PR TITLE
Fixed remaining issues in mysqli versions.xml

### DIFF
--- a/reference/mysqli/versions.xml
+++ b/reference/mysqli/versions.xml
@@ -71,18 +71,7 @@
  <function name="mysqli_release_savepoint" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="mysqli_report" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_result_current_field" from="PHP 5, PHP 7"/>
- <function name="mysqli_result_data_seek" from="PHP 5, PHP 7"/>
- <function name="mysqli_result_fetch_all" from="PHP 5 &gt;= 5.3.0, PHP 7"/>
- <function name="mysqli_result_fetch_array" from="PHP 5, PHP 7"/>
- <function name="mysqli_result_fetch_assoc" from="PHP 5, PHP 7"/>
- <function name="mysqli_result_fetch_field_direct" from="PHP 5, PHP 7"/>
- <function name="mysqli_result_fetch_field" from="PHP 5, PHP 7"/>
- <function name="mysqli_result_fetch_fields" from="PHP 5, PHP 7"/>
- <function name="mysqli_result_fetch_object" from="PHP 5, PHP 7"/>
- <function name="mysqli_result_fetch_row" from="PHP 5, PHP 7"/>
  <function name="mysqli_result_field_count" from="PHP 5, PHP 7"/>
- <function name="mysqli_result_field_seek" from="PHP 5, PHP 7"/>
- <function name="mysqli_result_free" from="PHP 5, PHP 7"/>
  <function name="mysqli_result_lengths" from="PHP 5, PHP 7"/>
  <function name="mysqli_result_num_rows" from="PHP 5, PHP 7"/>
  <function name="mysqli_rollback" from="PHP 5, PHP 7, PHP 8"/>

--- a/reference/mysqli/versions.xml
+++ b/reference/mysqli/versions.xml
@@ -48,7 +48,8 @@
  <function name="mysqli_get_server_info" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_get_server_version" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_get_warnings" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
- <function name="mysqli_host_info" from="PHP 5, PHP 7"/>
+  <!-- Property -->
+ <function name="mysqli_host_info" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_info" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_init" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_insert_id" from="PHP 5, PHP 7, PHP 8"/>
@@ -70,10 +71,14 @@
  <function name="mysqli_refresh" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="mysqli_release_savepoint" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="mysqli_report" from="PHP 5, PHP 7, PHP 8"/>
- <function name="mysqli_result_current_field" from="PHP 5, PHP 7"/>
- <function name="mysqli_result_field_count" from="PHP 5, PHP 7"/>
- <function name="mysqli_result_lengths" from="PHP 5, PHP 7"/>
- <function name="mysqli_result_num_rows" from="PHP 5, PHP 7"/>
+  <!-- Property -->
+ <function name="mysqli_result_current_field" from="PHP 5, PHP 7, PHP 8"/>
+  <!-- Property -->
+ <function name="mysqli_result_field_count" from="PHP 5, PHP 7, PHP 8"/>
+  <!-- Property -->
+ <function name="mysqli_result_lengths" from="PHP 5, PHP 7, PHP 8"/>
+  <!-- Property -->
+ <function name="mysqli_result_num_rows" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_rollback" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_savepoint" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="mysqli_select_db" from="PHP 5, PHP 7, PHP 8"/>

--- a/reference/mysqli/versions.xml
+++ b/reference/mysqli/versions.xml
@@ -63,7 +63,6 @@
  <function name="mysqli_poll" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="mysqli_prepare" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_query" from="PHP 5, PHP 7, PHP 8"/>
- <function name="mysqli_read_query_result" from="PHP 5, PHP 7"/>
  <function name="mysqli_real_connect" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_real_escape_string" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_real_query" from="PHP 5, PHP 7, PHP 8"/>
@@ -87,7 +86,6 @@
  <function name="mysqli_result_lengths" from="PHP 5, PHP 7"/>
  <function name="mysqli_result_num_rows" from="PHP 5, PHP 7"/>
  <function name="mysqli_rollback" from="PHP 5, PHP 7, PHP 8"/>
- <function name="mysqli_row_seek" from="PHP 5, PHP 7"/>
  <function name="mysqli_savepoint" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="mysqli_select_db" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_set_charset" from="PHP 5 &gt;= 5.0.5, PHP 7, PHP 8"/>


### PR DESCRIPTION
As salathe said, there don't need to be duplicate entries for methods in `mysqli_result`. However, for properties, I left it with a comment for compliance with the rest of the file. Otherwise, I would have to deduplicate the whole file. (it's something we might have to do in PHP 9). 
I also removed the two entries for functions that never existed in PHP. 