### PR TITLE
Move the SQL injection warning up the page

### DIFF
--- a/reference/mysqli/mysqli/query.xml
+++ b/reference/mysqli/mysqli/query.xml
@@ -26,6 +26,19 @@
    Performs a <parameter>query</parameter> against the database.
   </para>
   <para>
+   <warning>
+     <title>Security warning: SQL injection</title>
+     <para>
+        If the query contains any variable input then 
+        <link linkend="mysqli.quickstart.prepared-statements">parameterized
+        prepared statements</link> should be used instead. Alternatively, the
+        data must be properly formatted and all strings must be escaped using 
+        the <function>mysqli_real_escape_string</function>
+        function.
+      </para>
+    </warning>
+  </para>
+  <para>
    For non-DML queries (not INSERT, UPDATE or DELETE),
    this function is similar to calling 
    <function>mysqli_real_query</function> followed by either
@@ -77,17 +90,6 @@
       <para>
        The query string.
       </para>
-      <warning>
-       <title>Security warning: SQL injection</title>
-       <para>
-        If the query contains any variable input then 
-        <link linkend="mysqli.quickstart.prepared-statements">parameterized
-        prepared statements</link> should be used instead. Alternatively, the
-        data must be properly formatted and all strings must be escaped using 
-        the <function>mysqli_real_escape_string</function>
-        function.
-       </para>
-      </warning>
      </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
If you visit this page on a 1080p monitor, the SQL Injection warning is below the fold, so if you just skim the function reference, you will miss possibly the most important security notice for this function. This proposed change is to move the warning up to just after the method synopsis so it's visible before the first fold of the page.