### PR TITLE
fixed Comparison item between prepared and non-prepared statements.

### DIFF
--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -985,7 +985,7 @@ array(2) {
       <entry>n</entry>
      </row>
      <row>
-      <entry>Statement string transferred from client to server</entry>
+      <entry>Statement string transferred from client to server, repeated (n) execution</entry>
       <entry>1 template, n times bound parameter, if any</entry>
       <entry>n times and parsed every time</entry>
      </row>


### PR DESCRIPTION
https://www.php.net/manual/en/mysqli.quickstart.prepared-statements.php

The table `Comparison of prepared and non-prepared statements` has duplicate items `Statement string transferred from client to server`. This PR clarify difference between them.