### PR TITLE
Fix space and sort types that define mixed union type

### DIFF
--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -165,8 +165,8 @@ Stack trace:
   <para>
    <type>mixed</type> is equivalent to the <link linkend="language.types.declarations.union">union type</link>
    <type class="union">
-    <type>array</type><type>bool</type><type>callable</type><type>int</type><type>float</type>
-    <type>object</type><type>resource</type><type>string</type><type>null</type>
+    <type>object</type><type>resource</type><type>array</type><type>string</type>
+    <type>int</type><type>float</type><type>bool</type><type>null</type>
    </type>.
    Available as of PHP 8.0.0.
   </para>


### PR DESCRIPTION
There is a weird space after `float` which seems to be caused by the multi-line list of types. Made the list of types a single line to avoid it.

Also, the list was in a random order which made it awkward to read. There are probably many opinions on the correct order, but picked something that grouped types together better.

Original:
`array|bool|callable|int|float |object|resource|string|null`

New:
`object|resource|callable|array|string|int|float|bool|null`