### PR TITLE
Syslog does not support the %m format specificer

### DIFF
--- a/reference/network/functions/syslog.xml
+++ b/reference/network/functions/syslog.xml
@@ -89,10 +89,7 @@
      <term><parameter>message</parameter></term>
      <listitem>
       <para>
-       The message to send, except that the two characters
-       <literal>%m</literal> will be replaced by the error message string
-       (strerror) corresponding to the present value of
-       <errortype>errno</errortype>.
+       The message to send.
       </para>
      </listitem>
     </varlistentry>
@@ -142,7 +139,7 @@ closelog();
  <refsect1 role="notes">
   &reftitle.notes;
   <para>
-   On Windows NT, the syslog service is emulated using the Event
+   On Windows, the syslog service is emulated using the Event
    Log.
   </para>
   <note>


### PR DESCRIPTION
Nor any other printf specifier

Drop version name for Windows note as a drive by fix.