### PR TITLE
Fix typehint

### DIFF
--- a/reference/spl/recursivecallbackfilteriterator/construct.xml
+++ b/reference/spl/recursivecallbackfilteriterator/construct.xml
@@ -13,7 +13,7 @@
    <modifier>public</modifier>
    <methodname>RecursiveCallbackFilterIterator::__construct</methodname>
    <methodparam><type>RecursiveIterator</type><parameter>iterator</parameter></methodparam>
-   <methodparam><type>string</type><parameter>callback</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </constructorsynopsis>
   <para>
    Creates a filtered iterator from a <interfacename>RecursiveIterator</interfacename>


### PR DESCRIPTION
From manual page: https://php.net/class.recursivecallbackfilteriterator

---

The callback can be any callable, e.g. anonymous functions are supported