### PR TITLE
Array destructuring

### DIFF
--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -561,6 +561,28 @@ echo $baz;    // prints "baz"
    </informalexample>
 
    <para>
+    Array destructuring can be used in &foreach; to destructure
+    a multi-dimensional array while iterating over it.
+   </para>
+
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$source_array = [
+    [1, 'John'],
+    [2, 'Jane'],
+];
+
+foreach ($source_array as [$id, $name]) {
+    // logic here with $id and $name
+}
+?>
+]]>
+    </programlisting>
+   </informalexample>
+
+   <para>
     Array elements will be ignored if the variable is not provided. Array
     destructuring always starts at index 0.
    </para>

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -607,6 +607,16 @@ echo $baz;    // prints "baz"
 ]]>
     </programlisting>
    </informalexample>
+
+   <note>
+    <para>
+      Attempting to access an array key which has not been defined is
+      the same as accessing any other undefined variable:
+      an <constant>E_NOTICE</constant>-level error message
+      (<constant>E_WARNING</constant>-level as of PHP 8.0.0) will be
+      issued, and the result will be &null;.
+    </para>
+   </note>
   </sect3>
 
  </sect2><!-- end syntax -->

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -610,6 +610,12 @@ echo $baz;    // prints "baz"
 
    <note>
     <para>
+      Spread operator (<literal>...</literal>) is not supported in assignments.
+    </para>
+   </note>
+
+   <note>
+    <para>
       Attempting to access an array key which has not been defined is
       the same as accessing any other undefined variable:
       an <constant>E_NOTICE</constant>-level error message

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -541,7 +541,7 @@ Array
    <para>
     Arrays can be destructured using the <function>list</function> or
     <literal>[]</literal> (as of PHP 7.1.0) language constructs. These
-    constructs can be used to destructure an array into separate variables.
+    constructs can be used to destructure an array into distinct variables.
    </para>
 
    <informalexample>
@@ -561,8 +561,8 @@ echo $baz;    // prints "baz"
    </informalexample>
 
    <para>
-    Array elements can be skipped if the variable is not provided. Array
-    destructuring will always start at index 0.
+    Array elements will be ignored if the variable is not provided. Array
+    destructuring always starts at index 0.
    </para>
 
    <informalexample>

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -608,6 +608,26 @@ echo $baz;    // prints "baz"
     </programlisting>
    </informalexample>
 
+   <para>
+    Array destructuring can be used for easy swapping of two variables.
+   </para>
+
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$a = 1;
+$b = 2;
+
+[$b, $a] = [$a, $b];
+
+echo $a;    // prints 2
+echo $b;    // prints 1
+?>
+]]>
+    </programlisting>
+   </informalexample>
+
    <note>
     <para>
       Spread operator (<literal>...</literal>) is not supported in assignments.

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -375,9 +375,6 @@ function getArray() {
 }
 
 $secondElement = getArray()[1];
-
-// or
-list(, $secondElement) = getArray();
 ?>
 ]]>
     </programlisting>

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -536,8 +536,8 @@ Array
    <title>Array destructuring</title>
 
    <para>
-    Arrays can be destructured using the <function>list</function> or
-    <literal>[]</literal> (as of PHP 7.1.0) language constructs. These
+    Arrays can be destructured using the <literal>[]</literal> (as of PHP 7.1.0) or
+    <function>list</function> language constructs. These
     constructs can be used to destructure an array into distinct variables.
    </para>
 
@@ -581,7 +581,7 @@ foreach ($source_array as [$id, $name]) {
 
    <para>
     Array elements will be ignored if the variable is not provided. Array
-    destructuring always starts at index 0.
+    destructuring always starts at index <literal>0</literal>.
    </para>
 
    <informalexample>
@@ -649,7 +649,7 @@ echo $b;    // prints 1
 
    <note>
     <para>
-      Spread operator (<literal>...</literal>) is not supported in assignments.
+      The spread operator (<literal>...</literal>) is not supported in assignments.
     </para>
    </note>
 

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -579,6 +579,34 @@ echo $baz;    // prints "baz"
 ]]>
     </programlisting>
    </informalexample>
+
+   <para>
+    As of PHP 7.1.0, associative arrays can be destructured too. This also
+    allows for easier selection of the right element in numerically indexed
+    arrays as the index can be explicitly specified.
+   </para>
+
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$source_array = ['foo' => 1, 'bar' => 2, 'baz' => 3];
+
+// Assign the element at index 'baz' to the variable $three
+['baz' => $three] = $source_array;
+
+echo $three;    // prints 3
+
+$source_array = ['foo', 'bar', 'baz'];
+
+// Assign the element at index 2 to the variable $baz
+[2 => $baz] = $source_array;
+
+echo $baz;    // prints "baz"
+?>
+]]>
+    </programlisting>
+   </informalexample>
   </sect3>
 
  </sect2><!-- end syntax -->

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -559,6 +559,26 @@ echo $baz;    // prints "baz"
 ]]>
     </programlisting>
    </informalexample>
+
+   <para>
+    Array elements can be skipped if the variable is not provided. Array
+    destructuring will always start at index 0.
+   </para>
+
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$source_array = ['foo', 'bar', 'baz'];
+
+// Assign the element at index 2 to the variable $baz
+[, , $baz] = $source_array;
+
+echo $baz;    // prints "baz"
+?>
+]]>
+    </programlisting>
+   </informalexample>
   </sect3>
 
  </sect2><!-- end syntax -->

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -529,11 +529,38 @@ Array
 )
 ]]>
      </screen>
-    </informalexample>       
+    </informalexample>
 
    </note>
 
   </sect3>
+
+  <sect3 xml:id="language.types.array.syntax.destructuring">
+   <title>Array destructuring</title>
+
+   <para>
+    Arrays can be destructured using the <function>list</function> or
+    <literal>[]</literal> (as of PHP 7.1.0) language constructs. These
+    constructs can be used to destructure an array into separate variables.
+   </para>
+
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$source_array = ['foo', 'bar', 'baz'];
+
+[$foo, $bar, $baz] = $source_array;
+
+echo $foo;    // prints "foo"
+echo $bar;    // prints "bar"
+echo $baz;    // prints "baz"
+?>
+]]>
+    </programlisting>
+   </informalexample>
+  </sect3>
+
  </sect2><!-- end syntax -->
  
  <sect2 xml:id="language.types.array.useful-funcs">


### PR DESCRIPTION
Supercedes #145 and #451

I know that this duplicates the information from https://www.php.net/manual/en/function.list.php but I believe this information belongs on the array page. Unless we can somehow have a dedicated page for "array destructuring" that wouldn't be `list`-centric then I think having this information in both places is beneficial. Fewer people are using `list()` and nudging people to use the short syntax should be our goal. 

We could have a separate "book" for arrays, but it's also not really necessary. The page is long but not that long. 