### PR TITLE
Remove XSS and broken example from list() page

### DIFF
--- a/reference/array/functions/list.xml
+++ b/reference/array/functions/list.xml
@@ -123,24 +123,12 @@ var_dump($bar); // NULL
     <title>An example use of <function>list</function></title>
     <programlisting role="php">
 <![CDATA[
-<table>
- <tr>
-  <th>Employee name</th>
-  <th>Salary</th>
- </tr>
-
 <?php
-$result = $pdo->query("SELECT id, name, salary FROM employees");
-while (list($id, $name, $salary) = $result->fetch(PDO::FETCH_NUM)) {
-    echo " <tr>\n" .
-          "  <td><a href=\"info.php?id=$id\">$name</a></td>\n" .
-          "  <td>$salary</td>\n" .
-          " </tr>\n";
+$result = $pdo->query("SELECT id, name FROM employees");
+while (list($id, $name) = $result->fetch(PDO::FETCH_NUM)) {
+    echo "id: $id, name: $name\n";
 }
-
 ?>
-
-</table>
 ]]>
     </programlisting>
    </example>

--- a/reference/array/functions/list.xml
+++ b/reference/array/functions/list.xml
@@ -158,41 +158,6 @@ int(3)
   </para>
   <para>
    <example>
-    <title>Using <function>list</function> with array indices</title>
-    <programlisting role="php">
-<![CDATA[
-<?php
-
-$info = array('coffee', 'brown', 'caffeine');
-
-list($a[0], $a[1], $a[2]) = $info;
-
-var_dump($a);
-
-?>
-]]>
-    </programlisting>
-    <para>
-     Gives the following output (note the order of the elements compared in
-     which order they were written in the <function>list</function> syntax):
-    </para>
-    &example.outputs;
-    <screen>
-<![CDATA[
-array(3) {
-  [0]=>
-  string(6) "coffee"
-  [1]=>
-  string(5) "brown"
-  [2]=>
-  string(8) "caffeine"
-}
-]]>
-    </screen>
-   </example>
-  </para>
-  <para>
-   <example>
     <title><function>list</function> and order of index definitions</title>
     <simpara>
      The order in which the indices of the array to be consumed by


### PR DESCRIPTION
Let's not have XSS in the manual. 

The example was only applicable to PHP 5, but then the context got lost and the example was left in the manual. It was showing the right-to-left assignment of `list()` 