### PR TITLE
Fix documented return type for CachingIterator::hasNext()

### DIFF
--- a/reference/spl/cachingiterator/hasnext.xml
+++ b/reference/spl/cachingiterator/hasnext.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>void</type><methodname>CachingIterator::hasNext</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>CachingIterator::hasNext</methodname>
    <void />
   </methodsynopsis>
 


### PR DESCRIPTION
The return type for `CachingIterator::hasNext` is currently documented as `void` when it should be `bool`.