### PR TITLE
add eventConfig missing method

### DIFF
--- a/reference/event/eventconfig/requirefeatures.xml
+++ b/reference/event/eventconfig/requirefeatures.xml
@@ -41,7 +41,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success, otherwise &false;.
+   &return.success;
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/event/eventconfig/setflags.xml
+++ b/reference/event/eventconfig/setflags.xml
@@ -30,11 +30,8 @@
     </term>
     <listitem>
      <para>
-      Optional flags. One of
-      <literal>EventBase::LOOP_*</literal>
-      constants. See
-      <link linkend="eventbase.constants">EventBase constants</link>
-      .
+      One of <literal>EventBase::LOOP_*</literal>constants. 
+      See <link linkend="eventbase.constants">EventBase constants</link>.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/event/eventconfig/setflags.xml
+++ b/reference/event/eventconfig/setflags.xml
@@ -2,22 +2,23 @@
 <!-- $Revision$ -->
 <refentry xml:id="eventconfig.requirefeatures" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
-  <refname>EventConfig::requireFeatures</refname>
-  <refpurpose>Enters a required event method feature that the application demands</refpurpose>
+  <refname>EventConfig::setFlags</refname>
+  <refpurpose>Sets one or more flags to configure the eventual EventBase will be initialized</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier>
    <type>bool</type>
-   <methodname>EventConfig::requireFeatures</methodname>
+   <methodname>EventConfig::setFlags</methodname>
    <methodparam>
     <type>int</type>
-    <parameter>feature</parameter>
+    <parameter>flags</parameter>
    </methodparam>
   </methodsynopsis>
   <para>
-   Enters a required event method feature that the application demands
+   Sets one or more flags to configure what parts of 
+   the eventual EventBase will be initialized, and how they'll work.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -25,14 +26,15 @@
   <variablelist>
    <varlistentry>
     <term>
-     <parameter>feature</parameter>
+     <parameter>flags</parameter>
     </term>
     <listitem>
      <para>
-      Bitmask of required features. See
-      <link
-     linkend="eventconfig.constants">
-       <literal>EventConfig::FEATURE_*</literal> constants</link>
+      Optional flags. One of
+      <literal>EventBase::LOOP_*</literal>
+      constants. See
+      <link linkend="eventbase.constants">EventBase constants</link>
+      .
      </para>
     </listitem>
    </varlistentry>
@@ -44,38 +46,11 @@
    Returns &true; on success, otherwise &false;.
   </para>
  </refsect1>
- <refsect1 role="examples">
-  &reftitle.examples;
-  <example>
-   <title>
-    <function>EventConfig::requireFeatures</function> example</title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-$cfg = new EventConfig();
-
-// Create event_base associated with the config
-$base = new EventBase($cfg);
-
-// Require FDS feature
-if ($cfg->requireFeatures(EventConfig::FEATURE_FDS)) {
-    echo "FDS feature is now requried\n";
-
-    $base = new EventBase($cfg);
-    ($base->getFeatures() & EventConfig::FEATURE_FDS)
-        and print("FDS - arbitrary file descriptor types, and not just sockets\n");
-}
-?>
-]]>
-   </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-FDS feature is now requried
-FDS - arbitrary file descriptor types, and not just sockets
-]]>
-   </screen>
-  </example>
+<refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns &true; on success. Otherwise &false;.
+  </para>
  </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/event/eventconfig/setflags.xml
+++ b/reference/event/eventconfig/setflags.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="eventconfig.requirefeatures" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="eventconfig.setflags" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventConfig::setFlags</refname>
   <refpurpose>Sets one or more flags to configure the eventual EventBase will be initialized</refpurpose>

--- a/reference/event/eventconfig/setflags.xml
+++ b/reference/event/eventconfig/setflags.xml
@@ -30,7 +30,7 @@
     </term>
     <listitem>
      <para>
-      One of <literal>EventBase::LOOP_*</literal>constants. 
+      One of <literal>EventBase::LOOP_*</literal> constants. 
       See <link linkend="eventbase.constants">EventBase constants</link>.
      </para>
     </listitem>

--- a/reference/event/eventconfig/setflags.xml
+++ b/reference/event/eventconfig/setflags.xml
@@ -40,16 +40,10 @@
    </varlistentry>
   </variablelist>
  </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns &true; on success, otherwise &false;.
-  </para>
- </refsect1>
 <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success. Otherwise &false;.
+   &return.success;
   </para>
  </refsect1>
  <refsect1 role="seealso">

--- a/reference/event/versions.xml
+++ b/reference/event/versions.xml
@@ -39,6 +39,8 @@
  <function name="eventconfig::__construct" from="PECL event &gt;= 1.2.6-beta"/>
  <function name="eventconfig::avoidmethod" from="PECL event &gt;= 1.2.6-beta"/>
  <function name="eventconfig::requirefeatures" from="PECL event &gt;= 1.2.6-beta"/>
+ <function name="eventconfig::setFlags" from="PECL event &gt;= 2.0.2-alpha"/>
+ <function name="eventconfig::setMaxDispatchInterval" from="PECL event &gt;= 2.1.0-alpha"/>
  <function name='eventbufferevent' from='PECL event &gt;= 1.2.6-beta'/>
  <function name="eventbufferevent::__construct" from="PECL event &gt;= 1.2.6-beta"/>
  <function name="eventbufferevent::free" from="PECL event &gt;= 1.2.6-beta"/>

--- a/reference/event/versions.xml
+++ b/reference/event/versions.xml
@@ -39,8 +39,8 @@
  <function name="eventconfig::__construct" from="PECL event &gt;= 1.2.6-beta"/>
  <function name="eventconfig::avoidmethod" from="PECL event &gt;= 1.2.6-beta"/>
  <function name="eventconfig::requirefeatures" from="PECL event &gt;= 1.2.6-beta"/>
- <function name="eventconfig::setFlags" from="PECL event &gt;= 2.0.2-alpha"/>
- <function name="eventconfig::setMaxDispatchInterval" from="PECL event &gt;= 2.1.0-alpha"/>
+ <function name="eventconfig::setflags" from="PECL event &gt;= 2.0.2-alpha"/>
+ <function name="eventconfig::setmaxdispatchinterval" from="PECL event &gt;= 2.1.0-alpha"/>
  <function name='eventbufferevent' from='PECL event &gt;= 1.2.6-beta'/>
  <function name="eventbufferevent::__construct" from="PECL event &gt;= 1.2.6-beta"/>
  <function name="eventbufferevent::free" from="PECL event &gt;= 1.2.6-beta"/>


### PR DESCRIPTION
1. add `eventConfig::setFlags`. Source code reference: https://bitbucket.org/osmanov/pecl-event/src/1fa696a0dc145d5d5f40a144f7a27be31eaf14a5/php8/classes/event_config.c#lines-135
2. add `eventConfig::requireFeatures` missing return value description
3. add `EventConfig::setMaxDispatchInterval` required pecl event version