### PR TITLE
Remove memcache session.save_handler and .save_path from ini list

### DIFF
--- a/reference/memcache/ini.xml
+++ b/reference/memcache/ini.xml
@@ -86,7 +86,7 @@
    </tgroup>
   </table>
   <table>
-   <title>Additional Memcache Configuration Options</title>
+   <title>Session Configuration Options Affecting Memcache Behavior</title>
    <tgroup cols="4">
     <thead>
      <row>

--- a/reference/memcache/ini.xml
+++ b/reference/memcache/ini.xml
@@ -53,18 +53,6 @@
       <entry>Available since memcache 2.2.0.</entry>
      </row>
      <row>
-      <entry><link linkend="ini.session.save-handler">session.save_handler</link></entry>
-      <entry>"files"</entry>
-      <entry>PHP_INI_ALL</entry>
-      <entry>Supported since memcache 2.1.2</entry>
-     </row>
-     <row>
-      <entry><link linkend="ini.session.save-path">session.save_path</link></entry>
-      <entry>""</entry>
-      <entry>PHP_INI_ALL</entry>
-      <entry>Supported since memcache 2.1.2</entry>
-     </row>
-     <row>
       <entry><link linkend="ini.memcache.protocol">memcache.protocol</link></entry>
       <entry>ascii</entry>
       <entry>>PHP_INI_ALL</entry>
@@ -93,6 +81,33 @@
       <entry>15</entry>
       <entry>>PHP_INI_ALL</entry>
       <entry>Supported since memcache 3.0.4</entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+  <table>
+   <title>Additional Memcache Configuration Options</title>
+   <tgroup cols="4">
+    <thead>
+     <row>
+      <entry>&Name;</entry>
+      <entry>&Default;</entry>
+      <entry>&Changeable;</entry>
+      <entry>&Changelog;</entry>
+     </row>
+    </thead>
+    <tbody xml:id="memcache.ini.list.extra">
+     <row>
+      <entry><link linkend="ini.memcache.save-handler">session.save_handler</link></entry>
+      <entry>"files"</entry>
+      <entry>PHP_INI_ALL</entry>
+      <entry>Supported since memcache 2.1.2</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.memcache.save-path">session.save_path</link></entry>
+      <entry>""</entry>
+      <entry>PHP_INI_ALL</entry>
+      <entry>Supported since memcache 2.1.2</entry>
      </row>
     </tbody>
    </tgroup>
@@ -188,36 +203,6 @@
    </listitem>
   </varlistentry>
 
-  <varlistentry xml:id="ini.memcache.session-handler">
-   <term>
-    <parameter>session.save_handler</parameter>
-    <type>string</type>
-   </term>
-   <listitem>
-    <para>
-     Use memcache as a session handler by setting this value to <literal>memcache</literal>.
-    </para>
-   </listitem>
-  </varlistentry>
-
-  <varlistentry xml:id="ini.memcache.save-path">
-   <term>
-    <parameter>session.save_path</parameter>
-    <type>string</type>
-   </term>
-   <listitem>
-    <para>
-     Defines a comma separated of server urls to use for session storage, for example
-     <literal>"tcp://host1:11211, tcp://host2:11211"</literal>.
-    </para>
-    <para>
-     Each url may contain parameters which are applied to that server, they are the same 
-     as for the <function>Memcache::addServer</function> method. For example 
-     <literal>"tcp://host1:11211?persistent=1&amp;weight=1&amp;timeout=1&amp;retry_interval=15"</literal>
-    </para>
-   </listitem>
-  </varlistentry>
-
   <varlistentry xml:id="ini.memcache.protocol">
    <term>
     <parameter>memcache.protocol</parameter>
@@ -274,6 +259,36 @@
    <listitem>
     <para>
      
+    </para>
+   </listitem>
+  </varlistentry>
+
+  <varlistentry xml:id="ini.memcache.save-handler">
+   <term>
+    <parameter>session.save_handler</parameter>
+    <type>string</type>
+   </term>
+   <listitem>
+    <para>
+     Use memcache as a session handler by setting this value to <literal>memcache</literal>.
+    </para>
+   </listitem>
+  </varlistentry>
+
+  <varlistentry xml:id="ini.memcache.save-path">
+   <term>
+    <parameter>session.save_path</parameter>
+    <type>string</type>
+   </term>
+   <listitem>
+    <para>
+     Defines a comma separated of server urls to use for session storage, for example
+     <literal>"tcp://host1:11211, tcp://host2:11211"</literal>.
+    </para>
+    <para>
+     Each url may contain parameters which are applied to that server, they are the same 
+     as for the <function>Memcache::addServer</function> method. For example 
+     <literal>"tcp://host1:11211?persistent=1&amp;weight=1&amp;timeout=1&amp;retry_interval=15"</literal>
     </para>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
`session.save_handler` and `session.save_path` are INI settings of the
session module.  However, the memcache extension offers the memcache
session handler so it makes sense to document these two INI settings
for the memcache extension, but we don't want to include them in the
general INI list, so we split them into a separate "Additional Memcache
Configuration Options" table.

Fixes GH-814.