### PR TITLE
Mark a few interfaces as oointerface rather than ooclass

### DIFF
--- a/language/predefined/arrayaccess.xml
+++ b/language/predefined/arrayaccess.xml
@@ -26,9 +26,9 @@
 
 <!-- {{{ Class synopsis -->
     <classsynopsisinfo>
-     <ooclass>
-      <classname>ArrayAccess</classname>
-     </ooclass>
+     <oointerface>
+      <interfacename>ArrayAccess</interfacename>
+     </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
     

--- a/language/predefined/iterator.xml
+++ b/language/predefined/iterator.xml
@@ -27,9 +27,9 @@
 
 <!-- {{{ Class synopsis -->
     <classsynopsisinfo>
-     <ooclass>
-      <classname>Iterator</classname>
-     </ooclass>
+     <oointerface>
+      <interfacename>Iterator</interfacename>
+     </oointerface>
      
      <ooclass>
       <modifier>extends</modifier>

--- a/language/predefined/serializable.xml
+++ b/language/predefined/serializable.xml
@@ -37,9 +37,9 @@
 
 <!-- {{{ Class synopsis -->
     <classsynopsisinfo>
-     <ooclass>
-      <classname>Serializable</classname>
-     </ooclass>
+     <oointerface>
+      <interfacename>Serializable</interfacename>
+     </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
     

--- a/language/predefined/stringable.xml
+++ b/language/predefined/stringable.xml
@@ -27,7 +27,7 @@
 <!-- }}} -->
 
   <section xml:id="stringable.synopsis">
-   &reftitle.classsynopsis;
+   &reftitle.interfacesynopsis;
 
 <!-- {{{ Synopsis -->
    <classsynopsis>
@@ -35,9 +35,9 @@
 
 <!-- {{{ Class synopsis -->
     <classsynopsisinfo>
-     <ooclass>
-      <classname>Stringable</classname>
-     </ooclass>
+     <oointerface>
+      <interfacename>Stringable</interfacename>
+     </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
 

--- a/language/predefined/throwable.xml
+++ b/language/predefined/throwable.xml
@@ -35,9 +35,9 @@
 
 <!-- {{{ Class synopsis -->
     <classsynopsisinfo>
-     <ooclass>
-      <classname>Throwable</classname>
-     </ooclass>
+     <oointerface>
+      <interfacename>Throwable</interfacename>
+     </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
     

--- a/language/predefined/traversable.xml
+++ b/language/predefined/traversable.xml
@@ -50,9 +50,9 @@
 
 <!-- {{{ Class synopsis -->
     <classsynopsisinfo>
-     <ooclass>
-      <classname>Traversable</classname>
-     </ooclass>
+     <oointerface>
+      <interfacename>Traversable</interfacename>
+     </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
 

--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -20,7 +20,7 @@
 <!-- }}} -->
 
   <section xml:id="datetimeinterface.synopsis">
-   &reftitle.classsynopsis;
+   &reftitle.interfacesynopsis;
 
 <!-- {{{ Synopsis -->
    <classsynopsis>
@@ -28,9 +28,9 @@
 
 <!-- {{{ Class synopsis -->
     <classsynopsisinfo>
-     <ooclass>
-      <classname>DateTimeInterface</classname>
-     </ooclass>
+     <oointerface>
+      <interfacename>DateTimeInterface</interfacename>
+     </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
 

--- a/reference/json/jsonserializable.xml
+++ b/reference/json/jsonserializable.xml
@@ -28,9 +28,9 @@
 
 <!-- {{{ Class synopsis -->
     <classsynopsisinfo>
-     <ooclass>
-      <classname>JsonSerializable</classname>
-     </ooclass>
+     <oointerface>
+      <interfacename>JsonSerializable</interfacename>
+     </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
     

--- a/reference/reflection/reflector.xml
+++ b/reference/reflection/reflector.xml
@@ -19,7 +19,7 @@
 <!-- }}} -->
 
   <section xml:id="reflector.synopsis">
-   &reftitle.classsynopsis;
+   &reftitle.interfacesynopsis;
 
 <!-- {{{ Synopsis -->
    <classsynopsis>
@@ -27,9 +27,9 @@
 
 <!-- {{{ Class synopsis -->
     <classsynopsisinfo>
-     <ooclass>
-      <classname>Reflector</classname>
-     </ooclass>
+     <oointerface>
+      <interfacename>Reflector</interfacename>
+     </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
     

--- a/reference/session/sessionhandlerinterface.xml
+++ b/reference/session/sessionhandlerinterface.xml
@@ -25,7 +25,7 @@
 <!-- }}} -->
 
   <section xml:id="sessionhandlerinterface.synopsis">
-   &reftitle.classsynopsis;
+   &reftitle.interfacesynopsis;
 
 <!-- {{{ Synopsis -->
    <classsynopsis>
@@ -33,9 +33,9 @@
 
 <!-- {{{ Class synopsis -->
     <classsynopsisinfo>
-     <ooclass>
-      <classname>SessionHandlerInterface</classname>
-     </ooclass>
+     <oointerface>
+      <interfacename>SessionHandlerInterface</interfacename>
+     </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
 

--- a/reference/session/sessionidinterface.xml
+++ b/reference/session/sessionidinterface.xml
@@ -25,7 +25,7 @@
 <!-- }}} -->
 
   <section xml:id="sessionidinterface.synopsis">
-   &reftitle.classsynopsis;
+   &reftitle.interfacesynopsis;
 
 <!-- {{{ Synopsis -->
    <classsynopsis>
@@ -33,9 +33,9 @@
 
 <!-- {{{ Class synopsis -->
     <classsynopsisinfo>
-     <ooclass>
-      <classname>SessionIdInterface</classname>
-     </ooclass>
+     <oointerface>
+      <interfacename>SessionIdInterface</interfacename>
+     </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
     

--- a/reference/spl/countable.xml
+++ b/reference/spl/countable.xml
@@ -27,9 +27,9 @@
 
 <!-- {{{ Class synopsis -->
     <classsynopsisinfo>
-     <ooclass>
-      <classname>Countable</classname>
-     </ooclass>
+     <oointerface>
+      <interfacename>Countable</interfacename>
+     </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
     

--- a/reference/spl/outeriterator.xml
+++ b/reference/spl/outeriterator.xml
@@ -27,9 +27,9 @@
 
 <!-- {{{ Class synopsis -->
     <classsynopsisinfo>
-     <ooclass>
-      <classname>OuterIterator</classname>
-     </ooclass>
+     <oointerface>
+      <interfacename>OuterIterator</interfacename>
+     </oointerface>
 
      <ooclass>
       <modifier>extends</modifier>

--- a/reference/spl/recursiveiterator.xml
+++ b/reference/spl/recursiveiterator.xml
@@ -27,9 +27,9 @@
 
 <!-- {{{ Class synopsis -->
     <classsynopsisinfo>
-     <ooclass>
-      <classname>RecursiveIterator</classname>
-     </ooclass>
+     <oointerface>
+      <interfacename>RecursiveIterator</interfacename>
+     </oointerface>
 
      <ooclass>
       <modifier>extends</modifier>

--- a/reference/spl/seekableiterator.xml
+++ b/reference/spl/seekableiterator.xml
@@ -26,9 +26,9 @@
 
 <!-- {{{ Class synopsis -->
     <classsynopsisinfo>
-     <ooclass>
-      <classname>SeekableIterator</classname>
-     </ooclass>
+     <oointerface>
+      <interfacename>SeekableIterator</interfacename>
+     </oointerface>
      
      <ooclass>
       <modifier>extends</modifier>


### PR DESCRIPTION
A few more to come when the class synopsis pages are generated from stubs.

Needs https://github.com/php/phd/pull/50/ first!