### PR TITLE
additional return value fix of shell_exec func.

### DIFF
--- a/reference/exec/functions/shell-exec.xml
+++ b/reference/exec/functions/shell-exec.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>shell_exec</methodname>
+   <type class="union"><type>string</type><type>false</type><type>null</type></type><methodname>shell_exec</methodname>
    <methodparam><type>string</type><parameter>cmd</parameter></methodparam>
   </methodsynopsis>
   <para>


### PR DESCRIPTION
#821 newly added return `&false;` in case of pipe establish error, so we need to add it to signatures.