### PR TITLE
Sorting functions is stable, as of PHP 8.0.0.

### DIFF
--- a/reference/array/sorting.xml
+++ b/reference/array/sorting.xml
@@ -31,7 +31,7 @@
    </member>
    <member>
     If any of these sort functions evaluates two members as equal
-    then retain their original order.
+    then they retain their original order.
     Prior to PHP 8.0.0, their order were undefined (the sorting was not stable).
    </member>
   </simplelist>
@@ -167,4 +167,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/array/sorting.xml
+++ b/reference/array/sorting.xml
@@ -30,8 +30,9 @@
     variable itself, as opposed to returning a new sorted array
    </member>
    <member>
-    If any of these sort functions evaluates two members as equal then the
-    order is undefined (the sorting is not stable).
+    If any of these sort functions evaluates two members as equal
+    then retain their original order.
+    Prior to PHP 8.0.0, their order were undefined (the sorting was not stable).
    </member>
   </simplelist>
  </para>


### PR DESCRIPTION
https://www.php.net/manual/en/array.sorting.php

Updated sorting functions description, followed appendices/migration80/new-features.xml [*1].

[*1] https://github.com/php/doc-en/blob/fdd6debfb8fe88340e6c654a05c1ab7a51673aa0/appendices/migration80/new-features.xml#L502-L506