### PR TITLE
Document Flexible heredoc/nowdoc.

### DIFF
--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -216,7 +216,7 @@ echo 'Variables do not $expand $either';
    <simpara>
     The closing identifier may be indented by space or tab, in which case
     the indentation will be stripped from all lines in the doc string.
-    Prior to PHP 7.3.0, The closing identifier <emphasis>must</emphasis>
+    Prior to PHP 7.3.0, the closing identifier <emphasis>must</emphasis>
     begin in the first column of the line.
    </simpara>
 
@@ -262,7 +262,7 @@ c
    </example>
 
    <simpara>
-    If the closing identifier is indented further than any lines of the body, then a ParseError will be thrown:
+    If the closing identifier is indented further than any lines of the body, then a <classname>ParseError</classname> will be thrown:
    </simpara>
 
    <example>
@@ -340,7 +340,7 @@ PHP Parse error:  Invalid indentation - tabs and spaces cannot be mixed in examp
    </simpara>
 
    <example>
-    <title>You can continue expression after closing identifier.</title>
+    <title>Continuing an expression after a closing identifier</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -371,7 +371,7 @@ array(2) {
     <simpara>
      If the closing identifier was found at the start of a line, then
      regardless of whether it was a part of another word, it may be considered
-     as the closing identifier and causes ParseError.
+     as the closing identifier and causes a <classname>ParseError</classname>.
     </simpara>
 
     <example>
@@ -395,9 +395,9 @@ PHP Parse error:  syntax error, unexpected identifier "ING", expecting "]" in ex
     </example>
 
     <simpara>
-     To avoid this problem, It is safe for you to follow the simple rule:
+     To avoid this problem, it is safe for you to follow the simple rule:
      <emphasis>do not choose the closing identifier that appears in the body
-     of the text</emphasis>
+     of the text</emphasis>.
     </simpara>
 
    </warning>

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -286,7 +286,7 @@ PHP Parse error:  Invalid body indentation level (expecting an indentation level
    </example>
 
    <simpara>
-    When you indent the closing identifier, you can use tabs as well, however,
+    If the closing identifier is indented, tabs can be used as well, however,
     tabs and spaces <emphasis>must not</emphasis> be intermixed regarding
     the indentation of the closing identifier and the indentation of the body
      (up to the closing identifier). In any of these cases, a <classname>ParseError</classname> will be thrown.

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -214,16 +214,199 @@ echo 'Variables do not $expand $either';
    </simpara>
 
    <simpara>
-    The closing identifier <emphasis>must</emphasis> begin in the first column
-    of the line. Also, the identifier must follow the same naming rules as any
+    The closing identifier may be indented by space or tab, in which case
+    the indentation will be stripped from all lines in the doc string.
+    Prior to PHP 7.3.0, The closing identifier <emphasis>must</emphasis>
+    begin in the first column of the line.
+   </simpara>
+
+   <simpara>
+    Also, the closing identifier must follow the same naming rules as any
     other label in PHP: it must contain only alphanumeric characters and
     underscores, and must start with a non-digit character or underscore.
    </simpara>
 
+   <example>
+    <title>Basic Heredoc example as of PHP 7.3.0</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// no indentation
+echo <<<END
+      a
+     b
+    c
+\n
+END;
+
+// 4 spaces of indentation
+echo <<<END
+      a
+     b
+    c
+    END;
+]]>
+    </programlisting>
+    &example.outputs.73;
+    <screen>
+<![CDATA[
+      a
+     b
+    c
+
+  a
+ b
+c
+]]>
+    </screen>
+   </example>
+
+   <simpara>
+    If the closing identifier is indented further than any lines of the body, then a ParseError will be thrown:
+   </simpara>
+
+   <example>
+    <title>Closing identifier must not be indented further than any lines of the body, as of PHP 7.3.0</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+echo <<<END
+  a
+ b
+c
+   END;
+]]>
+    </programlisting>
+    &example.outputs.73;
+    <screen>
+<![CDATA[
+PHP Parse error:  Invalid body indentation level (expecting an indentation level of at least 3) in example.php on line 4
+]]>
+    </screen>
+   </example>
+
+   <simpara>
+    When you indent the closing identifier, you can use tabs as well, however,
+    tabs and spaces <emphasis>must not</emphasis> be intermixed regarding
+    the indentation of the closing identifier and the indentation of the body
+     (up to the closing identifier). In any of these cases, a ParseError will
+    be thrown.
+
+    These whitespace constraints have been included because mixing tabs and
+    spaces for indentation is harmful to legibility.
+   </simpara>
+
+   <example>
+    <title>Different indentation for body (spaces) closing identifier, as of PHP 7.3.0</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// All the following code do not work.
+
+// different indentation for body (spaces) ending marker (tabs)
+{
+	echo <<<END
+	 a
+		END;
+}
+
+// mixing spaces and tabs in body
+{
+    echo <<<END
+    	a
+     END;
+}
+
+// mixing spaces and tabs in ending marker
+{
+	echo <<<END
+		  a
+		 END;
+}
+]]>
+    </programlisting>
+    &example.outputs.73;
+    <screen>
+<![CDATA[
+PHP Parse error:  Invalid indentation - tabs and spaces cannot be mixed in example.php line 8
+]]>
+    </screen>
+   </example>
+
+   <simpara>
+    The closing identifier for the body string is not required to be
+    followed by a semicolon or newline. For example, the following code
+    is allowed as of PHP 7.3.0:
+   </simpara>
+
+   <example>
+    <title>You can continue expression after closing identifier.</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$values = [<<<END
+a
+  b
+    c
+END, 'd e f'];
+var_dump($values);
+]]>
+    </programlisting>
+    &example.outputs.73;
+    <screen>
+<![CDATA[
+array(2) {
+  [0] =>
+  string(11) "a
+  b
+    c"
+  [1] =>
+  string(5) "d e f"
+}
+]]>
+    </screen>
+   </example>
+
    <warning>
     <simpara>
-     It is very important to note that the line with the closing identifier must
-     contain no other characters, except a semicolon (<literal>;</literal>).
+     If the closing identifier was found at the start of a line, then
+     regardless of whether it was a part of another word, it may be considered
+     as the closing identifier and causes ParseError.
+    </simpara>
+
+    <example>
+     <title>Closing identifier in body of the string tends to cause ParseError</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+$values = [<<<END
+a
+b
+END ING
+END, 'd e f'];
+]]>
+     </programlisting>
+     &example.outputs.73;
+    <screen>
+<![CDATA[
+PHP Parse error:  syntax error, unexpected identifier "ING", expecting "]" in example.php on line 6
+]]>
+     </screen>
+    </example>
+
+    <simpara>
+     To avoid this problem, It is safe for you to follow the simple rule:
+     <emphasis>do not choose the closing identifier that appears in the body
+     of the text</emphasis>
+    </simpara>
+
+   </warning>
+
+   <warning>
+    <simpara>
+     Prior to PHP 7.3.0, it is very important to note that the line with the
+     closing identifier must contain no other characters, except a semicolon
+     (<literal>;</literal>).
      That means especially that the identifier
      <emphasis>may not be indented</emphasis>, and there may not be any spaces
      or tabs before or after the semicolon. It's also important to realize that
@@ -241,7 +424,7 @@ echo 'Variables do not $expand $either';
     </simpara>
 
     <example>
-     <title>Invalid example</title>
+     <title>Invalid example, prior to PHP 7.3.0</title>
      <programlisting role="php">
       <!-- This is an INVALID example -->
 <![CDATA[
@@ -257,7 +440,7 @@ bar
      </programlisting>
     </example>
     <example>
-     <title>Valid example</title>
+     <title>Valid example, even if prior to PHP 7.3.0</title>
      <programlisting role="php">
       <!-- This is a VALID example -->
 <![CDATA[

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -289,8 +289,7 @@ PHP Parse error:  Invalid body indentation level (expecting an indentation level
     When you indent the closing identifier, you can use tabs as well, however,
     tabs and spaces <emphasis>must not</emphasis> be intermixed regarding
     the indentation of the closing identifier and the indentation of the body
-     (up to the closing identifier). In any of these cases, a ParseError will
-    be thrown.
+     (up to the closing identifier). In any of these cases, a <classname>ParseError</classname> will be thrown.
 
     These whitespace constraints have been included because mixing tabs and
     spaces for indentation is harmful to legibility.

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -266,7 +266,7 @@ c
    </simpara>
 
    <example>
-    <title>Closing identifier must not be indented further than any lines of the body, as of PHP 7.3.0</title>
+    <title>Closing identifier must not be indented further than any lines of the body</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -296,7 +296,7 @@ PHP Parse error:  Invalid body indentation level (expecting an indentation level
    </simpara>
 
    <example>
-    <title>Different indentation for body (spaces) closing identifier, as of PHP 7.3.0</title>
+    <title>Different indentation for body (spaces) closing identifier</title>
     <programlisting role="php">
 <![CDATA[
 <?php


### PR DESCRIPTION
Newly documented Flexible heredoc/nowdoc, based on RFC [*1], 

Closes #741

[*1] https://wiki.php.net/rfc/flexible_heredoc_nowdoc_syntaxes