### PR TITLE
Remove abstract modifier from ArrayAccess methods

### DIFF
--- a/language/predefined/arrayaccess/offsetexists.xml
+++ b/language/predefined/arrayaccess/offsetexists.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>bool</type><methodname>ArrayAccess::offsetExists</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>ArrayAccess::offsetExists</methodname>
    <methodparam><type>mixed</type><parameter>offset</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/language/predefined/arrayaccess/offsetget.xml
+++ b/language/predefined/arrayaccess/offsetget.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>mixed</type><methodname>ArrayAccess::offsetGet</methodname>
+   <modifier>public</modifier> <type>mixed</type><methodname>ArrayAccess::offsetGet</methodname>
    <methodparam><type>mixed</type><parameter>offset</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -37,7 +37,7 @@
   </para>
 
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/language/predefined/arrayaccess/offsetset.xml
+++ b/language/predefined/arrayaccess/offsetset.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>ArrayAccess::offsetSet</methodname>
+   <modifier>public</modifier> <type>void</type><methodname>ArrayAccess::offsetSet</methodname>
    <methodparam><type>mixed</type><parameter>offset</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
@@ -80,7 +80,7 @@ Array
     </informalexample>
    </para>
   </note>
-  
+
   <note>
     <para>
       This function is not called in assignments by reference and otherwise

--- a/language/predefined/arrayaccess/offsetunset.xml
+++ b/language/predefined/arrayaccess/offsetunset.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>ArrayAccess::offsetUnset</methodname>
+   <modifier>public</modifier> <type>void</type><methodname>ArrayAccess::offsetUnset</methodname>
    <methodparam><type>mixed</type><parameter>offset</parameter></methodparam>
   </methodsynopsis>
   <para>


### PR DESCRIPTION
https://www.php.net/manual/en/class.arrayaccess.php

Now that ArrayAccess is shown as an interface, the `abstract` modifier doesn't make sense. This suggests that interfaces can/should use the abstract modifier when it isn't allowed.

```
abstract public offsetExists(mixed $offset): bool
abstract public offsetGet(mixed $offset): mixed
abstract public offsetSet(mixed $offset, mixed $value): void
abstract public offsetUnset(mixed $offset): void
```