### PR TITLE
Make StreamWrapper::stream_open() opened_path parameter nullable

### DIFF
--- a/reference/stream/streamwrapper/stream-open.xml
+++ b/reference/stream/streamwrapper/stream-open.xml
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
    <methodparam><type>string</type><parameter>mode</parameter></methodparam>
    <methodparam><type>int</type><parameter>options</parameter></methodparam>
-   <methodparam><type>string</type><parameter role="reference">opened_path</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter role="reference">opened_path</parameter></methodparam>
   </methodsynopsis>
   <para>
    This method is called immediately after the wrapper is initialized (f.e. by


### PR DESCRIPTION
If you use the suggested `string` type hint, you will get a TypeError if `STREAM_USE_PATH` isn't set (which is the default).

Closes https://github.com/php/doc-en/pull/753