### PR TITLE
Documentation for net_get_interfaces()

### DIFF
--- a/reference/network/functions/net-get-interfaces.xml
+++ b/reference/network/functions/net-get-interfaces.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.net-get-interfaces" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>net_get_interfaces</refname>
+  <refpurpose>Get network interfaces</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description"><!-- {{{ -->
+  &reftitle.description;
+  <methodsynopsis role="procedural">
+   <type class="union"><type>array</type><type>false</type></type><methodname>net_get_interfaces</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Returns an enumeration of network interfaces (adapters) on the local machine.
+  </para>
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="parameters"><!-- {{{ -->
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="returnvalues"><!-- {{{ -->
+  &reftitle.returnvalues;
+  <para>
+   This function returns an associative array where key  is the name of the interface and
+   the value an associative array of interface attributes,
+   &return.falseforfailure;. Each interface associative array contains
+   <table>
+    <title>Interface attributes</title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Attribute</entry>
+       <entry>Meaning</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>description</entry>
+       <entry>
+        Optional string value for description of the interface.
+       </entry>
+      </row>
+      <row>
+       <entry>mac</entry>
+       <entry>
+        Optional string value for MAC address of the interface.
+       </entry>
+      </row>
+      <row>
+       <entry>mtu</entry>
+       <entry>
+        Integer value for Maximum transmission unit (MTU) of the interface.
+       </entry>
+      </row>
+      <row>
+       <entry>unicast</entry>
+       <entry>
+        Array of associative arrays, see Unicast attributes below.
+       </entry>
+      </row>
+      <row>
+       <entry>up</entry>
+       <entry>
+       Boolean status (on/off) for interface.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>Unicast attributes</title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Attribute</entry>
+       <entry>Meaning</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>flags</entry>
+       <entry>
+        Integer value.
+       </entry>
+      </row>
+      <row>
+       <entry>family</entry>
+       <entry>
+        Integer value.
+       </entry>
+      </row>
+      <row>
+       <entry>address</entry>
+       <entry>
+        String value for address in either IPv4 or IPv6.
+       </entry>
+      </row>
+      <row>
+       <entry>netmask</entry>
+       <entry>
+        String value for netmask in either IPv4 or IPv6.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="errors"><!-- {{{ -->
+  &reftitle.errors;
+  <para>
+   Issues an E_WARNING on failure to get interface information.
+  </para>
+ </refsect1><!-- }}} -->
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/network/functions/net-get-interfaces.xml
+++ b/reference/network/functions/net-get-interfaces.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis role="procedural">
    <type class="union"><type>array</type><type>false</type></type><methodname>net_get_interfaces</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Returns an enumeration of network interfaces (adapters) on the local machine.
@@ -25,16 +25,19 @@
  <refsect1 role="returnvalues"><!-- {{{ -->
   &reftitle.returnvalues;
   <para>
-   This function returns an associative array where key  is the name of the interface and
+   Returns an associative &array; where the key is the name of the interface and
    the value an associative array of interface attributes,
-   &return.falseforfailure;. Each interface associative array contains
+   &return.falseforfailure;.
+  </para>
+  <para>
+   Each interface associative array contains:
    <table>
     <title>Interface attributes</title>
     <tgroup cols="2">
      <thead>
       <row>
-       <entry>Attribute</entry>
-       <entry>Meaning</entry>
+       <entry>&Name;</entry>
+       <entry>&Description;</entry>
       </row>
      </thead>
      <tbody>
@@ -78,8 +81,8 @@
     <tgroup cols="2">
      <thead>
       <row>
-       <entry>Attribute</entry>
-       <entry>Meaning</entry>
+       <entry>&Name;</entry>
+       <entry>&Description;</entry>
       </row>
      </thead>
      <tbody>
@@ -116,7 +119,7 @@
  <refsect1 role="errors"><!-- {{{ -->
   &reftitle.errors;
   <para>
-   Issues an E_WARNING on failure to get interface information.
+   Emits an <constant>E_WARNING</constant> on failure to get interface information.
   </para>
  </refsect1><!-- }}} -->
 

--- a/reference/network/versions.xml
+++ b/reference/network/versions.xml
@@ -29,6 +29,7 @@
  <function name="inet_pton" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
  <function name="ip2long" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="long2ip" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="net_get_interfaces" from="PHP 7 &gt;= 7.3, PHP 8"/>
  <function name="openlog" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="pfsockopen" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="setcookie" from="PHP 4, PHP 5, PHP 7, PHP 8"/>


### PR DESCRIPTION
Relates to #663 
Resolves https://bugs.php.net/bug.php?id=79251

Unsure where to put documentation for this function because it is a brand new file (`ext/standard/net.c`) in `php-src`, but I put it into **Other Services / Network / Network Functions**

Requires  more documentation regarding flags and family attributes for the unicast subarray.