### PR TITLE
Changed name of the capital of Ukraine to the correct one

### DIFF
--- a/reference/datetime/timezones.xml
+++ b/reference/datetime/timezones.xml
@@ -610,7 +610,7 @@
      </row>
      <row>
       <entry>Europe/Kaliningrad</entry>
-      <entry>Europe/Kiev</entry>
+      <entry>Europe/Kyiv</entry>
       <entry>Europe/Kirov</entry>
       <entry>Europe/Lisbon</entry>
      </row>


### PR DESCRIPTION
The capital of Ukraine is called **Kyiv**, not Kiev.
Please respect Ukraine as a country and all people that live there 🙏 

Proofs:
- [wiki](https://en.wikipedia.org/wiki/Kyiv)
- [another wiki](https://en.wikipedia.org/wiki/KyivNotKiev)
- [euronews](https://www.euronews.com/2019/06/21/kyiv-or-kiev-why-does-it-matter-so-much-to-ukrainians)
- [atlanticcouncil](https://www.atlanticcouncil.org/blogs/ukrainealert/kyiv-not-kiev-why-spelling-matters-in-ukraines-quest-for-an-independent-identity/)
- [nytimes](https://www.nytimes.com/2019/11/13/us/politics/kiev-pronunciation.html)
- [stanfordpolitics](https://stanfordpolitics.org/2020/01/06/kyiv-vs-kiev-what-two-letters-mean-for-ukrainian-independence/)
