### PR TITLE
Fix typo in example function call

### DIFF
--- a/language/attributes.xml
+++ b/language/attributes.xml
@@ -270,7 +270,7 @@ function dumpMyAttributeData($reflection) {
     }
 }
 
-dumpAttributeData(new ReflectionClass(Thing::class));
+dumpMyAttributeData(new ReflectionClass(Thing::class));
 ]]>
      </programlisting>
     </example>


### PR DESCRIPTION
# Description

Looks like the example function name and the function call do not match, if it's an oversight this commit fixes it.

![image](https://user-images.githubusercontent.com/6503258/129477307-f09fe8f0-6606-4b16-b277-231a2ecd62ac.png)
