### PR TITLE
clarify response type for Memcached::deleteMulti

### DIFF
--- a/reference/memcached/memcached/deletemulti.xml
+++ b/reference/memcached/memcached/deletemulti.xml
@@ -60,6 +60,8 @@
   &reftitle.returnvalues;
   <para>
    Returns array indexed by <parameter>keys</parameter> and where values are indicating whether operation succeeded or not.
+   In case of failed operations, a corresponding status code will be returned for the key.
+   See <link linkend="memcached.constants.res-failure">Memcached RES_* Constants</link> for more information.
    The <methodname>Memcached::getResultCode</methodname> will return
    <constant>Memcached::RES_NOTFOUND</constant> if the key does not exist.
   </para>


### PR DESCRIPTION
- the documentation does not clearly say that response 
  codes will be returned, although the implementation
  does exactly that.
 - see https://github.com/php-memcached-dev/php-memcached/blob/605a8a63a7461983512ce12601e995dad18f5a9b/php_memcached.c#L2278-L2282