### PR TITLE
Align return values for pcre_*  functions

### DIFF
--- a/reference/pcre/functions/preg-match-all.xml
+++ b/reference/pcre/functions/preg-match-all.xml
@@ -280,8 +280,7 @@ Array
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the number of full pattern matches (which might be zero),
-   or &false; if an error occurred.
+   Returns the number of full pattern matches (which might be zero),&return.falseforfailure;.
   </para>
  </refsect1>
 

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -248,8 +248,7 @@ Array
   &reftitle.returnvalues;
   <para>
    <function>preg_match</function> returns 1 if the <parameter>pattern</parameter>
-   matches given <parameter>subject</parameter>, 0 if it does not, or &false;
-   if an error occurred.
+   matches given <parameter>subject</parameter>, 0 if it does not,&return.falseforfailure;.
   </para>
   &return.falseproblem;
  </refsect1>


### PR DESCRIPTION
Re f33541d1561d9cf39eda962d02693f2fd90c3eae: align the return values of these 3 functions to say the same thing. 