### PR TITLE
Harmonize true/false usage in return value documentation

### DIFF
--- a/reference/apache/functions/apache-getenv.xml
+++ b/reference/apache/functions/apache-getenv.xml
@@ -46,8 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The value of the Apache environment variable on success, or &false; on
-   failure
+   The value of the Apache environment variable,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/apache/functions/apache-request-headers.xml
+++ b/reference/apache/functions/apache-request-headers.xml
@@ -27,8 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An associative array of all the HTTP headers in the current request, or
-   &false; on failure.
+   An associative array of all the HTTP headers in the current request,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/apache/functions/getallheaders.xml
+++ b/reference/apache/functions/getallheaders.xml
@@ -31,8 +31,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An associative array of all the HTTP headers in the current request, or
-   &false; on failure.
+   An associative array of all the HTTP headers in the current request,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/apache/functions/virtual.xml
+++ b/reference/apache/functions/virtual.xml
@@ -49,7 +49,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Performs the virtual command on success, or returns &false; on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/apcu/apcuiterator/gettotalhits.xml
+++ b/reference/apcu/apcuiterator/gettotalhits.xml
@@ -29,7 +29,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The number of hits on success, or &false; on failure.
+   The number of hits,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/apcu/apcuiterator/key.xml
+++ b/reference/apcu/apcuiterator/key.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the key on success, or &false; upon failure.
+   Returns the key,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/apcu/functions/apcu-add.xml
+++ b/reference/apcu/functions/apcu-add.xml
@@ -86,7 +86,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns TRUE if something has effectively been added into the cache, FALSE otherwise.
+   Returns &true; if something has effectively been added into the cache, &false; otherwise.
    Second syntax returns array with error keys.
   </para>
  </refsect1>

--- a/reference/apcu/functions/apcu-delete.xml
+++ b/reference/apcu/functions/apcu-delete.xml
@@ -39,7 +39,7 @@
   &reftitle.returnvalues;
   <para>
    If <parameter>key</parameter> is an &array;, an indexed &array; of the keys is returned.
-   Otherwise &true; is returned on success, or &false; on failure.
+   Otherwise &true; is returned on success,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/apcu/functions/apcu-fetch.xml
+++ b/reference/apcu/functions/apcu-fetch.xml
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The stored variable or array of variables on success; &false; on failure
+   The stored variable or array of variables,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/apcu/functions/apcu-sma-info.xml
+++ b/reference/apcu/functions/apcu-sma-info.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Array of Shared Memory Allocation data; &false; on failure.
+   Array of Shared Memory Allocation data,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/bzip2/functions/bzread.xml
+++ b/reference/bzip2/functions/bzread.xml
@@ -49,7 +49,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the uncompressed data, or &false; on error.
+   Returns the uncompressed data,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/bzip2/functions/bzwrite.xml
+++ b/reference/bzip2/functions/bzwrite.xml
@@ -55,7 +55,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the number of bytes written, or &false; on error.
+   Returns the number of bytes written,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-client-encoding.xml
+++ b/reference/cubrid/cubridmysql/cubrid-client-encoding.xml
@@ -34,10 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   A string that represents the CUBRID connection charset; on success.
-  </para>
-   <para>
-    &false; on failure.
+   A string that represents the CUBRID connection charset,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-data-seek.xml
+++ b/reference/cubrid/cubridmysql/cubrid-data-seek.xml
@@ -42,7 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success or &false; on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-db-name.xml
+++ b/reference/cubrid/cubridmysql/cubrid-db-name.xml
@@ -46,9 +46,11 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the database name on success, and &false; on failure. If &false;
-   is returned, use <function>cubrid_error</function> to determine the nature
-   of the error.
+   Returns the database name on success,,&return.falseforfailure;
+  </para>
+  <para>
+   If &false; is returned, use <function>cubrid_error</function> to determine
+   the nature of the error.
   </para>
  </refsect1>
  

--- a/reference/cubrid/cubridmysql/cubrid-fetch-assoc.xml
+++ b/reference/cubrid/cubridmysql/cubrid-fetch-assoc.xml
@@ -17,7 +17,7 @@
   <para>
     This function returns the associative array, that corresponds to the
     fetched row, and then moves the internal data pointer ahead, or returns
-    FALSE when the end is reached.
+    &false; when the end is reached.
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-fetch-field.xml
+++ b/reference/cubrid/cubridmysql/cubrid-fetch-field.xml
@@ -100,10 +100,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    Object with certain properties of the specific column, when process is successful.
-  </para>
-   <para>
-    &false; on failure.
+   Object with certain properties of the specific column,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-fetch-lengths.xml
+++ b/reference/cubrid/cubridmysql/cubrid-fetch-lengths.xml
@@ -14,9 +14,8 @@
    <methodparam><type>resource</type><parameter>result</parameter></methodparam>
   </methodsynopsis>
   <para>
-    This function returns an numeric array with the lengths of the values of
-    each field from the current row of the result set or it returns FALSE on
-    failure.
+    Returns a numeric array with the lengths of the values of each field from
+    the current row of the result set,&return.falseforfailure;
   </para>
   <note>
    <para>

--- a/reference/cubrid/cubridmysql/cubrid-field-len.xml
+++ b/reference/cubrid/cubridmysql/cubrid-field-len.xml
@@ -15,7 +15,7 @@
    <methodparam><type>int</type><parameter>field_offset</parameter></methodparam>
   </methodsynopsis>
   <para>
-    This function returns the maximum length of the specified field on success, or it returns FALSE on failure.
+    This function returns the maximum length of the specified field,&return.falseforfailure;
   </para>
  </refsect1>
 
@@ -38,10 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    Maximum length, when process is successful.
-  </para>
-   <para>
-    &false; on failure.
+    Maximum length of the field,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-field-name.xml
+++ b/reference/cubrid/cubridmysql/cubrid-field-name.xml
@@ -15,8 +15,7 @@
    <methodparam><type>int</type><parameter>field_offset</parameter></methodparam>
   </methodsynopsis>
   <para>
-    This function returns the name of the specified field index on success or
-    it returns FALSE on failure.
+    This function returns the name of the specified field index,&return.falseforfailure;
   </para>
  </refsect1>
 
@@ -43,10 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    Name of specified field index, on success.
-  </para>
-   <para>
-    &false; on failure.
+    Name of specified field index,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-field-seek.xml
+++ b/reference/cubrid/cubridmysql/cubrid-field-seek.xml
@@ -17,8 +17,7 @@
   <para>
     This function moves the result set cursor to the specified field offset.
     This offset is used by <function>cubrid_fetch_field</function> if it
-    doesn't include a field offset. It returns TRUE on success or FALSE on
-    failure.
+    doesn't include a field offset. &return.success;
   </para>
  </refsect1>
 
@@ -45,10 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &true; on success.
-  </para>
-   <para>
-    &false; on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-list-dbs.xml
+++ b/reference/cubrid/cubridmysql/cubrid-list-dbs.xml
@@ -34,10 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An numeric array with all existing Cubrid databases; on success.
-  </para>
-   <para>
-    &false; on failure.
+   An numeric array with all existing Cubrid databases,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-num-fields.xml
+++ b/reference/cubrid/cubridmysql/cubrid-num-fields.xml
@@ -14,8 +14,7 @@
    <methodparam><type>resource</type><parameter>result</parameter></methodparam>
   </methodsynopsis>
   <para>
-    This function returns the number of columns in the result set, on success,
-    or it returns FALSE on failure.
+    This function returns the number of columns in the result set,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-query.xml
+++ b/reference/cubrid/cubridmysql/cubrid-query.xml
@@ -53,7 +53,7 @@
   &reftitle.returnvalues;
   <para>
    For SELECT, SHOW, DESCRIBE, EXPLAIN and other statements returning resultset,
-   <function>cubrid_query</function> returns a <type>resource</type> on success, or &false; on error.
+   <function>cubrid_query</function> returns a <type>resource</type>,&return.falseforfailure;
   </para>
   <para>
    For other type of SQL statements, INSERT, UPDATE, DELETE, DROP, etc,

--- a/reference/cubrid/cubridmysql/cubrid-real-escape-string.xml
+++ b/reference/cubrid/cubridmysql/cubrid-real-escape-string.xml
@@ -51,10 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Escaped string version of the given string, on success.
-  </para>
-   <para>
-    &false; on failure.
+   Escaped string version of the given string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-result.xml
+++ b/reference/cubrid/cubridmysql/cubrid-result.xml
@@ -50,10 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Value of a specific field, on success (NULL if value if null).
-  </para>
-   <para>
-    &false; on failure.
+   Value of a specific field, on success (NULL if value if null)&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/cubrid/functions/cubrid-insert-id.xml
+++ b/reference/cubrid/functions/cubrid-insert-id.xml
@@ -17,7 +17,7 @@
    The <function>cubrid_insert_id</function> function retrieves the ID
    generated for the AUTO_INCREMENT column which is updated by the previous
    INSERT query. It returns 0 if the previous query does not generate new
-   rows, or FALSE on failure. 
+   rows, or &false; on failure. 
   </para>
 
   <note>

--- a/reference/curl/functions/curl-exec.xml
+++ b/reference/curl/functions/curl-exec.xml
@@ -35,7 +35,7 @@
   <para>
    &return.success; However, if the <constant>CURLOPT_RETURNTRANSFER</constant>
    option is <link linkend="function.curl-setopt">set</link>, it will return
-   the result on success, &false; on failure.
+   the result,&return.falseforfailure;.
   </para>
   &return.falseproblem;
   <note>

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -351,7 +351,7 @@
   <para>
    If <parameter>option</parameter> is given, returns its value.
    Otherwise, returns an associative array with the following elements 
-   (which correspond to <parameter>option</parameter>), or &false; on failure:
+   (which correspond to <parameter>option</parameter>),&return.falseforfailure;
    <itemizedlist>
     <listitem>
      <simpara>

--- a/reference/curl/functions/curl-init.xml
+++ b/reference/curl/functions/curl-init.xml
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a cURL handle on success, &false; on errors.
+   Returns a cURL handle on success,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/curl/functions/curl-multi-info-read.xml
+++ b/reference/curl/functions/curl-multi-info-read.xml
@@ -52,7 +52,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   On success, returns an associative array for the message, &false; on failure.
+   Returns an associative array for the message,&return.falseforfailure;
   </para>
   <para>
    <table>

--- a/reference/curl/functions/curl-multi-init.xml
+++ b/reference/curl/functions/curl-multi-init.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a cURL multi handle on success, &false; on failure.
+   Returns a cURL multi handle,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/datetime/functions/strtotime.xml
+++ b/reference/datetime/functions/strtotime.xml
@@ -62,7 +62,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a timestamp on success, &false; otherwise.
+   Returns a timestamp,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/dio/functions/dio-open.xml
+++ b/reference/dio/functions/dio-open.xml
@@ -126,7 +126,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   A file descriptor or &false; on error.
+   A file descriptor,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/dir/functions/getcwd.xml
+++ b/reference/dir/functions/getcwd.xml
@@ -26,8 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the current working directory on success, or &false; on
-   failure.
+   Returns the current working directory,&return.falseforfailure;
   </para> 
   <para>
    On some Unix variants, <function>getcwd</function> will return

--- a/reference/dir/functions/scandir.xml
+++ b/reference/dir/functions/scandir.xml
@@ -62,8 +62,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an <type>array</type> of filenames on success, or &false; on 
-   failure. If <parameter>directory</parameter> is not a directory, then 
+   Returns an <type>array</type> of filenames,&return.falseforfailure;.
+   If <parameter>directory</parameter> is not a directory, then 
    boolean &false; is returned, and an error of level 
    <constant>E_WARNING</constant> is generated.
   </para> 

--- a/reference/dom/domdocument/createattribute.xml
+++ b/reference/dom/domdocument/createattribute.xml
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The new <classname>DOMAttr</classname> or &false; if an error occurred.
+   The new <classname>DOMAttr</classname>,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="errors">

--- a/reference/dom/domdocument/createattributens.xml
+++ b/reference/dom/domdocument/createattributens.xml
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The new <classname>DOMAttr</classname> or &false; if an error occurred.
+   The new <classname>DOMAttr</classname>,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="errors">

--- a/reference/dom/domdocument/createcdatasection.xml
+++ b/reference/dom/domdocument/createcdatasection.xml
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The new <classname>DOMCDATASection</classname> or &false; if an error occurred.
+   The new <classname>DOMCDATASection</classname>,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="seealso">

--- a/reference/dom/domdocument/createcomment.xml
+++ b/reference/dom/domdocument/createcomment.xml
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The new <classname>DOMComment</classname> or &false; if an error occurred.
+   The new <classname>DOMComment</classname>,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="seealso">

--- a/reference/dom/domdocument/createdocumentfragment.xml
+++ b/reference/dom/domdocument/createdocumentfragment.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The new <classname>DOMDocumentFragment</classname> or &false; if an error occurred.
+   The new <classname>DOMDocumentFragment</classname>,&return.falseforfailure;
   </para>
  </refsect1> <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/dom/domdocument/createelement.xml
+++ b/reference/dom/domdocument/createelement.xml
@@ -50,8 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a new instance of class <classname>DOMElement</classname> or &false;
-   if an error occurred.
+   Returns a new instance of class <classname>DOMElement</classname>,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="errors">

--- a/reference/dom/domdocument/createelementns.xml
+++ b/reference/dom/domdocument/createelementns.xml
@@ -55,7 +55,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The new <classname>DOMElement</classname> or &false; if an error occurred.
+   The new <classname>DOMElement</classname>,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="errors">

--- a/reference/dom/domdocument/createentityreference.xml
+++ b/reference/dom/domdocument/createentityreference.xml
@@ -36,8 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The new <classname>DOMEntityReference</classname> or &false; if an error
-   occurred.
+   The new <classname>DOMEntityReference</classname>,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="errors">

--- a/reference/dom/domdocument/createprocessinginstruction.xml
+++ b/reference/dom/domdocument/createprocessinginstruction.xml
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The new <classname>DOMProcessingInstruction</classname> or &false; if an error occurred.
+   The new <classname>DOMProcessingInstruction</classname>,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="errors">

--- a/reference/dom/domdocument/createtextnode.xml
+++ b/reference/dom/domdocument/createtextnode.xml
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The new <classname>DOMText</classname> or &false; if an error occurred.
+   The new <classname>DOMText</classname>,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="seealso">

--- a/reference/dom/domdocument/save.xml
+++ b/reference/dom/domdocument/save.xml
@@ -47,7 +47,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the number of bytes written or &false; if an error occurred.
+   Returns the number of bytes written,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/dom/domdocument/savehtml.xml
+++ b/reference/dom/domdocument/savehtml.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the HTML, or &false; if an error occurred.
+   Returns the HTML,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/dom/domdocument/savehtmlfile.xml
+++ b/reference/dom/domdocument/savehtmlfile.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the number of bytes written or &false; if an error occurred.
+   Returns the number of bytes written,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/dom/domdocument/savexml.xml
+++ b/reference/dom/domdocument/savexml.xml
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the XML, or &false; if an error occurred.
+   Returns the XML,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="errors">

--- a/reference/dom/domnode/removechild.xml
+++ b/reference/dom/domnode/removechild.xml
@@ -36,6 +36,7 @@
   &reftitle.returnvalues;
   <para>
    If the child could be removed the function returns the old child.
+   Otherwise, returns &false;
   </para>
  </refsect1>
  <refsect1 role="errors">

--- a/reference/dom/domnode/replacechild.xml
+++ b/reference/dom/domnode/replacechild.xml
@@ -49,7 +49,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The old node or &false; if an error occur.
+   The old node,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="errors">

--- a/reference/eio/functions/eio-event-loop.xml
+++ b/reference/eio/functions/eio-event-loop.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <function>eio_event_loop</function> returns &true; on success,&return.falseforfailure;.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/eio/functions/eio-lstat.xml
+++ b/reference/eio/functions/eio-lstat.xml
@@ -61,7 +61,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <function>eio_lstat</function> returns request resource on success or &false; on error.
+   <function>eio_lstat</function> returns request resource,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/enchant/functions/enchant-broker-init.xml
+++ b/reference/enchant/functions/enchant-broker-init.xml
@@ -21,7 +21,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a broker resource on success or &false;.
+   Returns a broker resource,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/event/eventbuffer/read.xml
+++ b/reference/event/eventbuffer/read.xml
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns string read, or &false; on failure.
+   Returns string read,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="changelog">

--- a/reference/event/eventbuffer/substr.xml
+++ b/reference/event/eventbuffer/substr.xml
@@ -58,7 +58,7 @@
   <para>
    Returns the data substracted as a
    <type>string</type>
-   on success, or &false; on failure.
+  ,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="seealso">

--- a/reference/event/eventbuffer/write.xml
+++ b/reference/event/eventbuffer/write.xml
@@ -54,7 +54,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the number of bytes written, or &false; on error.
+   Returns the number of bytes written,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="seealso">

--- a/reference/event/eventbufferevent/sslgetcipherinfo.xml
+++ b/reference/event/eventbufferevent/sslgetcipherinfo.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a textual description of the cipher on success, or &false; on error.
+   Returns a textual description of the cipher,&return.falseforfailure;
   </para>
  </refsect1>
 </refentry>

--- a/reference/event/eventbufferevent/sslgetciphername.xml
+++ b/reference/event/eventbufferevent/sslgetciphername.xml
@@ -31,7 +31,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the current cipher name of the SSL connection, or &false; on error.
+   Returns the current cipher name of the SSL connection,&return.falseforfailure;
   </para>
  </refsect1>
 </refentry>

--- a/reference/event/eventbufferevent/sslgetcipherversion.xml
+++ b/reference/event/eventbufferevent/sslgetcipherversion.xml
@@ -31,7 +31,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the current cipher version of the SSL connection, or &false; on error.
+   Returns the current cipher version of the SSL connection,&return.falseforfailure;
   </para>
  </refsect1>
 </refentry>

--- a/reference/exec/functions/system.xml
+++ b/reference/exec/functions/system.xml
@@ -60,8 +60,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the last line of the command output on success, and &false;
-   on failure.
+   Returns the last line of the command output,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-copy.xml
+++ b/reference/fann/functions/fann-copy.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a copy of neural network resource on success, or &false; on error
+   Returns a copy of neural network resource,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-create-shortcut-array.xml
+++ b/reference/fann/functions/fann-create-shortcut-array.xml
@@ -43,9 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Returns a neural network resource on success, or &false; on error.
-  </para>
+  &fann.return.ann;
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/fann/functions/fann-create-shortcut.xml
+++ b/reference/fann/functions/fann-create-shortcut.xml
@@ -65,9 +65,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Returns a neural network resource on success, or &false; on error.
-  </para>
+  &fann.return.ann;
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/fann/functions/fann-create-sparse-array.xml
+++ b/reference/fann/functions/fann-create-sparse-array.xml
@@ -54,9 +54,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Returns a neural network resource on success, or &false; on error.
-  </para>
+  &fann.return.ann;
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/fann/functions/fann-create-sparse.xml
+++ b/reference/fann/functions/fann-create-sparse.xml
@@ -72,9 +72,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Returns a neural network resource on success, or &false; on error.
-  </para>
+  &fann.return.ann;
  </refsect1>
 
 

--- a/reference/fann/functions/fann-create-standard-array.xml
+++ b/reference/fann/functions/fann-create-standard-array.xml
@@ -51,9 +51,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Returns a neural network resource on success, or &false; on error.
-  </para>
+  &fann.return.ann;
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/fann/functions/fann-create-standard.xml
+++ b/reference/fann/functions/fann-create-standard.xml
@@ -69,9 +69,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Returns a neural network resource on success, or &false; on error.
-  </para>
+  &fann.return.ann;
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/fann/functions/fann-get-activation-function.xml
+++ b/reference/fann/functions/fann-get-activation-function.xml
@@ -59,7 +59,7 @@
   &reftitle.returnvalues;
   <para>
    <link linkend="constants.fann-train">Learning functions</link> constant or -1
-   if the neuron is not defined in the neural network, or &false; on error.
+   if the neuron is not defined in the neural network,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-activation-steepness.xml
+++ b/reference/fann/functions/fann-get-activation-steepness.xml
@@ -66,7 +66,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The activation steepness for the neuron or -1 if the neuron is not defined in the neural network, or &false; on error.
+   The activation steepness for the neuron or -1 if the neuron is not defined in the neural network,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-bit-fail-limit.xml
+++ b/reference/fann/functions/fann-get-bit-fail-limit.xml
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The bit fail limit, or &false; on error.
+   The bit fail limit,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-bit-fail.xml
+++ b/reference/fann/functions/fann-get-bit-fail.xml
@@ -39,7 +39,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The number of bits fail, or &false; on error.
+   The number of bits fail,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-cascade-activation-functions-count.xml
+++ b/reference/fann/functions/fann-get-cascade-activation-functions-count.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The number of cascade activation functions, or &false; on error.
+   The number of cascade activation functions,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-cascade-activation-functions.xml
+++ b/reference/fann/functions/fann-get-cascade-activation-functions.xml
@@ -41,7 +41,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The cascade activation functions, or &false; on error.
+   The cascade activation functions,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-cascade-activation-steepnesses-count.xml
+++ b/reference/fann/functions/fann-get-cascade-activation-steepnesses-count.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The number of activation steepnesses, or &false; on error.
+   The number of activation steepnesses,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-cascade-activation-steepnesses.xml
+++ b/reference/fann/functions/fann-get-cascade-activation-steepnesses.xml
@@ -39,7 +39,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The cascade activation steepnesses, or &false; on error.
+   The cascade activation steepnesses,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-cascade-candidate-change-fraction.xml
+++ b/reference/fann/functions/fann-get-cascade-candidate-change-fraction.xml
@@ -47,7 +47,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The cascade candidate change fraction, or &false; on error.
+   The cascade candidate change fraction,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-cascade-candidate-limit.xml
+++ b/reference/fann/functions/fann-get-cascade-candidate-limit.xml
@@ -40,7 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The candidate limit, or &false; on error.
+   The candidate limit,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-cascade-candidate-stagnation-epochs.xml
+++ b/reference/fann/functions/fann-get-cascade-candidate-stagnation-epochs.xml
@@ -40,7 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The number of cascade candidate stagnation epochs, or &false; on error.
+   The number of cascade candidate stagnation epochs,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-cascade-max-cand-epochs.xml
+++ b/reference/fann/functions/fann-get-cascade-max-cand-epochs.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The maximum candidate epochs, or &false; on error.
+   The maximum candidate epochs,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-cascade-max-out-epochs.xml
+++ b/reference/fann/functions/fann-get-cascade-max-out-epochs.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The maximum out epochs, or &false; on error.
+   The maximum out epochs,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-cascade-min-cand-epochs.xml
+++ b/reference/fann/functions/fann-get-cascade-min-cand-epochs.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The minimum candidate epochs, or &false; on error.
+   The minimum candidate epochs,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-cascade-min-out-epochs.xml
+++ b/reference/fann/functions/fann-get-cascade-min-out-epochs.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The minimum out epochs, or &false; on error.
+   The minimum out epochs,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-cascade-num-candidate-groups.xml
+++ b/reference/fann/functions/fann-get-cascade-num-candidate-groups.xml
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The number of candidate groups, or &false; on error.
+   The number of candidate groups,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-cascade-num-candidates.xml
+++ b/reference/fann/functions/fann-get-cascade-num-candidates.xml
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The number of candidates used during training, or &false; on error.
+   The number of candidates used during training,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-cascade-output-change-fraction.xml
+++ b/reference/fann/functions/fann-get-cascade-output-change-fraction.xml
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The cascade output change fraction, or &false; on error.
+   The cascade output change fraction,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-cascade-output-stagnation-epochs.xml
+++ b/reference/fann/functions/fann-get-cascade-output-stagnation-epochs.xml
@@ -40,7 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The number of cascade output stagnation epochs, or &false; on error.
+   The number of cascade output stagnation epochs,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-cascade-weight-multiplier.xml
+++ b/reference/fann/functions/fann-get-cascade-weight-multiplier.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The weight multiplier, or &false; on error.
+   The weight multiplier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-connection-rate.xml
+++ b/reference/fann/functions/fann-get-connection-rate.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The connection rate used when the network was created, or &false; on error.
+   The connection rate used when the network was created,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-errno.xml
+++ b/reference/fann/functions/fann-get-errno.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The error number, or &false; on error.
+   The error number,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-errstr.xml
+++ b/reference/fann/functions/fann-get-errstr.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The last error string, or &false; on error.
+   The last error string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-learning-momentum.xml
+++ b/reference/fann/functions/fann-get-learning-momentum.xml
@@ -39,7 +39,7 @@
   &reftitle.returnvalues;
   &fann.return.bool;
   <para>
-   The learning momentum, or &false; on error.
+   The learning momentum,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-learning-rate.xml
+++ b/reference/fann/functions/fann-get-learning-rate.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The learning rate, or &false; on error.
+   The learning rate,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-mse.xml
+++ b/reference/fann/functions/fann-get-mse.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The mean square error, or &false; on error.
+   The mean square error,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-network-type.xml
+++ b/reference/fann/functions/fann-get-network-type.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    <link linkend="constants.fann-nettype">Network type</link> constant, or &false; on error.
+    <link linkend="constants.fann-nettype">Network type</link> constant,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-num-input.xml
+++ b/reference/fann/functions/fann-get-num-input.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Number of input neurons, or &false; on error
+   Number of input neurons,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-num-layers.xml
+++ b/reference/fann/functions/fann-get-num-layers.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The number of leayers in the neural network, or &false; on error.
+   The number of leayers in the neural network,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-num-output.xml
+++ b/reference/fann/functions/fann-get-num-output.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Number of output neurons, or &false; on error
+   Number of output neurons,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-quickprop-decay.xml
+++ b/reference/fann/functions/fann-get-quickprop-decay.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The decay, or &false; on error.
+   The decay,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-quickprop-mu.xml
+++ b/reference/fann/functions/fann-get-quickprop-mu.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The mu factor, or &false; on error.
+   The mu factor,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-rprop-decrease-factor.xml
+++ b/reference/fann/functions/fann-get-rprop-decrease-factor.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The decrease factor, or &false; on error.
+   The decrease factor,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-rprop-delta-max.xml
+++ b/reference/fann/functions/fann-get-rprop-delta-max.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The maximum step-size, or &false; on error.
+   The maximum step-size,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-rprop-delta-min.xml
+++ b/reference/fann/functions/fann-get-rprop-delta-min.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The minimum step-size, or &false; on error.
+   The minimum step-size,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-rprop-delta-zero.xml
+++ b/reference/fann/functions/fann-get-rprop-delta-zero.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The initial step-size, or &false; on error.
+   The initial step-size,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-rprop-increase-factor.xml
+++ b/reference/fann/functions/fann-get-rprop-increase-factor.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The increase factor, or &false; on error.
+   The increase factor,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-sarprop-step-error-shift.xml
+++ b/reference/fann/functions/fann-get-sarprop-step-error-shift.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The sarprop step error shift , or &false; on error.
+   The sarprop step error shift,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-sarprop-step-error-threshold-factor.xml
+++ b/reference/fann/functions/fann-get-sarprop-step-error-threshold-factor.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    The sarprop step error threshold factor, or &false; on error.
+    The sarprop step error threshold factor,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-sarprop-temperature.xml
+++ b/reference/fann/functions/fann-get-sarprop-temperature.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The sarprop temperature, or &false; on error.
+   The sarprop temperature,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-sarprop-weight-decay-shift.xml
+++ b/reference/fann/functions/fann-get-sarprop-weight-decay-shift.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The sarprop weight decay shift, or &false; on error.
+   The sarprop weight decay shift,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-total-connections.xml
+++ b/reference/fann/functions/fann-get-total-connections.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Total number of connections in the entire network, or &false; on error
+   Total number of connections in the entire network,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-total-neurons.xml
+++ b/reference/fann/functions/fann-get-total-neurons.xml
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Total number of neurons in the entire network, or &false; on error.
+   Total number of neurons in the entire network,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-train-error-function.xml
+++ b/reference/fann/functions/fann-get-train-error-function.xml
@@ -39,7 +39,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The <link linkend="constants.fann-errorfunc">error function</link> constant, or &false; on error.
+   The <link linkend="constants.fann-errorfunc">error function</link> constant,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-train-stop-function.xml
+++ b/reference/fann/functions/fann-get-train-stop-function.xml
@@ -39,7 +39,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The <link linkend="constants.fann-stopfunc">stop function</link> constant, or &false; on error.
+   The <link linkend="constants.fann-stopfunc">stop function</link> constant,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-training-algorithm.xml
+++ b/reference/fann/functions/fann-get-training-algorithm.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <link linkend="constants.fann-train">Training algorithm</link> constant, or &false; on error.
+   <link linkend="constants.fann-train">Training algorithm</link> constant,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-length-train-data.xml
+++ b/reference/fann/functions/fann-length-train-data.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Number of elements in the train data <type>resource</type>, or &false; on error.
+   Number of elements in the train data <type>resource</type>,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-merge-train-data.xml
+++ b/reference/fann/functions/fann-merge-train-data.xml
@@ -40,7 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   New merged train data <type>resource</type>, or &false; on error.
+   New merged train data <type>resource</type>,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-num-input-train-data.xml
+++ b/reference/fann/functions/fann-num-input-train-data.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    The number of inputs, or &false; on error.
+    The number of inputs,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-num-output-train-data.xml
+++ b/reference/fann/functions/fann-num-output-train-data.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The number of outputs, or &false; on error.
+   The number of outputs,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-run.xml
+++ b/reference/fann/functions/fann-run.xml
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Array of output values, or &false; on error
+   Array of output values,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-set-sarprop-temperature.xml
+++ b/reference/fann/functions/fann-set-sarprop-temperature.xml
@@ -42,7 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   &fann.return.bool;
-  </refsect1>
+ </refsect1>
 
  <refsect1 role="notes">
   &reftitle.notes;

--- a/reference/fann/functions/fann-test-data.xml
+++ b/reference/fann/functions/fann-test-data.xml
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The updated MSE, or &false; on error.
+   The updated MSE,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-test.xml
+++ b/reference/fann/functions/fann-test.xml
@@ -51,7 +51,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns test outputs on success, or &false; on error.</para>
+  <para>Returns test outputs,&return.falseforfailure;</para>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/fann/functions/fann-train-epoch.xml
+++ b/reference/fann/functions/fann-train-epoch.xml
@@ -50,7 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The MSE, or &false; on error.
+   The MSE,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fbsql/functions/fbsql-blob-size.xml
+++ b/reference/fbsql/functions/fbsql-blob-size.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the BLOB size as an integer, or &false; on error.
+   Returns the BLOB size as an integer,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fbsql/functions/fbsql-clob-size.xml
+++ b/reference/fbsql/functions/fbsql-clob-size.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the CLOB size as an integer, or &false; on error.
+   Returns the CLOB size as an integer,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fbsql/functions/fbsql-connect.xml
+++ b/reference/fbsql/functions/fbsql-connect.xml
@@ -66,8 +66,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a positive FrontBase link identifier on success, or &false; on
-   errors.
+   Returns a positive FrontBase link identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fbsql/functions/fbsql-db-query.xml
+++ b/reference/fbsql/functions/fbsql-db-query.xml
@@ -52,8 +52,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a positive FrontBase result identifier to the query result, or
-   &false; on error.
+   Returns a positive FrontBase result identifier to the query result,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fbsql/functions/fbsql-fetch-field.xml
+++ b/reference/fbsql/functions/fbsql-fetch-field.xml
@@ -40,7 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an object containing field information, or &false; on errors.
+   Returns an object containing field information,&return.falseforfailure;
   </para>
   <para>
    The properties of the object are:

--- a/reference/fbsql/functions/fbsql-fetch-lengths.xml
+++ b/reference/fbsql/functions/fbsql-fetch-lengths.xml
@@ -33,8 +33,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an array, starting at offset 0, that corresponds to the lengths of
-   each field in the last row fetched by <function>fbsql_fetch_row</function>,
-   or &false; on error.
+   each field in the last row fetched by <function>fbsql_fetch_row</function>,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fbsql/functions/fbsql-list-dbs.xml
+++ b/reference/fbsql/functions/fbsql-list-dbs.xml
@@ -31,7 +31,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a result pointer or &false; on error.
+   Returns a result pointer,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fbsql/functions/fbsql-list-fields.xml
+++ b/reference/fbsql/functions/fbsql-list-fields.xml
@@ -48,7 +48,7 @@
   &reftitle.returnvalues;
   <para>
    Returns a result pointer which can be used with the
-   <literal>fbsql_field_xxx</literal> functions, or &false; on error.
+   <literal>fbsql_field_xxx</literal> functions,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fbsql/functions/fbsql-list-tables.xml
+++ b/reference/fbsql/functions/fbsql-list-tables.xml
@@ -40,7 +40,7 @@
   <para>
    Returns a result pointer which can be used with the
    <function>fbsql_tablename</function> function to read the actual table
-   names, or &false; on error.
+   names,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fbsql/functions/fbsql-pconnect.xml
+++ b/reference/fbsql/functions/fbsql-pconnect.xml
@@ -75,8 +75,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a positive FrontBase persistent link identifier on success, or
-   &false; on error.
+   Returns a positive FrontBase persistent link identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fdf/functions/fdf-create.xml
+++ b/reference/fdf/functions/fdf-create.xml
@@ -29,7 +29,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a FDF document handle, or &false; on error.
+   Returns a FDF document handle,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fdf/functions/fdf-open-string.xml
+++ b/reference/fdf/functions/fdf-open-string.xml
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a FDF document handle, or &false; on error.
+   Returns a FDF document handle,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fdf/functions/fdf-open.xml
+++ b/reference/fdf/functions/fdf-open.xml
@@ -42,7 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a FDF document handle, or &false; on error.
+   Returns a FDF document handle,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fdf/functions/fdf-save-string.xml
+++ b/reference/fdf/functions/fdf-save-string.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the document as a string, or &false; on error.
+   Returns the document as a string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fileinfo/functions/finfo-buffer.xml
+++ b/reference/fileinfo/functions/finfo-buffer.xml
@@ -73,7 +73,7 @@
   &reftitle.returnvalues;
   <para>
    Returns a textual description of the <parameter>string</parameter>
-   argument, or &false; if an error occurred.
+   argument,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/fileinfo/functions/finfo-file.xml
+++ b/reference/fileinfo/functions/finfo-file.xml
@@ -74,7 +74,7 @@
   &reftitle.returnvalues;
   <para>
    Returns a textual description of the contents of the
-   <parameter>filename</parameter> argument, or &false; if an error occurred.
+   <parameter>filename</parameter> argument,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/filesystem/functions/fstat.xml
+++ b/reference/filesystem/functions/fstat.xml
@@ -37,9 +37,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an array with the statistics of the file; the format of the array
-   is described in detail on the <function>stat</function> manual page.
-   Returns &false; on failure.
+   Returns an array with the statistics of the file,&return.falseforfailure;.
+   The format of the array is described in detail on the
+   <function>stat</function> manual page.
   </para>
  </refsect1>
 

--- a/reference/filesystem/functions/fwrite.xml
+++ b/reference/filesystem/functions/fwrite.xml
@@ -58,7 +58,7 @@
   &reftitle.returnvalues;
   <simpara>
    <function>fwrite</function> returns the number of bytes
-   written, or &false; on error.
+   written,&return.falseforfailure;
   </simpara>
  </refsect1>
 

--- a/reference/filesystem/functions/glob.xml
+++ b/reference/filesystem/functions/glob.xml
@@ -127,7 +127,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an array containing the matched files/directories, an empty array
-   if no file matched or &false; on error.
+   if no file matched,&return.falseforfailure;
   </para>
   <note>
    <para>

--- a/reference/filesystem/functions/is-executable.xml
+++ b/reference/filesystem/functions/is-executable.xml
@@ -36,8 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; if the filename exists and is executable, or &false; on
-   error.
+   Returns &true; if the filename exists and is executable,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/filesystem/functions/parse-ini-file.xml
+++ b/reference/filesystem/functions/parse-ini-file.xml
@@ -67,8 +67,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The settings are returned as an associative <type>array</type> on success,
-   and &false; on failure.
+   The settings are returned as an associative <type>array</type>,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/filesystem/functions/parse-ini-string.xml
+++ b/reference/filesystem/functions/parse-ini-string.xml
@@ -64,8 +64,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The settings are returned as an associative <type>array</type> on success,
-   and &false; on failure.
+   The settings are returned as an associative <type>array</type>,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/filesystem/functions/readlink.xml
+++ b/reference/filesystem/functions/readlink.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the contents of the symbolic link path or &false; on error.
+   Returns the contents of the symbolic link path,&return.falseforfailure;
   </para>
   <note>
    <simpara>

--- a/reference/filesystem/functions/tempnam.xml
+++ b/reference/filesystem/functions/tempnam.xml
@@ -54,8 +54,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the new temporary filename (with path), or &false; on
-   failure.
+   Returns the new temporary filename (with path),&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/filter/functions/filter-var-array.xml
+++ b/reference/filter/functions/filter-var-array.xml
@@ -65,8 +65,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An array containing the values of the requested variables on success, or &false; 
-   on failure. An array value will be &false; if the filter fails, or &null; if 
+   An array containing the values of the requested variables,&return.falseforfailure;
+   An array value will be &false; if the filter fails, or &null; if 
    the variable is not set.
   </para>
  </refsect1>

--- a/reference/ftp/functions/ftp-chmod.xml
+++ b/reference/ftp/functions/ftp-chmod.xml
@@ -52,7 +52,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the new file permissions on success or &false; on error.
+   Returns the new file permissions,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/ftp/functions/ftp-connect.xml
+++ b/reference/ftp/functions/ftp-connect.xml
@@ -57,7 +57,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a FTP stream on success or &false; on error.
+   Returns a FTP stream,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/ftp/functions/ftp-mkdir.xml
+++ b/reference/ftp/functions/ftp-mkdir.xml
@@ -42,7 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the newly created directory name on success or &false; on error.
+   Returns the newly created directory name,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ftp/functions/ftp-mlsd.xml
+++ b/reference/ftp/functions/ftp-mlsd.xml
@@ -39,8 +39,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an array of arrays with file infos from the specified directory on success or
-   &false; on error.
+   Returns an array of arrays with file infos from the specified directory,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/ftp/functions/ftp-nlist.xml
+++ b/reference/ftp/functions/ftp-nlist.xml
@@ -42,8 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an array of filenames from the specified directory on success or
-   &false; on error.
+   Returns an array of filenames from the specified directory,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/ftp/functions/ftp-pwd.xml
+++ b/reference/ftp/functions/ftp-pwd.xml
@@ -32,7 +32,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the current directory name or &false; on error.
+   Returns the current directory name,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/ftp/functions/ftp-ssl-connect.xml
+++ b/reference/ftp/functions/ftp-ssl-connect.xml
@@ -78,7 +78,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a SSL-FTP stream on success or &false; on error.
+   Returns a SSL-FTP stream,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ftp/functions/ftp-systype.xml
+++ b/reference/ftp/functions/ftp-systype.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the remote system type, or &false; on error.
+   Returns the remote system type,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/funchand/functions/call-user-func-array.xml
+++ b/reference/funchand/functions/call-user-func-array.xml
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the return value of the callback, or &false; on error.
+   Returns the return value of the callback,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/funchand/functions/create-function.xml
+++ b/reference/funchand/functions/create-function.xml
@@ -64,7 +64,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a unique function name as a string, or &false; on error.
+   Returns a unique function name as a string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/funchand/functions/forward-static-call-array.xml
+++ b/reference/funchand/functions/forward-static-call-array.xml
@@ -59,7 +59,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the function result, or &false; on error.
+   Returns the function result,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/funchand/functions/forward-static-call.xml
+++ b/reference/funchand/functions/forward-static-call.xml
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the function result, or &false; on error.
+   Returns the function result,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/funchand/functions/func-get-arg.xml
+++ b/reference/funchand/functions/func-get-arg.xml
@@ -42,7 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the specified argument, or &false; on error.
+   Returns the specified argument,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/gearman/gearmanclient/clone.xml
+++ b/reference/gearman/gearmanclient/clone.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   A <classname>GearmanClient</classname> on success, &false; on failure.
+   A <classname>GearmanClient</classname>,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/gettext/functions/bind-textdomain-codeset.xml
+++ b/reference/gettext/functions/bind-textdomain-codeset.xml
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   A <type>string</type> on success.
+   A <type>string</type> on success,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/hash/functions/hash-hkdf.xml
+++ b/reference/hash/functions/hash-hkdf.xml
@@ -83,7 +83,7 @@
   &reftitle.returnvalues;
   <para>
    Returns a string containing a raw binary representation of the derived key
-   (also known as output keying material - OKM); or &false; on failure.
+   (also known as output keying material - OKM),&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ibase/functions/ibase-blob-import.xml
+++ b/reference/ibase/functions/ibase-blob-import.xml
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the BLOB id on success, or &false; on error.
+   Returns the BLOB id,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ibase/functions/ibase-connect.xml
+++ b/reference/ibase/functions/ibase-connect.xml
@@ -117,7 +117,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an Firebird/InterBase link identifier on success, or &false; on error.
+   Returns an Firebird/InterBase link identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ibase/functions/ibase-pconnect.xml
+++ b/reference/ibase/functions/ibase-pconnect.xml
@@ -126,7 +126,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an InterBase link identifier on success, or &false; on error.
+   Returns an InterBase link identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ibase/functions/ibase-prepare.xml
+++ b/reference/ibase/functions/ibase-prepare.xml
@@ -67,7 +67,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a prepared query handle, or &false; on error.
+   Returns a prepared query handle,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ibase/functions/ibase-trans.xml
+++ b/reference/ibase/functions/ibase-trans.xml
@@ -84,7 +84,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a transaction handle, or &false; on error.
+   Returns a transaction handle,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ibm_db2/functions/db2-client-info.xml
+++ b/reference/ibm_db2/functions/db2-client-info.xml
@@ -137,7 +137,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an object on a successful call. Returns &false; on failure.
+   Returns an object,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagecolorset.xml
+++ b/reference/image/functions/imagecolorset.xml
@@ -68,7 +68,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The function returns &null; on success, &return.falseforfailure;.
+   &return.nullorfalse;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagegrabscreen.xml
+++ b/reference/image/functions/imagegrabscreen.xml
@@ -30,7 +30,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an image object on success, &false; on failure.
+   &gd.return.identifier;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagegrabwindow.xml
+++ b/reference/image/functions/imagegrabwindow.xml
@@ -50,7 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an image object on success, &false; on failure.
+   &gd.return.identifier;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imageloadfont.xml
+++ b/reference/image/functions/imageloadfont.xml
@@ -83,7 +83,7 @@
   &reftitle.returnvalues;
   <para>
    The font identifier which is always bigger than 5 to avoid conflicts with
-   built-in fonts or &false; on errors.
+   built-in fonts,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/image/functions/imagerotate.xml
+++ b/reference/image/functions/imagerotate.xml
@@ -59,7 +59,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an image object for the rotated image, &return.falseforfailure;.
+   &gd.return.identifier;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagesx.xml
+++ b/reference/image/functions/imagesx.xml
@@ -26,8 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return the width of the <parameter>image</parameter> or &false; on 
-   errors.
+   Return the width of the <parameter>image</parameter>,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagesy.xml
+++ b/reference/image/functions/imagesy.xml
@@ -26,8 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return the height of the <parameter>image</parameter> or &false; on 
-   errors.
+   Return the height of the <parameter>image</parameter>,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/imagick/imagickkernel/frommatrix.xml
+++ b/reference/imagick/imagickkernel/frommatrix.xml
@@ -30,7 +30,7 @@
     <term><parameter>array</parameter></term>
     <listitem>
      <para>
-      A matrix (i.e. 2d array) of values that define the kernel. Each element should be either a float value, or FALSE if that element shouldn't be used by the kernel.
+      A matrix (i.e. 2d array) of values that define the kernel. Each element should be either a float value, or &false; if that element shouldn't be used by the kernel.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/imap/functions/imap-list.xml
+++ b/reference/imap/functions/imap-list.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an array containing the names of the mailboxes or &false; in case of failure.
+   Returns an array containing the names of the mailboxes,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/imap/functions/imap-num-msg.xml
+++ b/reference/imap/functions/imap-num-msg.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return the number of messages in the current mailbox, as an integer, or &false; on error.
+   Return the number of messages in the current mailbox, as an integer,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="seealso">

--- a/reference/imap/functions/imap-open.xml
+++ b/reference/imap/functions/imap-open.xml
@@ -275,7 +275,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an IMAP stream on success or &false; on error.
+   Returns an IMAP stream,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/info/functions/assert-options.xml
+++ b/reference/info/functions/assert-options.xml
@@ -149,7 +149,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the original setting of any option or &false; on errors.
+   Returns the original setting of any option,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/info/functions/getmygid.xml
+++ b/reference/info/functions/getmygid.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the group ID of the current script, or &false; on error.
+   Returns the group ID of the current script,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/info/functions/getmyinode.xml
+++ b/reference/info/functions/getmyinode.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the current script's inode as an integer, or &false; on error.
+   Returns the current script's inode as an integer,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/info/functions/getmypid.xml
+++ b/reference/info/functions/getmypid.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the current PHP process ID, or &false; on error.
+   Returns the current PHP process ID,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/info/functions/getmyuid.xml
+++ b/reference/info/functions/getmyuid.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the user ID of the current script, or &false; on error.
+   Returns the user ID of the current script,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/info/functions/ini-set.xml
+++ b/reference/info/functions/ini-set.xml
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the old value on success, &false; on failure.
+   Returns the old value,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/info/functions/set-time-limit.xml
+++ b/reference/info/functions/set-time-limit.xml
@@ -47,7 +47,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success, or &false; on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/inotify/functions/inotify-init.xml
+++ b/reference/inotify/functions/inotify-init.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues"><!-- {{{ -->
   &reftitle.returnvalues;
   <para>
-   A stream resource or &false; on error.
+   A stream resource,&return.falseforfailure;
   </para>
  </refsect1><!-- }}} -->
  

--- a/reference/intl/dateformatter/format.xml
+++ b/reference/intl/dateformatter/format.xml
@@ -69,7 +69,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The formatted string or, if an error occurred, &false;.   
+   The formatted string,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/intl/dateformatter/settimezone.xml
+++ b/reference/intl/dateformatter/settimezone.xml
@@ -59,7 +59,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &null; on success and &false; on failure.
+   &return.nullorfalse;
   </para>
  </refsect1>
 

--- a/reference/intl/intlcalendar/add.xml
+++ b/reference/intl/intlcalendar/add.xml
@@ -74,7 +74,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success&return.falseforfailure;.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/intl/intlcalendar/clear.xml
+++ b/reference/intl/intlcalendar/clear.xml
@@ -57,8 +57,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success&return.falseforfailure;. Failure can only occur is
-   invalid arguments are provided.
+   &return.success; Failure can only occur if invalid arguments are provided.
   </para>
  </refsect1>
 

--- a/reference/intl/intlcalendar/roll.xml
+++ b/reference/intl/intlcalendar/roll.xml
@@ -66,7 +66,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success or &false; on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/intl/intlcalendar/set.xml
+++ b/reference/intl/intlcalendar/set.xml
@@ -141,7 +141,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success and &false; on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/intl/intlcalendar/setfirstdayofweek.xml
+++ b/reference/intl/intlcalendar/setfirstdayofweek.xml
@@ -59,7 +59,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success. Failure can only happen due to invalid parameters.
+   &return.success;
+   Failure can only happen due to invalid parameters.
   </para>
  </refsect1>
 

--- a/reference/intl/intlcalendar/setlenient.xml
+++ b/reference/intl/intlcalendar/setlenient.xml
@@ -58,7 +58,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success. Failure can only happen due to invalid parameters.
+   &return.success;
+   Failure can only happen due to invalid parameters.
   </para>
  </refsect1>
 

--- a/reference/intl/intlcalendar/setminimaldaysinfirstweek.xml
+++ b/reference/intl/intlcalendar/setminimaldaysinfirstweek.xml
@@ -61,7 +61,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &true; on success, &false; on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/intl/intlcalendar/setrepeatedwalltimeoption.xml
+++ b/reference/intl/intlcalendar/setrepeatedwalltimeoption.xml
@@ -63,7 +63,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success. Failure can only happen due to invalid parameters.
+   &return.success;
+   Failure can only happen due to invalid parameters.
   </para>
  </refsect1>
 

--- a/reference/intl/intlcalendar/setskippedwalltimeoption.xml
+++ b/reference/intl/intlcalendar/setskippedwalltimeoption.xml
@@ -78,7 +78,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success. Failure can only happen due to invalid parameters.
+   &return.success;
+   Failure can only happen due to invalid parameters.
   </para>
  </refsect1>
 

--- a/reference/intl/intlcalendar/settime.xml
+++ b/reference/intl/intlcalendar/settime.xml
@@ -58,7 +58,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success and &false; on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/intl/intlcalendar/settimezone.xml
+++ b/reference/intl/intlcalendar/settimezone.xml
@@ -57,7 +57,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success and &false; on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/intl/messageformatter/parse-message.xml
+++ b/reference/intl/messageformatter/parse-message.xml
@@ -74,7 +74,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An <type>array</type> containing items extracted, or &false; on error
+   An <type>array</type> containing items extracted,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/intl/messageformatter/parse.xml
+++ b/reference/intl/messageformatter/parse.xml
@@ -60,7 +60,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An <type>array</type> containing the items extracted, or &false; on error
+   An <type>array</type> containing the items extracted,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/intl/numberformatter/create.xml
+++ b/reference/intl/numberformatter/create.xml
@@ -93,7 +93,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns <classname>NumberFormatter</classname> object or &false; on error.
+   Returns <classname>NumberFormatter</classname> object,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/intl/numberformatter/format.xml
+++ b/reference/intl/numberformatter/format.xml
@@ -73,7 +73,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the string containing formatted value, or &false; on error.
+   Returns the string containing formatted value,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/intl/numberformatter/get-attribute.xml
+++ b/reference/intl/numberformatter/get-attribute.xml
@@ -65,7 +65,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return attribute value on success, or &false; on error.
+   Return attribute value,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/intl/numberformatter/get-symbol.xml
+++ b/reference/intl/numberformatter/get-symbol.xml
@@ -64,7 +64,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The symbol string or &false; on error.
+   The symbol string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/intl/numberformatter/get-text-attribute.xml
+++ b/reference/intl/numberformatter/get-text-attribute.xml
@@ -69,7 +69,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return attribute value on success, or &false; on error.
+   Return attribute value,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/intl/numberformatter/parse-currency.xml
+++ b/reference/intl/numberformatter/parse-currency.xml
@@ -74,7 +74,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The parsed numeric value or &false; on error.
+   The parsed numeric value,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/intl/numberformatter/parse.xml
+++ b/reference/intl/numberformatter/parse.xml
@@ -76,7 +76,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The value of the parsed number or &false; on error.
+   The value of the parsed number,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-add-ext.xml
+++ b/reference/ldap/functions/ldap-add-ext.xml
@@ -30,7 +30,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an LDAP result identifier or &false; on error.
+   Returns an LDAP result identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-bind-ext.xml
+++ b/reference/ldap/functions/ldap-bind-ext.xml
@@ -30,7 +30,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an LDAP result identifier or &false; on error.
+   Returns an LDAP result identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-delete-ext.xml
+++ b/reference/ldap/functions/ldap-delete-ext.xml
@@ -29,7 +29,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an LDAP result identifier or &false; on error.
+   Returns an LDAP result identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-exop-whoami.xml
+++ b/reference/ldap/functions/ldap-exop-whoami.xml
@@ -35,7 +35,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The data returned by the server, or &false; on error.
+   The data returned by the server,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-first-attribute.xml
+++ b/reference/ldap/functions/ldap-first-attribute.xml
@@ -68,8 +68,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the first attribute in the entry on success and &false; on
-   error.
+   Returns the first attribute in the entry,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-get-attributes.xml
+++ b/reference/ldap/functions/ldap-get-attributes.xml
@@ -65,8 +65,7 @@ return_value["attribute"][i] = (i+1)th value of the attribute
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a complete entry information in a multi-dimensional array
-   on success and &false; on error.
+   Returns a complete entry information in a multi-dimensional array,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-get-dn.xml
+++ b/reference/ldap/functions/ldap-get-dn.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the DN of the result entry and &false; on error.
+   Returns the DN of the result entry,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-list.xml
+++ b/reference/ldap/functions/ldap-list.xml
@@ -173,7 +173,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a search result identifier or &false; on error.
+   Returns a search result identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-mod-add-ext.xml
+++ b/reference/ldap/functions/ldap-mod-add-ext.xml
@@ -30,7 +30,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an LDAP result identifier or &false; on error.
+   Returns an LDAP result identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-mod-del-ext.xml
+++ b/reference/ldap/functions/ldap-mod-del-ext.xml
@@ -30,7 +30,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an LDAP result identifier or &false; on error.
+   Returns an LDAP result identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-mod-replace-ext.xml
+++ b/reference/ldap/functions/ldap-mod-replace-ext.xml
@@ -30,7 +30,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an LDAP result identifier or &false; on error.
+   Returns an LDAP result identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-next-attribute.xml
+++ b/reference/ldap/functions/ldap-next-attribute.xml
@@ -62,8 +62,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the next attribute in an entry on success and &false; on
-   error.
+   Returns the next attribute in an entry,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-read.xml
+++ b/reference/ldap/functions/ldap-read.xml
@@ -172,7 +172,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a search result identifier or &false; on error.
+   Returns a search result identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-rename-ext.xml
+++ b/reference/ldap/functions/ldap-rename-ext.xml
@@ -32,7 +32,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an LDAP result identifier or &false; on error.
+   Returns an LDAP result identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-search.xml
+++ b/reference/ldap/functions/ldap-search.xml
@@ -187,7 +187,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a search result identifier or &false; on error.
+   Returns a search result identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/mailparse/functions/mailparse-msg-parse-file.xml
+++ b/reference/mailparse/functions/mailparse-msg-parse-file.xml
@@ -43,8 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a <literal>MIME</literal> resource representing the structure, or
-   &false; on error.
+   Returns a <literal>MIME</literal> resource representing the structure,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/mbstring/functions/mb-convert-variables.xml
+++ b/reference/mbstring/functions/mb-convert-variables.xml
@@ -78,8 +78,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The character encoding before conversion for success, 
-   or &false; for failure.
+   The character encoding before conversion,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/mcrypt/functions/mcrypt-create-iv.xml
+++ b/reference/mcrypt/functions/mcrypt-create-iv.xml
@@ -76,7 +76,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the initialization vector, or &false; on error.
+   Returns the initialization vector,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/mcrypt/functions/mcrypt-module-open.xml
+++ b/reference/mcrypt/functions/mcrypt-module-open.xml
@@ -74,7 +74,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Normally it returns an encryption descriptor, or &false; on error.
+   Normally it returns an encryption descriptor,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/memcache/memcache/getextendedstats.xml
+++ b/reference/memcache/memcache/getextendedstats.xml
@@ -80,8 +80,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a two-dimensional associative array of server statistics or &false;
-   on failure.
+   Returns a two-dimensional associative array of server statistics,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/memcached/memcached/getoption.xml
+++ b/reference/memcached/memcached/getoption.xml
@@ -40,8 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the value of the requested option, or &false; on
-   error.
+   Returns the value of the requested option,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/memcached/memcached/getserverbykey.xml
+++ b/reference/memcached/memcached/getserverbykey.xml
@@ -40,8 +40,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an array containing three keys of <literal>host</literal>,
-   <literal>port</literal>, and <literal>weight</literal> on success or &false;
-   on failure.
+   <literal>port</literal>, and <literal>weight</literal>,&return.falseforfailure;
    &memcached.result.getresultcode;
   </para>
  </refsect1>

--- a/reference/mhash/functions/mhash-keygen-s2k.xml
+++ b/reference/mhash/functions/mhash-keygen-s2k.xml
@@ -81,7 +81,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the generated key as a string, or &false; on error.
+   Returns the generated key as a string,&return.falseforfailure;
   </para>
  </refsect1>
 </refentry>

--- a/reference/mhash/functions/mhash.xml
+++ b/reference/mhash/functions/mhash.xml
@@ -58,8 +58,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the resulting hash (also called digest) or HMAC as a string, or
-   &false; on error.
+   Returns the resulting hash (also called digest) or HMAC as a string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/misc/functions/sleep.xml
+++ b/reference/misc/functions/sleep.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns zero on success, or &false; on error.
+   Returns zero,&return.falseforfailure;
   </para>
   <para>
    If the call was interrupted by a signal, <function>sleep</function> returns

--- a/reference/misc/functions/sys-getloadavg.xml
+++ b/reference/misc/functions/sys-getloadavg.xml
@@ -14,7 +14,7 @@
   <para>
    Returns three samples representing the average system load
    (the number of processes in the system run queue) over the last 1, 5 and 15
-   minutes, respectively. Returns &false; on failure.
+   minutes, respectively,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/mysql/functions/mysql-db-name.xml
+++ b/reference/mysql/functions/mysql-db-name.xml
@@ -64,7 +64,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the database name on success, and &false; on failure. If &false;
+   Returns the database name,&return.falseforfailure; If &false;
    is returned, use <function>mysql_error</function> to determine the nature
    of the error.
   </para>

--- a/reference/mysql/functions/mysql-list-dbs.xml
+++ b/reference/mysql/functions/mysql-list-dbs.xml
@@ -39,8 +39,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a result pointer <type>resource</type> on success, or &false; on
-   failure. Use the <function>mysql_tablename</function> function to traverse 
+   Returns a result pointer <type>resource</type>,&return.falseforfailure;.
+   Use the <function>mysql_tablename</function> function to traverse 
    this result pointer, or any function for result tables, such as 
    <function>mysql_fetch_array</function>.
   </para>

--- a/reference/mysql/functions/mysql-pconnect.xml
+++ b/reference/mysql/functions/mysql-pconnect.xml
@@ -117,8 +117,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a MySQL persistent link identifier on success, or &false; on 
-   failure.
+   Returns a MySQL persistent link identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/mysql/functions/mysql-real-escape-string.xml
+++ b/reference/mysql/functions/mysql-real-escape-string.xml
@@ -73,7 +73,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the escaped string, or &false; on error.
+   Returns the escaped string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -132,7 +132,7 @@
    &return.falseforfailure;.
   </para>
   <para>
-   &return.nullorfalse;
+   <methodname>mysqli::connect</methodname> returns &null; on success&return.falseforfailure;.
   </para>
  </refsect1>
 

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -132,7 +132,7 @@
    &return.falseforfailure;.
   </para>
   <para>
-   <methodname>mysqli::connect</methodname> returns &null; on success&return.falseforfailure;.
+   &return.nullorfalse;
   </para>
  </refsect1>
 

--- a/reference/mysqli/mysqli/store-result.xml
+++ b/reference/mysqli/mysqli/store-result.xml
@@ -68,7 +68,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a buffered result object or &false; if an error occurred.
+   Returns a buffered result object,&return.falseforfailure;
   </para>
   <note>
    <para>

--- a/reference/mysqli/mysqli/use-result.xml
+++ b/reference/mysqli/mysqli/use-result.xml
@@ -53,7 +53,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an unbuffered result object or &false; if an error occurred.
+   Returns an unbuffered result object,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/mysqli/mysqli_stmt/result-metadata.xml
+++ b/reference/mysqli/mysqli_stmt/result-metadata.xml
@@ -65,7 +65,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a result object or &false; if an error occurred.
+   Returns a result object,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/oauth/oauth/getaccesstoken.xml
+++ b/reference/oauth/oauth/getaccesstoken.xml
@@ -75,7 +75,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an array containing the parsed OAuth response on success or &false; on failure.
+   Returns an array containing the parsed OAuth response,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/oauth/oauth/setrsacertificate.xml
+++ b/reference/oauth/oauth/setrsacertificate.xml
@@ -38,8 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success, or &false; on failure (e.g., the RSA certificate
-   cannot be parsed.)
+   &return.success; (e.g., the RSA certificate cannot be parsed)
   </para>
  </refsect1>
 

--- a/reference/oci8/OCI-Collection/max.xml
+++ b/reference/oci8/OCI-Collection/max.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the maximum number as an integer, or &false; on errors.
+   Returns the maximum number as an integer,&return.falseforfailure;.
   </para>
   <para>
    If the returned value is 0, then the number of elements is not limited.

--- a/reference/oci8/OCI-Collection/size.xml
+++ b/reference/oci8/OCI-Collection/size.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the number of elements in the collection or &false; on error. 
+   Returns the number of elements in the collection,&return.falseforfailure; 
   </para>
  </refsect1>
 

--- a/reference/oci8/OCI-Lob/load.xml
+++ b/reference/oci8/OCI-Lob/load.xml
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the contents of the object, or &false; on errors.
+   Returns the contents of the object,&return.falseforfailure;.
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-connect.xml
+++ b/reference/oci8/functions/oci-connect.xml
@@ -86,7 +86,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a connection identifier or &false; on error.
+   Returns a connection identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-field-name.xml
+++ b/reference/oci8/functions/oci-field-name.xml
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the name as a string, or &false; on errors.
+   Returns the name as a string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-field-precision.xml
+++ b/reference/oci8/functions/oci-field-precision.xml
@@ -50,7 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the precision as an integer, or &false; on errors.
+   Returns the precision as an integer,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-field-scale.xml
+++ b/reference/oci8/functions/oci-field-scale.xml
@@ -50,7 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the scale as an integer, or &false; on errors.
+   Returns the scale as an integer,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-field-size.xml
+++ b/reference/oci8/functions/oci-field-size.xml
@@ -45,8 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the size of a <parameter>field</parameter> in bytes, or &false; on
-   errors.
+   Returns the size of a <parameter>field</parameter> in bytes,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-field-type-raw.xml
+++ b/reference/oci8/functions/oci-field-type-raw.xml
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns Oracle's raw data type as a number, or &false; on errors.
+   Returns Oracle's raw data type as a number,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-field-type.xml
+++ b/reference/oci8/functions/oci-field-type.xml
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the field data type as a string, or &false; on errors.
+   Returns the field data type as a string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-new-collection.xml
+++ b/reference/oci8/functions/oci-new-collection.xml
@@ -56,8 +56,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a new <classname>OCICollection</classname> object or &false; on
-   error.
+   Returns a new <classname>OCICollection</classname> object,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-new-connect.xml
+++ b/reference/oci8/functions/oci-new-connect.xml
@@ -73,7 +73,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a connection identifier or &false; on error.
+   Returns a connection identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-new-cursor.xml
+++ b/reference/oci8/functions/oci-new-cursor.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a new statement handle, or &false; on error.
+   Returns a new statement handle,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-new-descriptor.xml
+++ b/reference/oci8/functions/oci-new-descriptor.xml
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a new LOB or FILE descriptor on success, &false; on error.
+   Returns a new LOB or FILE descriptor,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-num-fields.xml
+++ b/reference/oci8/functions/oci-num-fields.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the number of columns as an integer, or &false; on errors.
+   Returns the number of columns as an integer,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-num-rows.xml
+++ b/reference/oci8/functions/oci-num-rows.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the number of rows affected as an integer, or &false; on errors.
+   Returns the number of rows affected as an integer,&return.falseforfailure;.
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-parse.xml
+++ b/reference/oci8/functions/oci-parse.xml
@@ -60,7 +60,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a statement handle on success, or &false; on error.
+   Returns a statement handle,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-pconnect.xml
+++ b/reference/oci8/functions/oci-pconnect.xml
@@ -74,7 +74,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a connection identifier or &false; on error.
+   Returns a connection identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-server-version.xml
+++ b/reference/oci8/functions/oci-server-version.xml
@@ -35,7 +35,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the version information as a string or &false; on error.
+   Returns the version information as a string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-statement-type.xml
+++ b/reference/oci8/functions/oci-statement-type.xml
@@ -98,7 +98,7 @@
    </table>
   </para>
   <para>
-   Returns,&return.falseforfailure;
+   &return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-statement-type.xml
+++ b/reference/oci8/functions/oci-statement-type.xml
@@ -98,7 +98,7 @@
    </table>
   </para>
   <para>
-   Returns &false; on error.
+   Returns,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/openal/functions/openal-buffer-create.xml
+++ b/reference/openal/functions/openal-buffer-create.xml
@@ -23,8 +23,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an <link linkend="openal.resources">Open AL(Buffer)</link> resource on success or
-   &false; on failure.
+   Returns an <link linkend="openal.resources">Open AL(Buffer)</link> resource,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="seealso">

--- a/reference/openal/functions/openal-context-create.xml
+++ b/reference/openal/functions/openal-context-create.xml
@@ -31,8 +31,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an <link linkend="openal.resources">Open AL(Context)</link> resource on success or
-   &false; on failure.
+   Returns an <link linkend="openal.resources">Open AL(Context)</link> resource,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="seealso">

--- a/reference/openal/functions/openal-device-open.xml
+++ b/reference/openal/functions/openal-device-open.xml
@@ -32,8 +32,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an <link linkend="openal.resources">Open AL(Device)</link> resource on success or 
-   &false; on failure.
+   Returns an <link linkend="openal.resources">Open AL(Device)</link> resource,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="seealso">

--- a/reference/openal/functions/openal-source-create.xml
+++ b/reference/openal/functions/openal-source-create.xml
@@ -23,8 +23,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an <link linkend="openal.resources">Open AL(Source)</link> resource on success or
-   &false; on failure.
+   Returns an <link linkend="openal.resources">Open AL(Source)</link> resource,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="seealso">

--- a/reference/openssl/functions/openssl-cipher-iv-length.xml
+++ b/reference/openssl/functions/openssl-cipher-iv-length.xml
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the cipher length on success, or &false; on failure. 
+   Returns the cipher length,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/openssl/functions/openssl-csr-get-public-key.xml
+++ b/reference/openssl/functions/openssl-csr-get-public-key.xml
@@ -41,7 +41,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an <classname>OpenSSLAsymmetricKey</classname> on success, or &false; on error.
+   Returns an <classname>OpenSSLAsymmetricKey</classname>,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/openssl/functions/openssl-csr-sign.xml
+++ b/reference/openssl/functions/openssl-csr-sign.xml
@@ -92,7 +92,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an <classname>OpenSSLCertificate</classname> on success, &false; on failure.
+   Returns an <classname>OpenSSLCertificate</classname>,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/openssl/functions/openssl-pkey-get-details.xml
+++ b/reference/openssl/functions/openssl-pkey-get-details.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an array with the key details in success or &false; in failure.
+   Returns an array with the key details,&return.falseforfailure;.
    Returned array has indexes <literal>bits</literal> (number of bits),
    <literal>key</literal> (string representation of the public key) and
    <literal>type</literal> (type of the key which is one of

--- a/reference/openssl/functions/openssl-pkey-get-private.xml
+++ b/reference/openssl/functions/openssl-pkey-get-private.xml
@@ -55,7 +55,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an <classname>OpenSSLAsymmetricKey</classname> instance on success, or &false; on error.
+   Returns an <classname>OpenSSLAsymmetricKey</classname> instance,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/openssl/functions/openssl-pkey-get-public.xml
+++ b/reference/openssl/functions/openssl-pkey-get-public.xml
@@ -47,7 +47,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an <classname>OpenSSLAsymmetricKey</classname> instance on success, or &false; on error.
+   Returns an <classname>OpenSSLAsymmetricKey</classname> instance,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/openssl/functions/openssl-pkey-new.xml
+++ b/reference/openssl/functions/openssl-pkey-new.xml
@@ -42,8 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an <classname>OpenSSLAsymmetricKey</classname> instance for the pkey on success, or &false; on
-   error.
+   Returns an <classname>OpenSSLAsymmetricKey</classname> instance for the pkey,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/openssl/functions/openssl-spki-export-challenge.xml
+++ b/reference/openssl/functions/openssl-spki-export-challenge.xml
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the associated challenge string or &false; on failure.
+   Returns the associated challenge string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/openssl/functions/openssl-spki-export.xml
+++ b/reference/openssl/functions/openssl-spki-export.xml
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the associated PEM formatted public key or &false; on failure.
+   Returns the associated PEM formatted public key,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/openssl/functions/openssl-spki-new.xml
+++ b/reference/openssl/functions/openssl-spki-new.xml
@@ -56,7 +56,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a signed public key and challenge string or &false; on failure.
+   Returns a signed public key and challenge string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/pcntl/functions/pcntl-sigwaitinfo.xml
+++ b/reference/pcntl/functions/pcntl-sigwaitinfo.xml
@@ -84,7 +84,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a signal number on success, or &false; on error.
+   Returns a signal number,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -213,7 +213,7 @@
    </term>
    <listitem>
     <simpara>
-     Specifies that the fetch method shall return TRUE and assign the values of
+     Specifies that the fetch method shall return &true; and assign the values of
      the columns in the result set to the PHP variables to which they were
      bound with the <function>PDOStatement::bindParam</function> or
      <function>PDOStatement::bindColumn</function> methods.

--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -114,7 +114,7 @@
    all of the remaining rows in the result set. The array represents each
    row as either an array of column values or an object with properties
    corresponding to each column name. An empty array is returned if there
-   are zero results to fetch, or &false; on failure.
+   are zero results to fetch,&return.falseforfailure;
   </para>
   <para>
    Using this method to fetch large result sets will result in a heavy

--- a/reference/pdo_pgsql/PDO/pgsqlCopyFromArray.xml
+++ b/reference/pdo_pgsql/PDO/pgsqlCopyFromArray.xml
@@ -72,7 +72,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success,&return.falseforfailure;.
+   &return.success;
   </para>
  </refsect1>
 </refentry>

--- a/reference/pdo_pgsql/PDO/pgsqlCopyFromFile.xml
+++ b/reference/pdo_pgsql/PDO/pgsqlCopyFromFile.xml
@@ -72,7 +72,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success,&return.falseforfailure;.
+   &return.success;
   </para>
  </refsect1>
 </refentry>

--- a/reference/pdo_pgsql/PDO/pgsqlCopyToFile.xml
+++ b/reference/pdo_pgsql/PDO/pgsqlCopyToFile.xml
@@ -72,7 +72,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success,&return.falseforfailure;.
+   &return.success;
   </para>
  </refsect1>
 </refentry>

--- a/reference/pdo_pgsql/PDO/pgsqlLOBCreate.xml
+++ b/reference/pdo_pgsql/PDO/pgsqlLOBCreate.xml
@@ -46,8 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the OID of the newly created large object on success, or &false;
-   on failure.
+   Returns the OID of the newly created large object,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/pgsql/functions/pg-client-encoding.xml
+++ b/reference/pgsql/functions/pg-client-encoding.xml
@@ -58,7 +58,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    The client encoding, or &false; on error.
+    The client encoding,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/pgsql/functions/pg-connect.xml
+++ b/reference/pgsql/functions/pg-connect.xml
@@ -89,7 +89,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   PostgreSQL connection resource on success, &false; on failure.
+   PostgreSQL connection resource,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-convert.xml
+++ b/reference/pgsql/functions/pg-convert.xml
@@ -83,7 +83,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An <type>array</type> of converted values, or &false; on error.
+   An <type>array</type> of converted values,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-dbname.xml
+++ b/reference/pgsql/functions/pg-dbname.xml
@@ -43,7 +43,7 @@
   &reftitle.returnvalues;
   <para>
    A <type>string</type> containing the name of the database the 
-   <parameter>connection</parameter> is to, or &false; on error.
+   <parameter>connection</parameter> is to,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/pgsql/functions/pg-field-name.xml
+++ b/reference/pgsql/functions/pg-field-name.xml
@@ -56,7 +56,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The field name, or &false; on error.
+   The field name,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/pgsql/functions/pg-field-prtlen.xml
+++ b/reference/pgsql/functions/pg-field-prtlen.xml
@@ -72,7 +72,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The field printed length, or &false; on error.
+   The field printed length,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-field-table.xml
+++ b/reference/pgsql/functions/pg-field-table.xml
@@ -59,7 +59,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   On success either the fields table name or oid. Or, &false; on failure.
+   The fields table name or oid,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/pgsql/functions/pg-field-type.xml
+++ b/reference/pgsql/functions/pg-field-type.xml
@@ -64,8 +64,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   A <type>string</type> containing the base name of the field's type, or &false;
-   on error.
+   A <type>string</type> containing the base name of the field's type,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/pgsql/functions/pg-host.xml
+++ b/reference/pgsql/functions/pg-host.xml
@@ -45,7 +45,7 @@
   &reftitle.returnvalues;
   <para>
    A <type>string</type> containing the name of the host the 
-   <parameter>connection</parameter> is to, or &false; on error.
+   <parameter>connection</parameter> is to,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/pgsql/functions/pg-last-error.xml
+++ b/reference/pgsql/functions/pg-last-error.xml
@@ -57,7 +57,7 @@
   &reftitle.returnvalues;
   <para>
    A <type>string</type> containing the last error message on the 
-   given <parameter>connection</parameter>, or &false; on error.
+   given <parameter>connection</parameter>,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-last-notice.xml
+++ b/reference/pgsql/functions/pg-last-notice.xml
@@ -72,8 +72,7 @@
    given <parameter>connection</parameter> with
    <constant>PGSQL_NOTICE_LAST</constant>,
    an <type>array</type> with <constant>PGSQL_NOTICE_ALL</constant>,
-   a <type>bool</type> with <constant>PGSQL_NOTICE_CLEAR</constant>,
-   or &false; on error.
+   a <type>bool</type> with <constant>PGSQL_NOTICE_CLEAR</constant>,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/pgsql/functions/pg-last-oid.xml
+++ b/reference/pgsql/functions/pg-last-oid.xml
@@ -65,7 +65,7 @@
   &reftitle.returnvalues;
   <para>
    A <type>string</type> containing the OID assigned to the most recently inserted
-   row in the specified <parameter>connection</parameter>, or &false; on error or
+   row in the specified <parameter>connection</parameter>,&return.falseforfailure;or
    no available OID.
   </para>
  </refsect1>

--- a/reference/pgsql/functions/pg-lo-create.xml
+++ b/reference/pgsql/functions/pg-lo-create.xml
@@ -79,7 +79,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   A large object <varname>OID</varname> or &false; on error.
+   A large object <varname>OID</varname>,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-lo-open.xml
+++ b/reference/pgsql/functions/pg-lo-open.xml
@@ -75,7 +75,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   A large object resource or &false; on error.
+   A large object resource,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/pgsql/functions/pg-lo-read-all.xml
+++ b/reference/pgsql/functions/pg-lo-read-all.xml
@@ -52,7 +52,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Number of bytes read or &false; on error.
+   Number of bytes read,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/pgsql/functions/pg-lo-read.xml
+++ b/reference/pgsql/functions/pg-lo-read.xml
@@ -58,7 +58,7 @@
   &reftitle.returnvalues;
   <para>
    A <type>string</type> containing <parameter>len</parameter> bytes from the
-   large object, or &false; on error.
+   large object,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/pgsql/functions/pg-lo-write.xml
+++ b/reference/pgsql/functions/pg-lo-write.xml
@@ -69,7 +69,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The number of bytes written to the large object, or &false; on error.
+   The number of bytes written to the large object,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/pgsql/functions/pg-meta-data.xml
+++ b/reference/pgsql/functions/pg-meta-data.xml
@@ -58,7 +58,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An <type>array</type> of the table definition, or &false; on error.
+   An <type>array</type> of the table definition,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/pgsql/functions/pg-options.xml
+++ b/reference/pgsql/functions/pg-options.xml
@@ -43,7 +43,7 @@
   &reftitle.returnvalues;
   <para>
    A <type>string</type> containing the <parameter>connection</parameter>
-   options, or &false; on error.
+   options,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/pgsql/functions/pg-parameter-status.xml
+++ b/reference/pgsql/functions/pg-parameter-status.xml
@@ -82,8 +82,8 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>A <type>string</type> containing the value of the parameter, &false; on failure or invalid
-  <parameter>param_name</parameter>.</para>
+  <para>A <type>string</type> containing the value of the parameter,&return.falseforfailure; (including invalid
+  <parameter>param_name</parameter>)</para>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/pgsql/functions/pg-port.xml
+++ b/reference/pgsql/functions/pg-port.xml
@@ -45,8 +45,7 @@
   &reftitle.returnvalues;
   <para>
    An <type>int</type> containing the port number of the database
-   server the <parameter>connection</parameter> is to, 
-   or &false; on error.
+   server the <parameter>connection</parameter> is to,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/pgsql/functions/pg-send-execute.xml
+++ b/reference/pgsql/functions/pg-send-execute.xml
@@ -71,8 +71,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns &true; on success, &false; on failure.  Use <function>pg_get_result</function>
-  to determine the query result.</para>
+  <para>
+   &return.success;
+  </para>
+  <para>
+   Use <function>pg_get_result</function> to determine the query result.
+  </para>
  </refsect1>
  
  <refsect1 role="examples">

--- a/reference/pgsql/functions/pg-send-prepare.xml
+++ b/reference/pgsql/functions/pg-send-prepare.xml
@@ -70,8 +70,9 @@
  
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns &true; on success, &false; on failure.  Use <function>pg_get_result</function>
-  to determine the query result.</para>
+  <para>
+   &return.success; Use <function>pg_get_result</function> to determine the query result.
+  </para>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/pgsql/functions/pg-tty.xml
+++ b/reference/pgsql/functions/pg-tty.xml
@@ -52,7 +52,7 @@
   &reftitle.returnvalues;
   <para>
    A <type>string</type> containing the debug TTY of 
-   the <parameter>connection</parameter>, or &false; on error.
+   the <parameter>connection</parameter>,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/posix/functions/posix-ttyname.xml
+++ b/reference/posix/functions/posix-ttyname.xml
@@ -31,8 +31,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   On success, returns a <type>string</type> of the absolute path of the
-   <parameter>file_descriptor</parameter>. On failure, returns &false;
+   Returns a <type>string</type> of the absolute path of the
+   <parameter>file_descriptor</parameter>,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/ps/functions/ps-close-image.xml
+++ b/reference/ps/functions/ps-close-image.xml
@@ -50,7 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &null; on success&return.falseforfailure;.
+   &return.nullorfalse;
   </para>
  </refsect1>
 

--- a/reference/pspell/functions/pspell-config-create.xml
+++ b/reference/pspell/functions/pspell-config-create.xml
@@ -87,7 +87,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a pspell config identifier, or &false; on error.
+   Returns a pspell config identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/radius/functions/radius-demangle-mppe-key.xml
+++ b/reference/radius/functions/radius-demangle-mppe-key.xml
@@ -42,7 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the demangled string, or &false; on error.
+   Returns the demangled string,&return.falseforfailure;
   </para>
  </refsect1>
 </refentry>

--- a/reference/radius/functions/radius-demangle.xml
+++ b/reference/radius/functions/radius-demangle.xml
@@ -40,7 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the demangled string, or &false; on error.
+   Returns the demangled string,&return.falseforfailure;
   </para>
  </refsect1>
 </refentry>

--- a/reference/radius/functions/radius-get-vendor-attr.xml
+++ b/reference/radius/functions/radius-get-vendor-attr.xml
@@ -41,7 +41,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an associative array containing the attribute-type, vendor and the
-   data, or &false; on error.
+   data,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/radius/functions/radius-request-authenticator.xml
+++ b/reference/radius/functions/radius-request-authenticator.xml
@@ -31,7 +31,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the request authenticator as string, or &false; on error.
+   Returns the request authenticator as string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/radius/functions/radius-server-secret.xml
+++ b/reference/radius/functions/radius-server-secret.xml
@@ -31,7 +31,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the server's shared secret as string, or &false; on error.
+   Returns the server's shared secret as string,&return.falseforfailure;
   </para>
  </refsect1>
 </refentry>

--- a/reference/rar/rarentry/getattr.xml
+++ b/reference/rar/rarentry/getattr.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the attributes or &false; on error.
+   Returns the attributes,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/rar/rarentry/getcrc.xml
+++ b/reference/rar/rarentry/getcrc.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the CRC of the archive entry or &false; on error.
+   Returns the CRC of the archive entry,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/rar/rarentry/getfiletime.xml
+++ b/reference/rar/rarentry/getfiletime.xml
@@ -27,7 +27,7 @@
   &reftitle.returnvalues;
   <para>
    Returns entry last modification time as string in format 
-   <literal>YYYY-MM-DD HH:II:SS</literal>, or &false; on error.
+   <literal>YYYY-MM-DD HH:II:SS</literal>,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/rar/rarentry/gethostos.xml
+++ b/reference/rar/rarentry/gethostos.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the code of the host OS, or &false; on error.
+   Returns the code of the host OS,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/rar/rarentry/getmethod.xml
+++ b/reference/rar/rarentry/getmethod.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the method number or &false; on error.
+   Returns the method number,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/rar/rarentry/getname.xml
+++ b/reference/rar/rarentry/getname.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the entry name as a string, or &false; on error.
+   Returns the entry name as a string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/rar/rarentry/getpackedsize.xml
+++ b/reference/rar/rarentry/getpackedsize.xml
@@ -31,7 +31,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the packed size, or &false; on error.
+   Returns the packed size,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/rar/rarentry/getunpackedsize.xml
+++ b/reference/rar/rarentry/getunpackedsize.xml
@@ -31,7 +31,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the unpacked size, or &false; on error.
+   Returns the unpacked size,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/rar/rarentry/getversion.xml
+++ b/reference/rar/rarentry/getversion.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the version or &false; on error.
+   Returns the version,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/alert.xml
+++ b/reference/seaslog/seaslog/alert.xml
@@ -64,7 +64,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/closeloggerstream.xml
+++ b/reference/seaslog/seaslog/closeloggerstream.xml
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on released stream flow success, FALSE on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/critical.xml
+++ b/reference/seaslog/seaslog/critical.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/debug.xml
+++ b/reference/seaslog/seaslog/debug.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/emergency.xml
+++ b/reference/seaslog/seaslog/emergency.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/error.xml
+++ b/reference/seaslog/seaslog/error.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/flushbuffer.xml
+++ b/reference/seaslog/seaslog/flushbuffer.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on flush buffer success, FALSE on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/getbufferenabled.xml
+++ b/reference/seaslog/seaslog/getbufferenabled.xml
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on <link linkend="ini.seaslog.use-buffer">seaslog.use_buffer</link> is true.
+   Return &true; on <link linkend="ini.seaslog.use-buffer">seaslog.use_buffer</link> is true.
    If switch <link linkend="ini.seaslog.buffer-disabled-in-cli">seaslog.buffer_disabled_in_cli</link> on, and running in cli, 
    seaslog.use_buffer setting will be discarded, Seaslog write to the Data Store IMMEDIATELY.
   </para>

--- a/reference/seaslog/seaslog/info.xml
+++ b/reference/seaslog/seaslog/info.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/log.xml
+++ b/reference/seaslog/seaslog/log.xml
@@ -78,7 +78,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/notice.xml
+++ b/reference/seaslog/seaslog/notice.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/setbasepath.xml
+++ b/reference/seaslog/seaslog/setbasepath.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on setted base path success, FALSE on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/setdatetimeformat.xml
+++ b/reference/seaslog/seaslog/setdatetimeformat.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on setted datetime format success, FALSE on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/setlogger.xml
+++ b/reference/seaslog/seaslog/setlogger.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on created logger disectory success, FALSE on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/setrequestid.xml
+++ b/reference/seaslog/seaslog/setrequestid.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on set request_id success, FALSE on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/setrequestvariable.xml
+++ b/reference/seaslog/seaslog/setrequestvariable.xml
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on set success, FALSE on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/warning.xml
+++ b/reference/seaslog/seaslog/warning.xml
@@ -64,7 +64,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/sem/functions/sem-get.xml
+++ b/reference/sem/functions/sem-get.xml
@@ -76,8 +76,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a positive semaphore identifier on success, or &false; on
-   error.
+   Returns a positive semaphore identifier,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/session/functions/session-cache-limiter.xml
+++ b/reference/session/functions/session-cache-limiter.xml
@@ -124,8 +124,7 @@ Pragma: no-cache
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the name of the current cache limiter.
-   On failure to change the value, &false; is returned.
+   Returns the name of the current cache limiter,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/session/functions/session-gc.xml
+++ b/reference/session/functions/session-gc.xml
@@ -40,8 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <function>session_gc</function> returns number of deleted session
-   data for success, &false; for failure.
+   Returns number of deleted session data,&return.falseforfailure;
   </para>
   <para>
    Old save handlers do not return number of deleted session data, but 

--- a/reference/shmop/functions/shmop-open.xml
+++ b/reference/shmop/functions/shmop-open.xml
@@ -102,9 +102,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   On success <function>shmop_open</function> will return a <classname>Shmop</classname> instance that you can
-   use to access the shared memory segment you've created. &false; is
-   returned on failure.
+   Returns a <classname>Shmop</classname> instance that you can use to access
+   the shared memory segment you've created,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/snmp/functions/snmp2-get.xml
+++ b/reference/snmp/functions/snmp2-get.xml
@@ -72,7 +72,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns <acronym>SNMP</acronym> object value on success or &false; on error.
+   Returns <acronym>SNMP</acronym> object value,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/snmp/functions/snmp2-walk.xml
+++ b/reference/snmp/functions/snmp2-walk.xml
@@ -78,7 +78,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an array of <acronym>SNMP</acronym> object values starting from the
-   <parameter>object_id</parameter> as root or &false; on error.
+   <parameter>object_id</parameter> as root,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/snmp/functions/snmp3-get.xml
+++ b/reference/snmp/functions/snmp3-get.xml
@@ -117,7 +117,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns <acronym>SNMP</acronym> object value on success or &false; on error.
+   Returns <acronym>SNMP</acronym> object value,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/snmp/functions/snmp3-walk.xml
+++ b/reference/snmp/functions/snmp3-walk.xml
@@ -126,7 +126,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an array of <acronym>SNMP</acronym> object values starting from the
-   <parameter>object_id</parameter> as root or &false; on error.
+   <parameter>object_id</parameter> as root,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/snmp/functions/snmpget.xml
+++ b/reference/snmp/functions/snmpget.xml
@@ -74,7 +74,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns <acronym>SNMP</acronym> object value on success or &false; on error.
+   Returns <acronym>SNMP</acronym> object value,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/snmp/functions/snmpwalk.xml
+++ b/reference/snmp/functions/snmpwalk.xml
@@ -78,7 +78,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an array of <acronym>SNMP</acronym> object values starting from the
-   <parameter>object_id</parameter> as root or &false; on error.
+   <parameter>object_id</parameter> as root,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/snmp/functions/snmpwalkoid.xml
+++ b/reference/snmp/functions/snmpwalkoid.xml
@@ -90,7 +90,7 @@
   <para>
    Returns an associative array with object ids and their respective
    object value starting from the <parameter>object_id</parameter>
-   as root or &false; on error.
+   as root,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/snmp/snmp/get.xml
+++ b/reference/snmp/snmp/get.xml
@@ -59,7 +59,7 @@
   &reftitle.returnvalues;
   <para>
    Returns <acronym>SNMP</acronym> objects requested as string or array
-   depending on <parameter>objectId</parameter> type or &false; on error.
+   depending on <parameter>objectId</parameter> type,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/snmp/snmp/getnext.xml
+++ b/reference/snmp/snmp/getnext.xml
@@ -47,7 +47,7 @@
   &reftitle.returnvalues;
   <para>
    Returns <acronym>SNMP</acronym> objects requested as string or array
-   depending on <parameter>objectId</parameter> type or &false; on error.
+   depending on <parameter>objectId</parameter> type,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/sockets/functions/socket-addrinfo-bind.xml
+++ b/reference/sockets/functions/socket-addrinfo-bind.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a <classname>Socket</classname> instance on success or &false; on failure.
+   Returns a <classname>Socket</classname> instance,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/sockets/functions/socket-addrinfo-connect.xml
+++ b/reference/sockets/functions/socket-addrinfo-connect.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a <classname>Socket</classname> instance on success or &false; on failure.
+   Returns a <classname>Socket</classname> instance,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/sockets/functions/socket-addrinfo-lookup.xml
+++ b/reference/sockets/functions/socket-addrinfo-lookup.xml
@@ -56,8 +56,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an array of <classname>AddressInfo</classname> instances that can be used with the other socket_addrinfo functions.
-   On failure, &false; is returned.
+   Returns an array of <classname>AddressInfo</classname> instances that can be used with the other socket_addrinfo functions,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/sockets/functions/socket-get-option.xml
+++ b/reference/sockets/functions/socket-get-option.xml
@@ -414,7 +414,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the value of the given option, or &false; on errors.
+   Returns the value of the given option,&return.falseforfailure;.
   </para>
  </refsect1>
 

--- a/reference/sockets/functions/socket-import-stream.xml
+++ b/reference/sockets/functions/socket-import-stream.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &false; on failure.
+   The socket,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/sockets/functions/socket-recvmsg.xml
+++ b/reference/sockets/functions/socket-recvmsg.xml
@@ -50,7 +50,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
+   The number of bytes received,&return.falseforfailure;
   </para>
+  &return.falseproblem;
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/sockets/functions/socket-select.xml
+++ b/reference/sockets/functions/socket-select.xml
@@ -122,7 +122,7 @@ socket_select($r, $w, $e, 0);
   <para>
    On success <function>socket_select</function> returns the number of
    sockets contained in the modified arrays, which may be zero if
-   the timeout expires before anything interesting happens.On error &false;
+   the timeout expires before anything interesting happens. On error &false;
    is returned. The error code can be retrieved with
    <function>socket_last_error</function>.
   </para>

--- a/reference/sockets/functions/socket-send.xml
+++ b/reference/sockets/functions/socket-send.xml
@@ -102,7 +102,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <function>socket_send</function> returns the number of bytes sent, or &false; on error. 
+   Returns the number of bytes sent,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/sockets/functions/socket-sendto.xml
+++ b/reference/sockets/functions/socket-sendto.xml
@@ -122,7 +122,7 @@
   &reftitle.returnvalues;
   <para>
    <function>socket_sendto</function> returns the number of bytes sent to the
-   remote host, or &false; if an error occurred.
+   remote host,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-secretbox-open.xml
+++ b/reference/sodium/functions/sodium-crypto-secretbox-open.xml
@@ -55,6 +55,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
+   The plaintext,&return.falseforfailure;
    
   </para>
  </refsect1>

--- a/reference/solr/functions/solr-get-version.xml
+++ b/reference/solr/functions/solr-get-version.xml
@@ -28,7 +28,7 @@
   &reftitle.returnvalues;
   <!-- See also &return.success; -->
   <para>
-   It returns a string on success and &false; on failure.
+   It returns a string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/solr/solrdocument/getfield.xml
+++ b/reference/solr/solrdocument/getfield.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a SolrDocumentField on success and &false; on failure.
+   Returns a SolrDocumentField,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/solr/solrdocument/getfieldcount.xml
+++ b/reference/solr/solrdocument/getfieldcount.xml
@@ -29,7 +29,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an integer on success and &false; on failure.
+   Returns an integer,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/solr/solrinputdocument/getboost.xml
+++ b/reference/solr/solrinputdocument/getboost.xml
@@ -29,7 +29,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-  Returns the boost value on success and &false; on failure.
+  Returns the boost value,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/solr/solrinputdocument/getfield.xml
+++ b/reference/solr/solrinputdocument/getfield.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a SolrDocumentField object on success and &false; on failure.
+   Returns a SolrDocumentField object,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/solr/solrinputdocument/getfieldnames.xml
+++ b/reference/solr/solrinputdocument/getfieldnames.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an array on success and &false; on failure.
+   Returns an array,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/solr/solrinputdocument/toarray.xml
+++ b/reference/solr/solrinputdocument/toarray.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an array containing the fields. It returns &false; on failure.
+   Returns an array containing the fields,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/solr/solrparams/addparam.xml
+++ b/reference/solr/solrparams/addparam.xml
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a SolrParam object on success and &false; on failure.
+   Returns a SolrParam object,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/solr/solrparams/tostring.xml
+++ b/reference/solr/solrparams/tostring.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
- Returns a string on success and &false; on failure.
+ Returns a string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/spl/arrayobject/uasort.xml
+++ b/reference/spl/arrayobject/uasort.xml
@@ -32,10 +32,7 @@
       <para>
        Function <parameter>callback</parameter> should accept two
        parameters which will be filled by pairs of entries.
-       The comparison function must return an integer less than, equal
-       to, or greater than zero if the first argument is considered to
-       be respectively less than, equal to, or greater than the
-       second.
+       &return.callbacksort;
       </para>
      </listitem>
     </varlistentry>

--- a/reference/spl/arrayobject/uksort.xml
+++ b/reference/spl/arrayobject/uksort.xml
@@ -30,10 +30,7 @@
       <para>
        Function <parameter>callback</parameter> should accept two
        parameters which will be filled by pairs of entry keys.
-       The comparison function must return an integer less than, equal
-       to, or greater than zero if the first argument is considered to
-       be respectively less than, equal to, or greater than the
-       second.
+       &return.callbacksort;
       </para>
      </listitem>
     </varlistentry>

--- a/reference/spl/directoryiterator/key.xml
+++ b/reference/spl/directoryiterator/key.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The key for the current <classname>DirectoryIterator</classname> item on success, or &false; on failure.
+   The key for the current <classname>DirectoryIterator</classname> item,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/spl/splfileinfo/getatime.xml
+++ b/reference/spl/splfileinfo/getatime.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the time the file was last accessed on success, or &false; on failure.
+   Returns the time the file was last accessed,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/spl/splfileinfo/getctime.xml
+++ b/reference/spl/splfileinfo/getctime.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The last change time, in a Unix timestamp on success, or &false; on failure.
+   The last change time, in a Unix timestamp,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/spl/splfileinfo/getgroup.xml
+++ b/reference/spl/splfileinfo/getgroup.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The group id in numerical format on success, or &false; on failure.
+   The group id in numerical format,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/spl/splfileinfo/getinode.xml
+++ b/reference/spl/splfileinfo/getinode.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the inode number for the filesystem object on success, or &false; on failure.
+   Returns the inode number for the filesystem object,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/spl/splfileinfo/getlinktarget.xml
+++ b/reference/spl/splfileinfo/getlinktarget.xml
@@ -31,7 +31,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the target of the filesystem link on success, or &false; on failure.
+   Returns the target of the filesystem link,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/spl/splfileinfo/getmtime.xml
+++ b/reference/spl/splfileinfo/getmtime.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the last modified time for the file, in a Unix timestamp on success, or &false; on failure.
+   Returns the last modified time for the file, in a Unix timestamp,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/spl/splfileinfo/getowner.xml
+++ b/reference/spl/splfileinfo/getowner.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The owner id in numerical format on success, or &false; on failure.
+   The owner id in numerical format,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/spl/splfileinfo/getperms.xml
+++ b/reference/spl/splfileinfo/getperms.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the file permissions on success, or &false; on failure.
+   Returns the file permissions,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/spl/splfileinfo/getsize.xml
+++ b/reference/spl/splfileinfo/getsize.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The filesize in bytes on success, or &false; on failure.
+   The filesize in bytes,&return.falseforfailure;
   </para>
  </refsect1>
  

--- a/reference/spl/splfileobject/fgetcsv.xml
+++ b/reference/spl/splfileobject/fgetcsv.xml
@@ -74,7 +74,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an indexed array containing the fields read, or &false; on error.
+   Returns an indexed array containing the fields read,&return.falseforfailure;
   </para>
   <note>
    <para>

--- a/reference/spl/splfileobject/fgets.xml
+++ b/reference/spl/splfileobject/fgets.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a string containing the next line from the file, or &false; on error.
+   Returns a string containing the next line from the file,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/spl/splfileobject/fgetss.xml
+++ b/reference/spl/splfileobject/fgetss.xml
@@ -47,7 +47,7 @@
   &reftitle.returnvalues;
   <para>
    Returns a string containing the next line of the file with HTML and PHP
-   code stripped, or &false; on error.
+   code stripped,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/spl/splfileobject/ftell.xml
+++ b/reference/spl/splfileobject/ftell.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    Returns the position of the file pointer as an integer, or &false; on error.
+    Returns the position of the file pointer as an integer,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/spl/splfileobject/fwrite.xml
+++ b/reference/spl/splfileobject/fwrite.xml
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the number of bytes written, or &false; on error.
+   Returns the number of bytes written,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/sqlite3/sqlite3/busyTimeout.xml
+++ b/reference/sqlite3/sqlite3/busyTimeout.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on success, &return.falseforfailure;.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/sqlite3/sqlite3/createaggregate.xml
+++ b/reference/sqlite3/sqlite3/createaggregate.xml
@@ -149,7 +149,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; upon successful creation of the aggregate, &return.falseforfailure;.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/sqlite3/sqlite3/createfunction.xml
+++ b/reference/sqlite3/sqlite3/createfunction.xml
@@ -97,7 +97,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; upon successful creation of the function, &false; on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/sqlite3/sqlite3/exec.xml
+++ b/reference/sqlite3/sqlite3/exec.xml
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; if the query succeeded, &false; on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/sqlite3/sqlite3/loadextension.xml
+++ b/reference/sqlite3/sqlite3/loadextension.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; if the extension is successfully loaded, &false; on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/sqlite3/sqlite3result/reset.xml
+++ b/reference/sqlite3/sqlite3result/reset.xml
@@ -26,8 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; if the result set is successfully reset
-   back to the first row, &false; on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/sqlite3/sqlite3stmt/bindparam.xml
+++ b/reference/sqlite3/sqlite3stmt/bindparam.xml
@@ -119,8 +119,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; if the parameter is bound to the statement variable, &false;
-   on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/sqlite3/sqlite3stmt/clear.xml
+++ b/reference/sqlite3/sqlite3stmt/clear.xml
@@ -35,8 +35,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; on successful clearing of bound parameters, &false; on
-   failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/sqlite3/sqlite3stmt/execute.xml
+++ b/reference/sqlite3/sqlite3stmt/execute.xml
@@ -36,7 +36,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an <classname>SQLite3Result</classname> object on successful execution of the prepared
-   statement, &false; on failure.
+   statement,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/sqlite3/sqlite3stmt/reset.xml
+++ b/reference/sqlite3/sqlite3stmt/reset.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; if the statement is successfully reset, &return.falseforfailure;.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/ssh2/functions/ssh2-connect.xml
+++ b/reference/ssh2/functions/ssh2-connect.xml
@@ -249,7 +249,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a resource on success, or &false; on error.
+   Returns a resource,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/stream/functions/stream-socket-pair.xml
+++ b/reference/stream/functions/stream-socket-pair.xml
@@ -74,8 +74,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an <type>array</type> with the two socket resources on success, or
-   &false; on failure.
+   Returns an <type>array</type> with the two socket resources,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/stream/functions/stream-socket-server.xml
+++ b/reference/stream/functions/stream-socket-server.xml
@@ -106,7 +106,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the created stream, or &false; on error.
+   Returns the created stream,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/stream/php_user_filter/oncreate.xml
+++ b/reference/stream/php_user_filter/oncreate.xml
@@ -73,8 +73,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Your implementation of
-   this method should return &false; on failure, or &true; on success.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/strings/functions/md5-file.xml
+++ b/reference/strings/functions/md5-file.xml
@@ -50,7 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a string on success, &false; otherwise.
+   Returns the digest as a string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/strings/functions/sha1-file.xml
+++ b/reference/strings/functions/sha1-file.xml
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a string on success, &false; otherwise.
+   Returns a string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/svn/functions/svn-cat.xml
+++ b/reference/svn/functions/svn-cat.xml
@@ -48,8 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the string contents of the item from the repository on
-   success, and &false; on failure.
+   Returns the string contents of the item from the repository,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/svn/functions/svn-update.xml
+++ b/reference/svn/functions/svn-update.xml
@@ -57,7 +57,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns new revision number on success, returns &false; on failure.
+   Returns new revision number,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/swoole/swoole/connection/iterator/offsetexists.xml
+++ b/reference/swoole/swoole/connection/iterator/offsetexists.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns TRUE if the offset exists, otherwise FALSE.
+   Returns &true; if the offset exists, otherwise FALSE.
   </para>
  </refsect1>
 

--- a/reference/swoole/swoole/connection/iterator/valid.xml
+++ b/reference/swoole/swoole/connection/iterator/valid.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns TRUE if the current iterator position is valid, otherwise FALSE.
+   Returns &true; if the current iterator position is valid, otherwise FALSE.
   </para>
  </refsect1>
 

--- a/reference/taint/functions/is-tainted.xml
+++ b/reference/taint/functions/is-tainted.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE if the string is tainted, FALSE otherwise.
+   Return &true; if the string is tainted, &false; otherwise.
   </para>
  </refsect1>
 

--- a/reference/taint/functions/taint.xml
+++ b/reference/taint/functions/taint.xml
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-      Return TRUE if the transformation is done. Always return TRUE if the taint
+      Return &true; if the transformation is done. Always return &true; if the taint
       extension is not enabled.    
   </para>
  </refsect1>

--- a/reference/trader/functions/trader-acos.xml
+++ b/reference/trader/functions/trader-acos.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ad.xml
+++ b/reference/trader/functions/trader-ad.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-add.xml
+++ b/reference/trader/functions/trader-add.xml
@@ -44,7 +44,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-adosc.xml
+++ b/reference/trader/functions/trader-adosc.xml
@@ -79,7 +79,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-adx.xml
+++ b/reference/trader/functions/trader-adx.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-adxr.xml
+++ b/reference/trader/functions/trader-adxr.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-apo.xml
+++ b/reference/trader/functions/trader-apo.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-aroon.xml
+++ b/reference/trader/functions/trader-aroon.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-aroonosc.xml
+++ b/reference/trader/functions/trader-aroonosc.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-asin.xml
+++ b/reference/trader/functions/trader-asin.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-atan.xml
+++ b/reference/trader/functions/trader-atan.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-atr.xml
+++ b/reference/trader/functions/trader-atr.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-avgprice.xml
+++ b/reference/trader/functions/trader-avgprice.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-bbands.xml
+++ b/reference/trader/functions/trader-bbands.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-beta.xml
+++ b/reference/trader/functions/trader-beta.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-bop.xml
+++ b/reference/trader/functions/trader-bop.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cci.xml
+++ b/reference/trader/functions/trader-cci.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdl2crows.xml
+++ b/reference/trader/functions/trader-cdl2crows.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdl3blackcrows.xml
+++ b/reference/trader/functions/trader-cdl3blackcrows.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdl3inside.xml
+++ b/reference/trader/functions/trader-cdl3inside.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdl3linestrike.xml
+++ b/reference/trader/functions/trader-cdl3linestrike.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdl3outside.xml
+++ b/reference/trader/functions/trader-cdl3outside.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdl3starsinsouth.xml
+++ b/reference/trader/functions/trader-cdl3starsinsouth.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdl3whitesoldiers.xml
+++ b/reference/trader/functions/trader-cdl3whitesoldiers.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlabandonedbaby.xml
+++ b/reference/trader/functions/trader-cdlabandonedbaby.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdladvanceblock.xml
+++ b/reference/trader/functions/trader-cdladvanceblock.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlbelthold.xml
+++ b/reference/trader/functions/trader-cdlbelthold.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlbreakaway.xml
+++ b/reference/trader/functions/trader-cdlbreakaway.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlclosingmarubozu.xml
+++ b/reference/trader/functions/trader-cdlclosingmarubozu.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlconcealbabyswall.xml
+++ b/reference/trader/functions/trader-cdlconcealbabyswall.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlcounterattack.xml
+++ b/reference/trader/functions/trader-cdlcounterattack.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdldarkcloudcover.xml
+++ b/reference/trader/functions/trader-cdldarkcloudcover.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdldoji.xml
+++ b/reference/trader/functions/trader-cdldoji.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdldojistar.xml
+++ b/reference/trader/functions/trader-cdldojistar.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdldragonflydoji.xml
+++ b/reference/trader/functions/trader-cdldragonflydoji.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlengulfing.xml
+++ b/reference/trader/functions/trader-cdlengulfing.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdleveningdojistar.xml
+++ b/reference/trader/functions/trader-cdleveningdojistar.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdleveningstar.xml
+++ b/reference/trader/functions/trader-cdleveningstar.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlgapsidesidewhite.xml
+++ b/reference/trader/functions/trader-cdlgapsidesidewhite.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlgravestonedoji.xml
+++ b/reference/trader/functions/trader-cdlgravestonedoji.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlhammer.xml
+++ b/reference/trader/functions/trader-cdlhammer.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlhangingman.xml
+++ b/reference/trader/functions/trader-cdlhangingman.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlharami.xml
+++ b/reference/trader/functions/trader-cdlharami.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlharamicross.xml
+++ b/reference/trader/functions/trader-cdlharamicross.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlhighwave.xml
+++ b/reference/trader/functions/trader-cdlhighwave.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlhikkake.xml
+++ b/reference/trader/functions/trader-cdlhikkake.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlhikkakemod.xml
+++ b/reference/trader/functions/trader-cdlhikkakemod.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlhomingpigeon.xml
+++ b/reference/trader/functions/trader-cdlhomingpigeon.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlidentical3crows.xml
+++ b/reference/trader/functions/trader-cdlidentical3crows.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlinneck.xml
+++ b/reference/trader/functions/trader-cdlinneck.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlinvertedhammer.xml
+++ b/reference/trader/functions/trader-cdlinvertedhammer.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlkicking.xml
+++ b/reference/trader/functions/trader-cdlkicking.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlkickingbylength.xml
+++ b/reference/trader/functions/trader-cdlkickingbylength.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlladderbottom.xml
+++ b/reference/trader/functions/trader-cdlladderbottom.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdllongleggeddoji.xml
+++ b/reference/trader/functions/trader-cdllongleggeddoji.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdllongline.xml
+++ b/reference/trader/functions/trader-cdllongline.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlmarubozu.xml
+++ b/reference/trader/functions/trader-cdlmarubozu.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlmatchinglow.xml
+++ b/reference/trader/functions/trader-cdlmatchinglow.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlmathold.xml
+++ b/reference/trader/functions/trader-cdlmathold.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlmorningdojistar.xml
+++ b/reference/trader/functions/trader-cdlmorningdojistar.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlmorningstar.xml
+++ b/reference/trader/functions/trader-cdlmorningstar.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlonneck.xml
+++ b/reference/trader/functions/trader-cdlonneck.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlpiercing.xml
+++ b/reference/trader/functions/trader-cdlpiercing.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlrickshawman.xml
+++ b/reference/trader/functions/trader-cdlrickshawman.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlrisefall3methods.xml
+++ b/reference/trader/functions/trader-cdlrisefall3methods.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlseparatinglines.xml
+++ b/reference/trader/functions/trader-cdlseparatinglines.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlshootingstar.xml
+++ b/reference/trader/functions/trader-cdlshootingstar.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlshortline.xml
+++ b/reference/trader/functions/trader-cdlshortline.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlspinningtop.xml
+++ b/reference/trader/functions/trader-cdlspinningtop.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlstalledpattern.xml
+++ b/reference/trader/functions/trader-cdlstalledpattern.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlsticksandwich.xml
+++ b/reference/trader/functions/trader-cdlsticksandwich.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdltakuri.xml
+++ b/reference/trader/functions/trader-cdltakuri.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdltasukigap.xml
+++ b/reference/trader/functions/trader-cdltasukigap.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlthrusting.xml
+++ b/reference/trader/functions/trader-cdlthrusting.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdltristar.xml
+++ b/reference/trader/functions/trader-cdltristar.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlunique3river.xml
+++ b/reference/trader/functions/trader-cdlunique3river.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlupsidegap2crows.xml
+++ b/reference/trader/functions/trader-cdlupsidegap2crows.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlxsidegap3methods.xml
+++ b/reference/trader/functions/trader-cdlxsidegap3methods.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ceil.xml
+++ b/reference/trader/functions/trader-ceil.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cmo.xml
+++ b/reference/trader/functions/trader-cmo.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-correl.xml
+++ b/reference/trader/functions/trader-correl.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cos.xml
+++ b/reference/trader/functions/trader-cos.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cosh.xml
+++ b/reference/trader/functions/trader-cosh.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-dema.xml
+++ b/reference/trader/functions/trader-dema.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-div.xml
+++ b/reference/trader/functions/trader-div.xml
@@ -44,7 +44,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-dx.xml
+++ b/reference/trader/functions/trader-dx.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ema.xml
+++ b/reference/trader/functions/trader-ema.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-exp.xml
+++ b/reference/trader/functions/trader-exp.xml
@@ -34,7 +34,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-floor.xml
+++ b/reference/trader/functions/trader-floor.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ht-dcperiod.xml
+++ b/reference/trader/functions/trader-ht-dcperiod.xml
@@ -34,7 +34,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ht-dcphase.xml
+++ b/reference/trader/functions/trader-ht-dcphase.xml
@@ -34,7 +34,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ht-phasor.xml
+++ b/reference/trader/functions/trader-ht-phasor.xml
@@ -34,7 +34,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ht-sine.xml
+++ b/reference/trader/functions/trader-ht-sine.xml
@@ -34,7 +34,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ht-trendline.xml
+++ b/reference/trader/functions/trader-ht-trendline.xml
@@ -34,7 +34,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ht-trendmode.xml
+++ b/reference/trader/functions/trader-ht-trendmode.xml
@@ -34,7 +34,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-kama.xml
+++ b/reference/trader/functions/trader-kama.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-linearreg-angle.xml
+++ b/reference/trader/functions/trader-linearreg-angle.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-linearreg-intercept.xml
+++ b/reference/trader/functions/trader-linearreg-intercept.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-linearreg-slope.xml
+++ b/reference/trader/functions/trader-linearreg-slope.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-linearreg.xml
+++ b/reference/trader/functions/trader-linearreg.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ln.xml
+++ b/reference/trader/functions/trader-ln.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-log10.xml
+++ b/reference/trader/functions/trader-log10.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ma.xml
+++ b/reference/trader/functions/trader-ma.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-macd.xml
+++ b/reference/trader/functions/trader-macd.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-macdext.xml
+++ b/reference/trader/functions/trader-macdext.xml
@@ -88,7 +88,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-macdfix.xml
+++ b/reference/trader/functions/trader-macdfix.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-mama.xml
+++ b/reference/trader/functions/trader-mama.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-mavp.xml
+++ b/reference/trader/functions/trader-mavp.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-max.xml
+++ b/reference/trader/functions/trader-max.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-maxindex.xml
+++ b/reference/trader/functions/trader-maxindex.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-medprice.xml
+++ b/reference/trader/functions/trader-medprice.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-mfi.xml
+++ b/reference/trader/functions/trader-mfi.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-midpoint.xml
+++ b/reference/trader/functions/trader-midpoint.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-midprice.xml
+++ b/reference/trader/functions/trader-midprice.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-min.xml
+++ b/reference/trader/functions/trader-min.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-minindex.xml
+++ b/reference/trader/functions/trader-minindex.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-minmax.xml
+++ b/reference/trader/functions/trader-minmax.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-minmaxindex.xml
+++ b/reference/trader/functions/trader-minmaxindex.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-minus-di.xml
+++ b/reference/trader/functions/trader-minus-di.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-minus-dm.xml
+++ b/reference/trader/functions/trader-minus-dm.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-mom.xml
+++ b/reference/trader/functions/trader-mom.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-mult.xml
+++ b/reference/trader/functions/trader-mult.xml
@@ -44,7 +44,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-natr.xml
+++ b/reference/trader/functions/trader-natr.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-obv.xml
+++ b/reference/trader/functions/trader-obv.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-plus-di.xml
+++ b/reference/trader/functions/trader-plus-di.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-plus-dm.xml
+++ b/reference/trader/functions/trader-plus-dm.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ppo.xml
+++ b/reference/trader/functions/trader-ppo.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-roc.xml
+++ b/reference/trader/functions/trader-roc.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-rocp.xml
+++ b/reference/trader/functions/trader-rocp.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-rocr.xml
+++ b/reference/trader/functions/trader-rocr.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-rocr100.xml
+++ b/reference/trader/functions/trader-rocr100.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-rsi.xml
+++ b/reference/trader/functions/trader-rsi.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-sar.xml
+++ b/reference/trader/functions/trader-sar.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-sarext.xml
+++ b/reference/trader/functions/trader-sarext.xml
@@ -115,7 +115,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-sin.xml
+++ b/reference/trader/functions/trader-sin.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-sinh.xml
+++ b/reference/trader/functions/trader-sinh.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-sma.xml
+++ b/reference/trader/functions/trader-sma.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-sqrt.xml
+++ b/reference/trader/functions/trader-sqrt.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-stddev.xml
+++ b/reference/trader/functions/trader-stddev.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-stoch.xml
+++ b/reference/trader/functions/trader-stoch.xml
@@ -97,7 +97,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-stochf.xml
+++ b/reference/trader/functions/trader-stochf.xml
@@ -79,7 +79,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-stochrsi.xml
+++ b/reference/trader/functions/trader-stochrsi.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-sub.xml
+++ b/reference/trader/functions/trader-sub.xml
@@ -44,7 +44,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-sum.xml
+++ b/reference/trader/functions/trader-sum.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-t3.xml
+++ b/reference/trader/functions/trader-t3.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-tan.xml
+++ b/reference/trader/functions/trader-tan.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-tanh.xml
+++ b/reference/trader/functions/trader-tanh.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-tema.xml
+++ b/reference/trader/functions/trader-tema.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-trange.xml
+++ b/reference/trader/functions/trader-trange.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-trima.xml
+++ b/reference/trader/functions/trader-trima.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-trix.xml
+++ b/reference/trader/functions/trader-trix.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-tsf.xml
+++ b/reference/trader/functions/trader-tsf.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-typprice.xml
+++ b/reference/trader/functions/trader-typprice.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ultosc.xml
+++ b/reference/trader/functions/trader-ultosc.xml
@@ -79,7 +79,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-var.xml
+++ b/reference/trader/functions/trader-var.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-wclprice.xml
+++ b/reference/trader/functions/trader-wclprice.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-willr.xml
+++ b/reference/trader/functions/trader-willr.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-wma.xml
+++ b/reference/trader/functions/trader-wma.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data,&return.falseforfailure;</para>
  </refsect1>
 
 

--- a/reference/uodbc/functions/odbc-exec.xml
+++ b/reference/uodbc/functions/odbc-exec.xml
@@ -40,8 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an ODBC result identifier if the SQL command was executed
-   successfully, or &false; on error.
+   Returns an ODBC result identifier if the SQL command,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="changelog">

--- a/reference/uodbc/functions/odbc-fetch-into.xml
+++ b/reference/uodbc/functions/odbc-fetch-into.xml
@@ -57,8 +57,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the number of columns in the result;
-   &false; on error.
+   Returns the number of columns in the result,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/uodbc/functions/odbc-field-len.xml
+++ b/reference/uodbc/functions/odbc-field-len.xml
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the field length, or &false; on error.
+   Returns the field length,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="seealso">

--- a/reference/uodbc/functions/odbc-field-name.xml
+++ b/reference/uodbc/functions/odbc-field-name.xml
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the field name as a string, or &false; on error.
+   Returns the field name as a string,&return.falseforfailure;
   </para>
  </refsect1>
 </refentry>

--- a/reference/uodbc/functions/odbc-field-num.xml
+++ b/reference/uodbc/functions/odbc-field-num.xml
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the field number as a integer, or &false; on error.
+   Returns the field number as a integer,&return.falseforfailure;.
    Field numbering starts at 1.
   </para>
  </refsect1>

--- a/reference/uodbc/functions/odbc-field-scale.xml
+++ b/reference/uodbc/functions/odbc-field-scale.xml
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the field scale as a integer, or &false; on error.
+   Returns the field scale as a integer,&return.falseforfailure;
   </para>
  </refsect1>
 </refentry>

--- a/reference/uodbc/functions/odbc-field-type.xml
+++ b/reference/uodbc/functions/odbc-field-type.xml
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the field type as a string, or &false; on error.
+   Returns the field type as a string,&return.falseforfailure;
   </para>
  </refsect1>
 </refentry>

--- a/reference/uodbc/functions/odbc-gettypeinfo.xml
+++ b/reference/uodbc/functions/odbc-gettypeinfo.xml
@@ -44,8 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an ODBC result identifier or
-   &false; on failure.
+   Returns an ODBC result identifier,&return.falseforfailure;
   </para>
   <para>
    The result set has the following columns:

--- a/reference/uodbc/functions/odbc-prepare.xml
+++ b/reference/uodbc/functions/odbc-prepare.xml
@@ -51,7 +51,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an ODBC result identifier if the SQL command was prepared
-   successfully. Returns &false; on error.
+   successfully,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/uodbc/functions/odbc-result-all.xml
+++ b/reference/uodbc/functions/odbc-result-all.xml
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the number of rows in the result or &false; on error.
+   Returns the number of rows in the result,&return.falseforfailure;
   </para>
  </refsect1>
 </refentry>

--- a/reference/uodbc/functions/odbc-specialcolumns.xml
+++ b/reference/uodbc/functions/odbc-specialcolumns.xml
@@ -101,8 +101,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an ODBC result identifier or &false; on
-   failure.
+   Returns an ODBC result identifier,&return.falseforfailure;
   </para>
   <para>
    The result set has the following columns:

--- a/reference/url/functions/get-headers.xml
+++ b/reference/url/functions/get-headers.xml
@@ -58,8 +58,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an indexed or associative array with the headers, or &false; on
-   failure.
+   Returns an indexed or associative array with the headers,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/wddx/functions/wddx-packet-start.xml
+++ b/reference/wddx/functions/wddx-packet-start.xml
@@ -42,7 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a packet ID for use in later functions, or &false; on error.
+   Returns a packet ID for use in later functions,&return.falseforfailure;
   </para>
  </refsect1>
 </refentry>

--- a/reference/wddx/functions/wddx-serialize-value.xml
+++ b/reference/wddx/functions/wddx-serialize-value.xml
@@ -49,7 +49,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the WDDX packet, or &false; on error.
+   Returns the WDDX packet,&return.falseforfailure;
   </para>
  </refsect1>
 </refentry>

--- a/reference/wddx/functions/wddx-serialize-vars.xml
+++ b/reference/wddx/functions/wddx-serialize-vars.xml
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the WDDX packet, or &false; on error.
+   Returns the WDDX packet,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/wincache/functions/wincache-ucache-dec.xml
+++ b/reference/wincache/functions/wincache-ucache-dec.xml
@@ -58,7 +58,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Returns the decremented value on success and &false; on failure.
+   Returns the decremented value,&return.falseforfailure;
   </simpara>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/wincache/functions/wincache-ucache-inc.xml
+++ b/reference/wincache/functions/wincache-ucache-inc.xml
@@ -58,7 +58,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Returns the incremented value on success and &false; on failure.
+   Returns the incremented value,&return.falseforfailure;
   </simpara>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/xdiff/functions/xdiff-string-bpatch.xml
+++ b/reference/xdiff/functions/xdiff-string-bpatch.xml
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the patched string, or &false; on error.
+   Returns the patched string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/xdiff/functions/xdiff-string-patch-binary.xml
+++ b/reference/xdiff/functions/xdiff-string-patch-binary.xml
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the patched string, or &false; on error.
+   Returns the patched string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/xdiff/functions/xdiff-string-patch.xml
+++ b/reference/xdiff/functions/xdiff-string-patch.xml
@@ -76,7 +76,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the patched string, or &false; on error.
+   Returns the patched string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/xmlreader/xmlreader/expand.xml
+++ b/reference/xmlreader/xmlreader/expand.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The resulting <classname>DOMNode</classname> or &false; on error.
+   The resulting <classname>DOMNode</classname>,&return.falseforfailure;
   </para>
  </refsect1> 
 

--- a/reference/xsl/xsltprocessor/transformtodoc.xml
+++ b/reference/xsl/xsltprocessor/transformtodoc.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The resulting <classname>DOMDocument</classname> or &false; on error.
+   The resulting <classname>DOMDocument</classname>,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/xsl/xsltprocessor/transformtoxml.xml
+++ b/reference/xsl/xsltprocessor/transformtoxml.xml
@@ -35,7 +35,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The result of the transformation as a string or &false; on error.
+   The result of the transformation as a string,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/yac/yac/add.xml
+++ b/reference/yac/yac/add.xml
@@ -57,7 +57,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &boolean;, &true; on success, &false; on failure 
+   &return.success; 
    <note>
     <para>
      <methodname>Yac::add</methodname> may fail if cas lock could not obtain,

--- a/reference/yac/yac/get.xml
+++ b/reference/yac/yac/get.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   mixed on success, false on failure
+   mixed,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_request_http/getraw.xml
+++ b/reference/yaf/yaf_request_http/getraw.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return string on success, FALSE on failure.
+   Return string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/yaml/functions/yaml-emit-file.xml
+++ b/reference/yaml/functions/yaml-emit-file.xml
@@ -86,7 +86,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-  Returns &true; on success.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/yaz/functions/yaz-connect.xml
+++ b/reference/yaz/functions/yaz-connect.xml
@@ -187,7 +187,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   A connection resource on success, &false; on error.
+   A connection resource,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-read.xml
+++ b/reference/zip/functions/zip-entry-read.xml
@@ -53,7 +53,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the data read, empty string on end of a file, or &false; on error.
+   Returns the data read, empty string on end of a file,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/zlib/functions/gzgets.xml
+++ b/reference/zlib/functions/gzgets.xml
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The uncompressed string, or &false; on error.
+   The uncompressed string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/zlib/functions/gzgetss.xml
+++ b/reference/zlib/functions/gzgetss.xml
@@ -62,7 +62,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The uncompressed and stripped string, or &false; on error.
+   The uncompressed and stripped string,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/zlib/functions/gzinflate.xml
+++ b/reference/zlib/functions/gzinflate.xml
@@ -42,7 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The original uncompressed data or &false; on error.
+   The original uncompressed data,&return.falseforfailure;
   </para>
   <para>
    The function will return an error if the uncompressed data is more than

--- a/reference/zlib/functions/gzpassthru.xml
+++ b/reference/zlib/functions/gzpassthru.xml
@@ -53,7 +53,7 @@
   &reftitle.returnvalues;
   <para>
    The number of uncompressed characters read from <parameter>gz</parameter>
-   and passed through to the input, or &false; on error.
+   and passed through to the input,&return.falseforfailure;
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/zlib/functions/gzuncompress.xml
+++ b/reference/zlib/functions/gzuncompress.xml
@@ -42,7 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The original uncompressed data or &false; on error.
+   The original uncompressed data,&return.falseforfailure;
   </para>
   <para>
    The function will return an error if the uncompressed data is more than

--- a/reference/zlib/functions/zlib-encode.xml
+++ b/reference/zlib/functions/zlib-encode.xml
@@ -57,7 +57,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-
+   The compressed byte sequence as a string,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/create.xml
+++ b/reference/zookeeper/zookeeper/create.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the path of the new node (this might be different than the supplied path because of the ZOO_SEQUENCE flag) on success, and false on failure.
+   Returns the path of the new node (this might be different than the supplied path because of the ZOO_SEQUENCE flag),&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/get.xml
+++ b/reference/zookeeper/zookeeper/get.xml
@@ -60,7 +60,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the data on success, and false on failure.
+   Returns the data,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/getacl.xml
+++ b/reference/zookeeper/zookeeper/getacl.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return acl array on success and false on failure.
+   Return acl array,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/getchildren.xml
+++ b/reference/zookeeper/zookeeper/getchildren.xml
@@ -42,7 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an array with children paths on success, and false on failure.
+   Returns an array with children paths,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/getclientid.xml
+++ b/reference/zookeeper/zookeeper/getclientid.xml
@@ -24,7 +24,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the client session id on success, and false on failure.
+   Returns the client session id,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/getrecvtimeout.xml
+++ b/reference/zookeeper/zookeeper/getrecvtimeout.xml
@@ -24,7 +24,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the timeout for this session on success, and false on failure.
+   Returns the timeout for this session,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/getstate.xml
+++ b/reference/zookeeper/zookeeper/getstate.xml
@@ -24,7 +24,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the state of zookeeper connection on success, and false on failure.
+   Returns the state of zookeeper connection,&return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/isrecoverable.xml
+++ b/reference/zookeeper/zookeeper/isrecoverable.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   Returns true/false on success, and false on failure.
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/isrecoverable.xml
+++ b/reference/zookeeper/zookeeper/isrecoverable.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns true/false on success, and false on failure.
+   &return.success;
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeperconfig/get.xml
+++ b/reference/zookeeper/zookeeperconfig/get.xml
@@ -42,7 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the configuration string on success, and false on failure.
+   Returns the configuration string,&return.falseforfailure;
   </para>
  </refsect1>
 


### PR DESCRIPTION
This PR is not a result of some automatic find and replace. I have manually reviewed hundreds of files to make these changes.

My mission is to review every function return value which is dicsussing `true` and `false` values and to harmonize language used when there is a good reason to do so.

Reference below is made to some template entities, these are defined in https://github.com/php/doc-en/blob/de9c65c91ff1710d8b2d2ec955caea0162679305/language-snippets.ent

## Standardize success boolean text

```perl
/(<function>[a-z_]+</function>\W*)?return.*TRUE.*success.*FALSE.*failure\.?/i
/&boolean;, &true; on success, &false; on failure[.;]*/i
```

* If the return value is describing a bona fide `true`/`false` success boolean, use standardized text
  * :x: Old: `Returns &true; on success, or &false; on failure.`
  * :x: Old: `Return TRUE on record log information success, FALSE on failure.`
  * :white_check_mark: New: `&return.success;`

## Standardize onto `,&return.falseforfailure;`

```perl
/[ \n,;]*(on\W+success)?[ \n,;]*(or|and|returns)?[ \n,;]*&?false;?\W+\w+\W+(failure|errors?).?/i
```

* If this is a single statement, separated from a complicated explanation, do nothing
  * :white_check_mark: Current: (Lots of text, and then...) `Returns &false; on failure.`
* If the return value is describing a bona fide `true`/`false` success boolean, goto "Standardize success boolean text" above
* If this is a simple statement describing an expected return value, add a comma, use `&return.falseforfailure;`, and remove trailing period
  * :x: Old: `Returns the key on success, or &false; upon failure.`
  * :white_check_mark: New: `   Returns the key,&return.falseforfailure;`
  * :x: Old: `The stored variable or array of variables on success; &false; on failure`
  * :white_check_mark: New: `The stored variable or array of variables,&return.falseforfailure;`

* If the return value is flat-out wrong, correct it
  * :x: Old: `   Performs the virtual command on success, or returns &false; on failure.`
  * :white_check_mark: New: `&return.success;`

Note: it could be argued in English that every `,&return.falseforfailure;` should become `;&return.falseforfailure;` but that decision is above my paygrade.

## Format `true` and `false`

ℹ️ This part of the PR is extracted to https://github.com/php/doc-en/pull/862 for faster review and merge.

```perl
/ TRUE | FALSE /
```

And ignore any results inside a `<![CDATA[` section.

* If a true value, use `&true;`
* If a false value, use `&false;`

## Add `&return.falseproblem;` if needed

During manual review, if there is a function which could return `false` and also return zero or similar, then add `&return.falseproblem;`

## Use `&return.nullorfalse;`

```perl
/null\W+on success/i
```

Use `&return.nullorfalse;` if appropriate.

## Use other module-specific template variables as appropriate

Search for the replace-to text of each of the templates in https://github.com/php/doc-en/blob/de9c65c91ff1710d8b2d2ec955caea0162679305/language-snippets.ent to see if using the template entity name is appropriate.

## Scope creep

During my manual review I also:

- Corrected one whitespace issue on a line I was already editing
- Reflowed text on lines I was editing, sometimes
- Added new documentation for return values when the function return value was currently entirely undocumented by reading PHP source and upstream library documentation (two or three of these)