### PR TITLE
Use &true; &false; &null; semantically where appropriate

### DIFF
--- a/appendices/migration80/deprecated.xml
+++ b/appendices/migration80/deprecated.xml
@@ -26,7 +26,7 @@ function test($a, $b) {}      // After
     </para>
     <para>
      One exception to this rule are parameters of the form <code>Type $param = null</code>, where
-     the null default makes the type implicitly nullable. This usage remains allowed, but it is
+     the &null; default makes the type implicitly nullable. This usage remains allowed, but it is
      recommended to use an explicit nullable type instead:
     </para>
     <para>

--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -285,7 +285,7 @@ function test(int $arg = null) {}
       <simplelist>
        <member>
         Attempting to write to a property of a non-object. Previously this
-        implicitly created an stdClass object for null, false and empty strings.
+        implicitly created an stdClass object for &null;, &false; and empty strings.
        </member>
        <member>
         Attempting to append an element to an array for which the PHP_INT_MAX key
@@ -1257,7 +1257,7 @@ $array["key"];
      <methodname>ReflectionMethod::isDestructor</methodname> now also return &true; for
      <link linkend="object.construct">__construct()</link> and
      <link linkend="object.destruct">__destruct()</link> methods of interfaces.
-     Previously, this would only be true for methods of classes and traits.
+     Previously, this would only be &true; for methods of classes and traits.
     </para>
    </listitem>
    <listitem>

--- a/language/generators.xml
+++ b/language/generators.xml
@@ -274,7 +274,7 @@ foreach (input_parser($input) as $id => $fields) {
    </sect3>
 
    <sect3 xml:id="control-structures.yield.null">
-    <title>Yielding null values</title>
+    <title>Yielding &null; values</title>
 
     <para>
      Yield can be called without an argument to yield a &null; value with an

--- a/reference/apcu/functions/apcu-add.xml
+++ b/reference/apcu/functions/apcu-add.xml
@@ -86,7 +86,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns TRUE if something has effectively been added into the cache, FALSE otherwise.
+   Returns &true; if something has effectively been added into the cache, &false; otherwise.
    Second syntax returns array with error keys.
   </para>
  </refsect1>

--- a/reference/componere/componere/definition/isregistered.xml
+++ b/reference/componere/componere/definition/isregistered.xml
@@ -21,7 +21,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Shall return true if this Definition is registered
+   Shall return &true; if this Definition is registered
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-errno.xml
+++ b/reference/cubrid/cubridmysql/cubrid-errno.xml
@@ -19,7 +19,7 @@
   <para>
    The <function>cubrid_errno</function> function is used to get the
    error code of the error that occurred during the API execution.  Usually,
-   it gets the error code when API returns false as its return value.
+   it gets the error code when API returns &false;.
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-fetch-assoc.xml
+++ b/reference/cubrid/cubridmysql/cubrid-fetch-assoc.xml
@@ -17,7 +17,7 @@
   <para>
     This function returns the associative array, that corresponds to the
     fetched row, and then moves the internal data pointer ahead, or returns
-    FALSE when the end is reached.
+    &false; when the end is reached.
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-fetch-lengths.xml
+++ b/reference/cubrid/cubridmysql/cubrid-fetch-lengths.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
     This function returns an numeric array with the lengths of the values of
-    each field from the current row of the result set or it returns FALSE on
+    each field from the current row of the result set or it returns &false; on
     failure.
   </para>
   <note>

--- a/reference/cubrid/cubridmysql/cubrid-field-len.xml
+++ b/reference/cubrid/cubridmysql/cubrid-field-len.xml
@@ -15,7 +15,7 @@
    <methodparam><type>int</type><parameter>field_offset</parameter></methodparam>
   </methodsynopsis>
   <para>
-    This function returns the maximum length of the specified field on success, or it returns FALSE on failure.
+    This function returns the maximum length of the specified field on success, or it returns &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-field-name.xml
+++ b/reference/cubrid/cubridmysql/cubrid-field-name.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
     This function returns the name of the specified field index on success or
-    it returns FALSE on failure.
+    it returns &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-field-seek.xml
+++ b/reference/cubrid/cubridmysql/cubrid-field-seek.xml
@@ -17,7 +17,7 @@
   <para>
     This function moves the result set cursor to the specified field offset.
     This offset is used by <function>cubrid_fetch_field</function> if it
-    doesn't include a field offset. It returns TRUE on success or FALSE on
+    doesn't include a field offset. It returns &true; on success or &false; on
     failure.
   </para>
  </refsect1>

--- a/reference/cubrid/cubridmysql/cubrid-num-fields.xml
+++ b/reference/cubrid/cubridmysql/cubrid-num-fields.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
     This function returns the number of columns in the result set, on success,
-    or it returns FALSE on failure.
+    or it returns &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/cubrid/functions/cubrid-error-code-facility.xml
+++ b/reference/cubrid/functions/cubrid-error-code-facility.xml
@@ -17,7 +17,7 @@
     The <function>cubrid_error_code_facility</function> function is used to
     get the facility code (level in which the error occurred) from the error
     code of the error that occurred during the API execution. Usually, you can
-    get the error code when API returns false as its return value.
+    get the error code when API returns &false; as its return value.
   </para>
  </refsect1>
 

--- a/reference/cubrid/functions/cubrid-error-code.xml
+++ b/reference/cubrid/functions/cubrid-error-code.xml
@@ -16,7 +16,7 @@
   <para>
     The <function>cubrid_error_code</function> function is used to get the
     error code of the error that occurred during the API execution. Usually,
-    it gets the error code when API returns false as its return value.
+    it gets the error code when API returns &false; as its return value.
   </para>
  </refsect1>
 

--- a/reference/cubrid/functions/cubrid-insert-id.xml
+++ b/reference/cubrid/functions/cubrid-insert-id.xml
@@ -17,7 +17,7 @@
    The <function>cubrid_insert_id</function> function retrieves the ID
    generated for the AUTO_INCREMENT column which is updated by the previous
    INSERT query. It returns 0 if the previous query does not generate new
-   rows, or FALSE on failure. 
+   rows, or &false; on failure. 
   </para>
 
   <note>

--- a/reference/dom/domdocumenttype.xml
+++ b/reference/dom/domdocumenttype.xml
@@ -146,7 +146,7 @@
      <term><varname>internalSubset</varname></term>
      <listitem>
       <para>
-       The internal subset as a string, or null if there is none. This
+       The internal subset as a string, or &null; if there is none. This
        does not contain the delimiting square brackets.
       </para>
      </listitem>

--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -135,7 +135,7 @@
    </term>
    <listitem>
     <simpara>
-     Use NULL instead of FALSE on failure.
+     Use NULL instead of &false; on failure.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/gmp/functions/gmp-setbit.xml
+++ b/reference/gmp/functions/gmp-setbit.xml
@@ -44,7 +44,7 @@
      <term><parameter>value</parameter></term>
      <listitem>
       <para>
-       True to set the bit (set it to 1/on); false to clear the bit (set it to 0/off).
+       &true; to set the bit (set it to 1/on); &false; to clear the bit (set it to 0/off).
       </para>
      </listitem>
     </varlistentry>

--- a/reference/hash/functions/hash-file.xml
+++ b/reference/hash/functions/hash-file.xml
@@ -53,7 +53,7 @@
   &reftitle.returnvalues;
   <para>
    Returns a string containing the calculated message digest as lowercase hexits
-   unless <parameter>binary</parameter> is set to true in which case the raw
+   unless <parameter>binary</parameter> is set to &true; in which case the raw
    binary representation of the message digest is returned.
   </para>
  </refsect1>

--- a/reference/hash/functions/hash-final.xml
+++ b/reference/hash/functions/hash-final.xml
@@ -43,7 +43,7 @@
   &reftitle.returnvalues;
   <para>
    Returns a string containing the calculated message digest as lowercase hexits
-   unless <parameter>binary</parameter> is set to true in which case the raw
+   unless <parameter>binary</parameter> is set to &true; in which case the raw
    binary representation of the message digest is returned.
   </para>
  </refsect1>

--- a/reference/hash/functions/hash-hmac-file.xml
+++ b/reference/hash/functions/hash-hmac-file.xml
@@ -61,7 +61,7 @@
   &reftitle.returnvalues;
   <para>
    Returns a string containing the calculated message digest as lowercase hexits
-   unless <parameter>binary</parameter> is set to true in which case the raw
+   unless <parameter>binary</parameter> is set to &true; in which case the raw
    binary representation of the message digest is returned.
    Returns &false; when <parameter>algo</parameter> is unknown or is a
    non-cryptographic hash function, or if the file

--- a/reference/hash/functions/hash-hmac.xml
+++ b/reference/hash/functions/hash-hmac.xml
@@ -61,7 +61,7 @@
   &reftitle.returnvalues;
   <para>
    Returns a string containing the calculated message digest as lowercase hexits
-   unless <parameter>binary</parameter> is set to true in which case the raw
+   unless <parameter>binary</parameter> is set to &true; in which case the raw
    binary representation of the message digest is returned.
    Returns &false; when <parameter>algo</parameter> is unknown or is a
    non-cryptographic hash function.

--- a/reference/hash/functions/hash.xml
+++ b/reference/hash/functions/hash.xml
@@ -52,7 +52,7 @@
   &reftitle.returnvalues;
   <para>
    Returns a string containing the calculated message digest as lowercase hexits
-   unless <parameter>binary</parameter> is set to true in which case the raw
+   unless <parameter>binary</parameter> is set to &true; in which case the raw
    binary representation of the message digest is returned.
   </para>
  </refsect1>

--- a/reference/ibm_db2/ini.xml
+++ b/reference/ibm_db2/ini.xml
@@ -212,7 +212,7 @@
       is only for simple DB2 based websites that never require profile switching 
       and therefore can avoid all overhead of server mode additional QSQSRVR jobs. 
       This is a convenience override of db2_(p)connect to set the userid and password 
-      values to null without PHP source code changes. This override can be used in 
+      values to &null; without PHP source code changes. This override can be used in 
       combination with <parameter>ibm_db2.i5_all_pconnect</parameter> = 1.
       <itemizedlist>
        <listitem>

--- a/reference/imagick/imagick/getimageproperty.xml
+++ b/reference/imagick/imagick/getimageproperty.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a string containing the image property, false if a
+   Returns a string containing the image property, &false; if a
    property with the given name does not exist.
   </para>
  </refsect1>

--- a/reference/imagick/imagick/getregistry.xml
+++ b/reference/imagick/imagick/getregistry.xml
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Get the StringRegistry entry for the named key or false if not set.
+   Get the StringRegistry entry for the named key or &false; if not set.
   </para>
 
  </refsect1>

--- a/reference/imagick/imagick/setimagematte.xml
+++ b/reference/imagick/imagick/setimagematte.xml
@@ -27,7 +27,7 @@
      <term><parameter>matte</parameter></term>
      <listitem>
       <para>
-       True activates the matte channel and false disables it.
+       &true; activates the matte channel and &false; disables it.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/imagick/imagick/setprogressmonitor.xml
+++ b/reference/imagick/imagick/setprogressmonitor.xml
@@ -28,7 +28,7 @@
     <term><parameter>callback</parameter></term>
     <listitem>
      <para>
-      The progress function to call. It should return true if image processing should continue, or false if it should be cancelled. The offset parameter indicates the progress and the span parameter indicates the total amount of work needed to be done.
+      The progress function to call. It should return &true; if image processing should continue, or &false; if it should be cancelled. The offset parameter indicates the progress and the span parameter indicates the total amount of work needed to be done.
      </para>
      
      <methodsynopsis xmlns="http://docbook.org/ns/docbook">

--- a/reference/imagick/imagick/sigmoidalcontrastimage.xml
+++ b/reference/imagick/imagick/sigmoidalcontrastimage.xml
@@ -38,7 +38,7 @@
      <term><parameter>sharpen</parameter></term>
      <listitem>
       <para>
-       If true increase the contrast, if false decrease the contrast.
+       If &true; increase the contrast, if &false; decrease the contrast.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/imagick/imagickdraw/getclippath.xml
+++ b/reference/imagick/imagickdraw/getclippath.xml
@@ -21,7 +21,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a string containing the clip path ID or false if no clip path exists.
+   Returns a string containing the clip path ID or &false; if no clip path exists.
   </para>
  </refsect1>
 

--- a/reference/imagick/imagickdraw/getfont.xml
+++ b/reference/imagick/imagickdraw/getfont.xml
@@ -21,7 +21,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a string on success and false if no font is set.
+   Returns a string on success and &false; if no font is set.
   </para>
  </refsect1>
 

--- a/reference/imagick/imagickdraw/getfontfamily.xml
+++ b/reference/imagick/imagickdraw/getfontfamily.xml
@@ -21,7 +21,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the font family currently selected or false if font family is not set. 
+   Returns the font family currently selected or &false; if font family is not set. 
   </para>
  </refsect1>
 

--- a/reference/imagick/imagickdraw/gettextencoding.xml
+++ b/reference/imagick/imagickdraw/gettextencoding.xml
@@ -22,7 +22,7 @@
   &reftitle.returnvalues;
   <para>
    Returns a string specifying the code set
-   or false if text encoding is not set.
+   or &false; if text encoding is not set.
   </para>
  </refsect1>
 

--- a/reference/imagick/imagickkernel/frommatrix.xml
+++ b/reference/imagick/imagickkernel/frommatrix.xml
@@ -30,7 +30,7 @@
     <term><parameter>array</parameter></term>
     <listitem>
      <para>
-      A matrix (i.e. 2d array) of values that define the kernel. Each element should be either a float value, or FALSE if that element shouldn't be used by the kernel.
+      A matrix (i.e. 2d array) of values that define the kernel. Each element should be either a float value, or &false; if that element shouldn't be used by the kernel.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/imagick/imagickpixel/ispixelsimilarquantum.xml
+++ b/reference/imagick/imagickpixel/ispixelsimilarquantum.xml
@@ -15,7 +15,7 @@
    <methodparam choice="opt"><type>string</type><parameter>fuzz</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Returns true if the distance between two colors is less than the specified distance.
+   Returns &true; if the distance between two colors is less than the specified distance.
    The fuzz value should be in the range 0-QuantumRange.
    The maximum value represents the longest possible distance in the colorspace.
    e.g. from RGB(0, 0, 0) to RGB(255, 255, 255) for the RGB colorspace

--- a/reference/info/functions/getenv.xml
+++ b/reference/info/functions/getenv.xml
@@ -44,7 +44,7 @@
      <term><parameter>local_only</parameter></term>
      <listitem>
       <para>
-       Set to true to only return local environment variables (set by the operating system or putenv).
+       Set to &true; to only return local environment variables (set by the operating system or putenv).
       </para>
      </listitem>
     </varlistentry>

--- a/reference/intl/intlcalendar/equals.xml
+++ b/reference/intl/intlcalendar/equals.xml
@@ -25,7 +25,7 @@
    <methodparam><type>IntlCalendar</type><parameter>other</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Returns true if this calendar and the given calendar have the same time.
+   Returns &true; if this calendar and the given calendar have the same time.
    The settings, calendar types and field states do not have to be the same.
   </para>
  </refsect1>

--- a/reference/ldap/functions/ldap-control-paged-result.xml
+++ b/reference/ldap/functions/ldap-control-paged-result.xml
@@ -51,7 +51,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
      <listitem>
       <para>
        Indicates whether the pagination is critical or not. 
-       If true and if the server doesn't support pagination, the search
+       If &true; and if the server doesn't support pagination, the search
        will return no result.
       </para>
      </listitem>

--- a/reference/luasandbox/luasandbox/callfunction.xml
+++ b/reference/luasandbox/luasandbox/callfunction.xml
@@ -22,7 +22,7 @@
    recursive table accesses, as if the name were a Lua expression.
   </para>
   <para>
-   If the variable does not exist, or is not a function, false will be
+   If the variable does not exist, or is not a function, &false; will be
    returned and a warning issued.
   </para>
   <para>

--- a/reference/memcached/callbacks.xml
+++ b/reference/memcached/callbacks.xml
@@ -65,7 +65,7 @@ array(3) {
    Read-through cache callbacks are invoked when an item cannot be retrieved
    from the server. The callback is passed the Memcached object, the requested
    key, and the by-reference value variable. The callback is responsible for
-   setting the value and returning true or false. If the callback returns true,
+   setting the value and returning &true; or false. If the callback returns true,
    Memcached will store the populated value on the server and return it to the
    original calling function. Only <methodname>Memcached::get</methodname> and
    <methodname>Memcached::getByKey</methodname> support these callbacks,

--- a/reference/memcached/memcached/ispersistent.xml
+++ b/reference/memcached/memcached/ispersistent.xml
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns true if Memcache instance uses a persistent connection, false otherwise.
+   Returns &true; if Memcache instance uses a persistent connection, &false; otherwise.
   </para>
  </refsect1>
 

--- a/reference/memcached/memcached/ispristine.xml
+++ b/reference/memcached/memcached/ispristine.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the true if instance is recently created, false otherwise.
+   Returns the &true; if instance is recently created, &false; otherwise.
   </para>
  </refsect1>
 

--- a/reference/mysql_xdevapi/mysql_xdevapi/collection/createindex.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/collection/createindex.xml
@@ -61,7 +61,7 @@
       </listitem>
       <listitem>
         <para>
-          <code>required</code>: bool, (optional) true if the field is required to exist in the document. 
+          <code>required</code>: bool, (optional) &true; if the field is required to exist in the document. 
           Defaults to &false;, except for <literal>GEOJSON</literal> where it defaults to &true;.
          </para>
        </listitem>

--- a/reference/mysql_xdevapi/mysql_xdevapi/sqlstatementresult/fetchone.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/sqlstatementresult/fetchone.xml
@@ -30,7 +30,7 @@
   &reftitle.returnvalues;
   <para>
    The result, as an associative array. In case there is not any
-   result, null will be returned.
+   result, &null; will be returned.
   </para>
  </refsect1>
 

--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -213,7 +213,7 @@
    </term>
    <listitem>
     <simpara>
-     Specifies that the fetch method shall return TRUE and assign the values of
+     Specifies that the fetch method shall return &true; and assign the values of
      the columns in the result set to the PHP variables to which they were
      bound with the <function>PDOStatement::bindParam</function> or
      <function>PDOStatement::bindColumn</function> methods.

--- a/reference/pdo/pdostatement/nextrowset.xml
+++ b/reference/pdo/pdostatement/nextrowset.xml
@@ -44,7 +44,7 @@
      The following example shows how to call a stored procedure,
      MULTIPLE_ROWSETS, that returns three rowsets. We use a do / while loop to
      loop over the <function>PDOStatement::nextRowset</function> method, which
-     returns false and terminates the loop when no more rowsets can be returned.
+     returns &false; and terminates the loop when no more rowsets can be returned.
     </para>
     <programlisting role="php">
 <![CDATA[

--- a/reference/phar/Phar/extractTo.xml
+++ b/reference/phar/Phar/extractTo.xml
@@ -22,7 +22,7 @@
    The second parameter <parameter>files</parameter> can be either the name of a file or
    directory to extract, or an array of names of files and directories to extract.  By
    default, this method will not overwrite existing files, the third parameter can be
-   set to true to enable overwriting of files.
+   set to &true; to enable overwriting of files.
    This method is similar to <function>ZipArchive::extractTo</function>.
   </para>
  </refsect1>

--- a/reference/phar/Phar/isFileFormat.xml
+++ b/reference/phar/Phar/isFileFormat.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="phar.isfileformat" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Phar::isFileFormat</refname>
-  <refpurpose>Returns true if the phar archive is based on the tar/phar/zip file format depending on the parameter</refpurpose>
+  <refpurpose>Returns &true; if the phar archive is based on the tar/phar/zip file format depending on the parameter</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/phar/Phar/isWritable.xml
+++ b/reference/phar/Phar/isWritable.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="phar.iswritable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Phar::isWritable</refname>
-  <refpurpose>Returns true if the phar archive can be modified</refpurpose>
+  <refpurpose>Returns &true; if the phar archive can be modified</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/phar/PharData/extractTo.xml
+++ b/reference/phar/PharData/extractTo.xml
@@ -22,7 +22,7 @@
    The second parameter <literal>files</literal> can be either the name of a file or
    directory to extract, or an array of names of files and directories to extract.  By
    default, this method will not overwrite existing files, the third parameter can be
-   set to true to enable overwriting of files.
+   set to &true; to enable overwriting of files.
    This method is similar to <function>ZipArchive::extractTo</function>.
   </para>
  </refsect1>

--- a/reference/phar/PharData/isWritable.xml
+++ b/reference/phar/PharData/isWritable.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="phardata.iswritable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>PharData::isWritable</refname>
-  <refpurpose>Returns true if the tar/zip archive can be modified</refpurpose>
+  <refpurpose>Returns &true; if the tar/zip archive can be modified</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ps/functions/ps-show-boxed.xml
+++ b/reference/ps/functions/ps-show-boxed.xml
@@ -258,7 +258,7 @@
    <title>Hyphenation</title>
    <para>
     Text is hyphenated if the parameter <literal>hyphenation</literal> is set
-    to true and a valid hyphenation dictionary is set. pslib does not ship its own
+    to &true; and a valid hyphenation dictionary is set. pslib does not ship its own
     hyphenation dictionary but uses one from openoffice, scribus or koffice.
     You can find their dictionaries for different languages in one of the
     following directories if the software is installed:

--- a/reference/pthreads/mutex/create.xml
+++ b/reference/pthreads/mutex/create.xml
@@ -37,7 +37,7 @@
    <varlistentry>
     <term><parameter>lock</parameter></term>
     <listitem>
-     <para>Setting lock to true will lock the Mutex for the caller before returning the handle</para>
+     <para>Setting lock to &true; will lock the Mutex for the caller before returning the handle</para>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/pthreads/mutex/unlock.xml
+++ b/reference/pthreads/mutex/unlock.xml
@@ -50,7 +50,7 @@
    <varlistentry>
     <term><parameter>destroy</parameter></term>
     <listitem>
-     <para>When true pthreads will destroy the Mutex after a successful unlock.</para>
+     <para>When &true; pthreads will destroy the Mutex after a successful unlock.</para>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/seaslog/seaslog/alert.xml
+++ b/reference/seaslog/seaslog/alert.xml
@@ -64,7 +64,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   Return &true; on record log information success, &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/closeloggerstream.xml
+++ b/reference/seaslog/seaslog/closeloggerstream.xml
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on released stream flow success, FALSE on failure.
+   Return &true; on released stream flow success, &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/critical.xml
+++ b/reference/seaslog/seaslog/critical.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   Return &true; on record log information success, &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/debug.xml
+++ b/reference/seaslog/seaslog/debug.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   Return &true; on record log information success, &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/emergency.xml
+++ b/reference/seaslog/seaslog/emergency.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   Return &true; on record log information success, &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/error.xml
+++ b/reference/seaslog/seaslog/error.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   Return &true; on record log information success, &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/flushbuffer.xml
+++ b/reference/seaslog/seaslog/flushbuffer.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on flush buffer success, FALSE on failure.
+   Return &true; on flush buffer success, &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/info.xml
+++ b/reference/seaslog/seaslog/info.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   Return &true; on record log information success, &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/log.xml
+++ b/reference/seaslog/seaslog/log.xml
@@ -78,7 +78,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   Return &true; on record log information success, &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/notice.xml
+++ b/reference/seaslog/seaslog/notice.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   Return &true; on record log information success, &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/setbasepath.xml
+++ b/reference/seaslog/seaslog/setbasepath.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on setted base path success, FALSE on failure.
+   Return &true; on setted base path success, &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/setdatetimeformat.xml
+++ b/reference/seaslog/seaslog/setdatetimeformat.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on setted datetime format success, FALSE on failure.
+   Return &true; on setted datetime format success, &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/setlogger.xml
+++ b/reference/seaslog/seaslog/setlogger.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on created logger disectory success, FALSE on failure.
+   Return &true; on created logger disectory success, &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/setrequestid.xml
+++ b/reference/seaslog/seaslog/setrequestid.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on set request_id success, FALSE on failure.
+   Return &true; on set request_id success, &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/setrequestvariable.xml
+++ b/reference/seaslog/seaslog/setrequestvariable.xml
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on set success, FALSE on failure.
+   Return &true; on set success, &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/warning.xml
+++ b/reference/seaslog/seaslog/warning.xml
@@ -64,7 +64,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   Return &true; on record log information success, &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/solr/solrclient/adddocument.xml
+++ b/reference/solr/solrclient/adddocument.xml
@@ -45,7 +45,7 @@
               PECL Solr &lt; 2.0 $allowDups was used instead of $overwrite, which does the same functionality with exact opposite bool flag.
             </para>
             <para>
-              $allowDups = false is the same as $overwrite = true
+              $allowDups = &false; is the same as $overwrite = &true;
             </para>
         </warning>
      </listitem>

--- a/reference/solr/solrclient/getdebug.xml
+++ b/reference/solr/solrclient/getdebug.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a string on success and null if there is nothing to return.
+   Returns a string on success and &null; if there is nothing to return.
   </para>
  </refsect1>
 

--- a/reference/solr/solrinputdocument/haschilddocuments.xml
+++ b/reference/solr/solrinputdocument/haschilddocuments.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="solrinputdocument.haschilddocuments" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrInputDocument::hasChildDocuments</refname>
-  <refpurpose>Returns true if the document has any child documents</refpurpose>
+  <refpurpose>Returns &true; if the document has any child documents</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/solr/solrquery/getexpand.xml
+++ b/reference/solr/solrquery/getexpand.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="solrquery.getexpand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::getExpand</refname>
-  <refpurpose>Returns true if group expanding is enabled</refpurpose>
+  <refpurpose>Returns &true; if group expanding is enabled</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/solr/solrquery/getgroup.xml
+++ b/reference/solr/solrquery/getgroup.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="solrquery.getgroup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::getGroup</refname>
-  <refpurpose>Returns true if grouping is enabled</refpurpose>
+  <refpurpose>Returns &true; if grouping is enabled</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-    Returns true if grouping is enabled
+    Returns &true; if grouping is enabled
   </para>
 
  </refsect1>

--- a/reference/svm/svm/setoptions.xml
+++ b/reference/svm/svm/setoptions.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return true on success, throws SVMException on error.
+   Return &true; on success, throws SVMException on error.
   </para>
  </refsect1>
 </refentry>

--- a/reference/svm/svmmodel/checkprobabilitymodel.xml
+++ b/reference/svm/svmmodel/checkprobabilitymodel.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="svmmodel.checkprobabilitymodel" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SVMModel::checkProbabilityModel</refname>
-  <refpurpose>Returns true if the model has probability information</refpurpose>
+  <refpurpose>Returns &true; if the model has probability information</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Returns true if the model contains probability information.
+   Returns &true; if the model contains probability information.
   </para>
 
  </refsect1>

--- a/reference/svm/svmmodel/load.xml
+++ b/reference/svm/svmmodel/load.xml
@@ -39,7 +39,7 @@
   &reftitle.returnvalues;
   <para>
    Throws SVMException on error.
-   Returns true on success.
+   Returns &true; on success.
   </para>
  </refsect1>
 

--- a/reference/svm/svmmodel/save.xml
+++ b/reference/svm/svmmodel/save.xml
@@ -39,7 +39,7 @@
   &reftitle.returnvalues;
   <para>
    Throws SVMException on error. 
-   Returns true on success.
+   Returns &true; on success.
   </para>
  </refsect1>
 

--- a/reference/svn/functions/svn-fs-abort-txn.xml
+++ b/reference/svn/functions/svn-fs-abort-txn.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.svn-fs-abort-txn" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>svn_fs_abort_txn</refname>
-  <refpurpose>Abort a transaction, returns true if everything is okay, false otherwise</refpurpose>
+  <refpurpose>Abort a transaction, returns &true; if everything is okay, &false; otherwise</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
   </methodsynopsis>
   &warn.undocumented.func;
   <para>
-   Abort a transaction, returns true if everything is okay, false otherwise
+   Abort a transaction, returns &true; if everything is okay, &false; otherwise
   </para>
  </refsect1>
 <!--

--- a/reference/svn/functions/svn-fs-change-node-prop.xml
+++ b/reference/svn/functions/svn-fs-change-node-prop.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.svn-fs-change-node-prop" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>svn_fs_change_node_prop</refname>
-  <refpurpose>Return true if everything is ok, false otherwise</refpurpose>
+  <refpurpose>Return &true; if everything is ok, &false; otherwise</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
   </methodsynopsis>
   &warn.undocumented.func;
   <para>
-   Return true if everything is ok, false otherwise
+   Return &true; if everything is ok, &false; otherwise
   </para>
  </refsect1>
 <!--

--- a/reference/svn/functions/svn-fs-contents-changed.xml
+++ b/reference/svn/functions/svn-fs-contents-changed.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.svn-fs-contents-changed" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>svn_fs_contents_changed</refname>
-  <refpurpose>Return true if content is different, false otherwise</refpurpose>
+  <refpurpose>Return &true; if content is different, &false; otherwise</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
   </methodsynopsis>
   &warn.undocumented.func;
   <para>
-   Return true if content is different, false otherwise
+   Return &true; if content is different, &false; otherwise
   </para>
  </refsect1>
 <!--

--- a/reference/svn/functions/svn-fs-copy.xml
+++ b/reference/svn/functions/svn-fs-copy.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.svn-fs-copy" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>svn_fs_copy</refname>
-  <refpurpose>Copies a file or a directory, returns true if all is ok, false otherwise</refpurpose>
+  <refpurpose>Copies a file or a directory, returns &true; if all is ok, &false; otherwise</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
   </methodsynopsis>
   &warn.undocumented.func;
   <para>
-   Copies a file or a directory, returns true if all is ok, false otherwise
+   Copies a file or a directory, returns &true; if all is ok, &false; otherwise
   </para>
  </refsect1>
 <!--

--- a/reference/svn/functions/svn-fs-delete.xml
+++ b/reference/svn/functions/svn-fs-delete.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.svn-fs-delete" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>svn_fs_delete</refname>
-  <refpurpose>Deletes a file or a directory, return true if all is ok, false otherwise</refpurpose>
+  <refpurpose>Deletes a file or a directory, return &true; if all is ok, &false; otherwise</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
   </methodsynopsis>
   &warn.undocumented.func;
   <para>
-   Deletes a file or a directory, return true if all is ok, false otherwise
+   Deletes a file or a directory, return &true; if all is ok, &false; otherwise
   </para>
  </refsect1>
 <!--

--- a/reference/svn/functions/svn-fs-is-dir.xml
+++ b/reference/svn/functions/svn-fs-is-dir.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.svn-fs-is-dir" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>svn_fs_is_dir</refname>
-  <refpurpose>Return true if the path points to a directory, false otherwise</refpurpose>
+  <refpurpose>Return &true; if the path points to a directory, &false; otherwise</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
   </methodsynopsis>
   &warn.undocumented.func;
   <para>
-   Return true if the path points to a directory, false otherwise
+   Return &true; if the path points to a directory, &false; otherwise
   </para>
  </refsect1>
 <!--

--- a/reference/svn/functions/svn-fs-is-file.xml
+++ b/reference/svn/functions/svn-fs-is-file.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.svn-fs-is-file" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>svn_fs_is_file</refname>
-  <refpurpose>Return true if the path points to a file, false otherwise</refpurpose>
+  <refpurpose>Return &true; if the path points to a file, &false; otherwise</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
   </methodsynopsis>
   &warn.undocumented.func;
   <para>
-   Return true if the path points to a file, false otherwise
+   Return &true; if the path points to a file, &false; otherwise
   </para>
  </refsect1>
 <!--

--- a/reference/svn/functions/svn-fs-make-dir.xml
+++ b/reference/svn/functions/svn-fs-make-dir.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.svn-fs-make-dir" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>svn_fs_make_dir</refname>
-  <refpurpose>Creates a new empty directory, returns true if all is ok, false otherwise</refpurpose>
+  <refpurpose>Creates a new empty directory, returns &true; if all is ok, &false; otherwise</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
   </methodsynopsis>
   &warn.undocumented.func;
   <para>
-   Creates a new empty directory, returns true if all is ok, false otherwise
+   Creates a new empty directory, returns &true; if all is ok, &false; otherwise
   </para>
  </refsect1>
 <!--

--- a/reference/svn/functions/svn-fs-make-file.xml
+++ b/reference/svn/functions/svn-fs-make-file.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.svn-fs-make-file" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>svn_fs_make_file</refname>
-  <refpurpose>Creates a new empty file, returns true if all is ok, false otherwise</refpurpose>
+  <refpurpose>Creates a new empty file, returns &true; if all is ok, &false; otherwise</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
   </methodsynopsis>
   &warn.undocumented.func;
   <para>
-   Creates a new empty file, returns true if all is ok, false otherwise
+   Creates a new empty file, returns &true; if all is ok, &false; otherwise
   </para>
  </refsect1>
 <!--

--- a/reference/svn/functions/svn-fs-props-changed.xml
+++ b/reference/svn/functions/svn-fs-props-changed.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.svn-fs-props-changed" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>svn_fs_props_changed</refname>
-  <refpurpose>Return true if props are different, false otherwise</refpurpose>
+  <refpurpose>Return &true; if props are different, &false; otherwise</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
   </methodsynopsis>
   &warn.undocumented.func;
   <para>
-   Return true if props are different, false otherwise
+   Return &true; if props are different, &false; otherwise
   </para>
  </refsect1>
 <!--

--- a/reference/swoole/swoole/buffer/substr.xml
+++ b/reference/swoole/swoole/buffer/substr.xml
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>bool</type><parameter>remove</parameter></methodparam>
   </methodsynopsis>
   <para>
-    If $remove is set to be true and $offset is set to be 0, the data will be removed from the buffer. 
+    If $remove is set to be &true; and $offset is set to be 0, the data will be removed from the buffer. 
     The memory for storing the data will be released when the buffer object is deconstructed.
   </para>
 

--- a/reference/swoole/swoole/channel/push.xml
+++ b/reference/swoole/swoole/channel/push.xml
@@ -20,7 +20,7 @@
     If size of the data is more than 8KB, swoole channel will use temp files storage.
   </para>
   <para>
-    The function will return true if the write operation is succeeded, or return false if there is not enough space.
+    The function will return &true; if the write operation is succeeded, or return &false; if there is not enough space.
   </para>
 
  </refsect1>

--- a/reference/swoole/swoole/client/send.xml
+++ b/reference/swoole/swoole/client/send.xml
@@ -46,7 +46,7 @@
   &reftitle.returnvalues;
   <para>
    If the client sends data successfully, it returns the length of data sent. 
-   Or it returns false and sets $swoole_client->errCode. For sync client, 
+   Or it returns &false; and sets $swoole_client->errCode. For sync client, 
    there is no limit for the data to send. For async client, The limit 
    for the data to send is socket_buffer_size. 
   </para>

--- a/reference/swoole/swoole/connection/iterator/offsetexists.xml
+++ b/reference/swoole/swoole/connection/iterator/offsetexists.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns TRUE if the offset exists, otherwise FALSE.
+   Returns &true; if the offset exists, otherwise FALSE.
   </para>
  </refsect1>
 

--- a/reference/swoole/swoole/connection/iterator/valid.xml
+++ b/reference/swoole/swoole/connection/iterator/valid.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns TRUE if the current iterator position is valid, otherwise FALSE.
+   Returns &true; if the current iterator position is valid, otherwise FALSE.
   </para>
  </refsect1>
 

--- a/reference/taint/functions/is-tainted.xml
+++ b/reference/taint/functions/is-tainted.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE if the string is tainted, FALSE otherwise.
+   Return &true; if the string is tainted, &false; otherwise.
   </para>
  </refsect1>
 

--- a/reference/taint/functions/taint.xml
+++ b/reference/taint/functions/taint.xml
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-      Return TRUE if the transformation is done. Always return TRUE if the taint
+      Return &true; if the transformation is done. Always return &true; if the taint
       extension is not enabled.    
   </para>
  </refsect1>

--- a/reference/trader/functions/trader-acos.xml
+++ b/reference/trader/functions/trader-acos.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ad.xml
+++ b/reference/trader/functions/trader-ad.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-add.xml
+++ b/reference/trader/functions/trader-add.xml
@@ -44,7 +44,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-adosc.xml
+++ b/reference/trader/functions/trader-adosc.xml
@@ -79,7 +79,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-adx.xml
+++ b/reference/trader/functions/trader-adx.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-adxr.xml
+++ b/reference/trader/functions/trader-adxr.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-apo.xml
+++ b/reference/trader/functions/trader-apo.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-aroon.xml
+++ b/reference/trader/functions/trader-aroon.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-aroonosc.xml
+++ b/reference/trader/functions/trader-aroonosc.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-asin.xml
+++ b/reference/trader/functions/trader-asin.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-atan.xml
+++ b/reference/trader/functions/trader-atan.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-atr.xml
+++ b/reference/trader/functions/trader-atr.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-avgprice.xml
+++ b/reference/trader/functions/trader-avgprice.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-bbands.xml
+++ b/reference/trader/functions/trader-bbands.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-beta.xml
+++ b/reference/trader/functions/trader-beta.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-bop.xml
+++ b/reference/trader/functions/trader-bop.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cci.xml
+++ b/reference/trader/functions/trader-cci.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdl2crows.xml
+++ b/reference/trader/functions/trader-cdl2crows.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdl3blackcrows.xml
+++ b/reference/trader/functions/trader-cdl3blackcrows.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdl3inside.xml
+++ b/reference/trader/functions/trader-cdl3inside.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdl3linestrike.xml
+++ b/reference/trader/functions/trader-cdl3linestrike.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdl3outside.xml
+++ b/reference/trader/functions/trader-cdl3outside.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdl3starsinsouth.xml
+++ b/reference/trader/functions/trader-cdl3starsinsouth.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdl3whitesoldiers.xml
+++ b/reference/trader/functions/trader-cdl3whitesoldiers.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlabandonedbaby.xml
+++ b/reference/trader/functions/trader-cdlabandonedbaby.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdladvanceblock.xml
+++ b/reference/trader/functions/trader-cdladvanceblock.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlbelthold.xml
+++ b/reference/trader/functions/trader-cdlbelthold.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlbreakaway.xml
+++ b/reference/trader/functions/trader-cdlbreakaway.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlclosingmarubozu.xml
+++ b/reference/trader/functions/trader-cdlclosingmarubozu.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlconcealbabyswall.xml
+++ b/reference/trader/functions/trader-cdlconcealbabyswall.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlcounterattack.xml
+++ b/reference/trader/functions/trader-cdlcounterattack.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdldarkcloudcover.xml
+++ b/reference/trader/functions/trader-cdldarkcloudcover.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdldoji.xml
+++ b/reference/trader/functions/trader-cdldoji.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdldojistar.xml
+++ b/reference/trader/functions/trader-cdldojistar.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdldragonflydoji.xml
+++ b/reference/trader/functions/trader-cdldragonflydoji.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlengulfing.xml
+++ b/reference/trader/functions/trader-cdlengulfing.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdleveningdojistar.xml
+++ b/reference/trader/functions/trader-cdleveningdojistar.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdleveningstar.xml
+++ b/reference/trader/functions/trader-cdleveningstar.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlgapsidesidewhite.xml
+++ b/reference/trader/functions/trader-cdlgapsidesidewhite.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlgravestonedoji.xml
+++ b/reference/trader/functions/trader-cdlgravestonedoji.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlhammer.xml
+++ b/reference/trader/functions/trader-cdlhammer.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlhangingman.xml
+++ b/reference/trader/functions/trader-cdlhangingman.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlharami.xml
+++ b/reference/trader/functions/trader-cdlharami.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlharamicross.xml
+++ b/reference/trader/functions/trader-cdlharamicross.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlhighwave.xml
+++ b/reference/trader/functions/trader-cdlhighwave.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlhikkake.xml
+++ b/reference/trader/functions/trader-cdlhikkake.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlhikkakemod.xml
+++ b/reference/trader/functions/trader-cdlhikkakemod.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlhomingpigeon.xml
+++ b/reference/trader/functions/trader-cdlhomingpigeon.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlidentical3crows.xml
+++ b/reference/trader/functions/trader-cdlidentical3crows.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlinneck.xml
+++ b/reference/trader/functions/trader-cdlinneck.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlinvertedhammer.xml
+++ b/reference/trader/functions/trader-cdlinvertedhammer.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlkicking.xml
+++ b/reference/trader/functions/trader-cdlkicking.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlkickingbylength.xml
+++ b/reference/trader/functions/trader-cdlkickingbylength.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlladderbottom.xml
+++ b/reference/trader/functions/trader-cdlladderbottom.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdllongleggeddoji.xml
+++ b/reference/trader/functions/trader-cdllongleggeddoji.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdllongline.xml
+++ b/reference/trader/functions/trader-cdllongline.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlmarubozu.xml
+++ b/reference/trader/functions/trader-cdlmarubozu.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlmatchinglow.xml
+++ b/reference/trader/functions/trader-cdlmatchinglow.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlmathold.xml
+++ b/reference/trader/functions/trader-cdlmathold.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlmorningdojistar.xml
+++ b/reference/trader/functions/trader-cdlmorningdojistar.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlmorningstar.xml
+++ b/reference/trader/functions/trader-cdlmorningstar.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlonneck.xml
+++ b/reference/trader/functions/trader-cdlonneck.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlpiercing.xml
+++ b/reference/trader/functions/trader-cdlpiercing.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlrickshawman.xml
+++ b/reference/trader/functions/trader-cdlrickshawman.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlrisefall3methods.xml
+++ b/reference/trader/functions/trader-cdlrisefall3methods.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlseparatinglines.xml
+++ b/reference/trader/functions/trader-cdlseparatinglines.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlshootingstar.xml
+++ b/reference/trader/functions/trader-cdlshootingstar.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlshortline.xml
+++ b/reference/trader/functions/trader-cdlshortline.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlspinningtop.xml
+++ b/reference/trader/functions/trader-cdlspinningtop.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlstalledpattern.xml
+++ b/reference/trader/functions/trader-cdlstalledpattern.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlsticksandwich.xml
+++ b/reference/trader/functions/trader-cdlsticksandwich.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdltakuri.xml
+++ b/reference/trader/functions/trader-cdltakuri.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdltasukigap.xml
+++ b/reference/trader/functions/trader-cdltasukigap.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlthrusting.xml
+++ b/reference/trader/functions/trader-cdlthrusting.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdltristar.xml
+++ b/reference/trader/functions/trader-cdltristar.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlunique3river.xml
+++ b/reference/trader/functions/trader-cdlunique3river.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlupsidegap2crows.xml
+++ b/reference/trader/functions/trader-cdlupsidegap2crows.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cdlxsidegap3methods.xml
+++ b/reference/trader/functions/trader-cdlxsidegap3methods.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ceil.xml
+++ b/reference/trader/functions/trader-ceil.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cmo.xml
+++ b/reference/trader/functions/trader-cmo.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-correl.xml
+++ b/reference/trader/functions/trader-correl.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cos.xml
+++ b/reference/trader/functions/trader-cos.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-cosh.xml
+++ b/reference/trader/functions/trader-cosh.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-dema.xml
+++ b/reference/trader/functions/trader-dema.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-div.xml
+++ b/reference/trader/functions/trader-div.xml
@@ -44,7 +44,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-dx.xml
+++ b/reference/trader/functions/trader-dx.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ema.xml
+++ b/reference/trader/functions/trader-ema.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-exp.xml
+++ b/reference/trader/functions/trader-exp.xml
@@ -34,7 +34,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-floor.xml
+++ b/reference/trader/functions/trader-floor.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ht-dcperiod.xml
+++ b/reference/trader/functions/trader-ht-dcperiod.xml
@@ -34,7 +34,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ht-dcphase.xml
+++ b/reference/trader/functions/trader-ht-dcphase.xml
@@ -34,7 +34,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ht-phasor.xml
+++ b/reference/trader/functions/trader-ht-phasor.xml
@@ -34,7 +34,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ht-sine.xml
+++ b/reference/trader/functions/trader-ht-sine.xml
@@ -34,7 +34,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ht-trendline.xml
+++ b/reference/trader/functions/trader-ht-trendline.xml
@@ -34,7 +34,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ht-trendmode.xml
+++ b/reference/trader/functions/trader-ht-trendmode.xml
@@ -34,7 +34,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-kama.xml
+++ b/reference/trader/functions/trader-kama.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-linearreg-angle.xml
+++ b/reference/trader/functions/trader-linearreg-angle.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-linearreg-intercept.xml
+++ b/reference/trader/functions/trader-linearreg-intercept.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-linearreg-slope.xml
+++ b/reference/trader/functions/trader-linearreg-slope.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-linearreg.xml
+++ b/reference/trader/functions/trader-linearreg.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ln.xml
+++ b/reference/trader/functions/trader-ln.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-log10.xml
+++ b/reference/trader/functions/trader-log10.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ma.xml
+++ b/reference/trader/functions/trader-ma.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-macd.xml
+++ b/reference/trader/functions/trader-macd.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-macdext.xml
+++ b/reference/trader/functions/trader-macdext.xml
@@ -88,7 +88,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-macdfix.xml
+++ b/reference/trader/functions/trader-macdfix.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-mama.xml
+++ b/reference/trader/functions/trader-mama.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-mavp.xml
+++ b/reference/trader/functions/trader-mavp.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-max.xml
+++ b/reference/trader/functions/trader-max.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-maxindex.xml
+++ b/reference/trader/functions/trader-maxindex.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-medprice.xml
+++ b/reference/trader/functions/trader-medprice.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-mfi.xml
+++ b/reference/trader/functions/trader-mfi.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-midpoint.xml
+++ b/reference/trader/functions/trader-midpoint.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-midprice.xml
+++ b/reference/trader/functions/trader-midprice.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-min.xml
+++ b/reference/trader/functions/trader-min.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-minindex.xml
+++ b/reference/trader/functions/trader-minindex.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-minmax.xml
+++ b/reference/trader/functions/trader-minmax.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-minmaxindex.xml
+++ b/reference/trader/functions/trader-minmaxindex.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-minus-di.xml
+++ b/reference/trader/functions/trader-minus-di.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-minus-dm.xml
+++ b/reference/trader/functions/trader-minus-dm.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-mom.xml
+++ b/reference/trader/functions/trader-mom.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-mult.xml
+++ b/reference/trader/functions/trader-mult.xml
@@ -44,7 +44,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-natr.xml
+++ b/reference/trader/functions/trader-natr.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-obv.xml
+++ b/reference/trader/functions/trader-obv.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-plus-di.xml
+++ b/reference/trader/functions/trader-plus-di.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-plus-dm.xml
+++ b/reference/trader/functions/trader-plus-dm.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ppo.xml
+++ b/reference/trader/functions/trader-ppo.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-roc.xml
+++ b/reference/trader/functions/trader-roc.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-rocp.xml
+++ b/reference/trader/functions/trader-rocp.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-rocr.xml
+++ b/reference/trader/functions/trader-rocr.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-rocr100.xml
+++ b/reference/trader/functions/trader-rocr100.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-rsi.xml
+++ b/reference/trader/functions/trader-rsi.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-sar.xml
+++ b/reference/trader/functions/trader-sar.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-sarext.xml
+++ b/reference/trader/functions/trader-sarext.xml
@@ -115,7 +115,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-sin.xml
+++ b/reference/trader/functions/trader-sin.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-sinh.xml
+++ b/reference/trader/functions/trader-sinh.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-sma.xml
+++ b/reference/trader/functions/trader-sma.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-sqrt.xml
+++ b/reference/trader/functions/trader-sqrt.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-stddev.xml
+++ b/reference/trader/functions/trader-stddev.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-stoch.xml
+++ b/reference/trader/functions/trader-stoch.xml
@@ -97,7 +97,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-stochf.xml
+++ b/reference/trader/functions/trader-stochf.xml
@@ -79,7 +79,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-stochrsi.xml
+++ b/reference/trader/functions/trader-stochrsi.xml
@@ -70,7 +70,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-sub.xml
+++ b/reference/trader/functions/trader-sub.xml
@@ -44,7 +44,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-sum.xml
+++ b/reference/trader/functions/trader-sum.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-t3.xml
+++ b/reference/trader/functions/trader-t3.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-tan.xml
+++ b/reference/trader/functions/trader-tan.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-tanh.xml
+++ b/reference/trader/functions/trader-tanh.xml
@@ -35,7 +35,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-tema.xml
+++ b/reference/trader/functions/trader-tema.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-trange.xml
+++ b/reference/trader/functions/trader-trange.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-trima.xml
+++ b/reference/trader/functions/trader-trima.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-trix.xml
+++ b/reference/trader/functions/trader-trix.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-tsf.xml
+++ b/reference/trader/functions/trader-tsf.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-typprice.xml
+++ b/reference/trader/functions/trader-typprice.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-ultosc.xml
+++ b/reference/trader/functions/trader-ultosc.xml
@@ -79,7 +79,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-var.xml
+++ b/reference/trader/functions/trader-var.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-wclprice.xml
+++ b/reference/trader/functions/trader-wclprice.xml
@@ -52,7 +52,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-willr.xml
+++ b/reference/trader/functions/trader-willr.xml
@@ -61,7 +61,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/trader/functions/trader-wma.xml
+++ b/reference/trader/functions/trader-wma.xml
@@ -43,7 +43,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>Returns an array with calculated data or false on failure.</para>
+  <para>Returns an array with calculated data or &false; on failure.</para>
  </refsect1>
 
 

--- a/reference/ui/ui/controls/box/append.xml
+++ b/reference/ui/ui/controls/box/append.xml
@@ -35,7 +35,7 @@
     <term><parameter>stretchy</parameter></term>
     <listitem>
      <para>
-      Set true to stretch the control
+      Set &true; to stretch the control
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ui/ui/controls/form/append.xml
+++ b/reference/ui/ui/controls/form/append.xml
@@ -44,7 +44,7 @@
     <term><parameter>stretchy</parameter></term>
     <listitem>
      <para>
-      Should be set true to stretch the control
+      Should be set &true; to stretch the control
      </para>
     </listitem>
    </varlistentry>

--- a/reference/uopz/functions/uopz-set-return.xml
+++ b/reference/uopz/functions/uopz-set-return.xml
@@ -75,7 +75,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-  True if succeeded, false otherwise.
+  &true; if succeeded, &false; otherwise.
   </para>
  </refsect1>
 

--- a/reference/uopz/functions/uopz-unset-return.xml
+++ b/reference/uopz/functions/uopz-unset-return.xml
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-  True on success
+  &true; on success
   </para>
  </refsect1>
 

--- a/reference/wincache/functions/wincache-ocache-fileinfo.xml
+++ b/reference/wincache/functions/wincache-ocache-fileinfo.xml
@@ -64,8 +64,8 @@
     </listitem>
     <listitem>
      <simpara>
-      <literal>is_local_cache</literal> - true is the cache metadata is for a local cache instance, 
-       false if the metadata is for the global cache
+      <literal>is_local_cache</literal> - &true; if the cache metadata is for a local cache instance, 
+       &false; if the metadata is for the global cache
      </simpara>
     </listitem>
     <listitem>

--- a/reference/wincache/functions/wincache-scache-info.xml
+++ b/reference/wincache/functions/wincache-scache-info.xml
@@ -53,8 +53,8 @@
     </listitem>
     <listitem>
      <simpara>
-      <literal>is_local_cache</literal> - true is the cache metadata is for a local cache instance, 
-       false if the metadata is for the global cache
+      <literal>is_local_cache</literal> - &true; if the cache metadata is for a local cache instance, 
+       &false; if the metadata is for the global cache
      </simpara>
     </listitem>
     <listitem>

--- a/reference/wincache/functions/wincache-ucache-info.xml
+++ b/reference/wincache/functions/wincache-ucache-info.xml
@@ -64,8 +64,8 @@
     </listitem>
     <listitem>
      <simpara>
-      <literal>is_local_cache</literal> - true is the cache metadata is for a local cache instance, 
-       false if the metadata is for the global cache
+      <literal>is_local_cache</literal> - &true; if the cache metadata is for a local cache instance, 
+       &false; if the metadata is for the global cache
      </simpara>
     </listitem>
     <listitem>

--- a/reference/wkhtmltox/wkhtmltox/bits/load.xml
+++ b/reference/wkhtmltox/wkhtmltox/bits/load.xml
@@ -30,7 +30,7 @@
 </row>
 <row>
   <entry>load.repertCustomHeaders</entry>
-  <entry>set true to send with all requests</entry>
+  <entry>set &true; to send with all requests</entry>
   <entry>boolean</entry>
   <entry>&gt;= 0.1.0</entry>
 </row>

--- a/reference/wkhtmltox/wkhtmltox/pdf/object/construct.xml
+++ b/reference/wkhtmltox/wkhtmltox/pdf/object/construct.xml
@@ -55,19 +55,19 @@
          </row>
          <row>
           <entry>useExternalLinks</entry>
-          <entry>set true to convert external links in the input into external PDF links in the output</entry>
+          <entry>set &true; to convert external links in the input into external PDF links in the output</entry>
           <entry>boolean</entry>
           <entry>&gt;= 0.1.0</entry>
          </row>
          <row>
           <entry>useLocalLinks</entry>
-          <entry>set true to convert internal links in the input into internal PDF links in the output</entry>
+          <entry>set &true; to convert internal links in the input into internal PDF links in the output</entry>
           <entry>boolean</entry>
           <entry>&gt;= 0.1.0</entry>
          </row>
          <row>
           <entry>produceForms</entry>
-          <entry>set true to turn HTML forms into PDF forms</entry>
+          <entry>set &true; to turn HTML forms into PDF forms</entry>
           <entry>boolean</entry>
           <entry>&gt;= 0.1.0</entry>
          </row>
@@ -79,13 +79,13 @@
          </row>
          <row>
           <entry>includeInOutline</entry>
-          <entry>set true to include sections from this object in the outline and toc</entry>
+          <entry>set &true; to include sections from this object in the outline and toc</entry>
           <entry>boolean</entry>
           <entry>&gt;= 0.1.0</entry>
          </row>
          <row>
           <entry>pagesCount</entry>
-          <entry>set true to make page count in toc inclusive of the number of pages in this object</entry>
+          <entry>set &true; to make page count in toc inclusive of the number of pages in this object</entry>
           <entry>boolean</entry>
           <entry>&gt;= 0.1.0</entry>
          </row>
@@ -97,7 +97,7 @@
          </row>
          <row>
           <entry>toc.useDottedLines</entry>
-          <entry>set true to use dotted lines in toc</entry>
+          <entry>set &true; to use dotted lines in toc</entry>
           <entry>boolean</entry>
           <entry>&gt;= 0.1.0</entry>
          </row>
@@ -109,13 +109,13 @@
          </row>
          <row>
           <entry>toc.forwardLinks</entry>
-          <entry>set true to create links from toc to content</entry>
+          <entry>set &true; to create links from toc to content</entry>
           <entry>boolean</entry>
           <entry>&gt;= 0.1.0</entry>
          </row>
          <row>
           <entry>toc.backLinks</entry>
-          <entry>set true to create links from content to toc</entry>
+          <entry>set &true; to create links from content to toc</entry>
           <entry>boolean</entry>
           <entry>&gt;= 0.1.0</entry>
          </row>

--- a/reference/xdiff/functions/xdiff-file-diff.xml
+++ b/reference/xdiff/functions/xdiff-file-diff.xml
@@ -22,7 +22,7 @@
    <parameter>new_file</parameter> and stores it in <parameter>dest</parameter> file. The
    resulting file is human-readable. An optional <parameter>context</parameter> parameter
    specifies how many lines of context should be added around each change.
-   Setting <parameter>minimal</parameter> parameter to true will result in outputting the shortest
+   Setting <parameter>minimal</parameter> parameter to &true; will result in outputting the shortest
    patch file possible (can take a long time). 
   </para>
  </refsect1>

--- a/reference/xdiff/functions/xdiff-string-diff.xml
+++ b/reference/xdiff/functions/xdiff-string-diff.xml
@@ -21,7 +21,7 @@
    <parameter>new_data</parameter> string and returns it. The resulting diff is human-readable. 
    An optional <parameter>context</parameter> parameter specifies how many lines of context should be
    added around each change. Setting <parameter>minimal</parameter> parameter 
-   to true will result in outputting the shortest patch file possible (can take a long time). 
+   to &true; will result in outputting the shortest patch file possible (can take a long time). 
   </para>
  </refsect1>
 

--- a/reference/yac/yac/flush.xml
+++ b/reference/yac/yac/flush.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   bool, always true 
+   bool, always &true; 
   </para>
  </refsect1>
 

--- a/reference/yac/yac/get.xml
+++ b/reference/yac/yac/get.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   mixed on success, false on failure
+   mixed on success, &false; on failure
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_request_http/getraw.xml
+++ b/reference/yaf/yaf_request_http/getraw.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return string on success, FALSE on failure.
+   Return string on success, &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_request_simple/isxmlhttprequest.xml
+++ b/reference/yaf/yaf_request_simple/isxmlhttprequest.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Always returns false for <classname>Yaf_Request_Simple</classname>
+   Always returns &false; for <classname>Yaf_Request_Simple</classname>
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqdevice/setidlecallback.xml
+++ b/reference/zmq/zmqdevice/setidlecallback.xml
@@ -18,7 +18,7 @@
   <para>
    Sets the idle callback function. If idle timeout is defined the idle callback function
    shall be called if the internal poll loop times out without events. If the callback function
-   returns false or a value that evaluates to false the device is stopped.
+   returns &false; or a value that evaluates to &false; the device is stopped.
 
    The callback function signature is callback (mixed $user_data).
   </para>
@@ -32,7 +32,7 @@
     <listitem>
      <para>
       Callback function to invoke when the device is idle. Returning false
-      or a value that evaluates to false from this function will cause the 
+      or a value that evaluates to &false; from this function will cause the 
       device to stop.
      </para>
     </listitem>

--- a/reference/zmq/zmqdevice/settimercallback.xml
+++ b/reference/zmq/zmqdevice/settimercallback.xml
@@ -32,7 +32,7 @@
     <listitem>
      <para>
       Callback function to invoke when the device is idle. Returning false
-      or a value that evaluates to false from this function will cause the 
+      or a value that evaluates to &false; from this function will cause the 
       device to stop.
      </para>
     </listitem>

--- a/reference/zmq/zmqpoll/remove.xml
+++ b/reference/zmq/zmqpoll/remove.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns true if the item was removed and false if the object 
+   Returns &true; if the item was removed and &false; if the object 
    with given id does not exist in the poll set.
   </para>
  </refsect1>

--- a/reference/zmq/zmqsocket/recvmulti.xml
+++ b/reference/zmq/zmqsocket/recvmulti.xml
@@ -41,7 +41,7 @@
   <para>
    Returns the array of message parts. Throws ZMQSocketException in error. 
    If <constant>ZMQ::MODE_NOBLOCK</constant> is used and the operation would 
-   block &boolean; false shall be returned.
+   block &boolean; &false; shall be returned.
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqsocket/send.xml
+++ b/reference/zmq/zmqsocket/send.xml
@@ -49,7 +49,7 @@
   <para>
    Returns the current object. Throws ZMQSocketException on error. 
    If <constant>ZMQ::MODE_NOBLOCK</constant> is used and the operation would 
-   block &boolean; false shall be returned.
+   block &boolean; &false; shall be returned.
   </para>
  </refsect1>
 </refentry>

--- a/reference/zmq/zmqsocket/sendmulti.xml
+++ b/reference/zmq/zmqsocket/sendmulti.xml
@@ -49,7 +49,7 @@
   <para>
    Returns the current object. Throws ZMQSocketException on error. 
    If <constant>ZMQ::MODE_NOBLOCK</constant> is used and the operation would 
-   block &boolean; false shall be returned.
+   block &boolean; &false; shall be returned.
   </para>
  </refsect1>
 </refentry>

--- a/reference/zookeeper/zookeeper/create.xml
+++ b/reference/zookeeper/zookeeper/create.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the path of the new node (this might be different than the supplied path because of the ZOO_SEQUENCE flag) on success, and false on failure.
+   Returns the path of the new node (this might be different than the supplied path because of the ZOO_SEQUENCE flag) on success, and &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/get.xml
+++ b/reference/zookeeper/zookeeper/get.xml
@@ -60,7 +60,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the data on success, and false on failure.
+   Returns the data on success, and &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/getacl.xml
+++ b/reference/zookeeper/zookeeper/getacl.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return acl array on success and false on failure.
+   Return acl array on success and &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/getchildren.xml
+++ b/reference/zookeeper/zookeeper/getchildren.xml
@@ -42,7 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an array with children paths on success, and false on failure.
+   Returns an array with children paths on success, and &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/getclientid.xml
+++ b/reference/zookeeper/zookeeper/getclientid.xml
@@ -24,7 +24,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the client session id on success, and false on failure.
+   Returns the client session id on success, and &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/getrecvtimeout.xml
+++ b/reference/zookeeper/zookeeper/getrecvtimeout.xml
@@ -24,7 +24,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the timeout for this session on success, and false on failure.
+   Returns the timeout for this session on success, and &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/getstate.xml
+++ b/reference/zookeeper/zookeeper/getstate.xml
@@ -24,7 +24,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the state of zookeeper connection on success, and false on failure.
+   Returns the state of zookeeper connection on success, and &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/isrecoverable.xml
+++ b/reference/zookeeper/zookeeper/isrecoverable.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns true/false on success, and false on failure.
+   Returns &true;/&false; on success, and &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/setdeterministicconnorder.xml
+++ b/reference/zookeeper/zookeeper/setdeterministicconnorder.xml
@@ -16,8 +16,8 @@
    <methodparam><type>bool</type><parameter>yesOrNo</parameter></methodparam>
   </methodsynopsis>
   <para>
-   If passed a true value, will make the client connect to quorum peers in the order as specified in the zookeeper_init() call. A false value causes zookeeper_init() to permute the peer endpoints which is good for more even client connection distribution among the quorum peers.
-   ZooKeeper C Client uses false by default.
+   If passed a &true; value, will make the client connect to quorum peers in the order as specified in the zookeeper_init() call. A &false; value causes zookeeper_init() to permute the peer endpoints which is good for more even client connection distribution among the quorum peers.
+   ZooKeeper C Client uses &false; by default.
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeperconfig/get.xml
+++ b/reference/zookeeper/zookeeperconfig/get.xml
@@ -42,7 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the configuration string on success, and false on failure.
+   Returns the configuration string on success, and &false; on failure.
   </para>
  </refsect1>
 


### PR DESCRIPTION
This PR is not a result of some automatic find and replace. I have manually reviewed hundreds of files to make these changes.

# Format true and false

```perl
/ TRUE | FALSE | NULL /i
```

and ignore any results inside a `<![CDATA[` section or where "true"/"false" have meanings other than the boolean types inside PHP.

- If a true value, use `&true;`
- If a false value, use `&false;`
- If a null value, use `&null;`

# Why

Improve readability. Make long-term maintenance of translations easier.

# Effect on translations

The true, false and null values are semantic and this should help with the long-term maintenance of translations.

Translators will not need to think much about whether true means "真正的布尔值" or "真不变量" when seeing:

* `true color image`
* `return value of &true;`
* `this invariant is true if X and Y`
* null byte
* null-terminated

because I have already separated the cases of true and `&true;`.

# Scope creep

- This PR also fixes two typos of `true is` to become `true if` immediately on the lines a was editing.