### PR TITLE
Update basic-syntax.xml to fix typo

### DIFF
--- a/language/basic-syntax.xml
+++ b/language/basic-syntax.xml
@@ -45,7 +45,7 @@
    <para>
     <note>
      <para>
-      As short tags can be disabled it is recommened to only use the normal
+      As short tags can be disabled it is recommended to only use the normal
       tags (<code>&lt;?php ?&gt;</code> and <code>&lt;?= ?&gt;</code>) to
       maximise compatibility.
      </para>


### PR DESCRIPTION
Fixes typo in the note about not using short tags