### PR TITLE
fixed strict typing directive spelling.

### DIFF
--- a/appendices/migration80/other-changes.xml
+++ b/appendices/migration80/other-changes.xml
@@ -43,7 +43,8 @@
    <para>
     The math functions <function>abs</function>, <function>ceil</function>,
     <function>floor</function> and <function>round</function> now properly heed
-    the <link linkend="language.types.declarations.strict"><literal>strict_types</literal> declaration</link>. Previously, they coerced the first argument
+    <link linkend="language.types.declarations.strict">the <literal>strict_types</literal> directive</link>.
+    Previously, they coerced the first argument even in strict type mode.
     even in strict type mode.
    </para>
   </sect3>

--- a/appendices/migration80/other-changes.xml
+++ b/appendices/migration80/other-changes.xml
@@ -43,7 +43,7 @@
    <para>
     The math functions <function>abs</function>, <function>ceil</function>,
     <function>floor</function> and <function>round</function> now properly heed
-    the strict_type declaration. Previously, they coerced the first argument
+    the <link linkend="language.types.declarations.strict"><literal>strict_types</literal> declaration</link>. Previously, they coerced the first argument
     even in strict type mode.
    </para>
   </sect3>


### PR DESCRIPTION
Strict typing directive is not `strict_type`, but `strict_types`.
Also, we may be able to replace it with a link to strict typing page [*1]

[*1] https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.strict
