### PR TITLE
CI: Render XHTML chunked manual

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -39,14 +39,32 @@ jobs:
           path: "doc-base"
           repository: "php/doc-base"
 
+      - name: "Checkout php/phd"
+        uses: "actions/checkout@v2"
+        with:
+          path: "phd"
+          repository: "php/phd"
+
       - name: "Quality Assurance scripts"
         run: "php8.0 doc-base/scripts/qa/extensions.xml.php --check"
 
       - name: "Build documentation for ${{ matrix.language }}"
         run: "php8.0 doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}"
 
+      - name: "Render XHTML chunked ${{ matrix.language }} manual"
+        run: "php phd/render.php --docbook doc-base/.manual.xml --package PHP --format xhtml"
+
+      - name: "Archive XHTML chunked ${{ matrix.language }} manual"
+        run: "tar -cf output/php-chunked-xhtml.tar output/php-chunked-xhtml"
+
       - name: "Upload .manual.xml"
         uses: actions/upload-artifact@v2
         with:
           name: .manual.xml
           path: doc-base/.manual.xml
+
+      - name: "Upload XHTML chunked manual"
+        uses: actions/upload-artifact@v2
+        with:
+          name: php-chunked-xhtml
+          path: output/php-chunked-xhtml.tar


### PR DESCRIPTION
The rendered XHTML chunked manual is provided as artifact.

---

I think this is useful for those who don't have a full doc build environment set up, but it slows down CI considerably, and it's still not possible to view the docs online. Maybe we could push to GH pages or something, and the full workflow should only be run when manually triggered?

Thoughts welcome!