### PR TITLE
`locale` functions may fail and return null or false

### DIFF
--- a/reference/intl/locale/accept-from-http.xml
+++ b/reference/intl/locale/accept-from-http.xml
@@ -15,7 +15,7 @@
   <methodsynopsis>
    <modifier>public</modifier>
    <modifier>static</modifier>
-   <type>string</type>
+   <type class="union"><type>string</type><type>false</type></type>
    <methodname>Locale::acceptFromHttp</methodname>
    <methodparam><type>string</type><parameter>header</parameter></methodparam>
   </methodsynopsis>
@@ -23,7 +23,7 @@
    &style.procedural;
   </para>
   <methodsynopsis>
-   <type>string</type>
+   <type class="union"><type>string</type><type>false</type></type>
    <methodname>locale_accept_from_http</methodname>
    <methodparam><type>string</type><parameter>header</parameter></methodparam>
   </methodsynopsis>
@@ -54,6 +54,10 @@
   &reftitle.returnvalues;
   <para>
    The corresponding locale identifier.
+  </para>
+  <para>
+   Returns &false; when the length of <parameter>header</parameter> exceeds
+   <constant>INTL_MAX_LOCALE_LEN</constant>.
   </para>
  </refsect1>
 

--- a/reference/intl/locale/canonicalize.xml
+++ b/reference/intl/locale/canonicalize.xml
@@ -11,7 +11,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <modifier>static</modifier> <type>string</type><methodname>Locale::canonicalize</methodname>
+   <modifier>public</modifier> <modifier>static</modifier>
+   <type class="union"><type>string</type><type>null</type></type>
+   <methodname>Locale::canonicalize</methodname>
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -29,7 +31,7 @@
     <term><parameter>locale</parameter></term>
     <listitem>
      <para>
-      
+
      </para>
     </listitem>
    </varlistentry>
@@ -39,7 +41,11 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   
+   Canonicalized locale string.
+  </para>
+  <para>
+   Returns &null; when the length of <parameter>locale</parameter> exceeds
+   <constant>INTL_MAX_LOCALE_LEN</constant>.
   </para>
  </refsect1>
 

--- a/reference/intl/locale/filter-matches.xml
+++ b/reference/intl/locale/filter-matches.xml
@@ -15,7 +15,7 @@
   <methodsynopsis>
    <modifier>public</modifier>
    <modifier>static</modifier>
-   <type>bool</type>
+   <type class="union"><type>bool</type><type>null</type></type>
    <methodname>Locale::filterMatches</methodname>
    <methodparam><type>string</type><parameter>langtag</parameter></methodparam>
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
@@ -25,7 +25,7 @@
    &style.procedural;
   </para>
   <methodsynopsis>
-   <type>bool</type>
+   <type class="union"><type>bool</type><type>null</type></type>
    <methodname>locale_filter_matches</methodname>
    <methodparam><type>string</type><parameter>langtag</parameter></methodparam>
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
@@ -62,7 +62,7 @@
      <listitem>
      <para>
       If true, the arguments will be converted to canonical form before
-      matching. 
+      matching.
      </para>
      </listitem>
     </varlistentry>
@@ -76,6 +76,10 @@
   <para>
    &true; if $locale matches $langtag &false; otherwise.
   </para>
+  <para>
+   Returns &null; when the length of <parameter>locale</parameter> exceeds
+   <constant>INTL_MAX_LOCALE_LEN</constant>.
+  </para>
  </refsect1>
 
  <refsect1 role="examples">
@@ -85,9 +89,9 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-echo (locale_filter_matches('de-DEVA','de-DE', false)) ? "Matches" : "Does not match"; 
+echo (locale_filter_matches('de-DEVA','de-DE', false)) ? "Matches" : "Does not match";
 echo '; ';
-echo (locale_filter_matches('de-DE_1996','de-DE', false)) ? "Matches" : "Does not match"; 
+echo (locale_filter_matches('de-DE_1996','de-DE', false)) ? "Matches" : "Does not match";
 ?>
 ]]>
    </programlisting>
@@ -97,9 +101,9 @@ echo (locale_filter_matches('de-DE_1996','de-DE', false)) ? "Matches" : "Does no
    <programlisting role="php">
 <![CDATA[
 <?php
-echo (Locale::filterMatches('de-DEVA','de-DE', false)) ? "Matches" : "Does not match"; 
+echo (Locale::filterMatches('de-DEVA','de-DE', false)) ? "Matches" : "Does not match";
 echo '; ';
-echo (Locale::filterMatches('de-DE-1996','de-DE', false)) ? "Matches" : "Does not match"; 
+echo (Locale::filterMatches('de-DE-1996','de-DE', false)) ? "Matches" : "Does not match";
 ?>
 ]]>
    </programlisting>

--- a/reference/intl/locale/get-all-variants.xml
+++ b/reference/intl/locale/get-all-variants.xml
@@ -15,7 +15,7 @@
   <methodsynopsis>
    <modifier>public</modifier>
    <modifier>static</modifier>
-   <type>array</type>
+   <type class="union"><type>array</type><type>null</type></type>
    <methodname>Locale::getAllVariants</methodname>
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
   </methodsynopsis>
@@ -23,7 +23,7 @@
    &style.procedural;
   </para>
   <methodsynopsis>
-   <type>array</type>
+   <type class="union"><type>array</type><type>null</type></type>
    <methodname>locale_get_all_variants</methodname>
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
   </methodsynopsis>
@@ -52,8 +52,12 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The <type>array</type> containing the list of all variants subtag for the locale 
+   The <type>array</type> containing the list of all variants subtag for the locale
    or &null; if not present
+  </para>
+  <para>
+   Returns &null; when the length of <parameter>locale</parameter> exceeds
+   <constant>INTL_MAX_LOCALE_LEN</constant>.
   </para>
  </refsect1>
 

--- a/reference/intl/locale/get-keywords.xml
+++ b/reference/intl/locale/get-keywords.xml
@@ -15,7 +15,7 @@
   <methodsynopsis>
    <modifier>public</modifier>
    <modifier>static</modifier>
-   <type>array</type>
+   <type class="union"><type>array</type><type>null</type></type>
    <methodname>Locale::getKeywords</methodname>
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
   </methodsynopsis>
@@ -23,7 +23,7 @@
    &style.procedural;
   </para>
   <methodsynopsis>
-   <type>array</type>
+   <type class="union"><type>array</type><type>null</type></type>
    <methodname>locale_get_keywords</methodname>
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
   </methodsynopsis>
@@ -54,6 +54,10 @@
   <para>
    Associative <type>array</type> containing the keyword-value pairs for this locale
   </para>
+  <para>
+   Returns &null; when the length of <parameter>locale</parameter> exceeds
+   <constant>INTL_MAX_LOCALE_LEN</constant>.
+  </para>
  </refsect1>
 
  <refsect1 role="examples">
@@ -66,7 +70,7 @@
 $keywords_arr = locale_get_keywords('de_DE@currency=EUR;collation=PHONEBOOK');
 if ($keywords_arr) {
     foreach ($keywords_arr as $key => $value) {
-        echo "$key = $value\n"; 
+        echo "$key = $value\n";
     }
 }
 ?>
@@ -81,7 +85,7 @@ if ($keywords_arr) {
 $keywords_arr = Locale::getKeywords('de_DE@currency=EUR;collation=PHONEBOOK');
 if ($keywords_arr) {
     foreach ($keywords_arr as $key => $value) {
-        echo "$key = $value\n"; 
+        echo "$key = $value\n";
     }
 }
 ?>

--- a/reference/intl/locale/get-primary-language.xml
+++ b/reference/intl/locale/get-primary-language.xml
@@ -15,7 +15,7 @@
   <methodsynopsis>
    <modifier>public</modifier>
    <modifier>static</modifier>
-   <type>string</type>
+   <type class="union"><type>string</type><type>null</type></type>
    <methodname>Locale::getPrimaryLanguage</methodname>
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
   </methodsynopsis>
@@ -23,7 +23,7 @@
    &style.procedural;
   </para>
   <methodsynopsis>
-   <type>string</type>
+   <type class="union"><type>string</type><type>null</type></type>
    <methodname>locale_get_primary_language</methodname>
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
   </methodsynopsis>
@@ -52,7 +52,11 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The language code associated with the language or &null; in case of error.
+   The language code associated with the language.
+  </para>
+  <para>
+   Returns &null; when the length of <parameter>locale</parameter> exceeds
+   <constant>INTL_MAX_LOCALE_LEN</constant>.
   </para>
  </refsect1>
 

--- a/reference/intl/locale/get-region.xml
+++ b/reference/intl/locale/get-region.xml
@@ -15,7 +15,7 @@
   <methodsynopsis>
    <modifier>public</modifier>
    <modifier>static</modifier>
-   <type>string</type>
+   <type class="union"><type>string</type><type>null</type></type>
    <methodname>Locale::getRegion</methodname>
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
   </methodsynopsis>
@@ -23,7 +23,7 @@
    &style.procedural;
   </para>
   <methodsynopsis>
-   <type>string</type>
+   <type class="union"><type>string</type><type>null</type></type>
    <methodname>locale_get_region</methodname>
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
   </methodsynopsis>
@@ -53,6 +53,10 @@
   &reftitle.returnvalues;
   <para>
    The region subtag for the locale or &null; if not present
+  </para>
+  <para>
+   Returns &null; when the length of <parameter>locale</parameter> exceeds
+   <constant>INTL_MAX_LOCALE_LEN</constant>.
   </para>
  </refsect1>
 

--- a/reference/intl/locale/lookup.xml
+++ b/reference/intl/locale/lookup.xml
@@ -15,7 +15,7 @@
   <methodsynopsis>
    <modifier>public</modifier>
    <modifier>static</modifier>
-   <type>string</type>
+   <type class="union"><type>string</type><type>null</type></type>
    <methodname>Locale::lookup</methodname>
    <methodparam><type>array</type><parameter>langtag</parameter></methodparam>
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
@@ -26,7 +26,7 @@
    &style.procedural;
   </para>
   <methodsynopsis>
-   <type>string</type>
+   <type class="union"><type>string</type><type>null</type></type>
    <methodname>locale_lookup</methodname>
    <methodparam><type>array</type><parameter>langtag</parameter></methodparam>
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
@@ -34,9 +34,9 @@
    <methodparam choice="opt"><type>string</type><parameter>default</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Searches the items in <parameter>langtag</parameter> for the best match to 
+   Searches the items in <parameter>langtag</parameter> for the best match to
    the language range specified in <parameter>locale</parameter> according to
-   RFC 4647's lookup algorithm. 
+   RFC 4647's lookup algorithm.
   </para>
  </refsect1>
 
@@ -48,7 +48,7 @@
      <term><parameter>langtag</parameter></term>
      <listitem>
       <para>
-       An <type>array</type> containing a list of language tags to compare to 
+       An <type>array</type> containing a list of language tags to compare to
        <parameter>locale</parameter>. Maximum 100 items allowed.
       </para>
      </listitem>
@@ -89,6 +89,10 @@
   &reftitle.returnvalues;
   <para>
    The closest matching language tag or default value.
+  </para>
+  <para>
+   Returns &null; when the length of <parameter>locale</parameter> exceeds
+   <constant>INTL_MAX_LOCALE_LEN</constant>.
   </para>
  </refsect1>
 

--- a/reference/intl/locale/parse-locale.xml
+++ b/reference/intl/locale/parse-locale.xml
@@ -15,7 +15,7 @@
   <methodsynopsis>
    <modifier>public</modifier>
    <modifier>static</modifier>
-   <type>array</type>
+   <type class="union"><type>array</type><type>null</type></type>
    <methodname>Locale::parseLocale</methodname>
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
   </methodsynopsis>
@@ -23,7 +23,7 @@
    &style.procedural;
   </para>
   <methodsynopsis>
-   <type>array</type>
+   <type class="union"><type>array</type><type>null</type></type>
    <methodname>locale_parse</methodname>
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
   </methodsynopsis>


### PR DESCRIPTION
INTL_MAX_LOCALE_LEN limits the length of accepted locale. Anything
longer than that will result in a failure and the value returned
will either be `null` or `false`. So documentation must reflect that
in the return types.

This originated from https://bugs.php.net/bug.php?id=81383