### PR TITLE
Add documentation about the never type

### DIFF
--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -513,6 +513,22 @@ function foo(): X|Y {} // Allowed (redundancy is only known at runtime)
    </para>
   </sect3>
 
+  <sect3 xml:id="language.types.declarations.never">
+   <title>never</title>
+   <para>
+    <literal>never</literal> is a return type indicating the function does not
+    return. This means that it either calls <function>exit</function>, throws
+    an exception, or is an infinite loop.
+    Therefore it cannot be part of a union type declaration.
+    Available as of PHP 8.1.0.
+   </para>
+   <para>
+    <type>never</type> is, in type theory parlance, the bottom type.
+    Meaning it is the subtype of every other type and can replace any other
+    return type during inheritance.
+   </para>
+  </sect3>
+
   <sect3 xml:id="language.types.declarations.static">
    <title>static</title>
    <para>


### PR DESCRIPTION
Support to PhD to generate the link should also be added.

I don't know if it makes sense to clarify at the same type that ``mixed`` is the top type.

@muglug @ondrejmirtes could you have a look as the RFC authors?