### PR TITLE
Updated examples of casting to boolean

### DIFF
--- a/language/types/boolean.xml
+++ b/language/types/boolean.xml
@@ -134,6 +134,7 @@ if ($show_separators) {
 <![CDATA[
 <?php
 var_dump((bool) "");        // bool(false)
+var_dump((bool) "0");       // bool(false)
 var_dump((bool) 1);         // bool(true)
 var_dump((bool) -2);        // bool(true)
 var_dump((bool) "foo");     // bool(true)


### PR DESCRIPTION
Updated examples of casting to boolean adding one case that is pretty often appearing in code: string `"0"`.