### PR TITLE
partly resolve #77017 resources table layout problem

### DIFF
--- a/appendices/resources.xml
+++ b/appendices/resources.xml
@@ -643,9 +643,6 @@
       <function>ibase_blob_close</function>
      </entry>
      <entry> </entry>
-     <entry> </entry>
-     <entry> </entry>
-     <entry> </entry>
     </row>
    <row>
     <entry>interbase link</entry>


### PR DESCRIPTION
This probably resulted in extra added table cells that breaks the 5 column table layout.

![php doc en resources](https://user-images.githubusercontent.com/1839154/131936148-b25c3f44-f34c-4565-bfb6-f87b3d443070.png)