### PR TITLE
Add missing documentation for value parameter of numfmt_parse

### DIFF
--- a/reference/intl/numberformatter/parse.xml
+++ b/reference/intl/numberformatter/parse.xml
@@ -49,6 +49,14 @@
      </listitem>
     </varlistentry>
     <varlistentry>
+     <term><parameter>value</parameter></term>
+     <listitem>
+      <para>
+       The string to parse for the number.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
      <term><parameter>type</parameter></term>
      <listitem>
       <para>


### PR DESCRIPTION
First contribution, so go easy on me!

Seems like we're missing the documentation for the `$value` parameter from this function, which has confused at least my colleague @anotherjames that pointed this out to me.