### PR TITLE
Remove some unnecessary methodsynopsis role attributes

### DIFF
--- a/reference/com/com/construct.xml
+++ b/reference/com/com/construct.xml
@@ -8,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <constructorsynopsis role="oop">
+  <constructorsynopsis>
    <modifier>public</modifier> <methodname>com::__construct</methodname>
    <methodparam><type>string</type><parameter>module_name</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>string</type><type>null</type></type><parameter>server_name</parameter><initializer>&null;</initializer></methodparam>

--- a/reference/com/dotnet/construct.xml
+++ b/reference/com/dotnet/construct.xml
@@ -8,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <constructorsynopsis role="oop">
+  <constructorsynopsis>
    <modifier>public</modifier> <methodname>dotnet::__construct</methodname>
    <methodparam><type>string</type><parameter>assembly_name</parameter></methodparam>
    <methodparam><type>string</type><parameter>datatype_name</parameter></methodparam>

--- a/reference/com/variant/construct.xml
+++ b/reference/com/variant/construct.xml
@@ -8,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <constructorsynopsis role="oop">
+  <constructorsynopsis>
    <modifier>public</modifier> <methodname>variant::__construct</methodname>
    <methodparam choice="opt"><type>mixed</type><parameter>value</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer><constant>VT_EMPTY</constant></initializer></methodparam>

--- a/reference/csprng/functions/random-bytes.xml
+++ b/reference/csprng/functions/random-bytes.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.random-bytes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>random_bytes</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>string</type><methodname>random_bytes</methodname>
    <methodparam><type>int</type><parameter>length</parameter></methodparam>
   </methodsynopsis>
@@ -88,7 +87,6 @@ string(10) "385e33f741"
  </refsect1><!-- }}} -->
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/csprng/functions/random-int.xml
+++ b/reference/csprng/functions/random-int.xml
@@ -9,7 +9,7 @@
 
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>int</type><methodname>random_int</methodname>
    <methodparam><type>int</type><parameter>min</parameter></methodparam>
    <methodparam><type>int</type><parameter>max</parameter></methodparam>

--- a/reference/curl/curlfile/construct.xml
+++ b/reference/curl/curlfile/construct.xml
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>posted_filename</parameter><initializer>&null;</initializer></methodparam>
   </constructorsynopsis>
   <para>&style.procedural;</para>
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>CURLFile</type><methodname>curl_file_create</methodname>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>mime_type</parameter><initializer>&null;</initializer></methodparam>

--- a/reference/curl/functions/curl-multi-errno.xml
+++ b/reference/curl/functions/curl-multi-errno.xml
@@ -8,7 +8,7 @@
 
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>int</type><methodname>curl_multi_errno</methodname>
    <methodparam><type>CurlMultiHandle</type><parameter>multi_handle</parameter></methodparam>
   </methodsynopsis>

--- a/reference/hash/functions/hash-hmac-algos.xml
+++ b/reference/hash/functions/hash-hmac-algos.xml
@@ -9,7 +9,7 @@
 
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>array</type><methodname>hash_hmac_algos</methodname>
    <void />
   </methodsynopsis>

--- a/reference/hash/functions/hash-pbkdf2.xml
+++ b/reference/hash/functions/hash-pbkdf2.xml
@@ -8,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>string</type><methodname>hash_pbkdf2</methodname>
    <methodparam><type>string</type><parameter>algo</parameter></methodparam>
    <methodparam><type>string</type><parameter>password</parameter></methodparam>

--- a/reference/image/functions/imagesetclip.xml
+++ b/reference/image/functions/imagesetclip.xml
@@ -8,7 +8,7 @@
 
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>bool</type><methodname>imagesetclip</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x1</parameter></methodparam>

--- a/reference/imap/functions/imap-mutf7-to-utf8.xml
+++ b/reference/imap/functions/imap-mutf7-to-utf8.xml
@@ -8,7 +8,7 @@
 
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>imap_mutf7_to_utf8</methodname>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>

--- a/reference/imap/functions/imap-utf8-to-mutf7.xml
+++ b/reference/imap/functions/imap-utf8-to-mutf7.xml
@@ -8,7 +8,7 @@
 
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>imap_utf8_to_mutf7</methodname>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>

--- a/reference/misc/functions/sapi-windows-cp-conv.xml
+++ b/reference/misc/functions/sapi-windows-cp-conv.xml
@@ -9,7 +9,7 @@
 
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>string</type><methodname>sapi_windows_cp_conv</methodname>
    <methodparam><type class="union"><type>int</type><type>string</type></type><parameter>in_codepage</parameter></methodparam>
    <methodparam><type class="union"><type>int</type><type>string</type></type><parameter>out_codepage</parameter></methodparam>

--- a/reference/misc/functions/sapi-windows-cp-get.xml
+++ b/reference/misc/functions/sapi-windows-cp-get.xml
@@ -9,7 +9,7 @@
 
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>int</type><methodname>sapi_windows_cp_get</methodname>
    <methodparam choice="opt"><type>string</type><parameter>kind</parameter><initializer>""</initializer></methodparam>
   </methodsynopsis>

--- a/reference/misc/functions/sapi-windows-cp-is-utf8.xml
+++ b/reference/misc/functions/sapi-windows-cp-is-utf8.xml
@@ -9,7 +9,7 @@
 
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>bool</type><methodname>sapi_windows_cp_is_utf8</methodname>
    <void />
   </methodsynopsis>

--- a/reference/misc/functions/sapi-windows-cp-set.xml
+++ b/reference/misc/functions/sapi-windows-cp-set.xml
@@ -9,7 +9,7 @@
 
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>bool</type><methodname>sapi_windows_cp_set</methodname>
    <methodparam><type>int</type><parameter>cp</parameter></methodparam>
   </methodsynopsis>

--- a/reference/misc/functions/sapi-windows-vt100-support.xml
+++ b/reference/misc/functions/sapi-windows-vt100-support.xml
@@ -9,7 +9,7 @@
  
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>bool</type><methodname>sapi_windows_vt100_support</methodname>
    <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>enable</parameter></methodparam>

--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -8,7 +8,7 @@
  
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>bool</type><methodname>setcookie</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>value</parameter><initializer>""</initializer></methodparam>
@@ -19,7 +19,7 @@
    <methodparam choice="opt"><type>bool</type><parameter>httponly</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <para>Alternative signature available as of PHP 7.3.0:</para>
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>bool</type><methodname>setcookie</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>value</parameter><initializer>""</initializer></methodparam>

--- a/reference/network/functions/setrawcookie.xml
+++ b/reference/network/functions/setrawcookie.xml
@@ -8,7 +8,7 @@
  
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>bool</type><methodname>setrawcookie</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>value</parameter></methodparam>
@@ -19,7 +19,7 @@
    <methodparam choice="opt"><type>bool</type><parameter>httponly</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <para>Alternative signature available as of PHP 7.3.0:</para>
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>bool</type><methodname>setrawcookie</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>value</parameter></methodparam>

--- a/reference/openssl/functions/openssl-spki-export-challenge.xml
+++ b/reference/openssl/functions/openssl-spki-export-challenge.xml
@@ -8,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>openssl_spki_export_challenge</methodname>
    <methodparam><type>string</type><parameter>spki</parameter></methodparam>
   </methodsynopsis>

--- a/reference/openssl/functions/openssl-spki-export.xml
+++ b/reference/openssl/functions/openssl-spki-export.xml
@@ -8,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>openssl_spki_export</methodname>
    <methodparam><type>string</type><parameter>spki</parameter></methodparam>
   </methodsynopsis>

--- a/reference/openssl/functions/openssl-spki-new.xml
+++ b/reference/openssl/functions/openssl-spki-new.xml
@@ -8,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>openssl_spki_new</methodname>
    <methodparam><type>OpenSSLAsymmetricKey</type><parameter>private_key</parameter></methodparam>
    <methodparam><type>string</type><parameter>challenge</parameter></methodparam>

--- a/reference/openssl/functions/openssl-spki-verify.xml
+++ b/reference/openssl/functions/openssl-spki-verify.xml
@@ -8,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>bool</type><methodname>openssl_spki_verify</methodname>
    <methodparam><type>string</type><parameter>spki</parameter></methodparam>
   </methodsynopsis>

--- a/reference/snmp/snmp/close.xml
+++ b/reference/snmp/snmp/close.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
 
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>SNMP::close</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/snmp/snmp/get.xml
+++ b/reference/snmp/snmp/get.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
 
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type class="union"><type>array</type><type>bool</type></type><methodname>SNMP::get</methodname>
    <methodparam><type class="union"><type>array</type><type>string</type></type><parameter>objectId</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>preserveKeys</parameter><initializer>&false;</initializer></methodparam>

--- a/reference/snmp/snmp/geterrno.xml
+++ b/reference/snmp/snmp/geterrno.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
 
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>int</type><methodname>SNMP::getErrno</methodname>
    <void />
   </methodsynopsis>

--- a/reference/snmp/snmp/geterror.xml
+++ b/reference/snmp/snmp/geterror.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
 
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>string</type><methodname>SNMP::getError</methodname>
    <void />
   </methodsynopsis>

--- a/reference/snmp/snmp/getnext.xml
+++ b/reference/snmp/snmp/getnext.xml
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
 
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type class="union"><type>array</type><type>bool</type></type><methodname>SNMP::getnext</methodname>
    <methodparam><type class="union"><type>array</type><type>string</type></type><parameter>objectId</parameter></methodparam>
   </methodsynopsis>

--- a/reference/snmp/snmp/set.xml
+++ b/reference/snmp/snmp/set.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
 
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type class="union"><type>array</type><type>bool</type></type><methodname>SNMP::set</methodname>
    <methodparam><type class="union"><type>array</type><type>string</type></type><parameter>objectId</parameter></methodparam>
    <methodparam><type class="union"><type>array</type><type>string</type></type><parameter>type</parameter></methodparam>

--- a/reference/snmp/snmp/setsecurity.xml
+++ b/reference/snmp/snmp/setsecurity.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
 
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>SNMP::setSecurity</methodname>
    <methodparam><type>string</type><parameter>securityLevel</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>authProtocol</parameter><initializer>""</initializer></methodparam>

--- a/reference/snmp/snmp/walk.xml
+++ b/reference/snmp/snmp/walk.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
 
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type class="union"><type>array</type><type>bool</type></type><methodname>SNMP::walk</methodname>
    <methodparam><type class="union"><type>array</type><type>string</type></type><parameter>objectId</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>suffixAsKey</parameter><initializer>&false;</initializer></methodparam>

--- a/reference/sqlite3/sqlite3/enableExceptions.xml
+++ b/reference/sqlite3/sqlite3/enableExceptions.xml
@@ -10,7 +10,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>SQLite3::enableExceptions</methodname>
    <methodparam choice="opt"><type>bool</type><parameter>enable</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>

--- a/reference/zip/ziparchive/addglob.xml
+++ b/reference/zip/ziparchive/addglob.xml
@@ -8,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type class="union"><type>array</type><type>false</type></type><methodname>ZipArchive::addGlob</methodname>
    <methodparam><type>string</type><parameter>pattern</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>

--- a/reference/zip/ziparchive/addpattern.xml
+++ b/reference/zip/ziparchive/addpattern.xml
@@ -8,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type class="union"><type>array</type><type>false</type></type><methodname>ZipArchive::addPattern</methodname>
    <methodparam><type>string</type><parameter>pattern</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>path</parameter><initializer>"."</initializer></methodparam>


### PR DESCRIPTION
These attributes don't seem necessary for me, and only makes noise when method synopses are generated from stubs.