### PR TITLE
Remove some unnecessary abstract modifiers from methodsynopses

### DIFF
--- a/language/predefined/iterator/current.xml
+++ b/language/predefined/iterator/current.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="iterator.current" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Iterator::current</refname>
@@ -10,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>mixed</type><methodname>Iterator::current</methodname>
-   <void />
+   <modifier>public</modifier> <type>mixed</type><methodname>Iterator::current</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns the current element.
@@ -31,7 +30,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
@@ -52,4 +50,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/language/predefined/iterator/key.xml
+++ b/language/predefined/iterator/key.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>mixed</type><methodname>Iterator::key</methodname>
+   <modifier>public</modifier> <type>mixed</type><methodname>Iterator::key</methodname>
    <void/>
   </methodsynopsis>
   <para>

--- a/language/predefined/iterator/next.xml
+++ b/language/predefined/iterator/next.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="iterator.next" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Iterator::next</refname>
@@ -10,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>Iterator::next</methodname>
-   <void />
+   <modifier>public</modifier> <type>void</type><methodname>Iterator::next</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Moves the current position to the next element.
@@ -37,7 +36,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
@@ -58,4 +56,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/language/predefined/iterator/rewind.xml
+++ b/language/predefined/iterator/rewind.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="iterator.rewind" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Iterator::rewind</refname>
@@ -10,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>Iterator::rewind</methodname>
-   <void />
+   <modifier>public</modifier> <type>void</type><methodname>Iterator::rewind</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Rewinds back to the first element of the Iterator.
@@ -38,7 +37,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
@@ -59,4 +57,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/language/predefined/iterator/valid.xml
+++ b/language/predefined/iterator/valid.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="iterator.valid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Iterator::valid</refname>
@@ -10,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>bool</type><methodname>Iterator::valid</methodname>
-   <void />
+   <modifier>public</modifier> <type>bool</type><methodname>Iterator::valid</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    This method is called after <methodname>Iterator::rewind</methodname> and
@@ -34,7 +33,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
@@ -55,4 +53,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/language/predefined/iteratoraggregate/getiterator.xml
+++ b/language/predefined/iteratoraggregate/getiterator.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="iteratoraggregate.getiterator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IteratorAggregate::getIterator</refname>
@@ -10,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>Traversable</type><methodname>IteratorAggregate::getIterator</methodname>
-   <void />
+   <modifier>public</modifier> <type>Traversable</type><methodname>IteratorAggregate::getIterator</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns an external iterator.
@@ -39,7 +38,6 @@
  </refsect1><!-- }}} -->
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/predefined/serializable/serialize.xml
+++ b/language/predefined/serializable/serialize.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="serializable.serialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Serializable::serialize</refname>
@@ -10,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Serializable::serialize</methodname>
-   <void />
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Serializable::serialize</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Should return the string representation of the object.
@@ -50,7 +49,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/predefined/serializable/unserialize.xml
+++ b/language/predefined/serializable/unserialize.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>Serializable::unserialize</methodname>
+   <modifier>public</modifier> <type>void</type><methodname>Serializable::unserialize</methodname>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/language/predefined/throwable/getcode.xml
+++ b/language/predefined/throwable/getcode.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="throwable.getcode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Throwable::getCode</refname>
@@ -10,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>int</type><methodname>Throwable::getCode</methodname>
-   <void />
+   <modifier>public</modifier> <type>int</type><methodname>Throwable::getCode</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns the error code associated with the thrown object.
@@ -42,7 +41,6 @@
   </para>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/predefined/throwable/getfile.xml
+++ b/language/predefined/throwable/getfile.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="throwable.getfile" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Throwable::getFile</refname>
@@ -10,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>string</type><methodname>Throwable::getFile</methodname>
-   <void />
+   <modifier>public</modifier> <type>string</type><methodname>Throwable::getFile</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Get the name of the file in which the thrown object was created.
@@ -39,7 +38,6 @@
   </para>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/predefined/throwable/getline.xml
+++ b/language/predefined/throwable/getline.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="throwable.getline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Throwable::getLine</refname>
@@ -10,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>int</type><methodname>Throwable::getLine</methodname>
-   <void />
+   <modifier>public</modifier> <type>int</type><methodname>Throwable::getLine</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns the line number where the thrown object was instantiated.
@@ -39,7 +38,6 @@
   </para>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/predefined/throwable/getmessage.xml
+++ b/language/predefined/throwable/getmessage.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="throwable.getmessage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Throwable::getMessage</refname>
@@ -10,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>string</type><methodname>Throwable::getMessage</methodname>
-   <void />
+   <modifier>public</modifier> <type>string</type><methodname>Throwable::getMessage</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns the message associated with the thrown object.
@@ -39,7 +38,6 @@
   </para>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/predefined/throwable/getprevious.xml
+++ b/language/predefined/throwable/getprevious.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="throwable.getprevious" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Throwable::getPrevious</refname>
@@ -10,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type class="union"><type>Throwable</type><type>null</type></type> <methodname>Throwable::getPrevious</methodname>
-   <void />
+   <modifier>public</modifier> <type class="union"><type>Throwable</type><type>null</type></type><methodname>Throwable::getPrevious</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns any previous Throwable (for example, one provided as the third
@@ -41,7 +40,6 @@
   </para>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/predefined/throwable/gettrace.xml
+++ b/language/predefined/throwable/gettrace.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="throwable.gettrace" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Throwable::getTrace</refname>
@@ -10,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>array</type><methodname>Throwable::getTrace</methodname>
-   <void />
+   <modifier>public</modifier> <type>array</type><methodname>Throwable::getTrace</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns the stack trace as an <type>array</type>.
@@ -40,7 +39,6 @@
   </para>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/predefined/throwable/gettraceasstring.xml
+++ b/language/predefined/throwable/gettraceasstring.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="throwable.gettraceasstring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Throwable::getTraceAsString</refname>
@@ -10,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>string</type><methodname>Throwable::getTraceAsString</methodname>
-   <void />
+   <modifier>public</modifier> <type>string</type><methodname>Throwable::getTraceAsString</methodname>
+   <void/>
   </methodsynopsis>
   <para>
   </para>
@@ -38,7 +37,6 @@
   </para>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/predefined/weakmap/getiterator.xml
+++ b/language/predefined/weakmap/getiterator.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="weakmap.getiterator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>WeakMap::getIterator</refname>
@@ -10,8 +9,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>Traversable</type><methodname>WeakMap::getIterator</methodname>
-   <void />
+   <modifier>public</modifier> <type>Iterator</type><methodname>WeakMap::getIterator</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns an external iterator.
@@ -39,7 +38,6 @@
  </refsect1><!-- }}} -->
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/json/jsonserializable/jsonserialize.xml
+++ b/reference/json/jsonserializable/jsonserialize.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>mixed</type><methodname>JsonSerializable::jsonSerialize</methodname>
+   <modifier>public</modifier> <type>mixed</type><methodname>JsonSerializable::jsonSerialize</methodname>
    <void/>
   </methodsynopsis>
   <para>

--- a/reference/session/sessionhandlerinterface/close.xml
+++ b/reference/session/sessionhandlerinterface/close.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>bool</type><methodname>SessionHandlerInterface::close</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>SessionHandlerInterface::close</methodname>
    <void/>
   </methodsynopsis>
   <para>

--- a/reference/session/sessionhandlerinterface/destroy.xml
+++ b/reference/session/sessionhandlerinterface/destroy.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>bool</type><methodname>SessionHandlerInterface::destroy</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>SessionHandlerInterface::destroy</methodname>
    <methodparam><type>string</type><parameter>id</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/session/sessionhandlerinterface/gc.xml
+++ b/reference/session/sessionhandlerinterface/gc.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>SessionHandlerInterface::gc</methodname>
+   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>SessionHandlerInterface::gc</methodname>
    <methodparam><type>int</type><parameter>max_lifetime</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/session/sessionhandlerinterface/open.xml
+++ b/reference/session/sessionhandlerinterface/open.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>bool</type><methodname>SessionHandlerInterface::open</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>SessionHandlerInterface::open</methodname>
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>

--- a/reference/session/sessionhandlerinterface/write.xml
+++ b/reference/session/sessionhandlerinterface/write.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>bool</type><methodname>SessionHandlerInterface::write</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>SessionHandlerInterface::write</methodname>
    <methodparam><type>string</type><parameter>id</parameter></methodparam>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>

--- a/reference/session/sessionidinterface/create-sid.xml
+++ b/reference/session/sessionidinterface/create-sid.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>string</type><methodname>SessionIdInterface::create_sid</methodname>
+   <modifier>public</modifier> <type>string</type><methodname>SessionIdInterface::create_sid</methodname>
    <void/>
   </methodsynopsis>
   <para>

--- a/reference/session/sessionupdatetimestamphandlerinterface/updatetimestamp.xml
+++ b/reference/session/sessionupdatetimestamphandlerinterface/updatetimestamp.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>bool</type><methodname>SessionUpdateTimestampHandlerInterface::updateTimestamp</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>SessionUpdateTimestampHandlerInterface::updateTimestamp</methodname>
    <methodparam><type>string</type><parameter>id</parameter></methodparam>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>

--- a/reference/session/sessionupdatetimestamphandlerinterface/validateid.xml
+++ b/reference/session/sessionupdatetimestamphandlerinterface/validateid.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>bool</type><methodname>SessionUpdateTimestampHandlerInterface::validateId</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>SessionUpdateTimestampHandlerInterface::validateId</methodname>
    <methodparam><type>string</type><parameter>id</parameter></methodparam>
   </methodsynopsis>
   <para>


### PR DESCRIPTION
These are unnecessary since the `interface` keyword is displayed on the class synopsis pages.