### PR TITLE
Fix #81365: Flipping opcache.file_cache_only is broken

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -826,6 +826,12 @@
      <para>
       Enables or disables opcode caching in shared memory.
      </para>
+     <note>
+      <para>
+       Prior to PHP 8.1.0, disabling this directive with an already populated
+       file cache required to manually clear the file cache.
+      </para>
+     </note>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="ini.opcache.file-cache-consistency-checks">


### PR DESCRIPTION
@nikic, is that a correct interpretation of https://bugs.php.net/bug.php?id=81365#1629279195?