### PR TITLE
Add missing parameter defaults for `http_build_query`

### DIFF
--- a/reference/url/functions/http-build-query.xml
+++ b/reference/url/functions/http-build-query.xml
@@ -10,9 +10,9 @@
   &reftitle.description;
   <methodsynopsis>
    <type>string</type><methodname>http_build_query</methodname>
-   <methodparam><type>mixed</type><parameter>data</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>numeric_prefix</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>arg_separator</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>data</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>numeric_prefix</parameter><initializer>""</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>arg_separator</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>encoding_type</parameter><initializer><constant>PHP_QUERY_RFC1738</constant></initializer></methodparam>
   </methodsynopsis>
   <para>


### PR DESCRIPTION
This PR adds the missing parameter initializers for the `http_build_query` function And updates the signature to match the one in [/basic_functions.stub.php](https://github.com/php/php-src/blob/f983373e44dd45c7e09036fc67476fc946306b3c/ext/standard/basic_functions.stub.php#L1298). As discussed in #916 