### PR TITLE
Remove duplicate "Superglobals"

### DIFF
--- a/language/predefined/variables/superglobals.xml
+++ b/language/predefined/variables/superglobals.xml
@@ -4,7 +4,7 @@
 <phpdoc:varentry xmlns:phpdoc="http://php.net/ns/phpdoc" xml:id="language.variables.superglobals" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" role="noversion">
  <refnamediv>
   <refname>Superglobals</refname>
-  <refpurpose>Superglobals are built-in variables that are always available in all scopes</refpurpose>
+  <refpurpose>Bilt-in variables that are always available in all scopes</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">

--- a/language/predefined/variables/superglobals.xml
+++ b/language/predefined/variables/superglobals.xml
@@ -4,7 +4,7 @@
 <phpdoc:varentry xmlns:phpdoc="http://php.net/ns/phpdoc" xml:id="language.variables.superglobals" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" role="noversion">
  <refnamediv>
   <refname>Superglobals</refname>
-  <refpurpose>Bilt-in variables that are always available in all scopes</refpurpose>
+  <refpurpose>Built-in variables that are always available in all scopes</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">


### PR DESCRIPTION
In the site it looked like "Superglobals — Superglobals are built-in variables that are always available in all scopes" 
https://www.php.net/manual/en/language.variables.superglobals.php