### PR TITLE
Followed change of default value of display_startup_errors, as of PHP 8.0.0

### DIFF
--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -209,7 +209,7 @@
        <entry>"1"</entry>
        <entry>PHP_INI_ALL</entry>
        <entry>
-        Previous version of PHP 8.0.0, the default value was "0".
+        Prior to PHP 8.0.0, the default value was <literal>"0"</literal>.
        </entry>
       </row>
       <row>

--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -206,9 +206,11 @@
       </row>
       <row>
        <entry><link linkend="ini.display-startup-errors">display_startup_errors</link></entry>
-       <entry>"0"</entry>
+       <entry>"1"</entry>
        <entry>PHP_INI_ALL</entry>
-       <entry></entry>
+       <entry>
+        Previous version of PHP 8.0.0, the default value was "0".
+       </entry>
       </row>
       <row>
        <entry><link linkend="ini.docref-ext">docref_ext</link></entry>

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -30,9 +30,11 @@
     </row>
     <row>
      <entry><link linkend="ini.display-startup-errors">display_startup_errors</link></entry>
-     <entry>"0"</entry>
+     <entry>"1"</entry>
      <entry>PHP_INI_ALL</entry>
-     <entry></entry>
+     <entry>
+       Previous version of PHP 8.0.0, the default value was "0".
+     </entry>
     </row>
     <row>
      <entry><link linkend="ini.log-errors">log_errors</link></entry>

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -33,7 +33,7 @@
      <entry>"1"</entry>
      <entry>PHP_INI_ALL</entry>
      <entry>
-       Previous version of PHP 8.0.0, the default value was "0".
+       Prior to PHP 8.0.0, the default value was <literal>"0"</literal>.
      </entry>
     </row>
     <row>


### PR DESCRIPTION
Quoted from [appendices/migration80/incompatible.xml](https://github.com/php/doc-en/blob/master/appendices/migration80/incompatible.xml#L175-L180).

```
display_startup_errors is now enabled by default.
```

