### PR TITLE
Fix `password_needs_rehash` method signature

### DIFF
--- a/reference/password/functions/password-needs-rehash.xml
+++ b/reference/password/functions/password-needs-rehash.xml
@@ -12,8 +12,8 @@
   <methodsynopsis>
    <type>bool</type><methodname>password_needs_rehash</methodname>
    <methodparam><type>string</type><parameter>hash</parameter></methodparam>
-   <methodparam><type>mixed</type><parameter>algo</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>int</type><type>null</type></type><parameter>algo</parameter></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>[]</initializer></methodparam>
   </methodsynopsis>
   <para>
    This function checks to see if the supplied hash implements the algorithm


### PR DESCRIPTION
Noticed that the current method signature for `password_needs_rehash` in the [documentation](https://www.php.net/manual/en/function.password-needs-rehash.php) was wrong.

`$algo` should be of `string|int|null` like `password_hash` and not `mixed`. It was also missing the default initializer for `$options`.

This PR makes sure the signature matches up with the internal method signature found in [standard/basic_functions.stub.php](https://github.com/php/php-src/blob/c19e4b9997cd429c86c20e9210ff3d9b2e94171d/ext/standard/basic_functions.stub.php#L1511).