### PR TITLE
Updated error_reporting default value description.

### DIFF
--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -268,9 +268,15 @@
       </row>
       <row>
        <entry><link linkend="ini.error-reporting">error_reporting</link></entry>
-       <entry>NULL</entry>
+       <entry>E_ALL</entry>
        <entry>PHP_INI_ALL</entry>
-       <entry></entry>
+       <entry>
+        Prior to PHP 8.0.0, the default value was
+        <constant>E_ALL</constant> &amp;
+        ~<constant>E_NOTICE</constant> &amp;
+        ~<constant>E_STRICT</constant> &amp;
+        ~<constant>E_DEPRECATED</constant>
+       </entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exif.configuration.list')/*)"><xi:fallback/></xi:include>
       <row>

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -18,9 +18,15 @@
     <tbody>
     <row>
      <entry><link linkend="ini.error-reporting">error_reporting</link></entry>
-     <entry>NULL</entry>
+     <entry>E_ALL</entry>
      <entry>PHP_INI_ALL</entry>
-     <entry></entry>
+     <entry>
+      Prior to PHP 8.0.0, the default value was
+      <constant>E_ALL</constant> &amp;
+      ~<constant>E_NOTICE</constant> &amp;
+      ~<constant>E_STRICT</constant> &amp;
+      ~<constant>E_DEPRECATED</constant>
+     </entry>
     </row>
     <row>
      <entry><link linkend="ini.display-errors">display_errors</link></entry>
@@ -165,7 +171,8 @@
      </para>
      <para>
       The default value
-      is <constant>E_ALL</constant> &amp;
+      is <constant>E_ALL</constant> as of PHP 8.0.0,
+      previously, <constant>E_ALL</constant> &amp;
       ~<constant>E_NOTICE</constant> &amp;
       ~<constant>E_STRICT</constant> &amp;
       ~<constant>E_DEPRECATED</constant>. This setting does not


### PR DESCRIPTION
As of PHP 8.0.0, `error_reporting` ini derective default value was changed.

closes: #928