### PR TITLE
Remove `php_logo_guid` references

### DIFF
--- a/reference/info/functions/phpcredits.xml
+++ b/reference/info/functions/phpcredits.xml
@@ -167,7 +167,6 @@ phpcredits(CREDITS_ALL - CREDITS_FULLPAGE);
   <para>
    <simplelist>
     <member><function>phpversion</function></member>
-    <member><function>php_logo_guid</function></member>
     <member><function>phpinfo</function></member>
    </simplelist>
   </para>

--- a/reference/info/functions/phpinfo.xml
+++ b/reference/info/functions/phpinfo.xml
@@ -186,7 +186,6 @@ phpinfo(INFO_MODULES);
    <simplelist>
     <member><function>phpversion</function></member>
     <member><function>phpcredits</function></member>
-    <member><function>php_logo_guid</function></member>
     <member><function>ini_get</function></member>
     <member><function>ini_set</function></member>
     <member><function>get_loaded_extensions</function></member>

--- a/reference/info/functions/phpversion.xml
+++ b/reference/info/functions/phpversion.xml
@@ -123,7 +123,6 @@ if (PHP_VERSION_ID < 50207) {
     <member><function>version_compare</function></member>
     <member><function>phpinfo</function></member>
     <member><function>phpcredits</function></member>
-    <member><function>php_logo_guid</function></member>
     <member><function>zend_version</function></member>
    </simplelist>
   </para>

--- a/reference/info/functions/zend-version.xml
+++ b/reference/info/functions/zend-version.xml
@@ -58,7 +58,6 @@ Zend engine version: 2.2.0
    <simplelist>
     <member><function>phpinfo</function></member>
     <member><function>phpcredits</function></member>
-    <member><function>php_logo_guid</function></member>
     <member><function>phpversion</function></member>
    </simplelist>
   </para>


### PR DESCRIPTION
This PR removes 4 references to the now-removed `php_logo_guid` function.