### PR TITLE
[81385] Add `ReflectionProperty::isPromoted` documentation

### DIFF
--- a/reference/reflection/reflectionproperty/ispromoted.xml
+++ b/reference/reflection/reflectionproperty/ispromoted.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="reflectionproperty.ispromoted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionProperty::isPromoted</refname>
+  <refpurpose>Checks if property is promoted</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>ReflectionProperty::isPromoted</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Checks whether the property is promoted
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &true; if the property is promoted, &false; otherwise.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><methodname>ReflectionProperty::isPromoted</methodname> example</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+class Foo {
+    public $baz;
+
+    public function __construct(public $bar) {}
+}
+
+$o = new Foo(42);
+$o->baz = 42;
+
+$ro = new ReflectionObject($o);
+var_dump($ro->getProperty('bar')->isPromoted());
+var_dump($ro->getProperty('baz')->isPromoted());
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+bool(true)
+bool(false)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ReflectionProperty::isDefault</methodname></member>
+    <member><methodname>ReflectionProperty::isInitialized</methodname></member>
+    <member><methodname>ReflectionProperty::getValue</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/versions.xml
+++ b/reference/reflection/versions.xml
@@ -293,6 +293,7 @@
  <function name="reflectionproperty::getdefaultvalue" from="PHP 8"/>
  <function name="reflectionproperty::getattributes" from="PHP 8"/>
  <function name="reflectionproperty::hasdefaultvalue" from="PHP 8"/>
+ <function name="reflectionproperty::ispromoted" from="PHP 8"/>
 
  <function name="reflectionextension" from="PHP 5, PHP 7, PHP 8"/>
  <function name="reflectionextension::__clone" from="PHP 5, PHP 7, PHP 8"/>


### PR DESCRIPTION
This PR adds documentation for the `isPromoted` method on the `ReflectionProperty` class. It was generated using the gendoc script from [doc-base](https://github.com/php/doc-base/) and wording was based on [isPrivate](https://www.php.net/manual/en/reflectionproperty.isprivate.php) and example forked from [isDefault](https://www.php.net/manual/en/reflectionproperty.isdefault.php) and re worked to match `isPromoted`.

Feel free to suggest changes and or additions. 👍