### PR TITLE
mixed is a reserved word as of PHP 8.0.0.

### DIFF
--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -73,6 +73,11 @@
     </listitem>
     <listitem>
      <para>
+      <literal>mixed</literal> is now a reserved word, so it cannot be used to name a class, interface or trait, and is also prohibited from being used in namespaces.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
       Assertion failures now throw by default. If the old behavior is desired,
       <code>assert.exception=0</code> can be set in the INI settings.
      </para>

--- a/appendices/reserved.xml
+++ b/appendices/reserved.xml
@@ -536,6 +536,9 @@
         <entry>
          object (as of PHP 7.2)
         </entry>
+        <entry>
+         mixed (as of PHP 8.0)
+        </entry>
        </row>
       </tbody>
      </tgroup>
@@ -555,9 +558,6 @@
        <row>
         <entry>
          resource
-        </entry>
-        <entry>
-         mixed
         </entry>
         <entry>
          numeric


### PR DESCRIPTION
mixed is now reserved word as of PHP 8.0.0, so updated migration guide and reserved word list.

* trait
  - https://3v4l.org/kZ0Mc
* class
  - https://3v4l.org/5NCWs
* interface
  - https://3v4l.org/FsR5g