### PR TITLE
Migration guide from PHP 8.0 to PHP 8.1

### DIFF
--- a/appendices/migration81.xml
+++ b/appendices/migration81.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<appendix xml:id="migration81" xmlns="http://docbook.org/ns/docbook" xmlns:phd="http://www.php.net/ns/phd">
+ <title>Migrating from PHP 8.0.x to PHP 8.1.x</title>
+
+ &appendices.migration81.new-features;
+ &appendices.migration81.new-classes;
+ &appendices.migration81.new-functions;
+ &appendices.migration81.constants;
+ &appendices.migration81.incompatible;
+ &appendices.migration81.deprecated;
+
+ <sect1 phd:chunk="false" xml:id="migration81.intro">
+  <para>
+   This new minor version brings with it a number of
+   <link linkend="migration81.new-features">new features</link> and a
+   <link linkend="migration81.incompatible">few incompatibilities</link>
+   that should be tested for before switching PHP versions in production
+   environments.
+  </para>
+
+  <para>
+   &manual.migration.seealso;
+   <link linkend="migration71">7.1.x</link>,
+   <link linkend="migration72">7.2.x</link>,
+   <link linkend="migration73">7.3.x</link>,
+   <link linkend="migration74">7.4.x</link>,
+   <link linkend="migration80">8.0.x</link>.
+  </para>
+ </sect1>
+</appendix>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration81.xml
+++ b/appendices/migration81.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-
 <appendix xml:id="migration81" xmlns="http://docbook.org/ns/docbook" xmlns:phd="http://www.php.net/ns/phd">
  <title>Migrating from PHP 8.0.x to PHP 8.1.x</title>
 
@@ -31,7 +29,6 @@
   </para>
  </sect1>
 </appendix>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/appendices/migration81.xml
+++ b/appendices/migration81.xml
@@ -10,6 +10,7 @@
  &appendices.migration81.constants;
  &appendices.migration81.incompatible;
  &appendices.migration81.deprecated;
+ &appendices.migration80.other-changes;
 
  <sect1 phd:chunk="false" xml:id="migration81.intro">
   <para>

--- a/appendices/migration81.xml
+++ b/appendices/migration81.xml
@@ -8,7 +8,7 @@
  &appendices.migration81.constants;
  &appendices.migration81.incompatible;
  &appendices.migration81.deprecated;
- &appendices.migration80.other-changes;
+ &appendices.migration81.other-changes;
 
  <sect1 phd:chunk="false" xml:id="migration81.intro">
   <para>

--- a/appendices/migration81/constants.xml
+++ b/appendices/migration81/constants.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration81.constants" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>New Global Constants</title>
+
+ <sect2 xml:id="migration81.constants.mysqli">
+  <title>MySQLi</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>MYSQLI_REFRESH_REPLICA</constant></simpara>
+    <para>
+     This constant has been added as a replacement for
+     <constant>MYSQLI_REFRESH_SLAVE</constant>,
+     in line with an upstream change in MySQL.
+     The old constant is still available for backwards-compatibility reasons,
+     but may be deprecated/removed in the future.
+    </para>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.constants.sockets">
+  <title>Sockets</title>
+
+  <para>
+   The following socket options are now defined if they are supported:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>SO_ACCEPTFILTER</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_DONTTRUNC</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_WANTMORE</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_MARK</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>TCP_DEFER_ACCEPT</constant></simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration81/deprecated.xml
+++ b/appendices/migration81/deprecated.xml
@@ -77,7 +77,7 @@ $a[15.0]; // ok, as 15.0 == 15
 
    <para>
     Returning a value which is not an &array; from
-    <function>__sleep</function> now generates a diagnostic.
+    <link linkend="object.sleep">__sleep()</link> now generates a diagnostic.
    </para>
   </sect3>
 
@@ -215,7 +215,7 @@ $arr[] = 2;
   <title>IMAP</title>
 
   <para>
-   The <constant>NIL</constant> has been deprecated.
+   The <constant>NIL</constant> constant has been deprecated.
    Use <literal>0</literal> instead.
   </para>
  </sect2>
@@ -224,7 +224,7 @@ $arr[] = 2;
   <title>Intl</title>
 
   <para>
-   Calling <methodname>IntlCalendar::roll()</methodname> with a
+   Calling <methodname>IntlCalendar::roll</methodname> with a
    &boolean; argument is deprecated.
    Use <literal>1</literal> and <literal>-1</literal> instead of
    &true; and &false; respectively.
@@ -253,7 +253,7 @@ $arr[] = 2;
   <para>
    Calling <methodname>mysqli::get_client_info</methodname> or
    <function>mysqli_get_client_info</function> with the
-   <parameter>mysqli</parameter> has been deprecated.
+   <parameter>mysqli</parameter> argument has been deprecated.
    Call <function>mysqli_get_client_info</function> without any arguments
    to obtain the version information of the client library.
   </para>
@@ -303,8 +303,8 @@ $arr[] = 2;
   <title>SOAP</title>
 
   <para>
-   The <parameter>ssl_method</parameter> of
-   <methodname>SoapClient::__constructor</methodname> has been deprecated
+   The <literal>ssl_method</literal> option of
+   <methodname>SoapClient::__construct</methodname> has been deprecated
    in favor of SSL stream context options.
    <!-- The direct equivalent would be
     crypto_method, but min_proto_version/max_proto_version are recommended

--- a/appendices/migration81/deprecated.xml
+++ b/appendices/migration81/deprecated.xml
@@ -7,7 +7,7 @@
 
   <sect3 xml:id="migration81.deprecated.core.serialize-interface">
    <title>
-    Implementing <interface>Serializable</interface> without
+    Implementing <interfacename>Serializable</interfacename> without
     <function>__serialize</function> and <function>__unserialize</function>
    </title>
 
@@ -27,7 +27,7 @@
 
     <informalexample>
      <programlisting role="php">
-      <![CDATA[
+<![CDATA[
 <?php
 var_dump(str_contains("foobar", null));
 // Deprecated: Passing null to parameter #2 ($needle) of type string
@@ -40,19 +40,19 @@ var_dump(str_contains("foobar", null));
   </sect3>
 
   <sect3 xml:id="migration81.deprecated.core.implicit-float-conversion">
-   <title>Implicit incompatible <type>float</type> to <type>int</type> conversions</title>
+   <title>Implicit incompatible &float; to &integer; conversions</title>
 
    <para>
-    The implicit conversion of <type>float</type> to <type>int</type> which
+    The implicit conversion of &float; to &integer; which
     leads to a loss in precision is now deprecated.
-    This affects &array; keys, <type>int</type> type declarations in coercive mode,
-    and operators working on &interger;s.
+    This affects &array; keys, &integer; type declarations in coercive mode,
+    and operators working on &integer;s.
 
     <informalexample>
      <programlisting role="php">
 <![CDATA[
 <?php
-$a = []
+$a = [];
 $a[15.5]; // deprecated, as key value loses the 0.5 component
 $a[15.0]; // ok, as 15.0 == 15
 ?>
@@ -76,7 +76,7 @@ $a[15.0]; // ok, as 15.0 == 15
    <title>Returning a non-&array; from <function>__sleep</function></title>
 
    <para>
-    Returning a value which is not an <type>array</type> from
+    Returning a value which is not an &array; from
     <function>__sleep</function> now generates a diagnostic.
    </para>
   </sect3>
@@ -125,12 +125,14 @@ $arr[] = 2;   // deprecated
      <informalexample>
       <programlisting role="php">
 <![CDATA[
+<?php
 // From undefined
 $arr[] = 'some value';
 $arr['doesNotExist'][] = 2;
 // From null
 $arr = null;
 $arr[] = 2;
+?>
 ]]>
       </programlisting>
      </informalexample>
@@ -143,7 +145,7 @@ $arr[] = 2;
  <sect2 xml:id="migration81.deprecated.ctype">
   <title>ctype</title>
 
-  <sect3 xml:id="migration73.deprecated.core.string-search">
+  <sect3 xml:id="migration81.deprecated.ctype.nonstring-arguments">
    <title>Verifying non-string arguments</title>
 
    <para>
@@ -151,7 +153,7 @@ $arr[] = 2;
     In the future the argument will be interpreted as a string instead
     of an ASCII codepoint.
     Depending on the intended behavior, the argument should either be
-    casted to <type>string</type> or an explicit call to
+    casted to &string; or an explicit call to
     <function>chr</function> should be made.
     All <literal>ctype_*()</literal> functions are affected.
    </para>

--- a/appendices/migration81/deprecated.xml
+++ b/appendices/migration81/deprecated.xml
@@ -1,0 +1,336 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration81.deprecated">
+ <title>Deprecated Features</title>
+
+ <sect2 xml:id="migration81.deprecated.core">
+  <title>PHP Core</title>
+
+  <sect3 xml:id="migration81.deprecated.core.serialize-interface">
+   <title>
+    Implementing <interface>Serializable</interface> without
+    <function>__serialize</function> and <function>__unserialize</function>
+   </title>
+
+   <para>
+    Either only the new methods should be implemented, if no support for
+    PHP prior than version 7.4 is provided, or both should be implemented.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.deprecated.core.implicit-float-conversion">
+   <title>Implicit incompatible <type>float</type> to <type>int</type> conversions</title>
+
+   <para>
+    The implicit conversion of <type>float</type> to <type>int</type> which
+    leads to a loss in precision is now deprecated.
+    This affects &array; keys, <type>int</type> type declarations in coercive mode,
+    and operators working on &interger;s.
+
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+$a = []
+$a[15.5]; // deprecated, as key value loses the 0.5 component
+$a[15.0]; // ok, as 15.0 == 15
+?>
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.deprecated.core.static-trait">
+   <title>Calling a <modifier>static</modifier> element on a trait</title>
+
+   <para>
+    Calling a <modifier>static</modifier> method, or accessing a
+    <modifier>static</modifier> property directly on a trait is deprecated.
+    Static methods and properties should only be accessed on a class using the trait.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.deprecated.core.magic-sleep">
+   <title>Returning a non-&array; from <function>__sleep</function></title>
+
+   <para>
+    Returning a value which is not an <type>array</type> from
+    <function>__sleep</function> now generates a diagnostic.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.deprecated.core.void-by-ref">
+   <title>Returning by reference from a <type>void</type> function</title>
+
+   <para>
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+function &test(): void {}
+?>
+]]>
+     </programlisting>
+    </informalexample>
+    Such a function is contradictory, and already emits the following
+    <constant>E_NOTICE</constant> when called:
+    <literal>Only variable references should be returned by reference</literal>.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.deprecated.core.autovivification-false">
+   <title>Autovivification from &false;</title>
+   <para>
+    Autovivification is the process of creating a new &array; when
+    appending to a value.
+    Autovivification is prohibited from scalar values, &false; however
+    was an exception. This is now deprecated.
+
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+$arr = false;
+$arr[] = 2;   // deprecated
+?>
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+   <note>
+    <para>
+     Autovivification from &null; and undefined values is still allowed:
+     <informalexample>
+      <programlisting role="php">
+<![CDATA[
+// From undefined
+$arr[] = 'some value';
+$arr['doesNotExist'][] = 2;
+// From null
+$arr = null;
+$arr[] = 2;
+]]>
+      </programlisting>
+     </informalexample>
+    </para>
+   </note>
+  </sect3>
+
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.ctype">
+  <title>ctype</title>
+
+  <sect3 xml:id="migration73.deprecated.core.string-search">
+   <title>Verifying non-string arguments</title>
+
+   <para>
+    Passing a non-string argument is deprecated.
+    In the future the argument will be interpreted as a string instead
+    of an ASCII codepoint.
+    Depending on the intended behavior, the argument should either be
+    casted to <type>string</type> or an explicit call to
+    <function>chr</function> should be made.
+    All <literal>ctype_*()</literal> functions are affected.
+   </para>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.date">
+  <title>Date</title>
+
+  <para>
+   The <function>date_sunrise</function> and <function>date_sunset</function>
+   have been deprecated in favor of <function>date_sun_info</function>.
+  </para>
+
+  <para>
+   The <function>strptime</function> has been deprecated.
+   Use <function>date_parse_from_format</function> instead (for locale-independent parsing),
+   or <methodname>IntlDateFormatter::parse</methodname> (for locale-dependent parsing).
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.filter">
+  <title>Filter</title>
+
+  <para>
+   The <constant>FILTER_SANITIZE_STRING</constant> and
+   <constant>FILTER_SANITIZE_STRIPPED</constant> filters are deprecated.
+  </para>
+  <para>
+   The <link linkend="ini.filter.default">filter.default</link>
+   INI directive is deprecated.
+   <!-- TODO Check that filter.default_flags -->
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.gd">
+  <title>GD</title>
+
+  <para>
+   The <parameter>num_points</parameter> of <function>imageopenpolygon</function>
+   and <function>imagefilledpolygon</function> has been deprecated.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.hash">
+  <title>Hash</title>
+
+  <para>
+   The <function>mhash</function>,
+   <function>mhash_keygen_s2k</function>,
+   <function>mhash_count</function>,
+   <function>mhash_get_block_size</function>,
+   and <function>mhash_get_hash_name</function> have been deprecated.
+   Use the <literal>hash_*()</literal> functions instead.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.imap">
+  <title>IMAP</title>
+
+  <para>
+   The <constant>NIL</constant> has been deprecated.
+   Use <literal>0</literal> instead.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.intl">
+  <title>Intl</title>
+
+  <para>
+   Calling <methodname>IntlCalendar::roll()</methodname> with a
+   &boolean; argument is deprecated.
+   Use <literal>1</literal> and <literal>-1</literal> instead of
+   &true; and &false; respectively.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.mbstring">
+  <title>Multibyte String</title>
+
+  <para>
+   Calling <function>mb_check_encoding</function> without any arguments
+   is deprecated.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.mysqli">
+  <title>MySQLi</title>
+
+  <para>
+   The <property>mysqli_driver::$driver_version</property> property
+   has been deprecated.
+   It was meaningless and outdated, use <constant>PHP_VERSION_ID</constant>
+   instead.
+  </para>
+
+  <para>
+   Calling <methodname>mysqli::get_client_info</methodname> or
+   <function>mysqli_get_client_info</function> with the
+   <parameter>mysqli</parameter> has been deprecated.
+   Call <function>mysqli_get_client_info</function> without any arguments
+   to obtain the version information of the client library.
+  </para>
+
+  <para>
+   The <methodname>mysqli::init</methodname> method has been deprecated.
+   Replace calls to <methodname>parent::init</methodname> with
+   <methodname>parent::__construct</methodname>.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.oci8">
+  <title>OCI8</title>
+
+  <para>
+   The <link linkend="ini.oci8.old-oci-close-semantics">oci8.old_oci_close_semantics</link>
+   INI directive is deprecated.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.odbc">
+  <title>ODBC</title>
+
+  <para>
+   <function>odbc_result_all</function> has been deprecated.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.pdo">
+  <title>PDO</title>
+
+  <para>
+   The <constant>PDO::FETCH_SERIALIZE</constant> fetch mode has been deprecated.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.pgsql">
+  <title>PgSQL</title>
+
+  <para>
+   Not passing the connection argument to all <literal>pgsql_*()</literal>
+   functions has been deprecated.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.soap">
+  <title>SOAP</title>
+
+  <para>
+   The <parameter>ssl_method</parameter> of
+   <methodname>SoapClient::__constructor</methodname> has been deprecated
+   in favor of SSL stream context options.
+   <!-- The direct equivalent would be
+    crypto_method, but min_proto_version/max_proto_version are recommended
+    instead. -->
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.standard">
+  <title>Standard</title>
+
+  <para>
+   Calling <function>key</function>, <function>current</function>,
+   <function>next</function>, <function>prev</function>,
+   <function>reset</function>, or <function>end</function>
+   on &object;s is deprecated.
+   Either use <function>get_mangled_object_vars</function> on the
+   object first, or use <classname>ArrayIterator</classname>.
+  </para>
+
+  <para>
+   The <link linkend="ini.auto-detect-line-endings">auto_detect_line_endings</link>
+   INI directive is deprecated.
+   If necessary, handle <literal>"\r"</literal> line breaks manually instead.
+  </para>
+
+  <para>
+   The <constant>FILE_BINARY</constant> and
+   <constant>FILE_TEXT</constant> constants have been deprecated.
+   They never had any effect.
+  </para>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration81/deprecated.xml
+++ b/appendices/migration81/deprecated.xml
@@ -17,6 +17,28 @@
    </para>
   </sect3>
 
+  <sect3 xml:id="migration81.deprecated.core.null-not-nullable-internal">
+   <title>Passing &null; to non-nullable parameters of built-in functions</title>
+
+   <para>
+    Scalar types for built-in functions are nullable by default,
+    this behaviour is deprecated to align with the behaviour of user-defined
+    functions, where scalar types need to be marked as nullable explicitly.
+
+    <informalexample>
+     <programlisting role="php">
+      <![CDATA[
+<?php
+var_dump(str_contains("foobar", null));
+// Deprecated: Passing null to parameter #2 ($needle) of type string
+//             is deprecated
+?>
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+  </sect3>
+
   <sect3 xml:id="migration81.deprecated.core.implicit-float-conversion">
    <title>Implicit incompatible <type>float</type> to <type>int</type> conversions</title>
 

--- a/appendices/migration81/deprecated.xml
+++ b/appendices/migration81/deprecated.xml
@@ -13,7 +13,7 @@
 
    <para>
     Either only the new methods should be implemented, if no support for
-    PHP prior than version 7.4 is provided, or both should be implemented.
+    PHP prior to version 7.4 is provided, or both should be implemented.
    </para>
   </sect3>
 
@@ -150,7 +150,7 @@ $arr[] = 2;
 
    <para>
     Passing a non-string argument is deprecated.
-    In the future the argument will be interpreted as a string instead
+    In the future, the argument will be interpreted as a string instead
     of an ASCII codepoint.
     Depending on the intended behavior, the argument should either be
     casted to &string; or an explicit call to

--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -33,7 +33,7 @@
 
  </sect2>
 
- <sect2 xml:id="migration80.incompatible.resource2object">
+ <sect2 xml:id="migration81.incompatible.resource2object">
   <title>Resource to Object Migration</title>
 
   <para>
@@ -133,7 +133,7 @@
   <title>MySQLnd</title>
 
   <para>
-   The <link linkend="ini.mysqlnd.fetch-copy-data">mysqlnd.fetch_copy_data</link>
+   The <link linkend="ini.mysqlnd.fetch_data_copy">mysqlnd.fetch_data_copy</link>
    INI directive has been removed.
    This should not result in user-visible behavior changes.
   </para>
@@ -159,7 +159,7 @@
 
   <para>
    <constant>PDO::ATTR_STRINGIFY_FETCHES</constant> now stringifies values
-   of type <type>bool</type> to <literal>"0"</literal> or
+   of type &boolean; to <literal>"0"</literal> or
    <literal>"1"</literal>. Previously &boolean;s were not stringified.
   </para>
   <para>

--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration81.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Backward Incompatible Changes</title>
+
+ <sect2 xml:id="migration81.incompatible.core">
+  <title>PHP Core</title>
+
+  <sect3 xml:id="migration81.incompatible.core.globals-access">
+   <title>$GLOBALS access restrictions</title>
+
+   <para>
+    TODO
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.incompatible.core.static-variable-inheritance">
+   <title>
+    Usage of <modifier>static</modifier> variables in inherited methods
+   </title>
+
+   <para>
+    TODO
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.incompatible.core.type-compatibility-internal">
+   <title>Return type compatibility with internal classes</title>
+
+   <para>
+    TODO
+   </para>
+  </sect3>
+
+ </sect2>
+
+ <sect2 xml:id="migration80.incompatible.resource2object">
+  <title>Resource to Object Migration</title>
+
+  <para>
+   Several &resource;s have been migrated to &object;s.
+   Return value checks using <function>is_resource</function> should be replaced with checks for &false;.
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     The <link linkend="book.fileinfo">FileInfo</link> functions now accept and return,
+     respectively, <classname>finfo</classname> objects instead of
+     <literal>fileinfo</literal> &resource;s.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     The <link linkend="book.ftp">FTP</link> functions now accept and return,
+     respectively, <classname>FTP\Connection</classname> objects instead of
+     <literal>ftp</literal> &resource;s.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     The <link linkend="book.imap">IMAP</link> functions now accept and return,
+     respectively, <classname>IMAP\Connection</classname> objects instead of
+     <literal>imap</literal> &resource;s.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     The <link linkend="book.ldap">LDAP</link> functions now accept and return,
+     respectively, <classname>LDAP\Connection</classname> objects instead of
+     <literal>ldap link</literal> &resource;s.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     The <link linkend="book.ldap">LDAP</link> functions now accept and return,
+     respectively, <classname>LDAP\Result</classname> objects instead of
+     <literal>ldap result</literal> &resource;s.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     The <link linkend="book.ldap">LDAP</link> functions now accept and return,
+     respectively, <classname>LDAP\ResultEntry</classname> objects instead of
+     <literal>ldap result entry</literal> &resource;s.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     The <link linkend="book.pgsql">PgSQL</link> functions now accept and return,
+     respectively, <classname>PgSql\Connection</classname> objects instead of
+     <literal>ppgsql link</literal> &resource;s.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     The <link linkend="book.pgsql">PgSQL</link> functions now accept and return,
+     respectively, <classname>PgSql\Result</classname> objects instead of
+     <literal>ppgsql result</literal> &resource;s.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     The <link linkend="book.pgsql">PgSQL</link> functions now accept and return,
+     respectively, <classname>PgSql\Lob</classname> objects instead of
+     <literal>ppgsql large object</literal> &resource;s.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     The <link linkend="book.pspell">PSpell</link> functions now accept and return,
+     respectively, <classname>PSpell\Dictionary</classname> objects instead of
+     <literal>pspell</literal> &resource;s.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     The <link linkend="book.pspell">PSpell</link> functions now accept and return,
+     respectively, <classname>PSpell\Config</classname> objects instead of
+     <literal>pspell config</literal> &resource;s.
+    </para>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.incompatible.mysqli">
+  <title>MySQLi</title>
+
+  <para>
+   TODO
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.incompatible.mysqlnd">
+  <title>MySQLnd</title>
+
+  <para>
+   The <link linkend="ini.mysqlnd.fetch-copy-data">mysqlnd.fetch_copy_data</link>
+   INI directive has been removed.
+   This should not result in user-visible behavior changes.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.incompatible.openssl">
+  <title>OpenSSL</title>
+
+  <para>
+   EC private keys will now be exported in PKCS#8 format rather than
+   traditional format, just like all other keys.
+  </para>
+  <para>
+   <function>openssl_pkcs7_encrypt</function> and
+   <function>openssl_cms_encrypt</function> will now to default using
+   AES-128-CBC rather than RC2-40. The RC2-40 cipher is considered
+   insecure and not enabled by default by OpenSSL 3.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.incompatible.pdo">
+  <title>PHP Data Objects</title>
+
+  <para>
+   <constant>PDO::ATTR_STRINGIFY_FETCHES</constant> now stringifies values
+   of type <type>bool</type> to <literal>"0"</literal> or
+   <literal>"1"</literal>. Previously &boolean;s were not stringified.
+  </para>
+  <para>
+   Calling <methodname>PDO::bindColumn</methodname> with
+   <constant>PDO::PARAM_LOB</constant> will now constantly bind a stream
+   result, when <constant>PDO::ATTR_STRINGIFY_FETCHES</constant> is not enabled.
+   Previously the result would either be a stream or a string depending on
+   the used database driver and the time the binding is performed.
+  </para>
+
+  <sect3 xml:id="migration81.incompatible.pdo.mysql">
+   <title>MySQL Driver</title>
+
+   <para>
+    Integers and floats in result sets will now be returned using native
+    PHP types instead of &string;s when using emulated prepared statements.
+    This matches the behavior of native prepared statements.
+    The previous behaviour can be restored by enabling the
+    <constant>PDO::ATTR_STRINGIFY_FETCHES</constant> option.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.incompatible.pdo.sqlite">
+   <title>SQLite Driver</title>
+
+   <para>
+    Integers and floats in results sets will now be returned using native
+    PHP types.
+    The previous behaviour can be restored by enabling the
+    <constant>PDO::ATTR_STRINGIFY_FETCHES</constant> option.
+   </para>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration81.incompatible.phar">
+  <title>Phar</title>
+
+  <para>
+   To comply with the <interfacename>ArrayAccess</interfacename> interface,
+   <methodname>Phar::offsetUnset</methodname> and
+   <methodname>PharData::offsetUnset</methodname> no longer return a &boolean;.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.incompatible.standard">
+  <title>Standard</title>
+
+  <para>
+   TODO
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.incompatible.spl">
+  <title>Standard PHP Library (SPL)</title>
+
+  <para>
+   <classname>SplFixedArray</classname>, will now be JSON encoded like an &array;
+  </para>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -125,7 +125,40 @@
   <title>MySQLi</title>
 
   <para>
-   TODO
+   <function>mysqli_fetch_fields</function>, and
+   <function>mysqli_fetch_field_direct</function> will now always return
+   <literal>0</literal> for the <property>max_length</property>.
+   This information can be computed by iterating over the result set,
+   and taking the maximum length. This is what PHP was doing
+   internally previously.
+  </para>
+
+  <para>
+   The <constant>MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH</constant>
+   option no longer has any effect.
+  </para>
+
+  <para>
+   The <constant>MYSQLI_STORE_RESULT_COPY_DATA</constant>
+   option no longer has any effect.
+  </para>
+
+  <para>
+   <methodname>mysqli::connect</methodname> now returns &true; instead of &null; on success.
+  </para>
+
+  <para>
+   The default error handling mode has been changed from "silent" to "exceptions"
+   See the <link linkend="mysqli-driver.report-mode">MySQLi reporting mode</link>
+   page for more details on what changes this entails,
+   and how how to explicitly set this attribute.
+   To restore the previous behaviour use:
+   <code>mysqli_report(MYSQLI_REPORT_OFF);</code>
+  </para>
+
+  <para>
+   Classes extending <methodname>mysqli_stmt::execute</methodname>
+   are now required to specify the additional mandatory parameter.
   </para>
  </sect2>
 
@@ -208,7 +241,33 @@
   <title>Standard</title>
 
   <para>
-   TODO
+   <function>version_compare</function> no longer accepts undocumented operator abbreviations.
+  </para>
+
+  <para>
+   <function>htmlspecialchars</function>,
+   <function>htmlentities</function>,
+   <function>htmlspecialchars_decode</function>,
+   <function>html_entity_decode</function>,
+   and <function>get_html_translation_table</function>
+   now use <literal>ENT_QUOTES | ENT_SUBSTITUTE</literal> rather than
+   <constant>ENT_COMPAT</constant> by default.
+   This means that <literal>'</literal> is escaped to
+   <literal>&amp;#039;</literal> while previously nothing was done.
+   Additionally, malformed UTF-8 will be replaced by a Unicode substitution
+   character, instead of resulting in an empty string.
+  </para>
+
+  <para>
+   <function>debug_zval_dump</function> now prints the refcount of a reference
+   wrappers with their refcount, instead of only prepending
+   <literal>&amp;</literal> to the value.
+   This more accurately models reference representation since PHP 7.0.
+  </para>
+
+  <para>
+   <function>debug_zval_dump</function> now prints <literal>interned</literal>
+   instead of a dummy refcount for interned strings and immutable arrays.
   </para>
  </sect2>
 

--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -6,28 +6,66 @@
   <title>PHP Core</title>
 
   <sect3 xml:id="migration81.incompatible.core.globals-access">
-   <title>$GLOBALS access restrictions</title>
+   <title>$GLOBALS Access Restrictions</title>
 
    <para>
-    TODO
+    Access to the <varname>$GLOBALS</varname> array is now subject to
+    a number of restrictions.
+    Read and write access to individual array elements like
+    <code>$GLOBALS['var']</code> continues to work as-is.
+    Read-only access to the entire <varname>$GLOBALS</varname> array also
+    continues to be supported.
+    However, write access to the entire <varname>$GLOBALS</varname> array
+    is no longer supported. For example, <code>array_pop($GLOBALS)</code>
+    will result in an error.
    </para>
   </sect3>
 
   <sect3 xml:id="migration81.incompatible.core.static-variable-inheritance">
    <title>
-    Usage of <modifier>static</modifier> variables in inherited methods
+    Usage of <modifier>static</modifier> Variables in Inherited Methods
    </title>
 
    <para>
-    TODO
+    When a method using static variables is inherited (but not overridden), the
+    inherited method will now share static variables with the parent method.
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+class A {
+    public static function counter() {
+        static $counter = 0;
+        $counter++;
+        return $counter;
+    }
+}
+class B extends A {}
+var_dump(A::counter()); // int(1)
+var_dump(A::counter()); // int(2)
+var_dump(B::counter()); // int(3), previously int(1)
+var_dump(B::counter()); // int(4), previously int(2)
+?>
+]]>
+     </programlisting>
+    </informalexample>
+
+    This means that static variables in methods now behave the same way as
+    static properties.
    </para>
   </sect3>
 
   <sect3 xml:id="migration81.incompatible.core.type-compatibility-internal">
-   <title>Return type compatibility with internal classes</title>
+   <title>Return Type Compatibility with Internal Classes</title>
 
    <para>
-    TODO
+    Most non-final internal methods now require overriding methods to declare
+    a compatible return type, otherwise a deprecated notice is emitted during
+    inheritance validation.
+    In case the return type cannot be declared for an overriding method due to
+    PHP cross-version compatibility concerns,
+    a <code>#[ReturnTypeWillChange]</code> attribute can be added to silence
+    the deprecation notice.
    </para>
   </sect3>
 

--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -178,7 +178,9 @@ var_dump(B::counter()); // int(4), previously int(2)
 
   <para>
    The <constant>MYSQLI_STORE_RESULT_COPY_DATA</constant>
-   option no longer has any effect.
+   option no longer has any effect. Passing any value to the
+   <parameter>mode</parameter> parameter of
+   <methodname>mysqli::store_result</methodname> no longer has any effect.
   </para>
 
   <para>
@@ -188,8 +190,8 @@ var_dump(B::counter()); // int(4), previously int(2)
   <para>
    The default error handling mode has been changed from "silent" to "exceptions"
    See the <link linkend="mysqli-driver.report-mode">MySQLi reporting mode</link>
-   page for more details on what changes this entails,
-   and how how to explicitly set this attribute.
+   page for more details on what this entails,
+   and how to explicitly set this attribute.
    To restore the previous behaviour use:
    <code>mysqli_report(MYSQLI_REPORT_OFF);</code>
   </para>

--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -163,10 +163,10 @@
    <literal>"1"</literal>. Previously &boolean;s were not stringified.
   </para>
   <para>
-   Calling <methodname>PDO::bindColumn</methodname> with
+   Calling <methodname>PDOStatement::bindColumn</methodname> with
    <constant>PDO::PARAM_LOB</constant> will now constantly bind a stream
-   result, when <constant>PDO::ATTR_STRINGIFY_FETCHES</constant> is not enabled.
-   Previously the result would either be a stream or a string depending on
+   result when <constant>PDO::ATTR_STRINGIFY_FETCHES</constant> is not enabled.
+   Previously, the result would either be a stream or a string depending on
    the used database driver and the time the binding is performed.
   </para>
 

--- a/appendices/migration81/new-classes.xml
+++ b/appendices/migration81/new-classes.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration81.new-classes" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>New Classes and Interfaces</title>
+
+ <sect2 xml:id="migration81.new-classes.intl">
+  <title>Intl</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>IntlDatePatternGenerator</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -342,7 +342,7 @@ echo $h, "\n";
    <title>New INI directive <literal>mysqli.local_infile_directory</literal></title>
 
    <para>
-    The <link linkend="ini.mysqli.local-infile-directory">mysqlnd.local_infile_directory</link>
+    The <link linkend="ini.mysqli.local-infile-directory">mysqli.local_infile_directory</link>
     INI directive has been added, which can be used to specify a directory from
     which files are allowed to be loaded. It is only meaningful if
     <link linkend="ini.mysqli.allow-local-infile">mysqli.allow_local_infile</link>

--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -232,8 +232,107 @@ curl_setopt($curl, CURLOPT_POSTFIELDS, ['file' => $file]);
   <title>Hash</title>
 
   <para>
-   TODO
+   The following functions <function>hash</function>,
+   <function>hash_file</function>, and <function>hash_init</function>
+   now support an additional optional <parameter>options</parameter>
+   argument, which can be used to pass algorithm specific data.
   </para>
+
+  <sect3 xml:id="migration81.new-features.hash.murmurhash3">
+   <title>MurmurHash3</title>
+
+   <para>
+    Added support for <literal>MurmurHash3</literal> with streaming
+    support. The following variants are implemented:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <simpara>murmur3a, 32-bit hash</simpara>
+    </listitem>
+    <listitem>
+     <simpara>murmur3c, 128-bit hash for x86</simpara>
+    </listitem>
+    <listitem>
+     <simpara>murmur3f, 128-bit hash for x64</simpara>
+    </listitem>
+   </itemizedlist>
+
+   <para>
+    The initial hash state can be passed through the <literal>seed</literal>
+    key in the <parameter>options</parameter> array, for example:
+
+    <informalexample>
+     <programlisting role="php">
+      <![CDATA[
+<?php
+$h = hash("murmur3f", $data, options: ["seed" => 42]);
+echo $h, "\n";
+?>
+]]>
+     </programlisting>
+    </informalexample>
+
+    A valid seed value is within the range from <literal>0</literal>
+    to the platform defined <constant>UINT_MAX</constant>, usually
+    <literal>4294967295</literal>.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.hash.xxhash">
+   <title>xxHash</title>
+
+   <para>
+    Added support for <literal>xxHash</literal>.
+    The following variants are implemented:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <simpara>xxh32, 32-bit hash</simpara>
+    </listitem>
+    <listitem>
+     <simpara>xxh64, 64-bit hash</simpara>
+    </listitem>
+    <listitem>
+     <simpara>xxh3, 64-bit hash</simpara>
+    </listitem>
+    <listitem>
+     <simpara>xxh128, 128-bit hash</simpara>
+    </listitem>
+   </itemizedlist>
+
+   <para>
+    The initial hash state can be passed through the <literal>seed</literal>
+    key in the <parameter>options</parameter> array, for example:
+
+    <informalexample>
+     <programlisting role="php">
+      <![CDATA[
+<?php
+$h = hash("xxh3", $data, options: ["seed" => 42]);
+echo $h, "\n";
+?>
+]]>
+     </programlisting>
+    </informalexample>
+
+    Secret usage is supported through passing the <literal>secret</literal>
+    key in the <parameter>options</parameter> array, too:
+
+    <informalexample>
+     <programlisting role="php">
+      <![CDATA[
+<?php
+$h = hash("xxh3", $data, options: ["secret" => "at least 136 bytes long secret here"]);
+echo $h, "\n";
+?>
+]]>
+     </programlisting>
+    </informalexample>
+
+    Note, that the quality of the custom secret is crucial for the quality of the resulting hash.
+    It is highly recommended for the secret to use the best possible entropy.
+   </para>
+  </sect3>
  </sect2>
 
  <sect2 xml:id="migration81.new-features.mysqli">

--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -305,7 +305,6 @@ new PDO('sqlite:file:path/to/sqlite.db?mode=ro')
  </sect2>
 
 </sect1>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -1,0 +1,328 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration81.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>New Features</title>
+
+ <sect2 xml:id="migration81.new-features.core">
+  <title>PHP Core</title>
+
+  <sect3 xml:id="migration81.new-features.core.octal-literal-prefix">
+   <title>Integer Octal Literal Prefix</title>
+
+   <para>
+    Octal integers can now use an explicit
+    <literal>0o</literal>/<literal>0O</literal>
+    prefix in integer literals,
+    similarly to binary and hexadecimal integer literals.
+    <informalexample>
+     <programlisting role="php">
+      <![CDATA[
+<?php
+014;  // Non-prefix octal literal
+0o14; // Prefixed octal literal
+?>
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+   <!-- RFC: https://wiki.php.net/rfc/explicit_octal_notation -->
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.core.unpacking-string-keys">
+   <title>Array Unpacking with String Keys</title>
+
+   <para>
+    Added support for array unpacking with strings keys.
+    <!-- TODO Add an example -->
+   </para>
+   <!-- RFC: https://wiki.php.net/rfc/array_unpacking_string_keys -->
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.core.named-arg-after-unpack">
+   <title>Named Argument After Argument Unpacking</title>
+
+   <para>
+    It is now possible to specify named arguments after an argument unpack.
+    <!-- TODO Add an example -->
+    e.g.
+    foo(...$args, named: $arg).
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.core.upload-full-path-key">
+   <title>full-path Key for File Uploads</title>
+
+   <para>
+    File uploads now provide an additional <literal>full_path</literal> key,
+    which contains the full path (rather than just the basename) of the uploaded file.
+    This is intended for use in conjunction with "upload webkitdirectory".
+   </para>
+   <!-- RFC: https://wiki.php.net/rfc/array_unpacking_string_keys -->
+  </sect3>
+
+  <sect3 xml:id="migration80.new-features.core.enums">
+   <title>Enumerations</title>
+
+   <para>
+    Support for <!--<link linkend="language.enumeration">-->Enumerations<!--</link>--> has been added.
+    <!-- RFC: https://wiki.php.net/rfc/enumerations -->
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration80.new-features.core.fibers">
+   <title>Fibers</title>
+
+   <para>
+    Support for <!--<link linkend="language.fibers">-->Fibers<!--</link>--> has been added.
+    <!-- RFC: https://wiki.php.net/rfc/fibers -->
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration80.new-features.core.callable-syntax">
+   <title>First Class Callable Syntax</title>
+
+   <para>
+    Closures for callables can now be created using the syntax <code>myFunc(...)</code>,
+    which is identical to <code>Closure::fromCallable('myFunc')</code>.
+    <!-- RFC: https://wiki.php.net/rfc/first_class_callable_syntax -->
+   </para>
+   <note>
+    <simpara>
+     The <code>...</code> is part of the syntax, and not an omission.
+    </simpara>
+   </note>
+  </sect3>
+
+  <sect3 xml:id="migration80.new-features.core.intersection-types">
+   <title>Intersection Types</title>
+
+   <para>
+    Support for <!--<link linkend="language.types.declarations.intersection">-->intersection types<!--</link>--> has been added.
+    <!-- RFC: https://wiki.php.net/rfc/pure-intersection-types -->
+   </para>
+   <caution>
+    <simpara>
+     Intersection types cannot be used together with
+     <link linkend="language.types.declarations.union">union types</link>
+    </simpara>
+   </caution>
+  </sect3>
+
+  <sect3 xml:id="migration80.new-features.core.never-type">
+   <title>Never type</title>
+
+   <para>
+    A new return only type <type>never</type> has been added.
+    This indicates that a function either <function>exit</function>,
+    throws an exception, or doesn't terminate.
+    <!-- RFC: https://wiki.php.net/rfc/noreturn_type -->
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.core.new-in-initializer">
+   <title>&new; in Initializers</title>
+
+   <para>
+    It is now possible to use <code>new ClassName()</code> expressions as the
+    default value of a parameter, static variable, global constant initializers,
+    and as attribute arguments.
+    Objects can also be passed to <function>define</function> now.
+    <!-- TODO Add an example -->
+   </para>
+   <!-- RFC: https://wiki.php.net/rfc/new_in_initializers -->
+  </sect3>
+
+  <sect3 xml:id="migration80.new-features.core.readonly">
+   <title>Readonly properties</title>
+
+   <para>
+    Support for <code>readonly</code> properties has been added.
+    <!-- RFC: https://wiki.php.net/rfc/readonly_properties_v2 -->
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration80.new-features.core.final-constants">
+   <title>Final class constants</title>
+
+   <para>
+    Added support for the <modifier>final</modifier> modifier for class constants.
+    <!-- RFC: https://wiki.php.net/rfc/final_class_const -->
+   </para>
+  </sect3>
+
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.curl">
+  <title>CURL</title>
+  
+  <para>
+   Added the <constant>CURLOPT_DOH_URL</constant> option.
+  </para>
+
+  <para>
+   Added options for blob certificate when libcurl >= 7.71.0:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>CURLOPT_ISSUERCERT_BLOB</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_PROXY_ISSUERCERT</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_PROXY_ISSUERCERT_BLOB</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_PROXY_SSLCERT_BLOB</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_PROXY_SSLKEY_BLOB</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_SSLCERT_BLOB</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_SSLKEY_BLOB</constant></simpara>
+   </listitem>
+  </itemizedlist>
+
+  <para>
+   Added <classname>CURLStringFile</classname>, which can be used to post
+   a file from a &string; rather than a file:
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$file = new CURLStringFile($data, 'filename.txt', 'text/plain');
+curl_setopt($curl, CURLOPT_POSTFIELDS, ['file' => $file]);
+?>
+]]>
+    </programlisting>
+   </informalexample>
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.fpm">
+  <title>FPM</title>
+
+  <para>
+   Added openmetrics status format. It can be used by Prometheus to fetch FPM
+   metrics.
+  </para>
+  <para>
+   Added new pool option for the dynamic process manager called
+   <literal>pm.max_spawn_rate</literal>. It allows to start a number of children
+   at a faster rate when dynamic pm is selected.
+   The default value is <literal>32</literal> which was the previous
+   hard coded value.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.gd">
+  <title>GD</title>
+
+  <para>
+   Avix support is now available through
+   <function>imagecreatefromavif</function> and
+   <function>imageavif</function>,
+   if libgd has been built with Avix support.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.hash">
+  <title>Hash</title>
+
+  <para>
+   TODO
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.mysqli">
+  <title>MySQLi</title>
+
+  <para>
+   TODO
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.pdo_mysql">
+  <title>PDO</title>
+
+  <para>
+   The <constant>PDO::MYSQL_ATTR_LOCAL_INFILE_DIRECTORY</constant> attribute
+   has been added, which can be used to specify a directory from which files
+   are allowed to be loaded.
+   It is only meaningful if <constant>PDO::MYSQL_ATTR_LOCAL_INFILE</constant>
+   is not enabled, as all directories are allowed in that case.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.pdo_sqlite">
+  <title>PDO_SQLite</title>
+
+  <para>
+   SQLite's <literal>"file:"</literal> DSN syntax is now supported,
+   which allows specifying additional flags.
+   This feature is not available if open_basedir is set.
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+new PDO('sqlite:file:path/to/sqlite.db?mode=ro')
+?>
+]]>
+    </programlisting>
+   </informalexample>
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.posix">
+  <title>POSIX</title>
+
+  <para>
+   Added <constant>POSIX_RLIMIT_KQUEUES</constant> and <constant>POSIX_RLIMIT_NPTS</constant>.
+   These rlimits are only available on FreeBSD.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.standard">
+  <title>Standard</title>
+
+  <para>
+   <function>fputcsv</function> now accepts a new
+   <parameter>eol</parameter> argument which allow to define a custom
+   End of Line sequence, the default remains the same and is <literal>"\n"</literal>.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.spl">
+  <title>SPL</title>
+
+  <para>
+   <methodname>SplFileObject::fputcsv</methodname> now accepts a new
+   <parameter>eol</parameter> argument which allow to define a custom
+   End of Line sequence, the default remains the same and is <literal>"\n"</literal>.
+  </para>
+ </sect2>
+
+</sect1>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -111,7 +111,7 @@
    <title>Never type</title>
 
    <para>
-    A new return only type <type>never</type> has been added.
+    A new return only type &never; has been added.
     This indicates that a function either <function>exit</function>,
     throws an exception, or doesn't terminate.
     <!-- RFC: https://wiki.php.net/rfc/noreturn_type -->

--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -277,7 +277,7 @@ $stmt->execute([1, $username]);
    <title>New method <methodname>mysqli_result::fetch_column</methodname></title>
 
    <para>
-    <methodname>mysqli_result::mysqli_fetch_column</methodname>
+    <methodname>mysqli_result::fetch_column</methodname>
     has been added to allow fetching a single scalar value from the result set.
     The new method accepts an optional 0-based <parameter>column</parameter>
     parameter of type &integer; specifying which column to fetch from.

--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -342,10 +342,10 @@ echo $h, "\n";
    <title>New INI directive <literal>mysqli.local_infile_directory</literal></title>
 
    <para>
-    The <link linkend="ini.mysqlnd.fetch_data_copy">mysqlnd.local_infile_directory</link>
+    The <link linkend="ini.mysqli.local-infile-directory">mysqlnd.local_infile_directory</link>
     INI directive has been added, which can be used to specify a directory from
     which files are allowed to be loaded. It is only meaningful if
-    <link linkend="mysqli.allow_local_infile">mysqli.allow_local_infile</link>
+    <link linkend="ini.mysqli.allow-local-infile">mysqli.allow_local_infile</link>
     is not enabled, as all directories are allowed in that case.
    </para>
   </sect3>

--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -59,7 +59,7 @@
    <!-- RFC: https://wiki.php.net/rfc/array_unpacking_string_keys -->
   </sect3>
 
-  <sect3 xml:id="migration80.new-features.core.enums">
+  <sect3 xml:id="migration81.new-features.core.enums">
    <title>Enumerations</title>
 
    <para>
@@ -68,7 +68,7 @@
    </para>
   </sect3>
 
-  <sect3 xml:id="migration80.new-features.core.fibers">
+  <sect3 xml:id="migration81.new-features.core.fibers">
    <title>Fibers</title>
 
    <para>
@@ -77,7 +77,7 @@
    </para>
   </sect3>
 
-  <sect3 xml:id="migration80.new-features.core.callable-syntax">
+  <sect3 xml:id="migration81.new-features.core.callable-syntax">
    <title>First Class Callable Syntax</title>
 
    <para>
@@ -92,7 +92,7 @@
    </note>
   </sect3>
 
-  <sect3 xml:id="migration80.new-features.core.intersection-types">
+  <sect3 xml:id="migration81.new-features.core.intersection-types">
    <title>Intersection Types</title>
 
    <para>
@@ -107,7 +107,7 @@
    </caution>
   </sect3>
 
-  <sect3 xml:id="migration80.new-features.core.never-type">
+  <sect3 xml:id="migration81.new-features.core.never-type">
    <title>Never type</title>
 
    <para>
@@ -131,7 +131,7 @@
    <!-- RFC: https://wiki.php.net/rfc/new_in_initializers -->
   </sect3>
 
-  <sect3 xml:id="migration80.new-features.core.readonly">
+  <sect3 xml:id="migration81.new-features.core.readonly">
    <title>Readonly properties</title>
 
    <para>
@@ -140,7 +140,7 @@
    </para>
   </sect3>
 
-  <sect3 xml:id="migration80.new-features.core.final-constants">
+  <sect3 xml:id="migration81.new-features.core.final-constants">
    <title>Final class constants</title>
 
    <para>

--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -159,7 +159,7 @@
   </para>
 
   <para>
-   Added options for blob certificate when libcurl >= 7.71.0:
+   Added options for blob certificate when libcurl &gt;= 7.71.0:
   </para>
   <itemizedlist>
    <listitem>

--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -15,7 +15,7 @@
     similarly to binary and hexadecimal integer literals.
     <informalexample>
      <programlisting role="php">
-      <![CDATA[
+<![CDATA[
 <?php
 014;  // Non-prefix octal literal
 0o14; // Prefixed octal literal
@@ -239,9 +239,63 @@ curl_setopt($curl, CURLOPT_POSTFIELDS, ['file' => $file]);
  <sect2 xml:id="migration81.new-features.mysqli">
   <title>MySQLi</title>
 
-  <para>
-   TODO
-  </para>
+  <sect3 xml:id="migration81.new-features.mysqli.local_infile_directory">
+   <title>New INI directive <literal>mysqli.local_infile_directory</literal></title>
+
+   <para>
+    The <link linkend="ini.mysqlnd.fetch_data_copy">mysqlnd.local_infile_directory</link>
+    directive has been added, which can be used to specify a directory from
+    which files are allowed to be loaded. It is only meaningful if
+    <link linkend="mysqli.allow_local_infile">mysqli.allow_local_infile</link>
+    is not enabled, as all directories are allowed in that case.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.mysqli.bind-in-execute">
+   <title>Binding parameters in execute</title>
+
+   <para>
+    It is now possible to bind parameters by passing them as an array to 
+    <methodname>mysqli_stmt::execute</methodname>. All values will be bound as
+    strings. Only list arrays are allowed. This new feature is not available
+    when MySQLi is compiled with libmysqlclient.
+    <!-- RFC: https://wiki.php.net/rfc/mysqli_bind_in_execute -->
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+$stmt = $mysqli->prepare('INSERT INTO users(id, name) VALUES(?,?)');
+$stmt->execute([1, $username]);
+?>
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.mysqli.mysqli_fetch_column">
+   <title>New method <methodname>mysqli_result::fetch_column</methodname></title>
+
+   <para>
+    A new method has been added to <classname>mysqli_result</classname> called
+    <methodname>mysqli_result::fetch_column</methodname>.
+    It allows for fetching single scalar values from the result set.
+    The new method accepts an optional 0-based <parameter>column</parameter>
+    parameter of type &integer; specifying which column to fetch from.
+    <!-- RFC: https://wiki.php.net/rfc/mysqli_fetch_column -->
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+$result = $mysqli->query('SELECT username FROM users WHERE id = 123');
+echo $result->fetch_column();
+?>
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+  </sect3>
+
  </sect2>
 
  <sect2 xml:id="migration81.new-features.pdo_mysql">

--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -329,7 +329,7 @@ echo $h, "\n";
      </programlisting>
     </informalexample>
 
-    Note, that the quality of the custom secret is crucial for the quality of the resulting hash.
+    The quality of the custom secret is crucial for the quality of the resulting hash.
     It is highly recommended for the secret to use the best possible entropy.
    </para>
   </sect3>

--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -244,7 +244,7 @@ curl_setopt($curl, CURLOPT_POSTFIELDS, ['file' => $file]);
 
    <para>
     The <link linkend="ini.mysqlnd.fetch_data_copy">mysqlnd.local_infile_directory</link>
-    directive has been added, which can be used to specify a directory from
+    INI directive has been added, which can be used to specify a directory from
     which files are allowed to be loaded. It is only meaningful if
     <link linkend="mysqli.allow_local_infile">mysqli.allow_local_infile</link>
     is not enabled, as all directories are allowed in that case.
@@ -277,9 +277,8 @@ $stmt->execute([1, $username]);
    <title>New method <methodname>mysqli_result::fetch_column</methodname></title>
 
    <para>
-    A new method has been added to <classname>mysqli_result</classname> called
-    <methodname>mysqli_result::fetch_column</methodname>.
-    It allows for fetching single scalar values from the result set.
+    <methodname>mysqli_result::mysqli_fetch_column</methodname>
+    has been added to allow fetching a single scalar value from the result set.
     The new method accepts an optional 0-based <parameter>column</parameter>
     parameter of type &integer; specifying which column to fetch from.
     <!-- RFC: https://wiki.php.net/rfc/mysqli_fetch_column -->

--- a/appendices/migration81/new-functions.xml
+++ b/appendices/migration81/new-functions.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration81.new-functions">
+ <title>New Functions</title>
+
+ <sect2 xml:id="migration81.new-functions.core">
+  <title>PHP Core</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <function>array_is_list</function>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-functions.pcntl">
+  <title>Process Control</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <function>pcntl_rfork</function>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-functions.reflection">
+  <title>Reflection</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <methodname>ReflectionFunctionAbstract::getClosureUsedVariables</methodname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-functions.standard">
+  <title>Standard</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <function>fsync</function>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <function>fdatasync</function>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-functions.sodium">
+  <title>Sodium</title>
+
+  <sect3>
+   <title>XChaCha20</title>
+   <itemizedlist>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_stream_xchacha20</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_stream_xchacha20_keygen</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_stream_xchacha20_xor</function>
+     </simpara>
+    </listitem>
+   </itemizedlist>
+  </sect3>
+
+  <sect3>
+   <title>Ristretto255</title>
+
+   <para>
+    Ristretto255 functions are available as of libsodium 1.0.18.
+   </para>
+
+   <itemizedlist>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_add</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_from_hash</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_is_valid_point</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_random</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_scalar_add</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_scalar_complement</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_scalar_invert</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_scalar_mul</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_scalar_negate</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_scalar_random</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_scalar_reduce</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_scalar_sub</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_sub</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_scalarmult_ristretto255</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_scalarmult_ristretto255_base</function>
+     </simpara>
+    </listitem>
+   </itemizedlist>
+  </sect3>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration81/other-changes.xml
+++ b/appendices/migration81/other-changes.xml
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration81.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Other Changes</title>
+
+ <sect2 xml:id="migration81.other-changes.sapi">
+  <title>Changes in SAPI Modules</title>
+
+  <sect3 xml:id="migration81.other-changes.sapi.cli">
+   <title>CLI</title>
+
+   <para>
+    Using <code>-a</code> without the readline extension will now result in an error.
+    Previously, <code>-a</code> without readline had the same behavior as
+    calling php without any arguments, apart from printing an additional
+    <literal>"Interactive mode enabled"</literal> message.
+    This mode was <emphasis>not</emphasis> interactive.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.sapi.phpdbg">
+   <title>PHPDBG</title>
+
+   <para>
+    Remote functionality from phpdbg has been removed.
+   </para>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration81.other-changes.functions">
+  <title>Changed Functions</title>
+
+  <sect3 xml:id="migration81.other-changes.functions.core">
+   <title>Core</title>
+
+   <para>
+    The order of properties used in &foreach;, <function>var_dump</function>,
+    <function>serialize</function>, object comparison, etc. was changed.
+    Properties are now ordered naturally according to their declaration
+    and inheritance. Properties declared in a base class are going
+    to be before the child properties.
+   </para>
+   <para>
+    This order is consistent with internal layout of properties in
+    <code>zend_object</code> structure and repeats the order in
+    <code>default_properties_table[]</code> and <code>properties_info_table[]</code>.
+    The old order was not documented and was caused by class inheritance implementation details.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.functions.filter">
+   <title>Filter</title>
+
+   <para>
+    The <constant>FILTER_FLAG_ALLOW_OCTAL</constant> flag of the
+    <constant>FILTER_VALIDATE_INT</constant> filter
+    now accept octal string with the leading octal prefix
+    (<literal>"0o"</literal>/<literal>"0O"</literal>).
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.functions.gmp">
+   <title>GMP</title>
+
+   <para>
+    All GMP function now accept octal string with the leading octal prefix
+    (<literal>"0o"</literal>/<literal>"0O"</literal>).
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.functions.pdo-odbc">
+   <title>PDO ODBC</title>
+
+   <para>
+    <methodname>PDO::getAttributes</methodname> with
+    <constant>PDO::ATTR_SERVER_INFO</constant> and
+    <constant>PDO::ATTR_SERVER_VERSION</constant>
+    now return values instead of throwing <classname>PDOException</classname>.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.functions.reflection">
+   <title>Reflection</title>
+
+   <para>
+    <methodname>ReflectionProperty::setAccessible()</methodname> and
+    <methodname>ReflectionMethod::setAccessible()</methodname>
+    no longer have an effect.
+    Properties and methods are now always considered accessible via Reflection.
+   </para>
+   <para>
+    <simplelist>
+     <member><constant>ReflectionClassConstant::IS_PUBLIC</constant></member>
+     <member><constant>ReflectionClassConstant::IS_PROTECTED</constant></member>
+     <member><constant>ReflectionClassConstant::IS_PRIVATE</constant></member>
+    </simplelist>
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.functions.standard">
+   <title>Standard</title>
+
+   <para>
+    <function>syslog</function> is now binary safe.
+   </para>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration81.other-changes.extensions">
+  <title>Other Changes to Extensions</title>
+
+  <sect3 xml:id="migration81.other-changes.extensions.gd">
+   <title>GD</title>
+
+   <para>
+    <function>imagewebp</function> can now do lossless WebP encoding
+    by passing <constant>IMG_WEBP_LOSSLESS</constant> as the quality.
+   </para>
+   <para>
+    This constant is only defined, if the used libgd supports
+    lossless WebP encoding.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.extensions.mysqli">
+   <title>MySQLi</title>
+
+   <para>
+    <methodname>mysqli_stmt::next_result</methodname> and
+    <methodname>mysqli::fetch_all</methodname>
+    are now available when linking against libmysqlclient.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.extensions.openssl">
+   <title>OpenSSL</title>
+
+   <itemizedlist>
+    <listitem>
+     <para>
+      The OpenSSL extension now requires at least OpenSSL version 1.0.2.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      OpenSSL 3.0 is now supported. Be aware that many ciphers are no longer
+      enabled by default (part of the legacy provider), and that parameter
+      validation (e.g. minimum key sizes) is stricter now.
+     </para>
+    </listitem>
+   </itemizedlist>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.extensions.phar">
+   <title>Phar</title>
+
+   <itemizedlist>
+    <listitem>
+     <para>
+      SHA256 is now used by default for signatures.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Added support for OpenSSL_SHA256 and OpenSSL_SHA512 signatures.
+     </para>
+    </listitem>
+   </itemizedlist>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.extensions.snmp">
+   <title>SNMP</title>
+
+   <itemizedlist>
+    <listitem>
+     <para>
+      Added support for SHA256 and SHA512 for the security protocol.
+     </para>
+    </listitem>
+   </itemizedlist>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.extensions.standard">
+   <title>Standard</title>
+
+   <para>
+    <code>--with-password-argon2</code> now uses pkg-config to detect libargon2.
+    As such, an alternative libargon2 location should now be specified using
+    <envar>PKG_CONFIG_PATH</envar>.
+   </para>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration81.other-changes.ini">
+  <title>Changes to INI File Handling</title>
+
+  <itemizedlist>
+   <listitem>
+    <para>
+     The <link linkend="ini.log-errors-max-len">log_errors_max_len</link>
+     INI directive has been removed.
+     It no longer had an effect since PHP 8.0.0.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     A leading dollar in a quoted string can now be escaped: <literal>"\${"</literal> will now be
+     interpreted as a string with contents <literal>${</literal>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Backslashes in double quoted strings are now more consistently treated as
+     escape characters. Previously, <literal>"foo\\"</literal> followed by
+     something other than a newline was not considered as a terminated string.
+     It is now interpreted as a string with contents <literal>foo\</literal>.
+     However, as an exception, the string <literal>"foo\"</literal>
+     followed by a newline will continue to be treated as a valid string with
+     contents <literal>foo\</literal> rather than an unterminated string.
+     This exception exists to support naive uses of Windows file paths such as
+     <literal>"C:\foo\"</literal>.
+    </para>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+</sect1>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration81/other-changes.xml
+++ b/appendices/migration81/other-changes.xml
@@ -87,13 +87,6 @@
     no longer have an effect.
     Properties and methods are now always considered accessible via Reflection.
    </para>
-   <para>
-    <simplelist>
-     <member><constant>ReflectionClassConstant::IS_PUBLIC</constant></member>
-     <member><constant>ReflectionClassConstant::IS_PROTECTED</constant></member>
-     <member><constant>ReflectionClassConstant::IS_PRIVATE</constant></member>
-    </simplelist>
-   </para>
   </sect3>
 
   <sect3 xml:id="migration81.other-changes.functions.standard">

--- a/appendices/migration81/other-changes.xml
+++ b/appendices/migration81/other-changes.xml
@@ -9,7 +9,7 @@
    <title>CLI</title>
 
    <para>
-    Using <code>-a</code> without the readline extension will now result in an error.
+    Using <code>-a</code> without the <link linkend="book.readline">readline extension</link> will now result in an error.
     Previously, <code>-a</code> without readline had the same behavior as
     calling PHP without any arguments, apart from printing an additional
     <literal>"Interactive mode enabled"</literal> message.
@@ -21,7 +21,7 @@
    <title>PHPDBG</title>
 
    <para>
-    Remote functionality from phpdbg has been removed.
+    Remote functionality from <link linkend="book.phpdbg">phpdbg</link> has been removed.
    </para>
   </sect3>
  </sect2>
@@ -62,7 +62,7 @@
    <title>GMP</title>
 
    <para>
-    All GMP function now accept octal string with the leading octal prefix
+    All <link linkend="book.gmp">GMP</link> functions now accept octal string with the leading octal prefix
     (<literal>"0o"</literal>/<literal>"0O"</literal>).
    </para>
   </sect3>
@@ -137,7 +137,7 @@
    <itemizedlist>
     <listitem>
      <para>
-      The OpenSSL extension now requires at least OpenSSL version 1.0.2.
+      The <link linkend="book.openssl">OpenSSL extension</link> now requires at least OpenSSL version 1.0.2.
      </para>
     </listitem>
     <listitem>

--- a/appendices/migration81/other-changes.xml
+++ b/appendices/migration81/other-changes.xml
@@ -9,9 +9,9 @@
    <title>CLI</title>
 
    <para>
-    Using <code>-a</code> without the <link linkend="book.readline">readline extension</link> will now result in an error.
-    Previously, <code>-a</code> without readline had the same behavior as
-    calling PHP without any arguments, apart from printing an additional
+    Using <option>-a</option> without the <link linkend="book.readline">readline extension</link> will now result in an error.
+    Previously, <option>-a</option> without readline had the same behavior as
+    calling <command>php</command> without any arguments, apart from printing an additional
     <literal>"Interactive mode enabled"</literal> message.
     This mode was <emphasis>not</emphasis> interactive.
    </para>

--- a/appendices/migration81/other-changes.xml
+++ b/appendices/migration81/other-changes.xml
@@ -224,7 +224,6 @@
  </sect2>
 
 </sect1>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/appendices/migration81/other-changes.xml
+++ b/appendices/migration81/other-changes.xml
@@ -11,7 +11,7 @@
    <para>
     Using <code>-a</code> without the readline extension will now result in an error.
     Previously, <code>-a</code> without readline had the same behavior as
-    calling php without any arguments, apart from printing an additional
+    calling PHP without any arguments, apart from printing an additional
     <literal>"Interactive mode enabled"</literal> message.
     This mode was <emphasis>not</emphasis> interactive.
    </para>

--- a/appendices/migration81/other-changes.xml
+++ b/appendices/migration81/other-changes.xml
@@ -71,7 +71,7 @@
    <title>PDO ODBC</title>
 
    <para>
-    <methodname>PDO::getAttributes</methodname> with
+    <methodname>PDO::getAttribute</methodname> with
     <constant>PDO::ATTR_SERVER_INFO</constant> and
     <constant>PDO::ATTR_SERVER_VERSION</constant>
     now return values instead of throwing <classname>PDOException</classname>.
@@ -82,8 +82,8 @@
    <title>Reflection</title>
 
    <para>
-    <methodname>ReflectionProperty::setAccessible()</methodname> and
-    <methodname>ReflectionMethod::setAccessible()</methodname>
+    <methodname>ReflectionProperty::setAccessible</methodname> and
+    <methodname>ReflectionMethod::setAccessible</methodname>
     no longer have an effect.
     Properties and methods are now always considered accessible via Reflection.
    </para>


### PR DESCRIPTION
Currently missing sections:

 - [x] 1. Backward Incompatible Changes
    - [x] Core 
    - [x] MySQLi
    - [x] Standard
 - [x] 2. New Features
    - [x] Hash 
    - [x] MySQLi
 - [x] 4. Deprecated Functionality

From the [UPGRADING](https://github.com/php/php-src/blob/PHP-8.1/UPGRADING) document in the PHP-8.1 branch.