### PR TITLE
Fix `mixed` return type declarations and parameters of Misc. Functions

### DIFF
--- a/reference/misc/functions/get-browser.xml
+++ b/reference/misc/functions/get-browser.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>object</type><type>array</type><type>false</type></type><methodname>get_browser</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>user_agent</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>user_agent</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>return_array</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <para>
@@ -64,6 +64,11 @@
    enabled the browser to accept cookies or not. The only way to test if
    cookies are accepted is to set one with <function>setcookie</function>,
    reload, and check for the value.
+  </para>
+  <para>
+    Returns &false; when no information can be retrieved, such as when the
+    <link linkend="ini.browscap">browscap</link> configuration setting in 
+    &php.ini; has not been set.
   </para>
  </refsect1>
 

--- a/reference/misc/functions/get-browser.xml
+++ b/reference/misc/functions/get-browser.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>mixed</type><methodname>get_browser</methodname>
+   <type class="union"><type>object</type><type>array</type><type>false</type></type><methodname>get_browser</methodname>
    <methodparam choice="opt"><type>string</type><parameter>user_agent</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>return_array</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>

--- a/reference/misc/functions/highlight-file.xml
+++ b/reference/misc/functions/highlight-file.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>mixed</type><methodname>highlight_file</methodname>
+   <type class="union"><type>string</type><type>bool</type></type><methodname>highlight_file</methodname>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>return</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>

--- a/reference/misc/functions/highlight-string.xml
+++ b/reference/misc/functions/highlight-string.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>mixed</type><methodname>highlight_string</methodname>
+   <type class="union"><type>string</type><type>bool</type></type><methodname>highlight_string</methodname>
    <methodparam><type>string</type><parameter>str</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>return</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>

--- a/reference/misc/functions/highlight-string.xml
+++ b/reference/misc/functions/highlight-string.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>string</type><type>bool</type></type><methodname>highlight_string</methodname>
-   <methodparam><type>string</type><parameter>str</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>return</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
@@ -24,7 +24,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>str</parameter></term>
+     <term><parameter>string</parameter></term>
      <listitem>
       <para>
        The PHP code to be highlighted. This should include the opening tag.


### PR DESCRIPTION
Noticed that the return types for some functions in the Misc Functions were wrong.

This PR makes sure the return types matches up with the internal return types found in [standard/basic_functions.stub.php.](https://github.com/php/php-src/blob/master/ext/standard/basic_functions.stub.php)