### PR TITLE
Add note about GLOB_BRACE flag in Alpine

### DIFF
--- a/reference/filesystem/functions/glob.xml
+++ b/reference/filesystem/functions/glob.xml
@@ -113,8 +113,7 @@
        <note>
         <simpara>
          The <constant>GLOB_BRACE</constant> flag is not available on some non GNU
-         systems, like Solaris and Alpine Linux which could cause issues when
-         running the application in an Alpine-based docker container.
+         systems, like Solaris or Alpine Linux.
         </simpara>
        </note>
       </para>

--- a/reference/filesystem/functions/glob.xml
+++ b/reference/filesystem/functions/glob.xml
@@ -113,7 +113,8 @@
        <note>
         <simpara>
          The <constant>GLOB_BRACE</constant> flag is not available on some non GNU
-         systems, like Solaris.
+         systems, like Solaris and Alpine Linux which could cause issues when
+         running the application in an Alpine-based docker container.
         </simpara>
        </note>
       </para>


### PR DESCRIPTION
The use of the `GLOB_BRACE` flag causes the function to crash if the application runs in an alpine-based docker container. The note only mentions Solaris as an example where the flag doesn't work but Alpine seems like an important exception to mention as well as it is widely used to create docker images.