### PR TITLE
Fix methodsynopsis role of curl_file_create()

### DIFF
--- a/reference/curl/curlfile/construct.xml
+++ b/reference/curl/curlfile/construct.xml
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>posted_filename</parameter><initializer>&null;</initializer></methodparam>
   </constructorsynopsis>
   <para>&style.procedural;</para>
-  <methodsynopsis>
+  <methodsynopsis role="procedural">
    <type>CURLFile</type><methodname>curl_file_create</methodname>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>mime_type</parameter><initializer>&null;</initializer></methodparam>


### PR DESCRIPTION
It used to be erroneously removed.