### PR TITLE
Fix attribute example titles

### DIFF
--- a/language/attributes.xml
+++ b/language/attributes.xml
@@ -286,7 +286,7 @@ dumpMyAttributeData(new ReflectionClass(Thing::class));
    </para>
 
   <example>
-   <title>Using target specification to restrict where attributes can be used</title>
+   <title>Simple Attribute Class</title>
 
    <programlisting role="php">
 <![CDATA[
@@ -310,7 +310,7 @@ class MyAttribute
   </para>
 
   <example>
-   <title>Simple Attribute Class</title>
+   <title>Using target specification to restrict where attributes can be used</title>
 
    <programlisting role="php">
 <![CDATA[


### PR DESCRIPTION
As pointed out in #951, the titles in the [attribute classes](https://www.php.net/language.attributes.classes) example seems to be mixed up, this PR fixes that.