### PR TITLE
DOMDocument::documentElement property can be NULL

### DIFF
--- a/reference/dom/domdocument.xml
+++ b/reference/dom/domdocument.xml
@@ -61,7 +61,7 @@
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>readonly</modifier>
-     <type>DOMElement</type>
+     <type class="union"><type>DOMElement</type><type>null</type></type>
      <varname linkend="domdocument.props.documentelement">documentElement</varname>
     </fieldsynopsis>
     <fieldsynopsis>
@@ -200,7 +200,8 @@
      <listitem>
       <para>
        This is a convenience attribute that allows direct access to the
-       child node that is the document element of the document.
+       child node that is the document element of the document. This is
+       &null; when does not exists.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Property `documentElement` is `NULL` when there is no document element since PHP 5.4.0. https://3v4l.org/vOYYo

```php
var_dump( (new DOMDocument())->documentElement );
NULL
```

Other NULL properties on `DOMDocument` and `DOMNode` has been set before, see https://github.com/php/doc-en/pull/52