### PR TITLE
Add undocumented `array-filter` signature changes

### DIFF
--- a/reference/array/constants.xml
+++ b/reference/array/constants.xml
@@ -151,6 +151,7 @@
     <simpara>
      <constant>ARRAY_FILTER_USE_KEY</constant> is used with
      <function>array_filter</function> to pass each key as the first argument to the given callback function.
+     Available as of PHP 5.6.
     </simpara>
    </listitem>
   </varlistentry>
@@ -163,6 +164,7 @@
     <simpara>
      <constant>ARRAY_FILTER_USE_BOTH</constant> is used with
      <function>array_filter</function> to pass both value and key to the given callback function.
+     Available as of PHP 5.6.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/array/functions/array-filter.xml
+++ b/reference/array/functions/array-filter.xml
@@ -104,6 +104,19 @@
        <parameter>callback</parameter> is nullable now.
       </entry>
      </row>
+     <row>
+      <entry>5.6.0</entry>
+      <entry>
+       <parameter>mode</parameter> was added.
+      </entry>
+     </row>
+     <row>
+      <entry>5.6.0</entry>
+      <entry>
+       <constant>ARRAY_FILTER_USE_KEY</constant> and <constant>ARRAY_FILTER_USE_BOTH</constant>
+       <parameter>modes</parameter> were added.
+      </entry>
+     </row>
     </tbody>
    </tgroup>
   </informaltable>


### PR DESCRIPTION
The `array_filter` method signature changed as of PHP 5.6,
with a 3rd argument `$mode` being implemented.

- Update `array-filter` changelog
- Add `available as of` on the two related constants:
    - `ARRAY_FILTER_USE_KEY`
    - `ARRAY_FILTER_USE_BOTH`

Closes #956