### PR TITLE
Update Debian GNU/Linux installation notes

### DIFF
--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -17,31 +17,31 @@
  <para>
   While the instructions for building PHP on Unix apply to Debian as well,
   this manual page contains specific information for other options, such as
-  using either the <literal>apt-get</literal> or <literal>aptitude</literal>
+  using either the <literal>apt</literal> or <literal>aptitude</literal>
   commands. This manual page uses these two commands interchangeably.
  </para>
  <sect2 xml:id="install.unix.debian.apt">
   <title>Using APT</title>
    <simpara>
     First, note that other related packages may be desired like
-    <literal>libapache2-mod-php5</literal> to integrate with Apache 2, and
+    <literal>libapache-mod-php</literal> to integrate with Apache 2, and
     <literal>php-pear</literal> for PEAR.
    </simpara>
    <simpara>
     Second, before installing a package, it's wise to ensure the package list
     is up to date. Typically, this is done by running the command
-    <command>apt-get update</command>.
+    <command>apt update</command>.
    </simpara>
    <example xml:id="install.unix.debian.apt.example">
     <title>Debian Install Example with Apache 2</title>
     <programlisting role="shell">
 <![CDATA[
-# apt-get install php5-common libapache2-mod-php5 php5-cli
+# apt-get install php-common libapache-mod-php php-cli
 ]]>
     </programlisting>
    </example>
    <simpara>
-    APT will automatically install the PHP 5 module for Apache 2 and all of its
+    APT will automatically install the PHP module for Apache 2 and all of its
     dependencies, and then activate it.  Apache should be restarted in order for
     the changes take place. For example:
    </simpara>
@@ -63,22 +63,22 @@
     <link linkend="book.mysql">MySQL</link>,
     <link linkend="book.curl">cURL</link>,
     <link linkend="book.image">GD</link>,
-    etc. These may also be installed via the <literal>apt-get</literal> command.
+    etc. These may also be installed via the <literal>apt</literal> command.
    </simpara>
    <example xml:id="install.unix.debian.config.example">
-    <title>Methods for listing additional PHP 5 packages</title>
+    <title>Methods for listing additional PHP packages</title>
     <programlisting role="shell">
 <![CDATA[
-# apt-cache search php5
-# aptitude search php5
-# aptitude search php5 |grep -i mysql
+# apt-cache search php
+# apt search php | grep -i mysql
+# aptitude search php
 ]]>
     </programlisting>
    </example>
    <simpara>
     The examples will show a lot of packages including several PHP specific ones
-    like php5-cgi, php5-cli and php5-dev. Determine which are needed
-    and install them like any other with either <literal>apt-get</literal>
+    like php-cgi, php-cli and php-dev. Determine which are needed
+    and install them like any other with either <literal>apt</literal>
     or <literal>aptitude</literal>. And because Debian performs
     dependency checks, it'll prompt for those so for example to install
     MySQL and cURL:
@@ -87,15 +87,15 @@
     <title>Install PHP with MySQL, cURL</title>
     <programlisting role="shell">
 <![CDATA[
-# apt-get install php5-mysql php5-curl
+# apt install php-mysql php-curl
 ]]>
     </programlisting>
    </example>
    <simpara>
     APT will automatically add the appropriate lines to the
     different &php.ini; related files like 
-    <filename>/etc/php5/apache2/php.ini</filename>,
-    <filename>/etc/php5/conf.d/pdo.ini</filename>, etc. and depending on
+    <filename>/etc/php/7.4/php.ini</filename>,
+    <filename>/etc/php/7.4/conf.d/*.ini</filename>, etc. and depending on
     the extension will add entries similar to <literal>extension=foo.so</literal>.
     However, restarting the web server (like Apache) is required before these
     changes take affect.
@@ -122,7 +122,7 @@
    <listitem>
     <simpara>
      There are two basic commands for installing packages on Debian (and other
-     linux variants): <literal>apt-get</literal> and <literal>aptitude</literal>.
+     linux variants): <literal>apt</literal> and <literal>aptitude</literal>.
      However, explaining the subtle differences between these commands goes
      beyond the scope of this manual.
     </simpara>


### PR DESCRIPTION
Updated Debian GNU/Linux installation notes, based on Debian 11 (bullseye).

* we should replace php5 related package name.
* update ini file location.
* use not `apt-get`, but `apt` for interactive usage.
  - https://www.debian.org/doc/manuals/debian-reference/ch02.en.html#_literal_apt_literal_vs_literal_apt_get_literal_literal_apt_cache_literal_vs_literal_aptitude_literal

Closes #964 