### PR TITLE
[PHP 8.1] Use an `FTP\Connection` instance instead of a resource

### DIFF
--- a/appendices/resources.xml
+++ b/appendices/resources.xml
@@ -469,7 +469,7 @@
     <entry>
      <function>ftp_close</function>
     </entry>
-    <entry>FTP connection</entry>
+    <entry>FTP connection (prior to PHP 8.1.0)</entry>
    </row>
    <row>
     <entry>gd</entry>

--- a/appendices/resources.xml
+++ b/appendices/resources.xml
@@ -469,7 +469,7 @@
     <entry>
      <function>ftp_close</function>
     </entry>
-    <entry>FTP stream</entry>
+    <entry>FTP connection</entry>
    </row>
    <row>
     <entry>gd</entry>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1656,6 +1656,15 @@ the ASCII value of a single character (negative values have 256 added in order t
 characters in the Extended ASCII range). Any other integer is interpreted as a string
 containing the decimal digits of the integer.</para></note>'>
 
+<!-- FTP Notes -->
+<!ENTITY ftp.changelog.ftp-param '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.1.0</entry>
+ <entry>
+  <parameter>ftp</parameter> expects an <classname xmlns="http://docbook.org/ns/docbook">FTP\Connection</classname>
+  instance now; previously, a &resource; was expected.
+ </entry>
+</row>'>
+
 <!-- GMP Notes -->
 <!ENTITY gmp.return 'A <classname xmlns="http://docbook.org/ns/docbook">GMP</classname> object.'>
 <!ENTITY gmp.parameter '<para xmlns="http://docbook.org/ns/docbook">A <classname>GMP</classname> object, an &integer; or a numeric &string;.</para>'>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1660,10 +1660,11 @@ containing the decimal digits of the integer.</para></note>'>
 <!ENTITY ftp.changelog.ftp-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  <parameter>ftp</parameter> expects an <classname xmlns="http://docbook.org/ns/docbook">FTP\Connection</classname>
+  The <parameter>ftp</parameter> parameter expects an <classname>FTP\Connection</classname>
   instance now; previously, a &resource; was expected.
  </entry>
 </row>'>
+<!ENTITY ftp.parameter.ftp '<para xmlns="http://docbook.org/ns/docbook">An <classname>FTP\Connection</classname> instance.</para>'>
 
 <!-- GMP Notes -->
 <!ENTITY gmp.return 'A <classname xmlns="http://docbook.org/ns/docbook">GMP</classname> object.'>

--- a/reference/ftp/book.xml
+++ b/reference/ftp/book.xml
@@ -26,6 +26,7 @@
  &reference.ftp.constants;
  &reference.ftp.examples;
  &reference.ftp.reference;
+ &reference.ftp.ftp-connection;
 
 </book>
 

--- a/reference/ftp/book.xml
+++ b/reference/ftp/book.xml
@@ -26,7 +26,7 @@
  &reference.ftp.constants;
  &reference.ftp.examples;
  &reference.ftp.reference;
- &reference.ftp.ftp-connection;
+ &reference.ftp.ftp.connection;
 
 </book>
 

--- a/reference/ftp/examples.xml
+++ b/reference/ftp/examples.xml
@@ -36,7 +36,7 @@ if (!$upload) {
     echo "Uploaded $source_file to $ftp_server as $destination_file";
 }
 
-// close the FTP stream 
+// close the FTP connection 
 ftp_close($ftp); 
 ?>
 ]]>

--- a/reference/ftp/examples.xml
+++ b/reference/ftp/examples.xml
@@ -12,13 +12,13 @@
 <![CDATA[
 <?php
 // set up basic connection
-$conn_id = ftp_connect($ftp_server); 
+$ftp = ftp_connect($ftp_server); 
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass); 
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass); 
 
 // check connection
-if ((!$conn_id) || (!$login_result)) { 
+if ((!$ftp) || (!$login_result)) { 
     echo "FTP connection has failed!";
     echo "Attempted to connect to $ftp_server for user $ftp_user_name"; 
     exit; 
@@ -27,7 +27,7 @@ if ((!$conn_id) || (!$login_result)) {
 }
 
 // upload the file
-$upload = ftp_put($conn_id, $destination_file, $source_file, FTP_BINARY); 
+$upload = ftp_put($ftp, $destination_file, $source_file, FTP_BINARY); 
 
 // check upload status
 if (!$upload) { 
@@ -37,7 +37,7 @@ if (!$upload) {
 }
 
 // close the FTP stream 
-ftp_close($conn_id); 
+ftp_close($ftp); 
 ?>
 ]]>
     </programlisting>

--- a/reference/ftp/ftp-connection.xml
+++ b/reference/ftp/ftp-connection.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpdoc:classref xml:id="class.ftp-connection" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook">
+ <title>The FTP\Connection class</title>
+ <titleabbrev>FTP\Connection</titleabbrev>
+
+ <partintro>
+
+  <!-- {{{ FTP\Connection intro -->
+  <section xml:id="ftp-connection.intro">
+   &reftitle.intro;
+   <para>
+    A fully opaque class which replaces a <literal>ftp</literal> resource as of PHP 8.1.0.
+   </para>
+  </section>
+  <!-- }}} -->
+
+  <section xml:id="ftp-connection.synopsis">
+   &reftitle.classsynopsis;
+
+   <!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass>
+     <classname>FTP\Connection</classname>
+    </ooclass>
+
+    <!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>FTP\Connection</classname>
+     </ooclass>
+    </classsynopsisinfo>
+    <!-- }}} -->
+
+   </classsynopsis>
+   <!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+</phpdoc:classref>
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/ftp/ftp.connection.xml
+++ b/reference/ftp/ftp.connection.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpdoc:classref xml:id="class.ftp.connection" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook">
+<phpdoc:classref xml:id="class.ftp-connection" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook">
  <title>The FTP\Connection class</title>
  <titleabbrev>FTP\Connection</titleabbrev>
 
  <partintro>
 
   <!-- {{{ FTP\Connection intro -->
-  <section xml:id="ftp.connection.intro">
+  <section xml:id="ftp-connection.intro">
    &reftitle.intro;
    <para>
     A fully opaque class which replaces a <literal>ftp</literal> resource as of PHP 8.1.0.
@@ -14,7 +14,7 @@
   </section>
   <!-- }}} -->
 
-  <section xml:id="ftp.connection.synopsis">
+  <section xml:id="ftp-connection.synopsis">
    &reftitle.classsynopsis;
 
    <!-- {{{ Synopsis -->

--- a/reference/ftp/ftp.connection.xml
+++ b/reference/ftp/ftp.connection.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpdoc:classref xml:id="class.ftp-connection" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook">
+<phpdoc:classref xml:id="class.ftp.connection" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook">
  <title>The FTP\Connection class</title>
  <titleabbrev>FTP\Connection</titleabbrev>
 
  <partintro>
 
   <!-- {{{ FTP\Connection intro -->
-  <section xml:id="ftp-connection.intro">
+  <section xml:id="ftp.connection.intro">
    &reftitle.intro;
    <para>
     A fully opaque class which replaces a <literal>ftp</literal> resource as of PHP 8.1.0.
@@ -14,7 +14,7 @@
   </section>
   <!-- }}} -->
 
-  <section xml:id="ftp-connection.synopsis">
+  <section xml:id="ftp.connection.synopsis">
    &reftitle.classsynopsis;
 
    <!-- {{{ Synopsis -->

--- a/reference/ftp/functions/ftp-alloc.xml
+++ b/reference/ftp/functions/ftp-alloc.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ftp_alloc</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>int</type><parameter>size</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter role="reference">response</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
@@ -37,7 +37,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -67,6 +67,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -79,17 +97,17 @@
 $file = "/home/user/myfile";
 
 // connect to the server
-$conn_id = ftp_connect('ftp.example.com');
-$login_result = ftp_login($conn_id, 'anonymous', 'user@example.com');
+$ftp = ftp_connect('ftp.example.com');
+$login_result = ftp_login($ftp, 'anonymous', 'user@example.com');
 
-if (ftp_alloc($conn_id, filesize($file), $result)) {
+if (ftp_alloc($ftp, filesize($file), $result)) {
   echo "Space successfully allocated on server.  Sending $file.\n";
-  ftp_put($conn_id, '/incoming/myfile', $file, FTP_BINARY);
+  ftp_put($ftp, '/incoming/myfile', $file, FTP_BINARY);
 } else {
   echo "Unable to allocate space on server.  Server said: $result\n";
 }
 
-ftp_close($conn_id);
+ftp_close($ftp);
 
 ?>
 ]]>

--- a/reference/ftp/functions/ftp-alloc.xml
+++ b/reference/ftp/functions/ftp-alloc.xml
@@ -36,9 +36,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-append.xml
+++ b/reference/ftp/functions/ftp-append.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ftp_append</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>remote_filename</parameter></methodparam>
    <methodparam><type>string</type><parameter>local_filename</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_BINARY</constant></initializer></methodparam>
@@ -30,7 +30,7 @@
     <term><parameter>ftp</parameter></term>
     <listitem>
      <para>
-      
+      An <classname>FTP\Connection</classname> instance.
      </para>
     </listitem>
    </varlistentry>
@@ -66,6 +66,23 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 </refentry>

--- a/reference/ftp/functions/ftp-append.xml
+++ b/reference/ftp/functions/ftp-append.xml
@@ -29,9 +29,7 @@
    <varlistentry>
     <term><parameter>ftp</parameter></term>
     <listitem>
-     <para>
-      An <classname>FTP\Connection</classname> instance.
-     </para>
+      &ftp.parameter.ftp;
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/ftp/functions/ftp-cdup.xml
+++ b/reference/ftp/functions/ftp-cdup.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ftp_cdup</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
   </methodsynopsis>
   <para> 
    Changes to the parent directory.
@@ -23,7 +23,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -36,6 +36,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -45,26 +63,26 @@
 <![CDATA[
 <?php
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // change the current directory to html
-ftp_chdir($conn_id, 'html');
+ftp_chdir($ftp, 'html');
 
-echo ftp_pwd($conn_id); // /html 
+echo ftp_pwd($ftp); // /html 
 
 // return to the parent directory
-if (ftp_cdup($conn_id)) { 
+if (ftp_cdup($ftp)) { 
   echo "cdup successful\n";
 } else {
   echo "cdup not successful\n";
 }
 
-echo ftp_pwd($conn_id); // /
+echo ftp_pwd($ftp); // /
 
-ftp_close($conn_id);
+ftp_close($ftp);
 ?>
 ]]>
     </programlisting>

--- a/reference/ftp/functions/ftp-cdup.xml
+++ b/reference/ftp/functions/ftp-cdup.xml
@@ -22,9 +22,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/ftp/functions/ftp-chdir.xml
+++ b/reference/ftp/functions/ftp-chdir.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ftp_chdir</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>directory</parameter></methodparam>
   </methodsynopsis>
   <para> 
@@ -24,7 +24,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -46,6 +46,24 @@
    If changing directory fails, PHP will also throw a warning.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -56,27 +74,27 @@
 <?php
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server); 
+$ftp = ftp_connect($ftp_server); 
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass); 
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass); 
 
 // check connection
-if ((!$conn_id) || (!$login_result)) {
+if ((!$ftp) || (!$login_result)) {
     die("FTP connection has failed !");
 }
 
-echo "Current directory: " . ftp_pwd($conn_id) . "\n";
+echo "Current directory: " . ftp_pwd($ftp) . "\n";
 
 // try to change the directory to somedir
-if (ftp_chdir($conn_id, "somedir")) {
-    echo "Current directory is now: " . ftp_pwd($conn_id) . "\n";
+if (ftp_chdir($ftp, "somedir")) {
+    echo "Current directory is now: " . ftp_pwd($ftp) . "\n";
 } else { 
     echo "Couldn't change directory\n";
 }
 
 // close the connection
-ftp_close($conn_id);
+ftp_close($ftp);
 ?>
 ]]>
     </programlisting>

--- a/reference/ftp/functions/ftp-chdir.xml
+++ b/reference/ftp/functions/ftp-chdir.xml
@@ -23,9 +23,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-chmod.xml
+++ b/reference/ftp/functions/ftp-chmod.xml
@@ -25,9 +25,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-chmod.xml
+++ b/reference/ftp/functions/ftp-chmod.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>int</type><type>false</type></type><methodname>ftp_chmod</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>int</type><parameter>permissions</parameter></methodparam>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
@@ -26,7 +26,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -55,6 +55,24 @@
    Returns the new file permissions on success or &false; on error.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -66,20 +84,20 @@
 $file = 'public_html/index.php';
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // try to chmod $file to 644
-if (ftp_chmod($conn_id, 0644, $file) !== false) {
+if (ftp_chmod($ftp, 0644, $file) !== false) {
  echo "$file chmoded successfully to 644\n";
 } else {
  echo "could not chmod $file\n";
 }
 
 // close the connection
-ftp_close($conn_id);
+ftp_close($ftp);
 ?>
 ]]>
     </programlisting>

--- a/reference/ftp/functions/ftp-close.xml
+++ b/reference/ftp/functions/ftp-close.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ftp_close</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>ftp_close</function> closes the given link identifier
@@ -30,7 +30,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -43,6 +43,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -53,16 +71,16 @@
 <?php
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // print the current directory
-echo ftp_pwd($conn_id); // /
+echo ftp_pwd($ftp);
 
 // close this connection
-ftp_close($conn_id);
+ftp_close($ftp);
 ?>
 ]]>
     </programlisting>

--- a/reference/ftp/functions/ftp-close.xml
+++ b/reference/ftp/functions/ftp-close.xml
@@ -29,9 +29,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/ftp/functions/ftp-connect.xml
+++ b/reference/ftp/functions/ftp-connect.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type class="union"><type>resource</type><type>false</type></type><methodname>ftp_connect</methodname>
+   <type class="union"><type>FTP\Connection</type><type>false</type></type><methodname>ftp_connect</methodname>
    <methodparam><type>string</type><parameter>hostname</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>port</parameter><initializer>21</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>timeout</parameter><initializer>90</initializer></methodparam>
@@ -57,9 +57,33 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a FTP stream on success or &false; on error.
+   Returns an <classname>FTP\Connection</classname> instance on success,&return.falseforfailure;.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row xmlns="http://docbook.org/ns/docbook">
+      <entry>8.1.0</entry>
+      <entry>
+       Returns an <classname>FTP\Connection</classname> instance now;
+       previously, a &resource; was returned.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -72,7 +96,7 @@
 $ftp_server = "ftp.example.com";
 
 // set up a connection or die
-$conn_id = ftp_connect($ftp_server) or die("Couldn't connect to $ftp_server"); 
+$ftp = ftp_connect($ftp_server) or die("Couldn't connect to $ftp_server"); 
 
 ?>
 ]]>  

--- a/reference/ftp/functions/ftp-connect.xml
+++ b/reference/ftp/functions/ftp-connect.xml
@@ -72,7 +72,7 @@
      </row>
     </thead>
     <tbody>
-     <row xmlns="http://docbook.org/ns/docbook">
+     <row>
       <entry>8.1.0</entry>
       <entry>
        Returns an <classname>FTP\Connection</classname> instance now;

--- a/reference/ftp/functions/ftp-delete.xml
+++ b/reference/ftp/functions/ftp-delete.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ftp_delete</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -25,7 +25,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -46,6 +46,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -57,20 +75,20 @@
 $file = 'public_html/old.txt';
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // try to delete $file
-if (ftp_delete($conn_id, $file)) {
+if (ftp_delete($ftp, $file)) {
  echo "$file deleted successful\n";
 } else {
  echo "could not delete $file\n";
 }
 
 // close the connection
-ftp_close($conn_id);
+ftp_close($ftp);
 ?>
 ]]>
     </programlisting>

--- a/reference/ftp/functions/ftp-delete.xml
+++ b/reference/ftp/functions/ftp-delete.xml
@@ -24,9 +24,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-exec.xml
+++ b/reference/ftp/functions/ftp-exec.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ftp_exec</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>command</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -25,7 +25,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -47,6 +47,24 @@
    <literal>200</literal>); otherwise returns &false;.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -60,20 +78,20 @@
 $command = 'ls -al >files.txt';
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // execute command
-if (ftp_exec($conn_id, $command)) {
+if (ftp_exec($ftp, $command)) {
     echo "$command executed successfully\n";
 } else {
     echo "could not execute $command\n";
 }
 
 // close the connection
-ftp_close($conn_id);
+ftp_close($ftp);
 
 ?>
 ]]>

--- a/reference/ftp/functions/ftp-exec.xml
+++ b/reference/ftp/functions/ftp-exec.xml
@@ -24,9 +24,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-fget.xml
+++ b/reference/ftp/functions/ftp-fget.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ftp_fget</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
    <methodparam><type>string</type><parameter>remote_filename</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_BINARY</constant></initializer></methodparam>
@@ -28,7 +28,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -86,6 +86,7 @@
      </row>
     </thead>
     <tbody>
+     &ftp.changelog.ftp-param;
      <row>
       <entry>7.3.0</entry>
       <entry>
@@ -115,20 +116,20 @@ $local_file = 'localfile.txt';
 $handle = fopen($local_file, 'w');
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // try to download $remote_file and save it to $handle
-if (ftp_fget($conn_id, $handle, $remote_file, FTP_ASCII, 0)) {
+if (ftp_fget($ftp, $handle, $remote_file, FTP_ASCII, 0)) {
  echo "successfully written to $local_file\n";
 } else {
  echo "There was a problem while downloading $remote_file to $local_file\n";
 }
 
 // close the connection and the file handler
-ftp_close($conn_id);
+ftp_close($ftp);
 fclose($handle);
 ?>
 ]]>

--- a/reference/ftp/functions/ftp-fget.xml
+++ b/reference/ftp/functions/ftp-fget.xml
@@ -27,9 +27,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-fput.xml
+++ b/reference/ftp/functions/ftp-fput.xml
@@ -27,9 +27,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-fput.xml
+++ b/reference/ftp/functions/ftp-fput.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ftp_fput</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>remote_filename</parameter></methodparam>
    <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_BINARY</constant></initializer></methodparam>
@@ -28,7 +28,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -84,6 +84,7 @@
      </row>
     </thead>
     <tbody>
+     &ftp.changelog.ftp-param;
      <row>
       <entry>7.3.0</entry>
       <entry>
@@ -110,20 +111,20 @@ $file = 'somefile.txt';
 $fp = fopen($file, 'r');
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // try to upload $file
-if (ftp_fput($conn_id, $file, $fp, FTP_ASCII)) {
+if (ftp_fput($ftp, $file, $fp, FTP_ASCII)) {
     echo "Successfully uploaded $file\n";
 } else {
     echo "There was a problem while uploading $file\n";
 }
 
 // close the connection and the file handler
-ftp_close($conn_id);
+ftp_close($ftp);
 fclose($fp);
 
 ?>

--- a/reference/ftp/functions/ftp-get-option.xml
+++ b/reference/ftp/functions/ftp-get-option.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>int</type><type>bool</type></type><methodname>ftp_get_option</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -25,7 +25,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -67,6 +67,24 @@
    warning message is also thrown.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -76,7 +94,7 @@
 <![CDATA[
 <?php
 // Get the timeout of the given FTP stream
-$timeout = ftp_get_option($conn_id, FTP_TIMEOUT_SEC);
+$timeout = ftp_get_option($ftp, FTP_TIMEOUT_SEC);
 ?>
 ]]>
     </programlisting>

--- a/reference/ftp/functions/ftp-get-option.xml
+++ b/reference/ftp/functions/ftp-get-option.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.ftp-get-option" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ftp_get_option</refname>
-  <refpurpose>Retrieves various runtime behaviours of the current FTP stream</refpurpose>
+  <refpurpose>Retrieves various runtime behaviours of the current FTP connection</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -24,9 +24,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -93,7 +91,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// Get the timeout of the given FTP stream
+// Get the timeout of the given FTP connection
 $timeout = ftp_get_option($ftp, FTP_TIMEOUT_SEC);
 ?>
 ]]>

--- a/reference/ftp/functions/ftp-get.xml
+++ b/reference/ftp/functions/ftp-get.xml
@@ -27,9 +27,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-get.xml
+++ b/reference/ftp/functions/ftp-get.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ftp_get</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>local_filename</parameter></methodparam>
    <methodparam><type>string</type><parameter>remote_filename</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_BINARY</constant></initializer></methodparam>
@@ -28,7 +28,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -86,6 +86,7 @@
      </row>
     </thead>
     <tbody>
+     &ftp.changelog.ftp-param;
      <row>
       <entry>7.3.0</entry>
       <entry>
@@ -112,20 +113,20 @@ $local_file = 'local.zip';
 $server_file = 'server.zip';
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // try to download $server_file and save to $local_file
-if (ftp_get($conn_id, $local_file, $server_file, FTP_BINARY)) {
+if (ftp_get($ftp, $local_file, $server_file, FTP_BINARY)) {
     echo "Successfully written to $local_file\n";
 } else {
     echo "There was a problem\n";
 }
 
 // close the connection
-ftp_close($conn_id);
+ftp_close($ftp);
 
 ?>
 ]]>

--- a/reference/ftp/functions/ftp-login.xml
+++ b/reference/ftp/functions/ftp-login.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ftp_login</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>username</parameter></methodparam>
    <methodparam><type>string</type><parameter>password</parameter></methodparam>
   </methodsynopsis>
@@ -55,6 +55,24 @@
    If login fails, PHP will also throw a warning.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -69,17 +87,17 @@ $ftp_user = "foo";
 $ftp_pass = "bar";
 
 // set up a connection or die
-$conn_id = ftp_connect($ftp_server) or die("Couldn't connect to $ftp_server"); 
+$ftp = ftp_connect($ftp_server) or die("Couldn't connect to $ftp_server"); 
 
 // try to login
-if (@ftp_login($conn_id, $ftp_user, $ftp_pass)) {
+if (@ftp_login($ftp, $ftp_user, $ftp_pass)) {
     echo "Connected as $ftp_user@$ftp_server\n";
 } else {
     echo "Couldn't connect as $ftp_user\n";
 }
 
 // close the connection
-ftp_close($conn_id);  
+ftp_close($ftp);  
 ?>
 ]]>  
     </programlisting>

--- a/reference/ftp/functions/ftp-login.xml
+++ b/reference/ftp/functions/ftp-login.xml
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>password</parameter></methodparam>
   </methodsynopsis>
   <para> 
-   Logs in to the given FTP stream.
+   Logs in to the given FTP connection.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/ftp/functions/ftp-mdtm.xml
+++ b/reference/ftp/functions/ftp-mdtm.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>ftp_mdtm</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -35,7 +35,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -57,6 +57,24 @@
    error.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -69,13 +87,13 @@
 $file = 'somefile.txt';
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 //  get the last modified time
-$buff = ftp_mdtm($conn_id, $file);
+$buff = ftp_mdtm($ftp, $file);
 
 if ($buff != -1) {
     // somefile.txt was last modified on: March 26 2003 14:16:41.
@@ -85,7 +103,7 @@ if ($buff != -1) {
 }
 
 // close the connection
-ftp_close($conn_id);
+ftp_close($ftp);
 
 ?>
 ]]>

--- a/reference/ftp/functions/ftp-mdtm.xml
+++ b/reference/ftp/functions/ftp-mdtm.xml
@@ -34,9 +34,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-mkdir.xml
+++ b/reference/ftp/functions/ftp-mkdir.xml
@@ -23,9 +23,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-mkdir.xml
+++ b/reference/ftp/functions/ftp-mkdir.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>ftp_mkdir</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>directory</parameter></methodparam>
   </methodsynopsis>
   <para> 
@@ -24,7 +24,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -44,6 +44,23 @@
   <para>
    Returns the newly created directory name on success or &false; on error.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="errors">
@@ -66,20 +83,20 @@
 $dir = 'www';
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // try to create the directory $dir
-if (ftp_mkdir($conn_id, $dir)) {
+if (ftp_mkdir($ftp, $dir)) {
  echo "successfully created $dir\n";
 } else {
  echo "There was a problem while creating $dir\n";
 }
 
 // close the connection
-ftp_close($conn_id);
+ftp_close($ftp);
 ?>
 ]]>
     </programlisting>

--- a/reference/ftp/functions/ftp-mlsd.xml
+++ b/reference/ftp/functions/ftp-mlsd.xml
@@ -20,9 +20,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-mlsd.xml
+++ b/reference/ftp/functions/ftp-mlsd.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>array</type><type>false</type></type><methodname>ftp_mlsd</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>directory</parameter></methodparam>
   </methodsynopsis>
  </refsect1>
@@ -21,7 +21,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -43,6 +43,24 @@
    &false; on error.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -53,13 +71,13 @@
 <?php
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // get contents of the current directory
-$contents = ftp_mlsd($conn_id, ".");
+$contents = ftp_mlsd($ftp, ".");
 
 // output $contents
 var_dump($contents);

--- a/reference/ftp/functions/ftp-nb-continue.xml
+++ b/reference/ftp/functions/ftp-nb-continue.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>ftp_nb_continue</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
   </methodsynopsis>
   <para> 
    Continues retrieving/sending a file non-blocking.
@@ -23,7 +23,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -37,6 +37,24 @@
    or <constant>FTP_MOREDATA</constant>.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -47,11 +65,11 @@
 <?php
 
 // Initiate the download
-$ret = ftp_nb_get($my_connection, "test", "README", FTP_BINARY);
+$ret = ftp_nb_get($ftp, "test", "README", FTP_BINARY);
 while ($ret == FTP_MOREDATA) {
 
    // Continue downloading...
-   $ret = ftp_nb_continue($my_connection);
+   $ret = ftp_nb_continue($ftp);
 }
 if ($ret != FTP_FINISHED) {
    echo "There was an error downloading the file...";

--- a/reference/ftp/functions/ftp-nb-continue.xml
+++ b/reference/ftp/functions/ftp-nb-continue.xml
@@ -22,9 +22,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/ftp/functions/ftp-nb-fget.xml
+++ b/reference/ftp/functions/ftp-nb-fget.xml
@@ -32,9 +32,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-nb-fget.xml
+++ b/reference/ftp/functions/ftp-nb-fget.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>ftp_nb_fget</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
    <methodparam><type>string</type><parameter>remote_filename</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_BINARY</constant></initializer></methodparam>
@@ -33,7 +33,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -90,6 +90,7 @@
      </row>
     </thead>
     <tbody>
+     &ftp.changelog.ftp-param;
      <row>
       <entry>7.3.0</entry>
       <entry>
@@ -115,19 +116,19 @@
 $file = 'index.php';
 $fp = fopen($file, 'w');
 
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // Initiate the download
-$ret = ftp_nb_fget($conn_id, $fp, $file, FTP_BINARY);
+$ret = ftp_nb_fget($ftp, $fp, $file, FTP_BINARY);
 while ($ret == FTP_MOREDATA) {
 
    // Do whatever you want
    echo ".";
 
    // Continue downloading...
-   $ret = ftp_nb_continue($conn_id);
+   $ret = ftp_nb_continue($ftp);
 }
 if ($ret != FTP_FINISHED) {
    echo "There was an error downloading the file...";

--- a/reference/ftp/functions/ftp-nb-fput.xml
+++ b/reference/ftp/functions/ftp-nb-fput.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>ftp_nb_fput</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>remote_filename</parameter></methodparam>
    <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_BINARY</constant></initializer></methodparam>
@@ -33,7 +33,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -90,6 +90,7 @@
      </row>
     </thead>
     <tbody>
+     &ftp.changelog.ftp-param;
      <row>
       <entry>7.3.0</entry>
       <entry>
@@ -115,19 +116,19 @@ $file = 'index.php';
 
 $fp = fopen($file, 'r');
 
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // Initiate the upload
-$ret = ftp_nb_fput($conn_id, $file, $fp, FTP_BINARY);
+$ret = ftp_nb_fput($ftp, $file, $fp, FTP_BINARY);
 while ($ret == FTP_MOREDATA) {
 
    // Do whatever you want
    echo ".";
 
    // Continue upload...
-   $ret = ftp_nb_continue($conn_id);
+   $ret = ftp_nb_continue($ftp);
 }
 if ($ret != FTP_FINISHED) {
    echo "There was an error uploading the file...";

--- a/reference/ftp/functions/ftp-nb-fput.xml
+++ b/reference/ftp/functions/ftp-nb-fput.xml
@@ -32,9 +32,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-nb-get.xml
+++ b/reference/ftp/functions/ftp-nb-get.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>ftp_nb_get</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>local_filename</parameter></methodparam>
    <methodparam><type>string</type><parameter>remote_filename</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_BINARY</constant></initializer></methodparam>
@@ -33,7 +33,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -90,6 +90,7 @@
      </row>
     </thead>
     <tbody>
+     &ftp.changelog.ftp-param;
      <row>
       <entry>7.3.0</entry>
       <entry>
@@ -112,14 +113,14 @@
 <?php
 
 // Initiate the download
-$ret = ftp_nb_get($my_connection, "test", "README", FTP_BINARY);
+$ret = ftp_nb_get($ftp, "test", "README", FTP_BINARY);
 while ($ret == FTP_MOREDATA) {
    
    // Do whatever you want
    echo ".";
 
    // Continue downloading...
-   $ret = ftp_nb_continue($my_connection);
+   $ret = ftp_nb_continue($ftp);
 }
 if ($ret != FTP_FINISHED) {
    echo "There was an error downloading the file...";
@@ -136,9 +137,9 @@ if ($ret != FTP_FINISHED) {
 <?php
 
 // Initiate 
-$ret = ftp_nb_get($my_connection, "test", "README", FTP_BINARY, 
+$ret = ftp_nb_get($ftp, "test", "README", FTP_BINARY, 
                       filesize("test"));
-// OR: $ret = ftp_nb_get($my_connection, "test", "README", 
+// OR: $ret = ftp_nb_get($ftp, "test", "README", 
 //                           FTP_BINARY, FTP_AUTORESUME);
 while ($ret == FTP_MOREDATA) {
    
@@ -146,7 +147,7 @@ while ($ret == FTP_MOREDATA) {
    echo ".";
 
    // Continue downloading...
-   $ret = ftp_nb_continue($my_connection);
+   $ret = ftp_nb_continue($ftp);
 }
 if ($ret != FTP_FINISHED) {
    echo "There was an error downloading the file...";
@@ -166,16 +167,16 @@ if ($ret != FTP_FINISHED) {
 <?php
 
 // Disable Autoseek
-ftp_set_option($my_connection, FTP_AUTOSEEK, false);
+ftp_set_option($ftp, FTP_AUTOSEEK, false);
 
 // Initiate
-$ret = ftp_nb_get($my_connection, "newfile", "README", FTP_BINARY, 100);
+$ret = ftp_nb_get($ftp, "newfile", "README", FTP_BINARY, 100);
 while ($ret == FTP_MOREDATA) {
 
    /* ... */
    
    // Continue downloading...
-   $ret = ftp_nb_continue($my_connection);
+   $ret = ftp_nb_continue($ftp);
 }
 ?>
 ]]>

--- a/reference/ftp/functions/ftp-nb-get.xml
+++ b/reference/ftp/functions/ftp-nb-get.xml
@@ -32,9 +32,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-nb-put.xml
+++ b/reference/ftp/functions/ftp-nb-put.xml
@@ -31,9 +31,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-nb-put.xml
+++ b/reference/ftp/functions/ftp-nb-put.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>int</type><type>false</type></type><methodname>ftp_nb_put</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>remote_filename</parameter></methodparam>
    <methodparam><type>string</type><parameter>local_filename</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_BINARY</constant></initializer></methodparam>
@@ -32,7 +32,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -89,6 +89,7 @@
      </row>
     </thead>
     <tbody>
+     &ftp.changelog.ftp-param;
      <row>
       <entry>7.3.0</entry>
       <entry>
@@ -111,14 +112,14 @@
 <?php
 
 // Initiate the Upload
-$ret = ftp_nb_put($my_connection, "test.remote", "test.local", FTP_BINARY);
+$ret = ftp_nb_put($ftp, "test.remote", "test.local", FTP_BINARY);
 while ($ret == FTP_MOREDATA) {
    
    // Do whatever you want
    echo ".";
 
    // Continue uploading...
-   $ret = ftp_nb_continue($my_connection);
+   $ret = ftp_nb_continue($ftp);
 }
 if ($ret != FTP_FINISHED) {
    echo "There was an error uploading the file...";
@@ -135,9 +136,9 @@ if ($ret != FTP_FINISHED) {
 <?php
 
 // Initiate
-$ret = ftp_nb_put($my_connection, "test.remote", "test.local", 
+$ret = ftp_nb_put($ftp, "test.remote", "test.local", 
                       FTP_BINARY, ftp_size("test.remote"));
-// OR: $ret = ftp_nb_put($my_connection, "test.remote", "test.local", 
+// OR: $ret = ftp_nb_put($ftp, "test.remote", "test.local", 
 //                           FTP_BINARY, FTP_AUTORESUME);
 
 while ($ret == FTP_MOREDATA) {
@@ -146,7 +147,7 @@ while ($ret == FTP_MOREDATA) {
    echo ".";
 
    // Continue uploading...
-   $ret = ftp_nb_continue($my_connection);
+   $ret = ftp_nb_continue($ftp);
 }
 if ($ret != FTP_FINISHED) {
    echo "There was an error uploading the file...";

--- a/reference/ftp/functions/ftp-nlist.xml
+++ b/reference/ftp/functions/ftp-nlist.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>array</type><type>false</type></type><methodname>ftp_nlist</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>directory</parameter></methodparam>
   </methodsynopsis>
  </refsect1>
@@ -21,7 +21,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -30,7 +30,7 @@
      <listitem>
       <para>
        The directory to be listed. This parameter can also include arguments, eg.
-       ftp_nlist($conn_id, "-la /your/dir");
+       <literal>ftp_nlist($ftp, "-la /your/dir");</literal>.
        Note that this parameter isn't escaped so there may be some issues with
        filenames containing spaces and other characters. 
       </para>
@@ -46,6 +46,24 @@
    &false; on error.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -56,13 +74,13 @@
 <?php
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // get contents of the current directory
-$contents = ftp_nlist($conn_id, ".");
+$contents = ftp_nlist($ftp, ".");
 
 // output $contents
 var_dump($contents);

--- a/reference/ftp/functions/ftp-nlist.xml
+++ b/reference/ftp/functions/ftp-nlist.xml
@@ -20,9 +20,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-pasv.xml
+++ b/reference/ftp/functions/ftp-pasv.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ftp_pasv</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>bool</type><parameter>enable</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -31,7 +31,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -52,6 +52,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -64,23 +82,23 @@ $file = 'somefile.txt';
 $remote_file = 'readme.txt';
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // turn passive mode on
-ftp_pasv($conn_id, true);
+ftp_pasv($ftp, true);
 
 // upload a file
-if (ftp_put($conn_id, $remote_file, $file, FTP_ASCII)) {
+if (ftp_put($ftp, $remote_file, $file, FTP_ASCII)) {
  echo "successfully uploaded $file\n";
 } else {
  echo "There was a problem while uploading $file\n";
 }
 
 // close the connection
-ftp_close($conn_id);
+ftp_close($ftp);
 ?>
 ]]>
     </programlisting>

--- a/reference/ftp/functions/ftp-pasv.xml
+++ b/reference/ftp/functions/ftp-pasv.xml
@@ -30,9 +30,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-put.xml
+++ b/reference/ftp/functions/ftp-put.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ftp_put</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>remote_filename</parameter></methodparam>
    <methodparam><type>string</type><parameter>local_filename</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>FTP_BINARY</constant></initializer></methodparam>
@@ -27,7 +27,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -83,6 +83,7 @@
      </row>
     </thead>
     <tbody>
+     &ftp.changelog.ftp-param;
      <row>
       <entry>7.3.0</entry>
       <entry>
@@ -107,20 +108,20 @@ $file = 'somefile.txt';
 $remote_file = 'readme.txt';
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // upload a file
-if (ftp_put($conn_id, $remote_file, $file, FTP_ASCII)) {
+if (ftp_put($ftp, $remote_file, $file, FTP_ASCII)) {
  echo "successfully uploaded $file\n";
 } else {
  echo "There was a problem while uploading $file\n";
 }
 
 // close the connection
-ftp_close($conn_id);
+ftp_close($ftp);
 ?>
 ]]>
     </programlisting>

--- a/reference/ftp/functions/ftp-put.xml
+++ b/reference/ftp/functions/ftp-put.xml
@@ -26,9 +26,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-pwd.xml
+++ b/reference/ftp/functions/ftp-pwd.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>ftp_pwd</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
   </methodsynopsis>
   <para>
   </para>
@@ -22,7 +22,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -35,6 +35,24 @@
    Returns the current directory name or &false; on error.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -45,19 +63,19 @@
 <?php
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // change directory to public_html
-ftp_chdir($conn_id, 'public_html');
+ftp_chdir($ftp, 'public_html');
 
 // print current directory
-echo ftp_pwd($conn_id); // /public_html
+echo ftp_pwd($ftp); // /public_html
 
 // close the connection
-ftp_close($conn_id);
+ftp_close($ftp);
 ?>
 ]]>
     </programlisting>

--- a/reference/ftp/functions/ftp-pwd.xml
+++ b/reference/ftp/functions/ftp-pwd.xml
@@ -21,9 +21,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/ftp/functions/ftp-raw.xml
+++ b/reference/ftp/functions/ftp-raw.xml
@@ -23,9 +23,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-raw.xml
+++ b/reference/ftp/functions/ftp-raw.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>ftp_raw</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>command</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -24,7 +24,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -47,6 +47,24 @@
    <function>ftp_raw</function> determine if the command succeeded.  
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -55,12 +73,12 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$fp = ftp_connect("ftp.example.com");
+$ftp = ftp_connect("ftp.example.com");
 
 /* This is the same as: 
-   ftp_login($fp, "joeblow", "secret"); */
-ftp_raw($fp, "USER joeblow");
-ftp_raw($fp, "PASS secret");
+   ftp_login($ftp, "joeblow", "secret"); */
+ftp_raw($ftp, "USER joeblow");
+ftp_raw($ftp, "PASS secret");
 ?>
 ]]>
     </programlisting>

--- a/reference/ftp/functions/ftp-rawlist.xml
+++ b/reference/ftp/functions/ftp-rawlist.xml
@@ -25,9 +25,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-rawlist.xml
+++ b/reference/ftp/functions/ftp-rawlist.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>array</type><type>false</type></type><methodname>ftp_rawlist</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>directory</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>recursive</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
@@ -26,7 +26,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -62,6 +62,24 @@
    should be interpreted.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -72,16 +90,16 @@
 <?php
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // get the file list for /
-$buff = ftp_rawlist($conn_id, '/');
+$buff = ftp_rawlist($ftp, '/');
 
 // close the connection
-ftp_close($conn_id);
+ftp_close($ftp);
 
 // output the buffer
 var_dump($buff);

--- a/reference/ftp/functions/ftp-rename.xml
+++ b/reference/ftp/functions/ftp-rename.xml
@@ -25,9 +25,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-rename.xml
+++ b/reference/ftp/functions/ftp-rename.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ftp_rename</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>from</parameter></methodparam>
    <methodparam><type>string</type><parameter>to</parameter></methodparam>
   </methodsynopsis>
@@ -26,7 +26,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -56,6 +56,24 @@
    file), an <literal>E_WARNING</literal> error will be emitted.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -68,20 +86,20 @@ $old_file = 'somefile.txt.bak';
 $new_file = 'somefile.txt';
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // try to rename $old_file to $new_file
-if (ftp_rename($conn_id, $old_file, $new_file)) {
+if (ftp_rename($ftp, $old_file, $new_file)) {
  echo "successfully renamed $old_file to $new_file\n";
 } else {
  echo "There was a problem while renaming $old_file to $new_file\n";
 }
 
 // close the connection
-ftp_close($conn_id);
+ftp_close($ftp);
 ?>
 ]]>
     </programlisting>

--- a/reference/ftp/functions/ftp-rmdir.xml
+++ b/reference/ftp/functions/ftp-rmdir.xml
@@ -23,9 +23,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-rmdir.xml
+++ b/reference/ftp/functions/ftp-rmdir.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ftp_rmdir</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>directory</parameter></methodparam>
   </methodsynopsis>
   <para> 
@@ -24,7 +24,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -46,6 +46,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -58,19 +76,19 @@
 $dir = 'www/';
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // try to delete the directory $dir
-if (ftp_rmdir($conn_id, $dir)) {
+if (ftp_rmdir($ftp, $dir)) {
     echo "Successfully deleted $dir\n";
 } else {
     echo "There was a problem while deleting $dir\n";
 }
 
-ftp_close($conn_id);
+ftp_close($ftp);
 
 ?>
 ]]>

--- a/reference/ftp/functions/ftp-set-option.xml
+++ b/reference/ftp/functions/ftp-set-option.xml
@@ -14,8 +14,7 @@
    <methodparam><type class="union"><type>int</type><type>bool</type></type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
-   This function controls various runtime options for the specified FTP 
-   stream.
+   This function controls various runtime options for the specified FTP connection.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -25,9 +24,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-set-option.xml
+++ b/reference/ftp/functions/ftp-set-option.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ftp_set_option</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
    <methodparam><type class="union"><type>int</type><type>bool</type></type><parameter>value</parameter></methodparam>
   </methodsynopsis>
@@ -26,7 +26,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -90,6 +90,24 @@
    expected value for the given <parameter>option</parameter>.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -99,7 +117,7 @@
 <![CDATA[
 <?php
 // Set the network timeout to 10 seconds
-ftp_set_option($conn_id, FTP_TIMEOUT_SEC, 10);
+ftp_set_option($ftp, FTP_TIMEOUT_SEC, 10);
 ?>
 ]]>
     </programlisting>

--- a/reference/ftp/functions/ftp-site.xml
+++ b/reference/ftp/functions/ftp-site.xml
@@ -29,9 +29,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-site.xml
+++ b/reference/ftp/functions/ftp-site.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ftp_site</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>command</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -30,7 +30,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -52,6 +52,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -61,14 +79,14 @@
 <![CDATA[
 <?php
 // Connect to FTP server
-$conn = ftp_connect('ftp.example.com');
-if (!$conn) die('Unable to connect to ftp.example.com');
+$ftp = ftp_connect('ftp.example.com');
+if (!$ftp) die('Unable to connect to ftp.example.com');
 
 // Login as "user" with password "pass"
-if (!ftp_login($conn, 'user', 'pass')) die('Error logging into ftp.example.com');
+if (!ftp_login($ftp, 'user', 'pass')) die('Error logging into ftp.example.com');
 
 // Issue: "SITE CHMOD 0600 /home/user/privatefile" command to ftp server
-if (ftp_site($conn, 'CHMOD 0600 /home/user/privatefile')) {
+if (ftp_site($ftp, 'CHMOD 0600 /home/user/privatefile')) {
    echo "Command executed successfully.\n";
 } else {
    die('Command failed.');

--- a/reference/ftp/functions/ftp-size.xml
+++ b/reference/ftp/functions/ftp-size.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>ftp_size</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -30,7 +30,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -51,6 +51,24 @@
    Returns the file size on success, or -1 on error.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -63,13 +81,13 @@
 $file = 'somefile.txt';
 
 // set up basic connection
-$conn_id = ftp_connect($ftp_server);
+$ftp = ftp_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // get the size of $file
-$res = ftp_size($conn_id, $file);
+$res = ftp_size($ftp, $file);
 
 if ($res != -1) {
     echo "size of $file is $res bytes";
@@ -78,7 +96,7 @@ if ($res != -1) {
 }
 
 // close the connection
-ftp_close($conn_id);
+ftp_close($ftp);
 
 ?>
 ]]>

--- a/reference/ftp/functions/ftp-size.xml
+++ b/reference/ftp/functions/ftp-size.xml
@@ -29,9 +29,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/ftp/functions/ftp-ssl-connect.xml
+++ b/reference/ftp/functions/ftp-ssl-connect.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type class="union"><type>resource</type><type>false</type></type><methodname>ftp_ssl_connect</methodname>
+   <type class="union"><type>FTP\Connection</type><type>false</type></type><methodname>ftp_ssl_connect</methodname>
    <methodparam><type>string</type><parameter>hostname</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>port</parameter><initializer>21</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>timeout</parameter><initializer>90</initializer></methodparam>
@@ -78,8 +78,31 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a SSL-FTP stream on success or &false; on error.
+   Returns an <classname>FTP\Connection</classname> instance on success,&return.falseforfailure;.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row xmlns="http://docbook.org/ns/docbook">
+      <entry>8.1.0</entry>
+      <entry>
+       Returns an <classname>FTP\Connection</classname> instance now;
+       previously, a &resource; was returned.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
@@ -92,20 +115,20 @@
 <?php
 
 // set up basic ssl connection
-$conn_id = ftp_ssl_connect($ftp_server);
+$ftp = ftp_ssl_connect($ftp_server);
 
 // login with username and password
-$login_result = ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+$login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 if (!$login_result) {
     // PHP will already have raised an E_WARNING level message in this case
     die("can't login");
 }
 
-echo ftp_pwd($conn_id); // /
+echo ftp_pwd($ftp);
 
 // close the ssl connection
-ftp_close($conn_id);
+ftp_close($ftp);
 ?>
 ]]>
     </programlisting>

--- a/reference/ftp/functions/ftp-ssl-connect.xml
+++ b/reference/ftp/functions/ftp-ssl-connect.xml
@@ -93,7 +93,7 @@
      </row>
     </thead>
     <tbody>
-     <row xmlns="http://docbook.org/ns/docbook">
+     <row>
       <entry>8.1.0</entry>
       <entry>
        Returns an <classname>FTP\Connection</classname> instance now;

--- a/reference/ftp/functions/ftp-systype.xml
+++ b/reference/ftp/functions/ftp-systype.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>ftp_systype</methodname>
-   <methodparam><type>resource</type><parameter>ftp</parameter></methodparam>
+   <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
   </methodsynopsis>
   <para>
    Returns the system type identifier of the remote FTP server.
@@ -23,7 +23,7 @@
      <term><parameter>ftp</parameter></term>
      <listitem>
       <para>
-       The link identifier of the FTP connection.
+       An <classname>FTP\Connection</classname> instance.
       </para>
      </listitem>
     </varlistentry>
@@ -36,6 +36,24 @@
    Returns the remote system type, or &false; on error.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &ftp.changelog.ftp-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/ftp/functions/ftp-systype.xml
+++ b/reference/ftp/functions/ftp-systype.xml
@@ -22,9 +22,7 @@
     <varlistentry>
      <term><parameter>ftp</parameter></term>
      <listitem>
-      <para>
-       An <classname>FTP\Connection</classname> instance.
-      </para>
+       &ftp.parameter.ftp;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/ftp/setup.xml
+++ b/reference/ftp/setup.xml
@@ -22,17 +22,6 @@
  </section>
  <!-- }}} -->
 
- <!-- {{{ Resources -->
- <section xml:id="ftp.resources">
-  &reftitle.resources;
-  <para>
-   This extension uses one resource type, which is the link identifier
-   of the FTP connection, returned by <function>ftp_connect</function>
-   or <function>ftp_ssl_connect</function>.
-  </para>
- </section>
- <!-- }}} -->
-
 </chapter>
 
 <!-- Keep this comment at the end of the file

--- a/reference/ftp/versions.xml
+++ b/reference/ftp/versions.xml
@@ -40,6 +40,8 @@
  <function name="ftp_size" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="ftp_ssl_connect" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
  <function name="ftp_systype" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+
+ <function name='FTP\Connection' from='PHP 8 &gt;= 8.1.0'/>
 </versions>
 
 <!-- Keep this comment at the end of the file

--- a/reference/ftp/versions.xml
+++ b/reference/ftp/versions.xml
@@ -41,7 +41,7 @@
  <function name="ftp_ssl_connect" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
  <function name="ftp_systype" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 
- <function name='FTP\Connection' from='PHP 8 &gt;= 8.1.0'/>
+ <function name='ftp\connection' from='PHP 8 &gt;= 8.1.0'/>
 </versions>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Related [changelog](https://github.com/php/doc-en/commit/4d2479dcf35d82aca39ee61f8ab36ceed78a869c#diff-8290829d06b811e45b3f0e3b04e8b24f8f339e59e1c70a15e63bc8f5c97539f2R91-R93).

PR can wait for other PRs related to PHP 8.1 if there are no comments.