### PR TITLE
[PHP 8.1] Use an `IMAP\Connection` instance instead of a resource

### DIFF
--- a/appendices/resources.xml
+++ b/appendices/resources.xml
@@ -623,7 +623,7 @@
     <entry>
      <function>imap_close</function>
     </entry>
-    <entry>Link to IMAP, POP3 server</entry>
+    <entry>Link to IMAP, POP3 server (prior to PHP 8.1.0)</entry>
    </row>
    <row>
      <entry>interbase blob</entry>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -986,6 +986,18 @@ returned by <function>dbmopen</function>.</para></listitem></varlistentry>'>
 
 <!-- IMAP notes -->
 
+<!ENTITY imap.changelog.imap-param '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.1.0</entry>
+ <entry>
+  The <parameter>imap</parameter> parameter expects an <classname>IMAP\Connection</classname>
+  instance now; previously, a &resource; was expected.
+ </entry>
+</row>'>
+
+<!ENTITY imap.imap-parameter.imap '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>
+imap</parameter></term><listitem><para>An <classname>IMAP\Connection</classname> instance.</para></listitem></varlistentry>'>
+
+<!-- Deprecated -->
 <!ENTITY imap.imap-stream.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>
 imap</parameter></term><listitem><para>An IMAP stream returned by
 <function>imap_open</function>.</para></listitem></varlistentry>'>

--- a/reference/imap/book.xml
+++ b/reference/imap/book.xml
@@ -29,6 +29,7 @@
  &reference.imap.setup;
  &reference.imap.constants;
  &reference.imap.reference;
+ &reference.imap.imap.connection;
 
 </book>
 

--- a/reference/imap/functions/imap-append.xml
+++ b/reference/imap/functions/imap-append.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_append</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>folder</parameter></methodparam>
    <methodparam><type>string</type><parameter>message</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
@@ -23,7 +23,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>folder</parameter></term>
      <listitem>
@@ -85,6 +85,7 @@
      </row>
     </thead>
     <tbody>
+     &imap.changelog.imap-param;
      <row>
       <entry>8.0.0</entry>
       <entry>
@@ -104,12 +105,12 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$stream = imap_open("{imap.example.org}INBOX.Drafts", "username", "password");
+$imap = imap_open("{imap.example.org}INBOX.Drafts", "username", "password");
 
-$check = imap_check($stream);
+$check = imap_check($imap);
 echo "Msg Count before append: ". $check->Nmsgs . "\n";
 
-imap_append($stream, "{imap.example.org}INBOX.Drafts"
+imap_append($imap, "{imap.example.org}INBOX.Drafts"
                    , "From: me@example.com\r\n"
                    . "To: you@example.com\r\n"
                    . "Subject: test\r\n"
@@ -117,10 +118,10 @@ imap_append($stream, "{imap.example.org}INBOX.Drafts"
                    . "this is a test message, please ignore\r\n"
                    );
 
-$check = imap_check($stream);
+$check = imap_check($imap);
 echo "Msg Count after append : ". $check->Nmsgs . "\n";
 
-imap_close($stream);
+imap_close($imap);
 ?>
 ]]>
     </programlisting>

--- a/reference/imap/functions/imap-body.xml
+++ b/reference/imap/functions/imap-body.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>imap_body</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>int</type><parameter>message_num</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
@@ -30,7 +30,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>message_num</parameter></term>
      <listitem>
@@ -75,6 +75,24 @@
    Returns the body of the specified message, as a string, &return.falseforfailure;.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/imap/functions/imap-bodystruct.xml
+++ b/reference/imap/functions/imap-bodystruct.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>stdClass</type><type>false</type></type><methodname>imap_bodystruct</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>int</type><parameter>message_num</parameter></methodparam>
    <methodparam><type>string</type><parameter>section</parameter></methodparam>
   </methodsynopsis>
@@ -21,7 +21,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>message_num</parameter></term>
      <listitem>
@@ -50,6 +50,24 @@
    <function>imap_fetchstructure</function>.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/functions/imap-check.xml
+++ b/reference/imap/functions/imap-check.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>stdClass</type><type>false</type></type><methodname>imap_check</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
   </methodsynopsis>
   <para>
    Checks information about the current mailbox.
@@ -19,7 +19,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
    </variablelist>
   </para>
  </refsect1>
@@ -61,6 +61,24 @@
    Returns &false; on failure.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -70,8 +88,8 @@
 <![CDATA[
 <?php
 
-$imap_obj = imap_check($imap_stream);
-var_dump($imap_obj);
+$imap = imap_check($imap_stream);
+var_dump($imap);
 
 ?>
 ]]>

--- a/reference/imap/functions/imap-clearflag-full.xml
+++ b/reference/imap/functions/imap-clearflag-full.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_clearflag_full</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>sequence</parameter></methodparam>
    <methodparam><type>string</type><parameter>flag</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
@@ -24,7 +24,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>sequence</parameter></term>
      <listitem>
@@ -71,6 +71,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/functions/imap-close.xml
+++ b/reference/imap/functions/imap-close.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_close</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
@@ -20,7 +20,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
@@ -41,6 +41,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/functions/imap-createmailbox.xml
+++ b/reference/imap/functions/imap-createmailbox.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_createmailbox</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>mailbox</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -20,7 +20,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>mailbox</parameter></term>
      <listitem>
@@ -41,6 +41,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/imap/functions/imap-delete.xml
+++ b/reference/imap/functions/imap-delete.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_delete</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>message_num</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
@@ -25,7 +25,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>message_num</parameter></term>
      <listitem>
@@ -53,6 +53,24 @@
    Returns &true;.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/imap/functions/imap-deletemailbox.xml
+++ b/reference/imap/functions/imap-deletemailbox.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_deletemailbox</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>mailbox</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -20,7 +20,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>mailbox</parameter></term>
      <listitem>
@@ -40,6 +40,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/functions/imap-expunge.xml
+++ b/reference/imap/functions/imap-expunge.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_expunge</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
   </methodsynopsis>
   <para>
    Deletes all the messages marked for deletion by 
@@ -21,7 +21,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
    </variablelist>
   </para>
  </refsect1>
@@ -31,6 +31,24 @@
    Returns &true;.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/imap/functions/imap-fetch-overview.xml
+++ b/reference/imap/functions/imap-fetch-overview.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>array</type><type>false</type></type><methodname>imap_fetch_overview</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>sequence</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
@@ -23,7 +23,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>sequence</parameter></term>
      <listitem>
@@ -142,6 +142,23 @@
    </itemizedlist>
    The function returns &false; on failure.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/imap/functions/imap-fetchbody.xml
+++ b/reference/imap/functions/imap-fetchbody.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>imap_fetchbody</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>int</type><parameter>message_num</parameter></methodparam>
    <methodparam><type>string</type><parameter>section</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
@@ -23,7 +23,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>message_num</parameter></term>
      <listitem>
@@ -78,6 +78,24 @@
    text string, &return.falseforfailure;.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/functions/imap-fetchheader.xml
+++ b/reference/imap/functions/imap-fetchheader.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>imap_fetchheader</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>int</type><parameter>message_num</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
@@ -23,7 +23,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>message_num</parameter></term>
      <listitem>
@@ -72,6 +72,24 @@
    Returns the header of the specified message as a text string, &return.falseforfailure;.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/functions/imap-fetchmime.xml
+++ b/reference/imap/functions/imap-fetchmime.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>imap_fetchmime</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>int</type><parameter>message_num</parameter></methodparam>
    <methodparam><type>string</type><parameter>section</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
@@ -22,7 +22,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>message_num</parameter></term>
      <listitem>
@@ -77,6 +77,24 @@
    text string, &return.falseforfailure;.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/functions/imap-fetchstructure.xml
+++ b/reference/imap/functions/imap-fetchstructure.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>stdClass</type><type>false</type></type><methodname>imap_fetchstructure</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>int</type><parameter>message_num</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
@@ -21,7 +21,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>message_num</parameter></term>
      <listitem>
@@ -176,6 +176,24 @@
    </table>
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/functions/imap-gc.xml
+++ b/reference/imap/functions/imap-gc.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_gc</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>int</type><parameter>flags</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -20,7 +20,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-     &imap.imap-stream.description;
+     &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
@@ -42,6 +42,24 @@
   &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/imap/functions/imap-get-quota.xml
+++ b/reference/imap/functions/imap-get-quota.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>array</type><type>false</type></type><methodname>imap_get_quota</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>quota_root</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -24,7 +24,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>quota_root</parameter></term>
      <listitem>
@@ -59,6 +59,24 @@
    still available for use, although it is suggested to update.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/imap/functions/imap-get-quotaroot.xml
+++ b/reference/imap/functions/imap-get-quotaroot.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>array</type><type>false</type></type><methodname>imap_get_quotaroot</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>mailbox</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -22,7 +22,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>mailbox</parameter></term>
      <listitem>
@@ -48,6 +48,24 @@
    from the server.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/imap/functions/imap-getacl.xml
+++ b/reference/imap/functions/imap-getacl.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>array</type><type>false</type></type><methodname>imap_getacl</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>mailbox</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -20,7 +20,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>mailbox</parameter></term>
      <listitem>
@@ -40,6 +40,24 @@
    Returns an associative array of "folder" =&gt; "acl" pairs, &return.falseforfailure;.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -49,7 +67,7 @@
 <![CDATA[
 <?php
 
-print_r(imap_getacl($conn_id, 'user.joecool'));
+print_r(imap_getacl($imap, 'user.joecool'));
 
 ?>
 ]]>

--- a/reference/imap/functions/imap-getmailboxes.xml
+++ b/reference/imap/functions/imap-getmailboxes.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>array</type><type>false</type></type><methodname>imap_getmailboxes</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>reference</parameter></methodparam>
    <methodparam><type>string</type><parameter>pattern</parameter></methodparam>
   </methodsynopsis>
@@ -21,7 +21,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>reference</parameter></term>
      <listitem>
@@ -98,6 +98,24 @@
    The function returns &false; on failure.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/imap/functions/imap-getsubscribed.xml
+++ b/reference/imap/functions/imap-getsubscribed.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>array</type><type>false</type></type><methodname>imap_getsubscribed</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>reference</parameter></methodparam>
    <methodparam><type>string</type><parameter>pattern</parameter></methodparam>
   </methodsynopsis>
@@ -25,7 +25,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>reference</parameter></term>
      <listitem>
@@ -99,6 +99,24 @@
    The function returns &false; on failure.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/imap/functions/imap-headerinfo.xml
+++ b/reference/imap/functions/imap-headerinfo.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>stdClass</type><type>false</type></type><methodname>imap_headerinfo</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>int</type><parameter>message_num</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>from_length</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>subject_length</parameter><initializer>0</initializer></methodparam>
@@ -22,7 +22,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>message_num</parameter></term>
      <listitem>
@@ -278,6 +278,7 @@
      </row>
     </thead>
     <tbody>
+     &imap.changelog.imap-param;
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/imap/functions/imap-headers.xml
+++ b/reference/imap/functions/imap-headers.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>array</type><type>false</type></type><methodname>imap_headers</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
   </methodsynopsis>
   <para>
    Returns headers for all messages in a mailbox.
@@ -19,7 +19,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
    </variablelist>
   </para>
  </refsect1>
@@ -31,6 +31,24 @@
    Returns &false; on failure.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/imap/functions/imap-list.xml
+++ b/reference/imap/functions/imap-list.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>array</type><type>false</type></type><methodname>imap_list</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>reference</parameter></methodparam>
    <methodparam><type>string</type><parameter>pattern</parameter></methodparam>
   </methodsynopsis>
@@ -21,7 +21,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>reference</parameter></term>
      <listitem>
@@ -47,6 +47,24 @@
    Returns an array containing the names of the mailboxes or &false; in case of failure.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/imap/functions/imap-listscan.xml
+++ b/reference/imap/functions/imap-listscan.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>array</type><type>false</type></type><methodname>imap_listscan</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>reference</parameter></methodparam>
    <methodparam><type>string</type><parameter>pattern</parameter></methodparam>
    <methodparam><type>string</type><parameter>content</parameter></methodparam>
@@ -28,7 +28,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>reference</parameter></term>
      <listitem>
@@ -63,6 +63,24 @@
    <parameter>content</parameter> in the text of the mailbox, &return.falseforfailure;.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/functions/imap-lsub.xml
+++ b/reference/imap/functions/imap-lsub.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>array</type><type>false</type></type><methodname>imap_lsub</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>reference</parameter></methodparam>
    <methodparam><type>string</type><parameter>pattern</parameter></methodparam>
   </methodsynopsis>
@@ -21,7 +21,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>reference</parameter></term>
      <listitem>
@@ -47,6 +47,24 @@
    Returns an array of all the subscribed mailboxes, &return.falseforfailure;.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/functions/imap-mail-copy.xml
+++ b/reference/imap/functions/imap-mail-copy.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_mail_copy</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>message_nums</parameter></methodparam>
    <methodparam><type>string</type><parameter>mailbox</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
@@ -23,7 +23,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>message_nums</parameter></term>
      <listitem>
@@ -73,6 +73,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/functions/imap-mail-move.xml
+++ b/reference/imap/functions/imap-mail-move.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_mail_move</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>message_nums</parameter></methodparam>
    <methodparam><type>string</type><parameter>mailbox</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
@@ -23,7 +23,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>message_nums</parameter></term>
      <listitem>
@@ -67,6 +67,23 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/imap/functions/imap-mailboxmsginfo.xml
+++ b/reference/imap/functions/imap-mailboxmsginfo.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>stdClass</type><methodname>imap_mailboxmsginfo</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
   </methodsynopsis>
   <para>
    Checks the current mailbox status on the server. It is similar to
@@ -22,7 +22,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
    </variablelist>
   </para>
  </refsect1>
@@ -74,6 +74,24 @@
    Returns &false; on failure.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/imap/functions/imap-msgno.xml
+++ b/reference/imap/functions/imap-msgno.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>imap_msgno</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>int</type><parameter>message_uid</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -24,7 +24,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>message_uid</parameter></term>
      <listitem>
@@ -43,6 +43,24 @@
    <parameter>message_uid</parameter>.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/functions/imap-num-msg.xml
+++ b/reference/imap/functions/imap-num-msg.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>int</type><type>false</type></type><methodname>imap_num_msg</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
   </methodsynopsis>
   <para>
    Gets the number of messages in the current mailbox.
@@ -19,7 +19,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
    </variablelist>
   </para>
  </refsect1>
@@ -29,6 +29,24 @@
    Return the number of messages in the current mailbox, as an integer, or &false; on error.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/functions/imap-num-recent.xml
+++ b/reference/imap/functions/imap-num-recent.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>imap_num_recent</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
   </methodsynopsis>
   <para>
    Gets the number of recent messages in the current mailbox.
@@ -19,7 +19,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
    </variablelist>
   </para>
  </refsect1>
@@ -30,6 +30,24 @@
    integer.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/functions/imap-open.xml
+++ b/reference/imap/functions/imap-open.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type class="union"><type>resource</type><type>false</type></type><methodname>imap_open</methodname>
+   <type class="union"><type>IMAP\Connection</type><type>false</type></type><methodname>imap_open</methodname>
    <methodparam><type>string</type><parameter>mailbox</parameter></methodparam>
    <methodparam><type>string</type><parameter>user</parameter></methodparam>
    <methodparam><type>string</type><parameter>password</parameter></methodparam>
@@ -275,8 +275,31 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an IMAP stream on success or &false; on error.
+   Returns an <classname>IMAP\Connection</classname> instance on success,&return.falseforfailure;.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       Returns an <classname>IMAP\Connection</classname> instance now;
+       previously, a &resource; was returned.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/imap/functions/imap-ping.xml
+++ b/reference/imap/functions/imap-ping.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_ping</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>imap_ping</function> pings the stream to see if it's still
@@ -22,7 +22,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
    </variablelist>
   </para>
  </refsect1>
@@ -32,6 +32,24 @@
    Returns &true; if the stream is still alive, &false; otherwise.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/imap/functions/imap-renamemailbox.xml
+++ b/reference/imap/functions/imap-renamemailbox.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_renamemailbox</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>from</parameter></methodparam>
    <methodparam><type>string</type><parameter>to</parameter></methodparam>
   </methodsynopsis>
@@ -23,7 +23,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>from</parameter></term>
      <listitem>
@@ -53,6 +53,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/functions/imap-reopen.xml
+++ b/reference/imap/functions/imap-reopen.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_reopen</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>mailbox</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>retries</parameter><initializer>0</initializer></methodparam>
@@ -23,7 +23,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>mailbox</parameter></term>
      <listitem>
@@ -91,6 +91,23 @@
   <para>
    Returns &true; if the stream is reopened, &false; otherwise.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/imap/functions/imap-savebody.xml
+++ b/reference/imap/functions/imap-savebody.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_savebody</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type class="union"><type>resource</type><type>string</type><type>int</type></type><parameter>file</parameter></methodparam>
    <methodparam><type>int</type><parameter>message_num</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>section</parameter><initializer>""</initializer></methodparam>
@@ -23,7 +23,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>file</parameter></term>
      <listitem>
@@ -86,6 +86,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/functions/imap-search.xml
+++ b/reference/imap/functions/imap-search.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>array</type><type>false</type></type><methodname>imap_search</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>criteria</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>SE_FREE</constant></initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>charset</parameter><initializer>""</initializer></methodparam>
@@ -31,7 +31,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>criteria</parameter></term>
      <listitem>
@@ -199,6 +199,23 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="imap-search.examples">
@@ -206,11 +223,11 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$conn   = imap_open('{imap.example.com:993/imap/ssl}INBOX', 'foo@example.com', 'pass123', OP_READONLY);
+$imap   = imap_open('{imap.example.com:993/imap/ssl}INBOX', 'foo@example.com', 'pass123', OP_READONLY);
 
-$some   = imap_search($conn, 'SUBJECT "HOWTO be Awesome" SINCE "8 August 2008"', SE_UID);
-$msgnos = imap_search($conn, 'ALL');
-$uids   = imap_search($conn, 'ALL', SE_UID);
+$some   = imap_search($imap, 'SUBJECT "HOWTO be Awesome" SINCE "8 August 2008"', SE_UID);
+$msgnos = imap_search($imap, 'ALL');
+$uids   = imap_search($imap, 'ALL', SE_UID);
 
 print_r($some);
 print_r($msgnos);

--- a/reference/imap/functions/imap-set-quota.xml
+++ b/reference/imap/functions/imap-set-quota.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_set_quota</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>quota_root</parameter></methodparam>
    <methodparam><type>int</type><parameter>mailbox_size</parameter></methodparam>
   </methodsynopsis>
@@ -21,7 +21,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>quota_root</parameter></term>
      <listitem>
@@ -48,6 +48,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/imap/functions/imap-setacl.xml
+++ b/reference/imap/functions/imap-setacl.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_setacl</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>mailbox</parameter></methodparam>
    <methodparam><type>string</type><parameter>user_id</parameter></methodparam>
    <methodparam><type>string</type><parameter>rights</parameter></methodparam>
@@ -22,7 +22,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>mailbox</parameter></term>
      <listitem>
@@ -59,6 +59,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="notes">
   &reftitle.notes;
   <para>

--- a/reference/imap/functions/imap-setflag-full.xml
+++ b/reference/imap/functions/imap-setflag-full.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_setflag_full</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>sequence</parameter></methodparam>
    <methodparam><type>string</type><parameter>flag</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
@@ -24,7 +24,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>sequence</parameter></term>
      <listitem>
@@ -71,6 +71,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/imap/functions/imap-sort.xml
+++ b/reference/imap/functions/imap-sort.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>array</type><type>false</type></type><methodname>imap_sort</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>int</type><parameter>criteria</parameter></methodparam>
    <methodparam><type>bool</type><parameter>reverse</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
@@ -24,7 +24,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>criteria</parameter></term>
      <listitem>
@@ -138,6 +138,7 @@
      </row>
     </thead>
     <tbody>
+     &imap.changelog.imap-param;
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/imap/functions/imap-status.xml
+++ b/reference/imap/functions/imap-status.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>stdClass</type><type>false</type></type><methodname>imap_status</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>mailbox</parameter></methodparam>
    <methodparam><type>int</type><parameter>flags</parameter></methodparam>
   </methodsynopsis>
@@ -21,7 +21,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>mailbox</parameter></term>
      <listitem>
@@ -94,6 +94,24 @@
    be checked against any of the above constants.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/imap/functions/imap-subscribe.xml
+++ b/reference/imap/functions/imap-subscribe.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_subscribe</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>mailbox</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -20,7 +20,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>mailbox</parameter></term>
      <listitem>
@@ -40,6 +40,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/functions/imap-thread.xml
+++ b/reference/imap/functions/imap-thread.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>array</type><type>false</type></type><methodname>imap_thread</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>SE_FREE</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
@@ -20,7 +20,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
@@ -54,6 +54,24 @@
    </itemizedlist>
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/imap/functions/imap-uid.xml
+++ b/reference/imap/functions/imap-uid.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>int</type><type>false</type></type><methodname>imap_uid</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>int</type><parameter>message_num</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -26,7 +26,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>message_num</parameter></term>
      <listitem>
@@ -44,6 +44,24 @@
    The UID of the given message.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="notes">
   &reftitle.notes;
   <note>

--- a/reference/imap/functions/imap-undelete.xml
+++ b/reference/imap/functions/imap-undelete.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_undelete</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>message_num</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
@@ -22,7 +22,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>message_num</parameter></term>
      <listitem>
@@ -47,6 +47,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/functions/imap-unsubscribe.xml
+++ b/reference/imap/functions/imap-unsubscribe.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>imap_unsubscribe</methodname>
-   <methodparam><type>resource</type><parameter>imap</parameter></methodparam>
+   <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>mailbox</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -20,7 +20,7 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    &imap.imap-stream.description;
+    &imap.imap-parameter.imap;
     <varlistentry>
      <term><parameter>mailbox</parameter></term>
      <listitem>
@@ -40,6 +40,24 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &imap.changelog.imap-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/imap/imap.connection.xml
+++ b/reference/imap/imap.connection.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpdoc:classref xml:id="class.imap-connection" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook">
+ <title>The IMAP\Connection class</title>
+ <titleabbrev>IMAP\Connection</titleabbrev>
+
+ <partintro>
+
+  <!-- {{{ IMAP\Connection intro -->
+  <section xml:id="imap-connection.intro">
+   &reftitle.intro;
+   <para>
+    A fully opaque class which replaces a <literal>imap</literal> resource as of PHP 8.1.0.
+   </para>
+  </section>
+  <!-- }}} -->
+
+  <section xml:id="imap-connection.synopsis">
+   &reftitle.classsynopsis;
+
+   <!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass>
+     <classname>IMAP\Connection</classname>
+    </ooclass>
+
+    <!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>IMAP\Connection</classname>
+     </ooclass>
+    </classsynopsisinfo>
+    <!-- }}} -->
+
+   </classsynopsis>
+   <!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+</phpdoc:classref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imap/setup.xml
+++ b/reference/imap/setup.xml
@@ -53,16 +53,6 @@
  &reference.imap.ini;
  <!-- }}} -->
 
- <!-- {{{ Resources -->
- <section xml:id="imap.resources">
-  &reftitle.resources;
-  <para>
-   The <literal>imap</literal> resource as returned by
-   <function>imap_open</function> references an opened IMAP stream.
-  </para>
- </section>
- <!-- }}} -->
-
 </chapter>
 
 <!-- Keep this comment at the end of the file

--- a/reference/imap/setup.xml
+++ b/reference/imap/setup.xml
@@ -53,6 +53,16 @@
  &reference.imap.ini;
  <!-- }}} -->
 
+ <!-- {{{ Resources -->
+ <section xml:id="imap.resources">
+  &reftitle.resources;
+  <simpara>
+   Prior to PHP 8.1.0, this extension defined the resource type <literal>imap</literal> as returned by
+   <function>imap_open</function> references an opened IMAP stream.
+  </simpara>
+ </section>
+ <!-- }}} -->
+
 </chapter>
 
 <!-- Keep this comment at the end of the file

--- a/reference/imap/versions.xml
+++ b/reference/imap/versions.xml
@@ -82,6 +82,8 @@
  <function name="imap_utf7_encode" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="imap_utf8" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="imap_utf8_to_mutf7" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+
+ <function name='imap\connection' from='PHP 8 &gt;= 8.1.0'/>
 </versions>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Keep `imap.imap-stream.description` until all languages adapt the translation.

`IMAP\Connection` has not any methods.