### PR TITLE
Reword description on DOMDocument::domElement

### DIFF
--- a/reference/dom/domdocument.xml
+++ b/reference/dom/domdocument.xml
@@ -199,9 +199,8 @@
      <term><varname>documentElement</varname></term>
      <listitem>
       <para>
-       This is a convenience attribute that allows direct access to the
-       child node that is the document element of the document. This is
-       &null; when does not exists.
+       The <classname>DOMElement</classname> object that is the first
+       document element. If not found, this will return &null;.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dom/domdocument.xml
+++ b/reference/dom/domdocument.xml
@@ -200,7 +200,7 @@
      <listitem>
       <para>
        The <classname>DOMElement</classname> object that is the first
-       document element. If not found, this will return &null;.
+       document element. If not found, this evaluates to &null;.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
A better description for documentElement that can be `NULL`.

See #955
