### PR TITLE
Fix return value of Imagick::montageImage

### DIFF
--- a/reference/imagick/imagick/montageimage.xml
+++ b/reference/imagick/imagick/montageimage.xml
@@ -77,7 +77,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Creates a composite image and returns it as a new Imagick object.
+   Creates a composite image and returns it as a new <classname>Imagick</classname> object.
   </para>
  </refsect1>
  

--- a/reference/imagick/imagick/montageimage.xml
+++ b/reference/imagick/imagick/montageimage.xml
@@ -48,7 +48,7 @@
      <listitem>
       <para>
        Preferred image size and border size of each thumbnail
-       (e.g. 120x120+4+3>).
+       (e.g. 120x120+4+3).
       </para>
      </listitem>
     </varlistentry>
@@ -77,7 +77,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &imagick.return.success;
+   Creates a composite image and returns it as a new Imagick object.
   </para>
  </refsect1>
  


### PR DESCRIPTION
`Imagick::montageImage` returns a new Imagick, not bool.

Also `thumbnail_geometry` example looks like a typo.
`>` is indeed a valid geometry flag, but it makes sense only for dimensions, not offsets.
Therefore, `120x120+4+3>` would be silently parsed as `120x120>+4+3`
Too misleading for an example value.