### PR TITLE
[PHP 8.1] Use an Pspell\[Dictionary|Config] instance instead of a resource

### DIFF
--- a/reference/pspell/book.xml
+++ b/reference/pspell/book.xml
@@ -18,6 +18,8 @@
  &reference.pspell.setup;
  &reference.pspell.constants;
  &reference.pspell.reference;
+ &reference.pspell.pspell.dictionary;
+ &reference.pspell.pspell.config;
 
 </book>
 

--- a/reference/pspell/pspell.config.xml
+++ b/reference/pspell/pspell.config.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpdoc:classref xml:id="class.pspell-config" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook">
+ <title>The PSpell\Config class</title>
+ <titleabbrev>PSpell\Config</titleabbrev>
+
+ <partintro>
+
+  <!-- {{{ PSpell\Config intro -->
+  <section xml:id="pspell-config.intro">
+   &reftitle.intro;
+   <para>
+    A fully opaque class which replaces a <literal>pspell config</literal> resource as of PHP 8.1.0.
+   </para>
+  </section>
+  <!-- }}} -->
+
+  <section xml:id="pspell-config.synopsis">
+   &reftitle.classsynopsis;
+
+   <!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass>
+     <classname>PSpell\Config</classname>
+    </ooclass>
+
+    <!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>PSpell\Config</classname>
+     </ooclass>
+    </classsynopsisinfo>
+    <!-- }}} -->
+
+   </classsynopsis>
+   <!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+</phpdoc:classref>
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/pspell/pspell.dictionary.xml
+++ b/reference/pspell/pspell.dictionary.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpdoc:classref xml:id="class.pspell-dictionary" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook">
+ <title>The PSpell\Dictionary class</title>
+ <titleabbrev>PSpell\Dictionary</titleabbrev>
+
+ <partintro>
+
+  <!-- {{{ PSpell\Dictionary intro -->
+  <section xml:id="pspell-dictionary.intro">
+   &reftitle.intro;
+   <para>
+    A fully opaque class which replaces a <literal>pspell</literal> resource as of PHP 8.1.0.
+   </para>
+  </section>
+  <!-- }}} -->
+
+  <section xml:id="pspell-dictionary.synopsis">
+   &reftitle.classsynopsis;
+
+   <!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass>
+     <classname>PSpell\Dictionary</classname>
+    </ooclass>
+
+    <!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>PSpell\Dictionary</classname>
+     </ooclass>
+    </classsynopsisinfo>
+    <!-- }}} -->
+
+   </classsynopsis>
+   <!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+</phpdoc:classref>
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/pspell/setup.xml
+++ b/reference/pspell/setup.xml
@@ -28,7 +28,9 @@
  <!-- {{{ Resources -->
  <section xml:id="pspell.resources">
   &reftitle.resources;
-  &no.resource;
+  <para>
+   Prior to PHP 8.1.0, there were two resource types used in this extension. The first one is the dictionary link identifier, the second is a resource which holds pspell config.
+  </para>
  </section>
  <!-- }}} -->
 

--- a/reference/pspell/versions.xml
+++ b/reference/pspell/versions.xml
@@ -23,6 +23,10 @@
  <function name="pspell_save_wordlist" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
  <function name="pspell_store_replacement" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
  <function name="pspell_suggest" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
+
+<function name='pspell\dictionary' from='PHP 8 &gt;= 8.1.0'/>
+<function name='pspell\config' from='PHP 8 &gt;= 8.1.0'/>
+
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
- TODO
  * [x] added Pspell resource description prior to 8.1
    -  Currently, this description does not exist in setup.xml, but exists in [List of Resource Types](https://www.php.net/manual/en/resource.php)
  * [x] added Pspell related object class.
  * [ ] changes pspell function signature and parameters, changelog.

closes #972 