### PR TITLE
strspn() and strcspn(): Use proper parameter names in docs reference

### DIFF
--- a/reference/strings/functions/strcspn.xml
+++ b/reference/strings/functions/strcspn.xml
@@ -24,8 +24,8 @@
    If <parameter>offset</parameter> and <parameter>length</parameter>
    are omitted, then all of <parameter>string</parameter> will be
    examined. If they are included, then the effect will be the same as
-   calling <literal>strcspn(substr($subject, $start, $length),
-   $mask)</literal> (see <xref linkend="function.substr"/>
+   calling <literal>strcspn(substr($string, $offset, $length),
+   $characters)</literal> (see <xref linkend="function.substr"/>
    for more information).
   </para>
  </refsect1>

--- a/reference/strings/functions/strspn.xml
+++ b/reference/strings/functions/strspn.xml
@@ -26,8 +26,8 @@
    If <parameter>offset</parameter> and <parameter>length</parameter>
    are omitted, then all of <parameter>string</parameter> will be
    examined. If they are included, then the effect will be the same as
-   calling <literal>strspn(substr($subject, $start, $length),
-   $mask)</literal> (see <xref linkend="function.substr"/>
+   calling <literal>strspn(substr($string, $offset, $length),
+   $characters)</literal> (see <xref linkend="function.substr"/>
    for more information).
   </para>
   <para>


### PR DESCRIPTION
Commit e095023e408c8cb6378ae16bb6870343a3946919 renamed the `$subject`, `$mask`, and `$start` parameters of the `strspn()` and `strcspn()` functions to `$string`, `$characters`, and `$offset`, respectively.

For both of them, three instances in the code example were missed. This PR fixes them.