### PR TITLE
[PHP 8.1] Add `imageavif` and `imagecreatefromavif` functions

### DIFF
--- a/reference/image/functions/imageavif.xml
+++ b/reference/image/functions/imageavif.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.imageavif" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>imageavif</refname>
+  <refpurpose>&gd.image.output;</refpurpose>
+ </refnamediv>
+ 
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>imageavif</methodname>
+   <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>resource</type><type>string</type><type>null</type></type><parameter>file</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>quality</parameter><initializer>-1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>speed</parameter><initializer>-1</initializer></methodparam>
+  </methodsynopsis>
+  
+  <para>
+   Outputs or saves a <acronym>AVIF</acronym> Raster image from the given <parameter>image</parameter>.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    &gd.image.description;
+    <varlistentry>
+     <term><parameter>file</parameter></term>
+     <listitem>
+      <para>
+       &gd.image.path;
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>quality</parameter></term>
+     <listitem>
+      <para>
+       <parameter>quality</parameter> is optional, and ranges from 0 (worst quality, smaller file)
+       to 100 (best quality, larger file).
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>speed</parameter></term>
+     <listitem>
+      <para>
+       <parameter>speed</parameter> is optional, and ranges from 0 (slower CPU effort, smaller file)
+       to 9 (faster CPU effort, larger file).
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+  &gd.return.trueonerror;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>imagepng</function></member>
+   <member><function>imagewbmp</function></member>
+   <member><function>imagejpeg</function></member>
+   <member><function>imagetypes</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/image/functions/imageavif.xml
+++ b/reference/image/functions/imageavif.xml
@@ -46,8 +46,8 @@
      <term><parameter>speed</parameter></term>
      <listitem>
       <para>
-       <parameter>speed</parameter> is optional, and ranges from 0 (slower CPU effort, smaller file)
-       to 10 (faster CPU effort, larger file).
+       <parameter>speed</parameter> is optional, and ranges from 0 (slow, smaller file)
+       to 10 (fast, larger file).
        If <literal>-1</literal> is provided, the default value <literal>6</literal> is used.
       </para>
      </listitem>

--- a/reference/image/functions/imageavif.xml
+++ b/reference/image/functions/imageavif.xml
@@ -38,6 +38,7 @@
       <para>
        <parameter>quality</parameter> is optional, and ranges from 0 (worst quality, smaller file)
        to 100 (best quality, larger file).
+       If <literal>-1</literal> is provided, the default value <literal>30</literal> is used.
       </para>
      </listitem>
     </varlistentry>
@@ -47,6 +48,7 @@
       <para>
        <parameter>speed</parameter> is optional, and ranges from 0 (slower CPU effort, smaller file)
        to 10 (faster CPU effort, larger file).
+       If <literal>-1</literal> is provided, the default value <literal>6</literal> is used.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imageavif.xml
+++ b/reference/image/functions/imageavif.xml
@@ -46,7 +46,7 @@
      <listitem>
       <para>
        <parameter>speed</parameter> is optional, and ranges from 0 (slower CPU effort, smaller file)
-       to 9 (faster CPU effort, larger file).
+       to 10 (faster CPU effort, larger file).
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagecreatefromavif.xml
+++ b/reference/image/functions/imagecreatefromavif.xml
@@ -25,7 +25,7 @@
      <term><parameter>filename</parameter></term>
      <listitem>
       <para>
-        Path to the <acronym>AVIF</acronym> Raster image.
+        Path to the <acronym>AVIF</acronym> raster image.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagecreatefromavif.xml
+++ b/reference/image/functions/imagecreatefromavif.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.imagecreatefromavif" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>imagecreatefromavif</refname>
+  <refpurpose>&gd.image.new;</refpurpose>
+ </refnamediv>
+ 
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>GdImage</type><type>false</type></type><methodname>imagecreatefromavif</methodname>
+   <methodparam><type>string</type><parameter>filename</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>imagecreatefromavif</function> returns an image object
+   representing the image obtained from the given filename.
+  </para>
+ </refsect1>
+ 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>filename</parameter></term>
+     <listitem>
+      <para>
+        Path to the <acronym>AVIF</acronym> Raster image.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &gd.return.identifier;
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/image/versions.xml
+++ b/reference/image/versions.xml
@@ -16,6 +16,7 @@
  <function name="imagealphablending" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
  <function name="imageantialias" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
  <function name="imagearc" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imageavif" from="PHP 8 &gt;= 8.1.0"/>
  <function name="imagebmp" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
  <function name="imagechar" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="imagecharup" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
@@ -42,6 +43,7 @@
  <function name="imagecopyresampled" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
  <function name="imagecopyresized" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="imagecreate" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="imagecreatefromavif" from="PHP 8 &gt;= 8.1.0"/>
  <function name="imagecreatefrombmp" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
  <function name="imagecreatefromgd" from="PHP 4 &gt;= 4.0.7, PHP 5, PHP 7, PHP 8"/>
  <function name="imagecreatefromgd2" from="PHP 4 &gt;= 4.0.7, PHP 5, PHP 7, PHP 8"/>


### PR DESCRIPTION
Based on stubs:
- [imageavif](https://github.com/php/php-src/blob/PHP-8.1/ext/gd/gd.stub.php#L142) ([parameters](https://github.com/php/php-src/blob/master/ext/gd/libgd/gd_avif.c#L444))
- [imagecreatefromavif](https://github.com/php/php-src/blob/PHP-8.1/ext/gd/gd.stub.php#L88)