### PR TITLE
False isn't allowed for substr()'s $length

### DIFF
--- a/reference/strings/functions/substr.xml
+++ b/reference/strings/functions/substr.xml
@@ -88,7 +88,7 @@ $rest = substr("abcdef", -3, 1); // returns "d"
       </para>
       <para>
        If <parameter>length</parameter> is given and is <literal>0</literal>,
-       &false; or &null;, an empty string will be returned.
+       or &null;, an empty string will be returned.
       </para>
       <para>
        If <parameter>length</parameter> is omitted, the substring starting from

--- a/reference/strings/functions/substr.xml
+++ b/reference/strings/functions/substr.xml
@@ -88,10 +88,10 @@ $rest = substr("abcdef", -3, 1); // returns "d"
       </para>
       <para>
        If <parameter>length</parameter> is given and is <literal>0</literal>,
-       or &null;, an empty string will be returned.
+       an empty string will be returned.
       </para>
       <para>
-       If <parameter>length</parameter> is omitted, the substring starting from
+       If <parameter>length</parameter> is omitted or &null;, the substring starting from
        <parameter>offset</parameter> until the end of the string will be
        returned.
       </para>
@@ -137,6 +137,8 @@ $rest = substr("abcdef", -3, -1); // returns "de"
       <entry>8.0.0</entry>
       <entry>
        <parameter>length</parameter> is nullable now.
+       When <parameter>length</parameter> is explicitly set to &null;,
+       the function returns a substring finishing at the end of the string, when it previously returned an empty string.
       </entry>
      </row>
      <row>


### PR DESCRIPTION
When strict types are enabled, passing false currently throws the following error:

> Fatal error: Uncaught TypeError: substr(): Argument #3 ($length) must be of type ?int, bool given


See https://github.com/php/php-src/pull/7533.
