### PR TITLE
[PHP 8.1] Use GdFont

### DIFF
--- a/appendices/resources.xml
+++ b/appendices/resources.xml
@@ -559,7 +559,7 @@
     <entry>
      <function>imagedestroy</function>
     </entry>
-    <entry>GD Image</entry>
+    <entry>GD Image (prior to PHP 8.0.0)</entry>
    </row>
    <row>
     <entry>gd font</entry>
@@ -574,7 +574,7 @@
     <entry>
      None
     </entry>
-    <entry>Font for GD</entry>
+    <entry>Font for GD (prior to PHP 8.1.0)</entry>
    </row>
    <row>
     <entry>imap</entry>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -743,9 +743,16 @@ such as <function>imagecreatetruecolor</function>.</para></listitem></varlistent
 
 <!ENTITY gd.font.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>
 font</parameter></term><listitem><para>Can be 1, 2, 3, 4, 5 for built-in
-fonts in latin2 encoding (where higher numbers corresponding to larger fonts) or any of your
-own font identifiers registered with <function>imageloadfont</function>.
-</para></listitem></varlistentry>'>
+fonts in latin2 encoding (where higher numbers corresponding to larger fonts) or <classname>GdFont</classname> instance,
+returned by <function>imageloadfont</function>.</para></listitem></varlistentry>'>
+
+<!ENTITY gd.changelog.gdfont-instance '<row xmlns="http://docbook.org/ns/docbook">
+  <entry>8.1.0</entry>
+  <entry>
+  The <parameter>font</parameter> parameter now accepts both an <classname>GdFont</classname> instance
+  and an &integer;; previously only &integer; was accepted.
+  </entry>
+</row>'>
 
 <!ENTITY gd.ttf.fontfile "
     <varlistentry xmlns='http://docbook.org/ns/docbook'>

--- a/reference/image/book.xml
+++ b/reference/image/book.xml
@@ -140,6 +140,7 @@
  &reference.image.examples;
  &reference.image.reference;
  &reference.image.gdimage;
+ &reference.image.gdfont;
 
 </book>
 

--- a/reference/image/functions/imagechar.xml
+++ b/reference/image/functions/imagechar.xml
@@ -10,7 +10,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>imagechar</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
-   <methodparam><type>int</type><parameter>font</parameter></methodparam>
+   <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
    <methodparam><type>int</type><parameter>y</parameter></methodparam>
    <methodparam><type>string</type><parameter>char</parameter></methodparam>
@@ -83,6 +83,7 @@
      </row>
     </thead>
     <tbody>
+     &gd.changelog.gdfont-instance;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imagecharup.xml
+++ b/reference/image/functions/imagecharup.xml
@@ -10,7 +10,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>imagecharup</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
-   <methodparam><type>int</type><parameter>font</parameter></methodparam>
+   <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
    <methodparam><type>int</type><parameter>y</parameter></methodparam>
    <methodparam><type>string</type><parameter>char</parameter></methodparam>
@@ -80,6 +80,7 @@
      </row>
     </thead>
     <tbody>
+     &gd.changelog.gdfont-instance;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imagefontheight.xml
+++ b/reference/image/functions/imagefontheight.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>imagefontheight</methodname>
-   <methodparam><type>int</type><parameter>font</parameter></methodparam>
+   <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
   </methodsynopsis>
   <para>
    Returns the pixel height of a character in the specified font.
@@ -29,6 +29,26 @@
    Returns the pixel height of the font.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &gd.changelog.gdfont-instance;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/image/functions/imagefontwidth.xml
+++ b/reference/image/functions/imagefontwidth.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>imagefontwidth</methodname>
-   <methodparam><type>int</type><parameter>font</parameter></methodparam>
+   <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
   </methodsynopsis>
   <para>
    Returns the pixel width of a character in font.
@@ -29,6 +29,26 @@
    Returns the pixel width of the font.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+ &reftitle.changelog;
+ <para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &gd.changelog.gdfont-instance;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </para>
+</refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/image/functions/imageloadfont.xml
+++ b/reference/image/functions/imageloadfont.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type class="union"><type>int</type><type>false</type></type><methodname>imageloadfont</methodname>
+   <type class="union"><type>GdFont</type><type>false</type></type><methodname>imageloadfont</methodname>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -82,10 +82,35 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The font identifier which is always bigger than 5 to avoid conflicts with
-   built-in fonts or &false; on errors.
+   Returns an <classname>GdFont</classname> instance,&return.falseforfailure;.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.1.0</entry>
+       <entry>
+        Returns an <classname>GdFont</classname> instance now;
+        previously, an &integer; was returned.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/image/functions/imagestring.xml
+++ b/reference/image/functions/imagestring.xml
@@ -10,7 +10,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>imagestring</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
-   <methodparam><type>int</type><parameter>font</parameter></methodparam>
+   <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
    <methodparam><type>int</type><parameter>y</parameter></methodparam>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
@@ -79,6 +79,7 @@
      </row>
     </thead>
     <tbody>
+     &gd.changelog.gdfont-instance;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imagestringup.xml
+++ b/reference/image/functions/imagestringup.xml
@@ -10,7 +10,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>imagestringup</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
-   <methodparam><type>int</type><parameter>font</parameter></methodparam>
+   <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
    <methodparam><type>int</type><parameter>y</parameter></methodparam>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
@@ -80,6 +80,7 @@
      </row>
     </thead>
     <tbody>
+     &gd.changelog.gdfont-instance;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/gdfont.xml
+++ b/reference/image/gdfont.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpdoc:classref xml:id="class.gdfont" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook">
+ <title>The GdFont class</title>
+ <titleabbrev>GdFont</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ GdFont intro -->
+  <section xml:id="gdfont.intro">
+   &reftitle.intro;
+   <para>
+    A fully opaque class which replaces <literal>gd font</literal> resources as of PHP 8.1.0.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="gdfont.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>GdFont</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>GdFont</classname>
+     </ooclass>
+    </classsynopsisinfo>
+<!-- }}} -->
+    
+    <!-- <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo> -->
+    <!-- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gdimage')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"><xi:fallback/></xi:include> -->
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+ <!-- &reference.gd.entities.gdfont; -->
+
+</phpdoc:classref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/image/setup.xml
+++ b/reference/image/setup.xml
@@ -110,7 +110,7 @@
       <row>
        <entry><literal>gd font</literal></entry>
        <entry>Font resource internally created by <function>imageloadfont</function></entry>
-       <entry></entry>
+       <entry>Prior to PHP 8.1.0</entry>
       </row>
      </tbody>
     </tgroup>

--- a/reference/image/versions.xml
+++ b/reference/image/versions.xml
@@ -123,6 +123,7 @@
  <function name="png2wbmp" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7"/>
 
  <function name="gdimage" from="PHP 8"/>
+ <function name="gdfont" from="PHP 8 &gt;= 8.1.0"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
As of PHP [8.1.0](https://github.com/php/php-src/blob/PHP-8.1/ext/gd/gd.stub.php), a GdFont class was added.

Not sure about `gd font` resource.. because PHP 8.0 already [has](https://github.com/php/php-src/blob/PHP-8.0/ext/gd/gd.stub.php) int values instead of resources 🤔 