### PR TITLE
[PHP 8.1] Add `fdatasync` and `fsync` description

### DIFF
--- a/reference/filesystem/functions/fdatasync.xml
+++ b/reference/filesystem/functions/fdatasync.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.fdatasync" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>fdatasync</refname>
+  <refpurpose>Synchronizes data (but not meta-data) to the file</refpurpose>
+ </refnamediv>
+ 
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>fdatasync</methodname>
+   <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   This function synchronizes <parameter>stream</parameter> contents to storage media, just like <function>fsync</function> does,
+   but it does not synchronize file meta-data.
+   Note that this function is only effectively different in POSIX systems.
+   In Windows, this function is aliased to <function>fsync</function>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>stream</parameter></term>
+     <listitem>
+      &fs.validfp.all;
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>fdatasync</function> example</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$file = 'test.txt';
+
+$stream = fopen($file, 'w');
+fwrite($stream, 'test data');
+fwrite($stream, "\r\n");
+fwrite($stream, 'additional data');
+
+fdatasync($stream);
+fclose($stream);
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+ 
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>fflush</function></member>
+    <member><function>fsync</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/filesystem/functions/fsync.xml
+++ b/reference/filesystem/functions/fsync.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.fsync" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>fsync</refname>
+  <refpurpose>Synchronizes changes to the file (including meta-data)</refpurpose>
+ </refnamediv>
+ 
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>fsync</methodname>
+   <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   This function synchronizes changes to the file, including its meta-data. This is similar to <function>fflush</function>,
+   but it also instructs the operating system to write to the storage media.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>stream</parameter></term>
+     <listitem>
+      &fs.validfp.all;
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>fsync</function> example</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$file = 'test.txt';
+
+$stream = fopen($file, 'w');
+fwrite($stream, 'test data');
+fwrite($stream, "\r\n");
+fwrite($stream, 'additional data');
+
+fsync($stream);
+fclose($stream);
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+ 
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>fdatasync</function></member>
+    <member><function>fflush</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/filesystem/versions.xml
+++ b/reference/filesystem/versions.xml
@@ -16,6 +16,7 @@
  <function name="disk_total_space" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
  <function name="diskfreespace" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="fclose" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="fdatasync" from="PHP 8 &gt;= 8.1.0"/>
  <function name="feof" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="fflush" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
  <function name="fgetc" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
@@ -45,6 +46,7 @@
  <function name="fscanf" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
  <function name="fseek" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="fstat" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="fsync" from="PHP 8 &gt;= 8.1.0"/>
  <function name="ftell" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="ftruncate" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="fwrite" from="PHP 4, PHP 5, PHP 7, PHP 8"/>


### PR DESCRIPTION
Added [`fdatasync`](https://github.com/php/php-src/blob/PHP-8.1/ext/standard/basic_functions.stub.php#L1109) and [`fsync`](https://github.com/php/php-src/blob/PHP-8.1/ext/standard/basic_functions.stub.php#L1106) description.