### PR TITLE
Reword parameter description of set_exception_handler

### DIFF
--- a/reference/errorfunc/functions/set-exception-handler.xml
+++ b/reference/errorfunc/functions/set-exception-handler.xml
@@ -30,9 +30,10 @@
      <listitem>
       <para>
        The function to be called when an uncaught exception occurs.
-       Most errors are reported by throwing <classname>Error</classname>
-       exceptions, which will be caught by the handler as well. Both <classname>Error</classname>
-       and <classname>Exception</classname> implements the <classname>Throwable</classname> interface.
+       This handler function needs to accept one parameter,
+       which will be the <classname>Throwable</classname> object that was thrown.
+       Both <classname>Error</classname> and <classname>Exception</classname>
+       implement the <classname>Throwable</classname> interface.
        This is the handler signature:
       </para>
       <para>

--- a/reference/errorfunc/functions/set-exception-handler.xml
+++ b/reference/errorfunc/functions/set-exception-handler.xml
@@ -66,7 +66,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-function exception_handler($exception) {
+function exception_handler(Throwable $exception) {
   echo "Uncaught exception: " , $exception->getMessage(), "\n";
 }
 


### PR DESCRIPTION
This removes outdated PHP 5 information. 