### PR TITLE
improve headers_list() example

### DIFF
--- a/reference/network/functions/headers-list.xml
+++ b/reference/network/functions/headers-list.xml
@@ -5,7 +5,7 @@
   <refname>headers_list</refname>
   <refpurpose>Returns a list of response headers sent (or ready to send)</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -35,7 +35,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Examples using <function>headers_list</function></title>
+    <title>Example using <function>headers_list</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -45,10 +45,10 @@ setcookie('foo', 'bar');
 
 /* Define a custom response header
    This will be ignored by most clients */
-header("X-Sample-Test: foo");
+header("Example-Test: foo");
 
 /* Specify plain text content in our response */
-header('Content-type: text/plain');
+header('Content-Type: text/plain; charset=UTF-8');
 
 /* What headers are going to be sent? */
 var_dump(headers_list());
@@ -56,18 +56,16 @@ var_dump(headers_list());
 ?>
 ]]>
     </programlisting>
-    &example.outputs;
+    &example.outputs.similar;
     <screen>
 <![CDATA[
-array(4) {
+array(3) {
   [0]=>
-  string(23) "X-Powered-By: PHP/5.1.3"
-  [1]=>
   string(19) "Set-Cookie: foo=bar"
+  [1]=>
+  string(17) "Example-Test: foo"
   [2]=>
-  string(18) "X-Sample-Test: foo"
-  [3]=>
-  string(24) "Content-type: text/plain"
+  string(39) "Content-Type: text/plain; charset=UTF-8"
 }
 
 ]]>


### PR DESCRIPTION
Two things with the PHP example code:

1. `X-` prefix header names June 2012 [1], [2].

2.  PHP prepends the `default_charset` [3] on any `text/*` media type in Content-Type header (unless the `charset` is with the `header()` call. The example code output now has it (with the UTF-8 default).

[1]: https://datatracker.ietf.org/doc/html/rfc6648
[2]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
[3]: https://www.php.net/manual/en/ini.core.php#ini.default-charset