### PR TITLE
Remove unnecessary ext/date methodsynopsis roles

### DIFF
--- a/reference/datetime/dateinterval/construct.xml
+++ b/reference/datetime/dateinterval/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="dateinterval.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateInterval::__construct</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <constructorsynopsis role="oop">
+  <constructorsynopsis>
    <modifier>public</modifier> <methodname>DateInterval::__construct</methodname>
    <methodparam><type>string</type><parameter>duration</parameter></methodparam>
   </constructorsynopsis>
@@ -110,8 +109,7 @@
        roll-over-point (e.g. <literal>25</literal> hours is invalid).
       </para>
       <para>
-       These formats are based on the <link
-        xlink:href="&url.iso-8601.duration;">ISO 8601 duration
+       These formats are based on the <link xlink:href="&url.iso-8601.duration;">ISO 8601 duration
        specification</link>.
       </para>
      </listitem>
@@ -260,7 +258,6 @@ object(DateInterval)#1 (16) {
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/dateperiod/getdateinterval.xml
+++ b/reference/datetime/dateperiod/getdateinterval.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="dateperiod.getdateinterval" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DatePeriod::getDateInterval</refname>
@@ -12,9 +11,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>DateInterval</type><methodname>DatePeriod::getDateInterval</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Gets a <classname>DateInterval</classname> <type>object</type>
@@ -65,7 +64,6 @@ echo $interval->format('%d day');
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/dateperiod/getenddate.xml
+++ b/reference/datetime/dateperiod/getenddate.xml
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type class="union"><type>DateTimeInterface</type><type>null</type></type><methodname>DatePeriod::getEndDate</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/datetime/dateperiod/getrecurrences.xml
+++ b/reference/datetime/dateperiod/getrecurrences.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>DatePeriod::getRecurrences</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/datetime/dateperiod/getstartdate.xml
+++ b/reference/datetime/dateperiod/getstartdate.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="dateperiod.getstartdate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DatePeriod::getStartDate</refname>
@@ -12,9 +11,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>DateTimeInterface</type><methodname>DatePeriod::getStartDate</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Gets the start date of the period.
@@ -71,7 +70,6 @@ echo $start->format(DateTime::ISO8601);
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetime.xml
+++ b/reference/datetime/datetime.xml
@@ -54,7 +54,7 @@
      <xi:fallback />
     </xi:include>
     
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='oop'])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural' or @role='DateTimeImmutable' or @role='DateTimeInterface')])" />
 
    </classsynopsis>
 <!-- }}} -->

--- a/reference/datetime/datetime/construct.xml
+++ b/reference/datetime/datetime/construct.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-  <constructorsynopsis role="oop">
+  <constructorsynopsis>
    <modifier>public</modifier> <methodname>DateTime::__construct</methodname>
    <methodparam choice="opt"><type>string</type><parameter>datetime</parameter><initializer>"now"</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>DateTimeZone</type><type>null</type></type><parameter>timezone</parameter><initializer>&null;</initializer></methodparam>

--- a/reference/datetime/datetime/createfromimmutable.xml
+++ b/reference/datetime/datetime/createfromimmutable.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetime.createfromimmutable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTime::createFromImmutable</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type>DateTime</type><methodname>DateTime::createFromImmutable</methodname>
    <methodparam><type>DateTimeImmutable</type><parameter>object</parameter></methodparam>
   </methodsynopsis>
@@ -60,7 +59,6 @@ $mutable = DateTime::createFromImmutable( $date );
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetime/createfrominterface.xml
+++ b/reference/datetime/datetime/createfrominterface.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetime.createfrominterface" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTime::createFromInterface</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type>DateTime</type><methodname>DateTime::createFromInterface</methodname>
    <methodparam><type>DateTimeInterface</type><parameter>object</parameter></methodparam>
   </methodsynopsis>
@@ -62,7 +61,6 @@ $also_mutable = DateTime::createFromInterface($date);
   </para>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetime/set-state.xml
+++ b/reference/datetime/datetime/set-state.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetime.set-state" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTime::__set_state</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type>DateTime</type><methodname>DateTime::__set_state</methodname>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
   </methodsynopsis>
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/add.xml
+++ b/reference/datetime/datetimeimmutable/add.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::add</refname>
@@ -11,7 +10,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::add</methodname>
    <methodparam><type>DateInterval</type><parameter>interval</parameter></methodparam>
   </methodsynopsis>
@@ -22,7 +21,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/construct.xml
+++ b/reference/datetime/datetimeimmutable/construct.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-  <constructorsynopsis role="oop">
+  <constructorsynopsis>
    <modifier>public</modifier> <methodname>DateTimeImmutable::__construct</methodname>
    <methodparam choice="opt"><type>string</type><parameter>datetime</parameter><initializer>"now"</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>DateTimeZone</type><type>null</type></type><parameter>timezone</parameter><initializer>&null;</initializer></methodparam>

--- a/reference/datetime/datetimeimmutable/createfrominterface.xml
+++ b/reference/datetime/datetimeimmutable/createfrominterface.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.createfrominterface" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::createFromInterface</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::createFromInterface</methodname>
    <methodparam><type>DateTimeInterface</type><parameter>object</parameter></methodparam>
   </methodsynopsis>
@@ -62,7 +61,6 @@ $also_immutable = DateTimeImmutable::createFromInterface($date);
   </para>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/createfrommutable.xml
+++ b/reference/datetime/datetimeimmutable/createfrommutable.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.createfrommutable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::createFromMutable</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::createFromMutable</methodname>
    <methodparam><type>DateTime</type><parameter>object</parameter></methodparam>
   </methodsynopsis>
@@ -60,7 +59,6 @@ $immutable = DateTimeImmutable::createFromMutable( $date );
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/modify.xml
+++ b/reference/datetime/datetimeimmutable/modify.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.modify" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::modify</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type class="union"><type>DateTimeImmutable</type><type>false</type></type><methodname>DateTimeImmutable::modify</methodname>
    <methodparam><type>string</type><parameter>modifier</parameter></methodparam>
   </methodsynopsis>
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/set-state.xml
+++ b/reference/datetime/datetimeimmutable/set-state.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.set-state" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::__set_state</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::__set_state</methodname>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
   </methodsynopsis>
@@ -20,7 +19,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/setdate.xml
+++ b/reference/datetime/datetimeimmutable/setdate.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.setdate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::setDate</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setDate</methodname>
    <methodparam><type>int</type><parameter>year</parameter></methodparam>
    <methodparam><type>int</type><parameter>month</parameter></methodparam>
@@ -22,7 +21,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/setisodate.xml
+++ b/reference/datetime/datetimeimmutable/setisodate.xml
@@ -8,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setISODate</methodname>
    <methodparam><type>int</type><parameter>year</parameter></methodparam>
    <methodparam><type>int</type><parameter>week</parameter></methodparam>

--- a/reference/datetime/datetimeimmutable/settime.xml
+++ b/reference/datetime/datetimeimmutable/settime.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.settime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::setTime</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setTime</methodname>
    <methodparam><type>int</type><parameter>hour</parameter></methodparam>
    <methodparam><type>int</type><parameter>minute</parameter></methodparam>
@@ -23,7 +22,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/settimestamp.xml
+++ b/reference/datetime/datetimeimmutable/settimestamp.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.settimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::setTimestamp</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setTimestamp</methodname>
    <methodparam><type>int</type><parameter>timestamp</parameter></methodparam>
   </methodsynopsis>
@@ -20,7 +19,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/settimezone.xml
+++ b/reference/datetime/datetimeimmutable/settimezone.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.settimezone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::setTimezone</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setTimezone</methodname>
    <methodparam><type>DateTimeZone</type><parameter>timezone</parameter></methodparam>
   </methodsynopsis>
@@ -20,7 +19,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/sub.xml
+++ b/reference/datetime/datetimeimmutable/sub.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.sub" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::sub</refname>
@@ -11,7 +10,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::sub</methodname>
    <methodparam><type>DateInterval</type><parameter>interval</parameter></methodparam>
   </methodsynopsis>
@@ -22,7 +21,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeinterface/format.xml
+++ b/reference/datetime/datetimeinterface/format.xml
@@ -12,7 +12,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>string</type><methodname>DateTime::format</methodname>
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
   </methodsynopsis>

--- a/reference/datetime/datetimeinterface/getoffset.xml
+++ b/reference/datetime/datetimeinterface/getoffset.xml
@@ -12,7 +12,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>int</type><methodname>DateTime::getOffset</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/datetime/datetimeinterface/gettimestamp.xml
+++ b/reference/datetime/datetimeinterface/gettimestamp.xml
@@ -12,7 +12,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>int</type><methodname>DateTime::getTimestamp</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/datetime/datetimeinterface/gettimezone.xml
+++ b/reference/datetime/datetimeinterface/gettimezone.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetime.gettimezone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTime::getTimezone</refname>
@@ -91,7 +90,6 @@ Europe/London
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeinterface/wakeup.xml
+++ b/reference/datetime/datetimeinterface/wakeup.xml
@@ -10,7 +10,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>DateTime::__wakeup</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/datetime/datetimezone/construct.xml
+++ b/reference/datetime/datetimezone/construct.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-  <constructorsynopsis role="oop">
+  <constructorsynopsis>
    <modifier>public</modifier> <methodname>DateTimeZone::__construct</methodname>
    <methodparam><type>string</type><parameter>timezone</parameter></methodparam>
   </constructorsynopsis>


### PR DESCRIPTION
These are necessary to reduce diff with the output of `gen_stub.php`. Method lists on the class synopsis pages are left intact.

`DateTime`:
<img width="1048" alt="Screenshot 2021-10-11 at 22 38 20" src="https://user-images.githubusercontent.com/6057627/136852957-a5b720c9-074c-4a55-abfb-ad3cc0cfe5df.png">

`DateTimeImmutable`:
<img width="1098" alt="Screenshot 2021-10-11 at 22 38 47" src="https://user-images.githubusercontent.com/6057627/136852991-6e6bd3e7-b632-4cb0-b2a1-e57ffeb7472f.png">

`DateTimeInterface`:
<img width="943" alt="Screenshot 2021-10-11 at 22 38 35" src="https://user-images.githubusercontent.com/6057627/136853018-8c721923-f4d6-426f-ad66-706da53b7f5c.png">

