### PR TITLE
DateTime::createFromFormat - fix misleading epoch info

### DIFF
--- a/reference/datetime/datetime/createfromformat.xml
+++ b/reference/datetime/datetime/createfromformat.xml
@@ -259,14 +259,17 @@
          <row>
           <entry><literal>!</literal></entry>
           <entry>Resets all fields (year, month, day, hour, minute, second,
-          fraction and timezone information) to the Unix Epoch</entry>
+          fraction and timezone information) to zero-like values (
+           <literal>0</literal> for hour, minute, second and fraction,
+           <literal>1</literal> for month and day, <literal>1970</literal>
+           for year and <literal>UTC</literal> for timezone information)</entry>
           <entry>Without <literal>!,</literal> all fields will be set to the
           current date and time.</entry>
          </row>
          <row>
           <entry><literal>|</literal></entry>
           <entry>Resets all fields (year, month, day, hour, minute, second,
-          fraction and timezone information) to the Unix Epoch if they have
+          fraction and timezone information) to zero-like values if they have
           not been parsed yet</entry>
           <entry><literal>Y-m-d|</literal> will set the year, month and day
           to the information found in the string to parse, and sets the hour,


### PR DESCRIPTION
Current doc is referencing the Epoch time as the target of reseted value. But it can be misleading, because `Epoch time` is time point independently of Timezone. The `createFromFormat()` but doesn't target resetted values to Epoch time, but only to the zero-like values.

## What does mean?

Epoch time is NOT time representation (e.g.: `1970-01-01 00:00:00`), it's explicitly defined point in Timeline regardless to TimeZone. When you represent Epoch time in non-GTM Time zone, you MUST precising time to neutralize time zone shifting. 

That's mean `1970-01-01 00:00:00-08:00` is NOT Epoch time! Right is this: `1970-01-01 08:00:00-08:00`.

PHP doc is referencing resetting fields to Epoch time. It's misleading because when user define non-GTM Time zone, the PHP method `createFromFormat()` is reset fields to values which is not Epoch time.

## Examples

See the following example ([online version](https://3v4l.org/SDovL)):

```php
$date = DateTime::createFromFormat('!O', '+0200');

echo $date->format(DateTimeInterface::RFC3339_EXTENDED);
```

Current result is: `1970-01-01T00:00:00.000+02:00` – it's not a Epoch time.

You can also define Time zone out of string representation of time ([online version](https://3v4l.org/175ZL)):

```php
$date = DateTime::createFromFormat('!', '', new DateTimeZone('+0200'));

echo $date->format(DateTimeInterface::RFC3339_EXTENDED);
```

Current result is also: `1970-01-01T00:00:00.000+02:00` – it's not a Epoch time too.

