### PR TITLE
[PHP 8.1] Add IntlDatePatternGenerator description

### DIFF
--- a/reference/intl/book.xml
+++ b/reference/intl/book.xml
@@ -132,6 +132,7 @@
  &reference.intl.intlbreakiterator;
  &reference.intl.intlrulebasedbreakiterator;
  &reference.intl.intlcodepointbreakiterator;
+ &reference.intl.intldatepatterngenerator;
  &reference.intl.intlpartsiterator;
  &reference.intl.uconverter;
 

--- a/reference/intl/intldatepatterngenerator.xml
+++ b/reference/intl/intldatepatterngenerator.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpdoc:classref xmlns:phpdoc="http://php.net/ns/phpdoc" xml:id="class.intldatepatterngenerator" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The IntlDatePatternGenerator class</title>
+ <titleabbrev>IntlDatePatternGenerator</titleabbrev>
+
+ <partintro>
+
+  <!-- {{{ IntlDatePatternGenerator intro -->
+  <section xml:id="intldatepatterngenerator.intro">
+   &reftitle.intro;
+   
+   <simpara>
+    Generates localized date and/or time format pattern strings suitable for use in <classname>IntlDateFormatter</classname>.
+   </simpara> 
+  </section>
+  <!-- }}} -->
+
+  <section xml:id="intldatepatterngenerator.synopsis">
+   &reftitle.classsynopsis;
+
+   <!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass>
+     <classname>IntlDatePatternGenerator</classname>
+    </ooclass>
+
+   <!-- {{{ Class synopsis -->
+   <classsynopsisinfo>
+    <ooclass>
+     <classname>IntlDatePatternGenerator</classname>
+    </ooclass>
+   </classsynopsisinfo>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intldatepatterngenerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intldatepatterngenerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+   <!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+ &reference.intl.entities.intldatepatterngenerator;
+
+</phpdoc:classref>
+
+<!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+-->

--- a/reference/intl/intldatepatterngenerator.xml
+++ b/reference/intl/intldatepatterngenerator.xml
@@ -44,7 +44,6 @@
  &reference.intl.entities.intldatepatterngenerator;
 
 </phpdoc:classref>
-
 <!-- Keep this comment at the end of the file
  Local variables:
  mode: sgml

--- a/reference/intl/intldatepatterngenerator/create.xml
+++ b/reference/intl/intldatepatterngenerator/create.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="intldatepatterngenerator.create" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>IntlDatePatternGenerator::create</refname>
+  <refname>IntlDatePatternGenerator::__construct</refname>
+  <refpurpose>Creates a new IntlDatePatternGenerator instance</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>&style.oop;</para>
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>IntlDatePatternGenerator</type><type>null</type></type><methodname>IntlDatePatternGenerator::create</methodname>
+   <methodparam choice="opt"><type>string</type><parameter>locale</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.oop; (constructor)
+  </para>
+  <constructorsynopsis>
+   <modifier>public</modifier> <methodname>IntlDatePatternGenerator::__construct</methodname>
+   <methodparam choice="opt"><type>string</type><parameter>locale</parameter><initializer>&null;</initializer></methodparam>
+  </constructorsynopsis>
+  <para>
+   Creates a new <classname>IntlDatePatternGenerator</classname> instance.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>locale</parameter></term>
+    <listitem>
+     <para>
+      The locale.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns an <classname>IntlDatePatternGenerator</classname> instance on success, or &null; on failure.
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intldatepatterngenerator/create.xml
+++ b/reference/intl/intldatepatterngenerator/create.xml
@@ -12,7 +12,6 @@
    <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>IntlDatePatternGenerator</type><type>null</type></type><methodname>IntlDatePatternGenerator::create</methodname>
    <methodparam choice="opt"><type>string</type><parameter>locale</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>Constructor signature:</para>
   <constructorsynopsis>
    <modifier>public</modifier> <methodname>IntlDatePatternGenerator::__construct</methodname>
    <methodparam choice="opt"><type>string</type><parameter>locale</parameter><initializer>&null;</initializer></methodparam>

--- a/reference/intl/intldatepatterngenerator/create.xml
+++ b/reference/intl/intldatepatterngenerator/create.xml
@@ -8,14 +8,11 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>&style.oop;</para>
   <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>IntlDatePatternGenerator</type><type>null</type></type><methodname>IntlDatePatternGenerator::create</methodname>
    <methodparam choice="opt"><type>string</type><parameter>locale</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   &style.oop; (constructor)
-  </para>
+  <para>Constructor signature:</para>
   <constructorsynopsis>
    <modifier>public</modifier> <methodname>IntlDatePatternGenerator::__construct</methodname>
    <methodparam choice="opt"><type>string</type><parameter>locale</parameter><initializer>&null;</initializer></methodparam>
@@ -33,6 +30,7 @@
     <listitem>
      <para>
       The locale.
+      If &null; is passed, uses the ini setting <link linkend="ini.intl.default-locale">intl.default_locale</link>.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/intl/intldatepatterngenerator/getbestpattern.xml
+++ b/reference/intl/intldatepatterngenerator/getbestpattern.xml
@@ -43,7 +43,7 @@
    <example>
     <title><methodname>IntlDatePatternGenerator::getBestPattern</methodname> example</title>
     <programlisting role="php">
-     <![CDATA[
+<![CDATA[
 <?php
 
 $skeleton = 'YYYYMMdd';

--- a/reference/intl/intldatepatterngenerator/getbestpattern.xml
+++ b/reference/intl/intldatepatterngenerator/getbestpattern.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="intldatepatterngenerator.getbestpattern" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>IntlDatePatternGenerator::getBestPattern</refname>
+  <refpurpose>Determines the most suitable date/time format</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>IntlDatePatternGenerator::getBestPattern</methodname>
+   <methodparam><type>string</type><parameter>skeleton</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Determines which date/time format is most suitable for a particular locale.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>skeleton</parameter></term>
+    <listitem>
+     <para>
+      The skeleton.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns a format, accepted by <methodname>DateTimeInterface::format</methodname> on success, &return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><methodname>IntlDatePatternGenerator::getBestPattern</methodname> example</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+
+$skeleton = 'YYYYMMdd';
+$today = \DateTimeImmutable::createFromFormat('Y-m-d', '2021-04-24');
+ 
+$patternGenerator = new \IntlDatePatternGenerator('de_DE');
+$pattern = $patternGenerator->getBestPattern($skeleton);
+echo 'de: ', \IntlDateFormatter::formatObject($today, $pattern, 'de_DE'), "\n";
+ 
+$patternGenerator = new \IntlDatePatternGenerator('en_US');
+$pattern = $patternGenerator->getBestPattern($skeleton);
+echo 'en: ', \IntlDateFormatter::formatObject($today, $pattern, 'en_US');
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+de: 24.04.2021
+en: 04/24/2021
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/versions.xml
+++ b/reference/intl/versions.xml
@@ -264,6 +264,10 @@
  <function name="intlcodepointbreakiterator" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="intlcodepointbreakiterator::getlastcodepoint" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
 
+ <function name="intldatepatterngenerator" from="PHP 8 &gt;= 8.1.0"/>
+ <function name="intldatepatterngenerator::create" from="PHP 8 &gt;= 8.1.0"/>
+ <function name="intldatepatterngenerator::getbestpattern" from="PHP 8 &gt;= 8.1.0"/>
+
  <function name="intlpartsiterator" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="intlpartsiterator::getbreakiterator" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
 


### PR DESCRIPTION
Add `IntlDatePatternGenerator` description ([RFC](https://wiki.php.net/rfc/intldatetimepatterngenerator)).

Implementation php/php-src#6771