### PR TITLE
Opcache functions only apply to in-memory cache

### DIFF
--- a/reference/opcache/functions/opcache-get-status.xml
+++ b/reference/opcache/functions/opcache-get-status.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.opcache-get-status" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>opcache_get_status</refname>
-  <refpurpose>Get status information about the cache</refpurpose>
+  <refpurpose>Get status information about the cache that is stored in-memory.</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,7 +13,7 @@
    <methodparam choice="opt"><type>bool</type><parameter>include_scripts</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   This function returns state information about the cache instance
+   This function returns state information about the in-memory cache instance.
   </para>
  </refsect1>
 

--- a/reference/opcache/functions/opcache-get-status.xml
+++ b/reference/opcache/functions/opcache-get-status.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.opcache-get-status" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>opcache_get_status</refname>
-  <refpurpose>Get status information about the cache that is stored in-memory.</refpurpose>
+  <refpurpose>Get status information about the cache</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,7 +13,8 @@
    <methodparam choice="opt"><type>bool</type><parameter>include_scripts</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   This function returns state information about the in-memory cache instance.
+   This function returns state information about the in-memory cache instance. It will not return any
+   information about the file cache.
   </para>
  </refsect1>
 

--- a/reference/opcache/functions/opcache-invalidate.xml
+++ b/reference/opcache/functions/opcache-invalidate.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.opcache-invalidate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>opcache_invalidate</refname>
-  <refpurpose>Invalidates a cached script</refpurpose>
+  <refpurpose>Invalidates an in-memory cached script</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    This function invalidates a particular script from the opcode cache. If
    <parameter>force</parameter> is unset or &false;, the script will only be
    invalidated if the modification time of the script is newer than the cached
-   opcodes.
+   opcodes. This function only invalidates in-memory cache.
   </para>
  </refsect1>
 

--- a/reference/opcache/functions/opcache-invalidate.xml
+++ b/reference/opcache/functions/opcache-invalidate.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.opcache-invalidate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>opcache_invalidate</refname>
-  <refpurpose>Invalidates an in-memory cached script</refpurpose>
+  <refpurpose>Invalidates a cached script</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    This function invalidates a particular script from the opcode cache. If
    <parameter>force</parameter> is unset or &false;, the script will only be
    invalidated if the modification time of the script is newer than the cached
-   opcodes. This function only invalidates in-memory cache.
+   opcodes. This function only invalidates in-memory cache and not file cache.
   </para>
  </refsect1>
 

--- a/reference/opcache/functions/opcache-is-script-cached.xml
+++ b/reference/opcache/functions/opcache-is-script-cached.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.opcache-is-script-cached" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>opcache_is_script_cached</refname>
-  <refpurpose>Tells whether a script is cached in OPCache</refpurpose>
+  <refpurpose>Tells whether a script is cached in the in-memory OPCache</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,6 +15,7 @@
   <para>
    This function checks if a PHP script has been cached in OPCache. This can be
    used to more easily detect the "warming" of the cache for a particular script.
+   This function only checks in-memory cache.
   </para>
  </refsect1>
 

--- a/reference/opcache/functions/opcache-is-script-cached.xml
+++ b/reference/opcache/functions/opcache-is-script-cached.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.opcache-is-script-cached" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>opcache_is_script_cached</refname>
-  <refpurpose>Tells whether a script is cached in the in-memory OPCache</refpurpose>
+  <refpurpose>Tells whether a script is cached in OPCache</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
   <para>
    This function checks if a PHP script has been cached in OPCache. This can be
    used to more easily detect the "warming" of the cache for a particular script.
-   This function only checks in-memory cache.
+   This function only checks in-memory cache, not file cache.
   </para>
  </refsect1>
 

--- a/reference/opcache/functions/opcache-reset.xml
+++ b/reference/opcache/functions/opcache-reset.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.opcache-reset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>opcache_reset</refname>
-  <refpurpose>Resets the contents of the in-memory opcode cache</refpurpose>
+  <refpurpose>Resets the contents of the opcode cache</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    This function resets the entire opcode cache. After calling
    <function>opcache_reset</function>, all scripts will be reloaded and
    reparsed the next time they are hit. This function only resets
-   in-memory cache.
+   in-memory cache, not the file cache.
   </para>
  </refsect1>
 

--- a/reference/opcache/functions/opcache-reset.xml
+++ b/reference/opcache/functions/opcache-reset.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.opcache-reset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>opcache_reset</refname>
-  <refpurpose>Resets the contents of the opcode cache</refpurpose>
+  <refpurpose>Resets the contents of the in-memory opcode cache</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,8 @@
   <para>
    This function resets the entire opcode cache. After calling
    <function>opcache_reset</function>, all scripts will be reloaded and
-   reparsed the next time they are hit.
+   reparsed the next time they are hit. This function only resets
+   in-memory cache.
   </para>
  </refsect1>
 


### PR DESCRIPTION
The functions `opcache_get_status`, `opcache_invalidate`, `opcache_is_script_cached` and `opcache_reset` only apply to in-memory cache, not file cache. Also [fixes bug #75070](https://bugs.php.net/bug.php?id=75070).