### PR TITLE
fixed IntlChar::charFromName example return value.

### DIFF
--- a/reference/intl/intlchar/charfromname.xml
+++ b/reference/intl/intlchar/charfromname.xml
@@ -82,7 +82,7 @@ var_dump(IntlChar::charFromName("A RANDOM STRING WHICH DOESN'T CORRESPOND TO ANY
 int(65)
 int(9731)
 int(9843)
-bool(false)
+NULL
 ]]>
    </screen>
   </example>


### PR DESCRIPTION
Example return value is inconsistent with returnvalues section.

```
$ cat test.php
<?php
var_dump(IntlChar::charFromName("LATIN CAPITAL LETTER A"));
var_dump(IntlChar::charFromName("SNOWMAN"));
var_dump(IntlChar::charFromName("RECYCLING SYMBOL FOR TYPE-1 PLASTICS"));
var_dump(IntlChar::charFromName("A RANDOM STRING WHICH DOESN'T CORRESPOND TO ANY UNICODE CHARACTER"));

$ php test.php
/home/mumumu/test.php:2:
int(65)
/home/mumumu/test.php:3:
int(9731)
/home/mumumu/test.php:4:
int(9843)
/home/mumumu/test.php:5:
NULL
```