### PR TITLE
[PHP 8.1] Add ReflectionFunctionAbstract::getClosureUsedVariables

### DIFF
--- a/reference/reflection/reflectionfunctionabstract/getclosureusedvariables.xml
+++ b/reference/reflection/reflectionfunctionabstract/getclosureusedvariables.xml
@@ -2,7 +2,7 @@
 <refentry xml:id="reflectionfunctionabstract.getclosureusedvariables" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ReflectionFunctionAbstract::getClosureUsedVariables</refname>
-  <refpurpose>Returns an array of closure used variables</refpurpose>
+  <refpurpose>Returns an array of the used variables in the Closure</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -12,7 +12,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Returns an &array; of closure used variables.
+   Returns an &array; of the used variables in the <classname>Closure</classname>.
   </para>
 
  </refsect1>
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an &array; of closure used variables.
+   Returns an &array; of the used variables in the <classname>Closure</classname>.
   </para>
  </refsect1>
 

--- a/reference/reflection/reflectionfunctionabstract/getclosureusedvariables.xml
+++ b/reference/reflection/reflectionfunctionabstract/getclosureusedvariables.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="reflectionfunctionabstract.getclosureusedvariables" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>ReflectionFunctionAbstract::getClosureUsedVariables</refname>
+  <refpurpose>Returns an array of closure used variables</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>array</type><methodname>ReflectionFunctionAbstract::getClosureUsedVariables</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Returns an &array; of closure used variables.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns an &array; of closure used variables.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><methodname>ReflectionFunctionAbstract::getClosureUsedVariables</methodname> example</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$one = 1;
+$two = 2;
+
+$function = function() use ($one, $two) {
+    static $three = 3;
+};
+
+$reflector = new ReflectionFunction($function);
+
+var_dump($reflector->getClosureUsedVariables());
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+array(2) {
+  ["one"]=>
+  int(1)
+  ["two"]=>
+  int(2)
+}
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>ReflectionFunctionAbstract::getClosureScopeClass</function></member>
+    <member><function>ReflectionFunctionAbstract::getClosureThis</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/versions.xml
+++ b/reference/reflection/versions.xml
@@ -39,6 +39,7 @@
  <function name="reflectionfunctionabstract::isvariadic" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
  <function name="reflectionfunctionabstract::getclosurescopeclass" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
  <function name="reflectionfunctionabstract::getclosurethis" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
+ <function name="reflectionfunctionabstract::getclosureusedvariables" from="PHP 8 &gt;= 8.1.0"/>
  <function name="reflectionfunctionabstract::getdoccomment" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
  <function name="reflectionfunctionabstract::getendline" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="reflectionfunctionabstract::getextension" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>


### PR DESCRIPTION
Add `ReflectionFunctionAbstract::getClosureUsedVariables` description.

Based on [stubs](https://github.com/php/php-src/blob/PHP-8.1/ext/reflection/php_reflection.stub.php#L57).