### PR TITLE
Make password_needs_rehash() more prominent

### DIFF
--- a/reference/password/functions/password-hash.xml
+++ b/reference/password/functions/password-hash.xml
@@ -395,8 +395,8 @@ Argon2i hash: $argon2i$v=19$m=1024,t=2,p=2$YzJBSzV4TUhkMzc3d3laeg$zqU/1IN0/AogfP
   <para>
    <simplelist>
     <member><function>password_verify</function></member>
+    <member><function>password_needs_rehash</function></member>
     <member><function>crypt</function></member>
-    <member><link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.password.compat;">userland implementation</link></member>
     <member><function>sodium_crypto_pwhash_str</function></member>
    </simplelist>
   </para>

--- a/reference/password/functions/password-verify.xml
+++ b/reference/password/functions/password-verify.xml
@@ -62,6 +62,10 @@
   <para>
    <example>
     <title><function>password_verify</function> example</title>
+    <para>
+     This is a simplified example; it is recommended to rehash a correct password
+     if necessary; see <function>password_needs_rehash</function> for an example.
+    </para>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -90,6 +94,7 @@ Password is valid!
   &reftitle.seealso;
   <para>
    <simplelist>
+    <member><function>password_needs_rehash</function></member>
     <member><function>password_hash</function></member>
     <member><link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.password.compat;">userland implementation</link></member>
     <member><function>sodium_crypto_pwhash_str_verify</function></member>


### PR DESCRIPTION
Successful validation should usually be followed by re-hashing the
password, if necessary.  The `password_needs_rehash()` docs already
have a good example, but the `password_verify()` page does not mention
that at all.  Instead of duplicating the example, we refer to it.

We also remove the link to the password compatibility library, since it
is no longer relevant for the manual.