### PR TITLE
[PHP 8.1] Add cURL constants

### DIFF
--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -31,6 +31,17 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-doh-url">
+   <term>
+    <constant>CURLOPT_DOH_URL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Provides the DNS-over-HTTPS URL.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-dns-use-global-cache">
    <term>
     <constant>CURLOPT_DNS_USE_GLOBAL_CACHE</constant>
@@ -220,6 +231,17 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-issuercert-blob">
+   <term>
+    <constant>CURLOPT_ISSUERCERT_BLOB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Issuer SSL certificate from memory blob.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-url">
    <term>
     <constant>CURLOPT_URL</constant>
@@ -239,6 +261,50 @@
    <listitem>
     <simpara>
      
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-issuercert">
+   <term>
+    <constant>CURLOPT_PROXY_ISSUERCERT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Proxy issuer SSL certificate filename.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-issuercert-blob">
+   <term>
+    <constant>CURLOPT_PROXY_ISSUERCERT_BLOB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Proxy issuer SSL certificate from memory blob.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-sslcert-blob">
+   <term>
+    <constant>CURLOPT_PROXY_SSLCERT_BLOB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     SSL proxy client certificate from memory blob.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-sslkey-blob">
+   <term>
+    <constant>CURLOPT_PROXY_SSLKEY_BLOB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Private key for proxy cert from memory blob.
     </simpara>
    </listitem>
   </varlistentry>
@@ -617,6 +683,17 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-sslcert-blob">
+   <term>
+    <constant>CURLOPT_SSLCERT_BLOB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     SSL client certificate from memory blob.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-sslcertpasswd">
    <term>
     <constant>CURLOPT_SSLCERTPASSWD</constant>
@@ -625,6 +702,17 @@
    <listitem>
     <simpara>
      
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-sslkey-blob">
+   <term>
+    <constant>CURLOPT_SSLKEY_BLOB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Private key for client cert from memory blob.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -39,6 +39,7 @@
    <listitem>
     <simpara>
      Provides the DNS-over-HTTPS URL.
+     Available as of PHP 8.1.0 and cURL 7.62.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -239,6 +240,7 @@
    <listitem>
     <simpara>
      Issuer SSL certificate from memory blob.
+     Available as of PHP 8.1.0 and cURL 7.71.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -272,6 +274,7 @@
    <listitem>
     <simpara>
      Proxy issuer SSL certificate filename.
+     Available as of PHP 8.1.0 and cURL 7.71.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -283,6 +286,7 @@
    <listitem>
     <simpara>
      Proxy issuer SSL certificate from memory blob.
+     Available as of PHP 8.1.0 and cURL 7.71.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -294,6 +298,7 @@
    <listitem>
     <simpara>
      SSL proxy client certificate from memory blob.
+     Available as of PHP 8.1.0 and cURL 7.71.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -305,6 +310,7 @@
    <listitem>
     <simpara>
      Private key for proxy cert from memory blob.
+     Available as of PHP 8.1.0 and cURL 7.71.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -691,6 +697,7 @@
    <listitem>
     <simpara>
      SSL client certificate from memory blob.
+     Available as of PHP 8.1.0 and cURL 7.71.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -713,6 +720,7 @@
    <listitem>
     <simpara>
      Private key for client cert from memory blob.
+     Available as of PHP 8.1.0 and cURL 7.71.0.
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
Description:

- [`CURLOPT_DOH_URL`](https://curl.se/libcurl/c/CURLOPT_DOH_URL.html)
- [`CURLOPT_ISSUERCERT_BLOB`](https://curl.se/libcurl/c/CURLOPT_ISSUERCERT_BLOB.html)
- [`CURLOPT_PROXY_ISSUERCERT`](https://curl.se/libcurl/c/CURLOPT_PROXY_ISSUERCERT.html)
- [`CURLOPT_PROXY_ISSUERCERT_BLOB`](https://curl.se/libcurl/c/CURLOPT_PROXY_ISSUERCERT_BLOB.html)
- [`CURLOPT_PROXY_SSLCERT_BLOB`](https://curl.se/libcurl/c/CURLOPT_PROXY_SSLCERT_BLOB.html)
- [`CURLOPT_PROXY_SSLKEY_BLOB`](https://curl.se/libcurl/c/CURLOPT_PROXY_SSLKEY_BLOB.html)
- [`CURLOPT_SSLCERT_BLOB`](https://curl.se/libcurl/c/CURLOPT_SSLCERT_BLOB.html)
- [`CURLOPT_SSLKEY_BLOB`](https://curl.se/libcurl/c/CURLOPT_SSLKEY_BLOB.html)