### PR TITLE
Fix `openssl_cms_sign` parameters description

### DIFF
--- a/reference/openssl/functions/openssl-cms-sign.xml
+++ b/reference/openssl/functions/openssl-cms-sign.xml
@@ -48,7 +48,8 @@
     <term><parameter>certificate</parameter></term>
     <listitem>
      <para>
-      The name of the file containing the signing certificate.
+      The signing certificate.
+      See <link linkend="openssl.certparams">Key/Certificate parameters</link> for a list of valid values.
      </para>
     </listitem>
    </varlistentry>
@@ -56,7 +57,8 @@
     <term><parameter>private_key</parameter></term>
     <listitem>
      <para>
-       The name of file containing the key associated with <parameter>certificate</parameter>.
+      The key associated with <parameter>certificate</parameter>.
+      See <link linkend="openssl.certparams">Key/Certificate parameters</link> for a list of valid values.
      </para>
     </listitem>
    </varlistentry>
@@ -102,9 +104,25 @@
    &return.success;
   </para>
  </refsect1>
+ 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>openssl_cms_sign</function> example</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+openssl_cms_sign('input.txt', 'output.txt', 'file://cert.pem', 'file://privkey.pem', null, OPENSSL_CMS_BINARY, OPENSSL_ENCODING_DER, 'chain.pem');
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
Relates [`#80715`](https://bugs.php.net/bug.php?id=80715).