### PR TITLE
Correct the documented return types for `pow()`

### DIFF
--- a/reference/math/functions/pow.xml
+++ b/reference/math/functions/pow.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
    <methodsynopsis>
-   <type class="union"><type>int</type><type>float</type><type>object</type></type><methodname>pow</methodname>
+   <type class="union"><type>int</type><type>float</type></type><methodname>pow</methodname>
    <methodparam><type>mixed</type><parameter>num</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>exponent</parameter></methodparam>
   </methodsynopsis>


### PR DESCRIPTION
As far as I can tell, the `pow()` function cannot return an object.