### PR TITLE
[PHP 8.1] Add new sodium functions

### DIFF
--- a/reference/sodium/functions/sodium-crypto-stream-xchacha20-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-stream-xchacha20-keygen.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.sodium-crypto-stream-xchacha20-keygen" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>sodium_crypto_stream_xchacha20_keygen</refname>
+  <refpurpose>Returns a secure random key</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>sodium_crypto_stream_xchacha20_keygen</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Returns a secure random key for use with <function>sodium_crypto_stream_xchacha20</function>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns a 32-byte secure random key for use with <function>sodium_crypto_stream_xchacha20</function>.
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sodium/functions/sodium-crypto-stream-xchacha20-xor.xml
+++ b/reference/sodium/functions/sodium-crypto-stream-xchacha20-xor.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.sodium-crypto-stream-xchacha20-xor" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>sodium_crypto_stream_xchacha20_xor</refname>
+  <refpurpose>Encrypts a message using a nonce and a secret key (no authentication)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>sodium_crypto_stream_xchacha20_xor</methodname>
+   <methodparam><type>string</type><parameter>message</parameter></methodparam>
+   <methodparam><type>string</type><parameter>nonce</parameter></methodparam>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Encrypts a <parameter>message</parameter> using a <parameter>nonce</parameter>
+   and a secret <parameter>key</parameter> (no authentication).
+  </para>
+
+  <caution>
+   <para>
+    This encryption is unauthenticated, and does not prevent chosen-ciphertext attacks.
+    Make sure to combine the ciphertext with a Message Authentication Code,
+    for example with <function>sodium_crypto_aead_xchacha20poly1305_ietf_encrypt</function> function,
+    or <function>sodium_crypto_auth</function>.
+   </para>
+  </caution>
+  
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>message</parameter></term>
+    <listitem>
+     <para>
+      The message to encrypt.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>nonce</parameter></term>
+    <listitem>
+     <para>
+      24-byte nonce.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+      Key, possibly generated from <function>sodium_crypto_stream_xchacha20_keygen</function>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Encrypted message.
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sodium/functions/sodium-crypto-stream-xchacha20.xml
+++ b/reference/sodium/functions/sodium-crypto-stream-xchacha20.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.sodium-crypto-stream-xchacha20" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>sodium_crypto_stream_xchacha20</refname>
+  <refpurpose>Expands the key and nonce into a keystream of pseudorandom bytes</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>sodium_crypto_stream_xchacha20</methodname>
+   <methodparam><type>int</type><parameter>length</parameter></methodparam>
+   <methodparam><type>string</type><parameter>nonce</parameter></methodparam>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Expands the <parameter>key</parameter> and <parameter>nonce</parameter> into a keystream of pseudorandom bytes.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>length</parameter></term>
+    <listitem>
+     <para>
+      Number of bytes desired.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>nonce</parameter></term>
+    <listitem>
+     <para>
+      24-byte nonce.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+      Key, possibly generated from <function>sodium_crypto_stream_xchacha20_keygen</function>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns a pseudorandom stream that can be used with <function>sodium_crypto_stream_xchacha20_xor</function>.
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sodium/versions.xml
+++ b/reference/sodium/versions.xml
@@ -80,6 +80,9 @@
  <function name="sodium_crypto_sign_verify_detached" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
  <function name="sodium_crypto_stream" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
  <function name="sodium_crypto_stream_keygen" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_stream_xchacha20" from="PHP 8 &gt;= 8.1.0"/>
+ <function name="sodium_crypto_stream_xchacha20_keygen" from="PHP 8 &gt;= 8.1.0"/>
+ <function name="sodium_crypto_stream_xchacha20_xor" from="PHP 8 &gt;= 8.1.0"/>
  <function name="sodium_crypto_stream_xor" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
  <function name="sodium_add" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
  <function name="sodium_compare" from="PHP 7 &gt;= 7.2.0, PHP 8"/>


### PR DESCRIPTION
Added `sodium_crypto_stream_xchacha20`, `sodium_crypto_stream_xchacha20_keygen`, and `sodium_crypto_stream_xchacha20_xor` functions.

Based on [stubs](https://github.com/php/php-src/blob/master/ext/sodium/libsodium.stub.php#L203-L207).