### PR TITLE
[PHP 8.1] Document readonly properties.

### DIFF
--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -135,7 +135,7 @@
    <title>Readonly properties</title>
 
    <para>
-    Support for <code>readonly</code> properties has been added.
+    Support for <xref linkend="language.oop5.properties.readonly-properties" /> has been added.
     <!-- RFC: https://wiki.php.net/rfc/readonly_properties_v2 -->
    </para>
   </sect3>

--- a/language/oop5/inheritance.xml
+++ b/language/oop5/inheritance.xml
@@ -42,6 +42,26 @@
     other classes and interfaces.
    </para>
   </note>
+  <note>
+   <para>
+    It is not allowed to override a read-write property with a <link linkend="language.oop5.properties.readonly-properties">readonly property</link> or vice versa.
+    <example>
+     <programlisting role="php">
+<![CDATA[
+<?php
+
+class A {
+    public int $prop;
+}
+class B extends A {
+    // Illegal: read-write -> readonly
+    public readonly int $prop;
+}
+]]>
+     </programlisting>
+    </example>
+   </para>
+  </note>
 
   <sect2 xml:id="language.oop5.inheritance.examples">
    <example xml:id="language.oop5.inheritance.examples.ex1">

--- a/language/oop5/inheritance.xml
+++ b/language/oop5/inheritance.xml
@@ -57,6 +57,7 @@ class B extends A {
     // Illegal: read-write -> readonly
     public readonly int $prop;
 }
+?>
 ]]>
      </programlisting>
     </example>

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -186,6 +186,142 @@ Fatal error: Uncaught Error: Typed property Shape::$numberOfSides must not be ac
    </para>
   </sect2>
 
+  <sect2 xml:id="language.oop5.properties.readonly-properties">
+   <title>Readonly properties</title>
+   <para>
+    As of PHP 8.1.0, property can be declared with <code>readonly</code> modifier, which prevents modification of the property after initialization.
+    <example>
+     <title>Example of readonly properties</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+
+class Test {
+   public readonly string $prop;
+
+   public function __construct(string $prop) {
+       // Legal initialization.
+       $this->prop = $prop;
+   }
+}
+
+$test = new Test("foobar");
+// Legal read.
+var_dump($test->prop); // string(6) "foobar"
+
+// Illegal reassignment. It does not matter that the assigned value is the same.
+$test->prop = "foobar";
+// Error: Cannot modify readonly property Test::$prop
+]]>
+     </programlisting>
+    </example>
+    <note>
+     <para>
+      The readonly modifier can only be applied to <link linkend="language.oop5.properties.typed-properties">typed properties</link>.
+      A readonly property without type constraints can be created using the <xref linkend="language.types.declarations.mixed" /> type.
+     </para>
+    </note>
+    <note>
+     <para>
+      Readonly static properties are not supported.
+     </para>
+    </note>
+   </para>
+   <para>
+    A readonly property can only be initialized once, and only from the scope where it has been declared. Any other assignment or modification of the property will result in an <classname>Error</classname> exception.
+    <example>
+     <title>Illegal initilization of readonly properties</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+class Test1 {
+    public readonly string $prop;
+}
+
+$test1 = new Test1;
+// Illegal initialization outside of private scope.
+$test1->prop = "foobar";
+// Error: Cannot initialize readonly property Test1::$prop from global scope
+?>
+]]>
+     </programlisting>
+    </example>
+   </para>
+   <note>
+    <para>
+     Specifying an explicit default value on readonly properties is not allowed, because a readonly property with a default value is essentially the same as a constant, and thus not particularly useful.
+     <example>
+      <programlisting role="php">
+ <![CDATA[
+<?php
+
+class Test {
+    // Fatal error: Readonly property Test::$prop cannot have default value
+    public readonly int $prop = 42;
+}
+?>
+ ]]>
+      </programlisting>
+     </example>
+    </para>
+   </note>
+   <note>
+    <para>
+     Readonly properties cannot be <function>unset</function> once they are initialized. However, it is possible to unset a readonly property prior to initialization, from the scope where the property has been declared.
+    </para>
+   </note>
+   <para>
+    Modifications are not necessarily plain assignments, all of the following will also result in an <classname>Error</classname> exception:
+    <example>
+     <programlisting role="php">
+<![CDATA[
+<?php
+
+class Test {
+    public function __construct(
+        public readonly int $i = 0,
+        public readonly array $ary = [],
+    ) {}
+}
+
+$test = new Test;
+$test->i += 1;
+$test->i++;
+++$test->i;
+$test->ary[] = 1;
+$test->ary[0][] = 1;
+$ref =& $test->i;
+$test->i =& $ref;
+byRef($test->i);
+foreach ($test as &$prop);
+?>
+]]>
+     </programlisting>
+    </example>
+   </para>
+   <para>
+    However, readonly properties do not preclude interior mutability. Objects (or resources) stored in readonly properties may still be modified internally:
+    <example>
+     <programlisting role="php">
+<![CDATA[
+<?php
+
+class Test {
+    public function __construct(public readonly object $obj) {}
+}
+
+$test = new Test(new stdClass);
+// Legal interior mutation.
+$test->obj->foo = 1;
+// Illegal reassignment.
+$test->obj = new stdClass;
+?>
+]]>
+     </programlisting>
+    </example>
+   </para>
+  </sect2>
+
  </sect1>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -212,6 +212,7 @@ var_dump($test->prop); // string(6) "foobar"
 // Illegal reassignment. It does not matter that the assigned value is the same.
 $test->prop = "foobar";
 // Error: Cannot modify readonly property Test::$prop
+?>
 ]]>
      </programlisting>
     </example>
@@ -252,7 +253,7 @@ $test1->prop = "foobar";
      Specifying an explicit default value on readonly properties is not allowed, because a readonly property with a default value is essentially the same as a constant, and thus not particularly useful.
      <example>
       <programlisting role="php">
- <![CDATA[
+<![CDATA[
 <?php
 
 class Test {
@@ -260,7 +261,7 @@ class Test {
     public readonly int $prop = 42;
 }
 ?>
- ]]>
+]]>
       </programlisting>
      </example>
     </para>

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -189,7 +189,7 @@ Fatal error: Uncaught Error: Typed property Shape::$numberOfSides must not be ac
   <sect2 xml:id="language.oop5.properties.readonly-properties">
    <title>Readonly properties</title>
    <para>
-    As of PHP 8.1.0, property can be declared with <code>readonly</code> modifier, which prevents modification of the property after initialization.
+    As of PHP 8.1.0, a property can be declared with the <code>readonly</code> modifier, which prevents modification of the property after initialization.
     <example>
      <title>Example of readonly properties</title>
      <programlisting role="php">

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -231,7 +231,7 @@ $test->prop = "foobar";
    <para>
     A readonly property can only be initialized once, and only from the scope where it has been declared. Any other assignment or modification of the property will result in an <classname>Error</classname> exception.
     <example>
-     <title>Illegal initilization of readonly properties</title>
+     <title>Illegal initialization of readonly properties</title>
      <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/reflection/reflectionproperty/isprivate.xml
+++ b/reference/reflection/reflectionproperty/isprivate.xml
@@ -36,6 +36,7 @@
    <simplelist>
     <member><methodname>ReflectionProperty::isPublic</methodname></member>
     <member><methodname>ReflectionProperty::isProtected</methodname></member>
+    <member><methodname>ReflectionProperty::isReadOnly</methodname></member>
     <member><methodname>ReflectionProperty::isStatic</methodname></member>
    </simplelist>
   </para>

--- a/reference/reflection/reflectionproperty/isprotected.xml
+++ b/reference/reflection/reflectionproperty/isprotected.xml
@@ -36,6 +36,7 @@
    <simplelist>
     <member><methodname>ReflectionProperty::isPublic</methodname></member>
     <member><methodname>ReflectionProperty::isPrivate</methodname></member>
+    <member><methodname>ReflectionProperty::isReadOnly</methodname></member>
     <member><methodname>ReflectionProperty::isStatic</methodname></member>
    </simplelist>
   </para>

--- a/reference/reflection/reflectionproperty/isreadonly.xml
+++ b/reference/reflection/reflectionproperty/isreadonly.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-
 <refentry xml:id="reflectionproperty.isreadonly" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionProperty::isReadOnly</refname>

--- a/reference/reflection/reflectionproperty/isreadonly.xml
+++ b/reference/reflection/reflectionproperty/isreadonly.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="reflectionproperty.ispublic" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="reflectionproperty.isreadonly" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
-  <refname>ReflectionProperty::isPublic</refname>
-  <refpurpose>Checks if property is public</refpurpose>
+  <refname>ReflectionProperty::isReadOnly</refname>
+  <refpurpose>Checks if property is readonly</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>bool</type><methodname>ReflectionProperty::isPublic</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>ReflectionProperty::isReadOnly</methodname>
    <void />
   </methodsynopsis>
   <para>
-   Checks whether the property is public.
+   Checks whether the property is readonly.
   </para>
  </refsect1>
 
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &true; if the property is public, &false; otherwise.
+   &true; if the property is readonly, &false; otherwise.
   </para>
  </refsect1>
 
@@ -34,9 +34,9 @@
   &reftitle.seealso;
   <para>
    <simplelist>
+    <member><methodname>ReflectionProperty::isPublic</methodname></member>
     <member><methodname>ReflectionProperty::isProtected</methodname></member>
     <member><methodname>ReflectionProperty::isPrivate</methodname></member>
-    <member><methodname>ReflectionProperty::isReadOnly</methodname></member>
     <member><methodname>ReflectionProperty::isStatic</methodname></member>
    </simplelist>
   </para>

--- a/reference/reflection/reflectionproperty/isreadonly.xml
+++ b/reference/reflection/reflectionproperty/isreadonly.xml
@@ -12,7 +12,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Checks whether the property is readonly.
+   Checks whether the <link linkend="language.oop5.properties.readonly-properties">property is readonly</link>.
   </para>
  </refsect1>
 

--- a/reference/reflection/reflectionproperty/isstatic.xml
+++ b/reference/reflection/reflectionproperty/isstatic.xml
@@ -37,6 +37,7 @@
     <member><methodname>ReflectionProperty::isPublic</methodname></member>
     <member><methodname>ReflectionProperty::isProtected</methodname></member>
     <member><methodname>ReflectionProperty::isPrivate</methodname></member>
+    <member><methodname>ReflectionProperty::isReadOnly</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/reflection/versions.xml
+++ b/reference/reflection/versions.xml
@@ -281,6 +281,7 @@
  <function name="reflectionproperty::ispublic" from="PHP 5, PHP 7, PHP 8"/>
  <function name="reflectionproperty::isprivate" from="PHP 5, PHP 7, PHP 8"/>
  <function name="reflectionproperty::isprotected" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="reflectionproperty::isreadonly" from="PHP 8 &gt;= 8.1.0"/>
  <function name="reflectionproperty::isstatic" from="PHP 5, PHP 7, PHP 8"/>
  <function name="reflectionproperty::isdefault" from="PHP 5, PHP 7, PHP 8"/>
  <function name="reflectionproperty::getmodifiers" from="PHP 5, PHP 7, PHP 8"/>


### PR DESCRIPTION
Based on [RFC](https://wiki.php.net/rfc/readonly_properties_v2), added documentation of readonly properties.

- TODO
  - [x] language/oop5 related page
  - [x] appendices/migration81/new-features.xml
  - [x] ReflectionProperty::isReadOnly method.
  - [ ] Can we add `readonly` keyword to [List of Reserved Words](https://www.php.net/manual/en/reserved.php) page?
    * RFC states readonly keyword is reserved, however, [we can use it as function name](https://github.com/php/php-src/commit/76348f3378dbc0c92568380d23a8d75a777ae49c).