### PR TITLE
Add mention on question mark escape feature

### DIFF
--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -162,13 +162,12 @@ $yellow = $sth->fetchAll();
     <programlisting role="php">
 <![CDATA[
 <?php
-/* Execute a prepared statement which contains a question mark as sql statement */
 /* note: this is only valid on PostgreSQL databases */
-$sth = $dbh->prepare('SELECT '["a", "b", "c"]'::jsonb ?? ?);
-$sth->execute(array('a'));
-$resultTrue = $sth->fetchAll();
-$sth->execute(array('z'));
-$resultFalse = $sth->fetchAll();
+$sth = $dbh->prepare('SELECT * FROM issue WHERE tag::jsonb ?? ?);
+$sth->execute(array('feature'));
+$featuresIssues = $sth->fetchAll();
+$sth->execute(array('performance'));
+$performanceIssues = $sth->fetchAll();
 ?>
 ]]>
     </programlisting>

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -66,6 +66,9 @@
     which is natively supported by the driver.
    </simpara>
   </note>
+  <para>
+    Questions marks can be escaped by doubling them. That means that the “??” string will be translated to “?” when sending the query to the database.
+  </para>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -148,6 +151,22 @@ $sth->execute(array(150, 'red'));
 $red = $sth->fetchAll();
 $sth->execute(array(175, 'yellow'));
 $yellow = $sth->fetchAll();
+?>
+]]>
+    </programlisting>
+   </example>
+   <example>
+    <title>SQL statement template with question mark escaped</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+/* Execute a prepared statement which contains a question mark as sql statement */
+/* note: this is only valid on PostgreSQL databases */
+$sth = $dbh->prepare('SELECT '["a", "b", "c"]'::jsonb ?? ?);
+$sth->execute(array('a'));
+$resultTrue = $sth->fetchAll();
+$sth->execute(array('z'));
+$resultFalse = $sth->fetchAll();
 ?>
 ]]>
     </programlisting>

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -163,9 +163,9 @@ $yellow = $sth->fetchAll();
 <![CDATA[
 <?php
 /* note: this is only valid on PostgreSQL databases */
-$sth = $dbh->prepare('SELECT * FROM issue WHERE tag::jsonb ?? ?);
+$sth = $dbh->prepare('SELECT * FROM issues WHERE tag::jsonb ?? ?);
 $sth->execute(array('feature'));
-$featuresIssues = $sth->fetchAll();
+$featureIssues = $sth->fetchAll();
 $sth->execute(array('performance'));
 $performanceIssues = $sth->fetchAll();
 ?>

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -67,7 +67,9 @@
    </simpara>
   </note>
   <para>
-    Questions marks can be escaped by doubling them. That means that the “??” string will be translated to “?” when sending the query to the database.
+    Question marks can be escaped by doubling them. That means that
+    the <literal>??</literal> string will be translated to <literal>?</literal>
+    when sending the query to the database.
   </para>
  </refsect1>
  <refsect1 role="parameters">


### PR DESCRIPTION
Since PHP 7.4, it is possible to escape question mark in php pdo statement by doubling them: https://wiki.php.net/rfc/pdo_escape_placeholders

I add a simple statement and add an example.

I am sorry the example is only valid using Postgresql database. But some question on multiple places (like [on stackoverflow](https://stackoverflow.com/q/36173440/1572236)) are related to this database (and I use often this RDBMS, I do not know if this is in use elsewhere).