### PR TITLE
PCRE: add missing "Errors/Exceptions" section

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1863,6 +1863,11 @@ data must be properly formatted and all strings must be escaped using
 the <function>mysqli_real_escape_string</function>
 function.</para></warning>'>
 
+<!-- Notes for PCRE -->
+<!ENTITY pcre.pattern.warning '<para xmlns="http://docbook.org/ns/docbook">
+If the regex pattern passed does not compile to a valid regex, an <constant>E_WARNING</constant> is emitted.
+</para>'>
+
 <!-- Notes for SAPI/Apache -->
 <!ENTITY apache.req.module '<simpara xmlns="http://docbook.org/ns/docbook">This function is supported when PHP
 is installed as an Apache module webserver.

--- a/reference/pcre/functions/preg-filter.xml
+++ b/reference/pcre/functions/preg-filter.xml
@@ -37,6 +37,11 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &pcre.pattern.warning;
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/pcre/functions/preg-grep.xml
+++ b/reference/pcre/functions/preg-grep.xml
@@ -63,6 +63,11 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &pcre.pattern.warning;
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/pcre/functions/preg-match-all.xml
+++ b/reference/pcre/functions/preg-match-all.xml
@@ -284,6 +284,11 @@ Array
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &pcre.pattern.warning;
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -253,6 +253,11 @@ Array
   &return.falseproblem;
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &pcre.pattern.warning;
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>

--- a/reference/pcre/functions/preg-replace-callback-array.xml
+++ b/reference/pcre/functions/preg-replace-callback-array.xml
@@ -91,6 +91,11 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &pcre.pattern.warning;
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>

--- a/reference/pcre/functions/preg-replace-callback.xml
+++ b/reference/pcre/functions/preg-replace-callback.xml
@@ -148,6 +148,11 @@ fclose($fp);
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &pcre.pattern.warning;
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>

--- a/reference/pcre/functions/preg-replace.xml
+++ b/reference/pcre/functions/preg-replace.xml
@@ -148,6 +148,7 @@
    Using the "\e" modifier is an error;
    an <constant>E_WARNING</constant> is emitted in this case.
   </para>
+  &pcre.pattern.warning;
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/pcre/functions/preg-split.xml
+++ b/reference/pcre/functions/preg-split.xml
@@ -103,6 +103,11 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &pcre.pattern.warning;
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>


### PR DESCRIPTION
All PCRE pattern matching functions will throw a warning when an invalid regex is passed to the `$pattern` parameter.
See: https://3v4l.org/WkVIW

This was thus far undocumented behaviour.

This PR adds:
* The "Errors/Exceptions" section to each of the PCRE pattern matching function documentation pages (if it didn't exist yet).
* Adds a macro for the text snippet about the warning to display in the section and uses that in the "Errors/Exceptions" section for each function.