### PR TITLE
Update ISO 8601 text

### DIFF
--- a/reference/datetime/datetimeinterface/format.xml
+++ b/reference/datetime/datetimeinterface/format.xml
@@ -89,7 +89,7 @@
          </row>
          <row>
           <entry><literal>N</literal></entry>
-          <entry>ISO-8601 numeric representation of the day of the week</entry>
+          <entry>ISO 8601 numeric representation of the day of the week</entry>
           <entry><literal>1</literal> (for Monday) through <literal>7</literal> (for Sunday)</entry>
          </row>
          <row>
@@ -117,7 +117,7 @@
          </row>
          <row>
           <entry><literal>W</literal></entry>
-          <entry>ISO-8601 week number of year, weeks starting on Monday</entry>
+          <entry>ISO 8601 week number of year, weeks starting on Monday</entry>
           <entry>Example: <literal>42</literal> (the 42nd week in the year)</entry>
          </row>
          <row>
@@ -162,7 +162,7 @@
          </row>
          <row>
           <entry><literal>o</literal></entry>
-          <entry>ISO-8601 week-numbering year. This has the same value as
+          <entry>ISO 8601 week-numbering year. This has the same value as
            <literal>Y</literal>, except that if the ISO week number
            (<literal>W</literal>) belongs to the previous or next year, that year
            is used instead.</entry>


### PR DESCRIPTION
Use _ISO 8601_, instead of _ISO-8601_, for consistency and alignment with https://www.iso.org/iso-8601-date-and-time-format.html