### PR TITLE
php memory stream can't be passed to library on Windows

### DIFF
--- a/language/wrappers/php.xml
+++ b/language/wrappers/php.xml
@@ -71,12 +71,17 @@
    <simpara>
     <filename>php://memory</filename> and <filename>php://temp</filename> are
     read-write streams that allow temporary data to be stored in a file-like
-    wrapper. The only difference between the two is that
+    wrapper. One difference between the two is that
     <filename>php://memory</filename> will always store its data in memory,
     whereas <filename>php://temp</filename> will use a temporary file once the
     amount of data stored hits a predefined limit (the default is 2 MB). The
     location of this temporary file is determined in the same way as the
     <function>sys_get_temp_dir</function> function.
+   </simpara>
+   <simpara>
+    Casting memory stream to stdio streams (e.g. to be passed as a parameter
+    to a library) requires fopencookie() which is not available on Windows
+    and likely some other systems.
    </simpara>
    <simpara>
     The memory limit of <filename>php://temp</filename> can be controlled by


### PR DESCRIPTION
apparently.

e.g. fix needed for Imagick on windows: https://github.com/Imagick/imagick/pull/493