### PR TITLE
Cannot set mail.force_extra_parameters as PHP_INI_PERDIR

### DIFF
--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -452,7 +452,7 @@
       <row>
        <entry>mail.force_extra_parameters</entry>
        <entry>&null;</entry>
-       <entry>&php.ini; only</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>

--- a/reference/mail/ini.xml
+++ b/reference/mail/ini.xml
@@ -106,6 +106,11 @@
      parameters to the sendmail binary. These parameters will always replace
      the value of the 5th parameter to <function>mail</function>.
     </para>
+    <para>
+     In addition to the default behavior for <constant>INI_SYSTEM</constant>,
+     this value can also be set with <literal>php_value</literal>
+     in <filename>httpd.conf</filename> (but this is not recommended)
+    </para>
    </listitem>
   </varlistentry>
 

--- a/reference/mail/ini.xml
+++ b/reference/mail/ini.xml
@@ -31,7 +31,7 @@
     <row>
      <entry><link linkend="ini.mail.force_extra_parameters">mail.force_extra_parameters</link></entry>
      <entry>NULL</entry>
-     <entry><constant>INI_SYSTEM</constant>|<constant>INI_PERDIR</constant></entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry></entry>
     </row>
     <row>

--- a/reference/mail/ini.xml
+++ b/reference/mail/ini.xml
@@ -109,7 +109,7 @@
     <para>
      In addition to the default behavior for <constant>INI_SYSTEM</constant>,
      this value can also be set with <literal>php_value</literal>
-     in <filename>httpd.conf</filename> (but this is not recommended)
+     in <filename>httpd.conf</filename> (but this is not recommended).
     </para>
    </listitem>
   </varlistentry>

--- a/reference/mail/ini.xml
+++ b/reference/mail/ini.xml
@@ -106,11 +106,11 @@
      parameters to the sendmail binary. These parameters will always replace
      the value of the 5th parameter to <function>mail</function>.
     </para>
-    <para>
+    <simpara>
      In addition to the default behavior for <constant>INI_SYSTEM</constant>,
      this value can also be set with <literal>php_value</literal>
      in <filename>httpd.conf</filename> (but this is not recommended).
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
 


### PR DESCRIPTION
Documentation does not match: https://github.com/php/doc-en/blob/3cdd39bb9505e6735d802da83a04870cfa8f2311/appendices/ini.list.xml

This param cannot be set through PHP_INI_PERDIR because of https://bugs.php.net/bug.php?id=71901