### PR TITLE
Document Stringable::__toString() method

### DIFF
--- a/language/predefined/stringable.xml
+++ b/language/predefined/stringable.xml
@@ -13,15 +13,16 @@
    &reftitle.intro;
    <para>
     The <interfacename>Stringable</interfacename> interface denotes a class as
-    having a <function>__toString</function> method.  Unlike most interfaces,
-    <interfacename>Stringable</interfacename> is implicitly present on any class that
-    has the magic <function>__toString</function> method defined, although it
-    can and should be declared explicitly.
+    having a <link linkend="object.tostring">__toString()</link> method. Unlike
+    most interfaces, <interfacename>Stringable</interfacename> is implicitly
+    present on any class that has the magic
+    <link linkend="object.tostring">__toString()</link> method defined, although
+    it can and should be declared explicitly.
    </para>
    <para>
     Its primary value is to allow functions to type check against the union
-    type <literal>string|Stringable</literal> to accept either a string primitive
-    or an object that can be cast to a string.
+    type <literal>string|Stringable</literal> to accept either a string
+    primitive or an object that can be cast to a string.
    </para>
   </section>
 <!-- }}} -->
@@ -42,12 +43,9 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-<!-- Bring back if we add the toString method as its own page later. For now,
-     just link to the existing description in magic.xml.
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.stringable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
      <xi:fallback />
     </xi:include>
--->
    </classsynopsis>
 <!-- }}} -->
 
@@ -103,6 +101,7 @@ showStuff($ip);
 
  </partintro>
 
+ &language.predefined.stringable.tostring;
 </phpdoc:classref>
 
 <!-- Keep this comment at the end of the file

--- a/language/predefined/stringable.xml
+++ b/language/predefined/stringable.xml
@@ -13,16 +13,15 @@
    &reftitle.intro;
    <para>
     The <interfacename>Stringable</interfacename> interface denotes a class as
-    having a <link linkend="object.tostring">__toString()</link> method. Unlike
-    most interfaces, <interfacename>Stringable</interfacename> is implicitly
-    present on any class that has the magic
-    <link linkend="object.tostring">__toString()</link> method defined, although
-    it can and should be declared explicitly.
+    having a <link linkend="object.tostring">__toString()</link> method.  Unlike most interfaces,
+    <interfacename>Stringable</interfacename> is implicitly present on any class that
+    has the magic <link linkend="object.tostring">__toString()</link> method defined, although it
+    can and should be declared explicitly.
    </para>
    <para>
     Its primary value is to allow functions to type check against the union
-    type <literal>string|Stringable</literal> to accept either a string
-    primitive or an object that can be cast to a string.
+    type <literal>string|Stringable</literal> to accept either a string primitive
+    or an object that can be cast to a string.
    </para>
   </section>
 <!-- }}} -->

--- a/language/predefined/stringable/tostring.xml
+++ b/language/predefined/stringable/tostring.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<refentry xml:id="stringable.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Stringable::__toString</refname>
+  <refpurpose>Gets a string representation of the object</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>string</type><methodname>Stringable::__toString</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the <type>string</type> representation of the object.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><link linkend="object.tostring">__toString()</link></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/predefined/stringable/tostring.xml
+++ b/language/predefined/stringable/tostring.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>string</type><methodname>Stringable::__toString</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
   </para>
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the <type>string</type> representation of the object.
+   Returns the &string; representation of the object.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Also fixes links to __toString() magic method in Stringable interface docs.

See: https://github.com/php/doc-en/pull/478#issuecomment-965606202