### PR TITLE
Match return typehint with documentation

### DIFF
--- a/reference/array/functions/array-replace-recursive.xml
+++ b/reference/array/functions/array-replace-recursive.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>array_replace_recursive</methodname>
+   <type>?array</type><methodname>array_replace_recursive</methodname>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
    <methodparam rep="repeat"><type>array</type><parameter>replacements</parameter></methodparam>
   </methodsynopsis>


### PR DESCRIPTION
When an error occurs, null can be returned