### PR TITLE
strtotime - 'current time' = 'current time zone'

### DIFF
--- a/reference/datetime/functions/strtotime.xml
+++ b/reference/datetime/functions/strtotime.xml
@@ -17,7 +17,7 @@
    The function expects to be given a string containing an English date format
    and will try to parse that format into a Unix timestamp (the number of
    seconds since January 1 1970 00:00:00 UTC), relative to the timestamp given
-   in <parameter>baseTimestamp</parameter>, or the current time if
+   in <parameter>baseTimestamp</parameter>, or the current time zone if
    <parameter>baseTimestamp</parameter> is not supplied.
   </simpara>
   <warning>


### PR DESCRIPTION
   The function expects to be given a string containing an English date format
   and will try to parse that format into a Unix timestamp (the number of
   seconds since January 1 1970 00:00:00 UTC), relative to the timestamp given
   in <parameter>baseTimestamp</parameter>, or the current time **zone** if
   <parameter>baseTimestamp</parameter> is not supplied.
