### PR TITLE
PDOStatement colons for names in array example

### DIFF
--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -127,8 +127,9 @@ $sql = 'SELECT name, colour, calories
     FROM fruit
     WHERE calories < :calories AND colour = :colour';
 $sth = $dbh->prepare($sql, array(PDO::ATTR_CURSOR => PDO::CURSOR_FWDONLY));
-$sth->execute(array(':calories' => 150, ':colour' => 'red'));
+$sth->execute(array('calories' => 150, 'colour' => 'red'));
 $red = $sth->fetchAll();
+/* Array keys can be prefixed with colons ":" too (optional) */
 $sth->execute(array(':calories' => 175, ':colour' => 'yellow'));
 $yellow = $sth->fetchAll();
 ?>

--- a/reference/pdo/pdostatement/bindparam.xml
+++ b/reference/pdo/pdostatement/bindparam.xml
@@ -112,7 +112,8 @@ $colour = 'red';
 $sth = $dbh->prepare('SELECT name, colour, calories
     FROM fruit
     WHERE calories < :calories AND colour = :colour');
-$sth->bindParam(':calories', $calories, PDO::PARAM_INT);
+$sth->bindParam('calories', $calories, PDO::PARAM_INT);
+/* Names can be prefixed with colons ":" too (optional) */
 $sth->bindParam(':colour', $colour, PDO::PARAM_STR, 12);
 $sth->execute();
 ?>

--- a/reference/pdo/pdostatement/bindvalue.xml
+++ b/reference/pdo/pdostatement/bindvalue.xml
@@ -77,7 +77,8 @@ $colour = 'red';
 $sth = $dbh->prepare('SELECT name, colour, calories
     FROM fruit
     WHERE calories < :calories AND colour = :colour');
-$sth->bindValue(':calories', $calories, PDO::PARAM_INT);
+$sth->bindValue('calories', $calories, PDO::PARAM_INT);
+/* Names can be prefixed with colons ":" too (optional) */
 $sth->bindValue(':colour', $colour, PDO::PARAM_STR);
 $sth->execute();
 ?>

--- a/reference/pdo/pdostatement/execute.xml
+++ b/reference/pdo/pdostatement/execute.xml
@@ -77,8 +77,9 @@ $colour = 'gre';
 $sth = $dbh->prepare('SELECT name, colour, calories
     FROM fruit
     WHERE calories < :calories AND colour LIKE :colour');
-$sth->bindParam(':calories', $calories, PDO::PARAM_INT);
-$sth->bindValue(':colour', "%{$colour}%");
+$sth->bindParam('calories', $calories, PDO::PARAM_INT);
+/* Names can be prefixed with colons ":" too (optional) */
+$sth->bindValue(':colour', "%$colour%");
 $sth->execute();
 ?>
 ]]>
@@ -95,6 +96,8 @@ $colour = 'red';
 $sth = $dbh->prepare('SELECT name, colour, calories
     FROM fruit
     WHERE calories < :calories AND colour = :colour');
+$sth->execute(array('calories' => $calories, 'colour' => $colour));
+/* Array keys can be prefixed with colons ":" too (optional) */
 $sth->execute(array(':calories' => $calories, ':colour' => $colour));
 ?>
 ]]>


### PR DESCRIPTION
passing values for named parameters in an array allow array keys being
either the names of the named parameters or (alternatively) the names
prefixed with colons (\<colon> : \<U003A> COLON) mimicking the placeholders
in the SQL query.

therefore the example should show first verbatim names as the array keys
and then highlight the alternative way to have the array keys with a
dedicated comment within the examples code.