### PR TITLE
Clarify purpose of ReflectionType

### DIFF
--- a/reference/reflection/reflectiontype.xml
+++ b/reference/reflection/reflectiontype.xml
@@ -13,7 +13,7 @@
    &reftitle.intro;
    <para>
     The <classname>ReflectionType</classname> class reports
-    information about a function's return type.
+    information about a function's parameter/return type.
     The Reflection extension declares the following subtypes:
     <simplelist>
      <member><classname>ReflectionNamedType</classname> (as of PHP 7.1.0)</member>


### PR DESCRIPTION
When calling e.g. `ReflectionParameter::getType()` you get an instance of `ReflectionType`, too, see: https://www.php.net/manual/en/reflectionparameter.gettype.php