### PR TITLE
Remove incorrect return comment for ArrayObject::unserialize

### DIFF
--- a/reference/spl/arrayobject/unserialize.xml
+++ b/reference/spl/arrayobject/unserialize.xml
@@ -36,6 +36,13 @@
   </para>
  </refsect1>
 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/spl/arrayobject/unserialize.xml
+++ b/reference/spl/arrayobject/unserialize.xml
@@ -36,13 +36,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   The unserialized <classname>ArrayObject</classname>.
-  </para>
- </refsect1>
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>


### PR DESCRIPTION
The [ArrayObject::unserialize](https://www.php.net/manual/en/arrayobject.unserialize.php) has `void` return type so it looks a bit incorrect describing it as returning an "unserialized ArrayObject"
