### PR TITLE
Add stream_socket_client usage to stream_get_meta_data

### DIFF
--- a/reference/stream/functions/stream-get-meta-data.xml
+++ b/reference/stream/functions/stream-get-meta-data.xml
@@ -25,7 +25,7 @@
      <listitem>
       <para>
        The stream can be any stream created by <function>fopen</function>,
-       <function>fsockopen</function> and <function>pfsockopen</function>.
+       <function>fsockopen</function> <function>pfsockopen</function> and <function>stream_socket_client</function>.
       </para>
      </listitem>
     </varlistentry>
@@ -121,6 +121,14 @@
      stream.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     <literal>crypto</literal> (array) - the TLS connection metadata for this
+     stream. (Note: Only provided when used with a <link
+     linkend="function.stream-socket-client">stream_socket_client()</link>
+     resources.)
+    </para>
+   </listitem>
   </itemizedlist>
  </refsect1>
 
@@ -128,7 +136,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title><function>stream_get_meta_data</function> example</title>
+    <title><function>stream_get_meta_data</function> example using fopen</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -175,6 +183,61 @@ Array
     [timed_out] => 
     [blocked] => 1
     [eof] => 
+)
+]]>
+    </screen>
+   </example>
+   <example>
+    <title><function>stream_get_meta_data</function> example using stream_socket_client</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+$streamContext = stream_context_create(
+    [
+        'ssl' => [
+            'capture_peer_cert' => true,
+            'capture_peer_cert_chain' => true,
+            'disable_compression' => true,
+        ],
+    ]
+);
+
+$client = stream_socket_client(
+    'ssl://google.com:443',
+    $errorNumber,
+    $errorDescription,
+    40,
+    STREAM_CLIENT_CONNECT,
+    $streamContext
+);
+
+
+$meta = stream_get_meta_data($client);
+
+print_r($meta);
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+     <![CDATA[
+Array
+(
+    [crypto] => Array
+        (
+            [protocol] => TLSv1.3
+            [cipher_name] => TLS_AES_256_GCM_SHA384
+            [cipher_bits] => 256
+            [cipher_version] => TLSv1.3
+        )
+
+    [timed_out] =>
+    [blocked] => 1
+    [eof] =>
+    [stream_type] => tcp_socket/ssl
+    [mode] => r+
+    [unread_bytes] => 0
+    [seekable] =>
 )
 ]]>
     </screen>


### PR DESCRIPTION
As I reported to Psalm project in https://github.com/vimeo/psalm/issues/6947

I've discovered that Psalm was missing context for the `crypto` key-value when `stream_get_meta_data` is passed a `stream_socket_client` resource. When I reviewed PHP docs I found that this return data was also absent from the page.

From what I see this functionality was added to this function back in PHP 7.0's change cycle. So I believe adding this to the docs may have simply been overlooked.

Certainly open to feedback on how best to document the dynamic nature of this return value. Given that it only applies to PHP 7+ as well as only is returned for `stream_socket_resources`.