### PR TITLE
Document autovivification from false deprecation.

### DIFF
--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -437,6 +437,12 @@ $arr[] = <replaceable>value</replaceable>;
      error. Formerly, the string was silently converted to an array.
     </simpara>
    </note>
+   <note>
+    <simpara>
+     As of PHP 8.1.0, creating a new array from &false; value is deprecated.
+     Creating a new array from &null; and undefined values is still allowed.
+    </simpara>
+   </note>
 
    <para>
     To change a certain

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -422,7 +422,7 @@ $arr[] = <replaceable>value</replaceable>;
 // <replaceable>value</replaceable> may be any value of any type</synopsis>
    
    <para>
-    If <varname>$arr</varname> doesn't exist yet, it will be created, so this is
+    If <varname>$arr</varname> doesn't exist yet or is set to &null; or &false;, it will be created, so this is
     also an alternative way to create an <type>array</type>. This practice is
     however discouraged because if <varname>$arr</varname> already contains
     some value (e.g. <type>string</type> from request variable) then this


### PR DESCRIPTION
https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.autovivification-false

Based on php 8.1 migration guide, added autovivification note.