### PR TITLE
Document returning by reference from a void function deprecation.

### DIFF
--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -515,7 +515,7 @@ function foo(): X|Y {} // Allowed (redundancy is only known at runtime)
     <para>
      Returning by reference from a void function is deprecated as of PHP 8.1.0,
      because such a function is contradictory.
-     Previously, already emits the following
+     Previously, it already emitted the following
      <constant>E_NOTICE</constant> when called:
      <literal>Only variable references should be returned by reference</literal>.
 

--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -513,7 +513,7 @@ function foo(): X|Y {} // Allowed (redundancy is only known at runtime)
    </para>
    <note>
     <para>
-     Returning by reference from a void function is deprecated as of PHP 8.1.0,
+     Returning by reference from a <type>void</type> function is deprecated as of PHP 8.1.0,
      because such a function is contradictory.
      Previously, it already emitted the following
      <constant>E_NOTICE</constant> when called:

--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -511,6 +511,25 @@ function foo(): X|Y {} // Allowed (redundancy is only known at runtime)
     Therefore it cannot be part of a union type declaration.
     Available as of PHP 7.1.0.
    </para>
+   <note>
+    <para>
+     Returning by reference from a void function is deprecated as of PHP 8.1.0,
+     because such a function is contradictory.
+     Previously, already emits the following
+     <constant>E_NOTICE</constant> when called:
+     <literal>Only variable references should be returned by reference</literal>.
+
+     <informalexample>
+      <programlisting role="php">
+<![CDATA[
+<?php
+function &test(): void {}
+?>
+]]>
+      </programlisting>
+     </informalexample>
+    </para>
+   </note>
   </sect3>
 
   <sect3 xml:id="language.types.declarations.never">


### PR DESCRIPTION
Based on [8.1.0 migration guide](https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.void-by-ref), added deprecation note about `returning by reference from a void function`.