### PR TITLE
On page for key(), add link to array_key_first()

### DIFF
--- a/reference/array/functions/key.xml
+++ b/reference/array/functions/key.xml
@@ -86,6 +86,7 @@ fruit5
    <simplelist>
     <member><function>current</function></member>
     <member><function>next</function></member>
+    <member><function>array_key_first</function></member>
     <member><link linkend="control-structures.foreach">foreach</link></member>
    </simplelist>
   </para>


### PR DESCRIPTION
`key()` is often used to get the first key of the array. But it brings various issues related to the array internal pointer, hence the introduction of `array_key_first()` (and its sibling `array_key_last()`) in PHP 7.3. Thus, a "see also" link to this function seems really appropriate, especially as people may not be aware of this newer function.