### PR TITLE
[PHP 8.1] Remove final modifier from `__clone()`

### DIFF
--- a/reference/reflection/reflectionextension/clone.xml
+++ b/reference/reflection/reflectionextension/clone.xml
@@ -44,7 +44,7 @@
      <row>
       <entry>8.1.0</entry>
       <entry>
-       The class is no longer <modifier>final</modifier>.
+       The method is no longer <modifier>final</modifier>.
       </entry>
      </row>
     </tbody>

--- a/reference/reflection/reflectionextension/clone.xml
+++ b/reference/reflection/reflectionextension/clone.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="reflectionextension.clone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionExtension::__clone</refname>
@@ -10,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>private</modifier> <type>void</type><methodname>ReflectionExtension::__clone</methodname>
+   <modifier>private</modifier> <type>void</type><methodname>ReflectionExtension::__clone</methodname>
    <void />
   </methodsynopsis>
   <para>
@@ -42,7 +41,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/reflection/reflectionextension/clone.xml
+++ b/reference/reflection/reflectionextension/clone.xml
@@ -30,6 +30,28 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       The class is no longer <modifier>final</modifier>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/reflection/reflectionfunctionabstract/clone.xml
+++ b/reference/reflection/reflectionfunctionabstract/clone.xml
@@ -32,6 +32,28 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       The class is no longer <modifier>final</modifier>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/reflection/reflectionfunctionabstract/clone.xml
+++ b/reference/reflection/reflectionfunctionabstract/clone.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="reflectionfunctionabstract.clone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionFunctionAbstract::__clone</refname>
@@ -10,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>private</modifier> <type>void</type><methodname>ReflectionFunctionAbstract::__clone</methodname>
+   <modifier>private</modifier> <type>void</type><methodname>ReflectionFunctionAbstract::__clone</methodname>
    <void />
   </methodsynopsis>
   <para>
@@ -43,7 +42,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/reflection/reflectionparameter/clone.xml
+++ b/reference/reflection/reflectionparameter/clone.xml
@@ -32,6 +32,28 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       The class is no longer <modifier>final</modifier>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/reflection/reflectionparameter/clone.xml
+++ b/reference/reflection/reflectionparameter/clone.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="reflectionparameter.clone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionParameter::__clone</refname>
@@ -10,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>private</modifier> <type>void</type><methodname>ReflectionParameter::__clone</methodname>
+   <modifier>private</modifier> <type>void</type><methodname>ReflectionParameter::__clone</methodname>
    <void />
   </methodsynopsis>
   <para>
@@ -44,7 +43,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/reflection/reflectionproperty/clone.xml
+++ b/reference/reflection/reflectionproperty/clone.xml
@@ -32,6 +32,28 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       The class is no longer <modifier>final</modifier>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/reflection/reflectionproperty/clone.xml
+++ b/reference/reflection/reflectionproperty/clone.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="reflectionproperty.clone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionProperty::__clone</refname>
@@ -10,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>private</modifier> <type>void</type><methodname>ReflectionProperty::__clone</methodname>
+   <modifier>private</modifier> <type>void</type><methodname>ReflectionProperty::__clone</methodname>
    <void />
   </methodsynopsis>
   <para>
@@ -44,7 +43,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/reflection/reflectionzendextension/clone.xml
+++ b/reference/reflection/reflectionzendextension/clone.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="reflectionzendextension.clone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionZendExtension::__clone</refname>
@@ -10,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>private</modifier> <type>void</type><methodname>ReflectionZendExtension::__clone</methodname>
+   <modifier>private</modifier> <type>void</type><methodname>ReflectionZendExtension::__clone</methodname>
    <void />
   </methodsynopsis>
   <para>
@@ -35,7 +34,6 @@
 
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/reflection/reflectionzendextension/clone.xml
+++ b/reference/reflection/reflectionzendextension/clone.xml
@@ -32,6 +32,27 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       The class is no longer <modifier>final</modifier>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
- `ReflectionExtension::__clone()` — https://3v4l.org/SEPiF
- `ReflectionFunctionAbstract::__clone()` — https://3v4l.org/d2pT7
- `ReflectionParameter::__clone()` — https://3v4l.org/MBOVF
- `ReflectionProperty::__clone()` — https://3v4l.org/XcB7t
- `ReflectionZendExtension::__clone()` — https://3v4l.org/ksU1U