### PR TITLE
[PHP 8.0] Document returning a non-array from __sleep() warning.

### DIFF
--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -98,7 +98,7 @@
    </note>
    <note>
     <para>
-     As of PHP 8.1.0, returning a value which is not an array from <link linkend="object.sleep">__sleep()</link> generates a diagnostic.
+     As of PHP 8.0.0, returning a value which is not an array from <link linkend="object.sleep">__sleep()</link> generates a warning. Previously, it generated a notice.
     </para>
    </note>
    <para>

--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -96,6 +96,11 @@
      Use <link linkend="object.serialize">__serialize()</link> instead.
     </para>
    </note>
+   <note>
+    <para>
+     As of PHP 8.1.0, returning a value which is not an array from <link linkend="object.sleep">__sleep()</link> generates a diagnostic.
+    </para>
+   </note>
    <para>
     The intended use of <link linkend="object.sleep">__sleep()</link> is to commit pending
     data or perform similar cleanup tasks. Also, the function is


### PR DESCRIPTION
https://3v4l.org/m1pdW#v8.1rc3

Based on 8.1.0 [migration guide](https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.magic-sleep), added warning note about __sleep magic method.