### PR TITLE
[PHP 8.1] Add note about implementing Serializable without __serialize

### DIFF
--- a/language/predefined/serializable.xml
+++ b/language/predefined/serializable.xml
@@ -28,8 +28,7 @@
    
    <warning>
     <para>
-     As of PHP 8.1.0, a class which implements Serializable without also implementing <link linkend="object.serialize">__serialize()</link> and <link linkend="object.unserialize">__unserialize()</link> will generate a deprecation warning.
-     This interface will be removed in PHP 9.0.0.
+     As of PHP 8.1.0, a class which implements <interfacename>Serializable</interfacename> without also implementing <link linkend="object.serialize">__serialize()</link> and <link linkend="object.unserialize">__unserialize()</link> will generate a deprecation warning.
     </para>
    </warning>
   </section>

--- a/language/predefined/serializable.xml
+++ b/language/predefined/serializable.xml
@@ -25,6 +25,13 @@
     a constructor instead of calling __construct(). If you need to execute the standard
     constructor you may do so in the method.
    </para>
+   
+   <warning>
+    <para>
+     As of PHP 8.1.0, a class which implements Serializable without also implementing <link linkend="object.serialize">__serialize()</link> and <link linkend="object.unserialize">__unserialize()</link> will generate a deprecation warning.
+     This interface will be removed in PHP 9.0.0.
+    </para>
+   </warning>
   </section>
 <!-- }}} -->
 
@@ -100,15 +107,6 @@ string(15) "My private data"
  &language.predefined.serializable.unserialize;
 
 </phpdoc:classref>
-
-<note>
-    <para>
-        As of PHP 8.1.0, a class which implements Serializable without also implementing <link linkend="object.serialize">__serialize()</link> and <link linkend="object.unserialize">__unserialize()</link> will generate a deprecation warning.
-
-        This interface will be removed in PHP 9.0.0.
-    </para>
-</note>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/predefined/serializable.xml
+++ b/language/predefined/serializable.xml
@@ -101,6 +101,14 @@ string(15) "My private data"
 
 </phpdoc:classref>
 
+<note>
+    <para>
+        As of PHP 8.1.0, a class which implements Serializable without also implementing <link linkend="object.serialize">__serialize()</link> and <link linkend="object.unserialize">__unserialize()</link> will generate a deprecation warning.
+
+        This interface will be removed in PHP 9.0.0.
+    </para>
+</note>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
Apologies if this is poorly formed - wasn't able to get the documentation to build properly on my machine but this looks like a fairly straightforward change.

Ref #980 "Implementing Serializable without __serialize() and __unserialize()"

RFC reference https://wiki.php.net/rfc/phase_out_serializable