### PR TITLE
Correct note to state behavior is possible

### DIFF
--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -348,7 +348,7 @@ function get_item(): ?string {
 
   <note>
    <para>
-    Prior to PHP 7.1.0, it was possible to achieve nullable arguments by making
+    It is possible to achieve nullable arguments by making
     <literal>null</literal> the default value.
     This is not recommended as this breaks during inheritance.
    </para>


### PR DESCRIPTION
The behavior in the `Example #7 Old way to make arguments nullable` is still possible in PHP today.

For reference, I thought initially this was a bug in the PHP Core, and tried to add the respective test case in the PR:

https://github.com/php/php-src/pull/7627