### PR TITLE
mb_ overloading was removed in 8.0.0

### DIFF
--- a/reference/mbstring/overloading.xml
+++ b/reference/mbstring/overloading.xml
@@ -7,7 +7,7 @@
  </title>
 
  <para>
-  &warn.deprecated.feature-7-2-0;
+  &warn.deprecated.feature-7-2-0.removed-8-0-0;
  </para>
  <para>
   You might often find it difficult to get an existing PHP application


### PR DESCRIPTION
warning: untested, i don't know if `warn.deprecated.function-7-2-0.removed-8-0-0` is a real... thing. but i guess it's a real thing, after studying the code for similar error messages..