### PR TITLE
fixed typo

### DIFF
--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -839,7 +839,7 @@ $error_descriptions[8] = "This is just an informal notice";
    exceptions: integer properties are unaccessible;
    private variables have the class name prepended to the variable
    name; protected variables have a '*' prepended to the variable name. These
-   prepended values have <literal>NUL</literal> bytes on either side.
+   prepended values have <literal>NULL</literal> bytes on either side.
    Uninitialized <link linkend="language.oop5.properties.typed-properties">typed properties</link>
    are silently discarded.
   </para>
@@ -877,7 +877,7 @@ array (
   </informalexample>
 
   <para>
-   These <literal>NUL</literal> can result in some unexpected behaviour:
+   These <literal>NULL</literal> can result in some unexpected behaviour:
   </para>
 
   <informalexample>


### PR DESCRIPTION
`NUL` is a typo? 
the correct one is  `NULL`?