### PR TITLE
[8.0] Document remaining core changes

### DIFF
--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -170,13 +170,12 @@ $instance = new $className(); // new SimpleClass()
     is supported. This allows more complex instantiation if the expression
     produces a <type>string</type>.
    </para>
-   <para>
-    In the given example the arbitrary expression is a simple string concatenation.
-    However, this could also be a call to a function, or class method, that returns a
-    <type>string</type> containing the name of a valid class.
-   </para>
    <example>
     <title>Creating an instance using an arbitrary expression</title>
+    <para>
+     In the given example we show multiple examples of valid arbitrary expressions that produce a class name.
+     This shows a call to a function, string concatenation, and the <constant>::class</constant> constant.
+    </para>
     <programlisting role="php">
      <![CDATA[
 <?php
@@ -188,13 +187,13 @@ class ClassD extends ClassA {}
 
 function getSomeClass(): string
 {
-    return ClassA::class;
+    return 'ClassA';
 }
 
 var_dump(new (getSomeClass()));
 var_dump(new ('Class' . 'B'));
 var_dump(new ('Class' . 'C'));
-var_dump(new ClassD);
+var_dump(new (ClassD::class));
 ?>
 ]]>
     </programlisting>

--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -167,8 +167,8 @@ $instance = new $className(); // new SimpleClass()
    </example>
    <para>
     As of PHP 8.0.0, using <literal>new</literal> with arbitrary expressions
-    is supported. This allows more complex instance creation as long as the
-    expression produces a <type>string</type>.
+    is supported. This allows more complex instantiation if the expression
+    produces a <type>string</type>.
    </para>
    <para>
     In the given example the arbitrary expression is a simple string concatenation.

--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -166,6 +166,54 @@ $instance = new $className(); // new SimpleClass()
     </programlisting>
    </example>
    <para>
+    Starting in PHP 8.0 and forward using <literal>new</literal> with
+    arbitrary expressions is supported. This allows more complex instance creation
+    as long as the expression produces a <type>string</type>.
+   </para>
+   <para>
+    In the given example the arbitrary expression is a simple string concatenation.
+    However, this could also be a call to a function, or class method, that returns a
+    <type>string</type> containing the name of a valid class.
+   </para>
+   <example>
+    <title>Creating an instance using an arbitrary expression</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+
+trait VerboseConstruct {
+    public function __construct() {
+        echo static::class . '::' . __FUNCTION__ . PHP_EOL;
+    }
+}
+
+class ClassA extends \stdClass { use VerboseConstruct; }
+class ClassB extends \stdClass { use VerboseConstruct; }
+class ClassC extends ClassB {}
+class ClassD extends ClassA {}
+
+$className = 'Class';
+foreach (['A', 'B', 'C', 'D'] as $classSuffix) {
+    // Supported as of PHP 8.0+
+    new ($className . $classSuffix);
+    // Before PHP 8.0
+    // $fullClassName = $className . $classSuffix;
+    // new $fullClassName;
+}
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+     <![CDATA[
+ClassA::__construct
+ClassB::__construct
+ClassC::__construct
+ClassD::__construct
+]]>
+    </screen>
+   </example>
+   <para>
     In the class context, it is possible to create a new object by
     <literal>new self</literal> and <literal>new parent</literal>.
    </para>

--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -168,7 +168,7 @@ $instance = new $className(); // new SimpleClass()
    <para>
     As of PHP 8.0.0, using <literal>new</literal> with arbitrary expressions
     is supported. This allows more complex instantiation if the expression
-    produces a <type>string</type>.
+    produces a <type>string</type>. The express must be wrapped in parentheses.
    </para>
    <example>
     <title>Creating an instance using an arbitrary expression</title>

--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -181,35 +181,35 @@ $instance = new $className(); // new SimpleClass()
      <![CDATA[
 <?php
 
-trait VerboseConstruct {
-    public function __construct() {
-        echo static::class . '::' . __FUNCTION__ . PHP_EOL;
-    }
-}
-
-class ClassA extends \stdClass { use VerboseConstruct; }
-class ClassB extends \stdClass { use VerboseConstruct; }
+class ClassA extends \stdClass {}
+class ClassB extends \stdClass {}
 class ClassC extends ClassB {}
 class ClassD extends ClassA {}
 
-$className = 'Class';
-foreach (['A', 'B', 'C', 'D'] as $classSuffix) {
-    // Supported as of PHP 8.0.0
-    new ($className . $classSuffix);
-    // Before PHP 8.0
-    // $fullClassName = $className . $classSuffix;
-    // new $fullClassName;
+function getSomeClass(): string
+{
+    return ClassA::class;
 }
+
+var_dump(new (getSomeClass()));
+var_dump(new ('Class' . 'B'));
+var_dump(new ('Class' . 'C'));
+var_dump(new ClassD);
 ?>
 ]]>
     </programlisting>
     &example.outputs.8;
     <screen>
      <![CDATA[
-ClassA::__construct
-ClassB::__construct
-ClassC::__construct
-ClassD::__construct
+object(ClassA)#1 (0) {
+}
+object(ClassB)#1 (0) {
+}
+object(ClassC)#1 (0) {
+}
+object(ClassD)#1 (0) {
+}
+
 ]]>
     </screen>
    </example>

--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -194,7 +194,7 @@ class ClassD extends ClassA {}
 
 $className = 'Class';
 foreach (['A', 'B', 'C', 'D'] as $classSuffix) {
-    // Supported as of PHP 8.0+
+    // Supported as of PHP 8.0.0
     new ($className . $classSuffix);
     // Before PHP 8.0
     // $fullClassName = $className . $classSuffix;
@@ -203,7 +203,7 @@ foreach (['A', 'B', 'C', 'D'] as $classSuffix) {
 ?>
 ]]>
     </programlisting>
-    &example.outputs.similar;
+    &example.outputs.8;
     <screen>
      <![CDATA[
 ClassA::__construct

--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -168,7 +168,7 @@ $instance = new $className(); // new SimpleClass()
    <para>
     As of PHP 8.0.0, using <literal>new</literal> with arbitrary expressions
     is supported. This allows more complex instantiation if the expression
-    produces a <type>string</type>. The express must be wrapped in parentheses.
+    produces a <type>string</type>. The expressions must be wrapped in parentheses.
    </para>
    <example>
     <title>Creating an instance using an arbitrary expression</title>

--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -166,9 +166,9 @@ $instance = new $className(); // new SimpleClass()
     </programlisting>
    </example>
    <para>
-    Starting in PHP 8.0 and forward using <literal>new</literal> with
-    arbitrary expressions is supported. This allows more complex instance creation
-    as long as the expression produces a <type>string</type>.
+    As of PHP 8.0.0, using <literal>new</literal> with arbitrary expressions
+    is supported. This allows more complex instance creation as long as the
+    expression produces a <type>string</type>.
    </para>
    <para>
     In the given example the arbitrary expression is a simple string concatenation.

--- a/language/operators.xml
+++ b/language/operators.xml
@@ -2723,6 +2723,7 @@ bool(false)
    </para>
    <para>
     As of PHP 8.0.0, <literal>instanceof</literal> can now be used with arbitrary expressions.
+    The expression must be wrapped in parentheses and produce a <type>string</type>.
     <!-- RFC: https://wiki.php.net/rfc/variable_syntax_tweaks -->
     <example>
      <title>Using <literal>instanceof</literal> with an arbitrary expression</title>

--- a/language/operators.xml
+++ b/language/operators.xml
@@ -2736,31 +2736,25 @@ class ClassB extends \stdClass {}
 class ClassC extends ClassB {}
 class ClassD extends ClassA {}
 
-$className = 'Class';
-foreach ([new ClassA, new ClassB, new ClassC, new ClassD] as $class) {
-    echo "Checking on " . $class::class . PHP_EOL;
-    foreach (['A', 'B', 'C', 'D'] as $classSuffix) {
-        if ($class instanceof ($className . $classSuffix)) {
-            echo $class::class . ' is an instance of ' . ($className . $classSuffix) . PHP_EOL;
-        }
-    }
+function getSomeClass(): string
+{
+    return ClassA::class;
 }
+
+var_dump(new ClassA instanceof ('std' . 'Class'));
+var_dump(new ClassB instanceof ('Class' . 'B'));
+var_dump(new ClassC instanceof ('Class' . 'A'));
+var_dump(new ClassD instanceof (getSomeClass()));
 ?>
 ]]>
      </programlisting>
      &example.outputs.8;
      <screen>
       <![CDATA[
-Checking on ClassA
-ClassA is an instance of ClassA
-Checking on ClassB
-ClassB is an instance of ClassB
-Checking on ClassC
-ClassC is an instance of ClassB
-ClassC is an instance of ClassC
-Checking on ClassD
-ClassD is an instance of ClassA
-ClassD is an instance of ClassD
+bool(true)
+bool(true)
+bool(false)
+bool(true)
 ]]>
      </screen>
     </example>

--- a/language/operators.xml
+++ b/language/operators.xml
@@ -2721,6 +2721,50 @@ bool(false)
      </screen>
     </example>
    </para>
+   <para>
+    As of PHP 8.0, <literal>instanceof</literal> can now be used with
+    arbitrary expressions, like <code>$obj instanceof (expression)</code>.
+    <!-- RFC: https://wiki.php.net/rfc/variable_syntax_tweaks -->.
+    <example>
+     <title>Using <literal>instanceof</literal> with an arbitrary expression</title>
+     <programlisting role="php">
+      <![CDATA[
+<?php
+
+class ClassA extends \stdClass {}
+class ClassB extends \stdClass {}
+class ClassC extends ClassB {}
+class ClassD extends ClassA {}
+
+$className = 'Class';
+foreach ([new ClassA, new ClassB, new ClassC, new ClassD] as $class) {
+    echo "Checking on " . $class::class . PHP_EOL;
+    foreach (['A', 'B', 'C', 'D'] as $classSuffix) {
+        if ($class instanceof ($className . $classSuffix)) {
+            echo $class::class . ' is an instance of ' . ($className . $classSuffix) . PHP_EOL;
+        }
+    }
+}
+?>
+]]>
+     </programlisting>
+     &example.outputs.80;
+     <screen>
+      <![CDATA[
+Checking on ClassA
+ClassA is an instance of ClassA
+Checking on ClassB
+ClassB is an instance of ClassB
+Checking on ClassC
+ClassC is an instance of ClassB
+ClassC is an instance of ClassC
+Checking on ClassD
+ClassD is an instance of ClassA
+ClassD is an instance of ClassD
+]]>
+     </screen>
+    </example>
+   </para>
    <simpara>
     The <literal>instanceof</literal> operator has a functional variant
     with the <function>is_a</function> function.

--- a/language/operators.xml
+++ b/language/operators.xml
@@ -2748,7 +2748,7 @@ foreach ([new ClassA, new ClassB, new ClassC, new ClassD] as $class) {
 ?>
 ]]>
      </programlisting>
-     &example.outputs.80;
+     &example.outputs.8;
      <screen>
       <![CDATA[
 Checking on ClassA

--- a/language/operators.xml
+++ b/language/operators.xml
@@ -2722,8 +2722,8 @@ bool(false)
     </example>
    </para>
    <para>
-    As of PHP 8.0.0 <literal>instanceof</literal> can now be used with
-    arbitrary expressions, for example <code>$obj instanceof (expression)</code>.
+    As of PHP 8.0.0, <literal>instanceof</literal> can now be used with
+    arbitrary expressions, for example, <code>$obj instanceof (expression)</code>.
     <!-- RFC: https://wiki.php.net/rfc/variable_syntax_tweaks -->
     <example>
      <title>Using <literal>instanceof</literal> with an arbitrary expression</title>

--- a/language/operators.xml
+++ b/language/operators.xml
@@ -2723,7 +2723,7 @@ bool(false)
    </para>
    <para>
     As of PHP 8.0, <literal>instanceof</literal> can now be used with
-    arbitrary expressions, like <code>$obj instanceof (expression)</code>.
+    arbitrary expressions, for example <code>$obj instanceof (expression)</code>.
     <!-- RFC: https://wiki.php.net/rfc/variable_syntax_tweaks -->
     <example>
      <title>Using <literal>instanceof</literal> with an arbitrary expression</title>

--- a/language/operators.xml
+++ b/language/operators.xml
@@ -2723,7 +2723,7 @@ bool(false)
    </para>
    <para>
     As of PHP 8.0.0, <literal>instanceof</literal> can now be used with
-    arbitrary expressions, for example, <code>$obj instanceof (expression)</code>.
+    arbitrary expressions, for example, <code>$obj instanceof ('std' . 'Class')</code>.
     <!-- RFC: https://wiki.php.net/rfc/variable_syntax_tweaks -->
     <example>
      <title>Using <literal>instanceof</literal> with an arbitrary expression</title>

--- a/language/operators.xml
+++ b/language/operators.xml
@@ -2722,7 +2722,7 @@ bool(false)
     </example>
    </para>
    <para>
-    As of PHP 8.0, <literal>instanceof</literal> can now be used with
+    As of PHP 8.0.0 <literal>instanceof</literal> can now be used with
     arbitrary expressions, for example <code>$obj instanceof (expression)</code>.
     <!-- RFC: https://wiki.php.net/rfc/variable_syntax_tweaks -->
     <example>

--- a/language/operators.xml
+++ b/language/operators.xml
@@ -2722,8 +2722,7 @@ bool(false)
     </example>
    </para>
    <para>
-    As of PHP 8.0.0, <literal>instanceof</literal> can now be used with
-    arbitrary expressions, for example, <code>$obj instanceof ('std' . 'Class')</code>.
+    As of PHP 8.0.0, <literal>instanceof</literal> can now be used with arbitrary expressions.
     <!-- RFC: https://wiki.php.net/rfc/variable_syntax_tweaks -->
     <example>
      <title>Using <literal>instanceof</literal> with an arbitrary expression</title>

--- a/language/operators.xml
+++ b/language/operators.xml
@@ -2724,7 +2724,7 @@ bool(false)
    <para>
     As of PHP 8.0, <literal>instanceof</literal> can now be used with
     arbitrary expressions, like <code>$obj instanceof (expression)</code>.
-    <!-- RFC: https://wiki.php.net/rfc/variable_syntax_tweaks -->.
+    <!-- RFC: https://wiki.php.net/rfc/variable_syntax_tweaks -->
     <example>
      <title>Using <literal>instanceof</literal> with an arbitrary expression</title>
      <programlisting role="php">

--- a/reference/misc/functions/define.xml
+++ b/reference/misc/functions/define.xml
@@ -99,8 +99,7 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        passing <literal>true</literal> to <parameter>case_insensitive</parameter> will produce a warning.
-        Note that passing <literal>false</literal> is allowed and will not produce any warning at all.
+        Passing &true; to <parameter>case_insensitive</parameter> now emits an <constant>E_WARNING</constant>. Passing &false; is still allowed.
        </entry>
       </row>
       <row>

--- a/reference/misc/functions/define.xml
+++ b/reference/misc/functions/define.xml
@@ -71,6 +71,11 @@
         <literal>true</literal> will produce a warning.
        </simpara>
       </warning>
+      <note>
+       <para>
+        Case-insensitive constants are stored as lower-case.
+       </para>
+      </note>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/misc/functions/define.xml
+++ b/reference/misc/functions/define.xml
@@ -67,14 +67,10 @@
       <warning>
        <simpara>
         Defining case-insensitive constants is deprecated as of PHP 7.3.0.
-        In PHP 8.0 only <literal>false</literal> is an acceptable value.
+        In PHP 8.0 only <literal>false</literal> is an acceptable value, passing
+        <literal>true</literal> will produce a warning.
        </simpara>
       </warning>
-      <note>
-       <para>
-        Case-insensitive constants are stored as lower-case.
-       </para>
-      </note>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/misc/functions/define.xml
+++ b/reference/misc/functions/define.xml
@@ -67,6 +67,7 @@
       <warning>
        <simpara>
         Defining case-insensitive constants is deprecated as of PHP 7.3.0.
+        In PHP 8.0 only <literal>false</literal> is an acceptable value.
        </simpara>
       </warning>
       <note>

--- a/reference/misc/functions/define.xml
+++ b/reference/misc/functions/define.xml
@@ -67,7 +67,7 @@
       <warning>
        <simpara>
         Defining case-insensitive constants is deprecated as of PHP 7.3.0.
-        In PHP 8.0 only <literal>false</literal> is an acceptable value, passing
+        As of PHP 8.0.0, only <literal>false</literal> is an acceptable value, passing
         <literal>true</literal> will produce a warning.
        </simpara>
       </warning>

--- a/reference/misc/functions/define.xml
+++ b/reference/misc/functions/define.xml
@@ -100,6 +100,13 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.0.0</entry>
+       <entry>
+        passing <literal>true</literal> to <parameter>case_insensitive</parameter> will produce a warning.
+        Note that passing <literal>false</literal> is allowed and will not produce any warning at all.
+       </entry>
+      </row>
+      <row>
        <entry>7.3.0</entry>
        <entry>
         <parameter>case_insensitive</parameter> has been deprecated and will be removed in version 8.0.0.


### PR DESCRIPTION
This PR is an attempt to solve the remaining core items in: https://github.com/php/doc-en/issues/674

Specifically this will cover the following:

- [x] `new` and `instanceof` can now be used with arbitrary expressions
- [x] The ability to define case-insensitive constants has been removed. The third argument to define() may no longer be true.