### PR TITLE
Adjusting Changelog versions for getenv() & get_defined_functions() parameters

### DIFF
--- a/reference/funchand/functions/get-defined-functions.xml
+++ b/reference/funchand/functions/get-defined-functions.xml
@@ -61,7 +61,7 @@
       </entry>
      </row>
      <row>
-      <entry>7.0.15, 7.1.1</entry>
+      <entry>7.1.1</entry>
       <entry>
        The <parameter>exclude_disabled</parameter> parameter has been added.
       </entry>

--- a/reference/info/functions/getenv.xml
+++ b/reference/info/functions/getenv.xml
@@ -82,7 +82,7 @@
       </entry>
      </row>
      <row>
-      <entry>7.0.9</entry>
+      <entry>5.6.24</entry>
       <entry>
        The <parameter>local_only</parameter> parameter has been added.
       </entry>


### PR DESCRIPTION
The inconsistencies were detected during functions reflection inspections:
- for `get_defined_functions()`: https://3v4l.org/T7JFt
- for `getenv()`: https://3v4l.org/IVadX#v540