### PR TITLE
Drop use of noise word "respectively"

### DIFF
--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -81,78 +81,78 @@ var_dump(B::counter()); // int(4), previously int(2)
   <itemizedlist>
    <listitem>
     <para>
-     The <link linkend="book.fileinfo">FileInfo</link> functions now accept and return,
-     respectively, <classname>finfo</classname> objects instead of
+     The <link linkend="book.fileinfo">FileInfo</link> functions now accept and return
+     <classname>finfo</classname> objects instead of
      <literal>fileinfo</literal> &resource;s.
     </para>
    </listitem>
    <listitem>
     <para>
-     The <link linkend="book.ftp">FTP</link> functions now accept and return,
-     respectively, <classname>FTP\Connection</classname> objects instead of
+     The <link linkend="book.ftp">FTP</link> functions now accept and return
+     <classname>FTP\Connection</classname> objects instead of
      <literal>ftp</literal> &resource;s.
     </para>
    </listitem>
    <listitem>
     <para>
-     The <link linkend="book.imap">IMAP</link> functions now accept and return,
-     respectively, <classname>IMAP\Connection</classname> objects instead of
+     The <link linkend="book.imap">IMAP</link> functions now accept and return
+     <classname>IMAP\Connection</classname> objects instead of
      <literal>imap</literal> &resource;s.
     </para>
    </listitem>
    <listitem>
     <para>
-     The <link linkend="book.ldap">LDAP</link> functions now accept and return,
-     respectively, <classname>LDAP\Connection</classname> objects instead of
+     The <link linkend="book.ldap">LDAP</link> functions now accept and return
+     <classname>LDAP\Connection</classname> objects instead of
      <literal>ldap link</literal> &resource;s.
     </para>
    </listitem>
    <listitem>
     <para>
-     The <link linkend="book.ldap">LDAP</link> functions now accept and return,
-     respectively, <classname>LDAP\Result</classname> objects instead of
+     The <link linkend="book.ldap">LDAP</link> functions now accept and return
+     <classname>LDAP\Result</classname> objects instead of
      <literal>ldap result</literal> &resource;s.
     </para>
    </listitem>
    <listitem>
     <para>
-     The <link linkend="book.ldap">LDAP</link> functions now accept and return,
-     respectively, <classname>LDAP\ResultEntry</classname> objects instead of
+     The <link linkend="book.ldap">LDAP</link> functions now accept and return
+     <classname>LDAP\ResultEntry</classname> objects instead of
      <literal>ldap result entry</literal> &resource;s.
     </para>
    </listitem>
    <listitem>
     <para>
-     The <link linkend="book.pgsql">PgSQL</link> functions now accept and return,
-     respectively, <classname>PgSql\Connection</classname> objects instead of
+     The <link linkend="book.pgsql">PgSQL</link> functions now accept and return
+     <classname>PgSql\Connection</classname> objects instead of
      <literal>pgsql link</literal> &resource;s.
     </para>
    </listitem>
    <listitem>
     <para>
-     The <link linkend="book.pgsql">PgSQL</link> functions now accept and return,
-     respectively, <classname>PgSql\Result</classname> objects instead of
+     The <link linkend="book.pgsql">PgSQL</link> functions now accept and return
+     <classname>PgSql\Result</classname> objects instead of
      <literal>pgsql result</literal> &resource;s.
     </para>
    </listitem>
    <listitem>
     <para>
-     The <link linkend="book.pgsql">PgSQL</link> functions now accept and return,
-     respectively, <classname>PgSql\Lob</classname> objects instead of
+     The <link linkend="book.pgsql">PgSQL</link> functions now accept and return
+     <classname>PgSql\Lob</classname> objects instead of
      <literal>pgsql large object</literal> &resource;s.
     </para>
    </listitem>
    <listitem>
     <para>
-     The <link linkend="book.pspell">PSpell</link> functions now accept and return,
-     respectively, <classname>PSpell\Dictionary</classname> objects instead of
+     The <link linkend="book.pspell">PSpell</link> functions now accept and return
+     <classname>PSpell\Dictionary</classname> objects instead of
      <literal>pspell</literal> &resource;s.
     </para>
    </listitem>
    <listitem>
     <para>
-     The <link linkend="book.pspell">PSpell</link> functions now accept and return,
-     respectively, <classname>PSpell\Config</classname> objects instead of
+     The <link linkend="book.pspell">PSpell</link> functions now accept and return
+     <classname>PSpell\Config</classname> objects instead of
      <literal>pspell config</literal> &resource;s.
     </para>
    </listitem>


### PR DESCRIPTION
That's not what "respectively" means.

http://www.lexico.com/definition/respectively

"The PSpell functions now accept and return, respectively, PSpell\Config objects instead of pspell config resources."
means (a) there are precisely _two_ PSpell functions, where the first one (and you know which one that is) now accepts an object instead of a resource, and the second returns one.