### PR TITLE
Add list of attribute target constants

### DIFF
--- a/language/attributes.xml
+++ b/language/attributes.xml
@@ -336,13 +336,13 @@ class MyAttribute
    <para>The following targets can be specified:</para>
    
    <simplelist>
-    <member><literal>Attribute::TARGET_CLASS</literal></member>
-    <member><literal>Attribute::TARGET_FUNCTION</literal></member>
-    <member><literal>Attribute::TARGET_METHOD</literal></member>
-    <member><literal>Attribute::TARGET_PROPERTY</literal></member>
-    <member><literal>Attribute::TARGET_CLASS_CONSTANT</literal></member>
-    <member><literal>Attribute::TARGET_PARAMETER</literal></member>
-    <member><literal>Attribute::TARGET_ALL</literal></member>
+    <member><constant>Attribute::TARGET_CLASS</constant></member>
+    <member><constant>Attribute::TARGET_FUNCTION</constant></member>
+    <member><constant>Attribute::TARGET_METHOD</constant></member>
+    <member><constant>Attribute::TARGET_PROPERTY</constant></member>
+    <member><constant>Attribute::TARGET_CLASS_CONSTANT</constant></member>
+    <member><constant>Attribute::TARGET_PARAMETER</constant></member>
+    <member><constant>Attribute::TARGET_ALL</constant></member>
    </simplelist>
 
    <para>

--- a/language/attributes.xml
+++ b/language/attributes.xml
@@ -349,7 +349,7 @@ class MyAttribute
     By default an attribute can only be used once per declaration. If the attribute should be repeatable on declarations it must
     be specified as part of the bitmask to the <literal>#[Attribute]</literal> declaration.
    </para>
-   
+
    <example>
     <title>Using IS_REPEATABLE to allow attribute on a declaration multiple times</title>
 

--- a/language/attributes.xml
+++ b/language/attributes.xml
@@ -333,11 +333,23 @@ class MyAttribute
     </para>
    </example>
 
+   <para>The following targets can be specified:</para>
+   
+   <simplelist>
+    <member><literal>Attribute::TARGET_CLASS</literal></member>
+    <member><literal>Attribute::TARGET_FUNCTION</literal></member>
+    <member><literal>Attribute::TARGET_METHOD</literal></member>
+    <member><literal>Attribute::TARGET_PROPERTY</literal></member>
+    <member><literal>Attribute::TARGET_CLASS_CONSTANT</literal></member>
+    <member><literal>Attribute::TARGET_PARAMETER</literal></member>
+    <member><literal>Attribute::TARGET_ALL</literal></member>
+   </simplelist>
+
    <para>
     By default an attribute can only be used once per declaration. If the attribute should be repeatable on declarations it must
     be specified as part of the bitmask to the <literal>#[Attribute]</literal> declaration.
    </para>
-
+   
    <example>
     <title>Using IS_REPEATABLE to allow attribute on a declaration multiple times</title>
 


### PR DESCRIPTION
I wasn't able to find these anywhere in the Attributes documentation, and needed to use reflection to find the valid values.

I think the constant names are self-explanatory enough to not require additional information.