### PR TITLE
Moved [overview|example] of Fibers to language/fibers.xml page.

### DIFF
--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -81,7 +81,7 @@ $arr2 = [...$arr1, 'c' => 'd']; //[1, 'a', 'c' => 'd']
    <title>Fibers</title>
 
    <para>
-    Support for <link linkend="class.fiber">Fibers</link> has been added.
+    Support for <link linkend="language.fibers">Fibers</link> has been added.
     <!-- RFC: https://wiki.php.net/rfc/fibers -->
    </para>
   </sect3>

--- a/language/fibers.xml
+++ b/language/fibers.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<chapter xml:id="language.fibers" xmlns="http://docbook.org/ns/docbook">
+ <title>Fibers</title>
+
+ <simplesect xml:id="language.fibers.overview">
+  <title>Fibers overview</title>
+  <?phpdoc print-version-for="fiber"?>
+  <para>
+   Fibers represent full-stack, interruptible functions. Fibers may be suspended from anywhere in the call-stack,
+   pausing execution within the fiber until the fiber is resumed at a later time.
+  </para>
+  <para>
+   Fibers pause the entire execution stack, so the direct caller of the function does not need to change how it
+   invokes the function.
+  </para>
+  <para>
+   Execution may be interrupted anywhere in the call stack using <methodname>Fiber::suspend</methodname>
+   (that is, the call to <methodname>Fiber::suspend</methodname> may be in a deeply nested function or not
+   even exist at all).
+  </para>
+  <para>
+   Unlike stack-less <classname>Generator</classname>s, each <classname>Fiber</classname> has its own call stack,
+   allowing them to be paused within deeply nested function calls. A function declaring an interruption point
+   (that is, calling <methodname>Fiber::suspend</methodname>) need not change its return type, unlike a function using
+   &yield; which must return a <classname>Generator</classname> instance.
+  </para>
+  <para>
+   Fibers can be suspended in any function call, including those called from within the PHP VM, such as functions
+   provided to <function>array_map</function> or methods called by foreach on an
+   <classname>Iterator</classname> object.
+  </para>
+  <para>
+   Once suspended, execution of the fiber may be resumed with any value using <methodname>Fiber::resume</methodname>
+   or by throwing an exception into the fiber using <methodname>Fiber::throw</methodname>. The value is returned
+   (or exception thrown) from <methodname>Fiber::suspend</methodname>.
+  </para>
+
+  <example xml:id="language.fiber.example.basic"><!-- {{{ -->
+   <title>Basic usage</title>
+   <programlisting role="php">
+    <![CDATA[
+<?php
+$fiber = new Fiber(function (): void {
+   $value = Fiber::suspend('fiber');
+   echo "Value used to resume fiber: ", $value, PHP_EOL;
+});
+
+$value = $fiber->start();
+
+echo "Value from fiber suspending: ", $value, PHP_EOL;
+
+$fiber->resume('test');
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+    <![CDATA[
+Value from fiber suspending: fiber
+Value used to resume fiber: test
+]]>
+   </screen>
+  </example><!-- }}} -->
+
+ </simplesect>
+
+</chapter>
+ 
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/predefined/fiber.xml
+++ b/language/predefined/fiber.xml
@@ -12,31 +12,6 @@
     Fibers represent full-stack, interruptible functions. Fibers may be suspended from anywhere in the call-stack,
     pausing execution within the fiber until the fiber is resumed at a later time.
    </para>
-   <para>
-    Fibers pause the entire execution stack, so the direct caller of the function does not need to change how it
-    invokes the function.
-   </para>
-   <para>
-    Execution may be interrupted anywhere in the call stack using <methodname>Fiber::suspend</methodname>
-    (that is, the call to <methodname>Fiber::suspend</methodname> may be in a deeply nested function or not
-    even exist at all).
-   </para>
-   <para>
-    Unlike stack-less <classname>Generator</classname>s, each <classname>Fiber</classname> has its own call stack,
-    allowing them to be paused within deeply nested function calls. A function declaring an interruption point
-    (that is, calling <methodname>Fiber::suspend</methodname>) need not change its return type, unlike a function using
-    &yield; which must return a <classname>Generator</classname> instance.
-   </para>
-   <para>
-    Fibers can be suspended in any function call, including those called from within the PHP VM, such as functions
-    provided to <function>array_map</function> or methods called by foreach on an
-    <classname>Iterator</classname> object.
-   </para>
-   <para>
-    Once suspended, execution of the fiber may be resumed with any value using <methodname>Fiber::resume</methodname>
-    or by throwing an exception into the fiber using <methodname>Fiber::throw</methodname>. The value is returned
-    (or exception thrown) from <methodname>Fiber::suspend</methodname>.
-   </para>
   </section>
 <!-- }}} -->
 
@@ -63,35 +38,6 @@
    </classsynopsis>
 <!-- }}} -->
 
-  </section>
-
-  <section xml:id="fiber.examples">
-   <example xml:id="fiber.example.basic"><!-- {{{ -->
-    <title>Basic usage</title>
-    <programlisting role="php">
-     <![CDATA[
-<?php
-$fiber = new Fiber(function (): void {
-    $value = Fiber::suspend('fiber');
-    echo "Value used to resume fiber: ", $value, PHP_EOL;
-});
-
-$value = $fiber->start();
-
-echo "Value from fiber suspending: ", $value, PHP_EOL;
-
-$fiber->resume('test');
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-     <![CDATA[
-Value from fiber suspending: fiber
-Value used to resume fiber: test
-]]>
-    </screen>
-   </example><!-- }}} -->
   </section>
 
  </partintro>


### PR DESCRIPTION
Moved Fibers overview contents to be linked from the top page of manual, because it is core functionality like Generators.

We must merge https://github.com/php/doc-base/pull/53, or build will fail.