### PR TITLE
[PHP 8.1] Document the first class callable syntax.

### DIFF
--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -90,7 +90,7 @@ $arr2 = [...$arr1, 'c' => 'd']; //[1, 'a', 'c' => 'd']
    <title>First Class Callable Syntax</title>
 
    <para>
-    Closures for callables can now be created using the syntax <code>myFunc(...)</code>,
+    Closures for callables can now be created using <link linkend="functions.first_class_callable_syntax">the syntax <code>myFunc(...)</code></link>,
     which is identical to <code>Closure::fromCallable('myFunc')</code>.
     <!-- RFC: https://wiki.php.net/rfc/first_class_callable_syntax -->
    </para>

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1509,7 +1509,7 @@ var_export($x);  // Outputs 1
 
    <para>
     The first class callable syntax is introduced as of PHP 8.1.0, as a way of creating <link linkend="functions.anonymous">anonymous functions</link> from <link linkend="language.types.callable">callable</link>.
-    It supersedes existing callable encodings using strings and arrays.
+    It supersedes existing callable syntax using strings and arrays.
     The advantage of this syntax is that it is accessible to static analysis, and uses the scope at the point where the callable is acquired.
    </para>
 

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1504,6 +1504,127 @@ var_export($x);  // Outputs 1
    </sect2>
   </sect1>
 
+  <sect1 xml:id="functions.first_class_callable_syntax">
+   <title>First class callable syntax</title>
+
+   <para>
+    The first class callable syntax is introduced as of PHP 8.1.0, as a way to creating <link linkend="functions.anonymous">anonymous functions</link> from <link linkend="language.types.callable">callable</link>.
+    It supersedes existing callable encodings using strings and arrays.
+    The advantage of this syntax is that it is accessible to static analysis, and respects the scope at the point where the callable is created.
+   </para>
+
+   <para>
+    <code>CallableExpr(...)</code> syntax is used to create a <classname>Closure</classname> object from callable. <code>CallableExpr</code> accepts any expression that can be directly called in the PHP grammar:
+    <example>
+     <title>Simple first class callable syntax</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+
+class Foo {
+   public function method() {}
+   public static function staticmethod() {}
+   public function __invoke() {}
+}
+
+$obj = new Foo();
+$classStr = 'Foo';
+$methodStr = 'method';
+$staticmethodStr = 'staticmethod';
+
+
+$f1 = strlen(...);
+$f2 = $obj(...);  // invokable object
+$f3 = $obj->method(...);
+$f4 = $obj->$methodStr(...);
+$f5 = Foo::staticmethod(...);
+$f6 = $classStr::$staticmethodStr(...);
+
+// traditional callable using string, array
+$f7 = 'strlen'(...);
+$f8 = [$obj, 'method'](...);
+$f9 = [Foo::class, 'staticmethod'](...);
+?>
+]]>
+     </programlisting>
+    </example>
+   </para>
+
+   <note>
+    <para>
+      The <code>...</code> is part of the syntax, and not an omission.
+    </para>
+   </note>
+
+   <para>
+    <code>CallableExpr</code> has the same semantics as <methodname>Closure::fromCallable</methodname>.
+    That is, unlike callable using strings and arrays, <code>CallableExpr(...)</code> respects the scope at the point where it is created:
+    <example>
+     <title>Scope comparison of <code>CallableExpr(...)</code> and traditional callable</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+
+class Foo {
+    public function getPrivateMethod() {
+        return [$this, 'privateMethod'];
+    }
+
+    private function privateMethod() {
+        echo __METHOD__, "\n";
+    }
+}
+
+$foo = new Foo;
+$privateMethod = $foo->getPrivateMethod();
+$privateMethod();
+// Fatal error: Call to private method Foo::privateMethod() from global scope
+// This is because call is performed outside from Foo and visibility will be checked from this point.
+
+class Foo1 {
+    public function getPrivateMethod() {
+        // Uses the scope where the callable is acquired.
+        return $this->privateMethod(...); // identical to Closure::fromCallable([$this, 'privateMethod']);
+    }
+
+    private function privateMethod() {
+        echo __METHOD__, "\n";
+    }
+}
+
+$foo1 = new Foo1;
+$privateMethod = $foo1->getPrivateMethod();
+$privateMethod();  // Foo1::privateMethod
+?>
+]]>
+     </programlisting>
+    </example>
+
+   </para>
+
+   <note>
+    <para>
+     Object creation by this syntax (e.g <code>new Foo(...)</code>) is not supported, because <code>new Foo()</code> syntax is not considered a call.
+    </para>
+   </note>
+
+   <note>
+    <para>
+     The first-class callable syntax cannot be combined with the nullsafe operator. Both of the following result in a compile-time error:
+     <example>
+      <programlisting role="php">
+<![CDATA[
+<?php
+$obj?->method(...);
+$obj?->prop->method(...);
+?>
+]]>
+      </programlisting>
+     </example>
+    </para>
+   </note>
+  </sect1>
+
  </chapter>
  
 <!-- Keep this comment at the end of the file

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1508,9 +1508,9 @@ var_export($x);  // Outputs 1
    <title>First class callable syntax</title>
 
    <para>
-    The first class callable syntax is introduced as of PHP 8.1.0, as a way to creating <link linkend="functions.anonymous">anonymous functions</link> from <link linkend="language.types.callable">callable</link>.
+    The first class callable syntax is introduced as of PHP 8.1.0, as a way of creating <link linkend="functions.anonymous">anonymous functions</link> from <link linkend="language.types.callable">callable</link>.
     It supersedes existing callable encodings using strings and arrays.
-    The advantage of this syntax is that it is accessible to static analysis, and respects the scope at the point where the callable is created.
+    The advantage of this syntax is that it is accessible to static analysis, and uses the scope at the point where the callable is acquired.
    </para>
 
    <para>

--- a/language/predefined/closure/fromcallable.xml
+++ b/language/predefined/closure/fromcallable.xml
@@ -19,6 +19,11 @@
    callable in the current scope and throws a <classname>TypeError</classname>
    if it is not.
   </para>
+  <note>
+   <para>
+    As of PHP 8.1.0, <link linkend="functions.first_class_callable_syntax">First class callable syntax</link> has the same semantics as this method.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -43,6 +48,15 @@
    not callable in the current scope.
   </para>
  </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><link linkend="functions.anonymous">Anonymous functions</link></member>
+   <member><link linkend="functions.first_class_callable_syntax">First class callable syntax</link></member>
+  </simplelist>
+ </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/language/types/callable.xml
+++ b/language/types/callable.xml
@@ -48,6 +48,12 @@
    passed to a callback parameter.
   </para>
 
+  <note>
+   <para>
+    As of PHP 8.1.0, anonymous functions can also be created by using the <link linkend="functions.first_class_callable_syntax">first class callable syntax</link>.
+   </para>
+  </note>
+
   <para>
    Generally, any object implementing <link linkend="object.invoke">__invoke()</link> can also
    be passed to a callback parameter.

--- a/language/types/callable.xml
+++ b/language/types/callable.xml
@@ -50,7 +50,7 @@
 
   <note>
    <para>
-    As of PHP 8.1.0, anonymous functions can also be created by using the <link linkend="functions.first_class_callable_syntax">first class callable syntax</link>.
+    As of PHP 8.1.0, anonymous functions can also be created using the <link linkend="functions.first_class_callable_syntax">first class callable syntax</link>.
    </para>
   </note>
 


### PR DESCRIPTION
Added the first class callable syntax docs, based on https://wiki.php.net/rfc/first_class_callable_syntax.