### PR TITLE
[PHP 8.1] Document deprecated ctype non-string argument.

### DIFF
--- a/appendices/migration81/deprecated.xml
+++ b/appendices/migration81/deprecated.xml
@@ -153,7 +153,7 @@ $arr[] = 2;
     In the future, the argument will be interpreted as a string instead
     of an ASCII codepoint.
     Depending on the intended behavior, the argument should either be
-    casted to &string; or an explicit call to
+    cast to &string; or an explicit call to
     <function>chr</function> should be made.
     All <literal>ctype_*()</literal> functions are affected.
    </para>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1846,10 +1846,10 @@ the ASCII value of a single character (negative values have 256 added in order t
 characters in the Extended ASCII range). Any other integer is interpreted as a string
 containing the decimal digits of the integer.</para></note>'>
 
-<!ENTITY note.ctype.parameter.non-string '<note xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY note.ctype.parameter.non-string '<warning xmlns="http://docbook.org/ns/docbook"><para>
 As of PHP 8.1.0, passing a non-string argument is deprecated.
 In the future, the argument will be interpreted as a string instead of an ASCII codepoint.
-Depending on the intended behavior, the argument should either be casted to &string; or an explicit call to <function>chr</function> should be made.</para></note>'>
+Depending on the intended behavior, the argument should either be cast to &string; or an explicit call to <function>chr</function> should be made.</para></note>'>
 
 <!-- FTP Notes -->
 <!ENTITY ftp.changelog.ftp-param '<row xmlns="http://docbook.org/ns/docbook">

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1849,7 +1849,8 @@ containing the decimal digits of the integer.</para></note>'>
 <!ENTITY note.ctype.parameter.non-string '<warning xmlns="http://docbook.org/ns/docbook"><para>
 As of PHP 8.1.0, passing a non-string argument is deprecated.
 In the future, the argument will be interpreted as a string instead of an ASCII codepoint.
-Depending on the intended behavior, the argument should either be cast to &string; or an explicit call to <function>chr</function> should be made.</para></note>'>
+Depending on the intended behavior, the argument should either be cast to &string;
+or an explicit call to <function>chr</function> should be made.</para></warning>'>
 
 <!-- FTP Notes -->
 <!ENTITY ftp.changelog.ftp-param '<row xmlns="http://docbook.org/ns/docbook">

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1846,6 +1846,11 @@ the ASCII value of a single character (negative values have 256 added in order t
 characters in the Extended ASCII range). Any other integer is interpreted as a string
 containing the decimal digits of the integer.</para></note>'>
 
+<!ENTITY note.ctype.parameter.non-string '<note xmlns="http://docbook.org/ns/docbook"><para>
+As of PHP 8.1.0, passing a non-string argument is deprecated.
+In the future, the argument will be interpreted as a string instead of an ASCII codepoint.
+Depending on the intended behavior, the argument should either be casted to &string; or an explicit call to <function>chr</function> should be made.</para></note>'>
+
 <!-- FTP Notes -->
 <!ENTITY ftp.changelog.ftp-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>

--- a/reference/ctype/functions/ctype-alnum.xml
+++ b/reference/ctype/functions/ctype-alnum.xml
@@ -29,6 +29,7 @@
       <para>
        The tested string.
        &note.ctype.parameter.integer;
+       &note.ctype.parameter.non-string;
       </para>
      </listitem>
     </varlistentry>

--- a/reference/ctype/functions/ctype-alpha.xml
+++ b/reference/ctype/functions/ctype-alpha.xml
@@ -34,6 +34,7 @@
       <para>
        The tested string.
        &note.ctype.parameter.integer;
+       &note.ctype.parameter.non-string;
       </para>
      </listitem>
     </varlistentry>

--- a/reference/ctype/functions/ctype-cntrl.xml
+++ b/reference/ctype/functions/ctype-cntrl.xml
@@ -30,6 +30,7 @@
       <para>
        The tested string.
        &note.ctype.parameter.integer;
+       &note.ctype.parameter.non-string;
       </para>
      </listitem>
     </varlistentry>

--- a/reference/ctype/functions/ctype-digit.xml
+++ b/reference/ctype/functions/ctype-digit.xml
@@ -29,6 +29,7 @@
       <para>
        The tested string.
        &note.ctype.parameter.integer;
+       &note.ctype.parameter.non-string;
       </para>
      </listitem>
     </varlistentry>

--- a/reference/ctype/functions/ctype-graph.xml
+++ b/reference/ctype/functions/ctype-graph.xml
@@ -29,6 +29,7 @@
       <para>
        The tested string.
        &note.ctype.parameter.integer;
+       &note.ctype.parameter.non-string;
       </para>
      </listitem>
     </varlistentry>

--- a/reference/ctype/functions/ctype-lower.xml
+++ b/reference/ctype/functions/ctype-lower.xml
@@ -29,6 +29,7 @@
       <para>
        The tested string.
        &note.ctype.parameter.integer;
+       &note.ctype.parameter.non-string;
       </para>
      </listitem>
     </varlistentry>

--- a/reference/ctype/functions/ctype-print.xml
+++ b/reference/ctype/functions/ctype-print.xml
@@ -29,6 +29,7 @@
       <para>
        The tested string.
        &note.ctype.parameter.integer;
+       &note.ctype.parameter.non-string;
       </para>
      </listitem>
     </varlistentry>

--- a/reference/ctype/functions/ctype-punct.xml
+++ b/reference/ctype/functions/ctype-punct.xml
@@ -32,6 +32,7 @@
       <para>
        The tested string.
        &note.ctype.parameter.integer;
+       &note.ctype.parameter.non-string;
       </para>
      </listitem>
     </varlistentry>

--- a/reference/ctype/functions/ctype-space.xml
+++ b/reference/ctype/functions/ctype-space.xml
@@ -29,6 +29,7 @@
       <para>
        The tested string.
        &note.ctype.parameter.integer;
+       &note.ctype.parameter.non-string;
       </para>
      </listitem>
     </varlistentry>

--- a/reference/ctype/functions/ctype-upper.xml
+++ b/reference/ctype/functions/ctype-upper.xml
@@ -29,6 +29,7 @@
       <para>
        The tested string.
        &note.ctype.parameter.integer;
+       &note.ctype.parameter.non-string;
       </para>
      </listitem>
     </varlistentry>

--- a/reference/ctype/functions/ctype-xdigit.xml
+++ b/reference/ctype/functions/ctype-xdigit.xml
@@ -31,6 +31,7 @@
       <para>
        The tested string.
        &note.ctype.parameter.integer;
+       &note.ctype.parameter.non-string;
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.ctype