### PR TITLE
[PHP 8.1] Document passing null to scalar parameter of built-in functions

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -979,6 +979,12 @@ $func(); // prints "bar"
      be thrown in this case.
     </simpara>
    </note>
+   <note>
+    <simpara>
+     As of PHP 8.1.0, passing &null; to scalar parameter of built-in functions is deprecated.
+     Previously, scalar types for built-in functions are nullable by default, and &null; can be passed to them.
+    </simpara>
+   </note>
 
    <sect2 role="seealso">
     &reftitle.seealso;


### PR DESCRIPTION
https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.null-not-nullable-internal