### PR TITLE
Link to spl_object_id from similar functions.

### DIFF
--- a/reference/runkit7/functions/runkit7-object-id.xml
+++ b/reference/runkit7/functions/runkit7-object-id.xml
@@ -16,6 +16,9 @@
    <methodparam><type>object</type><parameter>obj</parameter></methodparam>
   </methodsynopsis>
   <para>
+   This function is equivalent to <function>spl_object_id</function>.
+  </para>
+  <para>
    This function returns a unique identifier for the object. The object id is
    unique for the lifetime of the object. Once the object is destroyed, its id
    may be reused for other objects. This behavior is similar to
@@ -53,6 +56,14 @@
    </para>
   </note>
  </refsect1> 
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>spl_object_id</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/spl/functions/spl-object-hash.xml
+++ b/reference/spl/functions/spl-object-hash.xml
@@ -17,7 +17,8 @@
    This function returns a unique identifier for the object. This id can be
    used as a hash key for storing objects, or for identifying an object, as long
    as the object is not destroyed. Once the object is destroyed, its hash may 
-   be reused for other objects.
+   be reused for other objects. This behavior is similar to
+   <function>spl_object_id</function>.
   </para>
  </refsect1>
 
@@ -70,6 +71,14 @@ $storage[$id] = $object;
    </para>
   </note>
  </refsect1> 
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>spl_object_id</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Encourage the use of spl_object_id instead.

Using an integer is faster and more memory-efficient than creating a 32-byte
string hash.

spl_object_hash historically obfuscated the object id with xor for security reasons, but it was sufficient for security to not expose raw pointers.

`runkit7_object_id` is one way to polyfill PHP 7.2+ `spl_object_id`
in older PHP 7 versions and continues to exist in the PECL.