### PR TITLE
Update fetchAll() return description to match summary wording

### DIFF
--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -4,7 +4,7 @@
  <refnamediv>
   <refname>PDOStatement::fetchAll</refname>
   <refpurpose>
-   Returns an array containing all of the result set rows
+   Fetches the remaining rows from a result set
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -111,7 +111,7 @@
   &reftitle.returnvalues;
   <para>
    <function>PDOStatement::fetchAll</function> returns an array containing
-   all of the rows in the result set. The array represents each
+   all of the remaining rows in the result set. The array represents each
    row as either an array of column values or an object with properties
    corresponding to each column name. An empty array is returned if there
    are zero results to fetch.

--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -111,7 +111,7 @@
   &reftitle.returnvalues;
   <para>
    <function>PDOStatement::fetchAll</function> returns an array containing
-   all of the remaining rows in the result set. The array represents each
+   all of the rows in the result set. The array represents each
    row as either an array of column values or an object with properties
    corresponding to each column name. An empty array is returned if there
    are zero results to fetch.


### PR DESCRIPTION
It either returns all or remaining rows. These aren't exactly the same operation which can be confusing.