### PR TITLE
Update documentation for PHP8

### DIFF
--- a/reference/strings/functions/substr.xml
+++ b/reference/strings/functions/substr.xml
@@ -87,8 +87,8 @@ $rest = substr("abcdef", -3, 1); // returns "d"
        beyond, an empty string will be returned.
       </para>
       <para>
-       If <parameter>length</parameter> is given and is <literal>0</literal> or
-       &false;, an empty string will be returned.
+       If <parameter>length</parameter> is given and is <literal>0</literal>,
+       an empty string will be returned.
       </para>
       <para>
        If <parameter>length</parameter> is omitted, the substring starting from

--- a/reference/strings/functions/substr.xml
+++ b/reference/strings/functions/substr.xml
@@ -87,8 +87,8 @@ $rest = substr("abcdef", -3, 1); // returns "d"
        beyond, an empty string will be returned.
       </para>
       <para>
-       If <parameter>length</parameter> is given and is <literal>0</literal>,
-       &false; or &null;, an empty string will be returned.
+       If <parameter>length</parameter> is given and is <literal>0</literal> or
+       &false;, an empty string will be returned.
       </para>
       <para>
        If <parameter>length</parameter> is omitted, the substring starting from
@@ -159,6 +159,7 @@ $rest = substr("abcdef", -3, -1); // returns "de"
 <![CDATA[
 <?php
 echo substr('abcdef', 1);     // bcdef
+echo substr("abcdef", 1, null); // bcdef; prior to PHP 8.0.0, empty string was returned
 echo substr('abcdef', 1, 3);  // bcd
 echo substr('abcdef', 0, 4);  // abcd
 echo substr('abcdef', 0, 8);  // abcdef


### PR DESCRIPTION
Length parameter to substr() behaves differently for PHP8+. It recognizes null as if no value was provided at all. Updated the documentation to reflect this.