### PR TITLE
date_default_timezone_get: unmention the warning

### DIFF
--- a/reference/datetime/functions/date-default-timezone-get.xml
+++ b/reference/datetime/functions/date-default-timezone-get.xml
@@ -28,18 +28,15 @@
       (if set)
      </para>
     </listitem>
-    <listitem>
-     <para>
-      A warning is shown when this stage is reached. Do not rely on it to be guessed
-      correctly, and set <link linkend="ini.date.timezone">date.timezone</link> to the correct timezone
-      instead.
-     </para>
-    </listitem>
    </itemizedlist>
   </para>
   <para>
    If none of the above succeed, <methodname>date_default_timezone_get</methodname>
    will return a default timezone of <literal>UTC</literal>.
+  </para>
+  <para>
+   To make sure the return value matches reality, explicitly set <link linkend="ini.date.timezone">date.timezone</link>
+   to the correct timezone instead of relying on the guessing.
   </para>
  </refsect1>
 


### PR DESCRIPTION
It has not been the case since PHP 7.0:
https://github.com/php/php-src/commit/b22caa81ee2797572279fc9aff0918c01f708de5