### PR TITLE
auto_detect_line_endings deprecated

### DIFF
--- a/reference/filesystem/ini.xml
+++ b/reference/filesystem/ini.xml
@@ -50,7 +50,7 @@
       <entry><link linkend="ini.auto-detect-line-endings">auto_detect_line_endings</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_ALL</entry>
-      <entry></entry>
+      <entry>Deprecated as of PHP 8.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.sys-temp-dir">sys_temp_dir</link></entry>


### PR DESCRIPTION
auto_detect_line_endings deprecated as of PHP 8.1.0

Spotted in tests and you can see it here:
https://3v4l.org/2pjOA