### PR TITLE
[PHP 8.1] mysqli::get_client_info is deprecated

### DIFF
--- a/reference/mysqli/mysqli/get-client-info.xml
+++ b/reference/mysqli/mysqli/get-client-info.xml
@@ -34,8 +34,40 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   A string that represents the MySQL client library version
+   A string that represents the MySQL client library version.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       Calling <function>mysqli_get_client_info</function> with the
+       <parameter>mysql</parameter> argument has been deprecated.
+       This function never required a parameter, but incorrectly allowed it as
+       an optional parameter.
+      </entry>
+     </row>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       The object-oriented style <methodname>mysqli::get_client_info</methodname>
+       has been deprecated.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.mysqli