### PR TITLE
[PHP 8.1] mysqli::init() is deprecated

### DIFF
--- a/reference/mysqli/mysqli/init.xml
+++ b/reference/mysqli/mysqli/init.xml
@@ -44,6 +44,31 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       The object-oriented style <methodname>mysqli::init</methodname> method
+       has been deprecated.
+       Replace calls to <methodname>parent::init</methodname> with
+       <methodname>parent::__construct</methodname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>


### PR DESCRIPTION
https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.mysqli