### PR TITLE
mysqli_driver::$driver_version is deprecated and $embedded is removed

### DIFF
--- a/reference/mysqli/mysqli_driver.xml
+++ b/reference/mysqli/mysqli_driver.xml
@@ -94,8 +94,8 @@
      <term><varname>driver_version</varname></term>
      <listitem>
       <para>The MySQLi Driver version</para>
-      <warning xmlns="http://docbook.org/ns/docbook"><simpara>This property has
-      been <emphasis>DEPRECATED</emphasis> as of PHP 8.1.0. Relying on this
+      <warning><simpara>This property has
+      been <emphasis>deprecated</emphasis> as of PHP 8.1.0. Relying on this
       property is highly discouraged.</simpara></warning>
      </listitem>
     </varlistentry>
@@ -103,8 +103,8 @@
      <term><varname>embedded</varname></term>
      <listitem>
       <para>Whether MySQLi Embedded support is enabled</para>
-      <warning xmlns="http://docbook.org/ns/docbook"><simpara>This property has
-      been <emphasis>REMOVED</emphasis> as of PHP 8.0.0.</simpara></warning>
+      <warning><simpara>This property has
+      been <emphasis>removed</emphasis> as of PHP 8.0.0.</simpara></warning>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="mysqli-driver.props.reconnect">

--- a/reference/mysqli/mysqli_driver.xml
+++ b/reference/mysqli/mysqli_driver.xml
@@ -94,12 +94,17 @@
      <term><varname>driver_version</varname></term>
      <listitem>
       <para>The MySQLi Driver version</para>
+      <warning xmlns="http://docbook.org/ns/docbook"><simpara>This property has
+      been <emphasis>DEPRECATED</emphasis> as of PHP 8.1.0. Relying on this
+      property is highly discouraged.</simpara></warning>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="mysqli-driver.props.embedded">
      <term><varname>embedded</varname></term>
      <listitem>
       <para>Whether MySQLi Embedded support is enabled</para>
+      <warning xmlns="http://docbook.org/ns/docbook"><simpara>This property has
+      been <emphasis>REMOVED</emphasis> as of PHP 8.0.0.</simpara></warning>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="mysqli-driver.props.reconnect">


### PR DESCRIPTION
https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.mysqli
https://github.com/php/php-src/pull/6407