### PR TITLE
Remove unnecessary DateTimeImmutable method synopsis roles

### DIFF
--- a/reference/datetime/datetimeimmutable/add.xml
+++ b/reference/datetime/datetimeimmutable/add.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::add</refname>
@@ -11,7 +10,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::add</methodname>
    <methodparam><type>DateInterval</type><parameter>interval</parameter></methodparam>
   </methodsynopsis>
@@ -22,7 +21,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/construct.xml
+++ b/reference/datetime/datetimeimmutable/construct.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-  <constructorsynopsis role="oop">
+  <constructorsynopsis>
    <modifier>public</modifier> <methodname>DateTimeImmutable::__construct</methodname>
    <methodparam choice="opt"><type>string</type><parameter>datetime</parameter><initializer>"now"</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>DateTimeZone</type><type>null</type></type><parameter>timezone</parameter><initializer>&null;</initializer></methodparam>

--- a/reference/datetime/datetimeimmutable/createfrominterface.xml
+++ b/reference/datetime/datetimeimmutable/createfrominterface.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.createfrominterface" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::createFromInterface</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::createFromInterface</methodname>
    <methodparam><type>DateTimeInterface</type><parameter>object</parameter></methodparam>
   </methodsynopsis>
@@ -62,7 +61,6 @@ $also_immutable = DateTimeImmutable::createFromInterface($date);
   </para>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/createfrommutable.xml
+++ b/reference/datetime/datetimeimmutable/createfrommutable.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.createfrommutable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::createFromMutable</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::createFromMutable</methodname>
    <methodparam><type>DateTime</type><parameter>object</parameter></methodparam>
   </methodsynopsis>
@@ -60,7 +59,6 @@ $immutable = DateTimeImmutable::createFromMutable( $date );
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/modify.xml
+++ b/reference/datetime/datetimeimmutable/modify.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.modify" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::modify</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type class="union"><type>DateTimeImmutable</type><type>false</type></type><methodname>DateTimeImmutable::modify</methodname>
    <methodparam><type>string</type><parameter>modifier</parameter></methodparam>
   </methodsynopsis>
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/set-state.xml
+++ b/reference/datetime/datetimeimmutable/set-state.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.set-state" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::__set_state</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::__set_state</methodname>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
   </methodsynopsis>
@@ -20,7 +19,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/setdate.xml
+++ b/reference/datetime/datetimeimmutable/setdate.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.setdate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::setDate</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setDate</methodname>
    <methodparam><type>int</type><parameter>year</parameter></methodparam>
    <methodparam><type>int</type><parameter>month</parameter></methodparam>
@@ -22,7 +21,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/setisodate.xml
+++ b/reference/datetime/datetimeimmutable/setisodate.xml
@@ -8,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setISODate</methodname>
    <methodparam><type>int</type><parameter>year</parameter></methodparam>
    <methodparam><type>int</type><parameter>week</parameter></methodparam>

--- a/reference/datetime/datetimeimmutable/settime.xml
+++ b/reference/datetime/datetimeimmutable/settime.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.settime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::setTime</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setTime</methodname>
    <methodparam><type>int</type><parameter>hour</parameter></methodparam>
    <methodparam><type>int</type><parameter>minute</parameter></methodparam>
@@ -23,7 +22,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/settimestamp.xml
+++ b/reference/datetime/datetimeimmutable/settimestamp.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.settimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::setTimestamp</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setTimestamp</methodname>
    <methodparam><type>int</type><parameter>timestamp</parameter></methodparam>
   </methodsynopsis>
@@ -20,7 +19,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/settimezone.xml
+++ b/reference/datetime/datetimeimmutable/settimezone.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.settimezone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::setTimezone</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setTimezone</methodname>
    <methodparam><type>DateTimeZone</type><parameter>timezone</parameter></methodparam>
   </methodsynopsis>
@@ -20,7 +19,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimeimmutable/sub.xml
+++ b/reference/datetime/datetimeimmutable/sub.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetimeimmutable.sub" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::sub</refname>
@@ -11,7 +10,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::sub</methodname>
    <methodparam><type>DateInterval</type><parameter>interval</parameter></methodparam>
   </methodsynopsis>
@@ -22,7 +21,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
The DateTimeImmutable class page doesn't depend on these roles. Followup to https://github.com/php/doc-en/pull/1011