### PR TITLE
Remove unnecessary DateInterval, DatePeriod, DateTime and DateTimeZone method synopsis roles

### DIFF
--- a/reference/datetime/dateinterval/construct.xml
+++ b/reference/datetime/dateinterval/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="dateinterval.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateInterval::__construct</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <constructorsynopsis role="oop">
+  <constructorsynopsis>
    <modifier>public</modifier> <methodname>DateInterval::__construct</methodname>
    <methodparam><type>string</type><parameter>duration</parameter></methodparam>
   </constructorsynopsis>
@@ -110,8 +109,7 @@
        roll-over-point (e.g. <literal>25</literal> hours is invalid).
       </para>
       <para>
-       These formats are based on the <link
-        xlink:href="&url.iso-8601.duration;">ISO 8601 duration
+       These formats are based on the <link xlink:href="&url.iso-8601.duration;">ISO 8601 duration
        specification</link>.
       </para>
      </listitem>
@@ -260,7 +258,6 @@ object(DateInterval)#1 (16) {
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/dateperiod/getdateinterval.xml
+++ b/reference/datetime/dateperiod/getdateinterval.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="dateperiod.getdateinterval" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DatePeriod::getDateInterval</refname>
@@ -12,9 +11,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>DateInterval</type><methodname>DatePeriod::getDateInterval</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Gets a <classname>DateInterval</classname> <type>object</type>
@@ -65,7 +64,6 @@ echo $interval->format('%d day');
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/dateperiod/getenddate.xml
+++ b/reference/datetime/dateperiod/getenddate.xml
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type class="union"><type>DateTimeInterface</type><type>null</type></type><methodname>DatePeriod::getEndDate</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/datetime/dateperiod/getrecurrences.xml
+++ b/reference/datetime/dateperiod/getrecurrences.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>DatePeriod::getRecurrences</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/datetime/dateperiod/getstartdate.xml
+++ b/reference/datetime/dateperiod/getstartdate.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="dateperiod.getstartdate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DatePeriod::getStartDate</refname>
@@ -12,9 +11,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <type>DateTimeInterface</type><methodname>DatePeriod::getStartDate</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Gets the start date of the period.
@@ -71,7 +70,6 @@ echo $start->format(DateTime::ISO8601);
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetime/construct.xml
+++ b/reference/datetime/datetime/construct.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-  <constructorsynopsis role="oop">
+  <constructorsynopsis>
    <modifier>public</modifier> <methodname>DateTime::__construct</methodname>
    <methodparam choice="opt"><type>string</type><parameter>datetime</parameter><initializer>"now"</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>DateTimeZone</type><type>null</type></type><parameter>timezone</parameter><initializer>&null;</initializer></methodparam>

--- a/reference/datetime/datetime/createfromimmutable.xml
+++ b/reference/datetime/datetime/createfromimmutable.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetime.createfromimmutable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTime::createFromImmutable</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type>DateTime</type><methodname>DateTime::createFromImmutable</methodname>
    <methodparam><type>DateTimeImmutable</type><parameter>object</parameter></methodparam>
   </methodsynopsis>
@@ -60,7 +59,6 @@ $mutable = DateTime::createFromImmutable( $date );
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetime/createfrominterface.xml
+++ b/reference/datetime/datetime/createfrominterface.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetime.createfrominterface" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTime::createFromInterface</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type>DateTime</type><methodname>DateTime::createFromInterface</methodname>
    <methodparam><type>DateTimeInterface</type><parameter>object</parameter></methodparam>
   </methodsynopsis>
@@ -62,7 +61,6 @@ $also_mutable = DateTime::createFromInterface($date);
   </para>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetime/set-state.xml
+++ b/reference/datetime/datetime/set-state.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="datetime.set-state" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTime::__set_state</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="oop">
+  <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type>DateTime</type><methodname>DateTime::__set_state</methodname>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
   </methodsynopsis>
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/datetime/datetimezone/construct.xml
+++ b/reference/datetime/datetimezone/construct.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>
-  <constructorsynopsis role="oop">
+  <constructorsynopsis>
    <modifier>public</modifier> <methodname>DateTimeZone::__construct</methodname>
    <methodparam><type>string</type><parameter>timezone</parameter></methodparam>
   </constructorsynopsis>


### PR DESCRIPTION
These roles are not necessary, since the respective class pages don't depend on them. Followup to #1011 