### PR TITLE
Drop Windows Notepad usage instructions

### DIFF
--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -174,20 +174,6 @@
     </para>
    </note>
    
-   <note>
-    <info><title>A Note on Windows Notepad</title></info>
-    <para>
-     If you are writing your PHP scripts using Windows Notepad, you will need
-     to ensure that your files are saved with the <filename>.php</filename> extension.
-     (Notepad adds a <filename>.txt</filename> extension to files automatically unless
-     you take one of the following steps to prevent it.)  When you save the file and
-     are prompted to provide a name for the file, place the filename in quotes 
-     (i.e. "<filename>hello.php</filename>").  Alternatively, you can click on the 
-     'Text Documents' drop-down menu in the 'Save' dialog box and change the setting 
-     to "All Files". You can then enter your filename without quotes.
-    </para>
-   </note>
-  
    <para>
     Now that you have successfully created a working PHP script, it is
     time to create the most famous PHP script!  Make a call to the


### PR DESCRIPTION
We should not encourage use of Notepad for editing PHP files, and those
who use it, should at least know how it works (after all, it's not that
complex).