### PR TITLE
Ambiguous phrasing in generators

### DIFF
--- a/language/generators.xml
+++ b/language/generators.xml
@@ -15,8 +15,11 @@
   </para>
 
   <para>
-   A generator allows you to write code that uses &foreach; to iterate over a
-   set of data without needing to build an array in memory, which may cause
+   A generator allows you to write a code that can disguise a regular loop 
+   the way it looks as though it's an array iterated over using &foreach;. 
+   In case your code expects an array, but each item is actually an iteration
+   result of some loop, then you can make it look as an array by creating 
+   a generator, without needing to build an array in memory, which may cause
    you to exceed a memory limit, or require a considerable amount of
    processing time to generate. Instead, you can write a generator function,
    which is the same as a normal
@@ -95,6 +98,17 @@ Single digit odd numbers from xrange(): 1 3 5 7 9
    </screen>
   </example>
 
+  <note>
+   <simpara>
+    It is important to understand that a generator is essentially a syntax sugar
+    that cannot really reduce the memory consumption. It's the undelying loop 
+    that does the job, providing one item at a time. While a generator simply 
+    allows to convert any other loop, such as &while; or &for; into &foreach;,
+    making it possible to use the uniform interface to access either arrays, 
+    streams or sequences generated on the fly.
+   </simpara>
+  </note> 
+
   <sect2 xml:id="language.generators.object">
    <title><classname>Generator</classname> objects</title>
    <para>
@@ -107,7 +121,6 @@ Single digit odd numbers from xrange(): 1 3 5 7 9
    </para>
   </sect2>
  </sect1>
-
  <sect1 xml:id="language.generators.syntax">
   <title>Generator syntax</title>
 

--- a/language/generators.xml
+++ b/language/generators.xml
@@ -103,7 +103,8 @@ Single digit odd numbers from xrange(): 1 3 5 7 9
     It is important to understand that a generator is essentially a syntax sugar
     that cannot really reduce the memory consumption. It's the undelying loop 
     that does the job, providing one item at a time. While a generator simply 
-    allows to convert any other loop, such as &while; or &for; into &foreach;,
+    allows to convert any other loop, such as <literal>while</literal> 
+    or <literal>for</literal> into <literal>foreach</literal>,
     making it possible to use the uniform interface to access either arrays, 
     streams or sequences generated on the fly.
    </simpara>


### PR DESCRIPTION
There is a widespread rumor that generators help to reduce the memory consumption. I see it everywhere. People constantly asking to explain how a generator can reduce the memory consumption, based on the ambiguous wording in the manual.