### PR TITLE
Generate ext/dom class synopses from stubs - part 2

### DIFF
--- a/reference/dom/domattr.xml
+++ b/reference/dom/domattr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<phpdoc:classref xmlns:phpdoc="http://php.net/ns/phpdoc" xml:id="class.domattr" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<phpdoc:classref xml:id="class.domattr" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>The <classname>DOMAttr</classname> class</title>
  <titleabbrev>DOMAttr</titleabbrev>
  
@@ -21,25 +21,22 @@
  
 <!-- {{{ Synopsis -->
    <classsynopsis>
-    <ooclass><classname>DOMAttr</classname></ooclass>
- 
-<!-- {{{ Class synopsis -->
+    <ooclass>
+     <classname>DOMAttr</classname>
+    </ooclass>
+
     <classsynopsisinfo>
      <ooclass>
       <classname>DOMAttr</classname>
      </ooclass>
- 
-<!-- If the class extends another one, use this -->
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>DOMNode</classname>
      </ooclass>
- 
     </classsynopsisinfo>
-<!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-<!-- If the property is documented below (xml:id=classname.props) use this -->
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>readonly</modifier>
@@ -72,19 +69,21 @@
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback />
+     <xi:fallback/>
     </xi:include>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domattr')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback />
+     <xi:fallback/>
     </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domattr')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
- 
-<!-- Again, if the class extends a class use this -->
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domattr')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
+     <xi:fallback/>
+    </xi:include>
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-   
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
+     <xi:fallback/>
+    </xi:include>
    </classsynopsis>
 <!-- }}} -->
  
@@ -144,7 +143,6 @@
  &reference.dom.entities.domattr;
  
 </phpdoc:classref>
- 
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
@@ -165,4 +163,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/dom/domcharacterdata.xml
+++ b/reference/dom/domcharacterdata.xml
@@ -92,7 +92,30 @@
    </variablelist>
   </section>
 <!-- }}} -->
- 
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        <classname>DOMCharacterData</classname> implements
+        <interfacename>DOMChildNode</interfacename> now.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
   <section role="seealso">
    &reftitle.seealso;
    <para>

--- a/reference/dom/domcharacterdata.xml
+++ b/reference/dom/domcharacterdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<phpdoc:classref xmlns:phpdoc="http://php.net/ns/phpdoc" xml:id="class.domcharacterdata" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<phpdoc:classref xml:id="class.domcharacterdata" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>The DOMCharacterData class</title>
  <titleabbrev>DOMCharacterData</titleabbrev>
  
@@ -21,23 +21,25 @@
  
 <!-- {{{ Synopsis -->
    <classsynopsis>
-    <ooclass><classname>DOMCharacterData</classname></ooclass>
- 
-<!-- {{{ Class synopsis -->
+    <ooclass>
+     <classname>DOMCharacterData</classname>
+    </ooclass>
+
     <classsynopsisinfo>
      <ooclass>
       <classname>DOMCharacterData</classname>
      </ooclass>
- 
-<!-- If the class extends another one, use this -->
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>DOMNode</classname>
      </ooclass>
- 
+
+     <oointerface>
+      <interfacename>DOMChildNode</interfacename>
+     </oointerface>
     </classsynopsisinfo>
-<!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 <!-- If the property is documented below (xml:id=domcharacterdata.props) use this -->
     <fieldsynopsis>
@@ -54,16 +56,18 @@
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback />
+     <xi:fallback/>
     </xi:include>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
- 
-<!-- Again, if the class extends a class use this -->
-    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
+     <xi:fallback/>
+    </xi:include>
 
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
+     <xi:fallback/>
+    </xi:include>
    </classsynopsis>
 <!-- }}} -->
  
@@ -103,7 +107,6 @@
  &reference.dom.entities.domcharacterdata;
  
 </phpdoc:classref>
- 
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
@@ -124,4 +127,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/dom/domdocument.xml
+++ b/reference/dom/domdocument.xml
@@ -366,6 +366,13 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
+        <classname>DOMDocument</classname> implements
+        <interfacename>DOMParentNode</interfacename> now.
+       </entry>
+      </row>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
         The unimplemented method <methodname>DOMDocument::renameNode</methodname>
         has been removed.
        </entry>

--- a/reference/dom/domdocument.xml
+++ b/reference/dom/domdocument.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<phpdoc:classref xmlns:phpdoc="http://php.net/ns/phpdoc" xml:id="class.domdocument" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<phpdoc:classref xml:id="class.domdocument" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>The DOMDocument class</title>
  <titleabbrev>DOMDocument</titleabbrev>
  
@@ -21,25 +21,26 @@
  
 <!-- {{{ Synopsis -->
    <classsynopsis>
-    <ooclass><classname>DOMDocument</classname></ooclass>
- 
-<!-- {{{ Class synopsis -->
+    <ooclass>
+     <classname>DOMDocument</classname>
+    </ooclass>
+
     <classsynopsisinfo>
      <ooclass>
       <classname>DOMDocument</classname>
      </ooclass>
- 
-<!-- If the class extends another one, use this -->
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>DOMNode</classname>
      </ooclass>
- 
+
+     <oointerface>
+      <interfacename>DOMParentNode</interfacename>
+     </oointerface>
     </classsynopsisinfo>
-<!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-<!-- If the property is documented below (xml:id=domdocument.props) use this -->
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>readonly</modifier>
@@ -152,14 +153,16 @@
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocument')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback />
+     <xi:fallback/>
     </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
- 
-<!-- Again, if the class extends a class use this -->
-    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
+     <xi:fallback/>
+    </xi:include>
 
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
+     <xi:fallback/>
+    </xi:include>
    </classsynopsis>
 <!-- }}} -->
  
@@ -396,7 +399,6 @@
  &reference.dom.entities.domdocument;
  
 </phpdoc:classref>
- 
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
@@ -417,4 +419,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/dom/domdocumentfragment.xml
+++ b/reference/dom/domdocumentfragment.xml
@@ -83,6 +83,29 @@
   </section>
 -->
 <!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        <classname>DOMDocumentFragment</classname> implements
+        <interfacename>DOMParentNode</interfacename> now.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
   
 <!-- {{{ See also -->
 <!--

--- a/reference/dom/domdocumentfragment.xml
+++ b/reference/dom/domdocumentfragment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<phpdoc:classref xmlns:phpdoc="http://php.net/ns/phpdoc" xml:id="class.domdocumentfragment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<phpdoc:classref xml:id="class.domdocumentfragment" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>The DOMDocumentFragment class</title>
  <titleabbrev>DOMDocumentFragment</titleabbrev>
  
@@ -22,23 +22,25 @@
  
 <!-- {{{ Synopsis -->
    <classsynopsis>
-    <ooclass><classname>DOMDocumentFragment</classname></ooclass>
- 
-<!-- {{{ Class synopsis -->
+    <ooclass>
+     <classname>DOMDocumentFragment</classname>
+    </ooclass>
+
     <classsynopsisinfo>
      <ooclass>
       <classname>DOMDocumentFragment</classname>
      </ooclass>
- 
-<!-- If the class extends another one, use this -->
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>DOMNode</classname>
      </ooclass>
- 
+
+     <oointerface>
+      <interfacename>DOMParentNode</interfacename>
+     </oointerface>
     </classsynopsisinfo>
-<!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 <!-- If the property is documented below (xml:id=domdocumentfragment.props) use this -->
 <!--
@@ -51,19 +53,19 @@
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback />
+     <xi:fallback/>
     </xi:include>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocumentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
- 
-<!-- Again, if the class extends a class use this -->
-    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocumentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
+     <xi:fallback/>
+    </xi:include>
 
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
+     <xi:fallback/>
+    </xi:include>
    </classsynopsis>
-<!-- }}} -->
- 
   </section>
  
 <!-- {{{ DOMDocumentFragment properties -->
@@ -100,7 +102,6 @@
  &reference.dom.entities.domdocumentfragment;
  
 </phpdoc:classref>
- 
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
@@ -121,4 +122,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/dom/domdocumenttype.xml
+++ b/reference/dom/domdocumenttype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<phpdoc:classref xmlns:phpdoc="http://php.net/ns/phpdoc" xml:id="class.domdocumenttype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<phpdoc:classref xml:id="class.domdocumenttype" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>The DOMDocumentType class</title>
  <titleabbrev>DOMDocumentType</titleabbrev>
  
@@ -21,25 +21,22 @@
  
 <!-- {{{ Synopsis -->
    <classsynopsis>
-    <ooclass><classname>DOMDocumentType</classname></ooclass>
- 
-<!-- {{{ Class synopsis -->
+    <ooclass>
+     <classname>DOMDocumentType</classname>
+    </ooclass>
+
     <classsynopsisinfo>
      <ooclass>
       <classname>DOMDocumentType</classname>
      </ooclass>
- 
-<!-- If the class extends another one, use this -->
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>DOMNode</classname>
      </ooclass>
- 
     </classsynopsisinfo>
-<!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-<!-- If the property is documented below (xml:id=domdocumenttype.props) use this -->
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>readonly</modifier>
@@ -82,15 +79,10 @@
      <xi:fallback />
     </xi:include>
 
- <!--
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocumenttype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
- -->
- 
-<!-- Again, if the class extends a class use this -->
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
+     <xi:fallback/>
+    </xi:include>
    </classsynopsis>
 <!-- }}} -->
  
@@ -171,7 +163,6 @@
  </partintro>
  
 </phpdoc:classref>
- 
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
@@ -192,4 +183,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/dom/domelement.xml
+++ b/reference/dom/domelement.xml
@@ -101,6 +101,30 @@
   </section>
 <!-- }}} -->
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        <classname>DOMElement</classname> implements
+        <interfacename>DOMParentNode</interfacename> and
+        <interfacename>DOMChildNode</interfacename> now.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
 <!-- {{{ Notes -->
   <section role="notes">
    &reftitle.notes;

--- a/reference/dom/domelement.xml
+++ b/reference/dom/domelement.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<phpdoc:classref xmlns:phpdoc="http://php.net/ns/phpdoc" xml:id="class.domelement" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<phpdoc:classref xml:id="class.domelement" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>The DOMElement class</title>
  <titleabbrev>DOMElement</titleabbrev>
  
@@ -22,25 +22,30 @@
  
 <!-- {{{ Synopsis -->
    <classsynopsis>
-    <ooclass><classname>DOMElement</classname></ooclass>
- 
-<!-- {{{ Class synopsis -->
+    <ooclass>
+     <classname>DOMElement</classname>
+    </ooclass>
+
     <classsynopsisinfo>
      <ooclass>
       <classname>DOMElement</classname>
      </ooclass>
- 
-<!-- If the class extends another one, use this -->
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>DOMNode</classname>
      </ooclass>
- 
+
+     <oointerface>
+      <interfacename>DOMParentNode</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>DOMChildNode</interfacename>
+     </oointerface>
     </classsynopsisinfo>
-<!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-<!-- If the property is documented below (xml:id=domelement.props) use this -->
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>readonly</modifier>
@@ -56,19 +61,21 @@
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback />
+     <xi:fallback/>
     </xi:include>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domelement')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback />
+     <xi:fallback/>
     </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domelement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
- 
-<!-- Again, if the class extends a class use this -->
-    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domelement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
+     <xi:fallback/>
+    </xi:include>
 
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
+     <xi:fallback/>
+    </xi:include>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domentity.xml
+++ b/reference/dom/domentity.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<phpdoc:classref xmlns:phpdoc="http://php.net/ns/phpdoc" xml:id="class.domentity" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<phpdoc:classref xml:id="class.domentity" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>The DOMEntity class</title>
  <titleabbrev>DOMEntity</titleabbrev>
  
@@ -20,25 +20,22 @@
  
 <!-- {{{ Synopsis -->
    <classsynopsis>
-    <ooclass><classname>DOMEntity</classname></ooclass>
- 
-<!-- {{{ Class synopsis -->
+    <ooclass>
+     <classname>DOMEntity</classname>
+    </ooclass>
+
     <classsynopsisinfo>
      <ooclass>
       <classname>DOMEntity</classname>
      </ooclass>
- 
-<!-- If the class extends another one, use this -->
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>DOMNode</classname>
      </ooclass>
- 
     </classsynopsisinfo>
-<!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-<!-- If the property is documented below (xml:id=domentity.props) use this -->
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>readonly</modifier>
@@ -77,17 +74,13 @@
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback />
+     <xi:fallback/>
     </xi:include>
 
- <!--
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domentity')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
- -->
-<!-- Again, if the class extends a class use this -->
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
+     <xi:fallback/>
+    </xi:include>
    </classsynopsis>
 <!-- }}} -->
  
@@ -176,7 +169,6 @@
  
  
 </phpdoc:classref>
- 
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
@@ -197,4 +189,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/dom/domxpath.xml
+++ b/reference/dom/domxpath.xml
@@ -6,7 +6,7 @@ Remove me once you perform substitutions
     DOMXPath
     dom
 -->
-<phpdoc:classref xmlns:phpdoc="http://php.net/ns/phpdoc" xml:id="class.domxpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<phpdoc:classref xml:id="class.domxpath" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>The DOMXPath class</title>
  <titleabbrev>DOMXPath</titleabbrev>
  
@@ -26,19 +26,17 @@ Remove me once you perform substitutions
  
 <!-- {{{ Synopsis -->
    <classsynopsis>
-    <ooclass><classname>DOMXPath</classname></ooclass>
- 
-<!-- {{{ Class synopsis -->
+    <ooclass>
+     <classname>DOMXPath</classname>
+    </ooclass>
+
     <classsynopsisinfo>
      <ooclass>
       <classname>DOMXPath</classname>
      </ooclass>
- 
     </classsynopsisinfo>
-<!-- }}} -->
- 
+
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-<!-- If the property is documented below (xml:id=domxpath.props) use this -->
     <fieldsynopsis>
      <modifier>public</modifier>
      <type>DOMDocument</type>
@@ -47,10 +45,11 @@ Remove me once you perform substitutions
  
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domxpath')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback />
+     <xi:fallback/>
     </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domxpath')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
- 
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domxpath')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
+     <xi:fallback/>
+    </xi:include>
    </classsynopsis>
 <!-- }}} -->
  
@@ -64,7 +63,7 @@ Remove me once you perform substitutions
     <varlistentry xml:id="domxpath.props.document">
      <term><varname>document</varname></term>
      <listitem>
-      <para></para>
+      <para/>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -89,7 +88,6 @@ Remove me once you perform substitutions
  &reference.dom.entities.domxpath;
  
 </phpdoc:classref>
- 
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
@@ -110,4 +108,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-


### PR DESCRIPTION
These are only syntactical changes + a few include fallbacks and `oointerfaces` were added.