### PR TITLE
Clarify class-types meaning in composite type description.

### DIFF
--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -395,7 +395,7 @@ NULL
    </listitem>
    <listitem>
     <simpara>
-     Intersection of class-types. As of PHP 8.1.0.
+     Intersection of class-types (interfaces and class names). As of PHP 8.1.0.
     </simpara>
    </listitem>
   </itemizedlist>


### PR DESCRIPTION
#982 is a great work, but the word `class-types` is misleading, especially for translators.
I considered it is only included classes, not interfaces.

refs: https://wiki.php.net/rfc/pure-intersection-types