### PR TITLE
Default value for error_reporting is E_ALL as of PHP 8.0.0

### DIFF
--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -164,25 +164,18 @@
       <link linkend="ini.display-errors">display_errors</link> directive.
      </para>
      <para>
-      The default value
-      is <constant>E_ALL</constant> &amp;
-      ~<constant>E_NOTICE</constant> &amp;
-      ~<constant>E_STRICT</constant> &amp;
-      ~<constant>E_DEPRECATED</constant>. This setting does not
-      show <constant>E_NOTICE</constant>, <constant>E_STRICT</constant>
-      and <constant>E_DEPRECATED</constant> level errors. You may want
-      to show them during development.
+      The default value is <constant>E_ALL</constant>.
      </para>
      <note>
-      <para>Enabling <constant>E_NOTICE</constant> during development has
-      some benefits. For debugging purposes: NOTICE messages will warn you
-      about possible bugs in your code. For example, use of unassigned values
-      is warned. It is extremely useful to find typos and
-      to save time for debugging. NOTICE messages will warn you about bad style.
-      For example, <literal>$arr[item]</literal> is better to be written as
-      <literal>$arr['item']</literal> since PHP tries to treat
-      <literal>"item"</literal> as constant. If it is not a constant, PHP assumes
-      it is a string index for the array.
+      <para>
+       Prior to PHP 8.0.0, the default value was:
+       <userinput><constant>E_ALL</constant> &amp;
+        ~<constant>E_NOTICE</constant> &amp;
+        ~<constant>E_STRICT</constant> &amp;
+        ~<constant>E_DEPRECATED</constant></userinput>.
+       This means diagnostics of level <constant>E_NOTICE</constant>,
+       <constant>E_STRICT</constant> and <constant>E_DEPRECATED</constant>
+       were not shown.
       </para>
      </note>
      <note>

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -166,18 +166,16 @@
      <para>
       The default value is <constant>E_ALL</constant>.
      </para>
-     <note>
-      <para>
-       Prior to PHP 8.0.0, the default value was:
-       <userinput><constant>E_ALL</constant> &amp;
-        ~<constant>E_NOTICE</constant> &amp;
-        ~<constant>E_STRICT</constant> &amp;
-        ~<constant>E_DEPRECATED</constant></userinput>.
-       This means diagnostics of level <constant>E_NOTICE</constant>,
-       <constant>E_STRICT</constant> and <constant>E_DEPRECATED</constant>
-       were not shown.
-      </para>
-     </note>
+     <para>
+      Prior to PHP 8.0.0, the default value was:
+      <userinput><constant>E_ALL</constant> &amp;
+       ~<constant>E_NOTICE</constant> &amp;
+       ~<constant>E_STRICT</constant> &amp;
+       ~<constant>E_DEPRECATED</constant></userinput>.
+      This means diagnostics of level <constant>E_NOTICE</constant>,
+      <constant>E_STRICT</constant> and <constant>E_DEPRECATED</constant>
+      were not shown.
+     </para>
      <note>
       <title>PHP Constants outside of PHP</title>
       <para>


### PR DESCRIPTION
I'm not sure if it's valuable to keep the note about the purpose of enabling E_NOTICE, as most of the information currently in this note is incorrect.

Also not sure how to enclose the old value, as ``<constant>`` is not a child of ``<code>`` or ``<literal>`` apparently...