### PR TITLE
Clarification for setting 0 to jit_hot_loop/func

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1109,6 +1109,7 @@
     <listitem>
      <para>
       After how many iterations a loop is considered hot.
+      Note: setting to 0 will disable JIT to trace and compile any iterations.
      </para>
     </listitem>
    </varlistentry>
@@ -1120,6 +1121,7 @@
     <listitem>
      <para>
       After how many calls a function is considered hot.
+      Note: setting to 0 will disable JIT to trace and compile any calls.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
I tried to tell JIT to compile every loop and function
by setting both opcache.jit_hot_loop and opcache.jit_hot_func
to 0, but failed to get the expected result.

After having read the source code and done simple experiments, I 
found that setting these two options to 0 will actually disable JIT to
compile any iterations and calls.

So I would like to add clarifications for this behavior in PHP manual.

Signed-off-by: Su, Tao <tao.su@intel.com>