### PR TITLE
[PHP 8.1] Calling a static element on a trait is deprecated

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -486,6 +486,11 @@ enum Size
    They may only include methods and static methods.  A trait with properties will
    result in a fatal error.
   </para>
+  
+  <para>
+   As of PHP 8.1.0, calling static trait element directly is deprecated.
+   It should only be accessed on a class using the trait.
+  </para>
 
   <programlisting role="php">
 <![CDATA[

--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -488,8 +488,8 @@ enum Size
   </para>
   
   <para>
-   As of PHP 8.1.0, calling static trait element directly is deprecated.
-   It should only be accessed on a class using the trait.
+   As of PHP 8.1.0, calling a static method, or accessing a static property directly on a trait is deprecated.
+   Static methods and properties should only be accessed on a class using the trait.
   </para>
 
   <programlisting role="php">


### PR DESCRIPTION
Deprecated Features [Changelog](https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.static-trait)