### PR TITLE
Deleting usage "limitation" to debugging

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -118,7 +118,7 @@ $a instanceof Suit;  // true
 
    <para>
     All Cases have a read-only property, <literal>name</literal>, that is the case-sensitive name
-    of the case itself.  That may sometimes be useful for debugging purposes.
+    of the case itself.
    </para>
 
    <programlisting role="php">


### PR DESCRIPTION
I think it's obvious that `->name` might be handy sometimes :-)