### PR TITLE
[PHP 8.1] Calling a static element on a trait is deprecated

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -486,11 +486,6 @@ enum Size
    They may only include methods and static methods.  A trait with properties will
    result in a fatal error.
   </para>
-  
-  <para>
-   As of PHP 8.1.0, calling a static method, or accessing a static property directly on a trait is deprecated.
-   Static methods and properties should only be accessed on a class using the trait.
-  </para>
 
   <programlisting role="php">
 <![CDATA[

--- a/language/oop5/traits.xml
+++ b/language/oop5/traits.xml
@@ -367,6 +367,10 @@ class MyHelloWorld {
    <para>
     Traits can define static variables, static methods and static properties.
    </para>
+   <para>
+    As of PHP 8.1.0, calling a static method, or accessing a static property directly on a trait is deprecated.
+    Static methods and properties should only be accessed on a class using the trait.
+   </para>
    <example xml:id="language.oop5.traits.static.ex1">
     <title>Static Variables</title>
     <programlisting role="php">

--- a/language/oop5/traits.xml
+++ b/language/oop5/traits.xml
@@ -367,10 +367,12 @@ class MyHelloWorld {
    <para>
     Traits can define static variables, static methods and static properties.
    </para>
-   <para>
-    As of PHP 8.1.0, calling a static method, or accessing a static property directly on a trait is deprecated.
-    Static methods and properties should only be accessed on a class using the trait.
-   </para>
+   <note>
+    <para>
+     As of PHP 8.1.0, calling a static method, or accessing a static property directly on a trait is deprecated.
+     Static methods and properties should only be accessed on a class using the trait.
+    </para>
+   </note>
    <example xml:id="language.oop5.traits.static.ex1">
     <title>Static Variables</title>
     <programlisting role="php">


### PR DESCRIPTION
Corrected,

@cmb69 @mumumu thanks!