### PR TITLE
Fix openssl cms encoding constants

### DIFF
--- a/reference/openssl/functions/openssl-cms-decrypt.xml
+++ b/reference/openssl/functions/openssl-cms-decrypt.xml
@@ -61,8 +61,8 @@
     <term><parameter>encoding</parameter></term>
     <listitem>
      <para>
-      The encoding of the input file. One of <constant>OPENSSL_CMS_SMIME</constant>,
-      <constant>OPENSLL_CMS_DER</constant> or <constant>OPENSSL_CMS_PEM</constant>.
+      The encoding of the input file. One of <constant>OPENSSL_ENCODING_SMIME</constant>,
+      <constant>OPENSSL_ENCODING_DER</constant> or <constant>OPENSSL_ENCODING_PEM</constant>.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/openssl/functions/openssl-cms-encrypt.xml
+++ b/reference/openssl/functions/openssl-cms-encrypt.xml
@@ -71,8 +71,8 @@
     <term><parameter>encoding</parameter></term>
     <listitem>
      <para>
-      An encoding to output. One of <constant>OPENSSL_CMS_SMIME</constant>,
-      <constant>OPENSLL_CMS_DER</constant> or <constant>OPENSSL_CMS_PEM</constant>.
+      An encoding to output. One of <constant>OPENSSL_ENCODING_SMIME</constant>,
+      <constant>OPENSSL_ENCODING_DER</constant> or <constant>OPENSSL_ENCODING_PEM</constant>.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/openssl/functions/openssl-cms-sign.xml
+++ b/reference/openssl/functions/openssl-cms-sign.xml
@@ -82,8 +82,8 @@
     <term><parameter>encoding</parameter></term>
     <listitem>
      <para>
-      The encoding of the output file. One of <constant>OPENSSL_CMS_SMIME</constant>,
-      <constant>OPENSLL_CMS_DER</constant> or <constant>OPENSSL_CMS_PEM</constant>.
+      The encoding of the output file. One of <constant>OPENSSL_ENCODING_SMIME</constant>,
+      <constant>OPENSSL_ENCODING_DER</constant> or <constant>OPENSSL_ENCODING_PEM</constant>.
      </para>
     </listitem>
    </varlistentry>
@@ -104,7 +104,7 @@
    &return.success;
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/openssl/functions/openssl-cms-verify.xml
+++ b/reference/openssl/functions/openssl-cms-verify.xml
@@ -81,7 +81,7 @@
     <term><parameter>pk7</parameter></term>
     <listitem>
      <para>
-      
+
      </para>
     </listitem>
    </varlistentry>
@@ -97,8 +97,8 @@
     <term><parameter>encoding</parameter></term>
     <listitem>
      <para>
-      The encoding of the input file. One of <constant>OPENSSL_CMS_SMIME</constant>,
-      <constant>OPENSLL_CMS_DER</constant> or <constant>OPENSSL_CMS_PEM</constant>.
+      The encoding of the input file. One of <constant>OPENSSL_ENCODING_SMIME</constant>,
+      <constant>OPENSSL_ENCODING_DER</constant> or <constant>OPENSSL_ENCODING_PEM</constant>.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Fix wrong encoding constants being used in openssl-cms-x docs.