### PR TITLE
Reorder DOMDocument properties

### DIFF
--- a/reference/dom/domdocument.xml
+++ b/reference/dom/domdocument.xml
@@ -44,41 +44,8 @@
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>readonly</modifier>
-     <type>string</type>
-     <varname linkend="domdocument.props.actualencoding">actualEncoding</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>readonly</modifier>
-     <type>DOMConfiguration</type>
-     <varname linkend="domdocument.props.config">config</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>readonly</modifier>
-     <type>DOMDocumentType</type>
+     <type class="union"><type>DOMDocumentType</type><type>null</type></type>
      <varname linkend="domdocument.props.doctype">doctype</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>readonly</modifier>
-     <type class="union"><type>DOMElement</type><type>null</type></type>
-     <varname linkend="domdocument.props.documentelement">documentElement</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <type class="union"><type>string</type><type>null</type></type>
-     <varname linkend="domdocument.props.documenturi">documentURI</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <type>string</type>
-     <varname linkend="domdocument.props.encoding">encoding</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <type>bool</type>
-     <varname linkend="domdocument.props.formatoutput">formatOutput</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
@@ -88,46 +55,20 @@
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
-     <type>bool</type>
-     <varname linkend="domdocument.props.preservewhitespace">preserveWhiteSpace</varname>
-     <initializer>&true;</initializer>
+     <modifier>readonly</modifier>
+     <type class="union"><type>DOMElement</type><type>null</type></type>
+     <varname linkend="domdocument.props.documentelement">documentElement</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
-     <type>bool</type>
-     <varname linkend="domdocument.props.recover">recover</varname>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="domdocument.props.actualencoding">actualEncoding</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
-     <type>bool</type>
-     <varname linkend="domdocument.props.resolveexternals">resolveExternals</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <type>bool</type>
-     <varname linkend="domdocument.props.standalone">standalone</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <type>bool</type>
-     <varname linkend="domdocument.props.stricterrorchecking">strictErrorChecking</varname>
-     <initializer>&true;</initializer>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <type>bool</type>
-     <varname linkend="domdocument.props.substituteentities">substituteEntities</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <type>bool</type>
-     <varname linkend="domdocument.props.validateonparse">validateOnParse</varname>
-     <initializer>&false;</initializer>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <type>string</type>
-     <varname linkend="domdocument.props.version">version</varname>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="domdocument.props.encoding">encoding</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
@@ -138,17 +79,92 @@
     <fieldsynopsis>
      <modifier>public</modifier>
      <type>bool</type>
+     <varname linkend="domdocument.props.standalone">standalone</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>bool</type>
      <varname linkend="domdocument.props.xmlstandalone">xmlStandalone</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
-     <type>string</type>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="domdocument.props.version">version</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
      <varname linkend="domdocument.props.xmlversion">xmlVersion</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>bool</type>
+     <varname linkend="domdocument.props.stricterrorchecking">strictErrorChecking</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="domdocument.props.documenturi">documentURI</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>mixed</type>
+     <varname linkend="domdocument.props.config">config</varname>
+     <initializer>null</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>bool</type>
+     <varname linkend="domdocument.props.formatoutput">formatOutput</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>bool</type>
+     <varname linkend="domdocument.props.validateonparse">validateOnParse</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>bool</type>
+     <varname linkend="domdocument.props.resolveexternals">resolveExternals</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>bool</type>
+     <varname linkend="domdocument.props.preservewhitespace">preserveWhiteSpace</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>bool</type>
+     <varname linkend="domdocument.props.recover">recover</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>bool</type>
+     <varname linkend="domdocument.props.substituteentities">substituteEntities</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>DOMElement</type><type>null</type></type>
+     <varname linkend="domdocument.props.firstelementchild">firstElementChild</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>DOMElement</type><type>null</type></type>
+     <varname linkend="domdocument.props.lastelementchild">lastElementChild</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="domdocument.props.childelementcount">childElementCount</varname>
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback />
+     <xi:fallback/>
     </xi:include>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
@@ -180,6 +196,12 @@
        is a readonly equivalent to
        <varname linkend="domdocument.props.encoding">encoding</varname>.
       </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="domdocument.props.childelementcount">
+     <term><varname>childElementCount</varname></term>
+     <listitem>
+      <para>The number of child elements.</para>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="domdocument.props.config">
@@ -224,6 +246,12 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry xml:id="domdocument.props.firstelementchild">
+     <term><varname>firstElementChild</varname></term>
+     <listitem>
+      <para>First child element or &null;.</para>
+     </listitem>
+    </varlistentry>
     <varlistentry xml:id="domdocument.props.formatoutput">
      <term><varname>formatOutput</varname></term>
      <listitem>
@@ -241,6 +269,12 @@
        The <classname>DOMImplementation</classname> object that handles 
        this document.
       </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="domdocument.props.lastelementchild">
+     <term><varname>lastElementChild</varname></term>
+     <listitem>
+      <para>Last child element or &null;.</para>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="domdocument.props.preservewhitespace">


### PR DESCRIPTION
This is the **last class synopsis page which can be normally synced** (and doesn't already have a pending PR). There are some remaining smaller sync issues though (on a total of 15 pages). Some classes don't declare properties (`DateInterval`), or they include methods in a custom way (`DateTimeImmutable`), or explicitly document overridden methods (`SplQueue::__construct()`) etc. The rest of the diff between the docs and the output of gen_stubs comes from missing constant generation support (~ 40-50 pages).

I include a before-after print screen about the properties of DOMDocument because the diff is not easy to overview:
<img width="1091" alt="Screenshot 2022-01-14 at 18 16 52" src="https://user-images.githubusercontent.com/6057627/149559116-a9b2261c-4f49-4f81-a56c-51203e23a952.png">
.