### PR TITLE
Clarification of jit_bisect_limit usage

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1052,7 +1052,9 @@
     <listitem>
      <para>
       Debugging option that disables JIT compilation after compiling a certain number of functions.
-      This may be helpful to bisect the source of a JIT miscompilation.
+      This may be helpful to bisect the source of a JIT miscompilation. Note: this option only works
+      when JIT trigger is set to 0 (compile on script load) or 1 (compile on first execution),
+      e.g., opcache.jit=1215. See more in <link linkend="ini.opcache.jit">opcache.jit</link> option.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1054,7 +1054,7 @@
       Debugging option that disables JIT compilation after compiling a certain number of functions.
       This may be helpful to bisect the source of a JIT miscompilation. Note: this option only works
       when JIT trigger is set to 0 (compile on script load) or 1 (compile on first execution),
-      e.g., opcache.jit=1215. See more in <link linkend="ini.opcache.jit">opcache.jit</link> option.
+      e.g., <code>opcache.jit=1215</code>. See more in <link linkend="ini.opcache.jit">opcache.jit</link> option.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
As a new bird to PHP interpreter, I tried to set jit_bisect_limit
with jit=tracing in order to debug/probe PHP JIT feature, but
failed to hit my breakpoint and hence got confused.

I found that jit_bisect_limit only works under special JIT trigger
mode like 0: on script load, or 1: on first execution, after heavily
reading source code and trial-and-error experiments.

So, I would like to clarify the usage in PHP manual.
Hopefully, this can save time cost and reduce confusion of new PHP
interpreter developers.

The patch is verified on my local machine with phd build and the
web content and link looks good.

Signed-off-by: Su, Tao <tao.su@intel.com>