### PR TITLE
Jit debug clarification

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1040,7 +1040,11 @@
     <listitem>
      <para>
       A bit mask specifying which JIT debug output to enable.
-      For possible values, please consult <filename>zend_jit.h</filename>.
+      For possible values, please consult
+      <link xmlns:xlink="http://www.w3.org/1999/xlink"
+            xlink:href="&url.php.git.src.master.view;ext/opcache/jit/zend_jit.h">
+       zend_jit.h
+      </link> (search for macro definitions beginning with <code>ZEND_JIT_DEBUG</code>).
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Clarify jit_debug option and link to zend_jit.h
    
    Clarify how to search for jit_debug options, and add an external link to
    PHP zend_jit.h source file.
    
    Hopefully, the clarification and link can save PHP the developer's and
    user's time/effort with a simple click jumping to where they should go.
    
    This patch has been verified on my local machine and link works well.
    
    This risk is that doc viewer could get a dead link if PHP source code
    file location moved or name changed in future. We just hope this is a
    rare case and will not happen so frequently. We depend on user's
    bug-report to fix any issue.
    
    Signed-off-by: Su, Tao <tao.su@intel.com>