### PR TITLE
Clarification for usage of JIT tunable options

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1114,7 +1114,9 @@
     <listitem>
      <para>
       After how many iterations a loop is considered hot.
-      Note: setting to 0 will disable JIT to trace and compile any iterations.
+      Valid value range is <code>[0,255]</code>; for any setting out of this range,
+      e.g., -1 or 256, default value will be used instead. Specially, a zero value
+      will disable JIT to trace and compile any loops.
      </para>
     </listitem>
    </varlistentry>
@@ -1126,7 +1128,9 @@
     <listitem>
      <para>
       After how many calls a function is considered hot.
-      Note: setting to 0 will disable JIT to trace and compile any calls.
+      Valid value range is <code>[0,255]</code>; for any setting out of this range,
+      e.g., -1 or 256, default value will be used instead. Specially, a zero value
+      will disable JIT to trace and compile any functions.
      </para>
     </listitem>
    </varlistentry>
@@ -1138,6 +1142,9 @@
     <listitem>
      <para>
       After how many returns a return is considered hot.
+      Valid value range is <code>[0,255]</code>; for any setting out of this range,
+      e.g., -1 or 256, default value will be used instead. Specially, a zero value
+      will disable JIT to trace and compile any returns.
      </para>
     </listitem>
    </varlistentry>
@@ -1149,6 +1156,9 @@
     <listitem>
      <para>
       After how many exits a side exit is considered hot.
+      Valid value range is <code>[0,255]</code>; for any setting out of this range,
+      e.g., -1 or 256, default value will be used instead. Specially, a zero value
+      will disable JIT to trace and compile any side exits.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
I once tuned jit_hot_func=300 in my php-fpm and did not catch 
the warning message, which is the main motivation for this patch 
after code reading.

This patch clarifies the usage of the four JIT tunable options -
jit_hot_{loop,func,return,side_exit} - in PHP manual which end users
should be aware of before they start to tune these options.

1. Valid value range
2. Default value will be used in case beyond valid range
3. Special case of zero value

The patch was verified on my machine with phd local website.

Signed-off-by: Su, Tao <tao.su@intel.com>