### PR TITLE
PDOStatement::bindParam maxLength is confusing

### DIFF
--- a/reference/pdo/pdostatement/bindparam.xml
+++ b/reference/pdo/pdostatement/bindparam.xml
@@ -66,7 +66,7 @@
         Explicit data type for the parameter using the <link linkend="pdo.constants"><literal>PDO::PARAM_*</literal>
         constants</link>.
         To return an INOUT parameter from a stored procedure, 
-        use the bitwise OR operator to set the PDO::PARAM_INPUT_OUTPUT bits
+        use the bitwise OR operator to set the <constant>PDO::PARAM_INPUT_OUTPUT</constant> bits
         for the <parameter>type</parameter> parameter.
        </para>
       </listitem>
@@ -78,7 +78,7 @@
         Length of the data type. To indicate that a parameter is an OUT
         parameter from a stored procedure, you must explicitly set the
         length.
-        Meaningful only when <parameter>type</parameter> parameter is PDO::PARAM_INPUT_OUTPUT.
+        Meaningful only when <parameter>type</parameter> parameter is <constant>PDO::PARAM_INPUT_OUTPUT</constant>.
        </para>
       </listitem>
      </varlistentry>

--- a/reference/pdo/pdostatement/bindparam.xml
+++ b/reference/pdo/pdostatement/bindparam.xml
@@ -78,6 +78,7 @@
         Length of the data type. To indicate that a parameter is an OUT
         parameter from a stored procedure, you must explicitly set the
         length.
+        Meaningful only when <parameter>type</parameter> parameter is PDO::PARAM_INPUT_OUTPUT.
        </para>
       </listitem>
      </varlistentry>
@@ -114,7 +115,7 @@ $sth = $dbh->prepare('SELECT name, colour, calories
     WHERE calories < :calories AND colour = :colour');
 $sth->bindParam('calories', $calories, PDO::PARAM_INT);
 /* Names can be prefixed with colons ":" too (optional) */
-$sth->bindParam(':colour', $colour, PDO::PARAM_STR, 12);
+$sth->bindParam(':colour', $colour, PDO::PARAM_STR);
 $sth->execute();
 ?>
 ]]>
@@ -132,7 +133,7 @@ $sth = $dbh->prepare('SELECT name, colour, calories
     FROM fruit
     WHERE calories < ? AND colour = ?');
 $sth->bindParam(1, $calories, PDO::PARAM_INT);
-$sth->bindParam(2, $colour, PDO::PARAM_STR, 12);
+$sth->bindParam(2, $colour, PDO::PARAM_STR);
 $sth->execute();
 ?>
 ]]>


### PR DESCRIPTION
https://www.php.net/manual/en/pdostatement.bindparam.php
___
It has no effect on input parameters, but is even passed in the examples.