### PR TITLE
Fix ini directive name for uopz extension

### DIFF
--- a/reference/uopz/setup.xml
+++ b/reference/uopz/setup.xml
@@ -98,7 +98,7 @@
     </varlistentry>
     <varlistentry xml:id="ini.uopz.overloads">
      <term>
-      <parameter>uopz.exit</parameter>
+      <parameter>uopz.overloads</parameter>
       <type>bool</type>
      </term>
      <listitem>


### PR DESCRIPTION
Directive `uopz.overloads` was misspelled as `uopz.exit` in the explanation section.