### PR TITLE
Add return value "AVIF Support" to gd_info()

### DIFF
--- a/reference/image/functions/gd-info.xml
+++ b/reference/image/functions/gd-info.xml
@@ -93,6 +93,12 @@
        <entry><type>bool</type> value.  &true;
         if <literal>WebP</literal> support is included.</entry>
       </row>
+      <row>
+       <entry>AVIF Support</entry>
+       <entry><type>bool</type> value.  &true;
+        if <literal>AVIF</literal> support is included.
+        Available as of PHP 8.1.0.</entry>
+      </row>
      </tbody>
     </tgroup>
    </table>
@@ -133,6 +139,8 @@ array(10) {
   bool(false)
   ["WebP Support"]=>
   bool(false)
+  ["AVIF Support"]=>
+  bool(false)
 }
 ]]>
     </screen>
@@ -148,6 +156,7 @@ array(10) {
    <member><function>imagegif</function></member>
    <member><function>imagewbmp</function></member>
    <member><function>imagewebp</function></member>
+   <member><function>imageavif</function></member>
    <member><function>imagetypes</function></member>
   </simplelist>
  </refsect1>


### PR DESCRIPTION
Available since PHP 8.1.
Other related documentation: #983