### PR TITLE
Fix argument type in EventBufferEvent::setCallback() method and make it mixed instead of string. Add missed $arg argument to signature of EventBufferEvent::__construct().

### DIFF
--- a/reference/event/eventbufferevent/construct.xml
+++ b/reference/event/eventbufferevent/construct.xml
@@ -44,6 +44,12 @@
     <parameter>eventcb</parameter>
     <initializer>&null;</initializer>
    </methodparam>
+   <methodparam
+   choice="opt">
+    <type>mixed</type>
+    <parameter>arg</parameter>
+    <initializer>&null;</initializer>
+   </methodparam>
   </methodsynopsis>
   <para>
    Create a buffer event on a socket, stream or a file descriptor. Passing

--- a/reference/event/eventbufferevent/setcallbacks.xml
+++ b/reference/event/eventbufferevent/setcallbacks.xml
@@ -24,7 +24,7 @@
     <parameter>eventcb</parameter>
    </methodparam>
    <methodparam choice="opt">
-    <type>string</type>
+    <type>mixed</type>
     <parameter>arg</parameter>
    </methodparam>
   </methodsynopsis>


### PR DESCRIPTION
$arg type should be mixed, like it is defined at other pages, e.g. in https://www.php.net/manual/en/eventbufferevent.about.callbacks.php
string type doesn't have big sense, because we want to pass there more complex data structures, like array.

EventBufferEvent::__construct() signature should contain the 7th argument "mixed $arg = null".