### PR TITLE
Grammer fix for paamayim-nekudotayim.xml docs

### DIFF
--- a/language/oop5/paamayim-nekudotayim.xml
+++ b/language/oop5/paamayim-nekudotayim.xml
@@ -78,7 +78,7 @@ OtherClass::doubleColon();
  </example>
 
  <para>
-  When an extending class overrides the parents definition of a method,
+  When an extending class overrides the parent's definition of a method,
   PHP will not call the parent's method. It's up to the extended class
   on whether or not the parent's method is called. This also applies to <link
   linkend="language.oop5.decon">Constructors and Destructors</link>, <link


### PR DESCRIPTION
The word "parents" in "When an extending class overrides the parents definition of a method,
  PHP will not call the parent's method." needs to be changed to "parent's".