### PR TITLE
Should use constant time sodium_bin2hex in examples

### DIFF
--- a/reference/sodium/functions/sodium-crypto-kx-keypair.xml
+++ b/reference/sodium/functions/sodium-crypto-kx-keypair.xml
@@ -46,7 +46,7 @@
 $keypair = sodium_crypto_kx_keypair();
 $secret = sodium_crypto_kx_secretkey($keypair);
 $public = sodium_crypto_kx_publickey($keypair);
-printf("secret: %s\npublic: %s", bin2hex($secret), bin2hex($public));
+printf("secret: %s\npublic: %s", sodium_bin2hex($secret), sodium_bin2hex($public));
 ?>
 ]]>
    </programlisting>


### PR DESCRIPTION
Examples should use best practice, in this case it should show using the constant time sodium implementation of bin2hex and not the standard PHP version. This helps prevent timing attacks in code.