### PR TITLE
Issue #1403 : PharData and PharFileInfo methods missing PHP8 compatibility 

### DIFF
--- a/reference/phar/versions.xml
+++ b/reference/phar/versions.xml
@@ -77,8 +77,8 @@
  <function name="phardata::buildfromiterator" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
  <function name="phardata::compress" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
  <function name="phardata::compressfiles" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
- <function name="phardata::_construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
- <function name="phardata::_destruct" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="phardata::__destruct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
  <function name="phardata::converttodata" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
  <function name="phardata::converttoexecutable" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
  <function name="phardata::copy" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
@@ -100,8 +100,8 @@
  <function name="pharfileinfo::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
  <function name="pharfileinfo::__destruct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
  <function name="pharfileinfo::chmod" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
- <function name="pharfileinfo_compress" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
- <function name="pharfileinfo_decompress" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
+ <function name="pharfileinfo::compress" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
+ <function name="pharfileinfo::decompress" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
  <function name="pharfileinfo::delmetadata" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.2.0"/>
  <function name="pharfileinfo::getcompressedsize" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
  <function name="pharfileinfo::getcontent" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>


### PR DESCRIPTION
- PharData::__construct and PharData::__destruct exists in PHP8.
- PharFileInfo::compress and PharFileInfo::decompress also.