### PR TITLE
Update libxml2 docs relating to entity validation

### DIFF
--- a/reference/libxml/constants.xml
+++ b/reference/libxml/constants.xml
@@ -46,6 +46,12 @@
     <simpara>
      Default DTD attributes
     </simpara>
+    <caution>
+     <simpara>
+      Enabling loading of DTD attributes will enable fetching of external entities.
+      The <link linkend="constant.libxml-nonet"><constant>LIBXML_NONET</constant></link> constant can be used to prevent this.
+     </simpara>
+    </caution>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.libxml-dtdload">
@@ -57,6 +63,12 @@
     <simpara>
      Load the external subset
     </simpara>
+    <caution>
+     <simpara>
+      Enabling loading of external subsets will enable fetching of external entities.
+      The <link linkend="constant.libxml-nonet"><constant>LIBXML_NONET</constant></link> constant can be used to prevent this.
+     </simpara>
+    </caution>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.libxml-dtdvalid">
@@ -68,6 +80,11 @@
     <simpara>
      Validate with the DTD
     </simpara>
+    <caution>
+     <simpara>
+      Enabling entity validation may facilitate XML External Entity (XXE) attacks.
+     </simpara>
+    </caution>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.libxml-html-noimplied">

--- a/reference/libxml/functions/libxml-disable-entity-loader.xml
+++ b/reference/libxml/functions/libxml-disable-entity-loader.xml
@@ -20,12 +20,17 @@
   <para>
    Disable/enable the ability to load external entities.
    Note that disabling the loading of external entities may cause general issues
-   with loading XML documents. However, as of libxml 2.9.0 entity substitution
+   with loading XML documents.
+  </para>
+  <para>
+   As of libxml 2.9.0 entity substitution
    is disabled by default, so there is no need to disable the loading of external
    entities,
-   unless there is the need to resolve internal entity references with <constant>LIBXML_NOENT</constant>.
+   unless there is the need to resolve internal entity references with <constant>LIBXML_NOENT</constant> or
+   <constant>LIBXML_DTDVALID</constant>.
    Generally, it is preferable to use <function>libxml_set_external_entity_loader</function>
    to suppress loading of external entities.
+   The <constant>LIBXML_NONET</constant> flag can be used to prevent loading of external entities.
   </para>
  </refsect1>
 
@@ -100,6 +105,8 @@
     <member><function>libxml_use_internal_errors</function></member>
     <member><function>libxml_set_external_entity_loader</function></member>
     <member><link linkend="libxml.constants">The <constant>LIBXML_NOENT</constant> constant</link></member>
+    <member><link linkend="libxml.constants">The <constant>LIBXML_DTDVALID</constant> constant</link></member>
+    <member><link linkend="libxml.constants">The <constant>LIBXML_NONET</constant> constant</link></member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
This commit adds warning that the `LIBXML_DTD_VALID` constant is also
susceptible to XXE exploit, and that the use of `LIBXML_DTDATTR` or
`LIBXML_DTDLOAD` constants will cause external entity fetching.

Also adds a note to the deprecated libxml_disable_entity_loader function
to note that LIBXML_NONET will prevent loading of external entities.

Prior to deprecation of the `libxml_disable_entity_loader` function, the
use of this function prevented both XXE via DTD parsing, and fetching of
external entities as specified by any of the above constants.

Fixes GH-1408.