### PR TITLE
Added passing null to array functions to backward incompatible changes

### DIFF
--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -301,6 +301,9 @@ function test(int $arg = null) {}
         Attempting to access unqualified constants which are undefined.
         Previously, unqualified constant accesses resulted in a warning and were interpreted as strings.
        </member>
+       <member>
+        Attempting to pass &null; as the array parameter to one of the array functions.
+       </member>
       </simplelist>
      </para>
      <para>


### PR DESCRIPTION
Is this already on the list somewhere and I'm just missing it?