### PR TITLE
`password_verify` is capable of verifying `crypt` hashes

### DIFF
--- a/reference/password/functions/password-hash.xml
+++ b/reference/password/functions/password-hash.xml
@@ -17,9 +17,7 @@
   </methodsynopsis>
   <para>
    <function>password_hash</function> creates a new password hash using a strong one-way hashing
-   algorithm. <function>password_hash</function> is compatible with <function>crypt</function>.
-   Therefore, password hashes created by <function>crypt</function> can be used with
-   <function>password_hash</function>.
+   algorithm.
   </para>
   <simpara>
    The following algorithms are currently supported:

--- a/reference/password/functions/password-verify.xml
+++ b/reference/password/functions/password-verify.xml
@@ -16,6 +16,9 @@
   </methodsynopsis>
   <para>
    Verifies that the given hash matches the given password.
+   <function>password_verify</function> is compatible with <function>crypt</function>.
+   Therefore, password hashes created by <function>crypt</function> can be used with
+   <function>password_verify</function>.
   </para>
   <para>
    Note that <function>password_hash</function> returns the algorithm, cost and salt 

--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -20,7 +20,10 @@
   <para>
    <function>crypt</function> will return a hashed string using the
    standard Unix <abbrev>DES</abbrev>-based algorithm or
-   alternative algorithms.
+   alternative algorithms. <function>password_verify</function> is
+   compatible with <function>crypt</function>. Therefore, password
+   hashes created by <function>crypt</function> can be used with
+   <function>password_verify</function>.
   </para>
   <para>
    The <parameter>salt</parameter> parameter is optional. However, <function>crypt</function> creates a weak hash without the <parameter>salt</parameter>, and raises an <constant>E_NOTICE</constant> error without it. Make sure to specify a strong enough salt for better security. 

--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -61,7 +61,7 @@
     <simpara>
      <constant>CRYPT_EXT_DES</constant> - Extended DES-based hash. The "salt" is a
      9-character string consisting of an underscore followed by 4 characters of iteration count
-     and 4 characters of salt. Each of these 4 characters encode 24 bits, least significant
+     and 4 characters of salt. Each of these 4-character strings encode 24 bits, least significant
      character first. The values 0 to 63 are encoded as "./0-9A-Za-z". Using invalid
      characters in the salt will cause crypt() to fail.
     </simpara>

--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -62,8 +62,8 @@
      <constant>CRYPT_EXT_DES</constant> - Extended DES-based hash. The "salt" is a
      9-character string consisting of an underscore followed by 4 characters of iteration count
      and 4 characters of salt. Each of these 4-character strings encode 24 bits, least significant
-     character first. The values 0 to 63 are encoded as "./0-9A-Za-z". Using invalid
-     characters in the salt will cause crypt() to fail.
+     character first. The values <literal>0</literal> to <literal>63</literal> are encoded as
+     <literal>./0-9A-Za-z</literal>. Using invalid characters in the salt will cause crypt() to fail.
     </simpara>
    </listitem>
    <listitem>

--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -57,9 +57,9 @@
    <listitem>
     <simpara>
      <constant>CRYPT_EXT_DES</constant> - Extended DES-based hash. The "salt" is a
-     9-character string consisting of an underscore followed by 4 bytes of iteration count and
-     4 bytes of salt. These are encoded as printable characters, 6 bits per character, least
-     significant character first. The values 0 to 63 are encoded as "./0-9A-Za-z". Using invalid
+     9-character string consisting of an underscore followed by 4 characters of iteration count
+     and 4 characters of salt. Each of these 4 characters encode 24 bits, least significant
+     character first. The values 0 to 63 are encoded as "./0-9A-Za-z". Using invalid
      characters in the salt will cause crypt() to fail.
     </simpara>
    </listitem>


### PR DESCRIPTION
> `password_verify` is compatible with `crypt`. Therefore, password hashes created by `crypt` can be used with `password_verify`.

Was added to `password_verify` and `crypt` and removed from `password_hash`. I believe it was added to `password_hash` instead of `password_verify`. Also fixed an error in `crypt` documentation confusing bytes and characters.