### PR TITLE
Add documentation for the `pm.status_listen` FPM INI option

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -492,6 +492,22 @@
        </para>
       </listitem>
      </varlistentry>
+     <varlistentry xml:id="pm.status-listen">
+      <term>
+       <parameter>pm.status_listen</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        The address on which to accept FastCGI status request. This creates a
+        new invisible pool that can handle requests independently and is useful
+        if the main pool is busy with long running requests because it is still
+        possible to get the status without waiting for the firsts. Valid syntaxes
+        are: 'ip.add.re.ss:port', 'port', '/path/to/unix/socket'.
+        Default value: value of the <literal>listen</literal> option.
+       </para>
+      </listitem>
+     </varlistentry>
      <varlistentry xml:id="ping.path">
       <term>
        <parameter>ping.path</parameter>


### PR DESCRIPTION
While looking at the content of the `www.conf` file of FPM, I found out a quite interesting option that isn't documented publicy. With this PR I'm adding the missing bits of doc. About the description, I took the one that was in the file itself and rewritten a small part of it to something less repetitive