### PR TITLE
Singular/plural correction

### DIFF
--- a/reference/array/sorting.xml
+++ b/reference/array/sorting.xml
@@ -30,9 +30,9 @@
     variable itself, as opposed to returning a new sorted array
    </member>
    <member>
-    If any of these sort functions evaluates two members as equal
+    If any sort function evaluates two members as equal
     then they retain their original order.
-    Prior to PHP 8.0.0, their order were undefined (the sorting was not stable).
+    Prior to PHP 8.0.0, their order was undefined (the sorting was not stable).
    </member>
   </simplelist>
  </para>


### PR DESCRIPTION
For the first change: The alternative would be "If any of these sort functions evaluate two members..." but that's much more wordy.
For the second: there are two equal members but they only one one order (which is retained)