### PR TITLE
Disambiguate semantics of `search_value`

### DIFF
--- a/reference/array/functions/array-keys.xml
+++ b/reference/array/functions/array-keys.xml
@@ -45,7 +45,7 @@
      <term><parameter>search_value</parameter></term>
      <listitem>
       <para>
-       If specified, then only keys containing these values are returned.
+       If specified, then only keys containing this value are returned.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
The definition of `search_value` in "Parameters" is a bit ambiguous. "these values" _could_ be interpreted to mean that if an array is passed as the `$search_value`, keys of elements of `$search_value` that match _any_ of those `$array` elements will be returned.
Note, the "Description" section does not have this ambiguity as it states "that value" instead of "those values".