### PR TITLE
Improve description of `empty` return value

### DIFF
--- a/reference/var/functions/empty.xml
+++ b/reference/var/functions/empty.xml
@@ -38,9 +38,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &false; if <parameter>var</parameter> exists and has a non-empty, non-zero value,
+   Returns &true; if <parameter>var</parameter> does not exist or has a value that is empty or equal to zero,
    aka falsey, see <link linkend="language.types.boolean.casting">conversion to boolean</link>.
-   Otherwise returns &true;.
+   Otherwise returns &false;.
   </para>
  </refsect1>
  <refsect1 role="examples">


### PR DESCRIPTION
Previously it was written from the negative perspective, which was confusing to understand.