### PR TITLE
PHP 8.1 | Other reserved words: add `never`

### DIFF
--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -132,6 +132,10 @@ ArgumentCountError - makeyogurt(): Argument #1 ($container) not passed
     <literal>readonly</literal> is a keyword now. However, it still may be used
     as function name.
    </para>
+   <para>
+    <literal>never</literal> is now a reserved word, so it cannot be used to name a class,
+    interface or trait, and is also prohibited from being used in namespaces.
+   </para>
   </sect3>
  </sect2>
 

--- a/appendices/reserved.xml
+++ b/appendices/reserved.xml
@@ -552,6 +552,9 @@
         <entry>
          mixed (as of PHP 8.0)
         </entry>
+        <entry>
+         never (as of PHP 8.1)
+        </entry>
        </row>
       </tbody>
      </tgroup>


### PR DESCRIPTION
Similar to PR #938 for the PHP 8.0 `mixed` reserved word, this commit adds the new reserved word `never` to the list of "Other reserved words" and adds a mention of this to the Backward Incompatible Changes page in the migration guide.