### PR TITLE
Add default value to setFetchMode's $constructorArgs with FETCH_CLASS

### DIFF
--- a/reference/pdo/pdostatement/setfetchmode.xml
+++ b/reference/pdo/pdostatement/setfetchmode.xml
@@ -25,7 +25,7 @@
    <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter><initializer>PDO::FETCH_CLASS</initializer></methodparam>
    <methodparam><type>string</type><parameter>class</parameter></methodparam>
-   <methodparam><type class="union"><type>array</type><type>null</type></type><parameter>constructorArgs</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>null</type></type><parameter>constructorArgs</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
   <methodsynopsis>


### PR DESCRIPTION
As per https://github.com/php/php-src/blob/888bec1be33818c91a3359319d6395fe5b700053/ext/pdo/pdo_stmt.c#L1764-L1822 and specifically https://github.com/php/php-src/blob/888bec1be33818c91a3359319d6395fe5b700053/ext/pdo/pdo_stmt.c#L1787