### PR TITLE
Improve readability of htmlentities.xml

### DIFF
--- a/reference/strings/functions/htmlentities.xml
+++ b/reference/strings/functions/htmlentities.xml
@@ -17,7 +17,11 @@
   </methodsynopsis>
   <para>
    This function is identical to <function>htmlspecialchars</function> in all
-   ways, except with <function>htmlentities</function>, all characters which have HTML character entity equivalents are translated into these entities. The <function>get_html_translation_table</function> function can be used to return the translation table used dependent upon the provided <parameter>flags</parameter> constants.
+   ways, except with <function>htmlentities</function>, all characters which
+   have HTML character entity equivalents are translated into these entities.
+   The <function>get_html_translation_table</function> function can be used
+   to return the translation table used dependent upon the provided
+   <parameter>flags</parameter> constants.
   </para>
   <para>
    If you want to decode instead (the reverse) you can use

--- a/reference/strings/functions/htmlentities.xml
+++ b/reference/strings/functions/htmlentities.xml
@@ -17,8 +17,7 @@
   </methodsynopsis>
   <para>
    This function is identical to <function>htmlspecialchars</function> in all
-   ways, except with <function>htmlentities</function>, all characters which
-   are applicable to the provided flags and have HTML character entity equivalents are translated into these entities.
+   ways, except with <function>htmlentities</function>, all characters which have HTML character entity equivalents are translated into these entities. The <function>get_html_translation_table</function> function can be used to return the translation table used dependent upon the provided <parameter>flags</parameter> constants.
   </para>
   <para>
    If you want to decode instead (the reverse) you can use

--- a/reference/strings/functions/htmlentities.xml
+++ b/reference/strings/functions/htmlentities.xml
@@ -18,7 +18,7 @@
   <para>
    This function is identical to <function>htmlspecialchars</function> in all
    ways, except with <function>htmlentities</function>, all characters which
-   have HTML character entity equivalents are translated into these entities.
+   are applicable to the provided flags and have HTML character entity equivalents are translated into these entities.
   </para>
   <para>
    If you want to decode instead (the reverse) you can use


### PR DESCRIPTION
This line now reads better when you're in a hurry (imo), and doesn't give the impression that ALL characters will be converted to entities.