### PR TITLE
GH Actions: version update for various predefined actions

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -21,20 +21,20 @@ jobs:
 
     steps:
       - name: "Checkout php/doc-${{ matrix.language }}"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           path: "${{ matrix.language }}"
           repository: "php/doc-${{ matrix.language }}"
 
       - name: "Checkout php/doc-en as fallback"
         if: "matrix.language != 'en'"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           path: "en"
           repository: "php/doc-en"
 
       - name: "Checkout php/doc-base"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           path: "doc-base"
           repository: "php/doc-base"
@@ -46,7 +46,7 @@ jobs:
         run: "php8.0 doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}"
 
       - name: "Upload .manual.xml"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: .manual.xml
           path: doc-base/.manual.xml


### PR DESCRIPTION
A number of predefined actions have had major release, which warrant an update the workflow(s).

These updates don't actually contain any changed functionality, they are mostly just a change of the Node version used by the action itself (from Node 14 to Node 16).

Refs:
* https://github.com/actions/checkout/releases
* https://github.com/actions/upload-artifact/releases