### PR TITLE
Fix CURLFile multiple files examples

### DIFF
--- a/reference/curl/curlfile/construct.xml
+++ b/reference/curl/curlfile/construct.xml
@@ -169,15 +169,12 @@ array(1) {
 <?php
 $request = curl_init('http://www.example.com/upload.php');
 curl_setopt($request, CURLOPT_POST, true);
-curl_setopt($request, 
-CURLOPT_SAFE_UPLOAD, true); curl_setopt(
-    $request,
-    CURLOPT_POSTFIELDS,
-    [
-        'blob[0]' => new CURLFile(realpath('first-file.jpg'), 'image/jpeg'),
-        'blob[1]' => new CURLFile(realpath('second-file.txt'), 'text/plain'),
-        'blob[2]' => new CURLFile(realpath('third-file.exe'), 'application/octet-stream'),
-    ] );
+curl_setopt($request, CURLOPT_SAFE_UPLOAD, true);
+curl_setopt($request, CURLOPT_POSTFIELDS, [
+    'blob[0]' => new CURLFile(realpath('first-file.jpg'), 'image/jpeg'),
+    'blob[1]' => new CURLFile(realpath('second-file.txt'), 'text/plain'),
+    'blob[2]' => new CURLFile(realpath('third-file.exe'), 'application/octet-stream'),
+]);
 curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
 
 echo curl_exec($request);
@@ -194,14 +191,12 @@ curl_close($request);
 // procedural
 $request = curl_init('http://www.example.com/upload.php');
 curl_setopt($request, CURLOPT_POST, true); 
-curl_setopt($request, CURLOPT_SAFE_UPLOAD, true); curl_setopt(
-    $request,
-    CURLOPT_POSTFIELDS,
-    [
-        'blob[0]' => curl_file_create(realpath('first-file.jpg'), 'image/jpeg'),
-        'blob[1]' => curl_file_create(realpath('second-file.txt'), 'text/plain'),
-        'blob[2]' => curl_file_create(realpath('third-file.exe'), 'application/octet-stream'),
-    ] );
+curl_setopt($request, CURLOPT_SAFE_UPLOAD, true);
+curl_setopt($request, CURLOPT_POSTFIELDS, [
+    'blob[0]' => curl_file_create(realpath('first-file.jpg'), 'image/jpeg'),
+    'blob[1]' => curl_file_create(realpath('second-file.txt'), 'text/plain'),
+    'blob[2]' => curl_file_create(realpath('third-file.exe'), 'application/octet-stream'),
+]);
 curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
 
 echo curl_exec($request);


### PR DESCRIPTION
This PR cleans up the examples for sending multiple files using curl. Currently, the examples are poorly formatted and hard to read with a `curl_setopt` function call being split up into two lines and beginning another `curl_setopt` call directly after it on the same line.

<details><summary>
<h4>Unformatted example</h>
</summary>

![Screen Shot 2022-03-11 at 1 29 38 AM](https://user-images.githubusercontent.com/2221746/157779007-f8110bb3-7e8b-443b-8d75-d15c264cb50e.png)
</details><details><summary>
<h4>Formatted example</h>
</summary>

![Screen Shot 2022-03-11 at 1 29 16 AM](https://user-images.githubusercontent.com/2221746/157779040-2d3536db-a2fb-45c9-af56-50aa8406ecad.png)
</details> 