### PR TITLE
PHP 8.1 | MigrationGuide/New classes: add missing classes

### DIFF
--- a/appendices/migration81/new-classes.xml
+++ b/appendices/migration81/new-classes.xml
@@ -2,6 +2,18 @@
 <sect1 xml:id="migration81.new-classes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>New Classes and Interfaces</title>
 
+ <sect2 xml:id="migration81.new-classes.curl">
+  <title>cURL</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>CURLStringFile</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
  <sect2 xml:id="migration81.new-classes.intl">
   <title>Intl</title>
 
@@ -9,6 +21,18 @@
    <listitem>
     <simpara>
      <classname>IntlDatePatternGenerator</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-classes.reflection">
+  <title>Reflection</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>ReflectionFiber</classname>
     </simpara>
    </listitem>
   </itemizedlist>


### PR DESCRIPTION
> Added `CURLStringFile`, which can be used to post a file from a string rather than a file

Refs:
* https://github.com/php/php-src/blob/f67986a9218f4889d9352a87c29337a5b6eaa4bd/UPGRADING#L231-L235
* https://github.com/php/php-src/pull/6456
* https://github.com/php/php-src/commit/e727919b97c4baeca93cb7700d4adf2e35a3530f

As part of the Fibers RFC/PR, the Reflection extension also received a new class.

* https://wiki.php.net/rfc/fibers
* https://github.com/php/php-src/pull/6875
* https://github.com/php/php-src/commit/c276c16b6627222c40bd43907475d664734b9abe

Note: I've not listed the `Fiber` and `FiberError` classes as those could be considered covered via the mention of Fibers on the "New Features" page, though happy to update the commit if so desired.