### PR TITLE
PHP 8.1 | MigrationGuide/New functions: add missing functions

### DIFF
--- a/appendices/migration81/new-functions.xml
+++ b/appendices/migration81/new-functions.xml
@@ -14,6 +14,23 @@
   </itemizedlist>
  </sect2>
 
+ <sect2 xml:id="migration81.new-functions.gd">
+  <title>GD</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <function>imagecreatefromavif</function>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <function>imageavif</function>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
  <sect2 xml:id="migration81.new-functions.pcntl">
   <title>Process Control</title>
 

--- a/appendices/migration81/new-functions.xml
+++ b/appendices/migration81/new-functions.xml
@@ -31,6 +31,23 @@
   </itemizedlist>
  </sect2>
 
+ <sect2 xml:id="migration81.new-functions.mysqli">
+  <title>MySQLi</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <function>mysqli_result::fetch_column</function>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <function>mysqli_fetch_column</function>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
  <sect2 xml:id="migration81.new-functions.pcntl">
   <title>Process Control</title>
 


### PR DESCRIPTION
### PHP 8.1 | MigrationGuide/New functions: add missing functions [1]

(mentioned in new features, but not in the new functions list)

> GD:
> * Avif support is now available through the `imagecreatefromavif()` and
>    `imageavif()` functions, if libgd has been built with avif support.

Refs:
* https://github.com/php/php-src/blob/f67986a9218f4889d9352a87c29337a5b6eaa4bd/UPGRADING#L245-L247
* https://github.com/php/php-src/pull/7026
* https://github.com/php/php-src/commit/81f6d36c90b8626660a6571cdc128265fa00697f

### PHP 8.1 | MigrationGuide/New functions: add missing functions [2]

(mentioned in new features, but not in the new functions list)

> `mysqli_result::fetch_column()` has been added to allow fetching a single scalar value from the result set.

While only the method is mentioned in the RFC and the Migration guide, a procedural version of the same was also implemented.

Refs:
* https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.mysqli.mysqli_fetch_column
* https://wiki.php.net/rfc/mysqli_fetch_column
* https://github.com/php/php-src/pull/6798
* https://github.com/php/php-src/commit/54222a6fe400948d30f1a519983d596e012fd6df