### PR TITLE
PHP 8.1 | MigrationGuide/New constants: add missing constants

### DIFF
--- a/appendices/migration81/constants.xml
+++ b/appendices/migration81/constants.xml
@@ -63,6 +63,19 @@
   </itemizedlist>
  </sect2>
 
+ <sect2 xml:id="migration81.constants.posix">
+  <title>POSIX</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>POSIX_RLIMIT_KQUEUES</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>POSIX_RLIMIT_NPTS</constant></simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
  <sect2 xml:id="migration81.constants.sockets">
   <title>Sockets</title>
 

--- a/appendices/migration81/constants.xml
+++ b/appendices/migration81/constants.xml
@@ -2,6 +2,37 @@
 <sect1 xml:id="migration81.constants" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>New Global Constants</title>
 
+ <sect2 xml:id="migration81.constants.curl">
+  <title>cURL</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>CURLOPT_DOH_URL</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_ISSUERCERT_BLOB</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_PROXY_ISSUERCERT</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_PROXY_ISSUERCERT_BLOB</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_PROXY_SSLCERT_BLOB</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_PROXY_SSLKEY_BLOB</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_SSLCERT_BLOB</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_SSLKEY_BLOB</constant></simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
  <sect2 xml:id="migration81.constants.mysqli">
   <title>MySQLi</title>
 

--- a/appendices/migration81/constants.xml
+++ b/appendices/migration81/constants.xml
@@ -33,6 +33,19 @@
   </itemizedlist>
  </sect2>
 
+ <sect2 xml:id="migration81.constants.gd">
+  <title>GD</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>IMG_AVIF</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>IMG_WEBP_LOSSLESS</constant></simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
  <sect2 xml:id="migration81.constants.mysqli">
   <title>MySQLi</title>
 

--- a/appendices/migration81/constants.xml
+++ b/appendices/migration81/constants.xml
@@ -101,6 +101,37 @@
   </itemizedlist>
  </sect2>
 
+ <sect2 xml:id="migration81.constants.sodium">
+  <title>Sodium</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>SODIUM_CRYPTO_STREAM_XCHACHA20_NONCEBYTES</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SODIUM_CRYPTO_STREAM_XCHACHA20_KEYBYTES</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SODIUM_CRYPTO_SCALARMULT_RISTRETTO255_BYTES</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SODIUM_CRYPTO_SCALARMULT_RISTRETTO255_SCALARBYTES</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SODIUM_CRYPTO_CORE_RISTRETTO255_BYTES</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SODIUM_CRYPTO_CORE_RISTRETTO255_HASHBYTES</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SODIUM_CRYPTO_CORE_RISTRETTO255_SCALARBYTES</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SODIUM_CRYPTO_CORE_RISTRETTO255_NONREDUCEDSCALARBYTES</constant></simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
  <sect2 xml:id="migration81.constants.tokenizer">
   <title>Tokenizer</title>
 

--- a/appendices/migration81/constants.xml
+++ b/appendices/migration81/constants.xml
@@ -101,6 +101,16 @@
   </itemizedlist>
  </sect2>
 
+ <sect2 xml:id="migration81.constants.tokenizer">
+  <title>Tokenizer</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>T_READONLY</constant></simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
 </sect1>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
### PHP 8.1 | MigrationGuide/New constants: add missing constants [1]

> * Added CURLOPT_DOH_URL option

> * Added certificate blob options when for libcurl >= 7.71.0:
>
>         CURLOPT_ISSUERCERT_BLOB
>         CURLOPT_PROXY_ISSUERCERT
>         CURLOPT_PROXY_ISSUERCERT_BLOB
>         CURLOPT_PROXY_SSLCERT_BLOB
>         CURLOPT_PROXY_SSLKEY_BLOB
>         CURLOPT_SSLCERT_BLOB
>         CURLOPT_SSLKEY_BLOB

Refs:
* https://github.com/php/php-src/blob/f67986a9218f4889d9352a87c29337a5b6eaa4bd/UPGRADING#L220-L229
* https://github.com/php/php-src/pull/6612
* https://github.com/php/php-src/commit/3dad63b5b25fc27604a38964b3bea885cbfbf1d3
* https://github.com/php/php-src/pull/7194
* https://github.com/php/php-src/commit/b11785c5e48437a0fd0e6935c52c372239838382

### PHP 8.1 | MigrationGuide/New constants: add missing constants [2]

> GD:
> * Avif support is now available through the `imagecreatefromavif()` and
>     `imageavif()` functions, if libgd has been built with avif support.

While not mentioned in the changelog entry, the commit to PHP does contain a new constant declaration...

Refs:
* https://github.com/php/php-src/blob/f67986a9218f4889d9352a87c29337a5b6eaa4bd/UPGRADING#L245-L247
* https://github.com/php/php-src/pull/7026
* https://github.com/php/php-src/commit/81f6d36c90b8626660a6571cdc128265fa00697f#diff-00d1efef2247b288c86a6c3bfefac111a4774fbc5453fdc02dcf36c4a23da283R373

> GD:
> * `imagewebp()` can do lossless WebP encoding by passing `IMG_WEBP_LOSSLESS` as
>    quality. This constant is only defined, if a libgd is used which supports
>    lossless WebP encoding.

Refs:
* https://github.com/php/php-src/blob/3a71fcf5caf042a4ce8a586a6b554fd70432e1e2/UPGRADING#L568-L571
* https://github.com/php/php-src/pull/7348
* https://github.com/php/php-src/commit/eb6c9eb936c62a5784874079747290672bd2faa2

### PHP 8.1 | MigrationGuide/New constants: add missing constants [3]

> Added `POSIX_RLIMIT_KQUEUES` and `POSIX_RLIMIT_NPTS`. These rlimits are only available on FreeBSD.

Refs:
* https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.posix
* https://github.com/php/php-src/pull/6608
* https://github.com/php/php-src/commit/ebca8deaaf3d7518bfe2fb135b331d9901d9134d

### PHP 8.1 | MigrationGuide/New constants: add missing constants [4]

Refs:
* https://wiki.php.net/rfc/readonly_properties_v2
* https://github.com/php/php-src/pull/7089
* https://github.com/php/php-src/commit/6780aaa53266a19c4d0116329c163a8fe65b5413

### PHP 8.1 | MigrationGuide/New constants: add missing constants [5]

While not mentioned anywhere at all, the commit to PHP itself adding support for the Sodium xchacha* functions, does declare a couple of new constants as well...

Refs:
* https://github.com/php/php-src/pull/6868
* https://github.com/php/php-src/commit/f7f1f7fce272c4f0a9a92dd939ce90a373d7fece#diff-3fe4027560fd299248af1dc1efe04287cc2b6418e8f01755c05c9db64b668b1eR352-R357

While not mentioned anywhere at all, the commit to PHP itself adding support for the Sodium ristretto255* functions, also declares a number of new constants as well...

Refs:
* https://github.com/php/php-src/pull/6922
* https://github.com/php/php-src/commit/9b794f8e5e6629e59e0af035e83bf7fca7dc1c62#diff-3fe4027560fd299248af1dc1efe04287cc2b6418e8f01755c05c9db64b668b1eR368-R381