### PR TITLE
PHP 8.1 | MigrationGuide/Deprecated: add missing function

### DIFF
--- a/appendices/migration81/deprecated.xml
+++ b/appendices/migration81/deprecated.xml
@@ -199,8 +199,9 @@ $arr[] = 2;
   <title>GD</title>
 
   <para>
-   The <parameter>num_points</parameter> of <function>imageopenpolygon</function>
-   and <function>imagefilledpolygon</function> has been deprecated.
+   The <parameter>num_points</parameter> of <function>imagepolygon</function>,
+   <function>imageopenpolygon</function> and <function>imagefilledpolygon</function>
+   has been deprecated.
   </para>
  </sect2>
 


### PR DESCRIPTION
> GD:
> The `$num_points` parameter of `image(open|filled)polygon` has been deprecated.

Refs:
* https://github.com/php/php-src/blob/f67986a9218f4889d9352a87c29337a5b6eaa4bd/UPGRADING#L397-L398
* https://github.com/php/php-src/pull/6789
* https://github.com/php/php-src/commit/e1285c4aa5eba7d1cc2865400c0c165201f9e5f8