### PR TITLE
PHP 8.1 | Update hash_algos() documentation

### DIFF
--- a/reference/hash/functions/hash-algos.xml
+++ b/reference/hash/functions/hash-algos.xml
@@ -39,6 +39,12 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.1.0</entry>
+       <entry>
+        Support for MurmurHash3 and xxHash algorithms has been added.
+       </entry>
+      </row>
+      <row>
        <entry>7.4.0</entry>
        <entry>
         Support for crc32c has been added.
@@ -56,14 +62,14 @@
    </informaltable>
   </para>
  </refsect1><!-- }}} -->
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
    <example>
     <title><function>hash_algos</function> example</title>
     <para>
-     As of PHP 7.4.0, <function>hash_algos</function> will return the
+     As of PHP 8.1.0, <function>hash_algos</function> will return the
      following list of algorithm names.
     </para>
     <programlisting role="php">
@@ -116,21 +122,28 @@ Array
     [35] => fnv164
     [36] => fnv1a64
     [37] => joaat
-    [38] => haval128,3
-    [39] => haval160,3
-    [40] => haval192,3
-    [41] => haval224,3
-    [42] => haval256,3
-    [43] => haval128,4
-    [44] => haval160,4
-    [45] => haval192,4
-    [46] => haval224,4
-    [47] => haval256,4
-    [48] => haval128,5
-    [49] => haval160,5
-    [50] => haval192,5
-    [51] => haval224,5
-    [52] => haval256,5
+    [38] => murmur3a
+    [39] => murmur3c
+    [40] => murmur3f
+    [41] => xxh32
+    [42] => xxh64
+    [43] => xxh3
+    [44] => xxh128
+    [45] => haval128,3
+    [46] => haval160,3
+    [47] => haval192,3
+    [48] => haval224,3
+    [49] => haval256,3
+    [50] => haval128,4
+    [51] => haval160,4
+    [52] => haval192,4
+    [53] => haval224,4
+    [54] => haval256,4
+    [55] => haval128,5
+    [56] => haval160,5
+    [57] => haval192,5
+    [58] => haval224,5
+    [59] => haval256,5
 )
 ]]>
     </screen>


### PR DESCRIPTION
> **MurmurHash3**
>
> Added support for MurmurHash3 with streaming support. The following variants are implemented:
> * murmur3a, 32-bit hash
> * murmur3c, 128-bit hash for x86
> * murmur3f, 128-bit hash for x64
>
> **xxHash**
>
> Added support for xxHash. The following variants are implemented:
> * xxh32, 32-bit hash
> * xxh64, 64-bit hash
> * xxh3, 64-bit hash
> * xxh128, 128-bit hash

Refs:
* https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.hash.murmurhash3
* https://github.com/php/php-src/pull/6059
* https://github.com/php/php-src/commit/72e91e9fc82b85d0c5a6ff043cd1b2daee6c26d0
* https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.hash.xxhash
* https://github.com/php/php-src/pull/6524
* https://github.com/php/php-src/commit/23590f7c5348de4f8b69da81439b7c42c7ba084c