### PR TITLE
Modernize examples on connect_error & connect_errno

### DIFF
--- a/reference/mysqli/mysqli/connect-errno.xml
+++ b/reference/mysqli/mysqli/connect-errno.xml
@@ -42,9 +42,10 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-/* @ is used to suppress default error messages */
-$mysqli = @new mysqli('localhost', 'fake_user', 'my_password', 'my_db');
 
+mysqli_report(MYSQLI_REPORT_OFF);
+/* @ is used to suppress warnings */
+$mysqli = @new mysqli('localhost', 'fake_user', 'wrong_password', 'does_not_exist');
 if ($mysqli->connect_errno) {
     /* Use your preferred error logging method here */
     error_log('Connection error: ' . $mysqli->connect_errno);
@@ -55,21 +56,16 @@ if ($mysqli->connect_errno) {
    <programlisting role="php">
 <![CDATA[
 <?php
-/* @ is used to suppress default error messages */
-$link = @mysqli_connect('localhost', 'fake_user', 'my_password', 'my_db');
 
+mysqli_report(MYSQLI_REPORT_OFF);
+/* @ is used to suppress warnings */
+$link = @mysqli_connect('localhost', 'fake_user', 'wrong_password', 'does_not_exist');
 if (!$link) {
     /* Use your preferred error logging method here */
     error_log('Connection error: ' . mysqli_connect_errno());
 }
 ]]>
    </programlisting>
-   &examples.outputs;
-   <screen>
-<![CDATA[
-Connection error: 1045
-]]>
-   </screen>
   </example>
  </refsect1>
 

--- a/reference/mysqli/mysqli/connect-error.xml
+++ b/reference/mysqli/mysqli/connect-error.xml
@@ -41,9 +41,10 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-/* @ is used to suppress default error messages */
-$mysqli = @new mysqli('localhost', 'fake_user', 'my_password', 'my_db');
 
+mysqli_report(MYSQLI_REPORT_OFF);
+/* @ is used to suppress warnings */
+$mysqli = @new mysqli('localhost', 'fake_user', 'wrong_password', 'does_not_exist');
 if ($mysqli->connect_error) {
     /* Use your preferred error logging method here */
     error_log('Connection error: ' . $mysqli->connect_error);
@@ -54,21 +55,16 @@ if ($mysqli->connect_error) {
    <programlisting role="php">
 <![CDATA[
 <?php
-/* @ is used to suppress default error messages */
-$link = @mysqli_connect('localhost', 'fake_user', 'my_password', 'my_db');
 
+mysqli_report(MYSQLI_REPORT_OFF);
+/* @ is used to suppress warnings */
+$link = @mysqli_connect('localhost', 'fake_user', 'wrong_password', 'does_not_exist');
 if (!$link) {
     /* Use your preferred error logging method here */
     error_log('Connection error: ' . mysqli_connect_error());
 }
 ]]>
    </programlisting>
-   &examples.outputs;
-   <screen>
-<![CDATA[
-Connection error: Access denied for user 'fake_user'@'localhost' (using password: YES)
-]]>
-   </screen>
   </example>
  </refsect1>
 


### PR DESCRIPTION
This is an attempt to provide a code example that works both on PHP 8.0 and 8.1. Due to how broken this functionality is, I can't think of a reasonable example that would make sense. 

I removed the output as outputting this information is a really bad idea. 

I thought about putting an example such as 
```
<?php

mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
$mysqli = new mysqli();
try {
    /* @ is used to suppress warnings */
    @$mysqli->real_connect('localhost', 'fake_user', 'my_password', 'does_not_exist');
} catch (mysqli_sql_exception $e) {
    /* Use your preferred error logging method here */
    error_log('Connection error: ' . $mysqli->connect_error);
}
```
but in the end, I decided that the older one is more relevant. 

I also wanted to add a note about warnings and why we use silence operator despite error reporting turned off, but I couldn't think of the suitable wording. 