### PR TITLE
Add missing param/return value sections

### DIFF
--- a/reference/pdo/pdo/setattribute.xml
+++ b/reference/pdo/pdo/setattribute.xml
@@ -16,87 +16,171 @@
   </methodsynopsis>
 
   <para>
-   Sets an attribute on the database handle. Some of the available generic
+   Sets an attribute on the database handle. Some available generic
    attributes are listed below; some drivers may make use of
    additional driver specific attributes.
    Note that driver specific attributes <emphasis>must not</emphasis> be used
    with other drivers.
    <itemizedlist>
-    <listitem><para>
-     <literal>PDO::ATTR_CASE</literal>: Force column names to a specific case.
-     <itemizedlist>
-      <listitem><para>
-       <literal>PDO::CASE_LOWER</literal>: Force column names to lower case.
-      </para></listitem>
-      <listitem><para>
-       <literal>PDO::CASE_NATURAL</literal>: Leave column names as returned by
-       the database driver.
-      </para></listitem>
-      <listitem><para>
-       <literal>PDO::CASE_UPPER</literal>: Force column names to upper case.
-      </para></listitem>
-     </itemizedlist>
-    </para></listitem>
-    <listitem><para><literal>PDO::ATTR_ERRMODE</literal>: Error reporting.
-     <itemizedlist>
-      <listitem><para><literal>PDO::ERRMODE_SILENT</literal>:
-       Just set error codes.</para></listitem>
-      <listitem><para><literal>PDO::ERRMODE_WARNING</literal>:
-       Raise <constant>E_WARNING</constant>.</para></listitem>
-      <listitem><para><literal>PDO::ERRMODE_EXCEPTION</literal>:
-       Throw <link linkend="class.pdoexception">exceptions</link>.</para></listitem>
-     </itemizedlist>
-    </para></listitem>
-    <listitem><para><literal>PDO::ATTR_ORACLE_NULLS</literal>
-     (available with all drivers, not just Oracle):
-     Conversion of NULL and empty strings.
-     <itemizedlist>
-      <listitem><para><literal>PDO::NULL_NATURAL</literal>:
-       No conversion.</para></listitem>
-      <listitem><para><literal>PDO::NULL_EMPTY_STRING</literal>:
-       Empty string is converted to &null;.</para></listitem>
-      <listitem><para><literal>PDO::NULL_TO_STRING</literal>:
-       NULL is converted to an empty string.</para></listitem>
-     </itemizedlist>
-    </para></listitem>
-    <listitem><para><literal>PDO::ATTR_STRINGIFY_FETCHES</literal>:
-     Convert numeric values to strings when fetching.
-     Requires <type>bool</type>.
-    </para></listitem>
-    <listitem><para><literal>PDO::ATTR_STATEMENT_CLASS</literal>:
-     Set user-supplied statement class derived from PDOStatement.
-     Cannot be used with persistent PDO instances.
-     Requires <literal>array(string classname, array(mixed constructor_args))</literal>.
-    </para></listitem>
-    <listitem><para><literal>PDO::ATTR_TIMEOUT</literal>:
-     Specifies the timeout duration in seconds.  Not all drivers support this option,
-     and its meaning may differ from driver to driver.  For example, sqlite will wait
-     for up to this time value before giving up on obtaining an writable lock, but
-     other drivers may interpret this as a connect or a read timeout interval.
-     Requires <type>int</type>.
-    </para></listitem>
-    <listitem><para><literal>PDO::ATTR_AUTOCOMMIT</literal>
-     (available in OCI, Firebird and MySQL):
-     Whether to autocommit every single statement.
-    </para></listitem>
-    <listitem><para><literal>PDO::ATTR_EMULATE_PREPARES</literal>
-     Enables or disables emulation of prepared statements.  Some drivers do 
-     not support native prepared statements or have limited support for them.
-     Use this setting to force PDO to either always emulate prepared 
-     statements (if &true; and emulated prepares are supported by the driver), or to try to use native prepared statements (if 
-     &false;).  It will always fall back to emulating the prepared statement
-     if the driver cannot successfully prepare the current query. 
-     Requires <type>bool</type>.
-     </para></listitem>
-    <listitem><para><literal>PDO::MYSQL_ATTR_USE_BUFFERED_QUERY</literal>
-    (available in MySQL):
-    Use buffered queries.
-    </para></listitem>
-    <listitem><para><literal>PDO::ATTR_DEFAULT_FETCH_MODE</literal>:
-    Set default fetch mode. Description of modes is available in
-    <function>PDOStatement::fetch</function> documentation.
-    </para></listitem>
+    <listitem>
+     <para>
+      <constant>PDO::ATTR_CASE</constant>: Force column names to a specific case.
+      <itemizedlist>
+       <listitem>
+        <para>
+         <constant>PDO::CASE_LOWER</constant>: Force column names to lower case.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         <constant>PDO::CASE_NATURAL</constant>: Leave column names as returned
+         by the database driver.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         <constant>PDO::CASE_UPPER</constant>: Force column names to upper case.
+        </para>
+       </listitem>
+      </itemizedlist>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <constant>PDO::ATTR_ERRMODE</constant>: Error reporting.
+      <itemizedlist>
+       <listitem>
+        <para>
+         <constant>PDO::ERRMODE_SILENT</constant>: Just set error codes.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         <constant>PDO::ERRMODE_WARNING</constant>:
+         Raise <constant>E_WARNING</constant>.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         <constant>PDO::ERRMODE_EXCEPTION</constant>:
+         Throw <classname>PDOException</classname>s.
+        </para>
+       </listitem>
+      </itemizedlist>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <constant>PDO::ATTR_ORACLE_NULLS</constant>
+      (available with all drivers, not just Oracle):
+      Conversion of NULL and empty strings.
+      <itemizedlist>
+       <listitem>
+        <para>
+         <constant>PDO::NULL_NATURAL</constant>:
+         No conversion.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         <constant>PDO::NULL_EMPTY_STRING</constant>:
+         Empty string is converted to &null;.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         <constant>PDO::NULL_TO_STRING</constant>:
+         &null; is converted to an empty string.
+        </para>
+       </listitem>
+      </itemizedlist>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <constant>PDO::ATTR_STRINGIFY_FETCHES</constant>:
+      Convert numeric values to strings when fetching.
+      Requires <type>bool</type>.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <constant>PDO::ATTR_STATEMENT_CLASS</constant>:
+      Set user-supplied statement class derived from PDOStatement.
+      Cannot be used with persistent PDO instances.
+      Requires <literal>array(string classname, array(mixed constructor_args))</literal>.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <constant>PDO::ATTR_TIMEOUT</constant>:
+      Specifies the timeout duration in seconds.
+      Not all drivers support this option, and its meaning may differ from driver to driver.
+      For example, sqlite will wait for up to this time value before giving up
+      on obtaining a writable lock, but other drivers may interpret this as a
+      connect or a read timeout interval.
+      Requires <type>int</type>.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <constant>PDO::ATTR_AUTOCOMMIT</constant>
+      (available in OCI, Firebird and MySQL):
+      Whether to autocommit every single statement.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <constant>PDO::ATTR_EMULATE_PREPARES</constant>
+      Enables or disables emulation of prepared statements.  Some drivers do
+      not support native prepared statements or have limited support for them.
+      Use this setting to force PDO to either always emulate prepared
+      statements (if &true; and emulated prepares are supported by the driver),
+      or to try to use native prepared statements (if &false;).
+      It will always fall back to emulating the prepared statement if the
+      driver cannot successfully prepare the current query.
+      Requires <type>bool</type>.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <constant>PDO::MYSQL_ATTR_USE_BUFFERED_QUERY</constant>
+      (available in MySQL): Use buffered queries.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <constant>PDO::ATTR_DEFAULT_FETCH_MODE</constant>: Set default fetch mode.
+      Description of the modes is available in the
+      <methodname>PDOStatement::fetch</methodname> documentation.
+     </para>
+    </listitem>
    </itemizedlist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>attribute</parameter></term>
+     <listitem>
+      <para>
+       The attribute to modify.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>value</parameter></term>
+     <listitem>
+      <para>
+       The value to set the <parameter>attribute</parameter>,
+       might require a specific type depending on the attribute.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
   </para>
  </refsect1>
 
@@ -104,6 +188,17 @@
   &reftitle.returnvalues;
   <para>
    &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>PDO::getAttribute</function></member>
+    <member><function>PDOStatement::getAttribute</function></member>
+    <member><function>PDOStatement::setAttribute</function></member>
+   </simplelist>
   </para>
  </refsect1>
 

--- a/reference/pdo/pdo/setattribute.xml
+++ b/reference/pdo/pdo/setattribute.xml
@@ -21,141 +21,219 @@
    additional driver specific attributes.
    Note that driver specific attributes <emphasis>must not</emphasis> be used
    with other drivers.
-   <itemizedlist>
-    <listitem>
-     <para>
-      <constant>PDO::ATTR_CASE</constant>: Force column names to a specific case.
-      <itemizedlist>
-       <listitem>
-        <para>
-         <constant>PDO::CASE_LOWER</constant>: Force column names to lower case.
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <constant>PDO::CASE_NATURAL</constant>: Leave column names as returned
-         by the database driver.
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <constant>PDO::CASE_UPPER</constant>: Force column names to upper case.
-        </para>
-       </listitem>
-      </itemizedlist>
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <constant>PDO::ATTR_ERRMODE</constant>: Error reporting.
-      <itemizedlist>
-       <listitem>
-        <para>
-         <constant>PDO::ERRMODE_SILENT</constant>: Just set error codes.
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <constant>PDO::ERRMODE_WARNING</constant>:
-         Raise <constant>E_WARNING</constant>.
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <constant>PDO::ERRMODE_EXCEPTION</constant>:
-         Throw <classname>PDOException</classname>s.
-        </para>
-       </listitem>
-      </itemizedlist>
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <constant>PDO::ATTR_ORACLE_NULLS</constant>
-      (available with all drivers, not just Oracle):
-      Conversion of NULL and empty strings.
-      <itemizedlist>
-       <listitem>
-        <para>
-         <constant>PDO::NULL_NATURAL</constant>:
-         No conversion.
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <constant>PDO::NULL_EMPTY_STRING</constant>:
-         Empty string is converted to &null;.
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <constant>PDO::NULL_TO_STRING</constant>:
-         &null; is converted to an empty string.
-        </para>
-       </listitem>
-      </itemizedlist>
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <constant>PDO::ATTR_STRINGIFY_FETCHES</constant>:
-      Convert numeric values to strings when fetching.
-      Requires <type>bool</type>.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <constant>PDO::ATTR_STATEMENT_CLASS</constant>:
-      Set user-supplied statement class derived from PDOStatement.
-      Cannot be used with persistent PDO instances.
-      Requires <literal>array(string classname, array(mixed constructor_args))</literal>.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <constant>PDO::ATTR_TIMEOUT</constant>:
-      Specifies the timeout duration in seconds.
-      Not all drivers support this option, and its meaning may differ from driver to driver.
-      For example, sqlite will wait for up to this time value before giving up
-      on obtaining a writable lock, but other drivers may interpret this as a
-      connect or a read timeout interval.
-      Requires <type>int</type>.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <constant>PDO::ATTR_AUTOCOMMIT</constant>
-      (available in OCI, Firebird and MySQL):
-      Whether to autocommit every single statement.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <constant>PDO::ATTR_EMULATE_PREPARES</constant>
-      Enables or disables emulation of prepared statements.  Some drivers do
-      not support native prepared statements or have limited support for them.
-      Use this setting to force PDO to either always emulate prepared
-      statements (if &true; and emulated prepares are supported by the driver),
-      or to try to use native prepared statements (if &false;).
-      It will always fall back to emulating the prepared statement if the
-      driver cannot successfully prepare the current query.
-      Requires <type>bool</type>.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <constant>PDO::MYSQL_ATTR_USE_BUFFERED_QUERY</constant>
-      (available in MySQL): Use buffered queries.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <constant>PDO::ATTR_DEFAULT_FETCH_MODE</constant>: Set default fetch mode.
-      Description of the modes is available in the
-      <methodname>PDOStatement::fetch</methodname> documentation.
-     </para>
-    </listitem>
-   </itemizedlist>
+   <variablelist>
+    <varlistentry>
+     <term><constant>PDO::ATTR_CASE</constant></term>
+     <listitem>
+      <para>
+       Force column names to a specific case.
+       Can take one of the following values:
+      </para>
+      <variablelist>
+       <varlistentry>
+        <term><constant>PDO::CASE_LOWER</constant></term>
+        <listitem>
+         <simpara>
+          Force column names to lower case.
+         </simpara>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><constant>PDO::CASE_NATURAL</constant></term>
+        <listitem>
+         <simpara>
+          Leave column names as returned by the database driver.
+         </simpara>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><constant>PDO::CASE_UPPER</constant></term>
+        <listitem>
+         <simpara>
+          Force column names to upper case.
+         </simpara>
+        </listitem>
+       </varlistentry>
+      </variablelist>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><constant>PDO::ATTR_ERRMODE</constant></term>
+     <listitem>
+      <para>
+       Error reporting mode of PDO.
+       Can take one of the following values:
+      </para>
+      <variablelist>
+       <varlistentry>
+        <term><constant>PDO::ERRMODE_SILENT</constant></term>
+        <listitem>
+         <simpara>
+          Only sets error codes.
+         </simpara>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><constant>PDO::ERRMODE_WARNING</constant></term>
+        <listitem>
+         <simpara>
+          Raises <constant>E_WARNING</constant> diagnostics.
+         </simpara>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><constant>PDO::ERRMODE_EXCEPTION</constant></term>
+        <listitem>
+         <simpara>
+          Throws <classname>PDOException</classname>s.
+         </simpara>
+        </listitem>
+       </varlistentry>
+      </variablelist>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><constant>PDO::ATTR_ORACLE_NULLS</constant></term>
+     <listitem>
+      <note>
+       <simpara>
+        This attribute is available with all drivers, not just Oracle.
+       </simpara>
+      </note>
+      <para>
+       Determines if and how &null; and empty strings should be converted.
+       Can take one of the following values:
+      </para>
+      <variablelist>
+       <varlistentry>
+        <term><constant>PDO::NULL_NATURAL</constant></term>
+        <listitem>
+         <simpara>
+          No conversion takes place.
+         </simpara>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><constant>PDO::NULL_EMPTY_STRING</constant></term>
+        <listitem>
+         <simpara>
+          Empty strings get converted to &null;.
+         </simpara>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><constant>PDO::NULL_TO_STRING</constant></term>
+        <listitem>
+         <simpara>
+          &null; gets converted to an empty string.
+         </simpara>
+        </listitem>
+       </varlistentry>
+      </variablelist>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><constant>PDO::ATTR_STRINGIFY_FETCHES</constant></term>
+     <listitem>
+      <para>
+       Whether to convert numeric values to strings when fetching.
+       Takes a value of type <type>bool</type>: &true; to enable and
+       &false; to disable. <!-- By default, ??? TODO. -->
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><constant>PDO::ATTR_STATEMENT_CLASS</constant></term>
+     <listitem>
+      <para>
+       Set user-supplied statement class derived from PDOStatement.
+       <!-- TODO improve description of the value it takes, or refer to other docs -->
+       Requires <literal>array(string classname, array(mixed constructor_args))</literal>.
+      </para>
+      <caution>
+       <simpara>
+        Cannot be used with persistent PDO instances.
+       </simpara>
+      </caution>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><constant>PDO::ATTR_TIMEOUT</constant></term>
+     <listitem>
+      <para>
+       Specifies the timeout duration in seconds.
+       Takes a value of type <type>int</type>.
+      </para>
+      <note>
+       <para>
+        Not all drivers support this option, and its meaning may differ from
+        driver to driver. For example, SQLite will wait for up to this time
+        value before giving up on obtaining a writable lock, but other drivers
+        may interpret this as a connection or a read timeout interval.
+       </para>
+      </note>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><constant>PDO::ATTR_AUTOCOMMIT</constant></term>
+     <listitem>
+      <note>
+       <simpara>
+        Only available for the OCI, Firebird, and MySQL drivers.
+       </simpara>
+      </note>
+      <para>
+       Whether to autocommit every single statement.
+       Takes a value of type <type>bool</type>: &true; to enable and
+       &false; to disable. By default, &true;.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><constant>PDO::ATTR_EMULATE_PREPARES</constant></term>
+     <listitem>
+      <note>
+       <simpara>
+        Only available for the OCI, Firebird, and MySQL drivers.
+       </simpara>
+      </note>
+      <para>
+       Whether enable or disable emulation of prepared statements.
+       Some drivers do not support prepared statements natively or have
+       limited support for them.
+       If set to &true; PDO will always emulate prepared statements,
+       otherwise PDO will attempt to use native prepared statements.
+       In case the driver cannot successfully prepare the current query,
+       PDO will always fall back to emulating the prepared statement.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><constant>PDO::MYSQL_ATTR_USE_BUFFERED_QUERY</constant></term>
+     <listitem>
+      <note>
+       <simpara>
+        Only available for the MySQL driver.
+       </simpara>
+      </note>
+      <para>
+       Whether to use buffered queries.
+       Takes a value of type <type>bool</type>: &true; to enable and
+       &false; to disable. By default, &false;.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><constant>PDO::ATTR_DEFAULT_FETCH_MODE</constant></term>
+     <listitem>
+      <para>
+       Set the default fetch mode.
+       A description of the modes and how to use them is available in the
+       <methodname>PDOStatement::fetch</methodname> documentation.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
   </para>
  </refsect1>
 

--- a/reference/pdo/pdostatement/getattribute.xml
+++ b/reference/pdo/pdostatement/getattribute.xml
@@ -28,6 +28,22 @@
 
  </refsect1>
 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>name</parameter></term>
+     <listitem>
+      <para>
+       The attribute to query.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/pdo/pdostatement/setattribute.xml
+++ b/reference/pdo/pdostatement/setattribute.xml
@@ -29,6 +29,31 @@
 
  </refsect1>
 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>attribute</parameter></term>
+     <listitem>
+      <para>
+       The attribute to modify.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>value</parameter></term>
+     <listitem>
+      <para>
+       The value to set the <parameter>attribute</parameter>,
+       might require a specific type depending on the attribute.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>


### PR DESCRIPTION
This, with #1457, fixes the remain (current) issues raised by the section order QA script #658.

After merging both of them we should add the check to CI so that a PR can't introduce section ordering issues.