### PR TITLE
Fix typo

### DIFF
--- a/reference/uodbc/functions/odbc-foreignkeys.xml
+++ b/reference/uodbc/functions/odbc-foreignkeys.xml
@@ -60,7 +60,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>pk_catalog</parameter></term>
+     <term><parameter>fk_catalog</parameter></term>
      <listitem>
       <para>
        The catalog (&apos;qualifier&apos; in ODBC 2 parlance) of the foreign key table.


### PR DESCRIPTION
Fix the typo in 5th parameter description of odbc_foreignkeys

fix https://github.com/php/doc-zh/issues/211