### PR TITLE
Fix constructorsynopsis usage in EV extension

### DIFF
--- a/reference/ev/evcheck.xml
+++ b/reference/ev/evcheck.xml
@@ -86,7 +86,8 @@
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('evwatcher.synopsis')/descendant::db:fieldsynopsis)" />
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evcheck')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evcheck')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evcheck')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evwatcher')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>

--- a/reference/ev/evcheck/construct.xml
+++ b/reference/ev/evcheck/construct.xml
@@ -7,7 +7,7 @@
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis>
    <modifier>public</modifier>
    <methodname>EvCheck::__construct</methodname>
    <methodparam>
@@ -22,7 +22,7 @@
     <type>int</type>
     <parameter>priority</parameter>
    </methodparam>
-  </methodsynopsis>
+  </constructorsynopsis>
   <para>
    Constructs the
    <classname>EvCheck</classname>
@@ -66,12 +66,7 @@
    </varlistentry>
   </variablelist>
  </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns EvCheck object on success.
-  </para>
- </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>

--- a/reference/ev/evchild.xml
+++ b/reference/ev/evchild.xml
@@ -64,7 +64,8 @@
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('evwatcher.synopsis')/descendant::db:fieldsynopsis)" />
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evchild')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evchild')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evchild')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evwatcher')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>

--- a/reference/ev/evchild/construct.xml
+++ b/reference/ev/evchild/construct.xml
@@ -7,7 +7,7 @@
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis>
    <modifier>public</modifier>
    <methodname>EvChild::__construct</methodname>
    <methodparam>
@@ -34,7 +34,7 @@
     <parameter>priority</parameter>
     <initializer>0</initializer>
    </methodparam>
-  </methodsynopsis>
+  </constructorsynopsis>
   <para>
    Constructs the
    <classname>EvChild</classname>
@@ -156,12 +156,7 @@
    </varlistentry>
   </variablelist>
  </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns EvChild object on success.
-  </para>
- </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>

--- a/reference/ev/evembed.xml
+++ b/reference/ev/evembed.xml
@@ -37,7 +37,8 @@
      <varname linkend="evembed.props.embed">embed</varname>
     </fieldsynopsis>
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evembed')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evembed')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evembed')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evwatcher')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>

--- a/reference/ev/evembed/construct.xml
+++ b/reference/ev/evembed/construct.xml
@@ -7,7 +7,7 @@
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis>
    <modifier>public</modifier>
    <methodname>EvEmbed::__construct</methodname>
    <methodparam>
@@ -26,7 +26,7 @@
     <type>int</type>
     <parameter>priority</parameter>
    </methodparam>
-  </methodsynopsis>
+  </constructorsynopsis>
   <para>
    This is a rather advanced watcher type that lets to embed one event loop
    into another(currently only IO events are supported in the embedded loop,
@@ -99,12 +99,7 @@
    </varlistentry>
   </variablelist>
  </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns EvEmbed object on success.
-  </para>
- </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
  <example>

--- a/reference/ev/evfork.xml
+++ b/reference/ev/evfork.xml
@@ -46,7 +46,8 @@
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('evwatcher.synopsis')/descendant::db:fieldsynopsis)" />
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evfork')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evfork')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evfork')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evwatcher')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>

--- a/reference/ev/evfork/construct.xml
+++ b/reference/ev/evfork/construct.xml
@@ -7,7 +7,7 @@
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis>
    <modifier>public</modifier>
    <methodname>EvFork::__construct</methodname>
    <methodparam>
@@ -26,7 +26,7 @@
     <parameter>priority</parameter>
     <initializer>0</initializer>
    </methodparam>
-  </methodsynopsis>
+  </constructorsynopsis>
   <para>
    Constructs the EvFork watcher object and starts the watcher automatically.
   </para>
@@ -68,12 +68,7 @@
    </varlistentry>
   </variablelist>
  </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns EvFork object on success.
-  </para>
- </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>

--- a/reference/ev/evidle.xml
+++ b/reference/ev/evidle.xml
@@ -70,7 +70,8 @@
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('evwatcher.synopsis')/descendant::db:fieldsynopsis)" />
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evidle')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evidle')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evidle')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evwatcher')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>

--- a/reference/ev/evidle/construct.xml
+++ b/reference/ev/evidle/construct.xml
@@ -7,7 +7,7 @@
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis>
    <modifier>public</modifier>
    <methodname>EvIdle::__construct</methodname>
    <methodparam>
@@ -22,7 +22,7 @@
     <type>int</type>
     <parameter>priority</parameter>
    </methodparam>
-  </methodsynopsis>
+  </constructorsynopsis>
   <para>
    Constructs the EvIdle watcher object and starts the watcher automatically.
   </para>
@@ -64,12 +64,7 @@
    </varlistentry>
   </variablelist>
  </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns EvIdle object on success.
-  </para>
- </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>

--- a/reference/ev/evio.xml
+++ b/reference/ev/evio.xml
@@ -82,7 +82,8 @@
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('evwatcher.synopsis')/descendant::db:fieldsynopsis)" />
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evio')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evio')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evio')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evwatcher')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>

--- a/reference/ev/evio/construct.xml
+++ b/reference/ev/evio/construct.xml
@@ -7,7 +7,7 @@
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis>
    <modifier>public</modifier>
    <methodname>EvIo::__construct</methodname>
    <methodparam>
@@ -30,7 +30,7 @@
     <type>int</type>
     <parameter>priority</parameter>
    </methodparam>
-  </methodsynopsis>
+  </constructorsynopsis>
   <para>
    Constructs EvIo watcher object and starts the watcher automatically.
   </para>
@@ -99,12 +99,7 @@
    </varlistentry>
   </variablelist>
  </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns EvIo object on success.
-  </para>
- </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>

--- a/reference/ev/evloop.xml
+++ b/reference/ev/evloop.xml
@@ -85,7 +85,8 @@
      <varname linkend="evloop.props.depth">depth</varname>
     </fieldsynopsis>
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evloop')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evloop')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evloop')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/ev/evloop/construct.xml
+++ b/reference/ev/evloop/construct.xml
@@ -7,7 +7,7 @@
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis>
    <modifier>public</modifier>
    <methodname>EvLoop::__construct</methodname>
    <methodparam choice="opt">
@@ -32,7 +32,7 @@
     <parameter>timeout_interval</parameter>
     <initializer>0.0</initializer>
    </methodparam>
-  </methodsynopsis>
+  </constructorsynopsis>
   <para>
    Constructs the event loop object.
   </para>
@@ -85,12 +85,7 @@
    </varlistentry>
   </variablelist>
  </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns new EvLoop object.
-  </para>
- </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>

--- a/reference/ev/evperiodic.xml
+++ b/reference/ev/evperiodic.xml
@@ -81,7 +81,8 @@
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('evwatcher.synopsis')/descendant::db:fieldsynopsis)" />
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evperiodic')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evperiodic')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evperiodic')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evwatcher')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>

--- a/reference/ev/evperiodic/construct.xml
+++ b/reference/ev/evperiodic/construct.xml
@@ -7,7 +7,7 @@
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis>
    <modifier>public</modifier>
    <methodname>EvPeriodic::__construct</methodname>
    <methodparam>
@@ -38,7 +38,7 @@
     <parameter>priority</parameter>
     <initializer>0</initializer>
    </methodparam>
-  </methodsynopsis>
+  </constructorsynopsis>
   <para>
    Constructs EvPeriodic watcher object and starts it automatically.
    <methodname>EvPeriodic::createStopped</methodname>
@@ -116,12 +116,7 @@
    </varlistentry>
   </variablelist>
  </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns EvPeriodic object on success.
-  </para>
- </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
 

--- a/reference/ev/evprepare.xml
+++ b/reference/ev/evprepare.xml
@@ -32,7 +32,8 @@
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('evwatcher.synopsis')/descendant::db:fieldsynopsis)" />
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evprepare')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evprepare')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evprepare')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evwatcher')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>

--- a/reference/ev/evprepare/construct.xml
+++ b/reference/ev/evprepare/construct.xml
@@ -7,7 +7,7 @@
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis>
    <modifier>public</modifier>
    <methodname>EvPrepare::__construct</methodname>
    <methodparam>
@@ -22,7 +22,7 @@
     <type>string</type>
     <parameter>priority</parameter>
    </methodparam>
-  </methodsynopsis>
+  </constructorsynopsis>
   <para>
    Constructs EvPrepare watcher object. And starts the watcher automatically.
    If need a stopped watcher consider using
@@ -66,12 +66,7 @@
    </varlistentry>
   </variablelist>
  </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns EvPrepare object on success.
-  </para>
- </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>

--- a/reference/ev/evsignal.xml
+++ b/reference/ev/evsignal.xml
@@ -69,7 +69,8 @@
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('evwatcher.synopsis')/descendant::db:fieldsynopsis)" />
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evsignal')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evsignal')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evsignal')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evwatcher')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>

--- a/reference/ev/evsignal/construct.xml
+++ b/reference/ev/evsignal/construct.xml
@@ -7,7 +7,7 @@
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis>
    <modifier>public</modifier>
    <methodname>EvSignal::__construct</methodname>
    <methodparam>
@@ -30,7 +30,7 @@
     <parameter>priority</parameter>
     <initializer>0</initializer>
    </methodparam>
-  </methodsynopsis>
+  </constructorsynopsis>
   <para>
    Constructs EvSignal watcher object and starts it automatically. For a
    stopped periodic watcher consider using
@@ -89,12 +89,7 @@
    </varlistentry>
   </variablelist>
  </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns EvSignal object on success.
-  </para>
- </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
  <example>

--- a/reference/ev/evstat.xml
+++ b/reference/ev/evstat.xml
@@ -87,7 +87,8 @@
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('evwatcher.synopsis')/descendant::db:fieldsynopsis)" />
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evstat')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evstat')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evstat')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evwatcher')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>

--- a/reference/ev/evstat/construct.xml
+++ b/reference/ev/evstat/construct.xml
@@ -7,7 +7,7 @@
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis>
    <modifier>public</modifier>
    <methodname>EvStat::__construct</methodname>
    <methodparam>
@@ -34,7 +34,7 @@
     <parameter>priority</parameter>
     <initializer>0</initializer>
    </methodparam>
-  </methodsynopsis>
+  </constructorsynopsis>
   <para>
    Constructs EvStat watcher object and starts the watcher automatically.
   </para>
@@ -101,12 +101,7 @@
    </varlistentry>
   </variablelist>
  </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns EvStat watcher object on succes.
-  </para>
- </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
 

--- a/reference/ev/evtimer.xml
+++ b/reference/ev/evtimer.xml
@@ -74,7 +74,8 @@
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('evwatcher.synopsis')/descendant::db:fieldsynopsis)" />
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evtimer')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evtimer')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evtimer')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evwatcher')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>

--- a/reference/ev/evtimer/construct.xml
+++ b/reference/ev/evtimer/construct.xml
@@ -7,7 +7,7 @@
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis>
    <modifier>public</modifier>
    <methodname>EvTimer::__construct</methodname>
    <methodparam>
@@ -34,7 +34,7 @@
     <parameter>priority</parameter>
     <initializer>0</initializer>
    </methodparam>
-  </methodsynopsis>
+  </constructorsynopsis>
   <para>
    Constructs an EvTimer watcher object.
   </para>
@@ -102,12 +102,7 @@
    </varlistentry>
   </variablelist>
  </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns EvTimer object on success.
-  </para>
- </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
  <example>

--- a/reference/ev/evwatcher.xml
+++ b/reference/ev/evwatcher.xml
@@ -56,7 +56,8 @@
      <varname linkend="evwatcher.props.priority">priority</varname>
     </fieldsynopsis>
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evwatcher')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evwatcher')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.evwatcher')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/ev/evwatcher/construct.xml
+++ b/reference/ev/evwatcher/construct.xml
@@ -7,12 +7,12 @@
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis>
    <modifier>abstract</modifier>
    <modifier>public</modifier>
    <methodname>EvWatcher::__construct</methodname>
    <void />
-  </methodsynopsis>
+  </constructorsynopsis>
   <para>
    <methodname>EvWatcher::__construct</methodname>
    is an abstract constructor of a watcher object implemented in the derived


### PR DESCRIPTION
Drop the return value section at the same time.