### PR TITLE
Update SPL class construtor pages

### DIFF
--- a/reference/spl/appenditerator/construct.xml
+++ b/reference/spl/appenditerator/construct.xml
@@ -21,14 +21,7 @@
   &reftitle.parameters;
   &no.function.parameters;
  </refsect1>
- 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.void;
-  </para>
- </refsect1>
- 
+
  <refsect1 role="examples"><!-- {{{ -->
   &reftitle.examples;
   <para>

--- a/reference/spl/arrayiterator/construct.xml
+++ b/reference/spl/arrayiterator/construct.xml
@@ -46,21 +46,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   An <classname>ArrayIterator</classname> <type>object</type>.
-  </para>
- </refsect1>
-
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   <function>ArrayIterator::__construct</function> throws an 
-   <classname>InvalidArgumentException</classname> if anything besides an array or an object is given.
-  </para>
- </refsect1>
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/spl/arrayobject/construct.xml
+++ b/reference/spl/arrayobject/construct.xml
@@ -53,29 +53,11 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns an ArrayObject object on success.
-  </para>
- </refsect1>
-
-
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
    Throws <classname>InvalidArgumentException</classname> when:
    <itemizedlist>
-    <listitem>
-     <simpara>
-      <parameter>array</parameter> is not an array or object
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      <parameter>flags</parameter> is not an integer
-     </simpara>
-    </listitem>
     <listitem>
      <simpara>
       <parameter>iteratorClass</parameter> is not an object that implements

--- a/reference/spl/arrayobject/construct.xml
+++ b/reference/spl/arrayobject/construct.xml
@@ -46,25 +46,11 @@
      <listitem>
       <para>
        Specify the class that will be used for iteration of the <classname>ArrayObject</classname> object.
+       The class must implement <interfacename>Iterator</interfacename>.
       </para>
      </listitem>
     </varlistentry>
    </variablelist>
-  </para>
- </refsect1>
-
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   Throws <classname>InvalidArgumentException</classname> when:
-   <itemizedlist>
-    <listitem>
-     <simpara>
-      <parameter>iteratorClass</parameter> is not an object that implements
-      <classname>Iterator</classname>
-     </simpara>
-    </listitem>
-   </itemizedlist>
   </para>
  </refsect1>
 

--- a/reference/spl/callbackfilteriterator/construct.xml
+++ b/reference/spl/callbackfilteriterator/construct.xml
@@ -46,13 +46,6 @@
   </variablelist>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.void;
-  </para>
- </refsect1>
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/spl/directoryiterator/construct.xml
+++ b/reference/spl/directoryiterator/construct.xml
@@ -43,7 +43,32 @@
   <para>
    Throws a <classname>ValueError</classname>
    if the <parameter>directory</parameter> is an empty string.
-   Prior to PHP 8.0.0, it threw a <classname>RuntimeException</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Now throws a <classname>ValueError</classname> if
+        <parameter>directory</parameter> is an empty string;
+        previously it threw a <classname>RuntimeException</classname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </para>
  </refsect1>
  

--- a/reference/spl/directoryiterator/construct.xml
+++ b/reference/spl/directoryiterator/construct.xml
@@ -41,8 +41,9 @@
    if the <parameter>directory</parameter> cannot be opened.
   </para>
   <para>
-   Throws a <classname>RuntimeException</classname>
+   Throws a <classname>ValueError</classname>
    if the <parameter>directory</parameter> is an empty string.
+   Prior to PHP 8.0.0, it threw a <classname>RuntimeException</classname>.
   </para>
  </refsect1>
  

--- a/reference/spl/directoryiterator/construct.xml
+++ b/reference/spl/directoryiterator/construct.xml
@@ -38,7 +38,7 @@
   &reftitle.errors;
   <para>
    Throws an <classname>UnexpectedValueException</classname>
-   if the <parameter>directory</parameter> cannot be opened.
+   if the <parameter>directory</parameter> does not exist.
   </para>
   <para>
    Throws a <classname>ValueError</classname>

--- a/reference/spl/filesystemiterator/construct.xml
+++ b/reference/spl/filesystemiterator/construct.xml
@@ -55,7 +55,7 @@
   &reftitle.errors;
   <para>
    Throws an <classname>UnexpectedValueException</classname>
-   if the <parameter>directory</parameter> cannot be opened.
+   if the <parameter>directory</parameter> does not exist.
   </para>
   <para>
    Throws a <classname>ValueError</classname>

--- a/reference/spl/filesystemiterator/construct.xml
+++ b/reference/spl/filesystemiterator/construct.xml
@@ -60,7 +60,32 @@
   <para>
    Throws a <classname>ValueError</classname>
    if the <parameter>directory</parameter> is an empty string.
-   Prior to PHP 8.0.0, it threw a <classname>RuntimeException</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Now throws a <classname>ValueError</classname> if
+        <parameter>directory</parameter> is an empty string;
+        previously it threw a <classname>RuntimeException</classname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </para>
  </refsect1>
 

--- a/reference/spl/filesystemiterator/construct.xml
+++ b/reference/spl/filesystemiterator/construct.xml
@@ -51,18 +51,16 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.void;
-  </para>
- </refsect1>
-
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
    Throws an <classname>UnexpectedValueException</classname>
-   if the <parameter>directory</parameter> cannot be found.
+   if the <parameter>directory</parameter> cannot be opened.
+  </para>
+  <para>
+   Throws a <classname>ValueError</classname>
+   if the <parameter>directory</parameter> is an empty string.
+   Prior to PHP 8.0.0, it threw a <classname>RuntimeException</classname>.
   </para>
  </refsect1>
 

--- a/reference/spl/filteriterator/construct.xml
+++ b/reference/spl/filteriterator/construct.xml
@@ -37,13 +37,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   The <classname>FilterIterator</classname>.
-  </para>
- </refsect1>
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/spl/globiterator/construct.xml
+++ b/reference/spl/globiterator/construct.xml
@@ -52,7 +52,32 @@
   <para>
    Throws a <classname>ValueError</classname>
    if the <parameter>directory</parameter> is an empty string.
-   Prior to PHP 8.0.0, it threw a <classname>RuntimeException</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Now throws a <classname>ValueError</classname> if
+        <parameter>directory</parameter> is an empty string;
+        previously it threw a <classname>RuntimeException</classname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </para>
  </refsect1>
 

--- a/reference/spl/globiterator/construct.xml
+++ b/reference/spl/globiterator/construct.xml
@@ -47,7 +47,7 @@
   &reftitle.errors;
   <para>
    Throws an <classname>UnexpectedValueException</classname>
-   if the <parameter>directory</parameter> cannot be opened.
+   if the <parameter>directory</parameter> does not exist.
   </para>
   <para>
    Throws a <classname>ValueError</classname>

--- a/reference/spl/globiterator/construct.xml
+++ b/reference/spl/globiterator/construct.xml
@@ -43,6 +43,19 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Throws an <classname>UnexpectedValueException</classname>
+   if the <parameter>directory</parameter> cannot be opened.
+  </para>
+  <para>
+   Throws a <classname>ValueError</classname>
+   if the <parameter>directory</parameter> is an empty string.
+   Prior to PHP 8.0.0, it threw a <classname>RuntimeException</classname>.
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/spl/infiniteiterator/construct.xml
+++ b/reference/spl/infiniteiterator/construct.xml
@@ -35,22 +35,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.void;
-  </para>
- </refsect1>
-
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   Throws an <constant>E_RECOVERABLE_ERROR</constant> if the
-   <parameter>iterator</parameter> parameter is not
-   an <classname>Iterator</classname>.
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/spl/iteratoriterator/construct.xml
+++ b/reference/spl/iteratoriterator/construct.xml
@@ -34,13 +34,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.void;
-  </para>
- </refsect1>
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/spl/limititerator/construct.xml
+++ b/reference/spl/limititerator/construct.xml
@@ -59,7 +59,40 @@
    Throws a <classname>ValueError</classname>
    if the <parameter>offset</parameter> is less than <literal>0</literal>
    or the <parameter>limit</parameter> is less than <literal>-1</literal>.
-   Prior to PHP 8.0.0, it threw an <classname>OutOfRangeException</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Now throws a <classname>ValueError</classname> if
+        <parameter>offset</parameter> is less than <literal>0</literal>;
+        previously it threw a <classname>RuntimeException</classname>.
+       </entry>
+      </row>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Now throws a <classname>ValueError</classname> if
+        <parameter>limit</parameter> is less than <literal>-1</literal>;
+        previously it threw a <classname>RuntimeException</classname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </para>
  </refsect1>
 

--- a/reference/spl/limititerator/construct.xml
+++ b/reference/spl/limititerator/construct.xml
@@ -53,19 +53,13 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   The new <classname>LimitIterator</classname>.
-  </para>
- </refsect1>
-
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Throws an <classname>OutOfRangeException</classname>
+   Throws a <classname>ValueError</classname>
    if the <parameter>offset</parameter> is less than <literal>0</literal>
    or the <parameter>limit</parameter> is less than <literal>-1</literal>.
+   Prior to PHP 8.0.0, it threw an <classname>OutOfRangeException</classname>.
   </para>
  </refsect1>
 

--- a/reference/spl/multipleiterator/construct.xml
+++ b/reference/spl/multipleiterator/construct.xml
@@ -42,14 +42,7 @@
    </variablelist>
   </para>
  </refsect1>
- 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.void;
-  </para>
- </refsect1>
- 
+
  <refsect1 role="examples"><!-- {{{ -->
   &reftitle.examples;
   <para>

--- a/reference/spl/norewinditerator/construct.xml
+++ b/reference/spl/norewinditerator/construct.xml
@@ -33,14 +33,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   A <methodname>NoRewindIterator</methodname> based on the passed in
-   <parameter>iterator</parameter>.
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/spl/parentiterator/construct.xml
+++ b/reference/spl/parentiterator/construct.xml
@@ -36,14 +36,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   The <classname>ParentIterator</classname>.
-  </para>
- </refsect1>
-
-
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/spl/recursivecachingiterator/construct.xml
+++ b/reference/spl/recursivecachingiterator/construct.xml
@@ -48,13 +48,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   The <classname>RecursiveCachingIterator</classname>.
-  </para>
- </refsect1>
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/spl/recursivecallbackfilteriterator/construct.xml
+++ b/reference/spl/recursivecallbackfilteriterator/construct.xml
@@ -47,13 +47,6 @@
   </variablelist>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.void;
-  </para>
- </refsect1>
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/spl/recursivedirectoryiterator/construct.xml
+++ b/reference/spl/recursivedirectoryiterator/construct.xml
@@ -55,7 +55,32 @@
   <para>
    Throws a <classname>ValueError</classname>
    if the <parameter>directory</parameter> is an empty string.
-   Prior to PHP 8.0.0, it threw a <classname>RuntimeException</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Now throws a <classname>ValueError</classname> if
+        <parameter>directory</parameter> is an empty string;
+        previously it threw a <classname>RuntimeException</classname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </para>
  </refsect1>
 

--- a/reference/spl/recursivedirectoryiterator/construct.xml
+++ b/reference/spl/recursivedirectoryiterator/construct.xml
@@ -50,7 +50,7 @@
   &reftitle.errors;
   <para>
    Throws an <classname>UnexpectedValueException</classname>
-   if the <parameter>directory</parameter> cannot be opened.
+   if the <parameter>directory</parameter> does not exist.
   </para>
   <para>
    Throws a <classname>ValueError</classname>

--- a/reference/spl/recursivedirectoryiterator/construct.xml
+++ b/reference/spl/recursivedirectoryiterator/construct.xml
@@ -46,18 +46,16 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Returns the newly created <classname>RecursiveDirectoryIterator</classname>.
-  </para>
- </refsect1>
-
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
    Throws an <classname>UnexpectedValueException</classname>
-   if the <parameter>directory</parameter> cannot be found or is not a directory.
+   if the <parameter>directory</parameter> cannot be opened.
+  </para>
+  <para>
+   Throws a <classname>ValueError</classname>
+   if the <parameter>directory</parameter> is an empty string.
+   Prior to PHP 8.0.0, it threw a <classname>RuntimeException</classname>.
   </para>
  </refsect1>
 

--- a/reference/spl/recursivefilteriterator/construct.xml
+++ b/reference/spl/recursivefilteriterator/construct.xml
@@ -34,13 +34,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.void;
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/spl/recursiveiteratoriterator/construct.xml
+++ b/reference/spl/recursiveiteratoriterator/construct.xml
@@ -67,14 +67,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.void;
-  </para>
- </refsect1>
-
-
  <refsect1 role="examples"><!-- {{{ -->
   &reftitle.examples;
   <para>

--- a/reference/spl/recursivetreeiterator/construct.xml
+++ b/reference/spl/recursivetreeiterator/construct.xml
@@ -64,14 +64,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.void;
-  </para>
- </refsect1>
-
-
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/spl/splfileobject/construct.xml
+++ b/reference/spl/splfileobject/construct.xml
@@ -61,13 +61,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.void;
-  </para>
- </refsect1>
-
  <refsect1 role="errors">
   &reftitle.errors;
   <para>

--- a/reference/spl/splfixedarray/construct.xml
+++ b/reference/spl/splfixedarray/construct.xml
@@ -39,7 +39,32 @@
   <para>
    Throws a <classname>ValueError</classname> when <parameter>size</parameter>
    is a negative integer.
-   Prior to PHP 8.0.0, it threw a <classname>InvalidArgumentException</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Now throws a <classname>ValueError</classname> if
+        <parameter>size</parameter> is a negative;
+        previously it threw a <classname>InvalidArgumentException</classname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </para>
  </refsect1>
  

--- a/reference/spl/splfixedarray/construct.xml
+++ b/reference/spl/splfixedarray/construct.xml
@@ -33,22 +33,13 @@
    </variablelist>
   </para>
  </refsect1>
- 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.void;
-  </para>
- </refsect1>
- 
+
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Throws <classname>InvalidArgumentException</classname> when <parameter>size</parameter> is a negative
-   number.
-  </para>
-  <para>
-   Raises <constant>E_WARNING</constant> when <parameter>size</parameter> cannot be parsed as a number.
+   Throws a <classname>ValueError</classname> when <parameter>size</parameter>
+   is a negative integer.
+   Prior to PHP 8.0.0, it threw a <classname>InvalidArgumentException</classname>.
   </para>
  </refsect1>
  

--- a/reference/spl/splheap/construct.xml
+++ b/reference/spl/splheap/construct.xml
@@ -22,13 +22,6 @@
   &no.function.parameters;
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.void;
-  </para>
- </refsect1>
-
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/spl/splpriorityqueue/construct.xml
+++ b/reference/spl/splpriorityqueue/construct.xml
@@ -22,13 +22,6 @@
   &no.function.parameters;
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.void;
-  </para>
- </refsect1>
-
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/spl/splqueue/construct.xml
+++ b/reference/spl/splqueue/construct.xml
@@ -28,13 +28,6 @@
   &no.function.parameters;
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.void;
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/spl/splstack/construct.xml
+++ b/reference/spl/splstack/construct.xml
@@ -28,13 +28,6 @@
   &no.function.parameters;
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.void;
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/spl/spltempfileobject/construct.xml
+++ b/reference/spl/spltempfileobject/construct.xml
@@ -40,13 +40,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.void;
-  </para>
- </refsect1>
-
  <refsect1 role="errors">
   &reftitle.errors;
   <para>


### PR DESCRIPTION
QA: remove return value section

Update some error sections

I dropped the error section when the exception was a ZPP like exception.