### PR TITLE
Update assert.xml

### DIFF
--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -172,7 +172,7 @@
       <warning>
        <para>
         Using <type>string</type> as the <parameter>assertion</parameter> is
-        <emphasis>DEPRECATED</emphasis> as of PHP 7.2.
+        <emphasis>DEPRECATED</emphasis> as of PHP 7.2 and <emphasis>REMOVED</emphasis> as of PHP 8.0.0.
        </para>
       </warning>
      </listitem>
@@ -224,6 +224,16 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+         assert() will no longer evaluate string arguments, instead they will be
+         treated like any other argument. assert($a == $b) should be used instead of
+         assert('$a == $b'). The assert.quiet_eval ini directive and
+         ASSERT_QUIET_EVAL constants have also been removed, as they would no longer
+         have any effect.
+       </entry>
+      </row>
       <row>
        <entry>8.0.0</entry>
        <entry>


### PR DESCRIPTION
As per the PHP changelog, the functionality to use a string for `assert` has been removed in PHP 8.0: https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L350-L354