### PR TITLE
Fix the return value description

### DIFF
--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -138,7 +138,7 @@
   &reftitle.returnvalues;
   <para>
    The return value of this function on success depends on the fetch type. In
-   all cases, &false; if there are no more rows.
+   all cases, &false; is returned on failure or if there are no more rows.
   </para>
  </refsect1>
 

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -138,7 +138,7 @@
   &reftitle.returnvalues;
   <para>
    The return value of this function on success depends on the fetch type. In
-   all cases, &false; is returned on failure.
+   all cases, &false; if there are no more rows.
   </para>
  </refsect1>
 


### PR DESCRIPTION
The comment in the source code [goes](https://github.com/php/php-src/blob/04a4864b655b6ace1150e512179f23ec0d47566f/ext/pdo/pdo_stmt.c#L1152) as "if there are no more rows" and doesn't mention any failure.