### PR TITLE
Add trailing semicolon to getDocComment

### DIFF
--- a/reference/reflection/reflectionclass/getdoccomment.xml
+++ b/reference/reflection/reflectionclass/getdoccomment.xml
@@ -49,7 +49,7 @@
 class TestClass { }
 
 $rc = new ReflectionClass('TestClass');
-var_dump($rc->getDocComment())
+var_dump($rc->getDocComment());
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
(First PR here, hi! 👋)

Although this is valid PHP, other functions' examples in the class (e.g. `getDefaultProperties` and `getConstructor`) contain this trailing semicolon—it makes sense to maintain consistency across these examples.

Closes #1432