### PR TITLE
Fix listing of unimplemented DOM methods

### DIFF
--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -816,7 +816,7 @@ $array["key"];
     <member><methodname>DOMNamedNodeMap::setNamedItem</methodname></member>
     <member><methodname>DOMNamedNodeMap::removeNamedItem</methodname></member>
     <member><methodname>DOMNamedNodeMap::setNamedItemNS</methodname></member>
-    <member><methodname>DOMNamedNodeMap::removeNamedItem</methodname></member>
+    <member><methodname>DOMNamedNodeMap::removeNamedItemNS</methodname></member>
     <member><methodname>DOMText::replaceWholeText</methodname></member>
     <member><methodname>DOMNode::compareDocumentPosition</methodname></member>
     <member><methodname>DOMNode::isEqualNode</methodname></member>


### PR DESCRIPTION
`DOMNamedNodeMap::removeNamedItem` is listed twice and I suspect the one after `DOMNamedNodeMap::setNamedItemNS` was meant to be `DOMNamedNodeMap::removeNamedItemNS` instead.