### PR TITLE
Remove "experimental" warning from Foreign Function Interface (#1495)

### DIFF
--- a/reference/ffi/book.xml
+++ b/reference/ffi/book.xml
@@ -8,7 +8,6 @@
 
  <preface xml:id="intro.ffi">
   &reftitle.intro;
-  &warn.experimental;
   <para>
    This extension allows the loading of shared libraries (<filename>.DLL</filename> or 
    <filename>.so</filename>), calling of C functions and accessing of C data structures


### PR DESCRIPTION
Foreign Function Interface (FFI) has been introduced in 2019 (PHP 7.4) and the API didn't change since then, it should probably be considered safe to use it.