### PR TITLE
Fix unpacking with string key example

### DIFF
--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -36,8 +36,8 @@
      <programlisting role="php">
 <![CDATA[
 <?php
-$arr1 = [1, 'a'];
-$arr2 = [...$arr1, 'c' => 'd']; //[1, 'a', 'c' => 'd']
+$arr1 = [1, 'a' => 'b'];
+$arr2 = [...$arr1, 'c' => 'd']; //[1, 'a' => 'b', 'c' => 'd']
 ?>
 ]]>
      </programlisting>


### PR DESCRIPTION
The example seems not relevant to me since it already works and produces the same output in the previous PHP versions.