### PR TITLE
PDO::MYSQL_ATTR_LOCAL_INFILE_DIRECTORY was added in PHP 8.1

### DIFF
--- a/reference/pdo_mysql/constants.xml
+++ b/reference/pdo_mysql/constants.xml
@@ -41,7 +41,7 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
    </term>
    <listitem>
     <para>
-     Enable <literal>LOAD LOCAL INFILE</literal>. Available as of PHP 8.1.0.
+     Enable <literal>LOAD LOCAL INFILE</literal>.
     </para>
     <para>
      Note, this constant can only be used in the <parameter>driver_options</parameter> 
@@ -57,7 +57,7 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
    <listitem>
     <para>
      Allows restricting LOCAL DATA loading to files located in this designated 
-     directory.
+     directory. Available as of PHP 8.1.0.
     </para>
     <para>
      Note, this constant can only be used in the <parameter>driver_options</parameter> 


### PR DESCRIPTION
The first change mentioned in the manual for `PDO::MYSQL_ATTR_LOCAL_INFILE_DIRECTORY` was 03f0ebc60c1e2c397ca81997646197d3d0cb4fed.

Then 607ec1f63c524e6951e7d3480377973788d495c5 stated about the version to which the constant was added.
However, it incorrectly appends to `MYSQL_ATTR_LOCAL_INFILE` instead of `MYSQL_ATTR_LOCAL_INFILE_DIRECTORY`.