### PR TITLE
Fix syntax errors in examples

### DIFF
--- a/appendices/migration56/openssl.xml
+++ b/appendices/migration56/openssl.xml
@@ -385,7 +385,7 @@ $pkey = openssl_pkey_new();
 openssl_pkey_export($pkey, 'secret passphrase');
 
 $spkac = openssl_spki_new($pkey, 'challenge string');
-$challenge = openssl_spki_export_challenge($spkac):
+$challenge = openssl_spki_export_challenge($spkac);
 echo $challenge;
 ?>
 ]]>

--- a/reference/cubrid/examples.xml
+++ b/reference/cubrid/examples.xml
@@ -129,7 +129,7 @@
     <?php
         $sql = "insert into olympic (host_year,host_nation,host_city,"
             . "opening_date,closing_date) values (2008, 'China', 'Beijing',"
-            . "to_date('08-08-2008','mm-dd- yyyy'),to_date('08-24-2008','mm-dd-yyyy')) ;"
+            . "to_date('08-08-2008','mm-dd- yyyy'),to_date('08-24-2008','mm-dd-yyyy')) ;";
         $result = cubrid_execute($cubrid_con, $sql);
         if ($result) {
             /**

--- a/reference/cubrid/functions/cubrid-connect-with-url.xml
+++ b/reference/cubrid/functions/cubrid-connect-with-url.xml
@@ -189,7 +189,7 @@ if ($con) {
    <programlisting role="php">
 <![CDATA[
 <?php
-$conn_url = "CUBRID:127.0.0.1:33000:demodb:dba::?login_timeout=100"
+$conn_url = "CUBRID:127.0.0.1:33000:demodb:dba::?login_timeout=100";
 $con = cubrid_connect_with_url ($conn_url);
 
 if ($con) {

--- a/reference/cubrid/functions/cubrid-pconnect-with-url.xml
+++ b/reference/cubrid/functions/cubrid-pconnect-with-url.xml
@@ -165,7 +165,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$conn_url = "CUBRID:127.0.0.1:33000:demodb:dba::"
+$conn_url = "CUBRID:127.0.0.1:33000:demodb:dba::";
 $con = cubrid_pconnect_with_url ($conn_url);
 
 if ($con) {
@@ -191,7 +191,7 @@ if ($con) {
    <programlisting role="php">
 <![CDATA[
 <?php
-$conn_url = "CUBRID:127.0.0.1:33000:demodb:dba::?althost=10.34.63.132:33088&rctime=100"
+$conn_url = "CUBRID:127.0.0.1:33000:demodb:dba::?althost=10.34.63.132:33088&rctime=100";
 $con = cubrid_pconnect_with_url ($conn_url);
 
 if ($con) {

--- a/reference/curl/functions/curl-multi-strerror.xml
+++ b/reference/curl/functions/curl-multi-strerror.xml
@@ -48,7 +48,7 @@
 <![CDATA[
 <?php
 // Create cURL handles
-$ch1 = curl_init("http://example.com"/);
+$ch1 = curl_init("http://example.com/");
 $ch2 = curl_init("http://php.net/");
 
 // Create a cURL multi handle

--- a/reference/ds/ds/map/get.xml
+++ b/reference/ds/ds/map/get.xml
@@ -118,7 +118,7 @@ int(10)
 <?php
 $map = new \Ds\Map(["a" => 1, "b" => 2, "c" => 3]);
 
-var_dump($map["a"])); // 1
+var_dump($map["a"]); // 1
 ?>
 ]]>
    </programlisting>

--- a/reference/expect/functions/expect-expectl.xml
+++ b/reference/expect/functions/expect-expectl.xml
@@ -163,7 +163,7 @@ while (true) {
         case EXP_EOF:
             break 2; // break both the switch statement and the while loop
         default:
-            die "Error has occurred!";
+            die("Error has occurred!");
     }
 }
 

--- a/reference/gearman/gearmanclient/addtask.xml
+++ b/reference/gearman/gearmanclient/addtask.xml
@@ -128,8 +128,8 @@ $client->setCompleteCallback("reverse_complete");
 
 # Add some tasks for a placeholder of where to put the results
 $results = array();
-$client->addTask("reverse", "Hello World!", &$results, "t1");
-$client->addTask("reverse", "!dlroW olleH", &$results, "t2");
+$client->addTask("reverse", "Hello World!", $results, "t1");
+$client->addTask("reverse", "!dlroW olleH", $results, "t2");
 
 $client->runTasks();
 

--- a/reference/image/functions/imageaffinematrixconcat.xml
+++ b/reference/image/functions/imageaffinematrixconcat.xml
@@ -61,8 +61,8 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$m1 = imageaffinematrixget(IMG_AFFINE_TRANSLATE, array('x' = 2, 'y' => 3));
-$m2 = imageaffinematrixget(IMG_AFFINE_SCALE, array('x' = 4, 'y' => 5));
+$m1 = imageaffinematrixget(IMG_AFFINE_TRANSLATE, array('x' => 2, 'y' => 3));
+$m2 = imageaffinematrixget(IMG_AFFINE_SCALE, array('x' => 4, 'y' => 5));
 $matrix = imageaffinematrixconcat($m1, $m2);
 print_r($matrix);
 ?>

--- a/reference/imagick/imagick/getsize.xml
+++ b/reference/imagick/imagick/getsize.xml
@@ -53,7 +53,7 @@ $img->scaleImage(400, 800);
 $size = $img->getSize();
 print_r($size);
 
-echo "$img->getImageWidth()."x".$img->getImageHeight();
+echo $img->getImageWidth()."x".$img->getImageHeight();
 ?>
 ]]>
     </programlisting>

--- a/reference/imagick/imagick/morphology.xml
+++ b/reference/imagick/imagick/morphology.xml
@@ -511,41 +511,39 @@
     </example>
 
     <example>
-      <title>Helper functon to get an image silhouette <function>Imagick::morphology</function></title>
+      <title>Helper function to get an image silhouette <function>Imagick::morphology</function></title>
       <programlisting role="php">
-      <![CDATA[
+<![CDATA[
 <?php
-    private function getCharacterOutline() {
+function getCharacterOutline() {
+    $imagick = new \Imagick(realpath("./images/character.png"));
+    $character = new \Imagick();
+    $character->newPseudoImage(
+        $imagick->getImageWidth(),
+        $imagick->getImageHeight(),
+        "canvas:white"
+    );
+    $canvas = new \Imagick();
+    $canvas->newPseudoImage(
+        $imagick->getImageWidth(),
+        $imagick->getImageHeight(),
+        "canvas:black"
+    );
 
-        $imagick = new \Imagick(realpath("./images/character.png"));
-        $character = new \Imagick();
-        $character->newPseudoImage(
-            $imagick->getImageWidth(),
-            $imagick->getImageHeight(),
-            "canvas:white"
-        );
-        $canvas = new \Imagick();
-        $canvas->newPseudoImage(
-            $imagick->getImageWidth(),
-            $imagick->getImageHeight(),
-            "canvas:black"
-        );
+    $character->compositeimage(
+        $imagick,
+        \Imagick::COMPOSITE_COPYOPACITY,
+        0, 0
+    );
+    $canvas->compositeimage(
+        $character,
+        \Imagick::COMPOSITE_ATOP,
+        0, 0
+    );
+    $canvas->setFormat('png');
 
-        $character->compositeimage(
-            $imagick,
-            \Imagick::COMPOSITE_COPYOPACITY,
-            0, 0
-        );
-        $canvas->compositeimage(
-            $character,
-            \Imagick::COMPOSITE_ATOP,
-            0, 0
-        );
-        $canvas->setFormat('png');
-
-        return $canvas;
-    }
-
+    return $canvas;
+}
 ?>
 ]]>
       </programlisting>

--- a/reference/intl/dateformatter/parse.xml
+++ b/reference/intl/dateformatter/parse.xml
@@ -122,13 +122,13 @@ $fmt = datefmt_create(
     IntlDateFormatter::GREGORIAN
 );
 echo 'Second parsed output is ' . datefmt_parse($fmt, 'Mittwoch, 20. Dezember 1989 16:00 Uhr GMT-08:00');
-?
+?>
 ]]>
     </programlisting>
    </example>
      &example.outputs;
      <screen>
-         <![CDATA[
+<![CDATA[
 First parsed output is 630201600
 Second parsed output is 630201600
 ]]>

--- a/reference/mysql_xdevapi/mysql_xdevapi/collection/dropindex.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/collection/dropindex.xml
@@ -70,7 +70,7 @@ $collection->createIndex(
 // ...
 
 if ($collection->dropIndex('myindex')) {
-    echo 'An index named 'myindex' was found, and dropped.';
+    echo "An index named 'myindex' was found, and dropped.";
 }
 ?>
 ]]>

--- a/reference/mysql_xdevapi/mysql_xdevapi/table/isview.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/table/isview.xml
@@ -46,7 +46,7 @@ $session->sql("CREATE TABLE addressbook.names(name text, age int)")->execute();
 $session->sql("INSERT INTO addressbook.names values ('John', 42), ('Sam', 33)")->execute();
 
 $schema = $session->getSchema("addressbook");
-$table  = $schema->getTable("names
+$table  = $schema->getTable("names");
 
 if ($table->isView()) {
     echo "This is a view.";

--- a/reference/oci8/functions/oci-password-change.xml
+++ b/reference/oci8/functions/oci-password-change.xml
@@ -142,7 +142,7 @@ if (!$c) {  // The original error wasn't 28001, or the password change failed
 }
 
 // Use the connection $c
-...
+// ...
 
 ?>
 ]]>

--- a/reference/seaslog/seaslog/getrequestid.xml
+++ b/reference/seaslog/seaslog/getrequestid.xml
@@ -43,7 +43,7 @@
 <?php
 
 var_dump(SeasLog::getRequestID());
-var_dump(SeasLog::setRequestID('reqeust_id_test_'.time()))
+var_dump(SeasLog::setRequestID('reqeust_id_test_'.time()));
 var_dump(SeasLog::getRequestID());
 
 ?>

--- a/reference/snmp/functions/snmp-read-mib.xml
+++ b/reference/snmp/functions/snmp-read-mib.xml
@@ -56,7 +56,7 @@
  print_r( snmprealwalk('localhost', 'public', '.1.3.6.1.2.1.2.3.4.5') );
  
  snmp_read_mib('./FOO-BAR-MIB.txt');
- print_r( snmprealwalk('localhost', 'public', 'FOO-BAR-MIB::someTable' );
+ print_r( snmprealwalk('localhost', 'public', 'FOO-BAR-MIB::someTable') );
 ?>
 ]]>
     </programlisting>

--- a/reference/snmp/functions/snmp2-getnext.xml
+++ b/reference/snmp/functions/snmp2-getnext.xml
@@ -86,7 +86,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$nameOfSecondInterface = snmp2_get_next('localhost', 'public', 'IF-MIB::ifName.1';
+$nameOfSecondInterface = snmp2_get_next('localhost', 'public', 'IF-MIB::ifName.1');
 ?>
 ]]>
     </programlisting>

--- a/reference/snmp/functions/snmpgetnext.xml
+++ b/reference/snmp/functions/snmpgetnext.xml
@@ -69,7 +69,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$nameOfSecondInterface = snmpgetnetxt('localhost', 'public', 'IF-MIB::ifName.1';
+$nameOfSecondInterface = snmpgetnetxt('localhost', 'public', 'IF-MIB::ifName.1');
 ?>
 ]]>
     </programlisting>

--- a/reference/sqlsrv/functions/sqlsrv-has-rows.xml
+++ b/reference/sqlsrv/functions/sqlsrv-has-rows.xml
@@ -50,7 +50,7 @@
 <![CDATA[
 <?php
 $server = "serverName\sqlexpress";
-$connectionInfo = array( "Database"=>"dbName", "UID"=>"username", "PWD"=>"password" )
+$connectionInfo = array( "Database"=>"dbName", "UID"=>"username", "PWD"=>"password" );
 $conn = sqlsrv_connect( $server, $connectionInfo );
 
 $stmt = sqlsrv_query( $conn, "SELECT * FROM Table_1");

--- a/reference/varnish/examples.xml
+++ b/reference/varnish/examples.xml
@@ -98,7 +98,7 @@ exit(0);
 $vl = new VarnishLog;
 while(1) {
     $line = $vl->getLine();
-    printf("%s %d %s", VarnishLog::getTagName($line['tag'], $line['id'],
+    printf("%s %d %s", VarnishLog::getTagName($line['tag']), $line['id'],
     $line['data']);
 }
 

--- a/reference/yaf/yaf-controller-abstract.xml
+++ b/reference/yaf/yaf-controller-abstract.xml
@@ -108,7 +108,7 @@
      <term><varname>actions</varname></term>
      <listitem>
       <para>
-      You can also define a action method in a separate PHP script by using
+      You can also define an action method in a separate PHP script by using
       this property and <classname>Yaf_Action_Abstract</classname>.
       <example>
        <title>define action in a separate file</title>
@@ -122,7 +122,7 @@ class IndexController extends Yaf_Controller_Abstract {
     );
 
     /* action method may have arguments */
-    public indexAction($name, $id) {
+    public function indexAction($name, $id) {
        /* $name and $id are unsafe raw data */
        assert($name == $this->getRequest()->getParam("name"));
        assert($id   == $this->_request->getParam("id"));
@@ -138,8 +138,8 @@ class IndexController extends Yaf_Controller_Abstract {
 <![CDATA[
 <?php
 class DummyAction extends Yaf_Action_Abstract {
-    /* a action class shall define this method  as the entry point */
-    public execute() {
+    /* an action class shall define this method as the entry point */
+    public function execute() {
     }
 }
 ?>

--- a/reference/yaf/yaf_application/bootstrap.xml
+++ b/reference/yaf/yaf_application/bootstrap.xml
@@ -72,8 +72,8 @@ class Bootstrap extends Yaf_Bootstrap_Abstract {
 <![CDATA[
 <?php
 
-defined('APPLICATION_PATH')                  // APPLICATION_PATH will be used in the ini config file
-    || define('APPLICATION_PATH', __DIR__));
+defined('APPLICATION_PATH') // APPLICATION_PATH will be used in the ini config file
+    || define('APPLICATION_PATH', __DIR__);
 
 $application = new Yaf_Application(APPLICATION_PATH.'/conf/application.ini');
 $application->bootstrap();

--- a/reference/yaf/yaf_plugin_abstract/routershutdown.xml
+++ b/reference/yaf/yaf_plugin_abstract/routershutdown.xml
@@ -79,6 +79,7 @@ class UserInitPlugin extends Yaf_Plugin_Abstract {
         $response->setRedirect("http://yourdomain.com/login/");
         return FALSE;
     }
+}
 ?>
 ]]>
    </programlisting>

--- a/reference/yaf/yaf_route_supervar/construct.xml
+++ b/reference/yaf/yaf_route_supervar/construct.xml
@@ -51,8 +51,9 @@
    /**
     * Add a supervar route to Yaf_Router route stack
     */
-    Yaf_Dispatcher::getInstance()->getRouter()->addRoute("name",
-        new Yaf_Route_Supervar("r"));
+    Yaf_Dispatcher::getInstance()->getRouter()->addRoute(
+        "name",
+        new Yaf_Route_Supervar("r")
     );
 ?>
 ]]>

--- a/reference/yaf/yaf_router/addroute.xml
+++ b/reference/yaf/yaf_router/addroute.xml
@@ -58,7 +58,7 @@ class Bootstrap extends Yaf_Bootstrap_Abstract{
         $router->addConfig(Yaf_Registry::get("config")->routes);
         /**
          * add a Rewrite route, then for a request uri: 
-         * http://***/product/list/22/foo
+         * http://example.com/product/list/22/foo
          * will be matched by this route, and result:
          *
          *  [module] => 
@@ -82,6 +82,7 @@ class Bootstrap extends Yaf_Bootstrap_Abstract{
         
         $router->addRoute('dummy', $route);
     }
+}
 ?>
 ]]>
    </programlisting>

--- a/reference/yaf/yaf_router/getcurrentroute.xml
+++ b/reference/yaf/yaf_router/getcurrentroute.xml
@@ -76,6 +76,7 @@ class Bootstrap extends Yaf_Bootstrap_Abstract{
     public function __initPlugins(Yaf_Dispatcher $dispatcher) {
         $dispatcher->registerPlugin(new DummyPlugin());
     }
+}
 ?>
 ]]>
    </programlisting>
@@ -87,11 +88,10 @@ class Bootstrap extends Yaf_Bootstrap_Abstract{
 <![CDATA[
 <?php
 class DummyPlugin extends Yaf_Plugin_Abstract {
-
     public function routerShutdown(Yaf_Request_Abstract $request, Yaf_Response_Abstract $response) {
          var_dump(Yaf_Dispatcher::getInstance()->getRouter()->getCurrentRoute());
     }
-?>
+}
 ?>
 ]]>
    </programlisting>

--- a/reference/yaf/yaf_view_simple/assign.xml
+++ b/reference/yaf/yaf_view_simple/assign.xml
@@ -63,6 +63,7 @@ class IndexController extends Yaf_Controller_Abstract {
         $this->getView()->assign("foo", "bar");
         $this->_view->assign( array( "key" => "value", "name" => "value"));
     }
+}
 ?>
 ]]>
    </programlisting>
@@ -77,7 +78,7 @@ class IndexController extends Yaf_Controller_Abstract {
  </head>  
 <body>
   <?php 
-    foreach ($this->_tpl_vars as $name => value) {
+    foreach ($this->_tpl_vars as $name => $value) {
          echo $$name; // or echo $this->_tpl_vars[$name];
     }
   ?>

--- a/reference/yaf/yaf_view_simple/assignref.xml
+++ b/reference/yaf/yaf_view_simple/assignref.xml
@@ -70,6 +70,7 @@ class IndexController extends Yaf_Controller_Abstract {
         //prevent the auto-render
         Yaf_Dispatcher::getInstance()->autoRender(FALSE);
     }
+}
 ?>
 ]]>
    </programlisting>

--- a/reference/yaf/yaf_view_simple/clear.xml
+++ b/reference/yaf/yaf_view_simple/clear.xml
@@ -54,6 +54,7 @@ class IndexController extends Yaf_Controller_Abstract {
         $this->getView()->clear("foo")->clear("bar"); // clear "foo" and "bar"
         $this->_view->clear(); //clear all assigned variables
     }
+}
 ?>
 ]]>
    </programlisting>

--- a/reference/yaf/yaf_view_simple/set.xml
+++ b/reference/yaf/yaf_view_simple/set.xml
@@ -60,6 +60,7 @@ class IndexController extends Yaf_Controller_Abstract {
     public function indexAction() {
         $this->getView()->foo = "bar"; // same as assign("foo", "bar");
     }
+}
 ?>
 ]]>
    </programlisting>


### PR DESCRIPTION
Found by running the ``check-examples.php`` QA script from base (https://github.com/php/doc-base/pull/58)