### PR TITLE
Add missing constant definition ReflectionAttribute::IS_INSTANCEOF

### DIFF
--- a/reference/reflection/reflectionattribute.xml
+++ b/reference/reflection/reflectionattribute.xml
@@ -36,6 +36,14 @@
      </oointerface>
     </classsynopsisinfo>
 
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="reflectionattribute.constants.is-instanceof">ReflectionAttribute::IS_INSTANCEOF</varname>
+     <initializer>2</initializer>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionattribute')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
      <xi:fallback/>
@@ -47,6 +55,35 @@
 <!-- }}} -->
 
   </section>
+
+  <!-- {{{ ReflectionAttribute constants -->
+  <section xml:id="reflectionattribute.constants">
+   &reftitle.constants;
+   <section xml:id="reflectionattribute.constants.flags">
+    <title>ReflectionAttribute Flags</title>
+    <variablelist>
+
+     <varlistentry xml:id="reflectionattribute.constants.is-instanceof">
+      <term><constant>ReflectionAttribute::IS_INSTANCEOF</constant></term>
+      <listitem>
+       <para>
+        Retrieve attributes using an
+        <parameter>instanceof</parameter> check.
+       </para>
+      </listitem>
+     </varlistentry>
+
+    </variablelist>
+    <note>
+     <para>
+      The values of these constants may change between PHP versions.
+      It is recommended to always use the constants
+      and not rely on the values directly.
+     </para>
+    </note>
+   </section>
+  </section>
+  <!-- }}} -->
 
  </partintro>
 


### PR DESCRIPTION
The constant `ReflectionAttribute::IS_INSTANCEOF` is missing from the [documentation](https://www.php.net/manual/en/class.reflectionattribute.php) entirely.

This PR adds the definition. I was unsure of the exact way to do it, but I made an educated guess based on the language and layout of other constant flags and reflection class constants (Most notably `array_filter` and `ReflectionMethod`).

I hope to create other PRs in the near future adding documentation to the `getAttributes()` methods on the various reflection classes, which will need to reference this constant.