### PR TITLE
Remove grossly outdated info

### DIFF
--- a/reference/url/functions/get-meta-tags.xml
+++ b/reference/url/functions/get-meta-tags.xml
@@ -44,8 +44,6 @@
 ]]>
         </programlisting>
        </example>
-       (pay attention to line endings - PHP uses a native function to
-       parse the input, so a Mac file won't work on Unix).
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
It seems that line endings are handled in an OS agnostic way by
`get_meta_tags()` for a long time now[1].  Thus, we drop the apparently
outdated info.

[1] <https://github.com/php/php-src/blob/60fffd296abce5fc071f3c173c25a2696cf683c6/ext/standard/file.c#L2442-L2445>