### PR TITLE
Add missing documentation for the ReflectionClass::getAttributes method

### DIFF
--- a/reference/reflection/reflectionclass/getattributes.xml
+++ b/reference/reflection/reflectionclass/getattributes.xml
@@ -17,8 +17,6 @@
    Returns all attributes declared on this class as an array of <type>ReflectionAttribute</type>.
   </para>
 
-  &warn.undocumented.func;
-
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,7 +26,8 @@
     <term><parameter>name</parameter></term>
     <listitem>
      <para>
-
+      Filter the results to include only <classname>ReflectionAttribute</classname>
+      instances for attributes matching this class name.
      </para>
     </listitem>
    </varlistentry>
@@ -36,7 +35,16 @@
     <term><parameter>flags</parameter></term>
     <listitem>
      <para>
-
+      Flags for determining how to filter the results, if <parameter>name</parameter>
+      is provided.
+     </para>
+     <para>
+      Default is <literal>0</literal> which will only return results for attributes that
+      are of the class <parameter>name</parameter>.
+     </para>
+     <para>
+      The only other option available, is to use <constant>ReflectionAttribute::IS_INSTANCEOF</constant>,
+      which will instead use <parameter>instanceof</parameter> for filtering.
      </para>
     </listitem>
    </varlistentry>
@@ -47,6 +55,125 @@
   &reftitle.returnvalues;
   <para>
    Array of attributes, as a <classname>ReflectionAttribute</classname> object.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Basic usage of <methodname>ReflectionClass::getAttributes</methodname></title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+#[Attribute]
+class Fruit {
+}
+
+#[Attribute]
+class Red {
+}
+
+#[Fruit]
+#[Red]
+class Apple {
+}
+
+$class = new ReflectionClass('Apple');
+$attributes = $class->getAttributes();
+print_r(array_map(fn($attribute) => $attribute->getName(), $attributes));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [0] => Fruit
+    [1] => Red
+)
+]]>
+    </screen>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Filtering results of <methodname>ReflectionClass::getAttributes</methodname> by class name</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+#[Attribute]
+class Fruit {
+}
+
+#[Attribute]
+class Red {
+}
+
+#[Fruit]
+#[Red]
+class Apple {
+}
+
+$class = new ReflectionClass('Apple');
+$attributes = $class->getAttributes('Fruit');
+print_r(array_map(fn($attribute) => $attribute->getName(), $attributes));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+     <![CDATA[
+Array
+(
+    [0] => Fruit
+)
+]]>
+    </screen>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>
+     Filtering results of <methodname>ReflectionClass::getAttributes</methodname> by class name, with
+     <constant>ReflectionAttribute::IS_INSTANCEOF</constant> flag.
+    </title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+interface Colour {
+}
+
+#[Attribute]
+class Fruit {
+}
+
+#[Attribute]
+class Red implements Colour {
+}
+
+#[Fruit]
+#[Red]
+class Apple {
+}
+
+$class = new ReflectionClass('Apple');
+$attributes = $class->getAttributes('Colour', ReflectionAttribute::IS_INSTANCEOF);
+print_r(array_map(fn($attribute) => $attribute->getName(), $attributes));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+     <![CDATA[
+Array
+(
+    [0] => Red
+)
+]]>
+    </screen>
+   </example>
   </para>
  </refsect1>
 

--- a/reference/reflection/reflectionclass/getattributes.xml
+++ b/reference/reflection/reflectionclass/getattributes.xml
@@ -166,7 +166,7 @@ print_r(array_map(fn($attribute) => $attribute->getName(), $attributes));
     </programlisting>
     &example.outputs;
     <screen>
-     <![CDATA[
+<![CDATA[
 Array
 (
     [0] => Red

--- a/reference/reflection/reflectionclass/getattributes.xml
+++ b/reference/reflection/reflectionclass/getattributes.xml
@@ -101,7 +101,7 @@ Array
    <example>
     <title>Filtering results of <methodname>ReflectionClass::getAttributes</methodname> by class name</title>
     <programlisting role="php">
-     <![CDATA[
+<![CDATA[
 <?php
 #[Attribute]
 class Fruit {

--- a/reference/reflection/reflectionclass/getattributes.xml
+++ b/reference/reflection/reflectionclass/getattributes.xml
@@ -62,7 +62,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Basic usage of <methodname>ReflectionClass::getAttributes</methodname></title>
+    <title>Basic usage</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -99,7 +99,7 @@ Array
   </para>
   <para>
    <example>
-    <title>Filtering results of <methodname>ReflectionClass::getAttributes</methodname> by class name</title>
+    <title>Filtering results by class name</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -135,10 +135,7 @@ Array
   </para>
   <para>
    <example>
-    <title>
-     Filtering results of <methodname>ReflectionClass::getAttributes</methodname> by class name, with
-     <constant>ReflectionAttribute::IS_INSTANCEOF</constant> flag.
-    </title>
+    <title>Filtering results by class name, with inheritance</title>
     <programlisting role="php">
      <![CDATA[
 <?php

--- a/reference/reflection/reflectionclass/getattributes.xml
+++ b/reference/reflection/reflectionclass/getattributes.xml
@@ -124,7 +124,7 @@ print_r(array_map(fn($attribute) => $attribute->getName(), $attributes));
     </programlisting>
     &example.outputs;
     <screen>
-     <![CDATA[
+<![CDATA[
 Array
 (
     [0] => Fruit

--- a/reference/reflection/reflectionclass/getattributes.xml
+++ b/reference/reflection/reflectionclass/getattributes.xml
@@ -142,7 +142,7 @@ Array
     <programlisting role="php">
      <![CDATA[
 <?php
-interface Colour {
+interface Color {
 }
 
 #[Attribute]

--- a/reference/reflection/reflectionclass/getattributes.xml
+++ b/reference/reflection/reflectionclass/getattributes.xml
@@ -44,7 +44,7 @@
      </para>
      <para>
       The only other option available, is to use <constant>ReflectionAttribute::IS_INSTANCEOF</constant>,
-      which will instead use <parameter>instanceof</parameter> for filtering.
+      which will instead use <literal>instanceof</literal> for filtering.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/reflection/reflectionclass/getattributes.xml
+++ b/reference/reflection/reflectionclass/getattributes.xml
@@ -64,7 +64,7 @@
    <example>
     <title>Basic usage of <methodname>ReflectionClass::getAttributes</methodname></title>
     <programlisting role="php">
-     <![CDATA[
+<![CDATA[
 <?php
 #[Attribute]
 class Fruit {


### PR DESCRIPTION
This PR updates the documentation  for the `ReflectionClass::getAttributes` method, including;
- Descriptions of parameters
- Example with no arguments
- Example with only `name` provided
- Example with `name` provided, and `flags` provided using `ReflectionAttribute::IS_INSTANCEOF`

The interface for the third example is called `Colour` (I'm from the UK), and I'm unsure of which spelling to go with. Am happy to change to `Color` if required.

If we can identify the ideal wording for any of this, once the PR is merged, if it is, I will go through and duplicate, with relevant examples, to all the following;
- `ReflectionClassConstant::getAttributes`
- `ReflectionFunctionAbstract::getAttributes`
- `ReflectionParameter::getAttributes`
- `ReflectionProperty::getAttributes`

<details>
<summary>If it helps, here's a screenshot of the page</summary>
<img src="https://user-images.githubusercontent.com/469515/164762071-c5cc67a8-3d2f-434c-89de-38d7e02755c3.png">
</details>

I suspect there may be a better way to explain the final part in the `flags` description, so I'm open to input.