### PR TITLE
[PHP 8.0] Add errors section for `version_compare`

### DIFF
--- a/reference/info/functions/version-compare.xml
+++ b/reference/info/functions/version-compare.xml
@@ -92,6 +92,14 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   As of PHP 8.0.0 throws <classname>ValueError</classname> if <parameter>operator</parameter> is not a valid comparison operator.
+   Prior to PHP 8.0.0 returned &null; without an error.
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>


### PR DESCRIPTION
Not sure that it should be documented...

https://3v4l.org/kPB2p
