### PR TITLE
All drivers implement getColumnMeta

### DIFF
--- a/reference/pdo/pdostatement/getcolumnmeta.xml
+++ b/reference/pdo/pdostatement/getcolumnmeta.xml
@@ -22,7 +22,8 @@
    <simpara>
     Some drivers may not implement
     <function>PDOStatement::getColumnMeta</function>,
-    as it is optional.
+    as it is optional. However, all extensions documented in the manual
+    implement this function.
    </simpara>
   </warning>
 

--- a/reference/pdo/pdostatement/getcolumnmeta.xml
+++ b/reference/pdo/pdostatement/getcolumnmeta.xml
@@ -20,18 +20,11 @@
   </para>
   <warning>
    <simpara>
-    Not all PDO drivers support
-    <function>PDOStatement::getColumnMeta</function>.
+    Some drivers may not implement
+    <function>PDOStatement::getColumnMeta</function>,
+    as it is optional.
    </simpara>
   </warning>
-
-  <para>The following drivers support this method:</para>
-  <itemizedlist>
-   <listitem><simpara><link linkend="ref.pdo-dblib">PDO_DBLIB</link></simpara></listitem>
-   <listitem><simpara><link linkend="ref.pdo-mysql">PDO_MYSQL</link></simpara></listitem>
-   <listitem><simpara><link linkend="ref.pdo-pgsql">PDO_PGSQL</link></simpara></listitem>
-   <listitem><simpara><link linkend="ref.pdo-sqlite">PDO_SQLITE</link></simpara></listitem>
-  </itemizedlist>
 
  </refsect1>
  <refsect1 role="parameters">


### PR DESCRIPTION
Since php/php-src@caa710037e663fd78f67533b29611183090068b2, all bundled drivers (Firebird and ODBC being the omissions before) implement this function. The third-party drivers, even the ones in massive states of disrepair, support it too. It's still optional, so a new PDO driver could take us by surprise, but the list is misleading, so just include the warning.