### PR TITLE
[PHP 8.1] Usage of static Variables in Inherited Methods

### DIFF
--- a/language/oop5/static.xml
+++ b/language/oop5/static.xml
@@ -59,34 +59,6 @@ $classname::aStaticMethod();
 ]]>
      </programlisting>
    </example>
-
-   <para>
-    As of PHP 8.1.0, when a method using static variables is inherited (but not overridden),
-    the inherited method will now share static variables with the parent method.
-    This means that static variables in methods now behave the same way as static properties.
-   </para>
-
-   <example>
-    <title>Usage of static Variables in Inherited Methods</title>
-    <programlisting role="php">
-<![CDATA[
-<?php
-class Foo {
-    public static function counter() {
-        static $counter = 0;
-        $counter++;
-        return $counter;
-    }
-}
-class Bar extends Foo {}
-var_dump(Foo::counter()); // int(1)
-var_dump(Foo::counter()); // int(2)
-var_dump(Bar::counter()); // int(3), prior to PHP 8.1.0 int(1)
-var_dump(Bar::counter()); // int(4), prior to PHP 8.1.0 int(2)
-?> 
-]]>
-    </programlisting>
-   </example>
   </sect2>
   
   <sect2 xml:id="language.oop5.static.properties">

--- a/language/oop5/static.xml
+++ b/language/oop5/static.xml
@@ -59,6 +59,34 @@ $classname::aStaticMethod();
 ]]>
      </programlisting>
    </example>
+
+   <para>
+    As of PHP 8.1.0, when a method using static variables is inherited (but not overridden),
+    the inherited method will now share static variables with the parent method.
+    This means that static variables in methods now behave the same way as static properties.
+   </para>
+
+   <example>
+    <title>Usage of static Variables in Inherited Methods</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+class Foo {
+    public static function counter() {
+        static $counter = 0;
+        $counter++;
+        return $counter;
+    }
+}
+class Bar extends Foo {}
+var_dump(Foo::counter()); // int(1)
+var_dump(Foo::counter()); // int(2)
+var_dump(Bar::counter()); // int(3), prior to PHP 8.1.0 int(1)
+var_dump(Bar::counter()); // int(4), prior to PHP 8.1.0 int(2)
+?> 
+]]>
+    </programlisting>
+   </example>
   </sect2>
   
   <sect2 xml:id="language.oop5.static.properties">

--- a/language/variables.xml
+++ b/language/variables.xml
@@ -485,7 +485,35 @@ function foo(){
 ]]>
      </programlisting>
     </example>
-   </para> 
+   </para>
+
+   <para>
+    As of PHP 8.1.0, when a method using static variables is inherited (but not overridden),
+    the inherited method will now share static variables with the parent method.
+    This means that static variables in methods now behave the same way as static properties.
+   </para>
+
+   <example>
+    <title>Usage of static Variables in Inherited Methods</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+class Foo {
+    public static function counter() {
+        static $counter = 0;
+        $counter++;
+        return $counter;
+    }
+}
+class Bar extends Foo {}
+var_dump(Foo::counter()); // int(1)
+var_dump(Foo::counter()); // int(2)
+var_dump(Bar::counter()); // int(3), prior to PHP 8.1.0 int(1)
+var_dump(Bar::counter()); // int(4), prior to PHP 8.1.0 int(2)
+?> 
+]]>
+    </programlisting>
+   </example>
 
    <note>
     <para>


### PR DESCRIPTION
Relates [Migration Guide](https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.static-variable-inheritance)