### PR TITLE
Collator::__construct() and Collator::create() do not accept null

### DIFF
--- a/reference/intl/collator/construct.xml
+++ b/reference/intl/collator/construct.xml
@@ -25,7 +25,8 @@
      <listitem>
       <para>
        The locale whose collation rules should be used. Special values for
-       locales can be passed in - if &null; is passed for the locale, the
+       locales can be passed in - if an empty string (<literal>""</literal>)
+       is passed for the locale, the
        default locale's collation rules will be used. If "root" is passed,
        <link xlink:href="&url.icu.uca;">UCA</link> rules will be used.
       </para>

--- a/reference/intl/collator/create.xml
+++ b/reference/intl/collator/create.xml
@@ -35,7 +35,8 @@
      <listitem>
       <para>
        The locale containing the required collation rules. Special values for
-       locales can be passed in - if &null; is passed for the locale, the
+       locales can be passed in - if an empty string (<literal>""</literal>)
+       is passed for the locale, the
        default locale collation rules will be used. If empty string ("") or
        "root" are passed, <link xlink:href="&url.icu.uca;">UCA</link> rules will be used.
       </para>


### PR DESCRIPTION
Fixes #1550