### PR TITLE
[PHP 8.1] Passing null to non-nullable parameters of built-in functions

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1075,7 +1075,9 @@ $func(); // prints "bar"
     <para>
      For example, <function>strlen</function> function expects the parameter <literal>string</literal>
      to be a non-nullable &string;.
-     For historical reasons, PHP allows passing &null; for this parameter in weak mode, and the parameter is implicitly casted to the accepted type. In contrast, a <classname>TypeError</classname> is emitted In strict mode.
+     For historical reasons, PHP allows passing &null; for this parameter in weak mode, and the parameter is
+     implicitly casted to <type>string</type>, resulting in a <literal>""</literal> value.
+     In contrast, a <classname>TypeError</classname> is emitted In strict mode.
     </para>
 
     <example>

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1065,10 +1065,34 @@ $func(); // prints "bar"
     </simpara>
    </note>
    <note>
-    <simpara>
+    <para>
      Scalar types for built-in functions are nullable by default.
-     As of PHP 8.1.0, passing &null; to a function parameter that is not declared nullable is not allowed and emits a deprecation notice.
-    </simpara>
+     As of PHP 8.1.0, passing &null; to a function parameter that is not declared nullable
+     is discouraged and emits a deprecation notice to align with the behavior of user-defined functions,
+     where scalar types need to be marked as nullable explicitly.
+    </para>
+
+    <para>
+     For example, <function>strlen</function> function expects the parameter <literal>string</literal>
+     to be a non-nullable &string;.
+     For historical reasons, PHP allowed passing &null; for this parameter.
+    </para>
+
+    <example>
+     <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(strlen(null));
+// "Deprecated: Passing null to parameter #1 ($string) of type string is deprecated" as of PHP 8.1.0
+// int(0)
+
+var_dump(str_contains("foobar", null));
+// "Deprecated: Passing null to parameter #2 ($needle) of type string is deprecated" as of PHP 8.1.0
+// bool(true)
+?> 
+]]>
+     </programlisting>
+    </example>
    </note>
 
    <sect2 role="seealso">

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1066,18 +1066,18 @@ $func(); // prints "bar"
    </note>
    <note>
     <para>
-     Scalar types for built-in functions are nullable by default in weak mode.
+     Scalar types for built-in functions are nullable by default in coercive mode.
      As of PHP 8.1.0, passing &null; to an internal function parameter that is not declared nullable
-     is discouraged and emits a deprecation notice in weak mode to align with the behavior of user-defined functions,
+     is discouraged and emits a deprecation notice in coercive mode to align with the behavior of user-defined functions,
      where scalar types need to be marked as nullable explicitly.
     </para>
 
     <para>
-     For example, <function>strlen</function> function expects the parameter <literal>string</literal>
+     For example, <function>strlen</function> function expects the parameter <literal>$string</literal>
      to be a non-nullable &string;.
-     For historical reasons, PHP allows passing &null; for this parameter in weak mode, and the parameter is
-     implicitly casted to <type>string</type>, resulting in a <literal>""</literal> value.
-     In contrast, a <classname>TypeError</classname> is emitted In strict mode.
+     For historical reasons, PHP allows passing &null; for this parameter in coercive mode, and the parameter is
+     implicitly cast to <type>string</type>, resulting in a <literal>""</literal> value.
+     In contrast, a <classname>TypeError</classname> is emitted in strict mode.
     </para>
 
     <example>

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1066,16 +1066,16 @@ $func(); // prints "bar"
    </note>
    <note>
     <para>
-     Scalar types for built-in functions are nullable by default.
-     As of PHP 8.1.0, passing &null; to a function parameter that is not declared nullable
-     is discouraged and emits a deprecation notice to align with the behavior of user-defined functions,
+     Scalar types for built-in functions are nullable by default in weak mode.
+     As of PHP 8.1.0, passing &null; to an internal function parameter that is not declared nullable
+     is discouraged and emits a deprecation notice in weak mode to align with the behavior of user-defined functions,
      where scalar types need to be marked as nullable explicitly.
     </para>
 
     <para>
      For example, <function>strlen</function> function expects the parameter <literal>string</literal>
      to be a non-nullable &string;.
-     For historical reasons, PHP allowed passing &null; for this parameter.
+     For historical reasons, PHP allows passing &null; for this parameter in weak mode, and the parameter is implicitly casted to the accepted type. In contrast, a <classname>TypeError</classname> is emitted In strict mode.
     </para>
 
     <example>

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1064,6 +1064,12 @@ $func(); // prints "bar"
      be thrown in this case.
     </simpara>
    </note>
+   <note>
+    <simpara>
+     Scalar types for built-in functions are nullable by default.
+     As of PHP 8.1.0, passing &null; to a function parameter that is not declared nullable is not allowed and emits a deprecation notice.
+    </simpara>
+   </note>
 
    <sect2 role="seealso">
     &reftitle.seealso;


### PR DESCRIPTION
Relates [Migration Guide](https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.null-not-nullable-internal)