### PR TITLE
Fix type for index in ZipArchive::replaceFile

### DIFF
--- a/reference/zip/ziparchive/replacefile.xml
+++ b/reference/zip/ziparchive/replacefile.xml
@@ -10,7 +10,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::replaceFile</methodname>
    <methodparam><type>string</type><parameter>filepath</parameter></methodparam>
-   <methodparam><type>string</type><parameter>index</parameter></methodparam>
+   <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>start</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>


### PR DESCRIPTION
In all of the `ZipArchive` methods, the `index` is always described as `int` (see https://www.php.net/manual/en/class.ziparchive.php). Only for the `replaceFile` it is documented as `string`. However, actually passing a `string` will trigger (in PHP 8.1.5)

> Fatal error: Uncaught TypeError: ZipArchive::replaceFile(): Argument #2 ($index) must be of type int, string given

> TypeError: ZipArchive::replaceFile(): Argument #2 ($index) must be of type int, string given

The error also appears in other languages of the documentation. But _replacefile.xml_ is only present in this repo. So I assume the other language docs will be automatically fixed after merging this?