### PR TITLE
functions/constant Minor tweak to "errors" section

### DIFF
--- a/reference/misc/functions/constant.xml
+++ b/reference/misc/functions/constant.xml
@@ -53,9 +53,8 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   An <classname>Error</classname> exception is thrown,
-   if the constant is not defined. Prior to PHP 8.0.0,
-   an <constant>E_WARNING</constant> level error was generated in that case.
+   If the constant is not defined, an <classname>Error</classname> exception is thrown.
+   Prior to PHP 8.0.0, an <constant>E_WARNING</constant> level error was generated in that case.
   </para>
  </refsect1>
 


### PR DESCRIPTION
https://www.php.net/manual/en/function.constant.php

This updates the text from:

> An Error exception is thrown, if the constant is not defined.

to:

> If the constant is not defined, an Error exception is thrown.

The existing text is more difficult to read as it puts the condition behind the result. If the existing text is preferred, I'd remove the comma.