### PR TITLE
Added a note about scientific notation strings

### DIFF
--- a/language/types/numeric-strings.xml
+++ b/language/types/numeric-strings.xml
@@ -30,6 +30,23 @@ NUM_STRING       ({INT_NUM_STRING} | {FLOAT_NUM_STRING})
   This is simply a string which starts like a numeric string followed by
   any characters.
  </para>
+ 
+ <note>
+  <para>
+   Any string that contains the letter <literal>E</literal> (case insensitive)
+   bounded by numbers will be seen as a number expressed in scientific notation.
+   This can produce unexpected results.
+   <programlisting role="php">
+<![CDATA[
+<?php
+var_dump("0D1" == "000"); // false, "0D1" is not scientific notation
+var_dump("0E1" == "000"); // true, "0E1" is 0 * (10 ^ 1), or 0
+var_dump("2E1" == "020"); // true, "2E1" is 2 * (10 ^ 1), or 20
+?>
+]]>
+   </programlisting>
+  </para>
+ </note>
 
  <sect2 xml:id="language.types.numeric-string.conversion">
   <title>Strings used in numeric contexts</title>

--- a/language/types/numeric-strings.xml
+++ b/language/types/numeric-strings.xml
@@ -30,7 +30,6 @@ NUM_STRING       ({INT_NUM_STRING} | {FLOAT_NUM_STRING})
   This is simply a string which starts like a numeric string followed by
   any characters.
  </para>
- 
  <note>
   <para>
    Any string that contains the letter <literal>E</literal> (case insensitive)


### PR DESCRIPTION
There's nothing explicit in the manual about scientific notation strings being interpreted as number. A section that people can be pointed to might be helpful