### PR TITLE
fix memcached.get `$$flags`

### DIFF
--- a/reference/memcached/memcached/get.xml
+++ b/reference/memcached/memcached/get.xml
@@ -13,7 +13,7 @@
    <modifier>public</modifier> <type>mixed</type><methodname>Memcached::get</methodname>
    <methodparam><type>string</type><parameter>key</parameter></methodparam>
    <methodparam choice="opt"><type>callable</type><parameter>cache_cb</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>$flags</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>Memcached::get</function> returns the item that was previously


### PR DESCRIPTION
method description on https://www.php.net/manual/en/memcached.get.php has `$$flags` in parameter