### PR TITLE
Fix: `Ds\Collection` extends `IteratorAggregate`.

### DIFF
--- a/reference/ds/ds.collection.xml
+++ b/reference/ds/ds.collection.xml
@@ -57,7 +57,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>1.4.0</entry>
+       <entry>PECL ds 1.4.0</entry>
        <entry>
         <classname>Collection</classname> implements
         <interfacename>IteratorAggregate</interfacename> now instead of just <interfacename>Traversable</interfacename>. (This change came to the polyfill in 1.4.1.)

--- a/reference/ds/ds.collection.xml
+++ b/reference/ds/ds.collection.xml
@@ -31,8 +31,8 @@
 
     <ooclass><classname>Ds\Collection</classname></ooclass>
 
-    <oointerface><interfacename>Traversable</interfacename></oointerface>
     <oointerface><interfacename>Countable</interfacename></oointerface>
+    <oointerface><interfacename>IteratorAggregate</interfacename></oointerface>
     <oointerface><interfacename>JsonSerializable</interfacename></oointerface>
 
     </classsynopsisinfo>

--- a/reference/ds/ds.collection.xml
+++ b/reference/ds/ds.collection.xml
@@ -45,6 +45,29 @@
 
   </section>
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>1.4.0</entry>
+       <entry>
+        <classname>Collection</classname> implements
+        <interfacename>IteratorAggregate</interfacename> now instead of just <interfacename>Traversable</interfacename>. (This change came to the polyfill in 1.4.1.)
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
 
  &reference.ds.ds.entities.collection;


### PR DESCRIPTION
Discovered in https://github.com/phpstan/phpstan/issues/7258.

`Ds\Collection` extends `IteratorAggregate` in both [the `php-ds/php-ds` polyfill](https://github.com/php-ds/polyfill/blob/master/src/Collection.php) and [the `ext-ds` extension](https://github.com/php-ds/ext-ds/blob/master/src/php/classes/php_collection_ce.c), so the documentation should be updated to reflect this.

Note that `Traversable` is removed from the `extends` because `IteratorAggregate` already extends `Traversable`.