### PR TITLE
Added gc_maxlifetime default value to description

### DIFF
--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -428,6 +428,7 @@
      (depending on <link
      linkend="ini.session.gc-probability">session.gc_probability</link> and
      <link linkend="ini.session.gc-divisor">session.gc_divisor</link>).
+     Defaults to <literal>1440</literal> (24 minutes).
     </simpara>
     <note>
      <simpara>


### PR DESCRIPTION
For consistency with all other constants, where the default value is also mentioned in the description so you don't have to go back to the table to look it up.