### PR TITLE
Add sane string to number comparison

### DIFF
--- a/language/operators.xml
+++ b/language/operators.xml
@@ -1692,7 +1692,9 @@ echo $a <=> $b; // 1
       <row>
        <entry><type>string</type>, <type>resource</type>, <type>int</type> or <type>float</type></entry>
        <entry><type>string</type>, <type>resource</type>, <type>int</type> or <type>float</type></entry>
-       <entry>Translate strings and resources to numbers, usual math</entry>
+       <entry>Translate strings and resources to numbers, usual math. Note that since PHP 8 this has changed for one case: 
+        When comparing a number to a non-numeric string, PHP 8
+        converts the number to a string and uses a string comparison.</entry>
       </row>
       <row>
        <entry><type>array</type></entry>


### PR DESCRIPTION
This case was missing in the table: https://www.php.net/releases/8.0/en.php#saner-string-to-number-comparisons