### PR TITLE
Argon2's memory_cost is in kilobytes, not bytes

### DIFF
--- a/reference/password/constants.xml
+++ b/reference/password/constants.xml
@@ -66,7 +66,7 @@
      <itemizedlist>
       <listitem>
        <para>
-        <literal>memory_cost</literal> (<type>int</type>) - Maximum memory (in bytes) that may 
+        <literal>memory_cost</literal> (<type>int</type>) - Maximum memory (in kibibytes) that may 
         be used to compute the Argon2 hash. Defaults to <constant>PASSWORD_ARGON2_DEFAULT_MEMORY_COST</constant>.
        </para>
       </listitem>


### PR DESCRIPTION
https://www.php.net/password-hash says "kibibytes", spec https://www.password-hashing.net/argon2-specs.pdf says "kilobytes", went with "kibibytes" to match the other docs page.