### PR TITLE
Clarify `aad` parameter in openssl-encrypt

### DIFF
--- a/reference/openssl/functions/openssl-decrypt.xml
+++ b/reference/openssl/functions/openssl-decrypt.xml
@@ -92,7 +92,7 @@
      <term><parameter>aad</parameter></term>
      <listitem>
       <para>
-       Additional authentication data.
+       Additional authenticated data.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/openssl/functions/openssl-encrypt.xml
+++ b/reference/openssl/functions/openssl-encrypt.xml
@@ -85,7 +85,7 @@
      <term><parameter>aad</parameter></term>
      <listitem>
       <para>
-       Additional authentication data.
+       Additional authenticated data.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
The `$aad` parameter in `openssl_encrypt` and `openssl_decrypt` is used to pass additional plaintext data that is `authenticated` (i.e. has integrity guaranteed, but no confidentiality). The current documentation uses the word `authentication` for this data, which is misleading and probably a typo of the intended `authenticated`.

The OpenSSL wiki uses `authenticated` consistently for the `$aad` parameter, and never `authentication`: https://wiki.openssl.org/index.php/EVP_Authenticated_Encryption_and_Decryption