### PR TITLE
Stricter return type for `getBackingType`

### DIFF
--- a/reference/reflection/reflectionenum/getbackingtype.xml
+++ b/reference/reflection/reflectionenum/getbackingtype.xml
@@ -79,7 +79,8 @@ string(6) "string"
      <row>
       <entry>8.2.0</entry>
       <entry>
-       The declared return type was narrowed to <classname>ReflectionNamedType</classname> from <classname>ReflectionType</classname>.
+       The declared return type was narrowed to <classname>ReflectionNamedType</classname>
+       from <classname>ReflectionType</classname>.
       </entry>
      </row>
     </tbody>

--- a/reference/reflection/reflectionenum/getbackingtype.xml
+++ b/reference/reflection/reflectionenum/getbackingtype.xml
@@ -85,7 +85,7 @@ string(6) "string"
     </tbody>
    </tgroup>
   </informaltable>
- </refsect1><!-- }}} -->
+ </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/reflection/reflectionenum/getbackingtype.xml
+++ b/reference/reflection/reflectionenum/getbackingtype.xml
@@ -65,7 +65,7 @@ string(6) "string"
    </example>
   </para>
  </refsect1>
- <refsect1 role="changelog"><!-- {{{ -->
+ <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
    <tgroup cols="2">

--- a/reference/reflection/reflectionenum/getbackingtype.xml
+++ b/reference/reflection/reflectionenum/getbackingtype.xml
@@ -31,7 +31,28 @@
    if the Enum has no backing type.
   </para>
  </refsect1>
-
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.2.0</entry>
+      <entry>
+       The declared return type was narrowed to <classname>ReflectionNamedType</classname>
+       from <classname>ReflectionType</classname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -64,28 +85,6 @@ string(6) "string"
     </screen>
    </example>
   </para>
- </refsect1>
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <informaltable>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>&Version;</entry>
-      <entry>&Description;</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>8.2.0</entry>
-      <entry>
-       The declared return type was narrowed to <classname>ReflectionNamedType</classname>
-       from <classname>ReflectionType</classname>.
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </informaltable>
  </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/reflection/reflectionenum/getbackingtype.xml
+++ b/reference/reflection/reflectionenum/getbackingtype.xml
@@ -65,7 +65,27 @@ string(6) "string"
    </example>
   </para>
  </refsect1>
-
+ <refsect1 role="changelog"><!-- {{{ -->
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.2.0</entry>
+      <entry>
+       The declared return type was narrowed to <classname>ReflectionNamedType</classname> from <classname>ReflectionType</classname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1><!-- }}} -->
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/reflection/reflectionenum/getbackingtype.xml
+++ b/reference/reflection/reflectionenum/getbackingtype.xml
@@ -86,6 +86,7 @@ string(6) "string"
    </example>
   </para>
  </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/reflection/reflectionenum/getbackingtype.xml
+++ b/reference/reflection/reflectionenum/getbackingtype.xml
@@ -8,12 +8,12 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type class="union"><type>ReflectionType</type><type>null</type></type><methodname>ReflectionEnum::getBackingType</methodname>
+   <modifier>public</modifier> <type class="union"><type>ReflectionNamedType</type><type>null</type></type><methodname>ReflectionEnum::getBackingType</methodname>
    <void />
   </methodsynopsis>
   <para>
    If the enumeration is a Backed Enum, this method will return an instance
-   of <classname>ReflectionType</classname> for the backing type of the Enum.
+   of <classname>ReflectionNamedType</classname> for the backing type of the Enum.
    If it is not a Backed Enum, it will return <literal>null</literal>.
   </para>
 
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An instance of <classname>ReflectionType</classname>, or <literal>null</literal>
+   An instance of <classname>ReflectionNamedType</classname>, or <literal>null</literal>
    if the Enum has no backing type.
   </para>
  </refsect1>


### PR DESCRIPTION
The only backing types for Enums are `int` and `string`. The proper return type for `ReflectionEnum::getBackingType()` is thus `null|ReflectionNamedType`.