### PR TITLE
mb-internal-encoding : ValueError Thrown on invalid encoding in PHP8

### DIFF
--- a/reference/mbstring/functions/mb-internal-encoding.xml
+++ b/reference/mbstring/functions/mb-internal-encoding.xml
@@ -69,6 +69,14 @@
     </thead>
     <tbody>
      &mbstring.changelog.encoding-nullable;
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       Now throws a <classname>ValueError</classname> if
+       <parameter>encoding</parameter> is an invalid encoding.
+       Previously a <constant>E_WARNING</constant> was emitted instead.
+      </entry>
+     </row>
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/mbstring/functions/mb-internal-encoding.xml
+++ b/reference/mbstring/functions/mb-internal-encoding.xml
@@ -48,6 +48,15 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   As of PHP 8.0.0, a <classname>ValueError</classname> is thrown if the
+   value of <parameter>encoding</parameter> is an invalid encoding.
+   Prior to PHP 8.0.0, a <constant>E_WARNING</constant> was emitted instead.
+  </para>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>


### PR DESCRIPTION
mb-internal-encoding() Thrown ValueError Thrown on invalid encoding since PHP8

Close #1611