### PR TITLE
ref the exact section of ISO8601 broken

### DIFF
--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -160,7 +160,7 @@
         This format is not compatible with ISO-8601, but is left this way for
         backward compatibility reasons. Use <constant>DateTime::ATOM</constant>
         or <constant>DATE_ATOM</constant> for compatibility with ISO-8601
-        instead.
+        instead. (ref ISO8601:2004 section 4.3.3 clause d)
        </simpara>
       </note>
      </listitem>


### PR DESCRIPTION
historically there has been much confusion about whether or not DateTime::ISO8601 actually breaks the ISO8601 specs

as late as a draft of "Deprecations for PHP 8.1" RFC incorrectly contained

>> There's a number of bug reports related to this. From what I understand, the core problem here is not that the ISO8601 format is wrong, it's just one of multiple legal ISO-8601 formats. As DateTime formats always refer to a specific format, not a set of multiple possible ones, there doesn't seem to be anything actionable here.

so it's probably a good idea to add a reference to the exact part of ISO8601 being broken.
related discussion: https://externals.io/message/113657#114883