### PR TITLE
Add note that ReflectionProperty::getDefaultValue() does not copy from promoted property

### DIFF
--- a/language/oop5/decon.xml
+++ b/language/oop5/decon.xml
@@ -159,7 +159,7 @@ class Point {
      <para>
       <link linkend="language.attributes">Attributes</link> placed on a
       promoted constructor argument will be replicated to both the property
-      and argument.
+      and argument.  Default values on a promoted constructor argument will be replicated only to the argument and not the property.
      </para>
     </note>
    </sect3>

--- a/reference/reflection/reflectionproperty/getdefaultvalue.xml
+++ b/reference/reflection/reflectionproperty/getdefaultvalue.xml
@@ -30,39 +30,6 @@
    between a &null; default value and an unitialized typed property.
    Use <methodname>ReflectionProperty::hasDefaultValue</methodname> to detect the difference.
   </para>
-  <note>
-   <simpara>
-    A promoted property has no default value:
-   </simpara>
-    <programlisting role="php">
-<![CDATA[
-<?php
-class Foo
-{
-    public function __construct(
-        public int $bin = 3,
-    )
-    {
-    }
-}
-$ro = new ReflectionClass(Foo::class);
-var_dump($ro->getConstructor()->getParameters()[0]->isDefaultValueAvailable());
-var_dump($ro->getConstructor()->getParameters()[0]->getDefaultValue());
-var_dump($ro->getProperty("bin")->hasDefaultValue());
-var_dump($ro->getProperty("bin")->getDefaultValue());
-?>
-]]>
- </programlisting>
-&example.outputs;
-  <screen>
-<![CDATA[
-bool(true)
-int(3)
-bool(false)
-NULL
-]]>
- </screen>
-  </note>
  </refsect1>
 
  <refsect1 role="examples">
@@ -77,12 +44,14 @@ class Foo {
     public $bar = 1;
     public ?int $baz;
     public int $boing = 0;
+    public function __construct(public string $bak = "default") { }
 }
 
 $ro = new ReflectionClass(Foo::class);
 var_dump($ro->getProperty('bar')->getDefaultValue());
 var_dump($ro->getProperty('baz')->getDefaultValue());
 var_dump($ro->getProperty('boing')->getDefaultValue());
+var_dump($ro->getProperty('bak')->getDefaultValue());
 ?>
 ]]>
  </programlisting>
@@ -92,6 +61,7 @@ var_dump($ro->getProperty('boing')->getDefaultValue());
 int(1)
 NULL
 int(0)
+NULL
 ]]>
  </screen>
    </example>

--- a/reference/reflection/reflectionproperty/getdefaultvalue.xml
+++ b/reference/reflection/reflectionproperty/getdefaultvalue.xml
@@ -30,6 +30,39 @@
    between a &null; default value and an unitialized typed property.
    Use <methodname>ReflectionProperty::hasDefaultValue</methodname> to detect the difference.
   </para>
+  <warning>
+   <simpara>
+    A promoted property has no default value:
+   </simpara>
+    <programlisting role="php">
+<![CDATA[
+<?php
+class Foo
+{
+    public function __construct(
+        public int $bin = 3,
+    )
+    {
+    }
+}
+$ro = new ReflectionClass(Foo::class);
+var_dump($ro->getConstructor()->getParameters()[0]->isDefaultValueAvailable());
+var_dump($ro->getConstructor()->getParameters()[0]->getDefaultValue());
+var_dump($ro->getProperty("bin")->hasDefaultValue());
+var_dump($ro->getProperty("bin")->getDefaultValue());
+?>
+]]>
+ </programlisting>
+&example.outputs;
+  <screen>
+<![CDATA[
+bool(true)
+int(3)
+bool(false)
+NULL
+]]>
+ </screen>
+  </warning>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/reflection/reflectionproperty/getdefaultvalue.xml
+++ b/reference/reflection/reflectionproperty/getdefaultvalue.xml
@@ -30,7 +30,7 @@
    between a &null; default value and an unitialized typed property.
    Use <methodname>ReflectionProperty::hasDefaultValue</methodname> to detect the difference.
   </para>
-  <warning>
+  <note>
    <simpara>
     A promoted property has no default value:
    </simpara>
@@ -62,7 +62,7 @@ bool(false)
 NULL
 ]]>
  </screen>
-  </warning>
+  </note>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Noticed this in https://3v4l.org/vZrFf - surprising behavior but clearly documented in https://wiki.php.net/rfc/constructor_promotion#desugaring.  Writing a similar example and adding a note to `ReflectionProperty::getDefaultValue()`.