### PR TITLE
Deleted cast to binary string example.

### DIFF
--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -262,22 +262,6 @@ $foo = ( int ) $bar;
    </para>
   </note>
 
-  <informalexample>
-   <simpara>
-    Casting literal <type>string</type>s and variables to binary
-    <type>string</type>s:
-   </simpara>
-
-   <programlisting role="php">
-<![CDATA[
-<?php
-$binary = (binary) $string;
-$binary = b"binary string";
-?>
-]]>
-   </programlisting>
-  </informalexample>
-
   <!-- TODO Remove or move into string context section? -->
   <note>
    <simpara>


### PR DESCRIPTION
deleted cast to binary string example by the following reason.

- `(binary)` and `(string)` are identical
- b prefix seems to be nothing processed specially[*1]
- all the following code is identical to (string) cast, not cast to binary string.
  * Currently there is no binary string type, isn't it?

```php
$binary = (binary) $string;
$binary = b"binary string";
```

[*1] https://github.com/php/php-src/blob/php-8.1.0/Zend/zend_language_scanner.l#L2445-L2730