### PR TITLE
ZipArchive::close deletes file if empty

### DIFF
--- a/reference/zip/ziparchive/close.xml
+++ b/reference/zip/ziparchive/close.xml
@@ -15,6 +15,10 @@
    Close opened or created archive and save changes. This method is
    automatically called at the end of the script.
   </para>
+  <para>
+   If the archive contains no files, the file is completely removed
+   (no empty archive is written).
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
ping @cmb69 

Simple copy/paste from libzip documentation
https://github.com/nih-at/libzip/blob/48695e84d566d87f36fb1328bb1880a4e9d8c1df/man/zip_close.mdoc#L50

To document (probably confusing) behavior.