### PR TITLE
Update documentation for ldap_search()

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1182,12 +1182,12 @@ Passing untrusted data to this parameter is <emphasis>insecure</emphasis>, unles
 <!ENTITY ldap.return-result 'Returns an <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instance,&return.falseforfailure;.'>
 <!ENTITY ldap.return-result-array 'Returns an <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instance, an array of <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instances,&return.falseforfailure;.'>
 
-<!ENTITY ldap.return-result-array-info 'It is also possible to perform parallel searches. In this case, the first argument should be an array of
-<classname xmlns="http://docbook.org/ns/docbook">LDAP\Connection</classname> instances, rather than a single one.
+<!ENTITY ldap.return-result-array-info '<para xmlns="http://docbook.org/ns/docbook">It is also possible to perform parallel searches. In this case, the first argument should be an array of
+<classname>LDAP\Connection</classname> instances, rather than a single one.
 If the searches should not all use the same base DN and filter, an array of base DNs and/or an array of filters can be passed as arguments instead.
-These arrays must be of the same size as the <classname xmlns="http://docbook.org/ns/docbook">LDAP\Connection</classname> instances array,
+These arrays must be of the same size as the <classname>LDAP\Connection</classname> instances array,
 since the first entries of the arrays are used for one search, the second entries are used for another, and so on.
-When doing parallel searches an array of <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instances is returned, except in case of error, when the return value will be &false;.'>
+When doing parallel searches an array of <classname>LDAP\Result</classname> instances is returned, except in case of error, when the return value will be &false;.</para>'>
 
 <!-- mbstring notes -->
 

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1179,7 +1179,8 @@ Passing untrusted data to this parameter is <emphasis>insecure</emphasis>, unles
  </entry>
 </row>'>
 
-<!ENTITY ldap.return-result 'Returns an <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instance, an array of <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname>,&return.falseforfailure;.'>
+<!ENTITY ldap.return-result 'Returns an <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instance,&return.falseforfailure;.'>
+<!ENTITY ldap.return-result-array 'Returns an <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instance, an array of <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instances,&return.falseforfailure;.'>
 
 <!-- mbstring notes -->
 

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1179,7 +1179,7 @@ Passing untrusted data to this parameter is <emphasis>insecure</emphasis>, unles
  </entry>
 </row>'>
 
-<!ENTITY ldap.return-result 'Returns an <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instance,&return.falseforfailure;.'>
+<!ENTITY ldap.return-result 'Returns an <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instance, an array of <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname>,&return.falseforfailure;.'>
 
 <!-- mbstring notes -->
 

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1182,6 +1182,13 @@ Passing untrusted data to this parameter is <emphasis>insecure</emphasis>, unles
 <!ENTITY ldap.return-result 'Returns an <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instance,&return.falseforfailure;.'>
 <!ENTITY ldap.return-result-array 'Returns an <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instance, an array of <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instances,&return.falseforfailure;.'>
 
+<!ENTITY ldap.return-result-array-info 'It is also possible to perform parallel searches. In this case, the first argument should be an array of
+<classname xmlns="http://docbook.org/ns/docbook">LDAP\Connection</classname> instances, rather than a single one.
+If the searches should not all use the same base DN and filter, an array of base DNs and/or an array of filters can be passed as arguments instead.
+These arrays must be of the same size as the <classname xmlns="http://docbook.org/ns/docbook">LDAP\Connection</classname> instances array,
+since the first entries of the arrays are used for one search, the second entries are used for another, and so on.
+When doing parallel searches an array of <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instances is returned, except in case of error, when the return value will be &false;.'>
+
 <!-- mbstring notes -->
 
 <!ENTITY note.mbstring.encoding.internal '<note xmlns="http://docbook.org/ns/docbook"><para>The internal encoding or the

--- a/reference/ldap/functions/ldap-list.xml
+++ b/reference/ldap/functions/ldap-list.xml
@@ -32,18 +32,7 @@
    current working directory.)
   </para>
   <para>
-   It is also possible to do parallel searches. To do this
-   you use an array of <classname>LDAP\Connection</classname> instances, rather than a single one,
-   as the first argument. If you don't want the same base DN and the
-   same filter for all the searches, you can also use an array of base DNs
-   and/or an array of filters. Those arrays must be of the same size as
-   the <classname>LDAP\Result</classname> instances array, since the first entries of the arrays are
-   used for one search, the second entries are used for another, and so
-   on. When doing parallel searches an array of LDAP\Result instances
-   is returned, except in case of error, when the return value
-   will be &false;. There are some rare cases where the
-   normal search returns &false; while the parallel search returns an
-   <classname>LDAP\Result</classname>.
+   &ldap.return-result-array-info;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-list.xml
+++ b/reference/ldap/functions/ldap-list.xml
@@ -31,6 +31,20 @@
    (Equivalent to typing "<command>ls</command>" and getting a list of files and folders in the
    current working directory.)
   </para>
+  <para>
+   It is also possible to do parallel searches. To do this
+   you use an array of <classname>LDAP\Connection</classname> instances, rather than a single one,
+   as the first argument. If you don't want the same base DN and the
+   same filter for all the searches, you can also use an array of base DNs
+   and/or an array of filters. Those arrays must be of the same size as
+   the <classname>LDAP\Result</classname> instances array, since the first entries of the arrays are
+   used for one search, the second entries are used for another, and so
+   on. When doing parallel searches an array of LDAP\Result instances
+   is returned, except in case of error, when the return value
+   will be &false;. There are some rare cases where the
+   normal search returns &false; while the parallel search returns an
+   <classname>LDAP\Result</classname>.
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -173,7 +187,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &ldap.return-result;
+   &ldap.return-result-array;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-list.xml
+++ b/reference/ldap/functions/ldap-list.xml
@@ -31,9 +31,7 @@
    (Equivalent to typing "<command>ls</command>" and getting a list of files and folders in the
    current working directory.)
   </para>
-  <para>
    &ldap.return-result-array-info;
-  </para>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/ldap/functions/ldap-read.xml
+++ b/reference/ldap/functions/ldap-read.xml
@@ -25,9 +25,7 @@
    directory with the scope <constant>LDAP_SCOPE_BASE</constant>. So it is
    equivalent to reading an entry from the directory.
   </para>
-  <para>
    &ldap.return-result-array-info;
-  </para>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/ldap/functions/ldap-read.xml
+++ b/reference/ldap/functions/ldap-read.xml
@@ -26,18 +26,7 @@
    equivalent to reading an entry from the directory.
   </para>
   <para>
-   It is also possible to do parallel searches. To do this
-   you use an array of <classname>LDAP\Connection</classname> instances, rather than a single one,
-   as the first argument. If you don't want the same base DN and the
-   same filter for all the searches, you can also use an array of base DNs
-   and/or an array of filters. Those arrays must be of the same size as
-   the <classname>LDAP\Result</classname> instances array, since the first entries of the arrays are
-   used for one search, the second entries are used for another, and so
-   on. When doing parallel searches an array of LDAP\Result instances
-   is returned, except in case of error, when the return value
-   will be &false;. There are some rare cases where the
-   normal search returns &false; while the parallel search returns an
-   <classname>LDAP\Result</classname>.
+   &ldap.return-result-array-info;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-read.xml
+++ b/reference/ldap/functions/ldap-read.xml
@@ -25,6 +25,20 @@
    directory with the scope <constant>LDAP_SCOPE_BASE</constant>. So it is
    equivalent to reading an entry from the directory.
   </para>
+  <para>
+   It is also possible to do parallel searches. To do this
+   you use an array of <classname>LDAP\Connection</classname> instances, rather than a single one,
+   as the first argument. If you don't want the same base DN and the
+   same filter for all the searches, you can also use an array of base DNs
+   and/or an array of filters. Those arrays must be of the same size as
+   the <classname>LDAP\Result</classname> instances array, since the first entries of the arrays are
+   used for one search, the second entries are used for another, and so
+   on. When doing parallel searches an array of LDAP\Result instances
+   is returned, except in case of error, when the return value
+   will be &false;. There are some rare cases where the
+   normal search returns &false; while the parallel search returns an
+   <classname>LDAP\Result</classname>.
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -172,7 +186,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &ldap.return-result;
+   &ldap.return-result-array;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-search.xml
+++ b/reference/ldap/functions/ldap-search.xml
@@ -26,18 +26,7 @@
    the entire directory.
   </para>
   <para>
-   From 4.0.5 on it's also possible to do parallel searches. To do this
-   you use an array of <classname>LDAP\Connection</classname> instances, rather than a single one,
-   as the first argument. If you don't want the same base DN and the
-   same filter for all the searches, you can also use an array of base DNs
-   and/or an array of filters. Those arrays must be of the same size as
-   the <classname>LDAP\Result</classname> instances array, since the first entries of the arrays are
-   used for one search, the second entries are used for another, and so
-   on. When doing parallel searches an array of LDAP\Result instances
-   is returned, except in case of error, when the return value
-   will be &false;. There are some rare cases where the
-   normal search returns &false; while the parallel search returns an
-   <classname>LDAP\Result</classname>.
+   &ldap.return-result-array-info;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-search.xml
+++ b/reference/ldap/functions/ldap-search.xml
@@ -25,9 +25,7 @@
    of <constant>LDAP_SCOPE_SUBTREE</constant>. This is equivalent to searching
    the entire directory.
   </para>
-  <para>
    &ldap.return-result-array-info;
-  </para>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/ldap/functions/ldap-search.xml
+++ b/reference/ldap/functions/ldap-search.xml
@@ -27,17 +27,17 @@
   </para>
   <para>
    From 4.0.5 on it's also possible to do parallel searches. To do this
-   you use an array of LDAP\Result instances, rather than a single one,
+   you use an array of <classname>LDAP\Result</classname> instances, rather than a single one,
    as the first argument. If you don't want the same base DN and the
    same filter for all the searches, you can also use an array of base DNs
    and/or an array of filters. Those arrays must be of the same size as
-   the LDAP\Result instances array, since the first entries of the arrays are
+   the <classname>LDAP\Result</classname> instances array, since the first entries of the arrays are
    used for one search, the second entries are used for another, and so
    on. When doing parallel searches an array of LDAP\Result instances
    is returned, except in case of error, when the return value
    will be &false;. There are some rare cases where the
    normal search returns &false; while the parallel search returns an
-   LDAP\Result.
+   <classname>LDAP\Result</classname>.
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-search.xml
+++ b/reference/ldap/functions/ldap-search.xml
@@ -27,7 +27,7 @@
   </para>
   <para>
    From 4.0.5 on it's also possible to do parallel searches. To do this
-   you use an array of <classname>LDAP\Result</classname> instances, rather than a single one,
+   you use an array of <classname>LDAP\Connection</classname> instances, rather than a single one,
    as the first argument. If you don't want the same base DN and the
    same filter for all the searches, you can also use an array of base DNs
    and/or an array of filters. Those arrays must be of the same size as
@@ -185,7 +185,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &ldap.return-result;
+   &ldap.return-result-array;
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-search.xml
+++ b/reference/ldap/functions/ldap-search.xml
@@ -27,19 +27,17 @@
   </para>
   <para>
    From 4.0.5 on it's also possible to do parallel searches. To do this
-   you use an array of link identifiers, rather than a single identifier,
+   you use an array of LDAP\Result instances, rather than a single one,
    as the first argument. If you don't want the same base DN and the
    same filter for all the searches, you can also use an array of base DNs
    and/or an array of filters. Those arrays must be of the same size as
-   the link identifier array since the first entries of the arrays are
+   the LDAP\Result instances array, since the first entries of the arrays are
    used for one search, the second entries are used for another, and so
-   on. When doing parallel searches an array of search result
-   identifiers is returned, except in case of error, then the entry
-   corresponding to the search will be &false;. This is very much like
-   the value normally returned, except that a result identifier is always
-   returned when a search was made. There are some rare cases where the
+   on. When doing parallel searches an array of LDAP\Result instances
+   is returned, except in case of error, when the return value
+   will be &false;. There are some rare cases where the
    normal search returns &false; while the parallel search returns an
-   identifier.
+   LDAP\Result.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Noticed that the array return type value was specified in the function signature but not in the documentation. I assume that it is an array of Ldap\Result :)

Additionally, the text about parallel searches seems to be out of date, as it is referencing the previous function signature. I also deleted a sentence that was confusing.