### PR TITLE
Add reference to get_defined_constants() and constant() each other

### DIFF
--- a/reference/info/functions/get-defined-constants.xml
+++ b/reference/info/functions/get-defined-constants.xml
@@ -138,6 +138,7 @@ Array
   <para>
    <simplelist>
     <member><function>defined</function></member>
+    <member><function>constant</function></member>
     <member><function>get_loaded_extensions</function></member>
     <member><function>get_defined_functions</function></member>
     <member><function>get_defined_vars</function></member>

--- a/reference/misc/functions/constant.xml
+++ b/reference/misc/functions/constant.xml
@@ -124,6 +124,7 @@ var_dump(constant('foo::'. $const)); // string(7) "foobar!"
    <simplelist>
     <member><function>define</function></member>
     <member><function>defined</function></member>
+    <member><function>get_defined_constants</function></member>
     <member>The section on <link linkend="language.constants">Constants</link></member>
    </simplelist>
   </para>


### PR DESCRIPTION
These functions are somewhat similar in use and are useful to be linked. Also, I couldn't reach it from the sidebar because the function categories are different.