### PR TITLE
Make the expression more clear

### DIFF
--- a/language/control-structures/return.xml
+++ b/language/control-structures/return.xml
@@ -53,7 +53,7 @@
  </para>
 
  <para>
-  As of PHP 7.1.0, return statements without an argument trigger <constant>E_COMPILE_ERROR</constant>,
+  As of PHP 7.1.0, return statements without an argument in functions which declare a return type trigger <constant>E_COMPILE_ERROR</constant>,
   unless the return type is <type>void</type>, in which case return statements
   with an argument trigger that error.
  </para>


### PR DESCRIPTION
I think the expression about return statement on page "[return](https://www.php.net/manual/en/function.return.php)" is not as clear as that on page "[Migrating from PHP 7.0.x to PHP 7.1.x](https://www.php.net/manual/en/migration71.incompatible.php#migration71.incompatible.typed-returns-compile-time)".