### PR TITLE
Disable trim_trailing_whitespace in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,4 @@ indent_size = 1
 indent_style = space
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = false


### PR DESCRIPTION
@cmb69 Following our discussing https://github.com/php/doc-en/pull/1650. I'm not sure what editors this is configuration affects, but won't hurt.