### PR TITLE
Add return null return value to in_array

### DIFF
--- a/reference/array/functions/in-array.xml
+++ b/reference/array/functions/in-array.xml
@@ -64,6 +64,9 @@
    Returns &true; if <parameter>needle</parameter> is found in the array,
    &false; otherwise.
   </para>
+  <para>
+  In PHP 7.4 or earlier, returns &null; if <parameter>haystack</parameter> is not an array.
+  </para>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;


### PR DESCRIPTION
See https://3v4l.org/7nIVl

I'm not entirely sure if this should be a docs fix or a fix to the engine behaviour, but I think we would want to keep the engine the same and adjust the docs.