### PR TITLE
Expand switch description and examples to deprecate comments.

### DIFF
--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -29,22 +29,16 @@
  </note>
 
  <para>
-  The following two examples are two different ways to write the
-  same thing, one using a series of <literal>if</literal> and
-  <literal>elseif</literal> statements, and the other using the
-  <literal>switch</literal> statement:
+  In the following example, each code block is equivalent.
+  One uses a series of <literal>if</literal> and
+  <literal>elseif</literal> statements, and the other a
+  <literal>switch</literal> statement.  In each case, the output is the same.
   <example>
    <title><literal>switch</literal> structure</title>
    <programlisting role="php">
 <![CDATA[
 <?php
-if ($i == 0) {
-    echo "i equals 0";
-} elseif ($i == 1) {
-    echo "i equals 1";
-} elseif ($i == 2) {
-    echo "i equals 2";
-}
+// This switch statement:
 
 switch ($i) {
     case 0:
@@ -57,33 +51,15 @@ switch ($i) {
         echo "i equals 2";
         break;
 }
-?>
-]]>
-   </programlisting>
-  </example>
-  <example>
-   <title><literal>switch</literal> structure allows usage of <type>string</type>s</title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-if ($i == 'apple') {
-    echo "i is apple";
-} elseif ($i == 'bar') {
-    echo "i is bar";
-} elseif ($i == 'cake') {
-    echo "i is cake";
-}
 
-switch ($i) {
-    case "apple":
-        echo "i is apple";
-        break;
-    case "bar":
-        echo "i is bar";
-        break;
-    case "cake":
-        echo "i is cake";
-        break;
+// Is equivalent to:
+
+if ($i == 0) {
+    echo "i equals 0";
+} elseif ($i == 1) {
+    echo "i equals 1";
+} elseif ($i == 2) {
+    echo "i equals 2";
 }
 ?>
 ]]>
@@ -224,17 +200,19 @@ switch ($target) {
         print "C";
         break;
     case $start - 4:
-        print "C";
+        print "D";
         break;
 }
+
+// Prints "B"
 ?>
 ]]>
    </programlisting>
   </informalexample>
  </para>
  <para>
-  For more complex comparisons, use the value <literal>true</literal> as the switch value.
-  Or, alternatively, use <literal>if</literal>-<literal>else</literal> blocks.
+  For more complex comparisons, the value <literal>true</literal> may be used as the switch value.
+  Or, alternatively, <literal>if</literal>-<literal>else</literal> blocks instead of <literal>switch</literal>.
   <informalexample>
    <programlisting role="php">
     <![CDATA[
@@ -253,9 +231,11 @@ switch (true) {
         print "C";
         break;
     case $start - $offset === 4:
-        print "C";
+        print "D";
         break;
 }
+
+// Prints "C"
 ?>
 ]]>
    </programlisting>

--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -278,6 +278,7 @@ switch($beer)
 {
     case 'tuborg';
     case 'carlsberg';
+    case 'stella';
     case 'heineken';
         echo 'Good choice';
         break;

--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -290,6 +290,15 @@ switch($beer)
    </programlisting>
   </informalexample>
  </para>
+
+ <sect2 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><link linkend="control-structures.match">match</link></member>
+   </simplelist>
+  </para>
+ </sect2>
 </sect1>
 
 <!-- Keep this comment at the end of the file

--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -66,6 +66,14 @@ switch ($i) {
    <programlisting role="php">
 <![CDATA[
 <?php
+if ($i == 'apple') {
+    echo "i is apple";
+} elseif ($i == 'bar') {
+    echo "i is bar";
+} elseif ($i == 'cake') {
+    echo "i is cake";
+}
+
 switch ($i) {
     case "apple":
         echo "i is apple";
@@ -181,6 +189,77 @@ switch ($i) {
     <constant>E_COMPILE_ERROR</constant> error.
    </simpara>
   </note>
+  <note>
+   <simpara>
+    Technically the <literal>default</literal> case may be listed
+    in any order. It will only be used if no other case matches.
+    However, by convention it is best to place it at the end as the
+    last branch.
+   </simpara>
+  </note>
+ </para>
+ <para>
+  If no <literal>case</literal> branch matches, and there is no <literal>default</literal>
+  branch, then no code will be executed, just as if no <literal>if</literal> statement was true.
+ </para>
+ <para>
+  A case value may be given as an expression. However, that expression will be
+  evaluated on its own and then loosely compared with the switch value. That means
+  it cannot be used for complex evaluations of the switch value.  For example:
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$target = 1;
+$start = 3;
+
+switch ($target) {
+    case $start - 1:
+        print "A";
+        break;
+    case $start - 2:
+        print "B";
+        break;
+    case $start - 3:
+        print "C";
+        break;
+    case $start - 4:
+        print "C";
+        break;
+}
+?>
+]]>
+   </programlisting>
+  </informalexample>
+ </para>
+ <para>
+  For more complex comparisons, use the value <literal>true</literal> as the switch value.
+  Or, alternatively, use <literal>if</literal>-<literal>else</literal> blocks.
+  <informalexample>
+   <programlisting role="php">
+    <![CDATA[
+<?php
+$offset = 1;
+$start = 3;
+
+switch (true) {
+    case $start - $offset === 1:
+        print "A";
+        break;
+    case $start - $offset === 2:
+        print "B";
+        break;
+    case $start - $offset === 3:
+        print "C";
+        break;
+    case $start - $offset === 4:
+        print "C";
+        break;
+}
+?>
+]]>
+   </programlisting>
+  </informalexample>
  </para>
  <para>
   The alternative syntax for control structures is supported with


### PR DESCRIPTION
I cleaned out most of the comments on the `switch` page.  These are the bits worth including.