### PR TITLE
Fix XMLParser example for more recent PHP versions

### DIFF
--- a/reference/xml/examples.xml
+++ b/reference/xml/examples.xml
@@ -13,27 +13,23 @@
 <![CDATA[
 <?php
 $file = "data.xml";
-$depth = array();
+$depth = 0;
 
 function startElement($parser, $name, $attrs)
 {
     global $depth;
 
-    if (!isset($depth[$parser])) {
-        $depth[$parser] = 0;
-    }
-
-    for ($i = 0; $i < $depth[$parser]; $i++) {
+    for ($i = 0; $i < $depth; $i++) {
         echo "  ";
     }
     echo "$name\n";
-    $depth[$parser]++;
+    $depth++;
 }
 
 function endElement($parser, $name)
 {
     global $depth;
-    $depth[$parser]--;
+    $depth--;
 }
 
 $xml_parser = xml_parser_create();


### PR DESCRIPTION
The example uses the `$parser` as array index, but that implicit
conversion to integer already raises a notice as of PHP 7.0.0, and
outright fails as of PHP 8.0.0, since the `$parser` is an object now.

Since there doesn't appear a good reason for `$depth` to be an array
which supports different parsers, we change it to an integer, what also
simplifies the example.

This basically integrates user note 127199.