### PR TITLE
fixed SOCKET_EBADF describe

### DIFF
--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -494,7 +494,7 @@
    </term>
    <listitem>
     <simpara>
-     Bad file descriptor.
+     Bad file descriptor number.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -494,7 +494,7 @@
    </term>
    <listitem>
     <simpara>
-     Bad file number.
+     Bad file descriptor.
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
> https://man7.org/linux/man-pages/man7/unix.7.html

> EBADF  This error can occur for [sendmsg(2)](https://man7.org/linux/man-pages/man2/sendmsg.2.html) when sending a file
>               descriptor as ancillary data over a UNIX domain socket
>               (see the description of SCM_RIGHTS, above), and indicates
>               that the file descriptor number that is being sent is not
 >              valid (e.g., it is not an open file descriptor).

I think it is more appropriate to replace  `Bad file number` with `Bad file descriptor`.