### PR TITLE
strtotime() fixes from comments

### DIFF
--- a/reference/datetime/functions/strtotime.xml
+++ b/reference/datetime/functions/strtotime.xml
@@ -18,7 +18,10 @@
    and will try to parse that format into a Unix timestamp (the number of
    seconds since January 1 1970 00:00:00 UTC), relative to the timestamp given
    in <parameter>baseTimestamp</parameter>, or the current time if
-   <parameter>baseTimestamp</parameter> is not supplied.
+   <parameter>baseTimestamp</parameter> is not supplied.  The date string parsing
+   is defined in <link linkend="datetime.formats">Date and Time Formats</link>, and
+   has several subtle considerations.  Reviewing the full details there is strongly
+   recommended.
   </simpara>
   <warning>
    <para>
@@ -97,89 +100,6 @@
   </para>
  </refsect1>
 
- <refsect1>
-  <para>
-   The order of date components varies in different parts of the world, as does
-   the separator commonly used.  The algorithm attempts to guess what date is intended
-   based on the separator used, as well as whether the date is specified using 2 digits or 4 digits.
-  </para>
-  <para>If the year component is 2 digits, then the algorithm is as follows:</para>
-  <simplelist>
-   <member>
-    Strings with a <literal>/</literal> separator are interpreted in US order.
-    That is, <literal>m/d/y</literal>.
-   </member>
-   <member>
-    Strings with a <literal>.</literal> separator are interpreted as a time, not a date.
-    That is, <literal>h.i.s</literal>.
-   </member>
-   <member>
-    Strings with a <literal>-</literal> separator are interpreted as an ISO 8601 (ATOM)
-    formatted date with the year first.  That is, <literal>y-m-d</literal>.
-   </member>
-  </simplelist>
-  <para>If the year component is 4 digits, then the algorithm is as follows:</para>
-  <simplelist>
-   <member>
-    Strings with a <literal>/</literal> separator are interpreted in US order.
-    That is, <literal>m/d/y</literal>.
-   </member>
-   <member>
-    Strings with a <literal>.</literal> separator are interpreted in international order.
-    That is, <literal>d.m.y</literal>.
-   </member>
-   <member>
-    Strings with a <literal>-</literal> separator are interpreted in international order.
-    That is, <literal>d-m-y</literal>.
-   </member>
-  </simplelist>
-  <para>If the selected interpretation results in an out of range month component, &false; will be returned.</para>
-  <para>
-   <example>
-    <title><function>time</function> example</title>
-    <programlisting role="php">
-     <![CDATA[
-<?php
-function format(string $s)
-{
-    print $s . ' is interpreted as ' . date('r', strtotime($s)) . PHP_EOL;
-}
-
-// Strings without timezones will be interpreted
-// in the system default timezone.
-date_default_timezone_set('America/Chicago');
-
-format('5/6/21');
-format('5.6.21');
-format('5-6-21');
-format('5/6/2021');
-format('5.6.2021');
-format('5-6-2021');
-
-format('5/20/21');
-format('5.20.21');
-format('5-20-21');
-?>
-]]>
-    </programlisting>
-    &example.outputs.similar;
-    <screen>
-     <![CDATA[
-5/6/21 is interpreted as Thu, 06 May 2021 00:00:00 -0500
-5.6.21 is interpreted as Mon, 4 Jul 2022 05:06:21 -0500  (date will be when the code is run)
-5-6-21 is interpreted as Tue, 21 Jun 2005 00:00:00 -0500
-5/6/2021 is interpreted as Thu, 06 May 2021 00:00:00 -0500
-5.6.2021 is interpreted as Sat, 05 Jun 2021 00:00:00 -0500
-5-6-2021 is interpreted as Sat, 05 Jun 2021 00:00:00 -0500
-]]>
-    </screen>
-   </example>
-  </para>
-  <para>
-   For the full description of the string parsing logic, see <link linkend="datetime.formats">Date and Time Formats</link>.
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -231,7 +151,7 @@ if (($timestamp = strtotime($str)) === false) {
     which will overflow into a timestamp on <literal>3 March</literal>.
     (In a leap year, it would be <literal>2 March</literal>.)  Using
     <code>strtotime('1 February')</code> or <code>strtotime('first day of February')</code>
-    would eliminate that problem.
+    would avoid that problem.
    </para>
   </note>
   <note>

--- a/reference/datetime/functions/strtotime.xml
+++ b/reference/datetime/functions/strtotime.xml
@@ -97,6 +97,82 @@
   </para>
  </refsect1>
 
+ <refsect1>
+  <para>
+   The order of date components varies in different parts of the world, as does
+   the separator commonly used.  The algorithm attempts to guess what date is intended
+   based on the separator used, as well as whether the date is specified using 2 digits or 4 digits.
+  </para>
+  <para>If the year component is 2 digits, then the algorithm is as follows:</para>
+  <simplelist>
+   <member>
+    Strings with a <literal>/</literal> separator are interpreted in US order.
+    That is, <literal>m/d/y</literal>.
+   </member>
+   <member>
+    Strings with a <literal>.</literal> separator are interpreted as a timestamp, not a date.
+    That is, <literal>h.i.s</literal>.
+   </member>
+   <member>
+    Strings with a <literal>-</literal> separator are interpreted as an ISO 8601 (ATOM)
+    formatted date with the year first.  That is, <literal>y-m-d</literal>.
+   </member>
+  </simplelist>
+  <para>If the year component is 4 digits, then the algorithm is as follows:</para>
+  <simplelist>
+   <member>
+    Strings with a <literal>/</literal> separator are interpreted in US order.
+    That is, <literal>m/d/y</literal>.
+   </member>
+   <member>
+    Strings with a <literal>.</literal> separator are interpreted in European order.
+    That is, <literal>d.m.y</literal>.
+   </member>
+   <member>
+    Strings with a <literal>-</literal> separator are interpreted in European order.
+    That is, <literal>d-m-y</literal>.
+   </member>
+  </simplelist>
+  <para>If the selected interpretation results in an illogical date (such as a month out of range), &false; will be returned.</para>
+  <para>
+   <example>
+    <title><function>time</function> example</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+function format(string $s)
+{
+    print $s . ' is interpreted as ' . date('r', strtotime($s)) . PHP_EOL;
+}
+
+format('5/6/21');
+format('5.6.21');
+format('5-6-21');
+format('5/6/2021');
+format('5.6.2021');
+format('5-6-2021');
+
+format('5/20/21');
+format('5.20.21');
+format('5-20-21');
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+     <![CDATA[
+5/6/21 is interpreted as Thu, 06 May 2021 00:00:00 +0200
+5.6.21 is interpreted as Mon, 4 Jul 2022 05:06:21 +0200 (date will be when the code is run)
+5-6-21 is interpreted as Tue, 21 Jun 2005 00:00:00 +0200
+5/6/2021 is interpreted as Thu, 06 May 2021 00:00:00 +0200
+5.6.2021 is interpreted as Sat, 05 Jun 2021 00:00:00 +0200
+5-6-2021 is interpreted as Sat, 05 Jun 2021 00:00:00 +0200
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -158,24 +234,6 @@ if (($timestamp = strtotime($str)) === false) {
     For 64-bit versions of PHP, the valid range of a timestamp is effectively
     infinite, as 64 bits can represent approximately 293 billion years in either
     direction.
-   </para>
-  </note>
-  <note>
-   <para>
-    Dates in the <literal>m/d/y</literal> or <literal>d-m-y</literal> formats
-    are disambiguated by looking at the separator between the various
-    components: if the separator is a slash (<literal>/</literal>), then the
-    American <literal>m/d/y</literal> is assumed; whereas if the separator is a
-    dash (<literal>-</literal>) or a dot (<literal>.</literal>), then the
-    European <literal>d-m-y</literal> format is assumed.
-    If, however, the year is given in a two digit format and the separator is a
-    dash (<literal>-</literal>), the date string is parsed as
-    <literal>y-m-d</literal>.
-   </para>
-   <para>
-    To avoid potential ambiguity, it's best to use ISO 8601
-    (<literal>YYYY-MM-DD</literal>) dates or
-    <methodname>DateTime::createFromFormat</methodname> when possible.
    </para>
   </note>
   <note>

--- a/reference/datetime/functions/strtotime.xml
+++ b/reference/datetime/functions/strtotime.xml
@@ -110,7 +110,7 @@
     That is, <literal>m/d/y</literal>.
    </member>
    <member>
-    Strings with a <literal>.</literal> separator are interpreted as a timestamp, not a date.
+    Strings with a <literal>.</literal> separator are interpreted as a time, not a date.
     That is, <literal>h.i.s</literal>.
    </member>
    <member>
@@ -125,15 +125,15 @@
     That is, <literal>m/d/y</literal>.
    </member>
    <member>
-    Strings with a <literal>.</literal> separator are interpreted in European order.
+    Strings with a <literal>.</literal> separator are interpreted in international order.
     That is, <literal>d.m.y</literal>.
    </member>
    <member>
-    Strings with a <literal>-</literal> separator are interpreted in European order.
+    Strings with a <literal>-</literal> separator are interpreted in international order.
     That is, <literal>d-m-y</literal>.
    </member>
   </simplelist>
-  <para>If the selected interpretation results in an illogical date (such as a month out of range), &false; will be returned.</para>
+  <para>If the selected interpretation results in an out of range month component, &false; will be returned.</para>
   <para>
    <example>
     <title><function>time</function> example</title>
@@ -144,6 +144,10 @@ function format(string $s)
 {
     print $s . ' is interpreted as ' . date('r', strtotime($s)) . PHP_EOL;
 }
+
+// Strings without timezones will be interpreted
+// in the system default timezone.
+date_default_timezone_set('America/Chicago');
 
 format('5/6/21');
 format('5.6.21');
@@ -161,15 +165,18 @@ format('5-20-21');
     &example.outputs.similar;
     <screen>
      <![CDATA[
-5/6/21 is interpreted as Thu, 06 May 2021 00:00:00 +0200
-5.6.21 is interpreted as Mon, 4 Jul 2022 05:06:21 +0200 (date will be when the code is run)
-5-6-21 is interpreted as Tue, 21 Jun 2005 00:00:00 +0200
-5/6/2021 is interpreted as Thu, 06 May 2021 00:00:00 +0200
-5.6.2021 is interpreted as Sat, 05 Jun 2021 00:00:00 +0200
-5-6-2021 is interpreted as Sat, 05 Jun 2021 00:00:00 +0200
+5/6/21 is interpreted as Thu, 06 May 2021 00:00:00 -0500
+5.6.21 is interpreted as Mon, 4 Jul 2022 05:06:21 -0500  (date will be when the code is run)
+5-6-21 is interpreted as Tue, 21 Jun 2005 00:00:00 -0500
+5/6/2021 is interpreted as Thu, 06 May 2021 00:00:00 -0500
+5.6.2021 is interpreted as Sat, 05 Jun 2021 00:00:00 -0500
+5-6-2021 is interpreted as Sat, 05 Jun 2021 00:00:00 -0500
 ]]>
     </screen>
    </example>
+  </para>
+  <para>
+   For the full description of the string parsing logic, see <link linkend="datetime.formats">Date and Time Formats</link>.
   </para>
  </refsect1>
 
@@ -221,8 +228,10 @@ if (($timestamp = strtotime($str)) === false) {
     of the date/time stamp is not provided, it will be taken verbatim from
     the <parameter>baseTimestamp</parameter>.  That is, <code>strtotime('February')</code>,
     if run on the 31st of May 2022, will be interpreted as <literal>31 February 2022</literal>,
-    which will get mangled into a timestamp on <literal>3 March</literal>.
-    (In a leap year, it would be <literal>2 March</literal>.)
+    which will overflow into a timestamp on <literal>3 March</literal>.
+    (In a leap year, it would be <literal>2 March</literal>.)  Using
+    <code>strtotime('1 February')</code> or <code>strtotime('first day of February')</code>
+    would eliminate that problem.
    </para>
   </note>
   <note>

--- a/reference/datetime/functions/strtotime.xml
+++ b/reference/datetime/functions/strtotime.xml
@@ -217,6 +217,16 @@ if (($timestamp = strtotime($str)) === false) {
   &reftitle.notes;
   <note>
    <para>
+    "Relative" date in this case also means that if a particular component
+    of the date/time stamp is not provided, it will be taken verbatim from
+    the <parameter>baseTimestamp</parameter>.  That is, <code>strtotime('February')</code>,
+    if run on the 31st of May 2022, will be interpreted as <literal>31 February 2022</literal>,
+    which will get mangled into a timestamp on <literal>3 March</literal>.
+    (In a leap year, it would be <literal>2 March</literal>.)
+   </para>
+  </note>
+  <note>
+   <para>
     If the number of the year is specified in a two digit format, the values
     between 00-69 are mapped to 2000-2069 and 70-99 to 1970-1999. See the notes
     below for possible differences on 32bit systems (possible dates might end on 


### PR DESCRIPTION
I deleted another bunch of comments.  These are the changes worth keeping.

In particular, the current discussion of separator parsing is incorrect, as the new code sample shows.  It's quite bonkers.