### PR TITLE
fixed preserve key in return value of preg_replace.

### DIFF
--- a/reference/pcre/functions/preg-replace.xml
+++ b/reference/pcre/functions/preg-replace.xml
@@ -67,10 +67,6 @@
        Note that backslashes in &string; literals may require to be escaped.
       </para>
       <para>
-       If the <parameter>replacement</parameter> array is associative, keys
-       will be preserved in the returned value.
-      </para>
-      <para>
        When working with a replacement pattern where a backreference is 
        immediately followed by another number (i.e.: placing a literal number
        immediately after a matched pattern), you cannot use the familiar 
@@ -106,6 +102,10 @@
        If <parameter>subject</parameter> is an array, then the search and
        replace is performed on every entry of <parameter>subject</parameter>,
        and the return value is an array as well.
+      </para>
+      <para>
+       If the <parameter>subject</parameter> array is associative, keys
+       will be preserved in the returned value.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
refs: https://github.com/php/doc-en/pull/1671/commits/c69fbf081307b1bbdbc3ccffd09a3dc518d4d39a

In preg_replace function, `<parameter>replacement</parameter>` key is not preserved in return value.
We should replace it with `<parameter>subject</parameter>`, I think.

```php
<?php

/*
  array(2) {
    ["subjectkey1"]=>
    string(4) "bbbb"
    ["subjectkey2"]=>
    string(4) "ccbb"
  }
*/
var_dump(
    preg_replace(
        ['pkey' => '/aa/'],
        ['rkey' => 'bb'],
        ['subjectkey1' => 'aaaa', 'subjectkey2' => 'ccaa']
    )
);
```