### PR TITLE
PHP 8.1: Update sanitize filters changelog with deprecations

### DIFF
--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -425,6 +425,13 @@ filter.default_flags = 0
       </thead>
       <tbody>
        <row>
+        <entry>8.1.0</entry>
+        <entry>
+         <constant>FILTER_SANITIZE_STRING</constant> and
+         <constant>FILTER_SANITIZE_STRIPPED</constant> has been deprecated.
+        </entry>
+       </row>
+       <row>
         <entry>8.0.0</entry>
         <entry>
          <constant>FILTER_SANITIZE_MAGIC_QUOTES</constant> has been removed.

--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -428,7 +428,7 @@ filter.default_flags = 0
         <entry>8.1.0</entry>
         <entry>
          <constant>FILTER_SANITIZE_STRING</constant> and
-         <constant>FILTER_SANITIZE_STRIPPED</constant> has been deprecated.
+         <constant>FILTER_SANITIZE_STRIPPED</constant> have been deprecated.
         </entry>
        </row>
        <row>


### PR DESCRIPTION
`FILTER_SANITIZE_STRING` and `FILTER_SANITIZE_STRIPPED` has been deprecated but were not added to the changelog in https://github.com/php/doc-en/pull/1193, only a note was added.