### PR TITLE
Fixed typo (1 character)

### DIFF
--- a/reference/datetime/formats.xml
+++ b/reference/datetime/formats.xml
@@ -804,7 +804,7 @@ class DateTime#1 (3) {
     "W".
    </para>
    <para>
-    The "T" in the SOAP, XMRPC and WDDX formats is case-sensitive, you
+    The "T" in the SOAP, XMLRPC and WDDX formats is case-sensitive, you
     can only use the upper case "T".
    </para>
    <para>


### PR DESCRIPTION
The "L" from "XMLRPC" was omitted in one place on the page visible [here](https://www.php.net/manual/en/datetime.formats.compound.php#:~:text=in%20the%20SOAP%2C-,XMRPC,-and%20WDDX%20formats).  This PR fixes the typo.