### PR TITLE
Added enum "Differences from objects" item regarding hoisting

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -585,8 +585,9 @@ $x = Direction::Up['short'];
    <member>Constructors and Destructors are forbidden.</member>
    <member>Inheritance is not supported. Enums may not extend or be extended.</member>
    <member>Static or object properties are not allowed.</member>
-   <member>Cloning an Enum case is not supported, as cases must be singleton instances</member>
+   <member>Cloning an Enum case is not supported, as cases must be singleton instances.</member>
    <member><link linkend="language.oop5.magic">Magic methods</link>, except for those listed below, are disallowed.</member>
+   <member>Enums must always be delcared before they are used.</member>
   </simplelist>
 
   <para>The following object functionality is available, and behaves just as it does on any other object:</para>

--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -587,7 +587,7 @@ $x = Direction::Up['short'];
    <member>Static or object properties are not allowed.</member>
    <member>Cloning an Enum case is not supported, as cases must be singleton instances.</member>
    <member><link linkend="language.oop5.magic">Magic methods</link>, except for those listed below, are disallowed.</member>
-   <member>Enums must always be delcared before they are used.</member>
+   <member>Enums must always be declared before they are used.</member>
   </simplelist>
 
   <para>The following object functionality is available, and behaves just as it does on any other object:</para>


### PR DESCRIPTION
This is a simple addition aimed to address #1564.
Looking at the documentation, I thought this would be the natural place for someone check such a difference as per the original poster of #1564.

This doesn't add the blog post link, nor go into technical detail, like discussed as options in the thread since I thought that goes too far into implementation detail, which is not stated for any other (arguably more significant) differences detailed for enums. 