### PR TITLE
FILTER_VALIDATE_BOOL: clarify non-string values

### DIFF
--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -43,7 +43,6 @@
           &null; is returned for all non-boolean values.
          </para>
          <para>
-          Non-string values are first converted to a string using <function>strval</function>.
           String values are trimmed using <function>trim</function> before comparison.
          </para>
         </entry>
@@ -107,7 +106,14 @@
          <constant>FILTER_FLAG_ALLOW_THOUSAND</constant>,
          <constant>FILTER_NULL_ON_FAILURE</constant>
         </entry>
-        <entry>Validates value as float, optionally from the specified range, and converts to float on success.</entry>
+        <entry>
+          <para>
+            Validates value as float, optionally from the specified range, and converts to float on success.
+          </para>
+          <para>
+            String values are trimmed using <function>trim</function> before comparison.
+          </para>
+        </entry>
        </row>
        <row>
         <entry><constant>FILTER_VALIDATE_INT</constant></entry>
@@ -122,7 +128,14 @@
          <constant>FILTER_FLAG_ALLOW_HEX</constant>,
          <constant>FILTER_NULL_ON_FAILURE</constant>
         </entry>
-        <entry>Validates value as integer, optionally from the specified range, and converts to int on success.</entry>
+        <entry>
+          <para>
+            Validates value as integer, optionally from the specified range, and converts to int on success.
+          </para>
+          <para>
+            String values are trimmed using <function>trim</function> before comparison.
+          </para>
+        </entry>
        </row>
        <row>
         <entry><constant>FILTER_VALIDATE_IP</constant></entry>

--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -42,6 +42,10 @@
           returned only for "0", "false", "off", "no", and "", and
           &null; is returned for all non-boolean values.
          </para>
+         <para>
+          Non-string values are first converted to a string using <function>strval</function>.
+          String values are trimmed using <function>trim</function> before comparison.
+         </para>
         </entry>
        </row>
        <row>

--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -107,12 +107,12 @@
          <constant>FILTER_NULL_ON_FAILURE</constant>
         </entry>
         <entry>
-          <para>
-            Validates value as float, optionally from the specified range, and converts to float on success.
-          </para>
-          <para>
-            String values are trimmed using <function>trim</function> before comparison.
-          </para>
+         <para>
+          Validates value as float, optionally from the specified range, and converts to float on success.
+         </para>
+         <para>
+          String values are trimmed using <function>trim</function> before comparison.
+         </para>
         </entry>
        </row>
        <row>
@@ -129,12 +129,12 @@
          <constant>FILTER_NULL_ON_FAILURE</constant>
         </entry>
         <entry>
-          <para>
-            Validates value as integer, optionally from the specified range, and converts to int on success.
-          </para>
-          <para>
-            String values are trimmed using <function>trim</function> before comparison.
-          </para>
+         <para>
+          Validates value as integer, optionally from the specified range, and converts to int on success.
+         </para>
+         <para>
+          String values are trimmed using <function>trim</function> before comparison.
+         </para>
         </entry>
        </row>
        <row>


### PR DESCRIPTION
It is not clear from the documentation that this filter accepts more than the listed values.
Eg. when using `FILTER_NULL_ON_FAILURE`, `null` is accepted (returns `false`, not `null`), which can be surprising.
Similarly, `'     1      '` (leading/trailing whitespace), `1.0` (float), and `new class { function __toString() { return '1'; } }` are also accepted.

It might also make sense to specifically add these values to the example values - cc #1475 for that.