### PR TITLE
Update document for jit_max_root_traces

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1097,7 +1097,8 @@
     </term>
     <listitem>
      <para>
-      Maximum number of root traces.
+      Maximum number of root traces. The root trace is an execution flow taking one path through the code firstly,
+      which is a unit of JIT compilation. JIT will not compile new code if it reaches this limit.
      </para>
     </listitem>
    </varlistentry>
@@ -1108,7 +1109,9 @@
     </term>
     <listitem>
      <para>
-      Maximum number of side traces a root trace may have.
+      Maximum number of side traces a root trace may have. The side trace is another execution flow that does not
+      follow the path of compiled root trace. Side traces belonging to the same root trace will not be compiled
+      if it reaches this limit.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Add more explanation for root trace and side trace in PHP manual.
Includes the influence when reach the maximum value of
opcache.jit_max_root_traces or opcache.jit_max_side_traces.

Signed-off-by:Wang, Xue <xue1.wang@intel.com>