### PR TITLE
Parameter offset explanation refers to field when it should be row.

### DIFF
--- a/reference/mysqli/mysqli_result/data-seek.xml
+++ b/reference/mysqli/mysqli_result/data-seek.xml
@@ -36,7 +36,7 @@
      <term><parameter>offset</parameter></term>
      <listitem>
       <para>
-       The field offset. Must be between zero and the total number of rows
+       The row offset. Must be between zero and the total number of rows
        minus one (0..<function>mysqli_num_rows</function> - 1).
       </para>
      </listitem>


### PR DESCRIPTION
From manual page: https://php.net/mysqli-result.data-seek

---

In the parameters section the part explaining the offset has the following line. 

> The field offset. Must be between zero and the total number of rows minus one (0..[mysqli_num_rows()](https://www.php.net/manual/en/mysqli-result.num-rows.php) - 1).

Shouldn't the **field offset** be **row offset** ?