### PR TITLE
Fix minor typo (the word "object" should be singular)

### DIFF
--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -99,7 +99,7 @@
    <para>
     The intended use of <link linkend="object.sleep">__sleep()</link> is to commit pending
     data or perform similar cleanup tasks. Also, the function is
-    useful if a very large objects doesn't need to be saved completely.
+    useful if a very large object doesn't need to be saved completely.
    </para>
    <para>
     Conversely, <function>unserialize</function> checks for the


### PR DESCRIPTION
In the current manual, the following is seen: "...if a very large objects...", where it should use the singular form. This PR fixes that so it becomes "...if a very large object...".