### PR TITLE
Add filter_var() to is_numeric() see also section

### DIFF
--- a/reference/var/functions/is-numeric.xml
+++ b/reference/var/functions/is-numeric.xml
@@ -186,6 +186,8 @@ foreach ($tests as $element) {
     <member><function>is_string</function></member>
     <member><function>is_object</function></member>
     <member><function>is_array</function></member>
+    <member><function>is_array</function></member>
+    <member><function>filter_var</function></member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
`filter_var` is a cool way to solve some of the [limitations](https://github.com/php/php-src/issues/9311) of `is_numeric` and therefore I suggest adding it in the see also section.