### PR TITLE
Using time() in its own example

### DIFF
--- a/reference/datetime/functions/time.xml
+++ b/reference/datetime/functions/time.xml
@@ -47,16 +47,19 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-echo 'Now:       '. date('Y-m-d') ."\n";
-echo 'Next Week: '. date('Y-m-d', strtotime('+1 week')) ."\n";
+$now = time();
+echo 'Timestamp: ' . $now . "\n";
+echo 'Date:      ' . date('Y-m-d', $now) . "\n";
+echo 'Next Week: ' . date('Y-m-d', strtotime('+1 week', $now)) . "\n";
 ?>
 ]]>
     </programlisting>
     &example.outputs.similar;
     <screen>
 <![CDATA[
-Now:       2022-06-04
-Next Week: 2022-06-11
+Timestamp: 1660337054
+Date:      2022-08-12
+Next Week: 2022-08-19
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
`time()` function was not used in the example of its own page, so I fixed that.