### PR TITLE
DateTime: change suggestion to DateTimeImmutable

### DIFF
--- a/reference/datetime/datetime.xml
+++ b/reference/datetime/datetime.xml
@@ -23,7 +23,7 @@
      Calling methods on objects of the class <classname>DateTime</classname>
      will change the information encapsulated in these objects, if you want to
      prevent that you will have to use <literal>clone</literal> operator to
-     create a new object. Use the <classname>DateTimeInterface</classname>
+     create a new object. Use <classname>DateTimeImmutable</classname>
      instead of <classname>DateTime</classname> to obtain this recommended
      behaviour by default.
     </para>


### PR DESCRIPTION
Using "the DateTimeInterface" instead of a DateTime object makes no sense, using a DateTimeImmutable instead of a DateTime does.