### PR TITLE
Remove backslash prefix for some ReturnTypeWillChange attributes

### DIFF
--- a/language/oop5/inheritance.xml
+++ b/language/oop5/inheritance.xml
@@ -136,7 +136,7 @@ class MyDateTime extends DateTime
     public function modify(string $modifier) { return false; }
 }
  
-// "Deprecated: Return type of MyDateTime::modify(string $modifier) should either be compatible with DateTime::modify(string $modifier): DateTime|false, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice" as of PHP 8.1.0
+// "Deprecated: Return type of MyDateTime::modify(string $modifier) should either be compatible with DateTime::modify(string $modifier): DateTime|false, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice" as of PHP 8.1.0
 ?> 
 ]]>
     </programlisting>
@@ -152,7 +152,7 @@ class MyDateTime extends DateTime
     public function modify(string $modifier): ?DateTime { return null; }
 }
  
-// "Deprecated: Return type of MyDateTime::modify(string $modifier): ?DateTime should either be compatible with DateTime::modify(string $modifier): DateTime|false, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice" as of PHP 8.1.0
+// "Deprecated: Return type of MyDateTime::modify(string $modifier): ?DateTime should either be compatible with DateTime::modify(string $modifier): DateTime|false, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice" as of PHP 8.1.0
 ?> 
 ]]>
     </programlisting>

--- a/language/oop5/inheritance.xml
+++ b/language/oop5/inheritance.xml
@@ -136,7 +136,7 @@ class MyDateTime extends DateTime
     public function modify(string $modifier) { return false; }
 }
  
-// "Deprecated: Return type of MyDateTime::modify(string $modifier) should either be compatible with DateTime::modify(string $modifier): DateTime|false, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice" as of PHP 8.1.0
+// "Deprecated: Return type of MyDateTime::modify(string $modifier) should either be compatible with DateTime::modify(string $modifier): DateTime|false, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice" as of PHP 8.1.0
 ?> 
 ]]>
     </programlisting>
@@ -152,7 +152,7 @@ class MyDateTime extends DateTime
     public function modify(string $modifier): ?DateTime { return null; }
 }
  
-// "Deprecated: Return type of MyDateTime::modify(string $modifier): ?DateTime should either be compatible with DateTime::modify(string $modifier): DateTime|false, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice" as of PHP 8.1.0
+// "Deprecated: Return type of MyDateTime::modify(string $modifier): ?DateTime should either be compatible with DateTime::modify(string $modifier): DateTime|false, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice" as of PHP 8.1.0
 ?> 
 ]]>
     </programlisting>

--- a/language/predefined/arrayaccess/offsetexists.xml
+++ b/language/predefined/arrayaccess/offsetexists.xml
@@ -79,7 +79,7 @@ class obj implements arrayaccess {
     public function offsetUnset($var): void {
         var_dump(__METHOD__);
     }
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($var) {
         var_dump(__METHOD__);
         return "value";

--- a/language/predefined/iterator.xml
+++ b/language/predefined/iterator.xml
@@ -82,13 +82,13 @@ class myIterator implements Iterator {
         $this->position = 0;
     }
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function current() {
         var_dump(__METHOD__);
         return $this->array[$this->position];
     }
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function key() {
         var_dump(__METHOD__);
         return $this->position;


### PR DESCRIPTION
These backslashes were previously added in 214335df7e8b11b517779aa3420d794f343a7309, 081cf71ecb97b239c1e07beaadb71af0b0c42764, and cfaa7659dab118ecf6b420c550a6b8183f4190ad

Based on previous discussion in https://github.com/php/doc-en/pull/1560, I think these can be removed. I'll note that these were the only examples in the manual that included a leading backslash for ReturnTypeWillChange.

The code examples do not use a namespace and refer to other global classes without a FQCN (e.g. Iterator); however, it's possible the ReturnTypeWillChange backslash was intentional. IIRC, attributes don't require a class to be defined so users blindly copying these examples into a namespaced file might encounter an unexpected error (unlike a missing Iterator interface, which would be very clear). In that case, perhaps we'd want to change _all_ examples with ReturnTypeWillChange to use a leading backslash.

@cmb69: Let me know if that's preferable and I can make the change. Either way, I don't think we need the backslash in the deprecation message comments.

----

Edit: apologies for pushing the `remove-attribute-escaping` branch to this repo. I intended to push it to my fork and didn't realize the mistake until after I opened this PR. I'll leave it in place for now and just delete it after we get this closed.