### PR TITLE
Removing try-catch from examples

### DIFF
--- a/reference/pdo/error-handling.xml
+++ b/reference/pdo/error-handling.xml
@@ -84,14 +84,8 @@ $dsn = 'mysql:dbname=testdb;host=127.0.0.1';
 $user = 'dbuser';
 $password = 'dbpass';
 
-try {
-    $dbh = new PDO($dsn, $user, $password);
-    $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-} catch (PDOException $e) {
-    echo 'Connection failed: ' . $e->getMessage();
-}
-
-?>
+$dbh = new PDO($dsn, $user, $password);
+$dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 ]]>
    </programlisting>
   </example>
@@ -112,16 +106,7 @@ $dsn = 'mysql:dbname=test;host=127.0.0.1';
 $user = 'googleguy';
 $password = 'googleguy';
 
-/*
-    Using try/catch around the constructor is still valid even though we set the ERRMODE to WARNING since
-    PDO::__construct will always throw a PDOException if the connection fails.
-*/
-try {
-    $dbh = new PDO($dsn, $user, $password, array(PDO::ATTR_ERRMODE => PDO::ERRMODE_WARNING));
-} catch (PDOException $e) {
-    echo 'Connection failed: ' . $e->getMessage();
-    exit;
-}
+$dbh = new PDO($dsn, $user, $password, array(PDO::ATTR_ERRMODE => PDO::ERRMODE_WARNING));
 
 // This will cause PDO to throw an error of level E_WARNING instead of an exception (when the table doesn't exist)
 $dbh->query("SELECT wrongcolumn FROM wrongtable");

--- a/reference/pdo/error-handling.xml
+++ b/reference/pdo/error-handling.xml
@@ -86,8 +86,21 @@ $password = 'dbpass';
 
 $dbh = new PDO($dsn, $user, $password);
 $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+// This will cause PDO to throw a PDOException (when the table doesn't exist)
+$dbh->query("SELECT wrongcolumn FROM wrongtable");
 ]]>
    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Fatal error: Uncaught PDOException: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'testdb.wrongtable' doesn't exist in /tmp/pdo_test.php:10
+Stack trace:
+#0 /tmp/pdo_test.php(10): PDO->query('SELECT wrongcol...')
+#1 {main}
+  thrown in /tmp/pdo_test.php on line 10
+]]>
+    </screen>
   </example>
  </para>
  <note>
@@ -110,14 +123,13 @@ $dbh = new PDO($dsn, $user, $password, array(PDO::ATTR_ERRMODE => PDO::ERRMODE_W
 
 // This will cause PDO to throw an error of level E_WARNING instead of an exception (when the table doesn't exist)
 $dbh->query("SELECT wrongcolumn FROM wrongtable");
-?>
 ]]>
    </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
 Warning: PDO::query(): SQLSTATE[42S02]: Base table or view not found: 1146 Table 'test.wrongtable' doesn't exist in
-/tmp/pdo_test.php on line 18
+/tmp/pdo_test.php on line 9
 ]]>
     </screen>
   </example>


### PR DESCRIPTION
Using try catch is irrelevant to examples and echoing errors out unconditionally is a bad practice.