### PR TITLE
Add "die()" as an option to exit a function with return typ "never"

### DIFF
--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -604,8 +604,8 @@ function &test(): void {}
    <title>never</title>
    <para>
     <literal>never</literal> is a return type indicating the function does not
-    return. This means that it either calls <function>exit</function>, throws
-    an exception, or is an infinite loop.
+    return. This means that it either calls <function>exit</function> or
+    <function>die</function>, throws an exception, or is an infinite loop.
     Therefore it cannot be part of a union type declaration.
     Available as of PHP 8.1.0.
    </para>


### PR DESCRIPTION
There was only the `exit()` function mentioned.