### PR TITLE
SoapClient::__construct - Fix method names referenced in trace option

### DIFF
--- a/reference/soap/soapclient/construct.xml
+++ b/reference/soap/soapclient/construct.xml
@@ -332,10 +332,10 @@
           <para>
            Captures request and response information, which can then be
            accessed with the methods
-           <methodname>SoapClient::getLastRequest</methodname>,
-           <methodname>SoapClient::getLastRequestHeaders</methodname>,
-           <methodname>SoapClient::getLastResponse</methodname>,
-           and <methodname>SoapClient::getLastResponseHeaders</methodname>.
+           <methodname>SoapClient::__getLastRequest</methodname>,
+           <methodname>SoapClient::__getLastRequestHeaders</methodname>,
+           <methodname>SoapClient::__getLastResponse</methodname>,
+           and <methodname>SoapClient::__getLastResponseHeaders</methodname>.
           </para>
           <para>
            If omitted, defaults to &false;


### PR DESCRIPTION
`SoapClient::getLastRequest` does not exist. 
The correct name is `SoapClient::__getLastRequest`

Same issue with `getLastRequestHeaders`, `getLastResponse`, and `getLastResponseHeaders`