### PR TITLE
Fix `is_numeric` example snippet

### DIFF
--- a/reference/var/functions/is-numeric.xml
+++ b/reference/var/functions/is-numeric.xml
@@ -137,8 +137,8 @@ NULL is NOT numeric
 $tests = [
     " 42",
     "42 ",
-    " 9001", // non-breaking space
-    "9001 ", // non-breaking space
+    "\u{A0}9001", // non-breaking space
+    "9001\u{A0}", // non-breaking space
 ];
 
 foreach ($tests as $element) {


### PR DESCRIPTION
Considering this output : 

https://onlinephp.io?s=nY4xC8IwEIX3QP7Dozi0ULWWLqLiJDiI7eAmUmq52qAmJYkiSP-7EUu3Lt70uPv47i3XTd1wNrJkrMEKR87gxkMSe2GXkxh9xjyKZl6I6RRSyfFZU3EV8gLTFCV1zBfBMHNacMZZpdy6rOF3rwuDEd3oTtIGeP9MooIvTC4fd9Ki9Pt7D3yHylrhWeicXo3StqdCWP2gABNXWhh0Elcr22b5Jt0tfooWdDP0h3CfHoalnLUf&v=8.1.9%2C8.0.22%2C7.4.30%2C7.0.33

Output for `is_numeric` are not the displayed ones on documentation.