### PR TITLE
Standardize casing for Enum examples.

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -731,18 +731,18 @@ Baz Enum:int {
 <?php
 enum SortOrder
 {
-    case ASC;
-    case DESC;
+    case Asc;
+    case Desc;
 }
 
-function query($fields, $filter, SortOrder $order = SortOrder::ASC) { ... }
+function query($fields, $filter, SortOrder $order = SortOrder::Asc) { ... }
 ?>
 ]]>
     </programlisting>
     <para>
      The <literal>query()</literal> function can now proceed safe in the knowledge that
-     <literal>$order</literal> is guaranteed to be either <literal>SortOrder::ASC</literal>
-     or <literal>SortOrder::DESC</literal>.  Any other value would have resulted in a
+     <literal>$order</literal> is guaranteed to be either <literal>SortOrder::Asc</literal>
+     or <literal>SortOrder::Desc</literal>.  Any other value would have resulted in a
      <classname>TypeError</classname>, so no further error checking or testing is needed.
     </para>
    </example>


### PR DESCRIPTION
Per #1780, if we're telling people to use CamelCase for enum cases, the docs should do so consistently.