### PR TITLE
Clarify Exception constructor for PHP 5

### DIFF
--- a/language/predefined/exception/construct.xml
+++ b/language/predefined/exception/construct.xml
@@ -17,6 +17,13 @@
   <para>
    Constructs the Exception.
   </para>
+  
+  <note>
+   <simpara>
+    This constructor signature applies only to PHP 7.0 and higher. 
+    The documentation for unsupported PHP versions has been discontinued.
+   </simpara>
+  </note>
  </refsect1>
  
  <refsect1 role="parameters">

--- a/language/predefined/exception/construct.xml
+++ b/language/predefined/exception/construct.xml
@@ -20,7 +20,7 @@
   
   <note>
    <simpara>
-    This constructor signature applies only to PHP 7.0 and higher. 
+    This constructor signature applies only to PHP 7.0 and higher.
     The documentation for unsupported PHP versions has been discontinued.
    </simpara>
   </note>


### PR DESCRIPTION
See: https://github.com/php/doc-en/issues/1793

Draft for clarifying why the constructor signature doesn't work for PHP 5, and why we're not documenting older versions.