### PR TITLE
fixed inconsistent description of is_a function.

### DIFF
--- a/reference/classobj/functions/is-a.xml
+++ b/reference/classobj/functions/is-a.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Checks if the given <parameter>object_or_class</parameter> is of this object type or has
-   this class as one of its parents.
+   this object type as one of its parents.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -34,7 +34,7 @@
      <term><parameter>class</parameter></term>
      <listitem>
       <para>
-       The class name
+       The class or interface name
       </para>
      </listitem>
     </varlistentry>
@@ -53,7 +53,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; if the object is of this class or has this class as one of
+   Returns &true; if the object is of this object type or has this object type as one of
    its parents, &false; otherwise.
   </para>
  </refsect1>


### PR DESCRIPTION
Fixed inconsistent description caused by https://github.com/php/doc-en/commit/2761e65ea261c33f65a7854b567a5821cf06aaa7.


 
