### PR TITLE
Add initial version of the PHP 8.2 migration guide

### DIFF
--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -279,6 +279,12 @@
        <entry></entry>
       </row>
       <row>
+       <entry><link linkend="ini.error-log-mode">error_log_mode</link></entry>
+       <entry>0o644</entry>
+       <entry>PHP_INI_ALL</entry>
+       <entry>Available as of PHP 8.2.0</entry>
+      </row>
+      <row>
        <entry><link linkend="ini.error-prepend-string">error_prepend_string</link></entry>
        <entry>NULL</entry>
        <entry>PHP_INI_ALL</entry>

--- a/appendices/migration82.xml
+++ b/appendices/migration82.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appendix xml:id="migration82" xmlns="http://docbook.org/ns/docbook" xmlns:phd="http://www.php.net/ns/phd">
+ <title>Migrating from PHP 8.1.x to PHP 8.2.x</title>
+
+ &appendices.migration82.new-features;
+ &appendices.migration82.new-functions;
+ &appendices.migration82.constants;
+ &appendices.migration82.incompatible;
+ &appendices.migration82.deprecated;
+ &appendices.migration82.other-changes;
+ &appendices.migration82.windows-support;
+
+ <sect1 phd:chunk="false" xml:id="migration82.intro">
+  <para>
+   This new minor version brings with it a number of
+   <link linkend="migration82.new-features">new features</link> and a
+   <link linkend="migration82.incompatible">few incompatibilities</link>
+   that should be tested for before switching PHP versions in production
+   environments.
+  </para>
+
+  <para>
+   &manual.migration.seealso;
+   <link linkend="migration71">7.1.x</link>,
+   <link linkend="migration72">7.2.x</link>,
+   <link linkend="migration73">7.3.x</link>,
+   <link linkend="migration74">7.4.x</link>,
+   <link linkend="migration80">8.0.x</link>,
+   <link linkend="migration81">8.1.x</link>.
+  </para>
+ </sect1>
+</appendix>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration82/constants.xml
+++ b/appendices/migration82/constants.xml
@@ -1,0 +1,526 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration82.constants" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>New Global Constants</title>
+
+ <sect2 xml:id="migration82.constants.com">
+  <title>COM</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>DISP_E_PARAMNOTFOUND</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>LOCALE_NEUTRAL</constant></simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration82.constants.curl">
+  <title>cURL</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <constant>CURLALTSVC_H1</constant> (libcurl >= 7.64.1)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLALTSVC_H2</constant> (libcurl >= 7.64.1)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLALTSVC_H3</constant> (libcurl >= 7.64.1)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLALTSVC_READONLYFILE</constant> (libcurl >= 7.64.1)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLAUTH_AWS_SIGV4</constant> (libcurl >= 7.75.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLE_PROXY</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLFTPMETHOD_DEFAULT</constant>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLHSTS_ENABLE</constant> (libcurl >= 7.74.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLHSTS_READONLYFILE</constant> (libcurl >= 7.74.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLINFO_PROXY_ERROR</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLINFO_REFERER</constant> (libcurl >= 7.76.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLINFO_RETRY_AFTER</constant> (libcurl >= 7.66.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLMOPT_MAX_CONCURRENT_STREAMS</constant> (libcurl >= 7.67.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_ALTSVC_CTRL</constant> (libcurl >= 7.64.1)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_ALTSVC</constant> (libcurl >= 7.64.1)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_AWS_SIGV4</constant> (libcurl >= 7.75.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_CAINFO_BLOB</constant> (libcurl >= 7.77.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_DOH_SSL_VERIFYHOST</constant> (libcurl >= 7.76.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_DOH_SSL_VERIFYPEER</constant> (libcurl >= 7.76.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_DOH_SSL_VERIFYSTATUS</constant> (libcurl >= 7.76.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_HSTS_CTRL</constant> (libcurl >= 7.74.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_HSTS</constant> (libcurl >= 7.74.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_MAIL_RCPT_ALLLOWFAILS</constant> (libcurl >= 7.69.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_MAXAGE_CONN</constant> (libcurl >= 7.65.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_MAXFILESIZE_LARGE</constant>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_MAXLIFETIME_CONN</constant> (libcurl >= 7.80.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_PROXY_CAINFO_BLOB</constant> (libcurl >= 7.77.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_SASL_AUTHZID</constant> (libcurl >= 7.66.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256</constant> (libcurl >= 7.80.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_SSL_EC_CURVES</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_UPKEEP_INTERVAL_MS</constant> (libcurl >= 7.62.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_UPLOAD_BUFFERSIZE</constant> (libcurl >= 7.62.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_XFERINFOFUNCTION</constant> (libcurl >= 7.32.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPROTO_MQTT</constant> (libcurl >= 7.71.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_BAD_ADDRESS_TYPE</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_BAD_VERSION</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_CLOSED</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_GSSAPI</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_GSSAPI_PERMSG</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_GSSAPI_PROTECTION</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_IDENTD_DIFFER</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_IDENTD</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_LONG_HOSTNAME</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_LONG_PASSWD</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_LONG_USER</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_NO_AUTH</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_OK</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_RECV_ADDRESS</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_RECV_AUTH</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_RECV_CONNECT</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_RECV_REQACK</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_REPLY_ADDRESS_TYPE_NOT_SUPPORTED</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_REPLY_COMMAND_NOT_SUPPORTED</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_REPLY_CONNECTION_REFUSED</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_REPLY_GENERAL_SERVER_FAILURE</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_REPLY_HOST_UNREACHABLE</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_REPLY_NETWORK_UNREACHABLE</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_REPLY_NOT_ALLOWED</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_REPLY_TTL_EXPIRED</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_REPLY_UNASSIGNED</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_REQUEST_FAILED</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_RESOLVE_HOST</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_SEND_AUTH</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_SEND_CONNECT</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_SEND_REQUEST</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_UNKNOWN_FAIL</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_UNKNOWN_MODE</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLPX_USER_REJECTED</constant> (libcurl >= 7.73.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLSSLOPT_AUTO_CLIENT_CERT</constant> (libcurl >= 7.77.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLSSLOPT_NATIVE_CA</constant> (libcurl >= 7.71.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLSSLOPT_NO_PARTIALCHAIN</constant> (libcurl >= 7.68.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLSSLOPT_REVOKE_BEST_EFFORT</constant> (libcurl >= 7.70.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURL_VERSION_GSASL</constant> (libcurl >= 7.76.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURL_VERSION_HSTS</constant> (libcurl >= 7.74.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURL_VERSION_HTTP3</constant> (libcurl >= 7.66.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURL_VERSION_UNICODE</constant> (libcurl >= 7.72.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURL_VERSION_ZSTD</constant> (libcurl >= 7.72.0)
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration82.constants.dba">
+  <title>DBA</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>DBA_LMDB_USE_SUB_DIR</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>DBA_LMDB_NO_SUB_DIR</constant></simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration82.constants.filter">
+  <title>Filter</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>FILTER_FLAG_GLOBAL_RANGE</constant></simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration82.constants.sockets">
+  <title>Sockets</title>
+
+  <para>
+   The following socket options are now defined if they are supported:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>SO_INCOMING_CPU</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_MEMINFO</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_RTABLE</constant> (OpenBSD)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>TCP_KEEPALIVE</constant> (MacOS)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>TCP_KEEPCNT</constant> (Linux, others)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>TCP_KEEPIDLE</constant> (Linux, others)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>TCP_KEEPINTVL</constant> (Linux, others)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>TCP_NOTSENT_LOWAT</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>LOCAL_CREDS_PERSISTENT</constant> (FreeBSD)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SCM_CREDS2</constant> (FreeBSD)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>LOCAL_CREDS</constant> (NetBSD)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_BPF_EXTENSIONS</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_SETFIB</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>TCP_CONGESTION</constant> (Linux, FreeBSD)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_ZEROCOPY</constant> (Linux)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>MSG_ZEROCOPY</constant> (Linux)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_ACCEPTFILTER</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_DONTTRUNC</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_WANTMORE</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_MARK</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>TCP_DEFER_ACCEPT</constant></simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+</sect1>
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/appendices/migration82/constants.xml
+++ b/appendices/migration82/constants.xml
@@ -485,21 +485,6 @@
    <listitem>
     <simpara><constant>MSG_ZEROCOPY</constant> (Linux)</simpara>
    </listitem>
-   <listitem>
-    <simpara><constant>SO_ACCEPTFILTER</constant></simpara>
-   </listitem>
-   <listitem>
-    <simpara><constant>SO_DONTTRUNC</constant></simpara>
-   </listitem>
-   <listitem>
-    <simpara><constant>SO_WANTMORE</constant></simpara>
-   </listitem>
-   <listitem>
-    <simpara><constant>SO_MARK</constant></simpara>
-   </listitem>
-   <listitem>
-    <simpara><constant>TCP_DEFER_ACCEPT</constant></simpara>
-   </listitem>
   </itemizedlist>
  </sect2>
 

--- a/appendices/migration82/deprecated.xml
+++ b/appendices/migration82/deprecated.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration82.deprecated">
+ <title>Deprecated Features</title>
+
+ <sect2 xml:id="migration82.deprecated.core">
+  <title>PHP Core</title>
+
+  <sect3 xml:id="migration82.deprecated.core.dynamic-properties">
+   <title>Usage of dynamic properties</title>
+
+   <para>
+    The creation of dynamic properties is deprecated, unless the class opts in by
+    using the <code>#[AllowDynamicProperties]</code> attribute.
+    <classname>stdClass</classname> allows dynamic properties.
+    <!-- Todo Link to magic methods -->
+    Usage of the __get()/__set() magic methods is not affected by this change.
+    A dynamic properties deprecation warning can be addressed by:
+
+    <itemizedlist>
+     <listitem>
+      <simpara>Declaring the property (preferred).</simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       Adding the <code>#[AllowDynamicProperties]</code> attribute to the class
+       (which also applies to all child classes).
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       Using a <classname>WeakMap</classname> if additional data needs to be
+       associated with an object which one does not own.
+      </simpara>
+     </listitem>
+    </itemizedlist>
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration82.deprecated.core.relative-callables">
+   <title>Relative callables</title>
+
+   <para>
+    Callables that are not accepted by the <code>$callable()</code> syntax
+    (but are accepted by <function>call_user_func</function>) are deprecated.
+
+    In particular:
+    <itemizedlist>
+     <listitem><simpara><code>"self::method"</code></simpara></listitem>
+     <listitem><simpara><code>"parent::method"</code></simpara></listitem>
+     <listitem><simpara><code>"static::method"</code></simpara></listitem>
+     <listitem><simpara><code>["self", "method"]</code></simpara></listitem>
+     <listitem><simpara><code>["parent", "method"]</code></simpara></listitem>
+     <listitem><simpara><code>["static", "method"]</code></simpara></listitem>
+     <listitem><simpara><code>["Foo", "Bar::method"]</code></simpara></listitem>
+     <listitem><simpara><code>[new Foo, "Bar::method"]</code></simpara></listitem>
+    </itemizedlist>
+
+    This does not affect normal method callables such as
+    <code>"A::method"</code> or <code>["A", "method"]</code>.
+   </para>
+   <!-- RFC: https://wiki.php.net/rfc/deprecate_partially_supported_callables -->
+   <!-- RFC: https://wiki.php.net/rfc/partially-supported-callables-expand-deprecation-notices -->
+  </sect3>
+
+  <sect3 xml:id="migration82.deprecated.core.dollar-brace-interpolation">
+   <title><code>"${var}"</code> and <code>"${expr}"</code> style interpolation</title>
+
+   <para>
+    The <code>"${var}"</code> and <code>"${expr}"</code> style of string
+    interpolation  are deprecated and will be removed in PHP 9.
+    Use <code>"$var"/"{$var}"</code> or <code>"{${expr}}"</code>, respectively.
+    <!-- RFC: https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation -->
+   </para>
+  </sect3>
+
+ </sect2>
+
+ <sect2 xml:id="migration82.deprecated.mbstring">
+  <title>MBString</title>
+
+  <para>
+   Usage of the <literal>QPrint</literal>, <literal>Base64</literal>,
+   <literal>Uuencode</literal>, and <literal>HTML-ENTITIES</literal>
+   'text encodings' is deprecated for all Mbstring functions.
+
+   Unlike all the other text encodings supported by Mbstring,
+   these do not encode a sequence of Unicode codepoints, but rather a sequence of raw bytes.
+   It is not clear what the correct return values for most Mbstring functions
+   should be when one of these non-encodings is specified.
+   Moreover, PHP has separate, built-in implementations of all of them;
+   for example, UUencoded data can be handled using
+   <function>convert_uuencode</function>/<function>convert_uudecode</function>.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration82.deprecated.spl">
+  <title>SPL</title>
+
+  <para>
+   The internal <methodname>SplFileInfo::_bad_state_ex</methodname> method
+   has been deprecated.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration82.deprecated.standard">
+  <title>Standard</title>
+
+  <para>
+   <function>utf8_encode</function> and <function>utf8_decode</function>
+   have been deprecated.
+  </para>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration82/deprecated.xml
+++ b/appendices/migration82/deprecated.xml
@@ -12,8 +12,7 @@
     The creation of dynamic properties is deprecated, unless the class opts in by
     using the <code>#[AllowDynamicProperties]</code> attribute.
     <classname>stdClass</classname> allows dynamic properties.
-    <!-- Todo Link to magic methods -->
-    Usage of the __get()/__set() magic methods is not affected by this change.
+    Usage of the <link linkend="object.get">__get()</link>/<link linkend="object.set">__set()</link> magic methods is not affected by this change.
     A dynamic properties deprecation warning can be addressed by:
 
     <itemizedlist>

--- a/appendices/migration82/deprecated.xml
+++ b/appendices/migration82/deprecated.xml
@@ -44,16 +44,16 @@
     (but are accepted by <function>call_user_func</function>) are deprecated.
 
     In particular:
-    <itemizedlist>
-     <listitem><simpara><code>"self::method"</code></simpara></listitem>
-     <listitem><simpara><code>"parent::method"</code></simpara></listitem>
-     <listitem><simpara><code>"static::method"</code></simpara></listitem>
-     <listitem><simpara><code>["self", "method"]</code></simpara></listitem>
-     <listitem><simpara><code>["parent", "method"]</code></simpara></listitem>
-     <listitem><simpara><code>["static", "method"]</code></simpara></listitem>
-     <listitem><simpara><code>["Foo", "Bar::method"]</code></simpara></listitem>
-     <listitem><simpara><code>[new Foo, "Bar::method"]</code></simpara></listitem>
-    </itemizedlist>
+    <simplelist>
+     <member><code>"self::method"</code></member>
+     <member><code>"parent::method"</code></member>
+     <member><code>"static::method"</code></member>
+     <member><code>["self", "method"]</code></member>
+     <member><code>["parent", "method"]</code></member>
+     <member><code>["static", "method"]</code></member>
+     <member><code>["Foo", "Bar::method"]</code></member>
+     <member><code>[new Foo, "Bar::method"]</code></member>
+    </simplelist>
 
     This does not affect normal method callables such as
     <code>"A::method"</code> or <code>["A", "method"]</code>.

--- a/appendices/migration82/deprecated.xml
+++ b/appendices/migration82/deprecated.xml
@@ -15,23 +15,17 @@
     Usage of the <link linkend="object.get">__get()</link>/<link linkend="object.set">__set()</link> magic methods is not affected by this change.
     A dynamic properties deprecation warning can be addressed by:
 
-    <itemizedlist>
-     <listitem>
-      <simpara>Declaring the property (preferred).</simpara>
-     </listitem>
-     <listitem>
-      <simpara>
-       Adding the <code>#[AllowDynamicProperties]</code> attribute to the class
-       (which also applies to all child classes).
-      </simpara>
-     </listitem>
-     <listitem>
-      <simpara>
-       Using a <classname>WeakMap</classname> if additional data needs to be
-       associated with an object which one does not own.
-      </simpara>
-     </listitem>
-    </itemizedlist>
+    <simplelist>
+     <member>Declaring the property (preferred).</member>
+     <member>
+      Adding the <code>#[AllowDynamicProperties]</code> attribute to the class
+      (which also applies to all child classes).
+     </member>
+     <member>
+      Using a <classname>WeakMap</classname> if additional data needs to be
+      associated with an object which one does not own.
+     </member>
+    </simplelist>
    </para>
   </sect3>
 

--- a/appendices/migration82/deprecated.xml
+++ b/appendices/migration82/deprecated.xml
@@ -74,11 +74,11 @@
   <para>
    Usage of the <literal>QPrint</literal>, <literal>Base64</literal>,
    <literal>Uuencode</literal>, and <literal>HTML-ENTITIES</literal>
-   'text encodings' is deprecated for all Mbstring functions.
+   'text encodings' is deprecated for all MBString functions.
 
-   Unlike all the other text encodings supported by Mbstring,
+   Unlike all the other text encodings supported by MBString,
    these do not encode a sequence of Unicode codepoints, but rather a sequence of raw bytes.
-   It is not clear what the correct return values for most Mbstring functions
+   It is not clear what the correct return values for most MBString functions
    should be when one of these non-encodings is specified.
    Moreover, PHP has separate, built-in implementations of all of them;
    for example, UUencoded data can be handled using

--- a/appendices/migration82/deprecated.xml
+++ b/appendices/migration82/deprecated.xml
@@ -18,7 +18,7 @@
     <simplelist>
      <member>Declaring the property (preferred).</member>
      <member>
-      Adding the <code>#[AllowDynamicProperties]</code> attribute to the class
+      Adding the <code>#[\AllowDynamicProperties]</code> attribute to the class
       (which also applies to all child classes).
      </member>
      <member>

--- a/appendices/migration82/deprecated.xml
+++ b/appendices/migration82/deprecated.xml
@@ -10,7 +10,7 @@
 
    <para>
     The creation of dynamic properties is deprecated, unless the class opts in by
-    using the <code>#[AllowDynamicProperties]</code> attribute.
+    using the <code>#[\AllowDynamicProperties]</code> attribute.
     <classname>stdClass</classname> allows dynamic properties.
     Usage of the <link linkend="object.get">__get()</link>/<link linkend="object.set">__set()</link> magic methods is not affected by this change.
     A dynamic properties deprecation warning can be addressed by:

--- a/appendices/migration82/deprecated.xml
+++ b/appendices/migration82/deprecated.xml
@@ -66,8 +66,8 @@
 
    <para>
     The <code>"${var}"</code> and <code>"${expr}"</code> style of string
-    interpolation  are deprecated and will be removed in PHP 9.
-    Use <code>"$var"/"{$var}"</code> or <code>"{${expr}}"</code>, respectively.
+    interpolation is deprecated.
+    Use <code>"$var"/"{$var}"</code> and <code>"{${expr}}"</code>, respectively.
     <!-- RFC: https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation -->
    </para>
   </sect3>

--- a/appendices/migration82/incompatible.xml
+++ b/appendices/migration82/incompatible.xml
@@ -34,7 +34,7 @@
 
   <para>
    The PDO_ODBC extension also escapes the username and password when a
-   connection string is passed. See the change to the ODBC extension for
+   connection string is passed. See the <link linkend="migration82.incompatible.odbc">change to the ODBC extension</link> for
    further details.
   </para>
  </sect2>
@@ -61,7 +61,7 @@
    <function>ucwords</function>,
    and <function>str_ireplace</function> are no longer locale-sensitive.
    They now perform ASCII case conversion, as if the locale were "C".
-   Localized versions of these functions are available in the MBString extension.
+   Localized versions of these functions are available in the <link linkend="book.mbstring">MBString extension</link>.
    Moreover, <function>array_change_key_case</function>, and sorting with
    <constant>SORT_FLAG_CASE</constant> now also use ASCII case conversion.
   </para>

--- a/appendices/migration82/incompatible.xml
+++ b/appendices/migration82/incompatible.xml
@@ -7,12 +7,12 @@
 
   <para>
    <methodname>DateTime::createFromImmutable</methodname> now has a tentative
-   return of <type>static</type>, previously it was <type>DateTime</type>.
+   return type of <type>static</type>, previously it was <type>DateTime</type>.
   </para>
 
   <para>
    <methodname>DateTimeImmutable::createFromMutable</methodname> now has a tentative
-   return of <type>static</type>, previously it was <type>DateTimeImmutable</type>.
+   return type of <type>static</type>, previously it was <type>DateTimeImmutable</type>.
   </para>
  </sect2>
 
@@ -106,12 +106,12 @@
 
   <para>
    <methodname>SplFileObject::hasChildren</methodname> now has a tentative
-   return of <type>false</type>, previously it was <type>bool</type>.
+   return type of <type>false</type>, previously it was <type>bool</type>.
   </para>
 
   <para>
    <methodname>SplFileObject::getChildren</methodname> now has a tentative
-   return of <type>null</type>, previously it was
+   return type of <type>null</type>, previously it was
    <type class="union"><type>RecursiveIterator</type><type>null</type></type>.
   </para>
 

--- a/appendices/migration82/incompatible.xml
+++ b/appendices/migration82/incompatible.xml
@@ -43,9 +43,11 @@
   <title>Standard</title>
 
   <para>
-   <function>glob</function> returns an empty &array; if all paths are restricted by <link linkend="ini.open-basedir">open_basedir</link>.
-   Previously the error was returned but that behavior was not consistent and
-   did not work correctly for all patterns.
+   <function>glob</function> now returns an empty &array; if all paths are
+   restricted by <link linkend="ini.open-basedir">open_basedir</link>.
+   Previously it returned &false;.
+   Moreover, a warning is now emitted even if only some paths are restricted by
+   <link linkend="ini.open-basedir">open_basedir</link>.
   </para>
 
   <para>
@@ -104,9 +106,11 @@
   </para>
 
   <para>
-   <classname>GlobIterator</classname> returns an empty &array; if all paths are
-   restricted by <link linkend="ini.open-basedir">open_basedir</link>. Previously the error was returned but that
-   behavior was not consistent and did not work correctly.
+   <classname>GlobIterator</classname> now returns an empty &array; if all
+   paths are restricted by <link linkend="ini.open-basedir">open_basedir</link>.
+   Previously it returned &false;.
+   Moreover, a warning is now emitted even if only some paths are restricted by
+   <link linkend="ini.open-basedir">open_basedir</link>.
   </para>
  </sect2>
 

--- a/appendices/migration82/incompatible.xml
+++ b/appendices/migration82/incompatible.xml
@@ -59,13 +59,13 @@
    <function>ucwords</function>,
    and <function>str_ireplace</function> are no longer locale-sensitive.
    They now perform ASCII case conversion, as if the locale were "C".
-   For localized versions of these functions are available in the MBString extension.
+   Localized versions of these functions are available in the MBString extension.
    Moreover, <function>array_change_key_case</function>, and sorting with
    <constant>SORT_FLAG_CASE</constant> now also use ASCII case conversion.
   </para>
 
   <para>
-   <function>str_split</function> returns an empty array for an empty string now.
+   <function>str_split</function> returns an empty &array; for an empty &string; now.
    Previously it returned an array with a single empty string entry.
    <function>mb_str_split</function> is not affected by this change as it was
    already behaving like that.

--- a/appendices/migration82/incompatible.xml
+++ b/appendices/migration82/incompatible.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration82.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Backward Incompatible Changes</title>
+
+ <sect2 xml:id="migration82.incompatible.date">
+  <title>Date</title>
+
+  <para>
+   <methodname>DateTime::createFromImmutable</methodname> now has a tentative
+   return of <type>static</type>, previously it was <type>DateTime</type>.
+  </para>
+
+  <para>
+   <methodname>DateTimeImmutable::createFromMutable</methodname> now has a tentative
+   return of <type>static</type>, previously it was <type>DateTimeImmutable</type>.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration82.incompatible.odbc">
+  <title>ODBC</title>
+
+  <para>
+   The ODBC extension now escapes the username and password for the case when
+   both a connection string and username/password are passed, and the string
+   must be appended to. Before, user values containing values needing escaping
+   could have created a malformed connection string, or injected values from
+   user-provided data. The escaping rules should be identical to the .NET BCL
+   DbConnectionOptions behaviour.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration82.incompatible.pdo-odbc">
+  <title>PDO_ODBC</title>
+
+  <para>
+   The PDO_ODBC extension also escapes the username and password when a
+   connection string is passed. See the change to the ODBC extension for
+   further details.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration82.incompatible.standard">
+  <title>Standard</title>
+
+  <para>
+   <function>glob</function>  returns empty array if all paths are restricted by open_basedir.
+   Previously the error was returned but that behavior was not consistent and
+   did not work correctly for all patterns.
+  </para>
+
+  <para>
+   <function>strtolower</function>,
+   <function>strtoupper</function>,
+   <function>stristr</function>,
+   <function>stripos</function>,
+   <function>strripos</function>,
+   <function>lcfirst</function>,
+   <function>ucfirst</function>,
+   <function>ucwords</function>,
+   and <function>str_ireplace</function> are no longer locale-sensitive.
+   They now perform ASCII case conversion, as if the locale were "C".
+   For localized versions of these functions are available in the MBString extension.
+   Moreover, <function>array_change_key_case</function>, and sorting with
+   <constant>SORT_FLAG_CASE</constant> now also use ASCII case conversion.
+  </para>
+
+  <para>
+   <function>str_split</function> returns an empty array for an empty string now.
+   Previously it returned an array with a single empty string entry.
+   <function>mb_str_split</function> is not affected by this change as it was
+   already behaving like that.
+  </para>
+
+  <para>
+   <function>ksort</function> and <function>krsort</function> now do numeric string
+   comparison under <constant>SORT_REGULAR</constant> using the standard PHP 8 rules now.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration82.incompatible.spl">
+  <title>Standard PHP Library (SPL)</title>
+
+  <para>
+   The following methods now enforce their signature:
+   <itemizedlist>
+    <listitem>
+     <simpara><methodname>SplFileInfo::_bad_state_ex</methodname></simpara>
+    </listitem>
+    <listitem>
+     <simpara><methodname>SplFileObject::getCsvControl</methodname></simpara>
+    </listitem>
+    <listitem>
+     <simpara><methodname>SplFileObject::fflush</methodname></simpara>
+    </listitem>
+    <listitem>
+     <simpara><methodname>SplFileObject::ftell</methodname></simpara>
+    </listitem>
+    <listitem>
+     <simpara><methodname>SplFileObject::fgetc</methodname></simpara>
+    </listitem>
+    <listitem>
+     <simpara><methodname>SplFileObject::fpassthru</methodname></simpara>
+    </listitem>
+   </itemizedlist>
+  </para>
+
+  <para>
+   <methodname>SplFileObject::hasChildren</methodname> now has a tentative
+   return of <type>false</type>, previously it was <type>bool</type>.
+  </para>
+
+  <para>
+   <methodname>SplFileObject::getChildren</methodname> now has a tentative
+   return of <type>null</type>, previously it was
+   <type class="union"><type>RecursiveIterator</type><type>null</type></type>.
+  </para>
+
+  <para>
+   <classname>GlobIterator</classname> returns empty array if all paths are
+   restricted by open_basedir. Previously the error was returned but that
+   behavior was not consistent and did not work correctly.
+  </para>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration82/incompatible.xml
+++ b/appendices/migration82/incompatible.xml
@@ -43,7 +43,7 @@
   <title>Standard</title>
 
   <para>
-   <function>glob</function>  returns empty array if all paths are restricted by open_basedir.
+   <function>glob</function> returns an empty &array; if all paths are restricted by <link linkend="ini.open-basedir">open_basedir</link>.
    Previously the error was returned but that behavior was not consistent and
    did not work correctly for all patterns.
   </para>
@@ -116,8 +116,8 @@
   </para>
 
   <para>
-   <classname>GlobIterator</classname> returns empty array if all paths are
-   restricted by open_basedir. Previously the error was returned but that
+   <classname>GlobIterator</classname> returns an empty &array; if all paths are
+   restricted by <link linkend="ini.open-basedir">open_basedir</link>. Previously the error was returned but that
    behavior was not consistent and did not work correctly.
   </para>
  </sect2>

--- a/appendices/migration82/incompatible.xml
+++ b/appendices/migration82/incompatible.xml
@@ -82,26 +82,14 @@
 
   <para>
    The following methods now enforce their signature:
-   <itemizedlist>
-    <listitem>
-     <simpara><methodname>SplFileInfo::_bad_state_ex</methodname></simpara>
-    </listitem>
-    <listitem>
-     <simpara><methodname>SplFileObject::getCsvControl</methodname></simpara>
-    </listitem>
-    <listitem>
-     <simpara><methodname>SplFileObject::fflush</methodname></simpara>
-    </listitem>
-    <listitem>
-     <simpara><methodname>SplFileObject::ftell</methodname></simpara>
-    </listitem>
-    <listitem>
-     <simpara><methodname>SplFileObject::fgetc</methodname></simpara>
-    </listitem>
-    <listitem>
-     <simpara><methodname>SplFileObject::fpassthru</methodname></simpara>
-    </listitem>
-   </itemizedlist>
+   <simplelist>
+    <member><methodname>SplFileInfo::_bad_state_ex</methodname></member>
+    <member><methodname>SplFileObject::getCsvControl</methodname></member>
+    <member><methodname>SplFileObject::fflush</methodname></member>
+    <member><methodname>SplFileObject::ftell</methodname></member>
+    <member><methodname>SplFileObject::fgetc</methodname></member>
+    <member><methodname>SplFileObject::fpassthru</methodname></member>
+   </simplelist>
   </para>
 
   <para>

--- a/appendices/migration82/new-features.xml
+++ b/appendices/migration82/new-features.xml
@@ -88,7 +88,7 @@
   </para>
 
   <para>
-   Exposed multiple new constants from libcurl 7.62 to 7.80.
+   Exposed <link linkend="migration82.constants.curl">multiple new constants</link> from libcurl 7.62 to 7.80.
   </para>
 
   <para>

--- a/appendices/migration82/new-features.xml
+++ b/appendices/migration82/new-features.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration82.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>New Features</title>
+
+ <sect2 xml:id="migration82.new-features.core">
+  <title>PHP Core</title>
+
+  <sect3 xml:id="migration82.new-features.core.sensitive-parameter">
+   <title>SensitiveParameter attribute</title>
+
+   <para>
+    Added the <code>#[\SensitiveParameter]</code> attribute to redact
+    sensitive data in backtraces.
+    <!-- RFC: https://wiki.php.net/rfc/redact_parameters_in_back_traces -->
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration82.new-features.core.error-log-mode-ini">
+   <title>error_log_mode INI directive</title>
+
+   <para>
+    The error_log_mode INI directive has been added which allows setting
+    the permissions for the error log file.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration82.new-features.core.enums-property-constant-expression">
+   <title>Enumerations properties in constant expressions</title>
+
+   <para>
+    It is now possible to fetch properties of
+    <link linkend="language.enumerations">Enumerations</link>
+    in constant expressions.
+    <!-- RFC: https://wiki.php.net/rfc/fetch_property_in_const_expressions -->
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration82.new-features.core.type-system">
+   <title>Type System Improvements</title>
+
+   <para>
+    It is now possible to use <type>null</type> and <type>false</type>
+    as stand-alone types.
+    <!-- RFC: https://wiki.php.net/rfc/null-false-standalone-types -->
+   </para>
+
+   <para>
+    The <type>true</type> has been added.
+    <!-- RFC: https://wiki.php.net/rfc/true-type -->
+   </para>
+
+   <para>
+    It is now possible to combine intersection and union types.
+    The type needs to be written in Disjoint Normal Form (DNF).
+    <!-- TODO Add an example -->
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration82.new-features.core.constant-in-traits">
+   <title>Constants in Traits</title>
+
+   <para>
+    It is now possible to defines constants in traits.
+    <!-- TODO Add an example -->
+   </para>
+   <!-- RFC: https://wiki.php.net/rfc/constants_in_traits -->
+  </sect3>
+
+  <sect3 xml:id="migration82.new-features.core.readonly-classes">
+   <title>Readonly Classes</title>
+
+   <para>
+    Support for <link linkend="language.oop5.properties.readonly-properties">readonly</link>
+    on classes has been added.
+    <!-- RFC: https://wiki.php.net/rfc/readonly_classes -->
+   </para>
+  </sect3>
+
+ </sect2>
+
+ <sect2 xml:id="migration82.new-features.curl">
+  <title>CURL</title>
+
+  <para>
+   Added the <constant>CURLINFO_EFFECTIVE_METHOD</constant> option,
+   which returns the effective HTTP method in the return value of
+   <function>curl_getinfo</function>.
+  </para>
+
+  <para>
+   Exposed multiple new constants from libcurl 7.62 to 7.80.
+  </para>
+
+  <para>
+   Added the <function>curl_upkeep</function> function to perform any connection upkeep checks.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration82.new-features.dba">
+  <title>DBA</title>
+
+  <para>
+   The LMDB Driver now accepts the <constant>DBA_LMDB_USE_SUB_DIR</constant> or
+   <constant>DBA_LMDB_NO_SUB_DIR</constant> flags to determine if it should
+   create a subdirectory or not when creating a database file.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration82.new-features.oci8">
+  <title>OCI8</title>
+
+  <para>
+   Added the oci8.prefetch_lob_size INI directive and
+   <function>oci_set_prefetch_lob</function> function to tune LOB query
+   performance by reducing the number of round-trips between PHP and
+   Oracle Databases when fetching LOBS.
+   This is usable with Oracle Database 12.2 or later.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration82.new-features.openssl">
+  <title>OpenSSL</title>
+
+  <para>
+   Added AEAD support for the chacha20-poly1305 algorithm.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration82.new-features.odbc">
+  <title>ODBC</title>
+
+  <para>
+   Added the <function>odbc_connection_string_is_quoted</function>,
+   <function>odbc_connection_string_should_quote</function>, and
+   <function>odbc_connection_string_quote</function> functions.
+   These are primarily used behind the scenes in the ODBC and PDO_ODBC extensions,
+   but are exposed to userland for easier unit testing, and for user
+   applications and libraries to perform quoting themselves.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration82.new-features.pcre">
+  <title>PCRE</title>
+
+  <para>
+   Added support for the <literal>n</literal> (NO_AUTO_CAPTURE) modifier,
+   which makes simple <code>(xyz)</code> groups non-capturing.
+   Only named groups like <code>(?&lt;name&gt;xyz)</code> are capturing.
+   This only affects which groups are capturing, it is still possible to use
+   numbered subpattern references, and the matches array will still contain
+   numbered results.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration82.new-features.random">
+  <title>Random</title>
+
+  <para>
+   This is a new extension which organises and consolidates existing
+   implementations related to random number generators.
+   New and better RNGs are available with scope issues eliminated.
+   <!-- RFC: https://wiki.php.net/rfc/rng_extension -->
+   <!-- RFC: https://wiki.php.net/rfc/random_extension_improvement -->
+  </para>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration82/new-features.xml
+++ b/appendices/migration82/new-features.xml
@@ -79,7 +79,7 @@
  </sect2>
 
  <sect2 xml:id="migration82.new-features.curl">
-  <title>CURL</title>
+  <title>cURL</title>
 
   <para>
    Added the <constant>CURLINFO_EFFECTIVE_METHOD</constant> option,

--- a/appendices/migration82/new-features.xml
+++ b/appendices/migration82/new-features.xml
@@ -19,7 +19,7 @@
    <title>error_log_mode INI directive</title>
 
    <para>
-    The error_log_mode INI directive has been added which allows setting
+    The <link linkend="ini.error-log-mode">error_log_mode</link> INI directive has been added which allows setting
     the permissions for the error log file.
    </para>
   </sect3>
@@ -110,7 +110,7 @@
   <title>OCI8</title>
 
   <para>
-   Added the oci8.prefetch_lob_size INI directive and
+   Added the <link linkend"ini.oci8.prefetch-lob-size">oci8.prefetch_lob_size</link> INI directive and
    <function>oci_set_prefetch_lob</function> function to tune LOB query
    performance by reducing the number of round-trips between PHP and
    Oracle Databases when fetching LOBS.

--- a/appendices/migration82/new-features.xml
+++ b/appendices/migration82/new-features.xml
@@ -6,7 +6,7 @@
   <title>PHP Core</title>
 
   <sect3 xml:id="migration82.new-features.core.sensitive-parameter">
-   <title>SensitiveParameter attribute</title>
+   <title>SensitiveParameter Attribute</title>
 
    <para>
     Added the <code>#[\SensitiveParameter]</code> attribute to redact
@@ -60,7 +60,7 @@
    <title>Constants in Traits</title>
 
    <para>
-    It is now possible to defines constants in traits.
+    It is now possible to define constants in traits.
     <!-- TODO Add an example -->
    </para>
    <!-- RFC: https://wiki.php.net/rfc/constants_in_traits -->
@@ -83,7 +83,7 @@
 
   <para>
    Added the <constant>CURLINFO_EFFECTIVE_METHOD</constant> option,
-   which returns the effective HTTP method in the return value of
+   which returns the effective <acronym>HTTP</acronym> method in the return value of
    <function>curl_getinfo</function>.
   </para>
 

--- a/appendices/migration82/new-features.xml
+++ b/appendices/migration82/new-features.xml
@@ -45,7 +45,7 @@
    </para>
 
    <para>
-    The <type>true</type> has been added.
+    The <type>true</type> type has been added.
     <!-- RFC: https://wiki.php.net/rfc/true-type -->
    </para>
 

--- a/appendices/migration82/new-features.xml
+++ b/appendices/migration82/new-features.xml
@@ -51,7 +51,7 @@
 
    <para>
     It is now possible to combine intersection and union types.
-    The type needs to be written in Disjoint Normal Form (DNF).
+    The type needs to be written in <acronym>DNF</acronym>.
     <!-- TODO Add an example -->
    </para>
   </sect3>

--- a/appendices/migration82/new-features.xml
+++ b/appendices/migration82/new-features.xml
@@ -110,7 +110,7 @@
   <title>OCI8</title>
 
   <para>
-   Added the <link linkend"ini.oci8.prefetch-lob-size">oci8.prefetch_lob_size</link> INI directive and
+   Added the <link linkend="ini.oci8.prefetch-lob-size">oci8.prefetch_lob_size</link> INI directive and
    <function>oci_set_prefetch_lob</function> function to tune LOB query
    performance by reducing the number of round-trips between PHP and
    Oracle Databases when fetching LOBS.

--- a/appendices/migration82/new-functions.xml
+++ b/appendices/migration82/new-functions.xml
@@ -4,99 +4,59 @@
 
  <sect2 xml:id="migration82.new-functions.curl">
   <title>cURL</title>
-
-  <itemizedlist>
-   <listitem>
-    <simpara>
-     <function>curl_upkeep</function>
-    </simpara>
-   </listitem>
-  </itemizedlist>
+  <simplelist>
+    <member><function>curl_upkeep</function></member>
+  </simplelist>
  </sect2>
 
  <sect2 xml:id="migration82.new-functions.mysqli">
   <title>MySQLi</title>
-
-  <itemizedlist>
-   <listitem>
-    <simpara>
-     <function>mysqli_execute_query</function>
-    </simpara>
-   </listitem>
-  </itemizedlist>
+  <simplelist>
+    <member><function>mysqli_execute_query</function></member>
+  </simplelist>
  </sect2>
 
  <sect2 xml:id="migration82.new-functions.openssl">
   <title>OpenSSL</title>
-
-  <itemizedlist>
-   <listitem>
-    <simpara>
-     <function>openssl_cipher_key_length</function>
-    </simpara>
-   </listitem>
-  </itemizedlist>
+  <simplelist>
+    <member><function>openssl_cipher_key_length</function></member>
+  </simplelist>
  </sect2>
 
  <sect2 xml:id="migration82.new-functions.reflection">
   <title>Reflection</title>
-
-  <itemizedlist>
-   <listitem>
-    <simpara>
-     <methodname>ReflectionFunction::isAnonymous</methodname>
-    </simpara>
-   </listitem>
-   <listitem>
-    <simpara>
-     <methodname>ReflectionMethod::hasPrototype</methodname>
-    </simpara>
-   </listitem>
-  </itemizedlist>
+  <simplelist>
+    <member>
+     <methodname>ReflectionFunction::isAnonymous</methodname></member>
+    <member>
+     <methodname>ReflectionMethod::hasPrototype</methodname></member>
+  </simplelist>
  </sect2>
 
  <sect2 xml:id="migration82.new-functions.sodium">
   <title>Sodium</title>
 
   <sect3>
-   <title>XChaCha20</title>
-   <itemizedlist>
-    <listitem>
-     <simpara>
-      <function>sodium_crypto_stream_xchacha20_xor_ic</function>
-     </simpara>
-    </listitem>
-   </itemizedlist>
+   <title>XChaCha20</title><simplelist>
+     <member>
+      <function>sodium_crypto_stream_xchacha20_xor_ic</function></member>
+   </simplelist>
   </sect3>
  </sect2>
 
  <sect2 xml:id="migration82.new-functions.standard">
   <title>Standard</title>
-
-  <itemizedlist>
-   <listitem>
-    <simpara>
-     <function>memory_reset_peak_usage</function>
-    </simpara>
-   </listitem>
-   <listitem>
-    <simpara>
-     <function>ini_parse_quantity</function>
-    </simpara>
-   </listitem>
-  </itemizedlist>
+  <simplelist>
+    <member><function>memory_reset_peak_usage</function></member>
+    <member><function>ini_parse_quantity</function></member>
+  </simplelist>
  </sect2>
 
  <sect2 xml:id="migration82.new-functions.xml">
   <title>XML</title>
-
-  <itemizedlist>
-   <listitem>
-    <simpara>
-     <function>libxml_get_external_entity_loader</function>
-    </simpara>
-   </listitem>
-  </itemizedlist>
+  <simplelist>
+    <member><function>libxml_get_external_entity_loader</function></member>
+  </simplelist>
  </sect2>
 
 </sect1>

--- a/appendices/migration82/new-functions.xml
+++ b/appendices/migration82/new-functions.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration82.new-functions">
+ <title>New Functions</title>
+
+ <sect2 xml:id="migration82.new-functions.curl">
+  <title>cURL</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <function>curl_upkeep</function>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration82.new-functions.mysqli">
+  <title>MySQLi</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <function>mysqli_execute_query</function>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration82.new-functions.openssl">
+  <title>OpenSSL</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <function>openssl_cipher_key_length</function>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration82.new-functions.reflection">
+  <title>Reflection</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <methodname>ReflectionFunction::isAnonymous</methodname>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <methodname>ReflectionMethod::hasPrototype</methodname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration82.new-functions.sodium">
+  <title>Sodium</title>
+
+  <sect3>
+   <title>XChaCha20</title>
+   <itemizedlist>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_stream_xchacha20_xor_ic</function>
+     </simpara>
+    </listitem>
+   </itemizedlist>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration82.new-functions.standard">
+  <title>Standard</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <function>memory_reset_peak_usage</function>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <function>ini_parse_quantity</function>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration82.new-functions.xml">
+  <title>XML</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <function>libxml_get_external_entity_loader</function>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -39,12 +39,9 @@
    <title>Core</title>
 
    <para>
-    The str*cmp,
-    <function>strcmp</function>,
-    <function>strcasecmp</function>,
-    <function>strncmp</function>,
-    <function>strncasecmp</function>,
-    str*pos, <function>substr_compare</function> functions, using binary safe string
+    The <function>strcmp</function>, <function>strcasecmp</function>,
+    <function>strncmp</function>, <function>strncasecmp</function>, and
+    <function>substr_compare</function> functions, using binary safe string
     comparison now return -1, 0 and 1.
    </para>
   </sect3>

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -241,17 +241,17 @@
    For backwards compatibility, interpretation of these values has not changed.
    This affects the following settings:
 
-   <!-- Todo Link INI Settings -->
+   <!-- TODO: Add missing INI links after directives have been documented -->
    <simplelist>
     <member><link linkend="ini.bcmath.scale">bcmath.scale</link></member>
     <member><link linkend="ini.com.code-page">com.code_page</link></member>
-    <member>default_socket_timeout</member>
+    <member><link linkend="ini.default-socket-timeout">default_socket_timeout</link></member>
     <member>fiber.stack_size</member>
-    <member>hard_timeout</member>
+    <member><link linkend="ini.hard-timeout">hard_timeout</link></member>
     <member><link linkend="ini.intl.error-level">intl.error_level</link></member>
     <member><link linkend="ini.ldap.max_links">ldap.max_links</link></member>
-    <member>max_input_nesting_level</member>
-    <member>max_input_vars</member>
+    <member><link linkend="ini.max-input-nesting-level">max_input_nesting_level</link></member>
+    <member><link linkend="ini.max-input-vars">max_input_vars</link></member>
     <member>mbstring.regex_retry_limit</member>
     <member>mbstring.regex_stack_limit</member>
     <member><link linkend="ini.mysqli.allow-local-infile">mysqli.allow_local_infile</link></member>
@@ -271,13 +271,13 @@
     <member><link linkend="ini.oci8.prefetch-lob-size">oci8.prefetch_lob_size</link></member>
     <member><link linkend="ini.oci8.privileged-connect">oci8.privileged_connect</link></member>
     <member><link linkend="ini.oci8.statement-cache-size">oci8.statement_cache_size</link></member>
-    <member>odbc.allow_persistent</member>
-    <member>odbc.check_persistent</member>
-    <member>odbc.defaultbinmode</member>
-    <member>odbc.default_cursortype</member>
-    <member>odbc.defaultlrl</member>
-    <member>odbc.max_links</member>
-    <member>odbc.max_persistent</member>
+    <member><link linkend="ini.uodbc.allow-persistent">odbc.allow_persistent</link></member>
+    <member><link linkend="ini.uodbc.check-persistent">odbc.check_persistent</link></member>
+    <member><link linkend="ini.uodbc.max-persistent">odbc.max_persistent</link></member>
+    <member><link linkend="ini.uodbc.max-links">odbc.max_links</link></member>
+    <member><link linkend="ini.uodbc.defaultbinmode">odbc.defaultbinmode</link></member>
+    <member><link linkend="ini.uodbc.defaultcursortype">odbc.default_cursortype</link></member>
+    <member><link linkend="ini.uodbc.defaultlrl">odbc.defaultlrl</link></member>
     <member><link linkend="ini.opcache.consistency-checks">opcache.consistency_checks</link></member>
     <member><link linkend="ini.opcache.file_update_protection">opcache.file_update_protection</link></member>
     <member><link linkend="ini.opcache.force-restart-timeout">opcache.force_restart_timeout</link></member>
@@ -302,14 +302,14 @@
     <member><link linkend="ini.opcache.opt_debug_level">opcache.opt_debug_level</link></member>
     <member><link linkend="ini.opcache.optimization-level">opcache.optimization_level</link></member>
     <member><link linkend="ini.opcache.revalidate-freq">opcache.revalidate_freq</link></member>
-    <member>output_buffering</member>
+    <member><link linkend="ini.output-buffering">output_buffering</link></member>
     <member><link linkend="ini.pcre.backtrack-limit">pcre.backtrack_limit</link></member>
     <member><link linkend="ini.pcre.recursion-limit">pcre.recursion_limit</link></member>
     <member><link linkend="ini.pgsql.max-links">pgsql.max_links</link></member>
     <member><link linkend="ini.pgsql.max-persistent">pgsql.max_persistent</link></member>
-    <member>post_max_size</member>
-    <member>realpath_cache_size</member>
-    <member>realpath_cache_ttl</member>
+    <member><link linkend="ini.post-max-size">post_max_size</link></member>
+    <member><link linkend="ini.realpath-cache-size">realpath_cache_size</link></member>
+    <member><link linkend="ini.realpath-cache-ttl">realpath_cache_ttl</link></member>
     <member><link linkend="ini.session.cache-expire">session.cache_expire</link></member>
     <member><link linkend="ini.session.cookie-lifetime">session.cookie_lifetime</link></member>
     <member><link linkend="ini.session.gc-divisor">session.gc_divisor</link></member>
@@ -318,10 +318,10 @@
     <member><link linkend="ini.soap.wsdl-cache-limit">soap.wsdl_cache_limit</link></member>
     <member><link linkend="ini.soap.wsdl-cache-ttl">soap.wsdl_cache_ttl</link></member>
     <member>unserialize_max_depth</member>
-    <member>upload_max_filesize</member>
-    <member>user_ini.cache_ttl</member>
-    <member>xmlrpc_error_number</member>
-    <member>zend.assertions</member>
+    <member><link linkend="ini.upload-max-filesize">upload_max_filesize</link></member>
+    <member><link linkend="ini.user-ini.cache-ttl">user_ini.cache_ttl</link></member>
+    <member><link linkend="ini.xmlrpc-error-number">xmlrpc_error_number</link></member>
+    <member><link linkend="ini.zend.assertions">zend.assertions</link></member>
     <member><link linkend="ini.zlib.output-compression-level">zlib.output_compression_level</link></member>
    </simplelist>
   </para>

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -242,248 +242,88 @@
    This affects the following settings:
 
    <!-- Todo Link INI Settings -->
-   <itemizedlist>
-    <listitem>
-     <simpara><link linkend="ini.bcmath.scale">bcmath.scale</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.com.code-page">com.code_page</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara>default_socket_timeout</simpara>
-    </listitem>
-    <listitem>
-     <simpara>fiber.stack_size</simpara>
-    </listitem>
-    <listitem>
-     <simpara>hard_timeout</simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.intl.error-level">intl.error_level</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.ldap.max_links">ldap.max_links</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara>max_input_nesting_level</simpara>
-    </listitem>
-    <listitem>
-     <simpara>max_input_vars</simpara>
-    </listitem>
-    <listitem>
-     <simpara>mbstring.regex_retry_limit</simpara>
-    </listitem>
-    <listitem>
-     <simpara>mbstring.regex_stack_limit</simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.mysqli.allow-local-infile">mysqli.allow_local_infile</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.mysqli.allow-persistent">mysqli.allow_persistent</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.mysqli.default-port">mysqli.default_port</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.mysqli.max-links">mysqli.max_links</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.mysqli.max-persistent">mysqli.max_persistent</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.mysqli.rollback-on-cached-plink">mysqli.rollback_on_cached_plink</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.mysqlnd.log-mask">mysqlnd.log_mask</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.mysqlnd.mempool-default-size">mysqlnd.mempool_default_size</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.mysqlnd.net-read-buffer-size">mysqlnd.net_read_buffer_size</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.mysqlnd.net-read-timeout">mysqlnd.net_read_timeout</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.oci8.default-prefetch">oci8.default_prefetch</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.oci8.max-persistent">oci8.max_persistent</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.oci8.persistent-timeout">oci8.persistent_timeout</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.oci8.ping-interval">oci8.ping_interval</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.oci8.prefetch-lob-size">oci8.prefetch_lob_size</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.oci8.privileged-connect">oci8.privileged_connect</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.oci8.statement-cache-size">oci8.statement_cache_size</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara>odbc.allow_persistent</simpara>
-    </listitem>
-    <listitem>
-     <simpara>odbc.check_persistent</simpara>
-    </listitem>
-    <listitem>
-     <simpara>odbc.defaultbinmode</simpara>
-    </listitem>
-    <listitem>
-     <simpara>odbc.default_cursortype</simpara>
-    </listitem>
-    <listitem>
-     <simpara>odbc.defaultlrl</simpara>
-    </listitem>
-    <listitem>
-     <simpara>odbc.max_links</simpara>
-    </listitem>
-    <listitem>
-     <simpara>odbc.max_persistent</simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.consistency-checks">opcache.consistency_checks</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.file_update_protection">opcache.file_update_protection</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.force-restart-timeout">opcache.force_restart_timeout</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.interned-strings-buffer">opcache.interned_strings_buffer</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.jit-bisect-limit">opcache.jit_bisect_limit</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.jit-blacklist-root-trace">opcache.jit_blacklist_root_trace</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.jit-blacklist-side-trace">opcache.jit_blacklist_side_trace</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.jit-debug">opcache.jit_debug</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.jit-hot-func">opcache.jit_hot_func</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.jit-hot-loop">opcache.jit_hot_loop</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.jit-hot-return">opcache.jit_hot_return</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.jit-hot-side-exit">opcache.jit_hot_side_exit</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.jit-max-exit-counters">opcache.jit_max_exit_counters</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.jit-max-loop-unrolls">opcache.jit_max_loop_unrolls</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.jit-max-polymorphic-calls">opcache.jit_max_polymorphic_calls</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.jit-max-recursive-calls">opcache.jit_max_recursive_calls</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.jit-max-recursive-return">opcache.jit_max_recursive_returns</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.jit-max-root-traces">opcache.jit_max_root_traces</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.jit-max-side-traces">opcache.jit_max_side_traces</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.log-verbosity-level">opcache.log_verbosity_level</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.max-file-size">opcache.max_file_size</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.opt_debug_level">opcache.opt_debug_level</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.optimization-level">opcache.optimization_level</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.opcache.revalidate-freq">opcache.revalidate_freq</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara>output_buffering</simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.pcre.backtrack-limit">pcre.backtrack_limit</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.pcre.recursion-limit">pcre.recursion_limit</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.pgsql.max-links">pgsql.max_links</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.pgsql.max-persistent">pgsql.max_persistent</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara>post_max_size</simpara>
-    </listitem>
-    <listitem>
-     <simpara>realpath_cache_size</simpara>
-    </listitem>
-    <listitem>
-     <simpara>realpath_cache_ttl</simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.session.cache-expire">session.cache_expire</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.session.cookie-lifetime">session.cookie_lifetime</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.session.gc-divisor">session.gc_divisor</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.session.gc-maxlifetime">session.gc_maxlifetime</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.session.gc-probability">session.gc_probability</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.soap.wsdl-cache-limit">soap.wsdl_cache_limit</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.soap.wsdl-cache-ttl">soap.wsdl_cache_ttl</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara>unserialize_max_depth</simpara>
-    </listitem>
-    <listitem>
-     <simpara>upload_max_filesize</simpara>
-    </listitem>
-    <listitem>
-     <simpara>user_ini.cache_ttl</simpara>
-    </listitem>
-    <listitem>
-     <simpara>xmlrpc_error_number</simpara>
-    </listitem>
-    <listitem>
-     <simpara>zend.assertions</simpara>
-    </listitem>
-    <listitem>
-     <simpara><link linkend="ini.zlib.output-compression-level">zlib.output_compression_level</link></simpara>
-    </listitem>
-   </itemizedlist>
+   <simplelist>
+    <member><link linkend="ini.bcmath.scale">bcmath.scale</link></member>
+    <member><link linkend="ini.com.code-page">com.code_page</link></member>
+    <member>default_socket_timeout</member>
+    <member>fiber.stack_size</member>
+    <member>hard_timeout</member>
+    <member><link linkend="ini.intl.error-level">intl.error_level</link></member>
+    <member><link linkend="ini.ldap.max_links">ldap.max_links</link></member>
+    <member>max_input_nesting_level</member>
+    <member>max_input_vars</member>
+    <member>mbstring.regex_retry_limit</member>
+    <member>mbstring.regex_stack_limit</member>
+    <member><link linkend="ini.mysqli.allow-local-infile">mysqli.allow_local_infile</link></member>
+    <member><link linkend="ini.mysqli.allow-persistent">mysqli.allow_persistent</link></member>
+    <member><link linkend="ini.mysqli.default-port">mysqli.default_port</link></member>
+    <member><link linkend="ini.mysqli.max-links">mysqli.max_links</link></member>
+    <member><link linkend="ini.mysqli.max-persistent">mysqli.max_persistent</link></member>
+    <member><link linkend="ini.mysqli.rollback-on-cached-plink">mysqli.rollback_on_cached_plink</link></member>
+    <member><link linkend="ini.mysqlnd.log-mask">mysqlnd.log_mask</link></member>
+    <member><link linkend="ini.mysqlnd.mempool-default-size">mysqlnd.mempool_default_size</link></member>
+    <member><link linkend="ini.mysqlnd.net-read-buffer-size">mysqlnd.net_read_buffer_size</link></member>
+    <member><link linkend="ini.mysqlnd.net-read-timeout">mysqlnd.net_read_timeout</link></member>
+    <member><link linkend="ini.oci8.default-prefetch">oci8.default_prefetch</link></member>
+    <member><link linkend="ini.oci8.max-persistent">oci8.max_persistent</link></member>
+    <member><link linkend="ini.oci8.persistent-timeout">oci8.persistent_timeout</link></member>
+    <member><link linkend="ini.oci8.ping-interval">oci8.ping_interval</link></member>
+    <member><link linkend="ini.oci8.prefetch-lob-size">oci8.prefetch_lob_size</link></member>
+    <member><link linkend="ini.oci8.privileged-connect">oci8.privileged_connect</link></member>
+    <member><link linkend="ini.oci8.statement-cache-size">oci8.statement_cache_size</link></member>
+    <member>odbc.allow_persistent</member>
+    <member>odbc.check_persistent</member>
+    <member>odbc.defaultbinmode</member>
+    <member>odbc.default_cursortype</member>
+    <member>odbc.defaultlrl</member>
+    <member>odbc.max_links</member>
+    <member>odbc.max_persistent</member>
+    <member><link linkend="ini.opcache.consistency-checks">opcache.consistency_checks</link></member>
+    <member><link linkend="ini.opcache.file_update_protection">opcache.file_update_protection</link></member>
+    <member><link linkend="ini.opcache.force-restart-timeout">opcache.force_restart_timeout</link></member>
+    <member><link linkend="ini.opcache.interned-strings-buffer">opcache.interned_strings_buffer</link></member>
+    <member><link linkend="ini.opcache.jit-bisect-limit">opcache.jit_bisect_limit</link></member>
+    <member><link linkend="ini.opcache.jit-blacklist-root-trace">opcache.jit_blacklist_root_trace</link></member>
+    <member><link linkend="ini.opcache.jit-blacklist-side-trace">opcache.jit_blacklist_side_trace</link></member>
+    <member><link linkend="ini.opcache.jit-debug">opcache.jit_debug</link></member>
+    <member><link linkend="ini.opcache.jit-hot-func">opcache.jit_hot_func</link></member>
+    <member><link linkend="ini.opcache.jit-hot-loop">opcache.jit_hot_loop</link></member>
+    <member><link linkend="ini.opcache.jit-hot-return">opcache.jit_hot_return</link></member>
+    <member><link linkend="ini.opcache.jit-hot-side-exit">opcache.jit_hot_side_exit</link></member>
+    <member><link linkend="ini.opcache.jit-max-exit-counters">opcache.jit_max_exit_counters</link></member>
+    <member><link linkend="ini.opcache.jit-max-loop-unrolls">opcache.jit_max_loop_unrolls</link></member>
+    <member><link linkend="ini.opcache.jit-max-polymorphic-calls">opcache.jit_max_polymorphic_calls</link></member>
+    <member><link linkend="ini.opcache.jit-max-recursive-calls">opcache.jit_max_recursive_calls</link></member>
+    <member><link linkend="ini.opcache.jit-max-recursive-return">opcache.jit_max_recursive_returns</link></member>
+    <member><link linkend="ini.opcache.jit-max-root-traces">opcache.jit_max_root_traces</link></member>
+    <member><link linkend="ini.opcache.jit-max-side-traces">opcache.jit_max_side_traces</link></member>
+    <member><link linkend="ini.opcache.log-verbosity-level">opcache.log_verbosity_level</link></member>
+    <member><link linkend="ini.opcache.max-file-size">opcache.max_file_size</link></member>
+    <member><link linkend="ini.opcache.opt_debug_level">opcache.opt_debug_level</link></member>
+    <member><link linkend="ini.opcache.optimization-level">opcache.optimization_level</link></member>
+    <member><link linkend="ini.opcache.revalidate-freq">opcache.revalidate_freq</link></member>
+    <member>output_buffering</member>
+    <member><link linkend="ini.pcre.backtrack-limit">pcre.backtrack_limit</link></member>
+    <member><link linkend="ini.pcre.recursion-limit">pcre.recursion_limit</link></member>
+    <member><link linkend="ini.pgsql.max-links">pgsql.max_links</link></member>
+    <member><link linkend="ini.pgsql.max-persistent">pgsql.max_persistent</link></member>
+    <member>post_max_size</member>
+    <member>realpath_cache_size</member>
+    <member>realpath_cache_ttl</member>
+    <member><link linkend="ini.session.cache-expire">session.cache_expire</link></member>
+    <member><link linkend="ini.session.cookie-lifetime">session.cookie_lifetime</link></member>
+    <member><link linkend="ini.session.gc-divisor">session.gc_divisor</link></member>
+    <member><link linkend="ini.session.gc-maxlifetime">session.gc_maxlifetime</link></member>
+    <member><link linkend="ini.session.gc-probability">session.gc_probability</link></member>
+    <member><link linkend="ini.soap.wsdl-cache-limit">soap.wsdl_cache_limit</link></member>
+    <member><link linkend="ini.soap.wsdl-cache-ttl">soap.wsdl_cache_ttl</link></member>
+    <member>unserialize_max_depth</member>
+    <member>upload_max_filesize</member>
+    <member>user_ini.cache_ttl</member>
+    <member>xmlrpc_error_number</member>
+    <member>zend.assertions</member>
+    <member><link linkend="ini.zlib.output-compression-level">zlib.output_compression_level</link></member>
+   </simplelist>
   </para>
  </sect2>
 

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -195,9 +195,10 @@
    <title>Session</title>
 
    <para>
-    <!-- Todo Link INI setting -->
-    Trying to change the SameSite cookie INI setting while the session is
-    active or output has already been sent will now fail and emit a warning.
+    Trying to change the
+    <link linkend="ini.session.cookie-samesite">session.cookie_samesite</link>
+    INI directive while the session is active or output has already been sent
+    will now fail and emit a warning.
     This aligns the behaviour with all other session INI settings.
    </para>
   </sect3>

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -162,8 +162,9 @@
     </listitem>
     <listitem>
      <simpara>
-      <!-- TODO Link -->
-      The INI directive mysqli.reconnect has been removed.
+      The INI directive
+      <link linkend="ini.mysqli.reconnect">mysqli.reconnect</link>
+      has been removed.
      </simpara>
     </listitem>
     <listitem>

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -207,8 +207,8 @@
    <title>SQLite3</title>
 
    <para>
-    <!-- Todo Link INI Setting -->
-    sqlite3.defensive is now <constant>PHP_INI_USER</constant>.
+    <link linkend="ini.sqlite3.defensive">sqlite3.defensive</link>
+    is now <constant>PHP_INI_USER</constant>.
    </para>
   </sect3>
 

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -86,7 +86,7 @@
    <para>
     <function>random_bytes</function> and <function>random_int</function>
     now throw a <classname>\Random\RandomException</classname> on CSPRNG failures.
-    Previously a plain <classname>Exception</classname> was thrown instead.
+    Previously a plain <classname>\Exception</classname> was thrown instead.
    </para>
   </sect3>
 

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -147,29 +147,18 @@
    <title>MySQLi</title>
 
    <para>
-    The support for libmysql has been removed. It's no longer possible to compile
-    mysqli with libmysql and all relevant functionality has been removed.
+    The support for libmysql has been removed. It is therefore no longer
+    possible to compile mysqli with libmysql.
+    The mysqli extension can therefore only be compiled with mysqlnd.
+    All relevant libmysqli functionality not available with mysqlnd has thus been removed:
+    <simplelist>
+     <member>The reconnect property of <classname>mysqli_driver</classname></member>
+     <member>
+      The <link linkend="ini.mysqli.reconnect">mysqli.reconnect</link> INI directive
+     </member>
+     <member>The <constant>MYSQLI_IS_MARIADB</constant> constant has been deprecated</member>
+    </simplelist>
    </para>
-
-   <itemizedlist>
-    <listitem>
-     <simpara>
-      The reconnect property of <classname>mysqli_driver</classname> has been removed.
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      The INI directive
-      <link linkend="ini.mysqli.reconnect">mysqli.reconnect</link>
-      has been removed.
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      The constant <constant>MYSQLI_IS_MARIADB</constant> has been deprecated.
-     </simpara>
-    </listitem>
-   </itemizedlist>
   </sect3>
 
   <sect3 xml:id="migration82.other-changes.extensions.oci8">

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -39,7 +39,12 @@
    <title>Core</title>
 
    <para>
-    The str*cmp, str*pos, <function>substr_compare</function> functions, using binary safe string
+    The str*cmp,
+    <function>strcmp</function>,
+    <function>strcasecmp</function>,
+    <function>strncmp</function>,
+    <function>strncasecmp</function>,
+    str*pos, <function>substr_compare</function> functions, using binary safe string
     comparison now return -1, 0 and 1.
    </para>
   </sect3>

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -25,7 +25,7 @@
    <title>CLI</title>
 
    <para>
-    The STDOUT, STDERR and STDIN are no longer closed on resource destruction
+    The STDOUT, STDERR and STDIN streams are no longer closed on resource destruction
     which is mostly when the CLI finishes. It is however still possible to
     explicitly close those streams using <function>fclose</function> and similar.
    </para>
@@ -42,7 +42,7 @@
     The <function>strcmp</function>, <function>strcasecmp</function>,
     <function>strncmp</function>, <function>strncasecmp</function>, and
     <function>substr_compare</function> functions, using binary safe string
-    comparison now return -1, 0 and 1.
+    comparison now return <literal>-1</literal>, <literal>0</literal> and <literal>1</literal>.
    </para>
   </sect3>
 

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -275,10 +275,10 @@
    <!-- Todo Link INI Settings -->
    <itemizedlist>
     <listitem>
-     <simpara>bcmath.scale</simpara>
+     <simpara><link linkend="ini.bcmath.scale">bcmath.scale</link></simpara>
     </listitem>
     <listitem>
-     <simpara>com.code_page</simpara>
+     <simpara><link linkend="ini.com.code-page">com.code_page</link></simpara>
     </listitem>
     <listitem>
      <simpara>default_socket_timeout</simpara>
@@ -290,10 +290,10 @@
      <simpara>hard_timeout</simpara>
     </listitem>
     <listitem>
-     <simpara>intl.error_level</simpara>
+     <simpara><link linkend="ini.intl.error-level">intl.error_level</link></simpara>
     </listitem>
     <listitem>
-     <simpara>ldap.max_links</simpara>
+     <simpara><link linkend="ini.ldap.max_links">ldap.max_links</link></simpara>
     </listitem>
     <listitem>
      <simpara>max_input_nesting_level</simpara>
@@ -308,58 +308,55 @@
      <simpara>mbstring.regex_stack_limit</simpara>
     </listitem>
     <listitem>
-     <simpara>mysqli.allow_local_infile</simpara>
+     <simpara><link linkend="ini.mysqli.allow-local-infile">mysqli.allow_local_infile</link></simpara>
     </listitem>
     <listitem>
-     <simpara>mysqli.allow_persistent</simpara>
+     <simpara><link linkend="ini.mysqli.allow-persistent">mysqli.allow_persistent</link></simpara>
     </listitem>
     <listitem>
-     <simpara>mysqli.default_port</simpara>
+     <simpara><link linkend="ini.mysqli.default-port">mysqli.default_port</link></simpara>
     </listitem>
     <listitem>
-     <simpara>mysqli.max_links</simpara>
+     <simpara><link linkend="ini.mysqli.max-links">mysqli.max_links</link></simpara>
     </listitem>
     <listitem>
-     <simpara>mysqli.max_persistent</simpara>
+     <simpara><link linkend="ini.mysqli.max-persistent">mysqli.max_persistent</link></simpara>
     </listitem>
     <listitem>
-     <simpara>mysqli.reconnect</simpara>
+     <simpara><link linkend="ini.mysqli.rollback-on-cached-plink">mysqli.rollback_on_cached_plink</link></simpara>
     </listitem>
     <listitem>
-     <simpara>mysqli.rollback_on_cached_plink</simpara>
+     <simpara><link linkend="ini.mysqlnd.log-mask">mysqlnd.log_mask</link></simpara>
     </listitem>
     <listitem>
-     <simpara>mysqlnd.log_mask</simpara>
+     <simpara><link linkend="ini.mysqlnd.mempool-default-size">mysqlnd.mempool_default_size</link></simpara>
     </listitem>
     <listitem>
-     <simpara>mysqlnd.mempool_default_size</simpara>
+     <simpara><link linkend="ini.mysqlnd.net-read-buffer-size">mysqlnd.net_read_buffer_size</link></simpara>
     </listitem>
     <listitem>
-     <simpara>mysqlnd.net_read_buffer_size</simpara>
+     <simpara><link linkend="ini.mysqlnd.net-read-timeout">mysqlnd.net_read_timeout</link></simpara>
     </listitem>
     <listitem>
-     <simpara>mysqlnd.net_read_timeout</simpara>
+     <simpara><link linkend="ini.oci8.default-prefetch">oci8.default_prefetch</link></simpara>
     </listitem>
     <listitem>
-     <simpara>oci8.default_prefetch</simpara>
+     <simpara><link linkend="ini.oci8.max-persistent">oci8.max_persistent</link></simpara>
     </listitem>
     <listitem>
-     <simpara>oci8.max_persistent</simpara>
+     <simpara><link linkend="ini.oci8.persistent-timeout">oci8.persistent_timeout</link></simpara>
     </listitem>
     <listitem>
-     <simpara>oci8.persistent_timeout</simpara>
+     <simpara><link linkend="ini.oci8.ping-interval">oci8.ping_interval</link></simpara>
     </listitem>
     <listitem>
-     <simpara>oci8.ping_interval</simpara>
+     <simpara><link linkend="ini.oci8.prefetch-lob-size">oci8.prefetch_lob_size</link></simpara>
     </listitem>
     <listitem>
-     <simpara>oci8.prefetch_lob_size</simpara>
+     <simpara><link linkend="ini.oci8.privileged-connect">oci8.privileged_connect</link></simpara>
     </listitem>
     <listitem>
-     <simpara>oci8.privileged_connect</simpara>
-    </listitem>
-    <listitem>
-     <simpara>oci8.statement_cache_size</simpara>
+     <simpara><link linkend="ini.oci8.statement-cache-size">oci8.statement_cache_size</link></simpara>
     </listitem>
     <listitem>
      <simpara>odbc.allow_persistent</simpara>
@@ -383,91 +380,91 @@
      <simpara>odbc.max_persistent</simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.consistency_checks</simpara>
+     <simpara><link linkend="ini.opcache.consistency-checks">opcache.consistency_checks</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.file_update_protection</simpara>
+     <simpara><link linkend="ini.opcache.file_update_protection">opcache.file_update_protection</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.force_restart_timeout</simpara>
+     <simpara><link linkend="ini.opcache.force-restart-timeout">opcache.force_restart_timeout</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.interned_strings_buffer</simpara>
+     <simpara><link linkend="ini.opcache.interned-strings-buffer">opcache.interned_strings_buffer</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.jit_bisect_limit</simpara>
+     <simpara><link linkend="ini.opcache.jit-bisect-limit">opcache.jit_bisect_limit</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.jit_blacklist_root_trace</simpara>
+     <simpara><link linkend="ini.opcache.jit-blacklist-root-trace">opcache.jit_blacklist_root_trace</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.jit_blacklist_side_trace</simpara>
+     <simpara><link linkend="ini.opcache.jit-blacklist-side-trace">opcache.jit_blacklist_side_trace</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.jit_debug</simpara>
+     <simpara><link linkend="ini.opcache.jit-debug">opcache.jit_debug</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.jit_hot_func</simpara>
+     <simpara><link linkend="ini.opcache.jit-hot-func">opcache.jit_hot_func</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.jit_hot_loop</simpara>
+     <simpara><link linkend="ini.opcache.jit-hot-loop">opcache.jit_hot_loop</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.jit_hot_return</simpara>
+     <simpara><link linkend="ini.opcache.jit-hot-return">opcache.jit_hot_return</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.jit_hot_side_exit</simpara>
+     <simpara><link linkend="ini.opcache.jit-hot-side-exit">opcache.jit_hot_side_exit</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.jit_max_exit_counters</simpara>
+     <simpara><link linkend="ini.opcache.jit-max-exit-counters">opcache.jit_max_exit_counters</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.jit_max_loop_unrolls</simpara>
+     <simpara><link linkend="ini.opcache.jit-max-loop-unrolls">opcache.jit_max_loop_unrolls</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.jit_max_polymorphic_calls</simpara>
+     <simpara><link linkend="ini.opcache.jit-max-polymorphic-calls">opcache.jit_max_polymorphic_calls</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.jit_max_recursive_calls</simpara>
+     <simpara><link linkend="ini.opcache.jit-max-recursive-calls">opcache.jit_max_recursive_calls</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.jit_max_recursive_returns</simpara>
+     <simpara><link linkend="ini.opcache.jit-max-recursive-return">opcache.jit_max_recursive_returns</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.jit_max_root_traces</simpara>
+     <simpara><link linkend="ini.opcache.jit-max-root-traces">opcache.jit_max_root_traces</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.jit_max_side_traces</simpara>
+     <simpara><link linkend="ini.opcache.jit-max-side-traces">opcache.jit_max_side_traces</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.log_verbosity_level</simpara>
+     <simpara><link linkend="ini.opcache.log-verbosity-level">opcache.log_verbosity_level</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.max_file_size</simpara>
+     <simpara><link linkend="ini.opcache.max-file-size">opcache.max_file_size</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.opt_debug_level</simpara>
+     <simpara><link linkend="ini.opcache.opt_debug_level">opcache.opt_debug_level</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.optimization_level</simpara>
+     <simpara><link linkend="ini.opcache.optimization-level">opcache.optimization_level</link></simpara>
     </listitem>
     <listitem>
-     <simpara>opcache.revalidate_freq</simpara>
+     <simpara><link linkend="ini.opcache.revalidate-freq">opcache.revalidate_freq</link></simpara>
     </listitem>
     <listitem>
      <simpara>output_buffering</simpara>
     </listitem>
     <listitem>
-     <simpara>pcre.backtrack_limit</simpara>
+     <simpara><link linkend="ini.pcre.backtrack-limit">pcre.backtrack_limit</link></simpara>
     </listitem>
     <listitem>
-     <simpara>pcre.recursion_limit</simpara>
+     <simpara><link linkend="ini.pcre.recursion-limit">pcre.recursion_limit</link></simpara>
     </listitem>
     <listitem>
-     <simpara>pgsql.max_links</simpara>
+     <simpara><link linkend="ini.pgsql.max-links">pgsql.max_links</link></simpara>
     </listitem>
     <listitem>
-     <simpara>pgsql.max_persistent</simpara>
+     <simpara><link linkend="ini.pgsql.max-persistent">pgsql.max_persistent</link></simpara>
     </listitem>
     <listitem>
      <simpara>post_max_size</simpara>
@@ -479,25 +476,25 @@
      <simpara>realpath_cache_ttl</simpara>
     </listitem>
     <listitem>
-     <simpara>session.cache_expire</simpara>
+     <simpara><link linkend="ini.session.cache-expire">session.cache_expire</link></simpara>
     </listitem>
     <listitem>
-     <simpara>session.cookie_lifetime</simpara>
+     <simpara><link linkend="ini.session.cookie-lifetime">session.cookie_lifetime</link></simpara>
     </listitem>
     <listitem>
-     <simpara>session.gc_divisor</simpara>
+     <simpara><link linkend="ini.session.gc-divisor">session.gc_divisor</link></simpara>
     </listitem>
     <listitem>
-     <simpara>session.gc_maxlifetime</simpara>
+     <simpara><link linkend="ini.session.gc-maxlifetime">session.gc_maxlifetime</link></simpara>
     </listitem>
     <listitem>
-     <simpara>session.gc_probability</simpara>
+     <simpara><link linkend="ini.session.gc-probability">session.gc_probability</link></simpara>
     </listitem>
     <listitem>
-     <simpara>soap.wsdl_cache_limit</simpara>
+     <simpara><link linkend="ini.soap.wsdl-cache-limit">soap.wsdl_cache_limit</link></simpara>
     </listitem>
     <listitem>
-     <simpara>soap.wsdl_cache_ttl</simpara>
+     <simpara><link linkend="ini.soap.wsdl-cache-ttl">soap.wsdl_cache_ttl</link></simpara>
     </listitem>
     <listitem>
      <simpara>unserialize_max_depth</simpara>
@@ -515,7 +512,7 @@
      <simpara>zend.assertions</simpara>
     </listitem>
     <listitem>
-     <simpara>zlib.output_compression_level</simpara>
+     <simpara><link linkend="ini.zlib.output-compression-level">zlib.output_compression_level</link></simpara>
     </listitem>
    </itemizedlist>
   </para>

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -1,0 +1,539 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration82.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Other Changes</title>
+
+ <sect2 xml:id="migration82.other-changes.core">
+  <title>Core changes</title>
+
+  <para>
+   The <type>iterable</type> type is now a built-in compile time alias for
+   <type class="union"><type>array</type><type>Traversable</type></type>.
+   Error messages relating to <literal>iterable</literal> will therefore
+   now use <literal>array|Traversable</literal>.
+   Type Reflection is preserved for single <literal>iterable</literal>
+   (and <literal>?iterable</literal>) to produce a
+   <classname>ReflectionNamedType</classname> with name <literal>iterable</literal>,
+   however usage of <literal>iterable</literal> in union types will be
+   converted to <literal>array|Traversable</literal>.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration82.other-changes.sapi">
+  <title>Changes in SAPI Modules</title>
+
+  <sect3 xml:id="migration82.other-changes.sapi.cli">
+   <title>CLI</title>
+
+   <para>
+    The STDOUT, STDERR and STDIN are no longer closed on resource destruction
+    which is mostly when the CLI finishes. It is however still possible to
+    explicitly close those streams using <function>fclose</function> and similar.
+   </para>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration82.other-changes.functions">
+  <title>Changed Functions</title>
+
+  <sect3 xml:id="migration82.other-changes.functions.core">
+   <title>Core</title>
+
+   <para>
+    The str*cmp, str*pos, <function>substr_compare</function> functions, using binary safe string
+    comparison now return -1, 0 and 1.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration82.other-changes.functions.dba">
+   <title>DBA</title>
+
+   <para>
+    <function>dba_open</function> and <function>dba_popen</function>
+    now have the following enforced signature:
+    <methodsynopsis>
+     <type class="union"><type>resource</type><type>false</type></type><methodname>dba_open</methodname>
+     <methodparam><type>string</type><parameter>path</parameter></methodparam>
+     <methodparam><type>string</type><parameter>mode</parameter></methodparam>
+     <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>handler</parameter><initializer>&null;</initializer></methodparam>
+     <methodparam choice="opt"><type>int</type><parameter>permission</parameter><initializer>0644</initializer></methodparam>
+     <methodparam choice="opt"><type>int</type><parameter>map_size</parameter><initializer>0</initializer></methodparam>
+    </methodsynopsis>
+   </para>
+   <para>
+    <function>dba_fetch</function>'s optional skip argument is now at the end
+    in line with PHP userland semantics. Its signature is now:
+    <methodsynopsis>
+     <type class="union"><type>string</type><type>false</type></type><methodname>dba_fetch</methodname>
+     <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>key</parameter></methodparam>
+     <methodparam><type>resource</type><parameter>handle</parameter></methodparam>
+     <methodparam><type>int</type><parameter>skip</parameter></methodparam>
+    </methodsynopsis>
+
+    The overloaded signature:
+    <methodsynopsis>
+     <type class="union"><type>string</type><type>false</type></type><methodname>dba_fetch</methodname>
+     <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>key</parameter></methodparam>
+     <methodparam><type>int</type><parameter>skip</parameter></methodparam>
+     <methodparam><type>resource</type><parameter>handle</parameter></methodparam>
+    </methodsynopsis>
+    is still accepted, but it is recommended to use the new standard variant.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration82.other-changes.functions.random">
+   <title>Random</title>
+
+   <para>
+    <function>random_bytes</function> and <function>random_int</function>
+    now throw a <classname>\Random\RandomException</classname> on CSPRNG failures.
+    Previously a plain <classname>Exception</classname> was thrown instead.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration82.other-changes.functions.spl">
+   <title>SPL</title>
+
+   <para>
+    The <parameter>iterator</parameter> parameter of
+    <function>iterator_to_array</function> and <function>iterator_count</function>
+    is widened to <type>iterable</type> from <classname>Iterator</classname>,
+    allowing arrays to be passed.
+    <!-- RFC: https://wiki.php.net/rfc/iterator_xyz_accept_array -->
+   </para>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration82.other-changes.extensions">
+  <title>Other Changes to Extensions</title>
+
+  <sect3 xml:id="migration82.other-changes.extensions.date">
+   <title>Date</title>
+
+   <para>
+    The properties of <classname>DatePeriod</classname> are now properly declared.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration82.other-changes.extensions.intl">
+   <title>Intl</title>
+
+   <para>
+    Instances of
+    <classname>IntlBreakIterator</classname>,
+    <classname>IntlRuleBasedBreakIterator</classname>,
+    <classname>IntlCodePointBreakIterator</classname>,
+    <classname>IntlPartsIterator</classname>,
+    <classname>IntlCalendar</classname>,
+    <classname>IntlCalendar</classname>,
+    <classname>Collator</classname>,
+    <classname>IntlIterator</classname>,
+    <classname>UConverter</classname>,
+    <classname>IntlDateFormatter</classname>,
+    <classname>IntlDatePatternGenerator</classname>,
+    <classname>MessageFormatter</classname>,
+    <classname>ResourceBundle</classname>,
+    <classname>Spoofchecker</classname>,
+    <classname>IntlTimeZone</classname>,
+    and <classname>Transliterator</classname>
+    are no longer serializable. Previously, they could be serialized, but
+    unserialization yielded unusable objects or failed.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration82.other-changes.extensions.mysqli">
+   <title>MySQLi</title>
+
+   <para>
+    The support for libmysql has been removed. It's no longer possible to compile
+    mysqli with libmysql and all relevant functionality has been removed.
+   </para>
+
+   <itemizedlist>
+    <listitem>
+     <simpara>
+      The reconnect property of <classname>mysqli_driver</classname> has been removed.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <!-- TODO Link -->
+      The INI directive mysqli.reconnect has been removed.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      The constant <constant>MYSQLI_IS_MARIADB</constant> has been deprecated.
+     </simpara>
+    </listitem>
+   </itemizedlist>
+  </sect3>
+
+  <sect3 xml:id="migration82.other-changes.extensions.oci8">
+   <title>OCI8</title>
+
+   <para>
+    The minimum Oracle Client library version required is now 11.2.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration82.other-changes.extensions.pcre">
+   <title>PCRE</title>
+
+   <para>
+    NUL characters (<literal>\0</literal>) in pattern strings are now supported.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration82.other-changes.extensions.session">
+   <title>Session</title>
+
+   <para>
+    <!-- Todo Link INI setting -->
+    Trying to change the SameSite cookie INI setting while the session is
+    active or output has already been sent will now fail and emit a warning.
+    This aligns the behaviour with all other session INI settings.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration82.other-changes.extensions.sqlite3">
+   <title>SQLite3</title>
+
+   <para>
+    <!-- Todo Link INI Setting -->
+    sqlite3.defensive is now <constant>PHP_INI_USER</constant>.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration82.other-changes.extensions.standard">
+   <title>Standard</title>
+
+   <para>
+    <function>getimagesize</function> now reports the actual image dimensions,
+    bits and channels of AVIF images. Previously, the dimensions have been reported as 0x0,
+    and bits and channels have not been reported at all.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration82.other-changes.extensions.tidy">
+   <title>Tidy</title>
+
+   <itemizedlist>
+    <listitem>
+     <simpara>
+      Properties of <classname>tidy</classname> are now properly declared.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      Properties of <classname>tidyNode</classname> are now properly declared as readonly.
+     </simpara>
+    </listitem>
+   </itemizedlist>
+  </sect3>
+
+  <sect3 xml:id="migration82.other-changes.extensions.zip">
+   <title>Zip</title>
+
+   <para>
+    The Zip extension has been updated to version 1.20.0,
+    which adds the following methods:
+    <itemizedlist>
+     <listitem>
+      <simpara>
+       <methodname>ZipArchive::clearError</methodname>
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       <methodname>ZipArchive::getStreamName</methodname>
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       <methodname>ZipArchive::getStreamIndex</methodname>
+      </simpara>
+     </listitem>
+    </itemizedlist>
+   </para>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration82.other-changes.ini">
+  <title>Changes to INI File Handling</title>
+
+  <para>
+   Parsing of some ill-formatted values will now trigger a warning when this
+   was silently ignored before.
+   For backwards compatibility, interpretation of these values has not changed.
+   This affects the following settings:
+
+   <!-- Todo Link INI Settings -->
+   <itemizedlist>
+    <listitem>
+     <simpara>bcmath.scale</simpara>
+    </listitem>
+    <listitem>
+     <simpara>com.code_page</simpara>
+    </listitem>
+    <listitem>
+     <simpara>default_socket_timeout</simpara>
+    </listitem>
+    <listitem>
+     <simpara>fiber.stack_size</simpara>
+    </listitem>
+    <listitem>
+     <simpara>hard_timeout</simpara>
+    </listitem>
+    <listitem>
+     <simpara>intl.error_level</simpara>
+    </listitem>
+    <listitem>
+     <simpara>ldap.max_links</simpara>
+    </listitem>
+    <listitem>
+     <simpara>max_input_nesting_level</simpara>
+    </listitem>
+    <listitem>
+     <simpara>max_input_vars</simpara>
+    </listitem>
+    <listitem>
+     <simpara>mbstring.regex_retry_limit</simpara>
+    </listitem>
+    <listitem>
+     <simpara>mbstring.regex_stack_limit</simpara>
+    </listitem>
+    <listitem>
+     <simpara>mysqli.allow_local_infile</simpara>
+    </listitem>
+    <listitem>
+     <simpara>mysqli.allow_persistent</simpara>
+    </listitem>
+    <listitem>
+     <simpara>mysqli.default_port</simpara>
+    </listitem>
+    <listitem>
+     <simpara>mysqli.max_links</simpara>
+    </listitem>
+    <listitem>
+     <simpara>mysqli.max_persistent</simpara>
+    </listitem>
+    <listitem>
+     <simpara>mysqli.reconnect</simpara>
+    </listitem>
+    <listitem>
+     <simpara>mysqli.rollback_on_cached_plink</simpara>
+    </listitem>
+    <listitem>
+     <simpara>mysqlnd.log_mask</simpara>
+    </listitem>
+    <listitem>
+     <simpara>mysqlnd.mempool_default_size</simpara>
+    </listitem>
+    <listitem>
+     <simpara>mysqlnd.net_read_buffer_size</simpara>
+    </listitem>
+    <listitem>
+     <simpara>mysqlnd.net_read_timeout</simpara>
+    </listitem>
+    <listitem>
+     <simpara>oci8.default_prefetch</simpara>
+    </listitem>
+    <listitem>
+     <simpara>oci8.max_persistent</simpara>
+    </listitem>
+    <listitem>
+     <simpara>oci8.persistent_timeout</simpara>
+    </listitem>
+    <listitem>
+     <simpara>oci8.ping_interval</simpara>
+    </listitem>
+    <listitem>
+     <simpara>oci8.prefetch_lob_size</simpara>
+    </listitem>
+    <listitem>
+     <simpara>oci8.privileged_connect</simpara>
+    </listitem>
+    <listitem>
+     <simpara>oci8.statement_cache_size</simpara>
+    </listitem>
+    <listitem>
+     <simpara>odbc.allow_persistent</simpara>
+    </listitem>
+    <listitem>
+     <simpara>odbc.check_persistent</simpara>
+    </listitem>
+    <listitem>
+     <simpara>odbc.defaultbinmode</simpara>
+    </listitem>
+    <listitem>
+     <simpara>odbc.default_cursortype</simpara>
+    </listitem>
+    <listitem>
+     <simpara>odbc.defaultlrl</simpara>
+    </listitem>
+    <listitem>
+     <simpara>odbc.max_links</simpara>
+    </listitem>
+    <listitem>
+     <simpara>odbc.max_persistent</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.consistency_checks</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.file_update_protection</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.force_restart_timeout</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.interned_strings_buffer</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.jit_bisect_limit</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.jit_blacklist_root_trace</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.jit_blacklist_side_trace</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.jit_debug</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.jit_hot_func</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.jit_hot_loop</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.jit_hot_return</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.jit_hot_side_exit</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.jit_max_exit_counters</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.jit_max_loop_unrolls</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.jit_max_polymorphic_calls</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.jit_max_recursive_calls</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.jit_max_recursive_returns</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.jit_max_root_traces</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.jit_max_side_traces</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.log_verbosity_level</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.max_file_size</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.opt_debug_level</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.optimization_level</simpara>
+    </listitem>
+    <listitem>
+     <simpara>opcache.revalidate_freq</simpara>
+    </listitem>
+    <listitem>
+     <simpara>output_buffering</simpara>
+    </listitem>
+    <listitem>
+     <simpara>pcre.backtrack_limit</simpara>
+    </listitem>
+    <listitem>
+     <simpara>pcre.recursion_limit</simpara>
+    </listitem>
+    <listitem>
+     <simpara>pgsql.max_links</simpara>
+    </listitem>
+    <listitem>
+     <simpara>pgsql.max_persistent</simpara>
+    </listitem>
+    <listitem>
+     <simpara>post_max_size</simpara>
+    </listitem>
+    <listitem>
+     <simpara>realpath_cache_size</simpara>
+    </listitem>
+    <listitem>
+     <simpara>realpath_cache_ttl</simpara>
+    </listitem>
+    <listitem>
+     <simpara>session.cache_expire</simpara>
+    </listitem>
+    <listitem>
+     <simpara>session.cookie_lifetime</simpara>
+    </listitem>
+    <listitem>
+     <simpara>session.gc_divisor</simpara>
+    </listitem>
+    <listitem>
+     <simpara>session.gc_maxlifetime</simpara>
+    </listitem>
+    <listitem>
+     <simpara>session.gc_probability</simpara>
+    </listitem>
+    <listitem>
+     <simpara>soap.wsdl_cache_limit</simpara>
+    </listitem>
+    <listitem>
+     <simpara>soap.wsdl_cache_ttl</simpara>
+    </listitem>
+    <listitem>
+     <simpara>unserialize_max_depth</simpara>
+    </listitem>
+    <listitem>
+     <simpara>upload_max_filesize</simpara>
+    </listitem>
+    <listitem>
+     <simpara>user_ini.cache_ttl</simpara>
+    </listitem>
+    <listitem>
+     <simpara>xmlrpc_error_number</simpara>
+    </listitem>
+    <listitem>
+     <simpara>zend.assertions</simpara>
+    </listitem>
+    <listitem>
+     <simpara>zlib.output_compression_level</simpara>
+    </listitem>
+   </itemizedlist>
+  </para>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -231,23 +231,11 @@
    <para>
     The Zip extension has been updated to version 1.20.0,
     which adds the following methods:
-    <itemizedlist>
-     <listitem>
-      <simpara>
-       <methodname>ZipArchive::clearError</methodname>
-      </simpara>
-     </listitem>
-     <listitem>
-      <simpara>
-       <methodname>ZipArchive::getStreamName</methodname>
-      </simpara>
-     </listitem>
-     <listitem>
-      <simpara>
-       <methodname>ZipArchive::getStreamIndex</methodname>
-      </simpara>
-     </listitem>
-    </itemizedlist>
+    <simplelist>
+     <member><methodname>ZipArchive::clearError</methodname></member>
+     <member><methodname>ZipArchive::getStreamName</methodname></member>
+     <member><methodname>ZipArchive::getStreamIndex</methodname></member>
+    </simplelist>
    </para>
   </sect3>
  </sect2>

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -57,6 +57,7 @@
      <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>handler</parameter><initializer>&null;</initializer></methodparam>
      <methodparam choice="opt"><type>int</type><parameter>permission</parameter><initializer>0644</initializer></methodparam>
      <methodparam choice="opt"><type>int</type><parameter>map_size</parameter><initializer>0</initializer></methodparam>
+     <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>flags</parameter><initializer>&null;</initializer></methodparam>
     </methodsynopsis>
    </para>
    <para>

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -211,18 +211,10 @@
   <sect3 xml:id="migration82.other-changes.extensions.tidy">
    <title>Tidy</title>
 
-   <itemizedlist>
-    <listitem>
-     <simpara>
-      Properties of <classname>tidy</classname> are now properly declared.
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      Properties of <classname>tidyNode</classname> are now properly declared as readonly.
-     </simpara>
-    </listitem>
-   </itemizedlist>
+   <para>
+    The properties of the <classname>tidy</classname> class are now properly declared.
+    And those of the <classname>tidyNode</classname> class are now properly declared as readonly.
+   </para>
   </sect3>
 
   <sect3 xml:id="migration82.other-changes.extensions.zip">

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -88,7 +88,7 @@
 
    <para>
     <function>random_bytes</function> and <function>random_int</function>
-    now throw a <classname>\Random\RandomException</classname> on CSPRNG failures.
+    now throw a <classname>\Random\RandomException</classname> on <acronym>CSPRNG</acronym> failures.
     Previously a plain <classname>\Exception</classname> was thrown instead.
    </para>
   </sect3>

--- a/appendices/migration82/windows-support.xml
+++ b/appendices/migration82/windows-support.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration82.windows-support" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Windows Support</title>
+
+ <sect2 xml:id="migration82.windows-support.core">
+  <title>Core</title>
+  <para>
+   Windows specific error messages are no longer localized, but instead
+   always displayed in English to better match PHP error messages.
+  </para>
+  <para>
+   Preliminary and highly experimental support for building on ARM64 has been added.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration82.windows-support.oci8">
+  <title>OCI8</title>
+  <para>
+   Because building against Oracle Client 10g is no longer supported anyway,
+   the configuration option <command>--with-oci8</command> has been dropped.
+   The <command>--with-oci8-11g</command>, <command>--with-oci8-12c</command> and
+   <command>--with-oci8-19</command> configuration options are still supported.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration82.windows-support.zip">
+  <title>Zip</title>
+  <para>
+   The Zip extension is upgraded to version 1.21.0,
+   and is now built as shared library (DLL) by default.
+  </para>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration82/windows-support.xml
+++ b/appendices/migration82/windows-support.xml
@@ -27,7 +27,7 @@
   <title>Zip</title>
   <para>
    The Zip extension is upgraded to version 1.21.0,
-   and is now built as shared library (DLL) by default.
+   and is now built as shared library (<acronym>DLL</acronym>) by default.
   </para>
  </sect2>
 

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -121,6 +121,12 @@
      <entry></entry>
     </row>
     <row>
+     <entry><link linkend="ini.error-log-mode">error_log_mode</link></entry>
+     <entry>0o644</entry>
+     <entry>PHP_INI_ALL</entry>
+     <entry>Available as of PHP 8.2.0</entry>
+    </row>
+    <row>
      <entry><link linkend="ini.syslog.facility">syslog.facility</link></entry>
      <entry>"LOG_USER"</entry>
      <entry>PHP_INI_SYSTEM</entry>
@@ -478,6 +484,19 @@
       For example, it is an error log in Apache or <literal>stderr</literal>
       in CLI.
       See also <function>error_log</function>.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="ini.error-log-mode">
+    <term>
+     <parameter>error_log_mode</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <para>
+      File mode for the file described set in
+      <link linkend="ini.error-log">error_log</link>.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/mysqli/ini.xml
+++ b/reference/mysqli/ini.xml
@@ -80,7 +80,7 @@
       <entry><link linkend="ini.mysqli.reconnect">mysqli.reconnect</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry></entry>
+      <entry>Removed as of PHP 8.2.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqli.rollback-on-cached-plink">mysqli.rollback_on_cached_plink</link></entry>

--- a/reference/sqlite3/ini.xml
+++ b/reference/sqlite3/ini.xml
@@ -26,8 +26,12 @@
      <row>
       <entry><link linkend="ini.sqlite3.defensive">sqlite3.defensive</link></entry>
       <entry>1</entry>
-      <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available as of PHP 7.2.17 and 7.3.4 for libsqlite ≥ 3.26.0.</entry>
+      <entry>PHP_INI_USER</entry>
+      <entry>
+       Available as of PHP 7.2.17 and 7.3.4 for libsqlite ≥ 3.26.0.
+       Prior to PHP 8.2.0 this setting was changeable only as
+       <constant>PHP_INI_SYSTEM</constant>.
+      </entry>
      </row>
     </tbody>
    </tgroup>


### PR DESCRIPTION
Will need a doc-base change to be added to the live version.

This covers the UPGRADING file.

I think it is best to merge this ASAP and handle adding examples and links in other PRs as needed.