### PR TITLE
add `FILTER_FLAG_GLOBAL_RANGE` documentation

### DIFF
--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -148,6 +148,7 @@
          <constant>FILTER_FLAG_IPV6</constant>,
          <constant>FILTER_FLAG_NO_PRIV_RANGE</constant>,
          <constant>FILTER_FLAG_NO_RES_RANGE</constant>,
+         <constant>FILTER_FLAG_GLOBAL_RANGE</constant>,
          <constant>FILTER_NULL_ON_FAILURE</constant>
         </entry>
         <entry>
@@ -736,6 +737,19 @@ filter.default_flags = 0
         <para>
          These are the ranges that are marked as Reserved-By-Protocol in
          <link xlink:href="&url.rfc;6890">RFC 6890</link>.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry><constant>FILTER_FLAG_GLOBAL_RANGE</constant></entry>
+       <entry>
+        <constant>FILTER_VALIDATE_IP</constant>
+       </entry>
+       <entry>
+        <para>
+         Fails validation for non global IPv4/IPv6 ranges as found in
+         <link xlink:href="&url.rfc;6890">RFC 6890</link> with the
+         Global attribute being False.
         </para>
        </entry>
       </row>

--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -749,7 +749,7 @@ filter.default_flags = 0
         <para>
          Fails validation for non global IPv4/IPv6 ranges as found in
          <link xlink:href="&url.rfc;6890">RFC 6890</link> with the
-         Global attribute being False.
+         <literal>Global</literal> attribute being <literal>False</literal>.
         </para>
        </entry>
       </row>

--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -832,6 +832,13 @@ filter.default_flags = 0
       </thead>
       <tbody>
        <row>
+        <entry>8.2.0</entry>
+        <entry>
+         <constant>FILTER_FLAG_GLOBAL_RANGE</constant> as a flag to
+         <constant>FILTER_VALIDATE_IP</constant> has been added.
+        </entry>
+       </row>
+       <row>
         <entry>7.3.0</entry>
         <entry>
          The explicit usage of <constant>FILTER_FLAG_SCHEME_REQUIRED</constant>


### PR DESCRIPTION
Hey there :vulcan_salute: 

this will add documentation for `FILTER_FLAG_GLOBAL_RANGE` as found in #1803 and added to PHP 8.2 with https://github.com/php/php-src/commit/d8fc05c05eb6fe189a663c599421a8457bc6c767
I was thinking to write down all global IP ranges (as you can see in the docs for `FILTER_FLAG_NO_PRIV_RANGE`), but it turns out that these are quite a few. So I thought it might be sufficient to link to the RFC where those global ranges are defined.

WDYT?

Kind regards
Florian