### PR TITLE
Fix Win32Service constant value error

### DIFF
--- a/reference/win32service/constants.xml
+++ b/reference/win32service/constants.xml
@@ -839,18 +839,18 @@
        No action.
       </entry>
      </row>
-     <row xml:id="constant.win32-sc-action-reboot">
-      <entry><constant>WIN32_SC_ACTION_REBOOT</constant></entry>
-      <entry>0x00000001</entry>
-      <entry>
-       Restart the server.
-      </entry>
-     </row>
      <row xml:id="constant.win32-sc-action-restart">
       <entry><constant>WIN32_SC_ACTION_RESTART</constant></entry>
-      <entry>0x00000002</entry>
+      <entry>0x00000001</entry>
       <entry>
        Restart the service.
+      </entry>
+     </row>
+     <row xml:id="constant.win32-sc-action-reboot">
+      <entry><constant>WIN32_SC_ACTION_REBOOT</constant></entry>
+      <entry>0x00000002</entry>
+      <entry>
+       Restart the server.
       </entry>
      </row>
      <row xml:id="constant.win32-sc-action-run-command">


### PR DESCRIPTION
Hi,

I'm the Win32Service PHP extension maintainer.

In Win32Service documentation, the constant values of `WIN32_SC_ACTION_REBOOT` and `WIN32_SC_ACTION_RESTART` is inverted.

Thank you a lot.