### PR TITLE
add docs for `random_int`/`random_bytes` changes in PHP 8.2

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -3589,8 +3589,8 @@ local: {
  </listitem>
  <listitem>
   <simpara>
-   If none of the aforementioned sources are available, then an
-   <classname>Exception</classname> will be thrown.
+   If none of the aforementioned sources are available, then a
+   <classname>\Random\RandomException</classname> will be thrown.
   </simpara>
  </listitem>
 </itemizedlist>
@@ -3599,7 +3599,7 @@ local: {
  <listitem xmlns="http://docbook.org/ns/docbook">
   <simpara>
    If an appropriate source of randomness cannot be found,
-   an <classname>Exception</classname> will be thrown.
+   a <classname>\Random\RandomException</classname> will be thrown.
   </simpara>
  </listitem>
  <listitem xmlns="http://docbook.org/ns/docbook">

--- a/reference/csprng/functions/random-bytes.xml
+++ b/reference/csprng/functions/random-bytes.xml
@@ -56,6 +56,30 @@
   </itemizedlist>
  </refsect1><!-- }}} -->
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.2.0</entry>
+      <entry>
+       In case of a CSPRNG failure, this function will now throw a
+       <classname>\Random\RandomException</classname>. Previously a plain
+       <classname>\Exception</classname> was thrown.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples"><!-- {{{ -->
   &reftitle.examples;
   <example xml:id="random-bytes.example.basic"><!-- {{{ -->

--- a/reference/csprng/functions/random-bytes.xml
+++ b/reference/csprng/functions/random-bytes.xml
@@ -70,7 +70,7 @@
      <row>
       <entry>8.2.0</entry>
       <entry>
-       In case of a CSPRNG failure, this function will now throw a
+       In case of a <acronym>CSPRNG</acronym> failure, this function will now throw a
        <classname>\Random\RandomException</classname>. Previously a plain
        <classname>\Exception</classname> was thrown.
       </entry>

--- a/reference/csprng/functions/random-int.xml
+++ b/reference/csprng/functions/random-int.xml
@@ -68,6 +68,30 @@
   </itemizedlist>
  </refsect1><!-- }}} -->
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.2.0</entry>
+      <entry>
+       In case of a CSPRNG failure, this function will now throw a
+       <classname>\Random\RandomException</classname>. Previously a plain
+       <classname>\Exception</classname> was thrown.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples"><!-- {{{ -->
   &reftitle.examples;
   <example xml:id="random-int.example.basic"><!-- {{{ -->

--- a/reference/csprng/functions/random-int.xml
+++ b/reference/csprng/functions/random-int.xml
@@ -82,7 +82,7 @@
      <row>
       <entry>8.2.0</entry>
       <entry>
-       In case of a CSPRNG failure, this function will now throw a
+       In case of a <acronym>CSPRNG</acronym> failure, this function will now throw a
        <classname>\Random\RandomException</classname>. Previously a plain
        <classname>\Exception</classname> was thrown.
       </entry>


### PR DESCRIPTION
Hey there :vulcan_salute:

this will add docs about the changes in PHP 8.2 to the `random_bytes` and `random_int` functions as per https://github.com/php/php-src/pull/9220

Kind regards
Florian

Refs: #1803 