### PR TITLE
Simplify example in `Stringable` docs.

### DIFF
--- a/language/predefined/stringable.xml
+++ b/language/predefined/stringable.xml
@@ -90,6 +90,9 @@ showStuff($ip);
      </screen>
     </example>
    </para>
+   <note>
+    <simpara>The above example uses <link linkend="language.oop5.decon.constructor.promotion">constructor property promotion</link>.</simpara>
+   </note>
   </section>
 
  </partintro>

--- a/language/predefined/stringable.xml
+++ b/language/predefined/stringable.xml
@@ -58,17 +58,12 @@
 <![CDATA[
 <?php
 class IPv4Address implements Stringable {
-    private string $oct1;
-    private string $oct2;
-    private string $oct3;
-    private string $oct4;
-
-    public function __construct(string $oct1, string $oct2, string $oct3, string $oct4) {
-        $this->oct1 = $oct1;
-        $this->oct2 = $oct2;
-        $this->oct3 = $oct3;
-        $this->oct4 = $oct4;
-    }
+    public function __construct(
+        private string $oct1,
+        private string $oct2,
+        private string $oct3,
+        private string $oct4,
+    ) {}
 
     public function __toString(): string {
         return "$this->oct1.$this->oct2.$this->oct3.$this->oct4";

--- a/language/predefined/stringable.xml
+++ b/language/predefined/stringable.xml
@@ -54,6 +54,7 @@
    <para>
     <example xml:id="stringable.basic-example">
      <title>Basic Stringable Usage</title>
+     <simpara>This uses <link linkend="language.oop5.decon.constructor.promotion">constructor property promotion</link>.</simpara>
      <programlisting role="php">
 <![CDATA[
 <?php
@@ -90,9 +91,6 @@ showStuff($ip);
      </screen>
     </example>
    </para>
-   <note>
-    <simpara>The above example uses <link linkend="language.oop5.decon.constructor.promotion">constructor property promotion</link>.</simpara>
-   </note>
   </section>
 
  </partintro>


### PR DESCRIPTION
Props to Gormack for the idea: https://www.php.net/manual/en/class.stringable.php#126627

The interface was introduced in PHP 8, and you know what else was introduced in that version? Promoted constructor properties. By reducing the boilerplate, the example becomes a lot more focused.