### PR TITLE
Update get_loaded_extensions() output example

### DIFF
--- a/reference/info/functions/get-loaded-extensions.xml
+++ b/reference/info/functions/get-loaded-extensions.xml
@@ -59,18 +59,38 @@ print_r(get_loaded_extensions());
 <![CDATA[
 Array
 (
-   [0] => xml
-   [1] => wddx
-   [2] => standard
-   [3] => session
-   [4] => posix
-   [5] => pgsql
-   [6] => pcre
-   [7] => gd
-   [8] => ftp
-   [9] => db
-   [10] => calendar
-   [11] => bcmath
+    [0] => Core
+    [1] => date
+    [2] => libxml
+    [3] => pcre
+    [4] => sqlite3
+    [5] => zlib
+    [6] => ctype
+    [7] => dom
+    [8] => fileinfo
+    [9] => filter
+    [10] => hash
+    [11] => json
+    [12] => mbstring
+    [13] => SPL
+    [14] => PDO
+    [15] => session
+    [16] => posix
+    [17] => Reflection
+    [18] => standard
+    [19] => SimpleXML
+    [20] => pdo_sqlite
+    [21] => Phar
+    [22] => tokenizer
+    [23] => xml
+    [24] => xmlreader
+    [25] => xmlwriter
+    [26] => gmp
+    [27] => iconv
+    [28] => intl
+    [29] => bcmath
+    [30] => sodium
+    [31] => Zend OPcache
 )
 ]]>
     </screen>


### PR DESCRIPTION
copied from https://3v4l.org/gcKp8

to stress the names are not in LC and `Core` is present