### PR TITLE
Add docs for new socket constants in PHP 8.2

### DIFF
--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -180,6 +180,17 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.so-meminfo">
+   <term>
+    <constant>SO_MEMINFO</constant> 
+    (<type>array</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.so-reuseaddr">
    <term>
     <constant>SO_REUSEADDR</constant> 

--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -6,29 +6,29 @@
  <variablelist>
   <varlistentry xml:id="constant.af-unix">
    <term>
-    <constant>AF_UNIX</constant> 
+    <constant>AF_UNIX</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.af-inet">
    <term>
-    <constant>AF_INET</constant> 
+    <constant>AF_INET</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.af-inet6">
    <term>
-    <constant>AF_INET6</constant> 
+    <constant>AF_INET6</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -39,106 +39,106 @@
   </varlistentry>
   <varlistentry xml:id="constant.sock-stream">
    <term>
-    <constant>SOCK_STREAM</constant> 
+    <constant>SOCK_STREAM</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.sock-dgram">
    <term>
-    <constant>SOCK_DGRAM</constant> 
+    <constant>SOCK_DGRAM</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.sock-raw">
    <term>
-    <constant>SOCK_RAW</constant> 
+    <constant>SOCK_RAW</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.sock-seqpacket">
    <term>
-    <constant>SOCK_SEQPACKET</constant> 
+    <constant>SOCK_SEQPACKET</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.sock-rdm">
    <term>
-    <constant>SOCK_RDM</constant> 
+    <constant>SOCK_RDM</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.msg-oob">
    <term>
-    <constant>MSG_OOB</constant> 
+    <constant>MSG_OOB</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.msg-waitall">
    <term>
-    <constant>MSG_WAITALL</constant> 
+    <constant>MSG_WAITALL</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.msg-peek">
    <term>
-    <constant>MSG_PEEK</constant> 
+    <constant>MSG_PEEK</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.msg-dontroute">
    <term>
-    <constant>MSG_DONTROUTE</constant> 
+    <constant>MSG_DONTROUTE</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.msg-eor">
    <term>
-    <constant>MSG_EOR</constant> 
+    <constant>MSG_EOR</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -149,7 +149,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.msg-eof">
    <term>
-    <constant>MSG_EOF</constant> 
+    <constant>MSG_EOF</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -160,51 +160,51 @@
   </varlistentry>
   <varlistentry xml:id="constant.so-debug">
    <term>
-    <constant>SO_DEBUG</constant> 
+    <constant>SO_DEBUG</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.so-incoming-cpu">
    <term>
-    <constant>SO_INCOMING_CPU</constant> 
+    <constant>SO_INCOMING_CPU</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.so-meminfo">
    <term>
-    <constant>SO_MEMINFO</constant> 
+    <constant>SO_MEMINFO</constant>
     (<type>array</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.so-reuseaddr">
    <term>
-    <constant>SO_REUSEADDR</constant> 
+    <constant>SO_REUSEADDR</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.so-reuseport">
    <term>
-    <constant>SO_REUSEPORT</constant> 
+    <constant>SO_REUSEPORT</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -217,150 +217,150 @@
   </varlistentry>
   <varlistentry xml:id="constant.so-keepalive">
    <term>
-    <constant>SO_KEEPALIVE</constant> 
+    <constant>SO_KEEPALIVE</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.so-dontroute">
    <term>
-    <constant>SO_DONTROUTE</constant> 
+    <constant>SO_DONTROUTE</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.so-linger">
    <term>
-    <constant>SO_LINGER</constant> 
+    <constant>SO_LINGER</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.so-broadcast">
    <term>
-    <constant>SO_BROADCAST</constant> 
+    <constant>SO_BROADCAST</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.so-oobinline">
    <term>
-    <constant>SO_OOBINLINE</constant> 
+    <constant>SO_OOBINLINE</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.so-sndbuf">
    <term>
-    <constant>SO_SNDBUF</constant> 
+    <constant>SO_SNDBUF</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.so-rcvbuf">
    <term>
-    <constant>SO_RCVBUF</constant> 
+    <constant>SO_RCVBUF</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.so-sndlowat">
    <term>
-    <constant>SO_SNDLOWAT</constant> 
+    <constant>SO_SNDLOWAT</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.so-rcvlowat">
    <term>
-    <constant>SO_RCVLOWAT</constant> 
+    <constant>SO_RCVLOWAT</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.so-sndtimeo">
    <term>
-    <constant>SO_SNDTIMEO</constant> 
+    <constant>SO_SNDTIMEO</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.so-rcvtimeo">
    <term>
-    <constant>SO_RCVTIMEO</constant> 
+    <constant>SO_RCVTIMEO</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.so-type">
    <term>
-    <constant>SO_TYPE</constant> 
+    <constant>SO_TYPE</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.so-error">
    <term>
-    <constant>SO_ERROR</constant> 
+    <constant>SO_ERROR</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.tcp-nodelay">
    <term>
-    <constant>TCP_NODELAY</constant> 
+    <constant>TCP_NODELAY</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -371,34 +371,34 @@
   </varlistentry>
   <varlistentry xml:id="constant.so-mark">
    <term>
-    <constant>SO_MARK</constant> 
+    <constant>SO_MARK</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.1.0 
+     Available as of PHP 8.1.0
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.so-user-cookie">
    <term>
-    <constant>SO_USER_COOKIE</constant> 
+    <constant>SO_USER_COOKIE</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.1.0 
+     Available as of PHP 8.1.0
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.so-acceptfilter">
    <term>
-    <constant>SO_ACCEPTFILTER</constant> 
+    <constant>SO_ACCEPTFILTER</constant>
     (<type>string</type>)
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.1.0 
+     Available as of PHP 8.1.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -437,56 +437,56 @@
   </varlistentry>
   <varlistentry xml:id="constant.sol-socket">
    <term>
-    <constant>SOL_SOCKET</constant> 
+    <constant>SOL_SOCKET</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.php-normal-read">
    <term>
-    <constant>PHP_NORMAL_READ</constant> 
+    <constant>PHP_NORMAL_READ</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.php-binary-read">
    <term>
-    <constant>PHP_BINARY_READ</constant> 
+    <constant>PHP_BINARY_READ</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.sol-tcp">
    <term>
-    <constant>SOL_TCP</constant> 
+    <constant>SOL_TCP</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.sol-udp">
    <term>
-    <constant>SOL_UDP</constant> 
+    <constant>SOL_UDP</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -500,7 +500,7 @@
  <variablelist>
   <varlistentry xml:id="constant.socket-eintr">
    <term>
-    <constant>SOCKET_EINTR</constant> 
+    <constant>SOCKET_EINTR</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -511,7 +511,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-ebadf">
    <term>
-    <constant>SOCKET_EBADF</constant> 
+    <constant>SOCKET_EBADF</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -522,7 +522,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eacces">
    <term>
-    <constant>SOCKET_EACCES</constant> 
+    <constant>SOCKET_EACCES</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -533,7 +533,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-efault">
    <term>
-    <constant>SOCKET_EFAULT</constant> 
+    <constant>SOCKET_EFAULT</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -544,7 +544,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-einval">
    <term>
-    <constant>SOCKET_EINVAL</constant> 
+    <constant>SOCKET_EINVAL</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -555,7 +555,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-emfile">
    <term>
-    <constant>SOCKET_EMFILE</constant> 
+    <constant>SOCKET_EMFILE</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -566,7 +566,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enametoolong">
    <term>
-    <constant>SOCKET_ENAMETOOLONG</constant> 
+    <constant>SOCKET_ENAMETOOLONG</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -577,7 +577,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enotempty">
    <term>
-    <constant>SOCKET_ENOTEMPTY</constant> 
+    <constant>SOCKET_ENOTEMPTY</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -588,7 +588,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eloop">
    <term>
-    <constant>SOCKET_ELOOP</constant> 
+    <constant>SOCKET_ELOOP</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -599,7 +599,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-ewouldblock">
    <term>
-    <constant>SOCKET_EWOULDBLOCK</constant> 
+    <constant>SOCKET_EWOULDBLOCK</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -610,7 +610,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eremote">
    <term>
-    <constant>SOCKET_EREMOTE</constant> 
+    <constant>SOCKET_EREMOTE</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -621,7 +621,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eusers">
    <term>
-    <constant>SOCKET_EUSERS</constant> 
+    <constant>SOCKET_EUSERS</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -632,7 +632,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enotsock">
    <term>
-    <constant>SOCKET_ENOTSOCK</constant> 
+    <constant>SOCKET_ENOTSOCK</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -643,7 +643,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-edestaddrreq">
    <term>
-    <constant>SOCKET_EDESTADDRREQ</constant> 
+    <constant>SOCKET_EDESTADDRREQ</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -654,7 +654,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-emsgsize">
    <term>
-    <constant>SOCKET_EMSGSIZE</constant> 
+    <constant>SOCKET_EMSGSIZE</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -665,7 +665,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eprototype">
    <term>
-    <constant>SOCKET_EPROTOTYPE</constant> 
+    <constant>SOCKET_EPROTOTYPE</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -676,7 +676,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eprotonosupport">
    <term>
-    <constant>SOCKET_EPROTONOSUPPORT</constant> 
+    <constant>SOCKET_EPROTONOSUPPORT</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -687,7 +687,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-esocktnosupport">
    <term>
-    <constant>SOCKET_ESOCKTNOSUPPORT</constant> 
+    <constant>SOCKET_ESOCKTNOSUPPORT</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -698,7 +698,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eopnotsupp">
    <term>
-    <constant>SOCKET_EOPNOTSUPP</constant> 
+    <constant>SOCKET_EOPNOTSUPP</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -709,7 +709,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-epfnosupport">
    <term>
-    <constant>SOCKET_EPFNOSUPPORT</constant> 
+    <constant>SOCKET_EPFNOSUPPORT</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -720,7 +720,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eafnosupport">
    <term>
-    <constant>SOCKET_EAFNOSUPPORT</constant> 
+    <constant>SOCKET_EAFNOSUPPORT</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -731,7 +731,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eaddrnotavail">
    <term>
-    <constant>SOCKET_EADDRNOTAVAIL</constant> 
+    <constant>SOCKET_EADDRNOTAVAIL</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -742,7 +742,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enetdown">
    <term>
-    <constant>SOCKET_ENETDOWN</constant> 
+    <constant>SOCKET_ENETDOWN</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -753,7 +753,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enetunreach">
    <term>
-    <constant>SOCKET_ENETUNREACH</constant> 
+    <constant>SOCKET_ENETUNREACH</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -764,7 +764,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enetreset">
    <term>
-    <constant>SOCKET_ENETRESET</constant> 
+    <constant>SOCKET_ENETRESET</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -775,7 +775,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-econnaborted">
    <term>
-    <constant>SOCKET_ECONNABORTED</constant> 
+    <constant>SOCKET_ECONNABORTED</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -786,7 +786,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-econnreset">
    <term>
-    <constant>SOCKET_ECONNRESET</constant> 
+    <constant>SOCKET_ECONNRESET</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -797,7 +797,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enobufs">
    <term>
-    <constant>SOCKET_ENOBUFS</constant> 
+    <constant>SOCKET_ENOBUFS</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -808,7 +808,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eisconn">
    <term>
-    <constant>SOCKET_EISCONN</constant> 
+    <constant>SOCKET_EISCONN</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -819,7 +819,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enotconn">
    <term>
-    <constant>SOCKET_ENOTCONN</constant> 
+    <constant>SOCKET_ENOTCONN</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -830,7 +830,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eshutdown">
    <term>
-    <constant>SOCKET_ESHUTDOWN</constant> 
+    <constant>SOCKET_ESHUTDOWN</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -841,7 +841,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-etimedout">
    <term>
-    <constant>SOCKET_ETIMEDOUT</constant> 
+    <constant>SOCKET_ETIMEDOUT</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -852,7 +852,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-econnrefused">
    <term>
-    <constant>SOCKET_ECONNREFUSED</constant> 
+    <constant>SOCKET_ECONNREFUSED</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -863,7 +863,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-ehostdown">
    <term>
-    <constant>SOCKET_EHOSTDOWN</constant> 
+    <constant>SOCKET_EHOSTDOWN</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -874,7 +874,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-ehostunreach">
    <term>
-    <constant>SOCKET_EHOSTUNREACH</constant> 
+    <constant>SOCKET_EHOSTUNREACH</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -885,7 +885,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-ealready">
    <term>
-    <constant>SOCKET_EALREADY</constant> 
+    <constant>SOCKET_EALREADY</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -896,7 +896,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-einprogress">
    <term>
-    <constant>SOCKET_EINPROGRESS</constant> 
+    <constant>SOCKET_EINPROGRESS</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -906,220 +906,220 @@
    </listitem>
   </varlistentry>
  </variablelist>
- 
+
  <simpara>
   The following constants are only defined under Windows.
  </simpara>
 
  <variablelist>
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
   <varlistentry xml:id="constant.socket-enoprotoopt">
    <term>
-    <constant>SOCKET_ENOPROTOOPT</constant> 
+    <constant>SOCKET_ENOPROTOOPT</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
-  
-  
-  
-  
-  
+
+
+
+
+
   <varlistentry xml:id="constant.socket-eaddrinuse">
    <term>
-    <constant>SOCKET_EADDRINUSE</constant> 
+    <constant>SOCKET_EADDRINUSE</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
+
+
+
   <varlistentry xml:id="constant.socket-etoomyrefs">
    <term>
-    <constant>SOCKET_ETOOMYREFS</constant> 
+    <constant>SOCKET_ETOOMYREFS</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
   <varlistentry xml:id="constant.socket-eproclim">
    <term>
-    <constant>SOCKET_EPROCLIM</constant> 
+    <constant>SOCKET_EPROCLIM</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="constant.socket-eduot">
    <term>
-    <constant>SOCKET_EDUOT</constant> 
+    <constant>SOCKET_EDUOT</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.socket-estale">
    <term>
-    <constant>SOCKET_ESTALE</constant> 
+    <constant>SOCKET_ESTALE</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="constant.socket-ediscon">
    <term>
-    <constant>SOCKET_EDISCON</constant> 
+    <constant>SOCKET_EDISCON</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.socket-sysnotready">
    <term>
-    <constant>SOCKET_SYSNOTREADY</constant> 
+    <constant>SOCKET_SYSNOTREADY</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.socket-vernotsupported">
    <term>
-    <constant>SOCKET_VERNOTSUPPORTED</constant> 
+    <constant>SOCKET_VERNOTSUPPORTED</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.socket-notinitialised">
    <term>
-    <constant>SOCKET_NOTINITIALISED</constant> 
+    <constant>SOCKET_NOTINITIALISED</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.socket-host-not-found">
    <term>
-    <constant>SOCKET_HOST_NOT_FOUND</constant> 
+    <constant>SOCKET_HOST_NOT_FOUND</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.socket-try-again">
    <term>
-    <constant>SOCKET_TRY_AGAIN</constant> 
+    <constant>SOCKET_TRY_AGAIN</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.socket-no-recovery">
    <term>
-    <constant>SOCKET_NO_RECOVERY</constant> 
+    <constant>SOCKET_NO_RECOVERY</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.socket-no-data">
    <term>
-    <constant>SOCKET_NO_DATA</constant> 
+    <constant>SOCKET_NO_DATA</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.socket-no-address">
    <term>
-    <constant>SOCKET_NO_ADDRESS</constant> 
+    <constant>SOCKET_NO_ADDRESS</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
  </variablelist>
 
  <simpara>
-  The following constants are only available on UNIX-like 
-  platforms. Each constant is only defined if their equal is 
+  The following constants are only available on UNIX-like
+  platforms. Each constant is only defined if their equal is
   available on the platform.
  </simpara>
 
  <variablelist>
   <varlistentry xml:id="constant.socket-eperm">
    <term>
-    <constant>SOCKET_EPERM</constant> 
+    <constant>SOCKET_EPERM</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1130,7 +1130,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enoent">
    <term>
-    <constant>SOCKET_ENOENT</constant> 
+    <constant>SOCKET_ENOENT</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1141,7 +1141,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eio">
    <term>
-    <constant>SOCKET_EIO</constant> 
+    <constant>SOCKET_EIO</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1152,7 +1152,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enxio">
    <term>
-    <constant>SOCKET_ENXIO</constant> 
+    <constant>SOCKET_ENXIO</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1163,7 +1163,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-e2big">
    <term>
-    <constant>SOCKET_E2BIG</constant> 
+    <constant>SOCKET_E2BIG</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1174,7 +1174,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eagain">
    <term>
-    <constant>SOCKET_EAGAIN</constant> 
+    <constant>SOCKET_EAGAIN</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1185,7 +1185,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enomem">
    <term>
-    <constant>SOCKET_ENOMEM</constant> 
+    <constant>SOCKET_ENOMEM</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1196,7 +1196,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enotblk">
    <term>
-    <constant>SOCKET_ENOTBLK</constant> 
+    <constant>SOCKET_ENOTBLK</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1207,7 +1207,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-ebusy">
    <term>
-    <constant>SOCKET_EBUSY</constant> 
+    <constant>SOCKET_EBUSY</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1218,7 +1218,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eexist">
    <term>
-    <constant>SOCKET_EEXIST</constant> 
+    <constant>SOCKET_EEXIST</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1229,7 +1229,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-exdev">
    <term>
-    <constant>SOCKET_EXDEV</constant> 
+    <constant>SOCKET_EXDEV</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1240,7 +1240,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enodev">
    <term>
-    <constant>SOCKET_ENODEV</constant> 
+    <constant>SOCKET_ENODEV</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1251,7 +1251,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enotdir">
    <term>
-    <constant>SOCKET_ENOTDIR</constant> 
+    <constant>SOCKET_ENOTDIR</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1262,7 +1262,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eisdir">
    <term>
-    <constant>SOCKET_EISDIR</constant> 
+    <constant>SOCKET_EISDIR</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1273,7 +1273,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enfile">
    <term>
-    <constant>SOCKET_ENFILE</constant> 
+    <constant>SOCKET_ENFILE</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1284,7 +1284,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enotty">
    <term>
-    <constant>SOCKET_ENOTTY</constant> 
+    <constant>SOCKET_ENOTTY</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1295,7 +1295,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enospc">
    <term>
-    <constant>SOCKET_ENOSPC</constant> 
+    <constant>SOCKET_ENOSPC</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1306,7 +1306,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-espipe">
    <term>
-    <constant>SOCKET_ESPIPE</constant> 
+    <constant>SOCKET_ESPIPE</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1317,7 +1317,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-erofs">
    <term>
-    <constant>SOCKET_EROFS</constant> 
+    <constant>SOCKET_EROFS</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1328,7 +1328,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-emlink">
    <term>
-    <constant>SOCKET_EMLINK</constant> 
+    <constant>SOCKET_EMLINK</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1339,7 +1339,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-epipe">
    <term>
-    <constant>SOCKET_EPIPE</constant> 
+    <constant>SOCKET_EPIPE</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1348,10 +1348,10 @@
     </simpara>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="constant.socket-enolck">
    <term>
-    <constant>SOCKET_ENOLCK</constant> 
+    <constant>SOCKET_ENOLCK</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1362,7 +1362,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enosys">
    <term>
-    <constant>SOCKET_ENOSYS</constant> 
+    <constant>SOCKET_ENOSYS</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1371,12 +1371,12 @@
     </simpara>
    </listitem>
   </varlistentry>
-  
-  
-  
+
+
+
   <varlistentry xml:id="constant.socket-enomsg">
    <term>
-    <constant>SOCKET_ENOMSG</constant> 
+    <constant>SOCKET_ENOMSG</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1387,7 +1387,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eidrm">
    <term>
-    <constant>SOCKET_EIDRM</constant> 
+    <constant>SOCKET_EIDRM</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1398,7 +1398,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-echrng">
    <term>
-    <constant>SOCKET_ECHRNG</constant> 
+    <constant>SOCKET_ECHRNG</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1409,7 +1409,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-el2nsync">
    <term>
-    <constant>SOCKET_EL2NSYNC</constant> 
+    <constant>SOCKET_EL2NSYNC</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1420,7 +1420,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-el3hlt">
    <term>
-    <constant>SOCKET_EL3HLT</constant> 
+    <constant>SOCKET_EL3HLT</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1431,7 +1431,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-el3rst">
    <term>
-    <constant>SOCKET_EL3RST</constant> 
+    <constant>SOCKET_EL3RST</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1442,7 +1442,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-elnrng">
    <term>
-    <constant>SOCKET_ELNRNG</constant> 
+    <constant>SOCKET_ELNRNG</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1453,7 +1453,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eunatch">
    <term>
-    <constant>SOCKET_EUNATCH</constant> 
+    <constant>SOCKET_EUNATCH</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1464,7 +1464,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enocsi">
    <term>
-    <constant>SOCKET_ENOCSI</constant> 
+    <constant>SOCKET_ENOCSI</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1475,7 +1475,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-el2hlt">
    <term>
-    <constant>SOCKET_EL2HLT</constant> 
+    <constant>SOCKET_EL2HLT</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1486,7 +1486,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-ebade">
    <term>
-    <constant>SOCKET_EBADE</constant> 
+    <constant>SOCKET_EBADE</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1497,7 +1497,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-ebadr">
    <term>
-    <constant>SOCKET_EBADR</constant> 
+    <constant>SOCKET_EBADR</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1508,7 +1508,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-exfull">
    <term>
-    <constant>SOCKET_EXFULL</constant> 
+    <constant>SOCKET_EXFULL</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1519,7 +1519,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enoano">
    <term>
-    <constant>SOCKET_ENOANO</constant> 
+    <constant>SOCKET_ENOANO</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1530,7 +1530,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-ebadrqc">
    <term>
-    <constant>SOCKET_EBADRQC</constant> 
+    <constant>SOCKET_EBADRQC</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1541,7 +1541,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-ebadslt">
    <term>
-    <constant>SOCKET_EBADSLT</constant> 
+    <constant>SOCKET_EBADSLT</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1552,7 +1552,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enostr">
    <term>
-    <constant>SOCKET_ENOSTR</constant> 
+    <constant>SOCKET_ENOSTR</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1563,7 +1563,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enodata">
    <term>
-    <constant>SOCKET_ENODATA</constant> 
+    <constant>SOCKET_ENODATA</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1574,7 +1574,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-etime">
    <term>
-    <constant>SOCKET_ETIME</constant> 
+    <constant>SOCKET_ETIME</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1585,7 +1585,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enosr">
    <term>
-    <constant>SOCKET_ENOSR</constant> 
+    <constant>SOCKET_ENOSR</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1596,7 +1596,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enonet">
    <term>
-    <constant>SOCKET_ENONET</constant> 
+    <constant>SOCKET_ENONET</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1605,10 +1605,10 @@
     </simpara>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="constant.socket-enolink">
    <term>
-    <constant>SOCKET_ENOLINK</constant> 
+    <constant>SOCKET_ENOLINK</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1619,7 +1619,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eadv">
    <term>
-    <constant>SOCKET_EADV</constant> 
+    <constant>SOCKET_EADV</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1630,7 +1630,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-esrmnt">
    <term>
-    <constant>SOCKET_ESRMNT</constant> 
+    <constant>SOCKET_ESRMNT</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1641,7 +1641,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-ecomm">
    <term>
-    <constant>SOCKET_ECOMM</constant> 
+    <constant>SOCKET_ECOMM</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1652,7 +1652,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eproto">
    <term>
-    <constant>SOCKET_EPROTO</constant> 
+    <constant>SOCKET_EPROTO</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1663,7 +1663,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-emultihop">
    <term>
-    <constant>SOCKET_EMULTIHOP</constant> 
+    <constant>SOCKET_EMULTIHOP</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1674,7 +1674,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-ebadmsg">
    <term>
-    <constant>SOCKET_EBADMSG</constant> 
+    <constant>SOCKET_EBADMSG</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1685,7 +1685,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enotuniq">
    <term>
-    <constant>SOCKET_ENOTUNIQ</constant> 
+    <constant>SOCKET_ENOTUNIQ</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1696,7 +1696,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-ebadfd">
    <term>
-    <constant>SOCKET_EBADFD</constant> 
+    <constant>SOCKET_EBADFD</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1707,7 +1707,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eremchg">
    <term>
-    <constant>SOCKET_EREMCHG</constant> 
+    <constant>SOCKET_EREMCHG</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1718,7 +1718,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-erestart">
    <term>
-    <constant>SOCKET_ERESTART</constant> 
+    <constant>SOCKET_ERESTART</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1729,7 +1729,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-estrpipe">
    <term>
-    <constant>SOCKET_ESTRPIPE</constant> 
+    <constant>SOCKET_ESTRPIPE</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1738,14 +1738,14 @@
     </simpara>
    </listitem>
   </varlistentry>
-  
-  
-  
-  
-  
+
+
+
+
+
   <varlistentry xml:id="constant.socket-eprotoopt">
    <term>
-    <constant>SOCKET_EPROTOOPT</constant> 
+    <constant>SOCKET_EPROTOOPT</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1754,14 +1754,14 @@
     </simpara>
    </listitem>
   </varlistentry>
-  
-  
-  
-  
-  
+
+
+
+
+
   <varlistentry xml:id="constant.socket-addrinuse">
    <term>
-    <constant>SOCKET_ADDRINUSE</constant> 
+    <constant>SOCKET_ADDRINUSE</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1770,19 +1770,19 @@
     </simpara>
    </listitem>
   </varlistentry>
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
+
+
+
   <varlistentry xml:id="constant.socket-etoomanyrefs">
    <term>
-    <constant>SOCKET_ETOOMANYREFS</constant> 
+    <constant>SOCKET_ETOOMANYREFS</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1791,15 +1791,15 @@
     </simpara>
    </listitem>
   </varlistentry>
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
   <varlistentry xml:id="constant.socket-eisnam">
    <term>
-    <constant>SOCKET_EISNAM</constant> 
+    <constant>SOCKET_EISNAM</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1810,7 +1810,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-eremoteio">
    <term>
-    <constant>SOCKET_EREMOTEIO</constant> 
+    <constant>SOCKET_EREMOTEIO</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1821,7 +1821,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-edquot">
    <term>
-    <constant>SOCKET_EDQUOT</constant> 
+    <constant>SOCKET_EDQUOT</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1832,7 +1832,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-enomedium">
    <term>
-    <constant>SOCKET_ENOMEDIUM</constant> 
+    <constant>SOCKET_ENOMEDIUM</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1843,7 +1843,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.socket-emediumtype">
    <term>
-    <constant>SOCKET_EMEDIUMTYPE</constant> 
+    <constant>SOCKET_EMEDIUMTYPE</constant>
     (<type>int</type>)
    </term>
    <listitem>

--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -169,6 +169,17 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.so-incoming-cpu">
+   <term>
+    <constant>SO_INCOMING_CPU</constant> 
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.so-reuseaddr">
    <term>
     <constant>SO_REUSEADDR</constant> 

--- a/reference/sockets/functions/socket-get-option.xml
+++ b/reference/sockets/functions/socket-get-option.xml
@@ -90,6 +90,24 @@
           </entry>
          </row>
          <row>
+          <entry><constant>SO_MEMINFO</constant></entry>
+          <entry>
+          Reports all meminfo related information in a single <function>socket_get_option</function> call
+          </entry>
+          <entry>
+           <type>array</type>. The array will contain nine keys:
+           <varname>rmem_alloc</varname> <type>int</type>,
+           <varname>rcvbuf</varname> <type>int</type>,
+           <varname>wmem_alloc</varname> <type>int</type>,
+           <varname>sndbuf</varname> <type>int</type>,
+           <varname>fwd_alloc</varname> <type>int</type>,
+           <varname>wmem_queued</varname> <type>int</type>,
+           <varname>optmem</varname> <type>int</type>,
+           <varname>backlog</varname> <type>int</type>,
+           <varname>drops</varname> <type>int</type>.
+          </entry>
+         </row>
+         <row>
           <entry><constant>SO_REUSEADDR</constant></entry>
           <entry>
            Reports whether local addresses can be reused.

--- a/reference/sockets/functions/socket-get-option.xml
+++ b/reference/sockets/functions/socket-get-option.xml
@@ -81,6 +81,15 @@
           </entry>
          </row>
          <row>
+          <entry><constant>SO_INCOMING_CPU</constant></entry>
+          <entry>
+           Reports the CPU affinity of a socket.
+          </entry>
+          <entry>
+           <type>int</type>
+          </entry>
+         </row>
+         <row>
           <entry><constant>SO_REUSEADDR</constant></entry>
           <entry>
            Reports whether local addresses can be reused.
@@ -488,6 +497,12 @@
     </thead>
     <tbody>
      &sockets.changelog.socket-param;
+     <row>
+      <entry>8.2.0</entry>
+      <entry>
+       Option <constant>SO_INCOMING_CPU</constant> added.
+      </entry>
+     </row>
     </tbody>
    </tgroup>
   </informaltable>


### PR DESCRIPTION
Hey there :vulcan_salute:

this PR will add the documentation for the following new Sockets constants as found in #1803 

- [x] SO_INCOMING_CPU
- [x]  SO_MEMINFO
- [ ]  SO_RTABLE (OpenBSD)
- [ ]  TCP_KEEPALIVE (MacOS)
- [ ]  TCP_KEEPCNT (Linux, others)
- [ ]  TCP_KEEPIDLE (Linux, others)
- [ ]  TCP_KEEPINTVL (Linux, others)
- [ ]  TCP_NOTSENT_LOWAT
- [ ]  LOCAL_CREDS_PERSISTENT (FreeBSD)
- [ ]  SCM_CREDS2 (FreeBSD)
- [ ]  LOCAL_CREDS (NetBSD)
- [ ]  SO_BPF_EXTENSIONS
- [ ]  SO_SETFIB
- [ ]  TCP_CONGESTION (Linux, FreeBSD)
- [ ]  SO_ZEROCOPY (Linux)
- [ ]  MSG_ZEROCOPY (Linux)

Kind regards
Florian