### PR TITLE
Fix PDO::prepare code style

### DIFF
--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -131,11 +131,11 @@
 $sql = 'SELECT name, colour, calories
     FROM fruit
     WHERE calories < :calories AND colour = :colour';
-$sth = $dbh->prepare($sql, array(PDO::ATTR_CURSOR => PDO::CURSOR_FWDONLY));
-$sth->execute(array('calories' => 150, 'colour' => 'red'));
+$sth = $dbh->prepare($sql, [PDO::ATTR_CURSOR => PDO::CURSOR_FWDONLY]);
+$sth->execute(['calories' => 150, 'colour' => 'red']);
 $red = $sth->fetchAll();
 /* Array keys can be prefixed with colons ":" too (optional) */
-$sth->execute(array(':calories' => 175, ':colour' => 'yellow'));
+$sth->execute([':calories' => 175, ':colour' => 'yellow']);
 $yellow = $sth->fetchAll();
 ?>
 ]]>
@@ -150,9 +150,9 @@ $yellow = $sth->fetchAll();
 $sth = $dbh->prepare('SELECT name, colour, calories
     FROM fruit
     WHERE calories < ? AND colour = ?');
-$sth->execute(array(150, 'red'));
+$sth->execute([150, 'red']);
 $red = $sth->fetchAll();
-$sth->execute(array(175, 'yellow'));
+$sth->execute([175, 'yellow']);
 $yellow = $sth->fetchAll();
 ?>
 ]]>


### PR DESCRIPTION
This PR replaces `array()` with square brackets `[]` in [PDO::prepare](https://www.php.net/manual/en/pdo.prepare.php) method examples. Right now they are inconsistent.

<img width="835" alt="Screenshot 2022-09-16 at 22 50 00" src="https://user-images.githubusercontent.com/1849174/190719777-47926348-a365-40be-9ea5-196685892c66.png">
