### PR TITLE
the default argument is nullable

### DIFF
--- a/reference/memcached/memcached/construct.xml
+++ b/reference/memcached/memcached/construct.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <constructorsynopsis>
    <modifier>public</modifier> <methodname>Memcached::__construct</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>persistent_id</parameter></methodparam>
+   <methodparam choice="opt"><type>?string</type><parameter>persistent_id</parameter><initializer>null</initializer></methodparam>
   </constructorsynopsis>
   <para>
    Creates a Memcached instance representing the connection to the memcache

--- a/reference/memcached/memcached/construct.xml
+++ b/reference/memcached/memcached/construct.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <constructorsynopsis>
    <modifier>public</modifier> <methodname>Memcached::__construct</methodname>
-   <methodparam choice="opt"><type>?string</type><parameter>persistent_id</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>persistent_id</parameter><initializer>null</initializer></methodparam>
   </constructorsynopsis>
   <para>
    Creates a Memcached instance representing the connection to the memcache


### PR DESCRIPTION
prototype is `?string $persistent_id=null`   - UNTESTED, i don't know if `<type>?string</type>` is actually valid or not.. someone should double-check that before merging