### PR TITLE
[PHP 8.1]  Calling mb_check_encoding() without argument is deprecated

### DIFF
--- a/reference/mbstring/functions/mb-check-encoding.xml
+++ b/reference/mbstring/functions/mb-check-encoding.xml
@@ -37,8 +37,7 @@
 
       <warning>
         <para>
-          As of PHP 8.1.0, omitting this parameter or passing NULL is deprecated and
-          emits an <constant>E_DEPRECATED</constant> warning.
+          As of PHP 8.1.0, omitting this parameter or passing &null; is deprecated.
         </para>
       </warning>
      </listitem>
@@ -76,7 +75,7 @@
      <row>
       <entry>8.1.0</entry>
       <entry>
-       Calling this function with null as <parameter>value</parameter> or without argument is deprecated.
+       Calling this function with &null; as <parameter>value</parameter> or without argument is deprecated.
       </entry>
      </row>
      <row>

--- a/reference/mbstring/functions/mb-check-encoding.xml
+++ b/reference/mbstring/functions/mb-check-encoding.xml
@@ -34,6 +34,13 @@
         The byte stream or &array; to check. If it is omitted, this function checks
         all the input from the beginning of the request.
       </para>
+
+      <warning>
+        <para>
+          As of PHP 8.1.0, omitting this parameter or passing NULL is deprecated and
+          emits an <constant>E_DEPRECATED</constant> warning.
+        </para>
+      </warning>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/mbstring/functions/mb-check-encoding.xml
+++ b/reference/mbstring/functions/mb-check-encoding.xml
@@ -67,6 +67,12 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.1.0</entry>
+      <entry>
+       Calling this function with null as <parameter>value</parameter> or without argument is deprecated.
+      </entry>
+     </row>
+     <row>
       <entry>8.0.0</entry>
       <entry>
        <parameter>value</parameter> and <parameter>encoding</parameter> are nullable now.


### PR DESCRIPTION
Passing null or omitting the arguments is deprecated as of this RFC https://wiki.php.net/rfc/deprecations_php_8_1 