### PR TITLE
Update the example in Stringable interface

### DIFF
--- a/language/predefined/stringable.xml
+++ b/language/predefined/stringable.xml
@@ -58,16 +58,12 @@
 <![CDATA[
 <?php
 class IPv4Address implements Stringable {
-    private string $oct1;
-    private string $oct2;
-    private string $oct3;
-    private string $oct4;
-
-    public function __construct(string $oct1, string $oct2, string $oct3, string $oct4) {
-        $this->oct1 = $oct1;
-        $this->oct2 = $oct2;
-        $this->oct3 = $oct3;
-        $this->oct4 = $oct4;
+    public function __construct(
+        private readonly string $oct1,
+        private readonly string $oct2,
+        private readonly string $oct3,
+        private readonly string $oct4,
+    ) {
     }
 
     public function __toString(): string {


### PR DESCRIPTION
The example in Stringable interface is updated to use the constructor promotion and readonly properties.