### PR TITLE
Fix grammar in code example comment

### DIFF
--- a/reference/filesystem/functions/tempnam.xml
+++ b/reference/filesystem/functions/tempnam.xml
@@ -96,7 +96,7 @@ $handle = fopen($tmpfname, "w");
 fwrite($handle, "writing to tempfile");
 fclose($handle);
 
-// do here something
+// do something here
 
 unlink($tmpfname);
 ?>


### PR DESCRIPTION
Updates a comment in the example as "do something here" is a more complete sentence than "do here something".