### PR TITLE
Document unserialize max_depth option

### DIFF
--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -652,12 +652,7 @@
        <entry>PHP_INI_ALL</entry>
        <entry>Deprecated as of PHP 7.2.0, removed as of PHP 8.0.0</entry>
       </row>
-      <row>
-       <entry><link linkend="ini.unserialize-callback-func">unserialize_callback_func</link></entry>
-       <entry>NULL</entry>
-       <entry>PHP_INI_ALL</entry>
-       <entry></entry>
-      </row>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('unserialize.configuration.list')/*)"><xi:fallback/></xi:include>
       <row>
        <entry>uploadprogress.file.filename_template</entry>
        <entry>"/tmp/upt_%s.txt"</entry>

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -317,7 +317,7 @@
     <member><link linkend="ini.session.gc-probability">session.gc_probability</link></member>
     <member><link linkend="ini.soap.wsdl-cache-limit">soap.wsdl_cache_limit</link></member>
     <member><link linkend="ini.soap.wsdl-cache-ttl">soap.wsdl_cache_ttl</link></member>
-    <member>unserialize_max_depth</member>
+    <member><link linkend="ini.unserialize-max-depth">unserialize_max_depth</link></member>
     <member><link linkend="ini.upload-max-filesize">upload_max_filesize</link></member>
     <member><link linkend="ini.user-ini.cache-ttl">user_ini.cache_ttl</link></member>
     <member><link linkend="ini.xmlrpc-error-number">xmlrpc_error_number</link></member>

--- a/language/oop5/autoload.xml
+++ b/language/oop5/autoload.xml
@@ -90,6 +90,7 @@ Fatal error: Interface 'ITest' not found in ...
     <simplelist>
      <member><function>unserialize</function></member>
      <member><link linkend="ini.unserialize-callback-func">unserialize_callback_func</link></member>
+     <member><link linkend="ini.unserialize-max-depth">unserialize_max_depth</link></member>
      <member><function>spl_autoload_register</function></member>
      <member><function>spl_autoload</function></member>
      <member><function>__autoload</function></member>

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -104,6 +104,18 @@
            </simpara>
           </entry>
          </row>
+         <row>
+          <entry><literal>max_depth</literal></entry>
+          <entry><type>int</type></entry>
+          <entry>
+           <simpara>
+            The maximum depth of structures permitted during unserialization,
+            and is intended to prevent stack overflows. The default depth limit
+            is <literal>4096</literal> and can be disabled by setting
+            <literal>max_depth</literal> to <literal>0</literal>.
+           </simpara>
+          </entry>
+         </row>
         </tbody>
        </tgroup>
       </table>
@@ -145,6 +157,13 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>7.4.0</entry>
+       <entry>
+        Added the <literal>max_depth</literal> element of
+        <parameter>options</parameter> to set the maximum depth of structures permitted during unserialization.
+       </entry>
+      </row>
       <row>
        <entry>7.1.0</entry>
        <entry>
@@ -237,6 +256,7 @@ function mycallback($classname)
     <member><function>serialize</function></member>
     <member><link linkend="language.oop5.autoload">Autoloading Classes</link></member>
     <member><link linkend="ini.unserialize-callback-func">unserialize_callback_func</link></member>
+    <member><link linkend="ini.unserialize-max-depth">unserialize_max_depth</link></member>
     <member><link linkend="object.wakeup">__wakeup()</link></member>
     <member><link linkend="object.serialize">__serialize()</link></member>
     <member><link linkend="object.unserialize">__unserialize()</link></member>

--- a/reference/var/ini.xml
+++ b/reference/var/ini.xml
@@ -68,7 +68,7 @@
       <literal>unserialize_max_depth=0</literal>.
      </para>
      <para>
-      See also <function>unserialize</function> and <link linkend="language.oop5.autoload">Autoloading Objects</link>.
+      See also <function>unserialize</function> and <link linkend="language.oop5.autoload">Autoloading Classes</link>.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/var/ini.xml
+++ b/reference/var/ini.xml
@@ -15,12 +15,18 @@
       <entry>&Changelog;</entry>
      </row>
     </thead>
-    <tbody>
+    <tbody xml:id="unserialize.configuration.list">
     <row>
      <entry><link linkend="ini.unserialize-callback-func">unserialize_callback_func</link></entry>
      <entry>&null;</entry>
      <entry>PHP_INI_ALL</entry>
      <entry></entry>
+    </row>
+    <row>
+     <entry><link linkend="ini.unserialize-max-depth">unserialize_max_depth</link></entry>
+     <entry>"4096"</entry>
+     <entry>PHP_INI_ALL</entry>
+     <entry>Available as of PHP 7.4.0.</entry>
     </row>
     </tbody>
    </tgroup>
@@ -43,6 +49,23 @@
       attempts to use an undefined class. A warning appears if the specified
       callback function is not defined, or if the callback function fails to
       define the missing class.
+     </para>
+     <para>
+      See also <function>unserialize</function> and <link linkend="language.oop5.autoload">Autoloading Classes</link>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.unserialize-max-depth">
+    <term xml:id="unserialize-max-depth">
+     <parameter>unserialize_max_depth</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <para>
+      The maximum depth of structures permitted during unserialization when
+      using <function>unserialize</function>, and is intended to prevent stack
+      overflows. This can be disabled by setting
+      <literal>unserialize_max_depth=0</literal>.
      </para>
      <para>
       See also <function>unserialize</function> and <link linkend="language.oop5.autoload">Autoloading Objects</link>.


### PR DESCRIPTION
Resolves #1822 

I initially set out to resolve just #1822 but noticed `max_depth` also wasn't documented as an option, so I took a swing at that, as well.