### PR TITLE
Added example for specifying max decimal places in sprintf

### DIFF
--- a/reference/strings/functions/sprintf.xml
+++ b/reference/strings/functions/sprintf.xml
@@ -206,6 +206,33 @@ echo $formatted;
    </screen>
   </example>
   <example>
+   <title><function>sprintf</function>: specifying the maximum number of decimal places</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$a = 1.0;
+$b = 1.1;
+$c = 1.12;
+$d = 1.123;
+
+echo sprintf('%.3h', $a) . "\n";
+echo sprintf('%.3h', $b) . "\n";
+echo sprintf('%.3h', $c) . "\n";
+echo sprintf('%.3h', $d) . "\n";
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1
+1.1
+1.12
+1.12
+]]>
+   </screen>
+  </example>
+  <example>
    <title><function>sprintf</function>: scientific notation</title>
    <programlisting role="php">
 <![CDATA[


### PR DESCRIPTION
Formatting numbers with a maximum number of decimal places (and not a fixed number of decimals) is a general need. But the description of the `g` specifier (and its variants `G`, `h` and `H`) is hard to understand.

The example helps to understand how to define the precision correctly.

If you like this PR I'd be happy if you would merge it or label it with [`hacktoberfest-accepted`](https://hacktoberfest.com/participation/). Thanks in advance.