### PR TITLE
Fix consistency for is_a()

### DIFF
--- a/reference/classobj/functions/is-a.xml
+++ b/reference/classobj/functions/is-a.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Checks if the given <parameter>object_or_class</parameter> is of this object type or has
-   this class as one of its parents.
+   this object type as one of its parents.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -53,8 +53,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; if the object is of this class or has this class as one of
-   its parents, &false; otherwise.
+   Returns &true; if the object is of this object type or has this object type
+   as one of its parents, &false; otherwise.
   </para>
  </refsect1>
  <refsect1 role="examples">


### PR DESCRIPTION
Hi there, 
During my work for the translation on doc-fr, i saw `reference/classobj/functions/is-a.xml` seems not very consistent. It's speak about "object type" and "class" for the same things, it's maybe better to keep only one of those ?

Related PR on doc-fr [here](https://github.com/php/doc-fr/pull/293) 

Thanks !