### PR TITLE
Outdated information about warning of array_change_key_case

### DIFF
--- a/reference/array/functions/array-change-key-case.xml
+++ b/reference/array/functions/array-change-key-case.xml
@@ -55,14 +55,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   Throws <constant>E_WARNING</constant> if <parameter>array</parameter> is
-   not an array.
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>


### PR DESCRIPTION
Function throws `Fatal error: Uncaught TypeError: array_change_key_case(): Argument #1 ($array) must be of type array` which is default value of generic incorrect type passed to the function. It's not anymore internal behavior of the function.