### PR TITLE
Document Key management API for ext-mongodb 1.15

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2827,6 +2827,142 @@ local: {
           </entry>
          </row>
 '>
+<!ENTITY mongodb.option.encryption.masterKey-options-by-provider '
+  <para xmlns="http://docbook.org/ns/docbook">
+   <table>
+    <title><literal>"aws"</literal> provider options</title>
+    <tgroup cols="3">
+     <thead>
+      <row>
+       <entry>Option</entry>
+       <entry>Type</entry>
+       <entry>Description</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>region</entry>
+       <entry>string</entry>
+       <entry>Required.</entry>
+      </row>
+      <row>
+       <entry>key</entry>
+       <entry>string</entry>
+       <entry>Required. The Amazon Resource Name (ARN) to the AWS customer master key (CMK).</entry>
+      </row>
+      <row>
+       <entry>endpoint</entry>
+       <entry>string</entry>
+       <entry>Optional. An alternate host identifier to send KMS requests to. May include port number.</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para xmlns="http://docbook.org/ns/docbook">
+   <table>
+    <title><literal>"azure"</literal> provider options</title>
+    <tgroup cols="3">
+     <thead>
+      <row>
+       <entry>Option</entry>
+       <entry>Type</entry>
+       <entry>Description</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>keyVaultEndpoint</entry>
+       <entry>string</entry>
+       <entry>Required. Host with optional port (e.g. "example.vault.azure.net").</entry>
+      </row>
+      <row>
+       <entry>keyName</entry>
+       <entry>string</entry>
+       <entry>Required.</entry>
+      </row>
+      <row>
+       <entry>keyVersion</entry>
+       <entry>string</entry>
+       <entry>Optional. A specific version of the named key. Defaults to using the key&apos;s primary version.</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para xmlns="http://docbook.org/ns/docbook">
+   <table>
+    <title><literal>"gcp"</literal> provider options</title>
+    <tgroup cols="3">
+     <thead>
+      <row>
+       <entry>Option</entry>
+       <entry>Type</entry>
+       <entry>Description</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>projectId</entry>
+       <entry>string</entry>
+       <entry>Required.</entry>
+      </row>
+      <row>
+       <entry>location</entry>
+       <entry>string</entry>
+       <entry>Required.</entry>
+      </row>
+      <row>
+       <entry>keyRing</entry>
+       <entry>string</entry>
+       <entry>Required.</entry>
+      </row>
+      <row>
+       <entry>keyName</entry>
+       <entry>string</entry>
+       <entry>Required.</entry>
+      </row>
+      <row>
+       <entry>keyVersion</entry>
+       <entry>string</entry>
+       <entry>Optional. A specific version of the named key. Defaults to using the key&apos;s primary version.</entry>
+      </row>
+      <row>
+       <entry>endpoint</entry>
+       <entry>string</entry>
+       <entry>Optional. Host with optional port. Defaults to "cloudkms.googleapis.com".</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para xmlns="http://docbook.org/ns/docbook">
+   <table>
+    <title><literal>"kmip"</literal> provider options</title>
+    <tgroup cols="3">
+     <thead>
+      <row>
+       <entry>Option</entry>
+       <entry>Type</entry>
+       <entry>Description</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>keyId</entry>
+       <entry>string</entry>
+       <entry>Optional. Unique identifier to a 96-byte KMIP secret data managed object. If unspecified, the driver creates a random 96-byte KMIP secret data managed object.</entry>
+      </row>
+      <row>
+       <entry>endpoint</entry>
+       <entry>string</entry>
+       <entry>Optional. Host with optional port.</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+'>
 <!ENTITY mongodb.option.encryption.tlsOptions '
          <row xmlns="http://docbook.org/ns/docbook">
           <entry>tlsOptions</entry>

--- a/reference/mongodb/mongodb/driver/clientencryption/addkeyaltname.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/addkeyaltname.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision: 344035 $ -->
+
+<refentry xml:id="mongodb-driver-clientencryption.addkeyaltname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::addKeyAltName</refname>
+  <refpurpose>Adds an alternate name to a key document</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\ClientEncryption::addKeyAltName</methodname>
+   <methodparam><type>MongoDB\BSON\Binary</type><parameter>keyId</parameter></methodparam>
+   <methodparam><type>string</type><parameter>keyAltName</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Adds <parameter>keyAltName</parameter> to the set of alternate names for the
+   key document with the given UUID <parameter>keyId</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>keyId</parameter></term>
+    <listitem>
+     <para>
+      A <classname>MongoDB\BSON\Binary</classname> instance with subtype 4
+      (UUID) identifying the key document.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><parameter>keyAltName</parameter></term>
+    <listitem>
+     <para>
+      Alternate name to add to the key document.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the previous version of the key document, or &null; if no document
+   matched.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.std;
+   <member>Throws <classname>MongoDB\Driver\Exception\RuntimeException</classname> on other errors.</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\ClientEncryption::getKeyByAltName</function></member>
+   <member><function>MongoDB\Driver\ClientEncryption::removeKeyAltName</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/clientencryption/createdatakey.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/createdatakey.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="mongodb-driver-clientencryption.createdatakey" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\Driver\ClientEncryption::createDataKey</refname>
-  <refpurpose>Create a new encryption data key</refpurpose>
+  <refpurpose>Creates a key document</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -27,8 +27,7 @@
     <listitem>
      <para>
       The KMS provider (e.g. <literal>"local"</literal>,
-      <literal>"aws"</literal>, <literal>"azure"</literal>,
-      <literal>"gcp"</literal>) that will be used to encrypt the new encryption
+      <literal>"aws"</literal>) that will be used to encrypt the new encryption
       key.
      </para>
     </listitem>
@@ -58,120 +57,7 @@
             data key. This option is required unless
             <parameter>kmsProvider</parameter> is <literal>"local"</literal>.
            </para>
-           <para>
-            If <parameter>kmsProvider</parameter> is <literal>"aws"</literal>,
-            this option is required and has the following fields:
-            <table>
-             <title>AWS masterKey options</title>
-             <tgroup cols="3">
-              <thead>
-               <row>
-                <entry>Option</entry>
-                <entry>Type</entry>
-                <entry>Description</entry>
-               </row>
-              </thead>
-              <tbody>
-               <row>
-                <entry>region</entry>
-                <entry>string</entry>
-                <entry>Required.</entry>
-               </row>
-               <row>
-                <entry>key</entry>
-                <entry>string</entry>
-                <entry>Required. The Amazon Resource Name (ARN) to the AWS customer master key (CMK).</entry>
-               </row>
-               <row>
-                <entry>endpoint</entry>
-                <entry>string</entry>
-                <entry>Optional. An alternate host identifier to send KMS requests to. May include port number.</entry>
-               </row>
-              </tbody>
-             </tgroup>
-            </table>
-           </para>
-           <para>
-            If <parameter>kmsProvider</parameter> is <literal>"azure"</literal>,
-            this option is required and has the following fields:
-            <table>
-             <title>Azure masterKey options</title>
-             <tgroup cols="3">
-              <thead>
-               <row>
-                <entry>Option</entry>
-                <entry>Type</entry>
-                <entry>Description</entry>
-               </row>
-              </thead>
-              <tbody>
-               <row>
-                <entry>keyVaultEndpoint</entry>
-                <entry>string</entry>
-                <entry>Required. Host with optional port (e.g. "example.vault.azure.net").</entry>
-               </row>
-               <row>
-                <entry>keyName</entry>
-                <entry>string</entry>
-                <entry>Required.</entry>
-               </row>
-               <row>
-                <entry>keyVersion</entry>
-                <entry>string</entry>
-                <entry>Optional. A specific version of the named key. Defaults to using the key's primary version.</entry>
-               </row>
-              </tbody>
-             </tgroup>
-            </table>
-           </para>
-           <para>
-            If <parameter>kmsProvider</parameter> is <literal>"gcp"</literal>,
-            this option is required and has the following fields:
-            <table>
-             <title>GCP masterKey options</title>
-             <tgroup cols="3">
-              <thead>
-               <row>
-                <entry>Option</entry>
-                <entry>Type</entry>
-                <entry>Description</entry>
-               </row>
-              </thead>
-              <tbody>
-               <row>
-                <entry>projectId</entry>
-                <entry>string</entry>
-                <entry>Required.</entry>
-               </row>
-               <row>
-                <entry>location</entry>
-                <entry>string</entry>
-                <entry>Required.</entry>
-               </row>
-               <row>
-                <entry>keyRing</entry>
-                <entry>string</entry>
-                <entry>Required.</entry>
-               </row>
-               <row>
-                <entry>keyName</entry>
-                <entry>string</entry>
-                <entry>Required.</entry>
-               </row>
-               <row>
-                <entry>keyVersion</entry>
-                <entry>string</entry>
-                <entry>Optional. A specific version of the named key. Defaults to using the key's primary version.</entry>
-               </row>
-               <row>
-                <entry>endpoint</entry>
-                <entry>string</entry>
-                <entry>Optional. Host with optional port. Defaults to "cloudkms.googleapis.com".</entry>
-               </row>
-              </tbody>
-             </tgroup>
-            </table>
-           </para>
+           &mongodb.option.encryption.masterKey-options-by-provider;
           </entry>
          </row>
          <row>
@@ -206,8 +92,8 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <simplelist>
-   &mongodb.throws.argumentparsing;
-   <member>Throws <classname>MongoDB\Driver\Exception\EncryptionException</classname> if an error occurs while creating the data key</member>
+   &mongodb.throws.std;
+   <member>Throws <classname>MongoDB\Driver\Exception\RuntimeException</classname> on other errors.</member>
   </simplelist>
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/clientencryption/deletekey.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/deletekey.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision: 344035 $ -->
+
+<refentry xml:id="mongodb-driver-clientencryption.deletekey" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::deleteKey</refname>
+  <refpurpose>Deletes a key document</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\ClientEncryption::deleteKey</methodname>
+   <methodparam><type>MongoDB\BSON\Binary</type><parameter>keyId</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Removes the key document with the given UUID <parameter>keyId</parameter>
+   from the key vault collection.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>keyId</parameter></term>
+    <listitem>
+     <para>
+      A <classname>MongoDB\BSON\Binary</classname> instance with subtype 4
+      (UUID) identifying the key document.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the result of the internal <literal>deleteOne</literal> operation on
+   the key vault collection.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.std;
+   <member>Throws <classname>MongoDB\Driver\Exception\RuntimeException</classname> on other errors.</member>
+  </simplelist>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/clientencryption/getkey.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/getkey.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision: 344035 $ -->
+
+<refentry xml:id="mongodb-driver-clientencryption.getkey" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::getKey</refname>
+  <refpurpose>Gets a key document</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\ClientEncryption::getKey</methodname>
+   <methodparam><type>MongoDB\BSON\Binary</type><parameter>keyId</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Finds a single key document in the key vault collection with the given UUID
+   <parameter>keyId</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>keyId</parameter></term>
+    <listitem>
+     <para>
+      A <classname>MongoDB\BSON\Binary</classname> instance with subtype 4
+      (UUID) identifying the key document.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the key document, or &null; if no document matched.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.std;
+   <member>Throws <classname>MongoDB\Driver\Exception\RuntimeException</classname> on other errors.</member>
+  </simplelist>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/clientencryption/getkeybyaltname.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/getkeybyaltname.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision: 344035 $ -->
+
+<refentry xml:id="mongodb-driver-clientencryption.getkeybyaltname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::getKeyByAltName</refname>
+  <refpurpose>Gets a key document by an alternate name</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\ClientEncryption::getKeyByAltName</methodname>
+   <methodparam><type>string</type><parameter>keyAltName</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Finds a single key document in the key vault collection with the given
+   alternate name <parameter>keyAltName</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+<varlistentry>
+    <term><parameter>keyAltName</parameter></term>
+    <listitem>
+     <para>
+      Alternate name for the key document.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the key document, or &null; if no document matched.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.std;
+   <member>Throws <classname>MongoDB\Driver\Exception\RuntimeException</classname> on other errors.</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\ClientEncryption::addKeyAltName</function></member>
+   <member><function>MongoDB\Driver\ClientEncryption::removeKeyAltName</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/clientencryption/getkeybyaltname.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/getkeybyaltname.xml
@@ -22,7 +22,7 @@
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
-<varlistentry>
+   <varlistentry>
     <term><parameter>keyAltName</parameter></term>
     <listitem>
      <para>

--- a/reference/mongodb/mongodb/driver/clientencryption/getkeys.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/getkeys.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision: 344035 $ -->
+
+<refentry xml:id="mongodb-driver-clientencryption.getkeys" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::getKeys</refname>
+  <refpurpose>Gets all key documents</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\ClientEncryption::getKeys</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Finds all key documents in the key vault collection.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  &mongodb.returns.cursor;
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.std;
+   <member>Throws <classname>MongoDB\Driver\Exception\RuntimeException</classname> on other errors.</member>
+  </simplelist>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/clientencryption/removekeyaltname.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/removekeyaltname.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision: 344035 $ -->
+
+<refentry xml:id="mongodb-driver-clientencryption.removekeyaltname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::removeKeyAltName</refname>
+  <refpurpose>Removes an alternate name from a key document</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\ClientEncryption::removeKeyAltName</methodname>
+   <methodparam><type>MongoDB\BSON\Binary</type><parameter>keyId</parameter></methodparam>
+   <methodparam><type>string</type><parameter>keyAltName</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Removes <parameter>keyAltName</parameter> from the set of alternate names for
+   the key document with the given UUID <parameter>keyId</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>keyId</parameter></term>
+    <listitem>
+     <para>
+      A <classname>MongoDB\BSON\Binary</classname> instance with subtype 4
+      (UUID) identifying the key document.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><parameter>keyAltName</parameter></term>
+    <listitem>
+     <para>
+      Alternate name to remove from the key document.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the previous version of the key document, or &null; if no document
+   matched.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.std;
+   <member>Throws <classname>MongoDB\Driver\Exception\RuntimeException</classname> on other errors.</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\ClientEncryption::addKeyAltName</function></member>
+   <member><function>MongoDB\Driver\ClientEncryption::getKeyByAltName</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/clientencryption/rewrapmanydatakey.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/rewrapmanydatakey.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision: 344035 $ -->
+
+<refentry xml:id="mongodb-driver-clientencryption.rewrapmanydatakey" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::rewrapManyDataKey</refname>
+  <refpurpose>Rewraps data keys</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\ClientEncryption::rewrapManyDataKey</methodname>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Rewraps (i.e. decrypts and re-encrypts) zero or more data keys in the key
+   vault collection that match the given <parameter>filter</parameter>.
+  </para>
+  <para>
+   If the <literal>"provider"</literal> option is not specified, matching data
+   keys will be rewrapped with their current KMS provider. Otherwise, matching
+   data keys will be re-encrypted according to the specified
+   <literal>"provider"</literal> and <literal>"masterKey"</literal> options.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &mongodb.parameter.filter;
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>RewrapManyDataKey options</title>
+       <tgroup cols="3">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry>provider</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <para>
+            The KMS provider (e.g. <literal>"local"</literal>,
+            <literal>"aws"</literal>) that will be used to re-encrypt the
+            matched data keys.
+           </para>
+           <para>
+            If a KMS provider is not specified, matched data keys will be
+            re-encrypted with their current KMS provider.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>masterKey</entry>
+          <entry><type>array</type></entry>
+          <entry>
+           <para>
+            The masterKey identifies a KMS-specific key used to encrypt the new
+            data key. This option should not be specified without the
+            <literal>"provider"</literal> option. This option is required if
+            <literal>"provider"</literal> is specified and not
+            <literal>"local"</literal>.
+           </para>
+           &mongodb.option.encryption.masterKey-options-by-provider;
+          </entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns an object, which will have an optional
+   <literal>bulkWriteResult</literal> property containing the result of the
+   internal <literal>bulkWrite</literal> operation as an object. If no data keys
+   matched the filter or the write was unacknowledged, the
+   <literal>bulkWriteResult</literal> property will be &null;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.std;
+   <member>Throws <classname>MongoDB\Driver\Exception\EncryptionException</classname> if an error occurs while decrypting or re-encrypting a data key.</member>
+   <member>Throws <classname>MongoDB\Driver\Exception\RuntimeException</classname> on other errors.</member>
+  </simplelist>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/clientencryption/rewrapmanydatakey.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/rewrapmanydatakey.xml
@@ -90,7 +90,7 @@
    <literal>bulkWriteResult</literal> property containing the result of the
    internal <literal>bulkWrite</literal> operation as an object. If no data keys
    matched the filter or the write was unacknowledged, the
-   <literal>bulkWriteResult</literal> property will be &null;
+   <literal>bulkWriteResult</literal> property will be &null;.
   </para>
  </refsect1>
 

--- a/reference/mongodb/versions.xml
+++ b/reference/mongodb/versions.xml
@@ -29,9 +29,16 @@
 
  <function name='mongodb\driver\clientencryption' from='mongodb &gt;=1.7.0'/>
  <function name='mongodb\driver\clientencryption::__construct' from='mongodb &gt;=1.14.0'/>
+ <function name='mongodb\driver\clientencryption::addkeyaltname' from='mongodb &gt;=1.15.0'/>
  <function name='mongodb\driver\clientencryption::createdatakey' from='mongodb &gt;=1.7.0'/>
  <function name='mongodb\driver\clientencryption::decrypt' from='mongodb &gt;=1.7.0'/>
+ <function name='mongodb\driver\clientencryption::deletekey' from='mongodb &gt;=1.15.0'/>
  <function name='mongodb\driver\clientencryption::encrypt' from='mongodb &gt;=1.7.0'/>
+ <function name='mongodb\driver\clientencryption::getkey' from='mongodb &gt;=1.15.0'/>
+ <function name='mongodb\driver\clientencryption::getkeybyaltname' from='mongodb &gt;=1.15.0'/>
+ <function name='mongodb\driver\clientencryption::getkeys' from='mongodb &gt;=1.15.0'/>
+ <function name='mongodb\driver\clientencryption::removekeyaltname' from='mongodb &gt;=1.15.0'/>
+ <function name='mongodb\driver\clientencryption::rewrapmanydatakey' from='mongodb &gt;=1.15.0'/>
 
  <function name='mongodb\driver\command' from='mongodb &gt;=1.0.0'/>
  <function name='mongodb\driver\command::__construct' from='mongodb &gt;=1.0.0'/>


### PR DESCRIPTION
Moves the masterKey docs to a common snippet, since it's duplicated for createDataKey and rewrapManyDataKey.

Also adds missing docs for the KMIP provider's masterKey document, which was introduced in version 1.12.

https://jira.mongodb.org/browse/PHPC-2093
https://jira.mongodb.org/browse/PHPC-1912