### PR TITLE
Removed obsolete mysqlnd install description.

### DIFF
--- a/reference/mysqlnd/install.xml
+++ b/reference/mysqlnd/install.xml
@@ -9,8 +9,7 @@
   </para>
 
   <para>
-    The MySQL database extensions must be configured to use the MySQL
-    Client Library. In order to use the MySQL Native Driver, PHP needs
+    In order to use the MySQL Native Driver, PHP needs
     to be built specifying that the MySQL database extensions are
     compiled with MySQL Native Driver support. This is done through
     configuration options prior to building the PHP source code.


### PR DESCRIPTION
We don't have to use MySQL Client Library(libmysqlclient) for installing MySQL database extension, because we already have mysqlnd.