### PR TITLE
Update return value for levenshtein

### DIFF
--- a/reference/strings/functions/levenshtein.xml
+++ b/reference/strings/functions/levenshtein.xml
@@ -113,7 +113,7 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       Prior to this version, <function>levenshtein</function> would return -1
+       Prior to this version, <function>levenshtein</function> would return <literal>-1</literal>
        if one of the argument strings is longer than 255 characters.
       </entry>
      </row>

--- a/reference/strings/functions/levenshtein.xml
+++ b/reference/strings/functions/levenshtein.xml
@@ -88,8 +88,7 @@
   &reftitle.returnvalues;
   <para>
    This function returns the Levenshtein-Distance between the
-   two argument strings or -1, if one of the argument strings
-   is longer than the limit of 255 characters.
+   two argument strings.
   </para>
  </refsect1>
 
@@ -109,6 +108,13 @@
       <entry>
        Prior to this version, <function>levenshtein</function> had to be called
        with either two or five arguments.
+      </entry>
+     </row>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       Prior to this version, <function>levenshtein</function> would return -1
+       if one of the argument strings is longer than 255 characters.
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
The character limit on the 2 string arguments for the levenshtein function was removed in PHP 8. The documentation should be updated to reflection this difference. 

https://github.com/php/php-src/commit/6a8c094e2d86a8d9294e4d7fddabd9486bc92ed8