### PR TITLE
Reduce overhead of SQL placeholder creation

### DIFF
--- a/reference/pdo/pdostatement/execute.xml
+++ b/reference/pdo/pdostatement/execute.xml
@@ -145,7 +145,7 @@ $sth->execute();
 /* Execute a prepared statement using an array of values for an IN clause */
 $params = array(1, 21, 63, 171);
 /* Create a string for the parameter placeholders filled to the number of params */
-$place_holders = implode(',', array_fill(0, count($params), '?'));
+$place_holders = '?'.str_repeat(', ?', count($params)-1);
 
 /*
     This prepares the statement with enough unnamed placeholders for every value

--- a/reference/pdo/pdostatement/execute.xml
+++ b/reference/pdo/pdostatement/execute.xml
@@ -145,7 +145,7 @@ $sth->execute();
 /* Execute a prepared statement using an array of values for an IN clause */
 $params = array(1, 21, 63, 171);
 /* Create a string for the parameter placeholders filled to the number of params */
-$place_holders = '?'.str_repeat(', ?', count($params)-1);
+$place_holders = '?' . str_repeat(', ?', count($params) - 1);
 
 /*
     This prepares the statement with enough unnamed placeholders for every value


### PR DESCRIPTION
The incredibly wasteful way this example creates SQL placeholders has long annoyed me, so here's a fix.