### PR TITLE
Fix #1897: Document limits of NumberFormatter and possible workaround

### DIFF
--- a/reference/intl/messageformatter/format-message.xml
+++ b/reference/intl/messageformatter/format-message.xml
@@ -30,8 +30,8 @@
   <para>
    Quick formatting function that formats the string without having to
    explicitly create the formatter object. Use this function when the format
-   operation is done only once and does not need and parameters or state to be
-   kept.
+   operation is done only once and does not need and parameters, state to be
+   kept or when wanting to customize the output by providing additional context to ICU directly.
   </para>
  </refsect1>
 
@@ -108,6 +108,23 @@ echo MessageFormatter::formatMessage("de", "{0,number,integer} Affen auf {1,numb
 4.560 Affen auf 123 Bäumen sind 37,073 Affen pro Baum
 ]]>
   </screen>
+  <example>
+   <title>Instructing ICU to format currency with common and with narrow currency symbol</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+echo msgfmt_format_message("cs_CZ", "{0, number, :: currency/CAD}", array(123.45));
+echo msgfmt_format_message("cs_CZ", "{0, number, :: currency/CAD unit-width-narrow}", array(123.45));
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+123,45 CA$
+123,45 $
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/intl/messageformatter/format-message.xml
+++ b/reference/intl/messageformatter/format-message.xml
@@ -110,6 +110,7 @@ echo MessageFormatter::formatMessage("de", "{0,number,integer} Affen auf {1,numb
   </screen>
   <example>
    <title>Instructing ICU to format currency with common and with narrow currency symbol</title>
+   <simpara>Requires ICU ≥ 67.</simpara>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/intl/messageformatter/format-message.xml
+++ b/reference/intl/messageformatter/format-message.xml
@@ -30,7 +30,7 @@
   <para>
    Quick formatting function that formats the string without having to
    explicitly create the formatter object. Use this function when the format
-   operation is done only once and does not need and parameters, state to be
+   operation is done only once and does not need any parameters or state to be
    kept or when wanting to customize the output by providing additional context to ICU directly.
   </para>
  </refsect1>

--- a/reference/intl/messageformatter/parse-message.xml
+++ b/reference/intl/messageformatter/parse-message.xml
@@ -30,7 +30,7 @@
   <para>
    Parses input string without explicitly creating the formatter object. Use
    this function when the format operation is done only once and does not need
-   and parameters or state to be kept.
+   any parameters or state to be kept.
   </para>
  </refsect1>
  

--- a/reference/intl/numberformatter/format-currency.xml
+++ b/reference/intl/numberformatter/format-currency.xml
@@ -114,6 +114,19 @@ echo $fmt->formatCurrency(1234567.891234567890000, "RUR")."\n";
   </screen>
  </refsect1>
 
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <para>
+    Formats achievable by this method of formatting cannot fully use the possibilities of underlying ICU library,
+    such as to format currency with narrow currency symbol.
+   </para>
+   <para>
+    To fully utilize them use <function>msgfmt_format_message</function>.
+   </para>
+  </note>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -121,6 +134,7 @@ echo $fmt->formatCurrency(1234567.891234567890000, "RUR")."\n";
     <member><function>numfmt_get_error_code</function></member>
     <member><function>numfmt_format</function></member>
     <member><function>numfmt_parse_currency</function></member>
+    <member><function>msgfmt_format_message</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/intl/numberformatter/format.xml
+++ b/reference/intl/numberformatter/format.xml
@@ -114,6 +114,19 @@ if(intl_is_failure($fmt->getErrorCode())) {
   </screen>
  </refsect1>
 
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <para>
+    Formats achievable by this method of formatting cannot fully use the possibilities of underlying ICU library,
+    such as to format currency with narrow currency symbol.
+   </para>
+   <para>
+    To fully utilize them use <function>msgfmt_format_message</function>.
+   </para>
+  </note>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -121,6 +134,7 @@ if(intl_is_failure($fmt->getErrorCode())) {
     <member><function>numfmt_get_error_code</function></member>
     <member><function>numfmt_format_currency</function></member>
     <member><function>numfmt_parse</function></member>
+    <member><function>msgfmt_format_message</function></member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
Document a way how to get currency formatted with narrow currency symbol as discussed in #1897.