### PR TITLE
Document new 8.2 curl constants

### DIFF
--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -4064,7 +4064,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 8.2.0 and cURL 7.77.0
+     Available as of PHP 8.2.0 and cURL 7.77.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -4075,7 +4075,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 8.2.0 and cURL 7.71.0
+     Available as of PHP 8.2.0 and cURL 7.71.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -4086,7 +4086,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 8.2.0 and cURL 7.68.0
+     Available as of PHP 8.2.0 and cURL 7.68.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -4097,7 +4097,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 8.2.0 and cURL 7.70.0
+     Available as of PHP 8.2.0 and cURL 7.70.0
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -190,6 +190,17 @@
        </simpara>
      </listitem>
    </varlistentry>
+   <varlistentry xml:id="constant.curlftpmethod-default">
+     <term>
+       <constant>CURLFTPMETHOD_DEFAULT</constant>
+       (<type>int</type>)
+     </term>
+     <listitem>
+       <simpara>
+        Available as of PHP 8.2.0 and cURL 7.15.3.
+       </simpara>
+     </listitem>
+   </varlistentry>
    <varlistentry xml:id="constant.curlopt-private">
      <term>
        <constant>CURLOPT_PRIVATE</constant>
@@ -1619,6 +1630,17 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlauth-aws-sigv4">
+   <term>
+    <constant>CURLAUTH_AWS_SIGV4</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.75.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-proxyauth">
    <term>
     <constant>CURLOPT_PROXYAUTH</constant>
@@ -2701,6 +2723,17 @@
    <listitem>
     <simpara>
      
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curle-proxy">
+   <term>
+    <constant>CURLE_PROXY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -3903,6 +3936,17 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlmopt-max-concurrent-streams">
+   <term>
+    <constant>CURLMOPT_MAX_CONCURRENT_STREAMS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.67.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlmopt-chunk-length-penalty-size">
    <term>
     <constant>CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE</constant>
@@ -4219,6 +4263,17 @@
    <listitem>
     <simpara>
      Available since PHP 7.0.7 and cURL 7.40.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlproto-mqtt">
+   <term>
+    <constant>CURLPROTO_MQTT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 8.2.0 and cURL 7.71.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -1252,7 +1252,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1263,7 +1262,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1274,7 +1272,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1285,7 +1282,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1307,7 +1303,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1318,7 +1313,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1329,7 +1323,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1351,7 +1344,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1362,7 +1354,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1395,7 +1386,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1406,7 +1396,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1461,7 +1450,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1472,7 +1460,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1483,7 +1470,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1494,7 +1480,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1505,7 +1490,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1516,7 +1500,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1527,7 +1510,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1538,7 +1520,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1549,7 +1530,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1560,7 +1540,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1571,7 +1550,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1582,7 +1560,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1593,7 +1570,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1615,7 +1591,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1626,7 +1601,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1637,7 +1611,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1659,7 +1632,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1681,7 +1653,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1692,7 +1663,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>
@@ -1714,7 +1684,6 @@
    </term>
    <listitem>
     <simpara>
-     
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -1550,6 +1550,28 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlinfo-proxy-error">
+   <term>
+    <constant>CURLINFO_PROXY_ERROR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 8.2.0 and cURL >= 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlinfo-referrer">
+   <term>
+    <constant>CURLINFO_REFERER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 8.2.0 and cURL >= 7.76.0
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlinfo-response-code">
    <term>
     <constant>CURLINFO_RESPONSE_CODE</constant>
@@ -1558,6 +1580,17 @@
    <listitem>
     <simpara>
      Available since cURL 7.10.8
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlinfo-retry-after">
+   <term>
+    <constant>CURLINFO_RETRY_AFTER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 8.2.0 and cURL >= 7.66.0
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -43,6 +43,43 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-doh-ssl-verifyhost">
+   <term>
+    <constant>CURLOPT_DOH_SSL_VERIFYHOST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Verify the DNS-over-HTTPS server's SSL certificate name fields against the host name.
+     Available as of PHP 8.2.0 and cURL 7.76.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-doh-ssl-verifypeer">
+   <term>
+    <constant>CURLOPT_DOH_SSL_VERIFYPEER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Verify the authenticity of the DNS-over-HTTPS server's SSL certificate.
+     Available as of PHP 8.2.0 and cURL 7.76.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-doh-ssl-verifypeer">
+   <term>
+    <constant>CURLOPT_DOH_SSL_VERIFYPEER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Tell cURL to verify the status of the DNS-over-HTTPS server certificate 
+     using the "Certificate Status Request" TLS extension (OCSP stapling).
+     Available as of PHP 8.2.0 and cURL 7.76.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-dns-use-global-cache">
    <term>
     <constant>CURLOPT_DNS_USE_GLOBAL_CACHE</constant>
@@ -1131,6 +1168,17 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-cainfo-blob">
+   <term>
+    <constant>CURLOPT_CAINFO_BLOB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.77.0
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-capath">
    <term>
     <constant>CURLOPT_CAPATH</constant>
@@ -1370,6 +1418,17 @@
    <listitem>
     <simpara>
      
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-aws-sigv4">
+   <term>
+    <constant>CURLOPT_AWS_SIGV4</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.75.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -4215,6 +4274,17 @@
    <listitem>
     <simpara>
      Available since PHP 7.3.0 and cURL 7.52.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-cainfo-blobl">
+   <term>
+    <constant>CURLOPT_PROXY_CAINFO_BLOB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 8.2.0 and cURL 7.77.0
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -4057,6 +4057,50 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlsslopt-auto-client-cert">
+   <term>
+    <constant>CURLSSLOPT_AUTO_CLIENT_CERT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 8.2.0 and cURL 7.77.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlsslopt-native-ca">
+   <term>
+    <constant>CURLSSLOPT_NATIVE_CA</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 8.2.0 and cURL 7.71.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlsslopt-no-partialchain">
+   <term>
+    <constant>CURLSSLOPT_NO_PARTIALCHAIN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 8.2.0 and cURL 7.68.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlsslopt-revoke-best-effort">
+   <term>
+    <constant>CURLSSLOPT_REVOKE_BEST_EFFORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 8.2.0 and cURL 7.70.0
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-username">
    <term>
     <constant>CURLOPT_USERNAME</constant>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -67,9 +67,9 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curlopt-doh-ssl-verifypeer">
+  <varlistentry xml:id="constant.curlopt-doh-ssl-verifystatus">
    <term>
-    <constant>CURLOPT_DOH_SSL_VERIFYPEER</constant>
+    <constant>CURLOPT_DOH_SSL_VERIFYSTATUS</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1616,7 +1616,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 8.2.0 and cURL >= 7.73.0
+     Available as of PHP 8.2.0 and cURL 7.73.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -1627,7 +1627,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 8.2.0 and cURL >= 7.76.0
+     Available as of PHP 8.2.0 and cURL 7.76.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -1649,7 +1649,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 8.2.0 and cURL >= 7.66.0
+     Available as of PHP 8.2.0 and cURL 7.66.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2104,7 +2104,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 8.2.0 and cURL 7.76.0
+     Available as of PHP 8.2.0 and cURL 7.76.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2139,7 +2139,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 8.2.0 and cURL 7.74.0
+     Available as of PHP 8.2.0 and cURL 7.74.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2243,7 +2243,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 8.2.0 and cURL 7.66.0
+     Available as of PHP 8.2.0 and cURL 7.66.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2325,7 +2325,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 8.2.0 and cURL 7.72.0
+     Available as of PHP 8.2.0 and cURL 7.72.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2348,7 +2348,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 8.2.0 and cURL 7.72.0
+     Available as of PHP 8.2.0 and cURL 7.72.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -4284,7 +4284,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 8.2.0 and cURL 7.77.0
+     Available as of PHP 8.2.0 and cURL 7.77.0
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -1278,6 +1278,50 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-hsts">
+   <term>
+    <constant>CURLOPT_HSTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.74.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-hsts-ctrl">
+   <term>
+    <constant>CURLOPT_HSTS_CTRL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.74.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlhsts-enable">
+   <term>
+    <constant>CURLHSTS_ENABLE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.74.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlhsts-readonlyfile">
+   <term>
+    <constant>CURLHSTS_READONLYFILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.74.0
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-sslkey">
    <term>
     <constant>CURLOPT_SSLKEY</constant>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -428,6 +428,17 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-upload-buffersize">
+   <term>
+    <constant>CURLOPT_UPLOAD_BUFFERSIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.62.0
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-post">
    <term>
     <constant>CURLOPT_POST</constant>
@@ -1058,6 +1069,39 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-maxage-conn">
+   <term>
+    <constant>CURLOPT_MAXAGE_CONN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.65.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-maxfilesize-large">
+   <term>
+    <constant>CURLOPT_MAXFILESIZE_LARGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.11.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-maxlifetime-conn">
+   <term>
+    <constant>CURLOPT_MAXLIFETIME_CONN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.80.0
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-maxredirs">
    <term>
     <constant>CURLOPT_MAXREDIRS</constant>
@@ -1209,6 +1253,17 @@
    <listitem>
     <simpara>
      
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssl-ec-curves">
+   <term>
+    <constant>CURLOPT_SSL_EC_CURVES</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -1572,6 +1627,28 @@
    <listitem>
     <simpara>
      
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-mail-rcpt-allowfails">
+   <term>
+    <constant>CURLOPT_MAIL_RCPT_ALLLOWFAILS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.69.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-upkeep-interval-ms">
+   <term>
+    <constant>CURLOPT_UPKEEP_INTERVAL_MS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.62.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -3441,6 +3518,17 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssh-host-public-key-md5">
+   <term>
+    <constant>CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.80.0
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-ssh-private-keyfile">
    <term>
     <constant>CURLOPT_SSH_PRIVATE_KEYFILE</constant>
@@ -3504,6 +3592,17 @@
    <listitem>
     <simpara>
      Available since cURL 7.19.1
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-sasl-ir">
+   <term>
+    <constant>CURLOPT_SASL_AUTHZID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.66.0
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -2038,6 +2038,17 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curl-version-gsasl">
+   <term>
+    <constant>CURL_VERSION_GSASL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 8.2.0 and cURL 7.76.0
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curl-version-gssapi">
    <term>
     <constant>CURL_VERSION_GSSAPI</constant>
@@ -2059,6 +2070,17 @@
     <simpara>
      Negotiate auth is supported.
      Available since PHP 7.3.0 and cURL 7.10.6 (deprecated since 7.38.0)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-hsts">
+   <term>
+    <constant>CURL_VERSION_HSTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 8.2.0 and cURL 7.74.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2155,6 +2177,17 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curl-version-http3">
+   <term>
+    <constant>CURL_VERSION_HTTP3</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 8.2.0 and cURL 7.66.0
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curl-version-largefile">
    <term>
     <constant>CURL_VERSION_LARGEFILE</constant>
@@ -2226,6 +2259,17 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curl-version-unicode">
+   <term>
+    <constant>CURL_VERSION_UNICODE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 8.2.0 and cURL 7.72.0
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curl-version-unix-sockets">
    <term>
     <constant>CURL_VERSION_UNIX_SOCKETS</constant>
@@ -2235,6 +2279,17 @@
     <simpara>
      Unix domain sockets support.
      Available since PHP 7.0.7 and cURL 7.40.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-zstd">
+   <term>
+    <constant>CURL_VERSION_ZSTD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available since PHP 8.2.0 and cURL 7.72.0
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -1829,6 +1829,380 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlpx-bad-address-type">
+   <term>
+    <constant>CURLPX_BAD_ADDRESS_TYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-bad-version">
+   <term>
+    <constant>CURLPX_BAD_VERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-closed">
+   <term>
+    <constant>CURLPX_CLOSED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-gssapi">
+   <term>
+    <constant>CURLPX_GSSAPI</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-gssapi-permsg">
+   <term>
+    <constant>CURLPX_GSSAPI_PERMSG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-gssapi-protection">
+   <term>
+    <constant>CURLPX_GSSAPI_PROTECTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-identd-differ">
+   <term>
+    <constant>CURLPX_IDENTD_DIFFER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-identd">
+   <term>
+    <constant>CURLPX_IDENTD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-long-hostname">
+   <term>
+    <constant>CURLPX_LONG_HOSTNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-long-passwd">
+   <term>
+    <constant>CURLPX_LONG_PASSWD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-long-user">
+   <term>
+    <constant>CURLPX_LONG_USER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-no-auth">
+   <term>
+    <constant>CURLPX_NO_AUTH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-ok">
+   <term>
+    <constant>CURLPX_OK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-recv-address">
+   <term>
+    <constant>CURLPX_RECV_ADDRESS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-recv-auth">
+   <term>
+    <constant>CURLPX_RECV_AUTH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-recv-connect">
+   <term>
+    <constant>CURLPX_RECV_CONNECT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-recv-reqack">
+   <term>
+    <constant>CURLPX_RECV_REQACK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-reply-address-type-not-supported">
+   <term>
+    <constant>CURLPX_REPLY_ADDRESS_TYPE_NOT_SUPPORTED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-reply-command-not-supported">
+   <term>
+    <constant>CURLPX_REPLY_COMMAND_NOT_SUPPORTED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-reply-connection-refused">
+   <term>
+    <constant>CURLPX_REPLY_CONNECTION_REFUSED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-reply-general-server-failure">
+   <term>
+    <constant>CURLPX_REPLY_GENERAL_SERVER_FAILURE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-reply-host-unreachable">
+   <term>
+    <constant>CURLPX_REPLY_HOST_UNREACHABLE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-reply-network-unreachable">
+   <term>
+    <constant>CURLPX_REPLY_NETWORK_UNREACHABLE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-reply-not-allowed">
+   <term>
+    <constant>CURLPX_REPLY_NOT_ALLOWED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-reply-ttl-expired">
+   <term>
+    <constant>CURLPX_REPLY_TTL_EXPIRED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-reply-unassigned">
+   <term>
+    <constant>CURLPX_REPLY_UNASSIGNED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-request-failed">
+   <term>
+    <constant>CURLPX_REQUEST_FAILED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-resolve-host">
+   <term>
+    <constant>CURLPX_RESOLVE_HOST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-send-auth">
+   <term>
+    <constant>CURLPX_SEND_AUTH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-send-connect">
+   <term>
+    <constant>CURLPX_SEND_CONNECT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-send-request">
+   <term>
+    <constant>CURLPX_SEND_REQUEST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-unknown-fail">
+   <term>
+    <constant>CURLPX_UNKNOWN_FAIL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-unknown-mode">
+   <term>
+    <constant>CURLPX_UNKNOWN_MODE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlpx-user-rejected">
+   <term>
+    <constant>CURLPX_USER_REJECTED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.73.0
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlinfo-referrer">
    <term>
     <constant>CURLINFO_REFERER</constant>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -1648,7 +1648,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 7.0.7 and cURL 7.38.0.
+     Available as of PHP 7.0.7 and cURL 7.38.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1670,7 +1670,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 7.0.7 and cURL 7.22.0
+     Available as of PHP 7.0.7 and cURL 7.22.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -1747,7 +1747,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since cURL 7.15.5
+     Available as of cURL 7.15.5
     </simpara>
    </listitem>
   </varlistentry>
@@ -1758,7 +1758,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since cURL 7.15.5
+     Available as of cURL 7.15.5
     </simpara>
    </listitem>
   </varlistentry>
@@ -1769,7 +1769,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 7.0.7 and cURL 7.37.0
+     Available as of PHP 7.0.7 and cURL 7.37.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -1780,7 +1780,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 7.0.7 and cURL 7.37.0
+     Available as of PHP 7.0.7 and cURL 7.37.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -4757,7 +4757,7 @@
    </term>
    <listitem>
     <simpara>
-     Available since PHP 8.2.0 and cURL 7.71.0.
+     Available as of PHP 8.2.0 and cURL 7.71.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -373,6 +373,72 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-altsvc">
+   <term>
+    <constant>CURLOPT_ALTSVC</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.64.1.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-altsvc-ctrl">
+   <term>
+    <constant>CURLOPT_ALTSVC_CTRL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.64.1.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlaltsvc-h1">
+   <term>
+    <constant>CURLALTSVC_H1</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.64.1.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlaltsvc-h2">
+   <term>
+    <constant>CURLALTSVC_H2</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.64.1.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlaltsvc-h3">
+   <term>
+    <constant>CURLALTSVC_H3</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.64.1.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlaltsvc-readonlyfile">
+   <term>
+    <constant>CURLALTSVC_READONLYFILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.64.1.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-header">
    <term>
     <constant>CURLOPT_HEADER</constant>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -74,7 +74,7 @@
    </term>
    <listitem>
     <simpara>
-     Tell cURL to verify the status of the DNS-over-HTTPS server certificate 
+     Tell cURL to verify the status of the DNS-over-HTTPS server certificate
      using the "Certificate Status Request" TLS extension (OCSP stapling).
      Available as of PHP 8.2.0 and cURL 7.76.0.
     </simpara>
@@ -3518,7 +3518,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curlopt-ssh-host-public-key-md5">
+  <varlistentry xml:id="constant.curlopt-ssh-host-public-key-sha256">
    <term>
     <constant>CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256</constant>
     (<type>int</type>)
@@ -3595,7 +3595,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curlopt-sasl-ir">
+  <varlistentry xml:id="constant.curlopt-sasl-authzid">
    <term>
     <constant>CURLOPT_SASL_AUTHZID</constant>
     (<type>int</type>)

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -140,7 +140,17 @@
         </listitem>
         <listitem>
          <simpara>
+          <constant>CURLINFO_REFERER</constant> - The referrer header
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
         <constant>CURLINFO_REQUEST_SIZE</constant> - Total size of issued requests, currently only for HTTP requests
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_RETRY_AFTER</constant> - The information from the <literal>Retry-After:</literal> header, or zero if there was no valid header.
          </simpara>
         </listitem>
         <listitem>
@@ -166,6 +176,11 @@
         <listitem>
          <simpara>
           <constant>CURLINFO_PRIVATE</constant> - Private data associated with this cURL handle, previously set with the <constant>CURLOPT_PRIVATE</constant> option of <function>curl_setopt</function>
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>CURLINFO_PROXY_ERROR</constant> - The detailed (SOCKS) proxy error
          </simpara>
         </listitem>
         <listitem>
@@ -507,6 +522,14 @@
      </thead>
      <tbody>
       &curl.changelog.handle-param;
+      <row>
+       <entry>8.2.0</entry>
+       <entry>
+        Introduced <constant>CURLINFO_PROXY_ERROR</constant>,
+        <constant>CURLINFO_REFERER</constant>,
+        <constant>CURLINFO_RETRY_AFTER</constant>.
+       </entry>
+      </row>
       <row>
        <entry>8.0.0</entry>
        <entry>

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -182,7 +182,8 @@
          <simpara>
           <constant>CURLINFO_PROXY_ERROR</constant> - The detailed (SOCKS) proxy error code when the most recent 
           transfer returned a <constant>CURLE_PROXY</constant> error. The returned value will be exactly one 
-          of the <constant>CURLPX_*</constant> values. The error code will be <constant>CURLPX_OK</constant> if no
+          of the <constant>CURLPX_<replaceable>*</replaceable></constant> values.
+          The error code will be <constant>CURLPX_OK</constant> if no
           response code was available.
          </simpara>
         </listitem>

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -180,8 +180,8 @@
         </listitem>
         <listitem>
          <simpara>
-          <constant>CURLINFO_PROXY_ERROR</constant> - The detailed (SOCKS) proxy error code when the most recent 
-          transfer returned a <constant>CURLE_PROXY</constant> error. The returned value will be exactly one 
+          <constant>CURLINFO_PROXY_ERROR</constant> - The detailed (SOCKS) proxy error code when the most recent
+          transfer returned a <constant>CURLE_PROXY</constant> error. The returned value will be exactly one
           of the <constant>CURLPX_<replaceable>*</replaceable></constant> values.
           The error code will be <constant>CURLPX_OK</constant> if no
           response code was available.

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -180,7 +180,10 @@
         </listitem>
         <listitem>
          <simpara>
-          <constant>CURLINFO_PROXY_ERROR</constant> - The detailed (SOCKS) proxy error
+          <constant>CURLINFO_PROXY_ERROR</constant> - The detailed (SOCKS) proxy error code when the most recent 
+          transfer returned a <constant>CURLE_PROXY</constant> error. The returned value will be exactly one 
+          of the <constant>CURLPX_*</constant> values. The error code will be <constant>CURLPX_OK</constant> if no
+          response code was available.
          </simpara>
         </listitem>
         <listitem>

--- a/reference/curl/functions/curl-multi-setopt.xml
+++ b/reference/curl/functions/curl-multi-setopt.xml
@@ -105,9 +105,10 @@
            <entry valign="top"><constant>CURLMOPT_MAX_CONCURRENT_STREAMS</constant></entry>
            <entry valign="top">
             The set number will be used as the maximum number of concurrent streams for a connections that cURL
-            should support on connections done using HTTP/2. Valid values range from 1 to 2147483647 (2^31 - 1).
+            should support on connections done using HTTP/2. Valid values range from
+            <literal>1</literal> to <literal>2147483647</literal> (<literal>2^31 - 1</literal>).
             The value passed here would be honored based on other system resources properties.
-            Default is 100.
+            Default is <literal>100</literal>.
            </entry>
           </row>
           <row>

--- a/reference/curl/functions/curl-multi-setopt.xml
+++ b/reference/curl/functions/curl-multi-setopt.xml
@@ -102,6 +102,15 @@
            </entry>
           </row>
           <row>
+           <entry valign="top"><constant>CURLMOPT_MAX_CONCURRENT_STREAMS</constant></entry>
+           <entry valign="top">
+            The set number will be used as the maximum number of concurrent streams for a connections that cURL
+            should support on connections done using HTTP/2. Valid values range from 1 to 2147483647 (2^31 - 1).
+            The value passed here would be honored based on other system resources properties.
+            Default is 100.
+           </entry>
+          </row>
+          <row>
            <entry valign="top"><constant>CURLMOPT_MAX_HOST_CONNECTIONS</constant></entry>
            <entry valign="top">
             Pass a number that specifies the maximum number of connections to a
@@ -193,6 +202,12 @@
      </thead>
      <tbody>
       &curl.changelog.multi-handle-param;
+      <row>
+       <entry>8.2.0</entry>
+       <entry>
+        Introduced <constant>CURLMOPT_MAX_CONCURRENT_STREAMS</constant>.
+       </entry>
+      </row>
       <row>
        <entry>7.1.0</entry>
        <entry>

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -777,11 +777,11 @@
              what methods it supports and pick the best one.
             </para>
             <para>
-             <constant>CURLAUTH_ANY</constant> sets all bits. cURL will automatically select 
+             <constant>CURLAUTH_ANY</constant> sets all bits. cURL will automatically select
              the one it finds most secure.
             </para>
             <para>
-             <constant>CURLAUTH_ANYSAFE</constant> sets all bits except <literal>CURLAUTH_BASIC</literal>. 
+             <constant>CURLAUTH_ANYSAFE</constant> sets all bits except <literal>CURLAUTH_BASIC</literal>.
              cURL will automatically select the one it finds most secure.
             </para>
            </entry>
@@ -954,6 +954,7 @@
              <constant>CURLPROTO_DICT</constant>,
              <constant>CURLPROTO_FILE</constant>,
              <constant>CURLPROTO_TFTP</constant>,
+             <constant>CURLPROTO_MQTT</constant>,
              <constant>CURLPROTO_ALL</constant>
             </para>
            </entry>
@@ -1311,6 +1312,17 @@
            </entry>
           </row>
           <row>
+           <entry valign="top"><constant>CURLMOPT_MAX_CONCURRENT_STREAMS</constant></entry>
+           <entry valign="top">
+            The set number will be used as the maximum number of concurrent streams for a connections that cURL
+            should support on connections done using HTTP/2. Valid values range from 1 to 2147483647 (2^31 - 1).
+            The value passed here would be honored based on other system resources properties.
+            Default is 100.
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
            <entry valign="top"><constant>CURLOPT_MAX_RECV_SPEED_LARGE</constant></entry>
            <entry valign="top">
             If a download exceeds this speed (counted in bytes per second) on
@@ -1367,8 +1379,9 @@
            <entry valign="top"><constant>CURLOPT_FTP_FILEMETHOD</constant></entry>
            <entry valign="top">
             Tell curl which method to use to reach a file on a FTP(S) server. Possible values are
-            <constant>CURLFTPMETHOD_MULTICWD</constant>, 
-            <constant>CURLFTPMETHOD_NOCWD</constant> and  
+            <constant>CURLFTPMETHOD_DEFAULT</constant>,
+            <constant>CURLFTPMETHOD_MULTICWD</constant>,
+            <constant>CURLFTPMETHOD_NOCWD</constant> and 
             <constant>CURLFTPMETHOD_SINGLECWD</constant>.
            </entry>
            <entry valign="top">
@@ -1714,11 +1727,11 @@
           <row>
            <entry valign="top"><constant>CURLOPT_PROXY_CAINFO</constant></entry>
            <entry valign="top">
-            The path to proxy Certificate Authority (CA) bundle. Set the path as a 
-            <type>string</type> naming a file holding one or more certificates to 
+            The path to proxy Certificate Authority (CA) bundle. Set the path as a
+            <type>string</type> naming a file holding one or more certificates to
             verify the HTTPS proxy with.
             This option is for connecting to an HTTPS proxy, not an HTTPS server.
-            Defaults set to the system path where libcurl's cacert bundle is assumed 
+            Defaults set to the system path where libcurl's cacert bundle is assumed
             to be stored.
            </entry>
            <entry valign="top">
@@ -1730,7 +1743,7 @@
            <entry valign="top">
             The name of a PEM file holding one or more certificates to verify the HTTPS proxy with.
             This option is for connecting to an HTTPS proxy, not an HTTPS server.
-            Defaults set to the system path where libcurl's cacert bundle is assumed 
+            Defaults set to the system path where libcurl's cacert bundle is assumed
             to be stored.
            </entry>
            <entry valign="top">

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -281,6 +281,31 @@
            </entry>
           </row>
           <row>
+           <entry valign="top"><constant>CURLOPT_ALTSVC</constant></entry>
+           <entry valign="top">
+            Pass the filename for cURL to use as the Alt-Svc cache file to read existing cache contents from and
+            possibly also write it back to a after a transfer, unless <constant>CURLALTSVC_READONLYFILE</constant>
+            is set via <constant>CURLOPT_ALTSVC_CTRL</constant>.
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_ALTSVC_CTRL</constant></entry>
+           <entry valign="top">
+            Populate the bitmask with the correct set of features to instruct cURL how to handle Alt-Svc for the
+            transfers using this handle. cURL only accepts Alt-Svc headers over HTTPS. It will also only complete
+            a request to an alternative origin if that origin is properly hosted over HTTPS.
+            Setting any bit will enable the alt-svc engine. The options are:
+            <constant>CURLALTSVC_H1</constant>,
+            <constant>CURLALTSVC_H2</constant>,
+            <constant>CURLALTSVC_H3</constant>, and
+            <constant>CURLALTSVC_READONLYFILE</constant>.
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
            <entry valign="top"><constant>CURLOPT_HEADER</constant></entry>
            <entry valign="top">
             &true; to include the header in the output.

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -1091,6 +1091,29 @@
              revocation checks for those SSL backends where such behavior is
              present.
             </simpara>
+            <simpara>
+             <constant>CURLSSLOPT_AUTO_CLIENT_CERT</constant>: automatically
+             locate and use a client certificate for authentication, when
+             requested by the server. This option is only supported for
+             Schannel (the native Windows SSL library).
+            </simpara>
+            <simpara>
+             <constant>CURLSSLOPT_NATIVE_CA</constant>: use the operating system's
+             native CA store for certificate verification. Works only on Windows 
+             when built to use OpenSSL. This option is experimental and behavior is subject to change.
+            </simpara>
+            <simpara>
+             <constant>CURLSSLOPT_NO_PARTIALCHAIN</constant>: do not accept "partial" certificate
+             chains, which cURL otherwise does by default. This option is only supported for OpenSSL
+             and will fail the certificate verification if the chain ends with
+             an intermediate certificate and not with a root certificate.
+            </simpara>
+            <simpara>
+             <constant>CURLSSLOPT_REVOKE_BEST_EFFORT</constant>: ignore certificate revocation checks
+             in case of missing or offline distribution points for those SSL backends where
+             such behavior is present. This option is only supported for Schannel (the native Windows SSL library).
+             If combined with <constant>CURLSSLOPT_NO_REVOKE</constant>, the latter takes precedence.
+            </simpara>
            </entry>
            <entry valign="top">
             Added in cURL 7.25.0. Available since PHP 7.0.7.

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -774,8 +774,8 @@
              Provides AWS V4 signature authentication on HTTP(S) header.
             </para>
             <para>
-             This option overrides the other auth types you might have set in CURLOPT_HTTPAUTH.
-             This method cannot be combined with other auth types.
+             This option overrides any other authentication types that have been set in
+             <constant>CURLOPT_HTTPAUTH</constant>. This method cannot be combined with other authentication types.
             </para>
            </entry>
            <entry valign="top">
@@ -1323,7 +1323,7 @@
             peer with. This option overrides <constant>CURLOPT_CAINFO</constant>.
            </entry>
            <entry valign="top">
-            Available since PHP 8.2.0 and cURL 7.77.0
+            Available as of PHP 8.2.0 and cURL 7.77.0
            </entry>
           </row>
           <row>
@@ -1633,7 +1633,7 @@
             to be stored.
            </entry>
            <entry valign="top">
-            Available since PHP 8.2.0 and libcurl &gt;= cURL 7.77.0.
+            Available as of PHP 8.2.0 and libcurl &gt;= cURL 7.77.0.
            </entry>
           </row>
           <row>

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -451,6 +451,17 @@
            </entry>
           </row>
           <row>
+           <entry valign="top"><constant>CURLOPT_SASL_AUTHZID</constant></entry>
+           <entry valign="top">
+            The null-terminated authorization identity (authzid) for the transfer. Only applicable to the PLAIN SASL
+            authentication mechanism where it is optional. When not specified, only the authentication identity
+            (authcid) as specified by the username will be sent to the server, along with the password.
+            The server will derive the authzid from the authcid when not provided, which it will then use internally.
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
            <entry valign="top"><constant>CURLOPT_SASL_IR</constant></entry>
            <entry valign="top">
             &true; to enable sending the initial response in the first packet.
@@ -585,6 +596,16 @@
            <entry valign="top"><constant>CURLOPT_UPLOAD</constant></entry>
            <entry valign="top">
             &true; to prepare for an upload.
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_UPLOAD_BUFFERSIZE</constant></entry>
+           <entry valign="top">
+            Preferred buffer size in bytes for the cURL upload buffer.
+            The upload buffer size by default is 64 kilobytes. The maximum buffer size allowed to be set is 2 megabytes.
+            The minimum buffer size allowed to be set is 16 kilobytes.
            </entry>
            <entry valign="top">
            </entry>
@@ -831,6 +852,37 @@
             The number of seconds the transfer speed should be below
             <constant>CURLOPT_LOW_SPEED_LIMIT</constant> before PHP considers
             the transfer too slow and aborts.
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_MAXAGE_CONN</constant></entry>
+           <entry valign="top">
+            The maximum idle time allowed for an existing connection to be considered for reuse.
+            Default maximum age is set to 118 seconds.
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_MAXFILESIZE_LARGE</constant></entry>
+           <entry valign="top">
+            The maximum file size in bytes allowed to download. If the file requested is found larger than this value,
+            the transfer will not start and <constant>CURLE_FILESIZE_EXCEEDED</constant> will be returned.
+            The file size is not always known prior to download, and for such files this option has no effect even if
+            the file transfer ends up being larger than this given limit.
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_MAXLIFETIME_CONN</constant></entry>
+           <entry valign="top">
+            The maximum time in seconds, since the creation of the connection, that is allowed for an existing
+            connection to have for it to be considered for reuse. If a connection is found in the cache that is older
+            than this value, it will instead be closed once any in-progress transfers are complete.
+            Default is 0 seconds, meaning the option is disabled and all connections are eligible for reuse.
            </entry>
            <entry valign="top">
            </entry>
@@ -1230,6 +1282,32 @@
            </entry>
            <entry valign="top">
             Added in cURL 7.59.0. Available since PHP 7.3.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_MAIL_RCPT_ALLLOWFAILS</constant></entry>
+           <entry valign="top">
+            Allow RCPT TO command to fail for some recipients.
+           </entry>
+           <entry valign="top">
+            When sending data to multiple recipients, by default cURL will abort SMTP conversation if at least one of
+            the recipients causes RCPT TO command to return an error. This option tells cURL to ignore errors and
+            proceed with the remaining valid recipients. If all recipients trigger RCPT TO failures and this flag is
+            set, cURL will abort the SMTP conversation and return the error received from the last RCPT TO command.
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_UPKEEP_INTERVAL_MS</constant></entry>
+           <entry valign="top">
+            Some protocols have "connection upkeep" mechanisms. These mechanisms usually send some traffic
+            on existing connections in order to keep them alive. This option defines the connection upkeep interval.
+            Currently, the only protocol with a connection upkeep mechanism is HTTP/2. When the connection upkeep
+            interval is exceeded, an HTTP/2 PING frame is sent on the connection.
+            Default is 60 seconds.
+           </entry>
+           <entry valign="top">
            </entry>
           </row>
           <row>
@@ -1877,6 +1955,15 @@
            </entry>
           </row>
           <row>
+           <entry valign="top"><constant>CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256</constant></entry>
+           <entry valign="top">
+            Base64-encoded SHA256 hash of the remote host's public key.
+            The transfer will fail if the given hash does not match the hash the remote host provides.
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
            <entry valign="top"><constant>CURLOPT_SSH_PUBLIC_KEYFILE</constant></entry>
            <entry valign="top">
             The file name for your public key. If not used, libcurl defaults to 
@@ -1906,6 +1993,17 @@
             A list of ciphers to use for SSL. For example,
             <literal>RC4-SHA</literal> and <literal>TLSv1</literal> are valid
             cipher lists.
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_SSL_EC_CURVES</constant></entry>
+           <entry valign="top">
+            A colon delimited list of elliptic curve algorithms. For example,
+            <literal>X25519:P-521</literal> is a valid list of two elliptic curves.
+            This option defines the client's key exchange algorithms in the SSL handshake,
+            if the SSL backend cURL is built to use supports it.
            </entry>
            <entry valign="top">
            </entry>

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -768,6 +768,29 @@
            </entry>
           </row>
           <row>
+           <entry valign="top"><constant>CURLOPT_HSTS</constant></entry>
+           <entry valign="top">
+            <para>
+             HSTS (HTTP Strict Transport Security) cache file name.
+            </para>
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_HSTS_CTRL</constant></entry>
+           <entry valign="top">
+            <para>
+             Controls HSTS (HTTP Strict Transport Security) behavior. Populate the bitmask with the correct set of
+             features to instruct cURL how to handle HSTS for the transfers using this handle.
+             <constant>CURLHSTS_ENABLE</constant> enables the in-memory HSTS cache. If the HSTS cache file is defined,
+             set <constant>CURLHSTS_READONLYFILE</constant> to make the file read-only.
+            </para>
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
            <entry valign="top"><constant>CURLOPT_AWS_SIGV4</constant></entry>
            <entry valign="top">
             <para>

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -816,7 +816,7 @@
            <entry valign="top"><constant>CURLOPT_MAXAGE_CONN</constant></entry>
            <entry valign="top">
             The maximum idle time allowed for an existing connection to be considered for reuse.
-            Default maximum age is set to 118 seconds.
+            Default maximum age is set to <literal>118</literal> seconds.
            </entry>
            <entry valign="top">
            </entry>
@@ -1271,7 +1271,7 @@
             on existing connections in order to keep them alive. This option defines the connection upkeep interval.
             Currently, the only protocol with a connection upkeep mechanism is HTTP/2. When the connection upkeep
             interval is exceeded, an HTTP/2 PING frame is sent on the connection.
-            Default is 60 seconds.
+            Default is <literal>60</literal> seconds.
            </entry>
            <entry valign="top">
            </entry>

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -281,31 +281,6 @@
            </entry>
           </row>
           <row>
-           <entry valign="top"><constant>CURLOPT_ALTSVC</constant></entry>
-           <entry valign="top">
-            Pass the filename for cURL to use as the Alt-Svc cache file to read existing cache contents from and
-            possibly also write it back to a after a transfer, unless <constant>CURLALTSVC_READONLYFILE</constant>
-            is set via <constant>CURLOPT_ALTSVC_CTRL</constant>.
-           </entry>
-           <entry valign="top">
-           </entry>
-          </row>
-          <row>
-           <entry valign="top"><constant>CURLOPT_ALTSVC_CTRL</constant></entry>
-           <entry valign="top">
-            Populate the bitmask with the correct set of features to instruct cURL how to handle Alt-Svc for the
-            transfers using this handle. cURL only accepts Alt-Svc headers over HTTPS. It will also only complete
-            a request to an alternative origin if that origin is properly hosted over HTTPS.
-            Setting any bit will enable the alt-svc engine. The options are:
-            <constant>CURLALTSVC_H1</constant>,
-            <constant>CURLALTSVC_H2</constant>,
-            <constant>CURLALTSVC_H3</constant>, and
-            <constant>CURLALTSVC_READONLYFILE</constant>.
-           </entry>
-           <entry valign="top">
-           </entry>
-          </row>
-          <row>
            <entry valign="top"><constant>CURLOPT_HEADER</constant></entry>
            <entry valign="top">
             &true; to include the header in the output.
@@ -476,17 +451,6 @@
            </entry>
           </row>
           <row>
-           <entry valign="top"><constant>CURLOPT_SASL_AUTHZID</constant></entry>
-           <entry valign="top">
-            The null-terminated authorization identity (authzid) for the transfer. Only applicable to the PLAIN SASL
-            authentication mechanism where it is optional. When not specified, only the authentication identity
-            (authcid) as specified by the username will be sent to the server, along with the password.
-            The server will derive the authzid from the authcid when not provided, which it will then use internally.
-           </entry>
-           <entry valign="top">
-           </entry>
-          </row>
-          <row>
            <entry valign="top"><constant>CURLOPT_SASL_IR</constant></entry>
            <entry valign="top">
             &true; to enable sending the initial response in the first packet.
@@ -621,16 +585,6 @@
            <entry valign="top"><constant>CURLOPT_UPLOAD</constant></entry>
            <entry valign="top">
             &true; to prepare for an upload.
-           </entry>
-           <entry valign="top">
-           </entry>
-          </row>
-          <row>
-           <entry valign="top"><constant>CURLOPT_UPLOAD_BUFFERSIZE</constant></entry>
-           <entry valign="top">
-            Preferred buffer size in bytes for the cURL upload buffer.
-            The upload buffer size by default is 64 kilobytes. The maximum buffer size allowed to be set is 2 megabytes.
-            The minimum buffer size allowed to be set is 16 kilobytes.
            </entry>
            <entry valign="top">
            </entry>
@@ -814,43 +768,6 @@
            </entry>
           </row>
           <row>
-           <entry valign="top"><constant>CURLOPT_HSTS</constant></entry>
-           <entry valign="top">
-            <para>
-             HSTS (HTTP Strict Transport Security) cache file name.
-            </para>
-           </entry>
-           <entry valign="top">
-           </entry>
-          </row>
-          <row>
-           <entry valign="top"><constant>CURLOPT_HSTS_CTRL</constant></entry>
-           <entry valign="top">
-            <para>
-             Controls HSTS (HTTP Strict Transport Security) behavior. Populate the bitmask with the correct set of
-             features to instruct cURL how to handle HSTS for the transfers using this handle.
-             <constant>CURLHSTS_ENABLE</constant> enables the in-memory HSTS cache. If the HSTS cache file is defined,
-             set <constant>CURLHSTS_READONLYFILE</constant> to make the file read-only.
-            </para>
-           </entry>
-           <entry valign="top">
-           </entry>
-          </row>
-          <row>
-           <entry valign="top"><constant>CURLOPT_AWS_SIGV4</constant></entry>
-           <entry valign="top">
-            <para>
-             Provides AWS V4 signature authentication on HTTP(S) header.
-            </para>
-            <para>
-             This option overrides any other authentication types that have been set in
-             <constant>CURLOPT_HTTPAUTH</constant>. This method cannot be combined with other authentication types.
-            </para>
-           </entry>
-           <entry valign="top">
-           </entry>
-          </row>
-          <row>
            <entry valign="top"><constant>CURLOPT_INFILESIZE</constant></entry>
            <entry valign="top">
             The expected size, in bytes, of the file when uploading a file to
@@ -877,6 +794,20 @@
             The number of seconds the transfer speed should be below
             <constant>CURLOPT_LOW_SPEED_LIMIT</constant> before PHP considers
             the transfer too slow and aborts.
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_MAIL_RCPT_ALLLOWFAILS</constant></entry>
+           <entry valign="top">
+            Allow RCPT TO command to fail for some recipients.
+           </entry>
+           <entry valign="top">
+            When sending data to multiple recipients, by default cURL will abort SMTP conversation if at least one of
+            the recipients causes RCPT TO command to return an error. This option tells cURL to ignore errors and
+            proceed with the remaining valid recipients. If all recipients trigger RCPT TO failures and this flag is
+            set, cURL will abort the SMTP conversation and return the error received from the last RCPT TO command.
            </entry>
            <entry valign="top">
            </entry>
@@ -930,6 +861,17 @@
             Default value of <literal>20</literal> is set to prevent infinite redirects.
             Setting to <literal>-1</literal> allows inifinite redirects, and <literal>0</literal>
             refuses all redirects.
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLMOPT_MAX_CONCURRENT_STREAMS</constant></entry>
+           <entry valign="top">
+            The set number will be used as the maximum number of concurrent streams for a connections that cURL
+            should support on connections done using HTTP/2. Valid values range from 1 to 2147483647 (2^31 - 1).
+            The value passed here would be honored based on other system resources properties.
+            Default is 100.
            </entry>
            <entry valign="top">
            </entry>
@@ -1334,20 +1276,6 @@
            </entry>
           </row>
           <row>
-           <entry valign="top"><constant>CURLOPT_MAIL_RCPT_ALLLOWFAILS</constant></entry>
-           <entry valign="top">
-            Allow RCPT TO command to fail for some recipients.
-           </entry>
-           <entry valign="top">
-            When sending data to multiple recipients, by default cURL will abort SMTP conversation if at least one of
-            the recipients causes RCPT TO command to return an error. This option tells cURL to ignore errors and
-            proceed with the remaining valid recipients. If all recipients trigger RCPT TO failures and this flag is
-            set, cURL will abort the SMTP conversation and return the error received from the last RCPT TO command.
-           </entry>
-           <entry valign="top">
-           </entry>
-          </row>
-          <row>
            <entry valign="top"><constant>CURLOPT_UPKEEP_INTERVAL_MS</constant></entry>
            <entry valign="top">
             Some protocols have "connection upkeep" mechanisms. These mechanisms usually send some traffic
@@ -1360,12 +1288,11 @@
            </entry>
           </row>
           <row>
-           <entry valign="top"><constant>CURLMOPT_MAX_CONCURRENT_STREAMS</constant></entry>
+           <entry valign="top"><constant>CURLOPT_UPLOAD_BUFFERSIZE</constant></entry>
            <entry valign="top">
-            The set number will be used as the maximum number of concurrent streams for a connections that cURL
-            should support on connections done using HTTP/2. Valid values range from 1 to 2147483647 (2^31 - 1).
-            The value passed here would be honored based on other system resources properties.
-            Default is 100.
+            Preferred buffer size in bytes for the cURL upload buffer.
+            The upload buffer size by default is 64 kilobytes. The maximum buffer size allowed to be set is 2 megabytes.
+            The minimum buffer size allowed to be set is 16 kilobytes.
            </entry>
            <entry valign="top">
            </entry>
@@ -1465,6 +1392,45 @@
            </entry>
            <entry valign="top">
             Available since PHP 7.3.0 and cURL 7.53.0
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_ALTSVC</constant></entry>
+           <entry valign="top">
+            Pass the filename for cURL to use as the Alt-Svc cache file to read existing cache contents from and
+            possibly also write it back to a after a transfer, unless <constant>CURLALTSVC_READONLYFILE</constant>
+            is set via <constant>CURLOPT_ALTSVC_CTRL</constant>.
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_ALTSVC_CTRL</constant></entry>
+           <entry valign="top">
+            Populate the bitmask with the correct set of features to instruct cURL how to handle Alt-Svc for the
+            transfers using this handle. cURL only accepts Alt-Svc headers over HTTPS. It will also only complete
+            a request to an alternative origin if that origin is properly hosted over HTTPS.
+            Setting any bit will enable the alt-svc engine. The options are:
+            <constant>CURLALTSVC_H1</constant>,
+            <constant>CURLALTSVC_H2</constant>,
+            <constant>CURLALTSVC_H3</constant>, and
+            <constant>CURLALTSVC_READONLYFILE</constant>.
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_AWS_SIGV4</constant></entry>
+           <entry valign="top">
+            <para>
+             Provides AWS V4 signature authentication on HTTP(S) header.
+            </para>
+            <para>
+             This option overrides any other authentication types that have been set in
+             <constant>CURLOPT_HTTPAUTH</constant>. This method cannot be combined with other authentication types.
+            </para>
+           </entry>
+           <entry valign="top">
            </entry>
           </row>
           <row>
@@ -1635,6 +1601,29 @@
             string may be a plain IP address, a hostname, a network
             interface name (under Unix), or just a plain '-' to use the
             systems default IP address.
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_HSTS</constant></entry>
+           <entry valign="top">
+            <para>
+             HSTS (HTTP Strict Transport Security) cache file name.
+            </para>
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_HSTS_CTRL</constant></entry>
+           <entry valign="top">
+            <para>
+             Controls HSTS (HTTP Strict Transport Security) behavior. Populate the bitmask with the correct set of
+             features to instruct cURL how to handle HSTS for the transfers using this handle.
+             <constant>CURLHSTS_ENABLE</constant> enables the in-memory HSTS cache. If the HSTS cache file is defined,
+             set <constant>CURLHSTS_READONLYFILE</constant> to make the file read-only.
+            </para>
            </entry>
            <entry valign="top">
            </entry>
@@ -1990,6 +1979,17 @@
            <entry valign="top">
             The contents of the <literal>"Referer: "</literal> header to be used
             in a HTTP request.
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_SASL_AUTHZID</constant></entry>
+           <entry valign="top">
+            The authorization identity (authzid) for the transfer. Only applicable to the PLAIN SASL
+            authentication mechanism where it is optional. When not specified, only the authentication identity
+            (authcid) as specified by the username will be sent to the server, along with the password.
+            The server will derive the authzid from the authcid when not provided, which it will then use internally.
            </entry>
            <entry valign="top">
            </entry>

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -866,17 +866,6 @@
            </entry>
           </row>
           <row>
-           <entry valign="top"><constant>CURLMOPT_MAX_CONCURRENT_STREAMS</constant></entry>
-           <entry valign="top">
-            The set number will be used as the maximum number of concurrent streams for a connections that cURL
-            should support on connections done using HTTP/2. Valid values range from 1 to 2147483647 (2^31 - 1).
-            The value passed here would be honored based on other system resources properties.
-            Default is 100.
-           </entry>
-           <entry valign="top">
-           </entry>
-          </row>
-          <row>
            <entry valign="top"><constant>CURLOPT_PORT</constant></entry>
            <entry valign="top">
             An alternative port number to connect to.

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -1030,7 +1030,7 @@
             </simpara>
             <simpara>
              <constant>CURLSSLOPT_NATIVE_CA</constant>: use the operating system's
-             native CA store for certificate verification. Works only on Windows 
+             native CA store for certificate verification. Works only on Windows
              when built to use OpenSSL. This option is experimental and behavior is subject to change.
             </simpara>
             <simpara>
@@ -1345,7 +1345,7 @@
             Tell curl which method to use to reach a file on a FTP(S) server. Possible values are
             <constant>CURLFTPMETHOD_DEFAULT</constant>,
             <constant>CURLFTPMETHOD_MULTICWD</constant>,
-            <constant>CURLFTPMETHOD_NOCWD</constant> and 
+            <constant>CURLFTPMETHOD_NOCWD</constant>, and
             <constant>CURLFTPMETHOD_SINGLECWD</constant>.
            </entry>
            <entry valign="top">

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -746,6 +746,7 @@
              <constant>CURLAUTH_DIGEST</constant>,
              <constant>CURLAUTH_GSSNEGOTIATE</constant>,
              <constant>CURLAUTH_NTLM</constant>,
+             <constant>CURLAUTH_AWS_SIGV4</constant>,
              <constant>CURLAUTH_ANY</constant>, and
              <constant>CURLAUTH_ANYSAFE</constant>.
             </para>
@@ -755,12 +756,26 @@
              what methods it supports and pick the best one.
             </para>
             <para>
-             <constant>CURLAUTH_ANY</constant> is an alias for
-             <literal>CURLAUTH_BASIC | CURLAUTH_DIGEST | CURLAUTH_GSSNEGOTIATE | CURLAUTH_NTLM</literal>.
+             <constant>CURLAUTH_ANY</constant> sets all bits. cURL will automatically select 
+             the one it finds most secure.
             </para>
             <para>
-             <constant>CURLAUTH_ANYSAFE</constant> is an alias for
-             <literal>CURLAUTH_DIGEST | CURLAUTH_GSSNEGOTIATE | CURLAUTH_NTLM</literal>.
+             <constant>CURLAUTH_ANYSAFE</constant> sets all bits except <literal>CURLAUTH_BASIC</literal>. 
+             cURL will automatically select the one it finds most secure.
+            </para>
+           </entry>
+           <entry valign="top">
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_AWS_SIGV4</constant></entry>
+           <entry valign="top">
+            <para>
+             Provides AWS V4 signature authentication on HTTP(S) header.
+            </para>
+            <para>
+             This option overrides the other auth types you might have set in CURLOPT_HTTPAUTH.
+             This method cannot be combined with other auth types.
             </para>
            </entry>
            <entry valign="top">
@@ -1302,6 +1317,16 @@
            </entry>
           </row>
           <row>
+           <entry valign="top"><constant>CURLOPT_CAINFO_BLOB</constant></entry>
+           <entry valign="top">
+            The name of a PEM file holding one or more certificates to verify the
+            peer with. This option overrides <constant>CURLOPT_CAINFO</constant>.
+           </entry>
+           <entry valign="top">
+            Available since PHP 8.2.0 and cURL 7.77.0
+           </entry>
+          </row>
+          <row>
            <entry valign="top"><constant>CURLOPT_CAPATH</constant></entry>
            <entry valign="top">
             A directory that holds multiple CA certificates. Use this option
@@ -1597,6 +1622,18 @@
            </entry>
            <entry valign="top">
             Available since PHP 7.3.0 and libcurl &gt;= cURL 7.52.0.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLOPT_PROXY_CAINFO_BLOB</constant></entry>
+           <entry valign="top">
+            The name of a PEM file holding one or more certificates to verify the HTTPS proxy with.
+            This option is for connecting to an HTTPS proxy, not an HTTPS server.
+            Defaults set to the system path where libcurl's cacert bundle is assumed 
+            to be stored.
+           </entry>
+           <entry valign="top">
+            Available since PHP 8.2.0 and libcurl &gt;= cURL 7.77.0.
            </entry>
           </row>
           <row>


### PR DESCRIPTION
Hi, thought I can help with #1803 regarding the curl constants. This PR starts with the curlinfo constants added in one commit. Made a list below, but I could use some pointers as to what goes where, which other pages need to be updated, if I'm missing any I had planned below.

- [x] Updated constants list and [getinfo options](https://www.php.net/manual/en/function.curl-getinfo.php)
CURLINFO_PROXY_ERROR (libcurl >= 7.73.0) https://curl.se/libcurl/c/CURLINFO_PROXY_ERROR.html
CURLINFO_REFERER     (libcurl >= 7.76.0) https://curl.se/libcurl/c/CURLINFO_REFERER.html
CURLINFO_RETRY_AFTER (libcurl >= 7.66.0) https://curl.se/libcurl/c/CURLINFO_RETRY_AFTER.html

- [x] Update constants list
CURL_VERSION_GSASL (libcurl >= 7.76.0)
CURL_VERSION_HSTS (libcurl >= 7.74.0)
CURL_VERSION_HTTP3 (libcurl >= 7.66.0)
CURL_VERSION_UNICODE (libcurl >= 7.72.0)
CURL_VERSION_ZSTD (libcurl >= 7.72.0)

- [x] Update constants list and [setopt options](https://www.php.net/manual/en/function.curl-setopt.php)
CURLAUTH_AWS_SIGV4 (libcurl >= 7.75.0)
CURLOPT_AWS_SIGV4 (libcurl >= 7.75.0) https://curl.se/libcurl/c/CURLOPT_AWS_SIGV4.html
CURLOPT_CAINFO_BLOB (libcurl >= 7.77.0) https://curl.se/libcurl/c/CURLOPT_CAINFO_BLOB.html
CURLOPT_PROXY_CAINFO_BLOB (libcurl >= 7.77.0) https://curl.se/libcurl/c/CURLOPT_PROXY_CAINFO_BLOB.html
CURLOPT_DOH_SSL_VERIFYHOST (libcurl >= 7.76.0) https://curl.se/libcurl/c/CURLOPT_DOH_SSL_VERIFYHOST.html
CURLOPT_DOH_SSL_VERIFYPEER (libcurl >= 7.76.0) https://curl.se/libcurl/c/CURLOPT_DOH_SSL_VERIFYPEER.html
CURLOPT_DOH_SSL_VERIFYSTATUS (libcurl >= 7.76.0) https://curl.se/libcurl/c/CURLOPT_DOH_SSL_VERIFYSTATUS.html

- [x] Update constants list and [setopt options](https://www.php.net/manual/en/function.curl-setopt.php)
CURLOPT_MAIL_RCPT_ALLLOWFAILS (libcurl >= 7.69.0) https://curl.se/libcurl/c/CURLOPT_MAIL_RCPT_ALLLOWFAILS.html
CURLOPT_MAXAGE_CONN (libcurl >= 7.65.0) https://curl.se/libcurl/c/CURLOPT_MAXAGE_CONN.html
CURLOPT_MAXFILESIZE_LARGE https://curl.se/libcurl/c/CURLOPT_MAXFILESIZE_LARGE.html
CURLOPT_MAXLIFETIME_CONN (libcurl >= 7.80.0) https://curl.se/libcurl/c/CURLOPT_MAXLIFETIME_CONN.html
CURLOPT_SASL_AUTHZID (libcurl >= 7.66.0) https://curl.se/libcurl/c/CURLOPT_SASL_AUTHZID.html
CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256 (libcurl >= 7.80.0) https://curl.se/libcurl/c/CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256.html
CURLOPT_SSL_EC_CURVES (libcurl >= 7.73.0) https://curl.se/libcurl/c/CURLOPT_SSL_EC_CURVES.html
CURLOPT_UPKEEP_INTERVAL_MS (libcurl >= 7.62.0) https://curl.se/libcurl/c/CURLOPT_UPKEEP_INTERVAL_MS.html
CURLOPT_UPLOAD_BUFFERSIZE (libcurl >= 7.62.0) https://curl.se/libcurl/c/CURLOPT_UPLOAD_BUFFERSIZE.html

- [x] HSTS related
CURLHSTS_ENABLE (libcurl >= 7.74.0) https://curl.se/libcurl/c/CURLOPT_HSTS_CTRL.html
CURLHSTS_READONLYFILE (libcurl >= 7.74.0) https://curl.se/libcurl/c/CURLOPT_HSTS_CTRL.html
CURLOPT_HSTS_CTRL (libcurl >= 7.74.0) https://curl.se/libcurl/c/CURLOPT_HSTS_CTRL.html
CURLOPT_HSTS (libcurl >= 7.74.0) https://curl.se/libcurl/c/CURLOPT_HSTS.html

- [x] Update constants list and [setopt options](https://www.php.net/manual/en/function.curl-setopt.php)
CURLAUTH_AWS_SIGV4 (libcurl >= 7.75.0)

- [x] alt_svc related
CURLOPT_ALTSVC (libcurl >= 7.64.1) https://curl.se/libcurl/c/CURLOPT_ALTSVC.html
CURLOPT_ALTSVC_CTRL (libcurl >= 7.64.1) https://curl.se/libcurl/c/CURLOPT_ALTSVC_CTRL.html
CURLALTSVC_H1 (libcurl >= 7.64.1)
CURLALTSVC_H2 (libcurl >= 7.64.1)
CURLALTSVC_H3 (libcurl >= 7.64.1)
CURLALTSVC_READONLYFILE (libcurl >= 7.64.1)

- [x] PROTO_*
CURLPROTO_MQTT (libcurl >= 7.71.0)

- [x] PX_* responses when getting detailed socks proxy errors via `CURLINFO_PROXY_ERROR` - https://curl.se/libcurl/c/CURLINFO_PROXY_ERROR.html
CURLPX_BAD_ADDRESS_TYPE (libcurl >= 7.73.0)
CURLPX_BAD_VERSION (libcurl >= 7.73.0)
CURLPX_CLOSED (libcurl >= 7.73.0)
CURLPX_GSSAPI (libcurl >= 7.73.0)
CURLPX_GSSAPI_PERMSG (libcurl >= 7.73.0)
CURLPX_GSSAPI_PROTECTION (libcurl >= 7.73.0)
CURLPX_IDENTD_DIFFER (libcurl >= 7.73.0)
CURLPX_IDENTD (libcurl >= 7.73.0)
CURLPX_LONG_HOSTNAME (libcurl >= 7.73.0)
CURLPX_LONG_PASSWD (libcurl >= 7.73.0)
CURLPX_LONG_USER (libcurl >= 7.73.0)
CURLPX_NO_AUTH (libcurl >= 7.73.0)
CURLPX_OK (libcurl >= 7.73.0)
CURLPX_RECV_ADDRESS (libcurl >= 7.73.0)
CURLPX_RECV_AUTH (libcurl >= 7.73.0)
CURLPX_RECV_CONNECT (libcurl >= 7.73.0)
CURLPX_RECV_REQACK (libcurl >= 7.73.0)
CURLPX_REPLY_ADDRESS_TYPE_NOT_SUPPORTED (libcurl >= 7.73.0)
CURLPX_REPLY_COMMAND_NOT_SUPPORTED (libcurl >= 7.73.0)
CURLPX_REPLY_CONNECTION_REFUSED (libcurl >= 7.73.0)
CURLPX_REPLY_GENERAL_SERVER_FAILURE (libcurl >= 7.73.0)
CURLPX_REPLY_HOST_UNREACHABLE (libcurl >= 7.73.0)
CURLPX_REPLY_NETWORK_UNREACHABLE (libcurl >= 7.73.0)
CURLPX_REPLY_NOT_ALLOWED (libcurl >= 7.73.0)
CURLPX_REPLY_TTL_EXPIRED (libcurl >= 7.73.0)
CURLPX_REPLY_UNASSIGNED (libcurl >= 7.73.0)
CURLPX_REQUEST_FAILED (libcurl >= 7.73.0)
CURLPX_RESOLVE_HOST (libcurl >= 7.73.0)
CURLPX_SEND_AUTH (libcurl >= 7.73.0)
CURLPX_SEND_CONNECT (libcurl >= 7.73.0)
CURLPX_SEND_REQUEST (libcurl >= 7.73.0)
CURLPX_UNKNOWN_FAIL (libcurl >= 7.73.0)
CURLPX_UNKNOWN_MODE (libcurl >= 7.73.0)
CURLPX_USER_REJECTED (libcurl >= 7.73.0)

- [x] SSLOPT_* - update constants list and document on getinfo - https://curl.se/libcurl/c/CURLOPT_SSL_OPTIONS.html
CURLSSLOPT_AUTO_CLIENT_CERT (libcurl >= 7.77.0)
CURLSSLOPT_NATIVE_CA (libcurl >= 7.71.0)
CURLSSLOPT_NO_PARTIALCHAIN (libcurl >= 7.68.0)
CURLSSLOPT_REVOKE_BEST_EFFORT (libcurl >= 7.70.0)

- [x] CURLE_PROXY (libcurl >= 7.73.0)

- [x] CURLFTPMETHOD_DEFAULT

- [x] CURLMOPT_MAX_CONCURRENT_STREAMS (libcurl >= 7.67.0)