### PR TITLE
DOMNode::$prefix is not nullable

### DIFF
--- a/reference/dom/domnode.xml
+++ b/reference/dom/domnode.xml
@@ -235,7 +235,7 @@
     <varlistentry xml:id="domnode.props.prefix">
      <term><varname>prefix</varname></term>
      <listitem>
-      <para>The namespace prefix of this node, or &null; if it is unspecified.</para>
+      <para>The namespace prefix of this node.</para>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="domnode.props.localname">


### PR DESCRIPTION
The fieldsynopsis above documents it as non-nullable, so don't say it can be null. Checking the source of dom_node_prefix_read(), it has always returned a string since the initial commit, it can't return null.