### PR TITLE
Updates for hash functions that now throw errors

### DIFF
--- a/reference/hash/functions/hash-equals.xml
+++ b/reference/hash/functions/hash-equals.xml
@@ -52,14 +52,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   Emits an <constant>E_WARNING</constant> message when either of the
-   supplied parameters is not a string.
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/hash/functions/hash-hkdf.xml
+++ b/reference/hash/functions/hash-hkdf.xml
@@ -83,17 +83,43 @@
   &reftitle.returnvalues;
   <para>
    Returns a string containing a raw binary representation of the derived key
-   (also known as output keying material - OKM); or &false; on failure.
+   (also known as output keying material - OKM).
   </para>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   An <constant>E_WARNING</constant> will be raised if <parameter>key</parameter>
+   Throws a <classname>ValueError</classname> exception if <parameter>key</parameter>
    is empty, <parameter>algo</parameter> is unknown/non-cryptographic,
    <parameter>length</parameter> is less than <literal>0</literal> or too large
    (greater than 255 times the size of the hash function).
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Now throws a <classname>ValueError</classname> exception on error.
+        Previously, &false; was returned and an <constant>E_WARNING</constant>
+        message was emitted.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </para>
  </refsect1>
 

--- a/reference/hash/functions/hash-hmac-file.xml
+++ b/reference/hash/functions/hash-hmac-file.xml
@@ -63,9 +63,15 @@
    Returns a string containing the calculated message digest as lowercase hexits
    unless <parameter>binary</parameter> is set to true in which case the raw
    binary representation of the message digest is returned.
-   Returns &false; when <parameter>algo</parameter> is unknown or is a
-   non-cryptographic hash function, or if the file
-   <parameter>filename</parameter> cannot be read.
+   Returns &false; if the file <parameter>filename</parameter> cannot be read.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Throws a <classname>ValueError</classname> exception if
+   <parameter>algo</parameter> is unknown or is a non-cryptographic hash function.
   </para>
  </refsect1>
 
@@ -81,6 +87,14 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Now throws a <classname>ValueError</classname> exception if
+        <parameter>algo</parameter> is unknown or is a non-cryptographic hash
+        function; previously, &false; was returned instead.
+       </entry>
+      </row>
       <row>
        <entry>7.2.0</entry>
        <entry>Usage of non-cryptographic hash functions (adler32, crc32, crc32b, fnv132, fnv1a32, fnv164, fnv1a64, joaat) was disabled.</entry>

--- a/reference/hash/functions/hash-hmac.xml
+++ b/reference/hash/functions/hash-hmac.xml
@@ -66,6 +66,15 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Throws a <classname>ValueError</classname> exception if
+   <parameter>algo</parameter> is unknown or is a non-cryptographic hash
+   function.
+  </para>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -81,8 +90,8 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        <function>hash_hmac</function> now throws a <classname>ValueError</classname>
-        exception if <parameter>algo</parameter> is unknown or is a
+        Now throws a <classname>ValueError</classname> exception if
+        <parameter>algo</parameter> is unknown or is a
         non-cryptographic hash function; previously, &false; was returned instead.
        </entry>
       </row>

--- a/reference/hash/functions/hash-init.xml
+++ b/reference/hash/functions/hash-init.xml
@@ -71,6 +71,15 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Throws a <classname>ValueError</classname> exception if
+   <parameter>algo</parameter> is unknown or is a non-cryptographic hash
+   function, or if <parameter>key</parameter> is empty.
+  </para>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -86,6 +95,16 @@
       <row>
        <entry>8.1.0</entry>
        <entry>The <parameter>options</parameter> parameter has been added.</entry>
+      </row>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Now throws an <classname>ValueError</classname> exception if the
+        <parameter>algo</parameter> is unknown or is a non-cryptographic hash
+        function, or if <parameter>key</parameter> is empty. Previously,
+        &false; was returned and an <constant>E_WARNING</constant> message was
+        emitted.
+       </entry>
       </row>
       <row>
        <entry>7.2.0</entry>

--- a/reference/hash/functions/hash-pbkdf2.xml
+++ b/reference/hash/functions/hash-pbkdf2.xml
@@ -98,7 +98,7 @@
  <refsect1 role="errors"><!-- {{{ -->
   &reftitle.errors;
   <para>
-   An <constant>E_WARNING</constant> will be raised if the algorithm is
+   Throws a <classname>ValueError</classname> exception if the algorithm is
    unknown, the <parameter>iterations</parameter> parameter is less than or
    equal to <literal>0</literal>, the <parameter>length</parameter> is less
    than <literal>0</literal> or the <parameter>salt</parameter> is too long
@@ -118,6 +118,14 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Now throws a <classname>ValueError</classname> exception on error.
+        Previously, &false; was returned and an <constant>E_WARNING</constant>
+        message was emitted.
+       </entry>
+      </row>
       <row>
        <entry>7.2.0</entry>
        <entry>Usage of non-cryptographic hash functions (adler32, crc32, crc32b, fnv132, fnv1a32, fnv164, fnv1a64, joaat) was disabled.</entry>


### PR DESCRIPTION
Update the manual for the changes to the hash functions by Mark Randall in August 2019 and subsequent tweaks by Máté Kocsis in March 2020.

Build tested.