### PR TITLE
Rewrite outdated note for session_unset()

### DIFF
--- a/reference/session/functions/session-unset.xml
+++ b/reference/session/functions/session-unset.xml
@@ -59,20 +59,19 @@
    <para>
     If <varname>$_SESSION</varname> is used, use <function>unset</function> to
     unregister a session variable, i.e.
-    <literal>unset ($_SESSION['varname']);</literal>.
+    <code>unset($_SESSION['varname']);</code>.
    </para>
   </note>
   <caution>
    <para>
     Do NOT unset the whole <varname>$_SESSION</varname> with
-    <literal>unset($_SESSION)</literal> as this will disable the registering
+    <code>unset($_SESSION)</code> as this will disable the registering
     of session variables through the <varname>$_SESSION</varname> superglobal.
    </para>
   </caution>
   <note>
    <para>
-    Only use <function>session_unset</function> for older deprecated code
-    that does not use <varname>$_SESSION</varname>.
+    The use of <function>session_unset</function> is identical to <code>$_SESSION = []</code>.
    </para>
   </note>
  </refsect1>


### PR DESCRIPTION
This was meant to be used when  was still around.

Fixes #1906