### PR TITLE
Extend ext/random documentation (3)

### DIFF
--- a/reference/random/functions/random-bytes.xml
+++ b/reference/random/functions/random-bytes.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues"><!-- {{{ -->
   &reftitle.returnvalues;
   <para>
-   Returns a string containing the requested number of cryptographically
+   A string containing the requested number of cryptographically
    secure random bytes.
   </para>
  </refsect1><!-- }}} -->

--- a/reference/random/functions/random-int.xml
+++ b/reference/random/functions/random-int.xml
@@ -50,7 +50,7 @@
  <refsect1 role="returnvalues"><!-- {{{ -->
   &reftitle.returnvalues;
   <para>
-   Returns a cryptographically secure, uniformly selected integer from the closed interval
+   A cryptographically secure, uniformly selected integer from the closed interval
    [<parameter>min</parameter>, <parameter>max</parameter>]. Both
    <parameter>min</parameter> and <parameter>max</parameter> are
    possible return values.

--- a/reference/random/random.cryptosafeengine.xml
+++ b/reference/random/random.cryptosafeengine.xml
@@ -9,7 +9,7 @@
   <section xml:id="random-cryptosafeengine.intro">
    &reftitle.intro;
    <para>
-
+    A marker interface indicating that the <type>Random\Engine</type> returns cryptographically secure randomness.
    </para>
   </section>
 <!-- }}} -->

--- a/reference/random/random.randomerror.xml
+++ b/reference/random/random.randomerror.xml
@@ -9,7 +9,7 @@
   <section xml:id="random-randomerror.intro">
    &reftitle.intro;
    <para>
-
+    The base class for <type>Error</type>s that occur during generation or use of randomness.
    </para>
   </section>
 <!-- }}} -->

--- a/reference/random/random.randomexception.xml
+++ b/reference/random/random.randomexception.xml
@@ -9,7 +9,7 @@
   <section xml:id="random-randomexception.intro">
    &reftitle.intro;
    <para>
-
+    The base class for <type>Exception</type>s that occur during generation or use of randomness.
    </para>
   </section>
 <!-- }}} -->

--- a/reference/random/random.randomizer.xml
+++ b/reference/random/random.randomizer.xml
@@ -58,7 +58,9 @@
     <varlistentry xml:id="random-randomizer.props.engine">
      <term><varname>engine</varname></term>
      <listitem>
-      <para/>
+      <para>
+       The low-level source of randomness for the <type>Random\Randomizer</type>’s methods.
+      </para>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/random/random/engine/generate.xml
+++ b/reference/random/random/engine/generate.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-
+   A non-empty string containing random bytes.
   </para>
  </refsect1>
 

--- a/reference/random/random/engine/mt19937/construct.xml
+++ b/reference/random/random/engine/mt19937/construct.xml
@@ -27,7 +27,14 @@
     <term><parameter>seed</parameter></term>
     <listitem>
      <para>
+      Fills the state with values generated with a linear congruential generator
+      that was seeded with <parameter>seed</parameter> interpreted as an unsigned
+      32 bit integer.
+     </para>
 
+     <para>
+      If <parameter>seed</parameter> is omitted or &null;, a random unsigned
+      32 bit integer will be used.
      </para>
     </listitem>
    </varlistentry>
@@ -35,7 +42,32 @@
     <term><parameter>mode</parameter></term>
     <listitem>
      <para>
-
+      Use one of the following constants to specify the implementation of the algorithm to use.
+      <informaltable>
+       <tgroup cols="2">
+        <thead>
+         <row>
+          <entry>Constant</entry>
+          <entry>&Description;</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry><constant>MT_RAND_MT19937</constant></entry>
+          <entry>
+           Uses the standardized Mt19937 implementation.
+          </entry>
+         </row>
+         <row>
+          <entry><constant>MT_RAND_PHP</constant></entry>
+          <entry>
+           Uses an incorrect implementation for backwards compatibility with <function>mt_srand</function> before
+           PHP 7.1.
+          </entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </informaltable>
      </para>
     </listitem>
    </varlistentry>

--- a/reference/random/random/engine/mt19937/generate.xml
+++ b/reference/random/random/engine/mt19937/generate.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-
+   A string representing an unsigned 32 bit integer in little-endian order.
   </para>
  </refsect1>
 

--- a/reference/random/random/engine/pcgoneseq128xslrr64/construct.xml
+++ b/reference/random/random/engine/pcgoneseq128xslrr64/construct.xml
@@ -47,7 +47,8 @@
           <entry><type>int</type></entry>
           <entry>
            Fills the state by setting the state to <literal>0</literal>, advancing the engine one step,
-           adding the value of <parameter>seed</parameter>, and advancing the engine another step.
+           adding the value of <parameter>seed</parameter> interpreted as an unsigned 64 bit integer,
+           and advancing the engine another step.
           </entry>
          </row>
          <row>

--- a/reference/random/random/engine/pcgoneseq128xslrr64/generate.xml
+++ b/reference/random/random/engine/pcgoneseq128xslrr64/generate.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-
+   A string representing an unsigned 64 bit integer in little-endian order.
   </para>
  </refsect1>
 

--- a/reference/random/random/engine/secure/generate.xml
+++ b/reference/random/random/engine/secure/generate.xml
@@ -27,8 +27,15 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-
+   A string containing <constant>PHP_INT_SIZE</constant> cryptographically secure random bytes.
   </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <itemizedlist>
+   &csprng.errors;
+  </itemizedlist>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/random/random/engine/xoshiro256starstar/generate.xml
+++ b/reference/random/random/engine/xoshiro256starstar/generate.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-
+   A string representing an unsigned 64 bit integer in little-endian order.
   </para>
  </refsect1>
 

--- a/reference/random/random/randomizer/getbytes.xml
+++ b/reference/random/random/randomizer/getbytes.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a string containing the requested number of random bytes.
+   A string containing the requested number of random bytes.
   </para>
  </refsect1>
 

--- a/reference/random/random/randomizer/getint.xml
+++ b/reference/random/random/randomizer/getint.xml
@@ -47,7 +47,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a uniformly selected integer from the closed interval
+   A uniformly selected integer from the closed interval
    [<parameter>min</parameter>, <parameter>max</parameter>]. Both
    <parameter>min</parameter> and <parameter>max</parameter> are
    possible return values.


### PR DESCRIPTION
With this PR, the parameters and return values should be described for every method, except:

- Randomizer::nextInt(): This method isn't great and I'm not sure what can be usefully written there.
- The various __serialize(), __unserialize(), __debugInfo() methods. Is there some existing documentation where I can steal from?

What's missing and is intentionally omitted so far:

- Description for Random\Engine.
- Long-form descriptions for the methods.
- Examples.
- Further Cleanup