### PR TITLE
Mark `*.xml` as `linguist-detectable`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.xml linguist-detectable


### PR DESCRIPTION
This should fix the repository's language statistics, so that it doesn't show as HTML, due to one HTML file.

see https://github.com/github/linguist/blob/master/docs/overrides.md#detectable