### PR TITLE
Fix ssh2_shell termtype parameter name

### DIFF
--- a/reference/ssh2/functions/ssh2-shell.xml
+++ b/reference/ssh2/functions/ssh2-shell.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type class="union"><type>resource</type><type>false</type></type><methodname>ssh2_shell</methodname>
    <methodparam><type>resource</type><parameter>session</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>term_type</parameter><initializer>"vanilla"</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>termtype</parameter><initializer>"vanilla"</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>env</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>width</parameter><initializer>80</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>height</parameter><initializer>25</initializer></methodparam>
@@ -36,10 +36,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>term_type</parameter></term>
+     <term><parameter>termtype</parameter></term>
      <listitem>
       <para>
-       <parameter>term_type</parameter> should correspond to one of the
+       <parameter>termtype</parameter> should correspond to one of the
        entries in the target system's <literal>/etc/termcap</literal> file.
       </para>
      </listitem>


### PR DESCRIPTION
This is reflected as `termtype` - https://github.com/php/pecl-networking-ssh2/blob/master/ssh2.c#L1427.

Found while updating psalm function maps.