### PR TITLE
Configure linguist highlighting for `*.ent` files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.xml linguist-detectable
+*.ent linguist-language=XML linguist-detectable


### PR DESCRIPTION
see php/doc-en@91bdc784307128c56aeb90e91772b0cca254d36f