### PR TITLE
Improve documentation of the Memcached delete methods

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1262,7 +1262,7 @@ encoding value will be used.</para>'>
 <!ENTITY memcached.note.delete-time '<note xmlns="http://docbook.org/ns/docbook"><simpara>
        As of memcached 1.3.0 (released 2009) this feature is no longer
        supported. Passing a non-zero <parameter>time</parameter> will cause
-       libMemcached to raise an error.
+       libmemcached to raise an error.
       </simpara></note>
 '>
 

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1259,6 +1259,13 @@ encoding value will be used.</para>'>
 
 <!-- memcached notes -->
 
+<!ENTITY memcached.note.delete-time '<note xmlns="http://docbook.org/ns/docbook"><simpara>
+       As of memcached 1.3.0 (released 2009) this feature is no longer
+       supported. Passing a non-zero <parameter>time</parameter> will cause
+       libMemcached to raise an error.
+      </simpara></note>
+'>
+
 <!ENTITY memcached.parameter.expiration 'The expiration time, defaults to 0. See <link
  linkend="memcached.expiration" xmlns="http://docbook.org/ns/docbook">Expiration Times</link> for more info.'>
 
@@ -1271,6 +1278,19 @@ encoding value will be used.</para>'>
 <!ENTITY memcached.parameter.value 'The value to store.'>
 
 <!ENTITY memcached.result.getresultcode 'Use <methodname xmlns="http://docbook.org/ns/docbook">Memcached::getResultCode</methodname> if necessary.'>
+
+<!ENTITY memcached.result.delete-multi '<para xmlns="http://docbook.org/ns/docbook">
+   Returns an array indexed by <parameter>keys</parameter>. Each element
+   is &true; if the corresponding key was deleted, or one of the
+   <constant>Memcached::RES_*</constant> constants if the corresponding deletion
+   failed.
+   </para>
+  <para xmlns="http://docbook.org/ns/docbook">
+   The <methodname>Memcached::getResultCode</methodname> will return
+   the result code for the last executed delete operation, that is, the delete
+   operation for the last element of <parameter>keys</parameter>.
+  </para>
+'>
 
 <!-- password notes -->
 

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1262,7 +1262,8 @@ encoding value will be used.</para>'>
 <!ENTITY memcached.note.delete-time '<note xmlns="http://docbook.org/ns/docbook"><simpara>
        As of memcached 1.3.0 (released 2009) this feature is no longer
        supported. Passing a non-zero <parameter>time</parameter> will cause
-       libmemcached to raise an error.
+       the deletion to fail. <methodname>Memcached::getResultCode</methodname>
+       will return <constant>MEMCACHED_INVALID_ARGUMENTS</constant>.
       </simpara></note>
 '>
 

--- a/reference/memcached/memcached/delete.xml
+++ b/reference/memcached/memcached/delete.xml
@@ -15,19 +15,7 @@
    <methodparam choice="opt"><type>int</type><parameter>time</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>Memcached::delete</function> deletes the
-   <parameter>key</parameter> from the server. The <parameter>time</parameter>
-   parameter is the amount of time in seconds (or Unix time until which) the
-   client wishes the server to refuse <literal>add</literal> and
-   <literal>replace</literal> commands for this key. For this amount of time,
-   the item is put into a delete queue, which means that it won't possible to
-   retrieve it by the <literal>get</literal> command, but
-   <literal>add</literal> and <literal>replace</literal> command with this key
-   will also fail (the <literal>set</literal> command will succeed, however).
-   After the time passes, the item is finally deleted from server memory. The
-   parameter <parameter>time</parameter> defaults to 0 (which means that the
-   item will be deleted immediately and further storage commands with this key
-   will succeed).
+   Delete the <parameter>key</parameter> from the server.
   </para>
  </refsect1>
 
@@ -49,6 +37,7 @@
       <para>
        The amount of time the server will wait to delete the item.
       </para>
+      &memcached.note.delete-time;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/memcached/memcached/deletebykey.xml
+++ b/reference/memcached/memcached/deletebykey.xml
@@ -49,6 +49,7 @@
       <para>
        The amount of time the server will wait to delete the item.
       </para>
+      &memcached.note.delete-time;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/memcached/memcached/deletemulti.xml
+++ b/reference/memcached/memcached/deletemulti.xml
@@ -15,21 +15,8 @@
    <methodparam choice="opt"><type>int</type><parameter>time</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>Memcached::deleteMulti</function> deletes the array of
-   <parameter>keys</parameter> from the server. The <parameter>time</parameter>
-   parameter is the amount of time in seconds (or Unix time until which) the
-   client wishes the server to refuse <literal>add</literal> and
-   <literal>replace</literal> commands for these keys. For this amount of time,
-   the item is put into a delete queue, which means that it won't be possible to
-   retrieve it by the <literal>get</literal> command, but
-   <literal>add</literal> and <literal>replace</literal> command with these keys
-   will also fail (the <literal>set</literal> command will succeed, however).
-   After the time passes, the item is finally deleted from server memory. The
-   parameter <parameter>time</parameter> defaults to 0 (which means that the
-   item will be deleted immediately and further storage commands with these keys
-   will succeed).
+   Delete the array of <parameter>keys</parameter> from the server.
   </para>
-
  </refsect1>
 
  <refsect1 role="parameters">
@@ -50,6 +37,7 @@
       <para>
        The amount of time the server will wait to delete the items.
       </para>
+      &memcached.note.delete-time;
      </listitem>
     </varlistentry>
    </variablelist>
@@ -58,11 +46,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Returns array indexed by <parameter>keys</parameter> and where values are indicating whether operation succeeded or not.
-   The <methodname>Memcached::getResultCode</methodname> will return
-   <constant>Memcached::RES_NOTFOUND</constant> if the key does not exist.
-  </para>
+  &memcached.result.delete-multi;
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/memcached/memcached/deletemultibykey.xml
+++ b/reference/memcached/memcached/deletemultibykey.xml
@@ -50,6 +50,7 @@
       <para>
        The amount of time the server will wait to delete the items.
       </para>
+      &memcached.note.delete-time;
      </listitem>
     </varlistentry>
    </variablelist>
@@ -58,11 +59,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   &return.success;
-   The <methodname>Memcached::getResultCode</methodname> will return
-   <constant>Memcached::RES_NOTFOUND</constant> if the key does not exist.
-  </para>
+  &memcached.result.delete-multi;
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
* Note that it's always an error to specify a non-zero time parameter, and delete the long-winded explanations of what it is meant to do.
* Expand the description of the return value from deleteMulti().
* Replace the incorrect description of the return value of deleteMultiByKey(). Use the one from deleteMulti() instead.
* Explain what getResultCode() will return after deleteMulti().