### PR TITLE
Document OpenSSL legacy.dll provider on Windows

### DIFF
--- a/reference/openssl/configure.xml
+++ b/reference/openssl/configure.xml
@@ -73,6 +73,15 @@
     Ensure that non-privileged users are not allowed to modify <filename>openssl.cnf</filename>.
    </simpara>
   </caution>
+  <simpara>
+   As of OpenSSL 3.0.0, which is used on Windows by default as of PHP 8.2.0, several
+   algorithms have been deemed legacy. Such algorithms have commonly fallen out of use,
+   have been deemed insecure by the cryptography community, or something similar.
+   These algorithms are still available via the legacy provider
+   (<filename>extras/ssl/legacy.dll</filename>); its usage is described in the
+   <link xlink:href="&url.openssl.config;#Provider-Configuration">provider configuration</link>
+   section of the OpenSSL manual.
+  </simpara>
  </note>
 
  <simplesect role="changelog">


### PR DESCRIPTION
Cf. <https://github.com/php/php-src/issues/9890>.

Requires https://github.com/php/doc-base/pull/77. Note that this should not be merged yet, since legacy.dll is not yet shipped with the official Windows binaries.