### PR TITLE
Stop referring to `openssl_random_pseudo_bytes()` outside of ext/openssl

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -20,8 +20,8 @@ highly discouraged.</simpara></warning>'>
 <!-- Cautions -->
 <!ENTITY caution.cryptographically-insecure '<caution xmlns="http://docbook.org/ns/docbook"><para>This function does not
 generate cryptographically secure values, and should not be used for cryptographic purposes. If you need a
-cryptographically secure value, consider using <function>random_int</function>, <function>random_bytes</function>, or
-<function>openssl_random_pseudo_bytes</function> instead.</para></caution>'>
+cryptographically secure value, consider using <function>random_int</function> or <function>random_bytes</function>
+instead.</para></caution>'>
 
 <!-- Notes -->
 

--- a/reference/hash/functions/hash-pbkdf2.xml
+++ b/reference/hash/functions/hash-pbkdf2.xml
@@ -147,9 +147,8 @@
 $password = "password";
 $iterations = 1000;
 
-// Generate a random IV using openssl_random_pseudo_bytes()
-// random_bytes() or another suitable source of randomness
-$salt = openssl_random_pseudo_bytes(16);
+// Generate a cryptographically secure random IV using random_bytes()
+$salt = random_bytes(16);
 
 $hash = hash_pbkdf2("sha256", $password, $salt, $iterations, 20);
 var_dump($hash);

--- a/reference/random/functions/mt-rand.xml
+++ b/reference/random/functions/mt-rand.xml
@@ -149,7 +149,6 @@ echo mt_rand(5, 15);
     <member><function>mt_getrandmax</function></member>
     <member><function>random_int</function></member>
     <member><function>random_bytes</function></member>
-    <member><function>openssl_random_pseudo_bytes</function></member>
     <member><function>rand</function></member>
    </simplelist>
   </para>

--- a/reference/random/functions/rand.xml
+++ b/reference/random/functions/rand.xml
@@ -148,7 +148,6 @@ echo rand(5, 15);
     <member><function>mt_rand</function></member>
     <member><function>random_int</function></member>
     <member><function>random_bytes</function></member>
-    <member><function>openssl_random_pseudo_bytes</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/random/functions/random-bytes.xml
+++ b/reference/random/functions/random-bytes.xml
@@ -105,7 +105,6 @@ string(10) "385e33f741"
   &reftitle.seealso;
   <simplelist>
    <member><function>random_int</function></member>
-   <member><function>openssl_random_pseudo_bytes</function></member>
    <member><function>bin2hex</function></member>
   </simplelist>
  </refsect1><!-- }}} -->

--- a/reference/session/sessionhandler.xml
+++ b/reference/session/sessionhandler.xml
@@ -143,8 +143,8 @@ function decrypt($edata, $password) {
  * @return base64 encrypted data
  */
 function encrypt($data, $password) {
-    // Set a random salt
-    $salt = openssl_random_pseudo_bytes(16);
+    // Generate a cryptographically secure random salt using random_bytes()
+    $salt = random_bytes(16);
 
     $salted = '';
     $dx = '';


### PR DESCRIPTION
The `random_bytes()` and `random_int()` alternatives are available since since PHP 7.0, are available by default and directly map to the OS' CSPRNG and thus are likely more secure.

Thus this PR stops mentioning `openssl_random_pseudo_bytes()` as a possible option any more to keep things simple for the reader.