### PR TITLE
random: Remove TypeError listitem from `&csprng.errors;`

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -3773,12 +3773,6 @@ local: {
    a <classname>Random\RandomException</classname> will be thrown.
   </simpara>
  </listitem>
- <listitem xmlns="http://docbook.org/ns/docbook">
-  <simpara>
-    If invalid parameters are given, a <classname>TypeError</classname>
-    will be thrown.
-  </simpara>
- </listitem>
 '>
 <!ENTITY csprng.function.backport '
  <note xmlns="http://docbook.org/ns/docbook">


### PR DESCRIPTION
There are two reasons for this:

- It's standard functionality that a TypeError will be thrown for improper parameter types. This is nothing special for the CSPRNG functionality.
- The snippet is now also used for `Secure::generate()` which does not take any parameters.