### PR TITLE
Rewrite and flesh out string interpolation docs

### DIFF
--- a/appendices/tokens.xml
+++ b/appendices/tokens.xml
@@ -204,8 +204,10 @@ defined('T_FN') || define('T_FN', 10001);
     <row xml:id="constant.t-curly-open">
      <entry><constant>T_CURLY_OPEN</constant></entry>
      <entry>{$</entry>
-     <entry><link linkend="language.types.string.parsing.complex">complex
-     variable parsed syntax</link></entry>
+     <entry>
+      <link linkend="language.types.string.parsing.advanced">advanced</link>
+      variable string interpolation
+     </entry>
     </row>
     <row xml:id="constant.t-dec">
      <entry><constant>T_DEC</constant></entry>
@@ -255,8 +257,10 @@ defined('T_FN') || define('T_FN', 10001);
     <row xml:id="constant.t-dollar-open-curly-braces">
      <entry><constant>T_DOLLAR_OPEN_CURLY_BRACES</constant></entry>
      <entry>${</entry>
-     <entry><link linkend="language.types.string.parsing.complex">complex
-     variable parsed syntax</link></entry>
+     <entry>
+      <link linkend="language.types.string.parsing.basic">basic</link>
+      variable string interpolation
+     </entry>
     </row>
     <row xml:id="constant.t-double-arrow">
      <entry><constant>T_DOUBLE_ARROW</constant></entry>
@@ -799,8 +803,10 @@ defined('T_FN') || define('T_FN', 10001);
     <row xml:id="constant.t-string-varname">
      <entry><constant>T_STRING_VARNAME</constant></entry>
      <entry>"${a</entry>
-     <entry><link linkend="language.types.string.parsing.complex">complex
-     variable parsed syntax</link></entry>
+     <entry>
+      <link linkend="language.variables.variable">variable variables</link>
+      to interpolate in a string
+     </entry>
     </row>
     <row xml:id="constant.t-switch">
      <entry><constant>T_SWITCH</constant></entry>

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -199,7 +199,7 @@ echo 'Variables do not $expand $either';
    <para>
     The most important feature of double-quoted <type>string</type>s is the fact
     that variable names will be expanded. See
-    <link linkend="language.types.string.parsing">string parsing</link> for
+    <link linkend="language.types.string.parsing">string interpolation</link> for
     details.
    </para>
   </sect3>
@@ -592,7 +592,7 @@ FOOBAR;
    <para>
     Nowdocs are to single-quoted strings what heredocs are to double-quoted
     strings. A nowdoc is specified similarly to a heredoc, but <emphasis>no
-    parsing is done</emphasis> inside a nowdoc. The construct is ideal for
+    String interpolation is done</emphasis> inside a nowdoc. The construct is ideal for
     embedding PHP code or other large blocks of text without the need for
     escaping. It shares some features in common with the SGML
     <literal>&lt;![CDATA[ ]]&gt;</literal> construct, in that it declares a
@@ -684,7 +684,7 @@ EOT;
   </sect3>
 
   <sect3 xml:id="language.types.string.parsing">
-   <title>Variable substitution</title>
+   <title>String interpolation</title>
 
    <simpara>
     When a <type>string</type> is specified in double quotes or with heredoc,
@@ -907,7 +907,7 @@ Changing the character at index -3 to o gives strong.
 
     <simpara>
      The advanced syntax permits the interpolation of
-     <emphasis>variables</emphasis> with arbitrary access expressions.
+     <emphasis>variables</emphasis> with arbitrary accessors.
     </simpara>
 
     <simpara>
@@ -945,8 +945,16 @@ echo "This is { $great}";
 // Works, outputs: This is fantastic
 echo "This is {$great}";
 
+class Square {
+    public $width;
+
+    public function __construct(int $width) { $this->width = $width; }
+}
+
+$square = new Square(5);
+
 // Works
-echo "This square is {$square->width}00 centimeters broad.";
+echo "This square is {$square->width}00 centimeters wide.";
 
 
 // Works, quoted keys only work using the curly brace syntax

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -693,28 +693,25 @@ EOT;
 
    <simpara>
     There are two types of syntax: a
-    <link linkend="language.types.string.parsing.simple">simple</link> one and a
-    <link linkend="language.types.string.parsing.complex">complex</link> one.
-    The simple syntax is the most common and convenient. It provides a way to
+    <link linkend="language.types.string.parsing.simple">basic</link> one and an
+    <link linkend="language.types.string.parsing.complex">advanced</link> one.
+    The basic syntax is the most common and convenient. It provides a way to
     embed a variable, an <type>array</type> value, or an <type>object</type>
     property in a <type>string</type> with a minimum of effort.
    </simpara>
 
    <simpara>
-    The complex syntax can be recognised by the
+    The advanced syntax can be recognised by the
     curly braces surrounding the expression.
    </simpara>
 
    <sect4 xml:id="language.types.string.parsing.simple">
-    <title>Simple syntax</title>
+    <title>Basic syntax</title>
 
     <simpara>
      If a dollar sign (<literal>$</literal>) is encountered, the parser will
      greedily take as many tokens as possible to form a valid variable name.
-     Enclose the variable name in curly braces to explicitly specify the end of
-     the name.
     </simpara>
-
     <informalexample>
      <programlisting role="php">
 <![CDATA[
@@ -722,6 +719,93 @@ EOT;
 $juice = "apple";
 
 echo "He drank some $juice juice." . PHP_EOL;
+
+?>
+]]>
+     </programlisting>
+     &example.outputs;
+     <screen>
+<![CDATA[
+He drank some apple juice.
+]]>
+     </screen>
+    </informalexample>
+
+    <note>
+     <simpara>
+      If it is not possible to form a valid name the dollar sign remains
+      in the string:
+     </simpara>
+     <informalexample>
+      <programlisting role="php">
+<![CDATA[
+<?php
+echo "No interpolation $  has happened\n";
+echo "No interpolation $\n has happened\n";
+echo "No interpolation $2 has happened\n";
+?>
+]]>
+      </programlisting>
+      &example.outputs;
+      <screen>
+<![CDATA[
+No interpolation $  has happened
+No interpolation $
+ has happened
+No interpolation $2 has happened
+]]>
+      </screen>
+     </informalexample>
+    </note>
+
+    <simpara>
+     As any valid character for a variable name is used to form the name of
+     the variable to look up, it is possible to enclose the variable name in
+     curly braces to explicitly specify the end of the name.
+    </simpara>
+    <warning>
+     <para>
+      This syntax is deprecated as of PHP 8.2.0, as it can be interpreted as
+      <link linkend="language.variables.variable">variable variables</link>:
+      <informalexample>
+       <programlisting role="php">
+<![CDATA[
+<?php
+const foo = 'bar';
+$foo = 'foo';
+$bar = 'bar';
+var_dump("${foo}");
+var_dump("${(foo)}");
+?>
+]]>
+       </programlisting>
+       &example.outputs.82;
+       <screen>
+<![CDATA[
+Deprecated: Using ${var} in strings is deprecated, use {$var} instead in file on line 6
+
+Deprecated: Using ${expr} (variable variables) in strings is deprecated, use {${expr}} instead in file on line 9
+string(3) "foo"
+string(3) "bar"
+]]>
+       </screen>
+       &example.outputs;
+       <screen>
+<![CDATA[
+string(3) "foo"
+string(3) "bar"
+]]>
+       </screen>
+      </informalexample>
+      The <link linkend="language.types.string.parsing.complex">advanced</link>
+      string interpolation syntax should be used instead.
+     </para>
+    </warning>
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+$juice = "apple";
 
 // Unintended. "s" is a valid character for a variable name, so this refers to $juices, not $juice.
 echo "He drank some juice made of $juices." . PHP_EOL;
@@ -732,10 +816,20 @@ echo "He drank some juice made of {$juice}s.";
 ?>
 ]]>
      </programlisting>
-     &example.outputs;
+     &example.outputs.82;
      <screen>
 <![CDATA[
-He drank some apple juice.
+Deprecated: Using ${var} in strings is deprecated, use {$var} instead in file on line 8
+
+Warning: Undefined variable $juices in file on line 5
+He drank some juice made of .
+He drank some juice made of apples.
+]]>
+     </screen>
+     &example.outputs.8;
+     <screen>
+<![CDATA[
+Warning: Undefined variable $juices in file on line 5
 He drank some juice made of .
 He drank some juice made of apples.
 ]]>
@@ -816,16 +910,17 @@ Changing the character at index -3 to o gives strong.
     </example>
 
     <simpara>
-     For anything more complex, you should use the complex syntax.
+     For anything more complex, the
+     <link linkend="language.types.string.parsing.complex">advanced</link>
+     syntax must be used.
     </simpara>
    </sect4>
 
    <sect4 xml:id="language.types.string.parsing.complex">
-    <title>Complex (curly) syntax</title>
+    <title>Advanced (curly) syntax</title>
 
     <simpara>
-     This isn't called complex because the syntax is complex, but because it
-     allows for the use of complex expressions.
+     The advanced syntax allows for the use of complex expressions.
     </simpara>
 
     <simpara>

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -693,8 +693,8 @@ EOT;
 
    <simpara>
     There are two types of syntax: a
-    <link linkend="language.types.string.parsing.simple">basic</link> one and an
-    <link linkend="language.types.string.parsing.complex">advanced</link> one.
+    <link linkend="language.types.string.parsing.basic">basic</link> one and an
+    <link linkend="language.types.string.parsing.advanced">advanced</link> one.
     The basic syntax is the most common and convenient. It provides a way to
     embed a variable, an <type>array</type> value, or an <type>object</type>
     property in a <type>string</type> with a minimum of effort.
@@ -705,7 +705,7 @@ EOT;
     curly braces surrounding the expression.
    </simpara>
 
-   <sect4 xml:id="language.types.string.parsing.simple">
+   <sect4 xml:id="language.types.string.parsing.basic">
     <title>Basic syntax</title>
 
     <simpara>
@@ -804,7 +804,7 @@ string(3) "bar"
 ]]>
        </screen>
       </informalexample>
-      The <link linkend="language.types.string.parsing.complex">advanced</link>
+      The <link linkend="language.types.string.parsing.advanced">advanced</link>
       string interpolation syntax should be used instead.
      </para>
     </warning>
@@ -872,7 +872,7 @@ He drank some purple juice.
       The basic syntax does not permit access to an array entry which has a key
       containing a minus (<literal>-</literal>) sign.
       Attempting to do will result in a parse error. The
-      <link linkend="language.types.string.parsing.complex">advanced</link>
+      <link linkend="language.types.string.parsing.advanced">advanced</link>
       syntax must be used instead.
       <informalexample>
        <programlisting role="php">
@@ -897,7 +897,7 @@ Parse error: syntax error, unexpected token "-", expecting "]" in file on line 3
      <simpara>
       Because the array key is unquoted, it is not possible to refer to a
       constant with the basic syntax. Use the
-      <link linkend="language.types.string.parsing.complex">advanced</link>
+      <link linkend="language.types.string.parsing.advanced">advanced</link>
       syntax instead.
      </simpara>
     </note>
@@ -1002,12 +1002,12 @@ Fatal error: Uncaught Error: Object of class A could not be converted to string
 
     <simpara>
      For anything more complex, the
-     <link linkend="language.types.string.parsing.complex">advanced</link>
+     <link linkend="language.types.string.parsing.advanced">advanced</link>
      syntax must be used.
     </simpara>
    </sect4>
 
-   <sect4 xml:id="language.types.string.parsing.complex">
+   <sect4 xml:id="language.types.string.parsing.advanced">
     <title>Advanced (curly) syntax</title>
 
     <simpara>

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -710,7 +710,7 @@ EOT;
 
     <simpara>
      If a dollar sign (<literal>$</literal>) is encountered, the parser will
-     greedily take as many tokens as possible to form a valid variable name.
+     consume as many characters as possible to form a valid variable name.
     </simpara>
     <informalexample>
      <programlisting role="php">
@@ -731,76 +731,11 @@ He drank some apple juice.
      </screen>
     </informalexample>
 
-    <note>
-     <simpara>
-      If it is not possible to form a valid name the dollar sign remains
-      in the string:
-     </simpara>
-     <informalexample>
-      <programlisting role="php">
-<![CDATA[
-<?php
-echo "No interpolation $  has happened\n";
-echo "No interpolation $\n has happened\n";
-echo "No interpolation $2 has happened\n";
-?>
-]]>
-      </programlisting>
-      &example.outputs;
-      <screen>
-<![CDATA[
-No interpolation $  has happened
-No interpolation $
- has happened
-No interpolation $2 has happened
-]]>
-      </screen>
-     </informalexample>
-    </note>
-
     <simpara>
      As any valid character for a variable name is used to form the name of
      the variable to look up, it is possible to enclose the variable name in
      curly braces to explicitly specify the end of the name.
     </simpara>
-    <warning>
-     <para>
-      This syntax is deprecated as of PHP 8.2.0, as it can be interpreted as
-      <link linkend="language.variables.variable">variable variables</link>:
-      <informalexample>
-       <programlisting role="php">
-<![CDATA[
-<?php
-const foo = 'bar';
-$foo = 'foo';
-$bar = 'bar';
-var_dump("${foo}");
-var_dump("${(foo)}");
-?>
-]]>
-       </programlisting>
-       &example.outputs.82;
-       <screen>
-<![CDATA[
-Deprecated: Using ${var} in strings is deprecated, use {$var} instead in file on line 6
-
-Deprecated: Using ${expr} (variable variables) in strings is deprecated, use {${expr}} instead in file on line 9
-string(3) "foo"
-string(3) "bar"
-]]>
-       </screen>
-       &example.outputs;
-       <screen>
-<![CDATA[
-string(3) "foo"
-string(3) "bar"
-]]>
-       </screen>
-      </informalexample>
-      The <link linkend="language.types.string.parsing.complex">advanced</link>
-      string interpolation syntax should be used instead.
-     </para>
-    </warning>
     <informalexample>
      <programlisting role="php">
 <![CDATA[
@@ -835,38 +770,90 @@ He drank some juice made of apples.
 ]]>
      </screen>
     </informalexample>
+    <warning>
+     <para>
+      This syntax is deprecated as of PHP 8.2.0, as it can be interpreted as
+      <link linkend="language.variables.variable">variable variables</link>:
+      <informalexample>
+       <programlisting role="php">
+  <![CDATA[
+<?php
+const foo = 'bar';
+$foo = 'foo';
+$bar = 'bar';
+var_dump("${foo}");
+var_dump("${(foo)}");
+?>
+]]>
+       </programlisting>
+       &example.outputs.82;
+       <screen>
+  <![CDATA[
+Deprecated: Using ${var} in strings is deprecated, use {$var} instead in file on line 6
+
+Deprecated: Using ${expr} (variable variables) in strings is deprecated, use {${expr}} instead in file on line 9
+string(3) "foo"
+string(3) "bar"
+]]>
+       </screen>
+       &example.outputs;
+       <screen>
+  <![CDATA[
+string(3) "foo"
+string(3) "bar"
+]]>
+       </screen>
+      </informalexample>
+      The <link linkend="language.types.string.parsing.complex">advanced</link>
+      string interpolation syntax should be used instead.
+     </para>
+    </warning>
+
+    <note>
+     <simpara>
+      If it is not possible to form a valid name the dollar sign remains
+      in the string:
+     </simpara>
+     <informalexample>
+      <programlisting role="php">
+<![CDATA[
+<?php
+echo "No interpolation $  has happened\n";
+echo "No interpolation $\n has happened\n";
+echo "No interpolation $2 has happened\n";
+?>
+]]>
+      </programlisting>
+      &example.outputs;
+      <screen>
+<![CDATA[
+No interpolation $  has happened
+No interpolation $
+ has happened
+No interpolation $2 has happened
+]]>
+      </screen>
+     </informalexample>
+    </note>
 
     <simpara>
-     Similarly, an <type>array</type> index or an <type>object</type> property
-     can be parsed. With array indices, the closing square bracket
-     (<literal>]</literal>) marks the end of the index. The same rules apply to
-     object properties as to simple variables.
+     Moreover, the basic syntax permits access to the first, and only the first,
+     dimension of an array by using array indices (<literal>[]</literal>).
+     The key, must be an unquoted literal value.
     </simpara>
 
-    <example><title>Simple syntax example</title>
+    <example>
+     <title>Interpolating the value of the first dimension of an array with the basic syntax</title>
      <programlisting role="php">
 <![CDATA[
 <?php
-$juices = array("apple", "orange", "koolaid1" => "purple");
+$juices = array("apple", "orange", "string_key" => "purple");
 
-echo "He drank some $juices[0] juice.".PHP_EOL;
-echo "He drank some $juices[1] juice.".PHP_EOL;
-echo "He drank some $juices[koolaid1] juice.".PHP_EOL;
-
-class people {
-    public $john = "John Smith";
-    public $jane = "Jane Smith";
-    public $robert = "Robert Paulsen";
-
-    public $smith = "Smith";
-}
-
-$people = new people();
-
-echo "$people->john drank some $juices[0] juice.".PHP_EOL;
-echo "$people->john then said hello to $people->jane.".PHP_EOL;
-echo "$people->john's wife greeted $people->robert.".PHP_EOL;
-echo "$people->robert greeted the two $people->smiths."; // Won't work
+echo "He drank some $juices[0] juice.";
+echo PHP_EOL;
+echo "He drank some $juices[1] juice.";
+echo PHP_EOL;
+echo "He drank some $juices[string_key] juice.";
 ?>
 ]]>
      </programlisting>
@@ -876,13 +863,44 @@ echo "$people->robert greeted the two $people->smiths."; // Won't work
 He drank some apple juice.
 He drank some orange juice.
 He drank some purple juice.
-John Smith drank some apple juice.
-John Smith then said hello to Jane Smith.
-John Smith's wife greeted Robert Paulsen.
-Robert Paulsen greeted the two .
 ]]>
      </screen>
     </example>
+
+    <warning>
+     <para>
+      The basic syntax does not permit access to an array entry which has a key
+      containing a minus (<literal>-</literal>) sign.
+      Attempting to do will result in a parse error. The
+      <link linkend="language.types.string.parsing.complex">advanced</link>
+      syntax must be used instead.
+      <informalexample>
+       <programlisting role="php">
+<![CDATA[
+<?php
+$a = ["string-key" => "value"];
+echo "Array value: $a[string-key]";
+?>
+]]>
+       </programlisting>
+       &example.outputs.similar;
+       <screen>
+<![CDATA[
+Parse error: syntax error, unexpected token "-", expecting "]" in file on line 3
+]]>
+       </screen>
+      </informalexample>
+     </para>
+    </warning>
+
+    <note>
+     <simpara>
+      Because the array key is unquoted, it is not possible to refer to a
+      constant with the basic syntax. Use the
+      <link linkend="language.types.string.parsing.complex">advanced</link>
+      syntax instead.
+     </simpara>
+    </note>
 
     <simpara>
      As of PHP 7.1.0 also <emphasis>negative</emphasis> numeric indices are
@@ -910,6 +928,79 @@ Changing the character at index -3 to o gives strong.
     </example>
 
     <simpara>
+     Similarly, it is possible to interpolate a non-static property of an
+     object. And it is impossible access a nested property.
+    </simpara>
+    <example>
+     <title>Interpolating the value of non-static property with the basic syntax</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+class A {
+    public $s = "string";
+}
+
+$o = new A();
+
+echo "Object value: $o->s.";
+?>
+]]>
+     </programlisting>
+     &example.outputs;
+     <screen>
+<![CDATA[
+Object value: string.
+]]>
+     </screen>
+    </example>
+
+    <example>
+     <title>Non-example demonstrating the impossibility to access nested or static properties</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+class A {
+    public static $bar = 'bar';
+}
+$a = new A();
+echo "Property $a::bar";
+?>
+]]>
+     </programlisting>
+     &example.outputs.similar;
+     <screen>
+<![CDATA[
+Fatal error: Uncaught Error: Object of class A could not be converted to string
+]]>
+     </screen>
+     <programlisting role="php">
+<![CDATA[
+<?php
+class A {
+    public $foo = 'foo';
+    public static $bar = 'bar';
+}
+class B {
+    public $o;
+}
+
+$a = new A();
+$b = new B();
+$b->o = $a;
+
+echo "Property $b->o->foo";
+?>
+]]>
+     </programlisting>
+     &example.outputs.similar;
+     <screen>
+<![CDATA[
+Fatal error: Uncaught Error: Object of class A could not be converted to string
+]]>
+     </screen>
+    </example>
+
+    <simpara>
      For anything more complex, the
      <link linkend="language.types.string.parsing.complex">advanced</link>
      syntax must be used.
@@ -920,11 +1011,13 @@ Changing the character at index -3 to o gives strong.
     <title>Advanced (curly) syntax</title>
 
     <simpara>
-     The advanced syntax allows for the use of complex expressions.
+     The advanced syntax permits the interpolation of
+     <emphasis>variables</emphasis> with arbitrary access expressions.
     </simpara>
 
     <simpara>
-     Any scalar variable, array element or object property with a
+     Any scalar variable, array element or object property
+     (<modifier>static</modifier> or not) with a
      <type>string</type> representation can be included via this syntax.
      The expression is written the same way as it would appear outside the
      <type>string</type>, and then wrapped in <literal>{</literal> and
@@ -938,10 +1031,18 @@ Changing the character at index -3 to o gives strong.
      <programlisting role="php">
 <![CDATA[
 <?php
-// Show all errors
-error_reporting(E_ALL);
 
+const DATA_KEY = 'const-key';
 $great = 'fantastic';
+$arr = [
+    '1',
+    '2',
+    '3',
+    [41, 42, 43],
+    'key' => 'Indexed value',
+    'const-key' => 'Key with minus sign',
+    'foo' => ['foo1', 'foo2', 'foo3']
+];
 
 // Won't work, outputs: This is { fantastic}
 echo "This is { $great}";
@@ -960,112 +1061,28 @@ echo "This works: {$arr['key']}";
 // Works
 echo "This works: {$arr[4][3]}";
 
-// This is wrong for the same reason as $foo[bar] is wrong  outside a string.
-// PHP first looks for a constant named foo, and throws an error if not found.
-// If the constant is found, its value (and not 'foo' itself) would be used
-// for the array index.
-echo "This is wrong: {$arr[foo][3]}";
+echo "This works: {$arr[DATA_KEY]}";
 
-// Works. When using multi-dimensional arrays, always use braces around arrays
+// When using multidimensional arrays, always use braces around arrays
 // when inside of strings
 echo "This works: {$arr['foo'][3]}";
 
-// Works.
-echo "This works: " . $arr['foo'][3];
+echo "This works: {$obj->values[3]->name}";
 
-echo "This works too: {$obj->values[3]->name}";
+echo "This works: {$obj->$staticProp}";
 
-echo "This is the value of the var named $name: {${$name}}";
-
-echo "This is the value of the var named by the return value of getName(): {${getName()}}";
-
-echo "This is the value of the var named by the return value of \$object->getName(): {${$object->getName()}}";
-
-// Won't work, outputs: This is the return value of getName(): {getName()}
-echo "This is the return value of getName(): {getName()}";
-
-// Won't work, outputs: C:\folder\{fantastic}.txt
-echo "C:\folder\{$great}.txt"
-// Works, outputs: C:\folder\fantastic.txt
-echo "C:\\folder\\{$great}.txt"
 ?>
 ]]>
-<!-- maybe it's better to leave this out??
-// this works, but i disencourage its use, since this is NOT
-// involving functions, rather than mere variables, arrays and objects.
-$beer = 'Heineken';
-echo "I'd like to have another {${ strrev('reeb') }}, hips";
- -->
      </programlisting>
     </informalexample>
-
-    <para>
-     It is also possible to access class properties using variables
-     within strings using this syntax.
-    </para>
-
-   <informalexample>
-    <programlisting role="php">
-<![CDATA[
-<?php
-class foo {
-    var $bar = 'I am bar.';
-}
-
-$foo = new foo();
-$bar = 'bar';
-$baz = array('foo', 'bar', 'baz', 'quux');
-echo "{$foo->$bar}\n";
-echo "{$foo->{$baz[1]}}\n";
-?>
-]]>
-    </programlisting>
-   &example.outputs;
-   <screen>
-<![CDATA[
-I am bar.
-I am bar.
-]]>
-   </screen>
-   </informalexample>
 
     <note>
-     <para>
-      The value accessed from functions, method calls, static class variables,
-      and class constants inside
-      <literal>{$}</literal> will be interpreted as the name
-      of a variable in the scope in which the string is defined. Using
-      single curly braces (<literal>{}</literal>) will not work for
-      accessing the return values of functions or methods or the
-      values of class constants or static class variables.
-     </para>
+     <simpara>
+      As this syntax allows arbitrary expressions it is possible to use
+      <link linkend="language.variables.variable">variable variables</link>
+      within the advanced syntax.
+     </simpara>
     </note>
-
-    <informalexample>
-     <programlisting role="php">
-<![CDATA[
-<?php
-// Show all errors.
-error_reporting(E_ALL);
-
-class beers {
-    const softdrink = 'rootbeer';
-    public static $ale = 'ipa';
-}
-
-$rootbeer = 'A & W';
-$ipa = 'Alexander Keith\'s';
-
-// This works; outputs: I'd like an A & W
-echo "I'd like an {${beers::softdrink}}\n";
-
-// This works too; outputs: I'd like an Alexander Keith's
-echo "I'd like an {${beers::$ale}}\n";
-?>
-]]>
-     </programlisting>
-    </informalexample>
-
    </sect4>
   </sect3>
 

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -684,11 +684,11 @@ EOT;
   </sect3>
 
   <sect3 xml:id="language.types.string.parsing">
-   <title>Variable parsing</title>
+   <title>Variable substitution</title>
 
    <simpara>
     When a <type>string</type> is specified in double quotes or with heredoc,
-    <link linkend="language.variables">variables</link> are parsed within it.
+    <link linkend="language.variables">variables</link> can be substituted within it.
    </simpara>
 
    <simpara>
@@ -700,17 +700,12 @@ EOT;
     property in a <type>string</type> with a minimum of effort.
    </simpara>
 
-   <simpara>
-    The advanced syntax can be recognised by the
-    curly braces surrounding the expression.
-   </simpara>
-
    <sect4 xml:id="language.types.string.parsing.basic">
     <title>Basic syntax</title>
-
     <simpara>
-     If a dollar sign (<literal>$</literal>) is encountered, the parser will
-     consume as many characters as possible to form a valid variable name.
+     If a dollar sign (<literal>$</literal>) is encountered, the characters
+     that follow it which can be used in a variable name will be interpreted
+     as such and substituted.
     </simpara>
     <informalexample>
      <programlisting role="php">
@@ -732,51 +727,46 @@ He drank some apple juice.
     </informalexample>
 
     <simpara>
-     As any valid character for a variable name is used to form the name of
-     the variable to look up, it is possible to enclose the variable name in
-     curly braces to explicitly specify the end of the name.
+     Formally, the structure for the basic variable substitution syntax is
+     as follows:
     </simpara>
     <informalexample>
-     <programlisting role="php">
+     <programlisting>
 <![CDATA[
-<?php
-$juice = "apple";
+string-variable::
+     variable-name   (offset-or-property)?
+   | ${   expression   }
 
-// Unintended. "s" is a valid character for a variable name, so this refers to $juices, not $juice.
-echo "He drank some juice made of $juices." . PHP_EOL;
+offset-or-property::
+     offset-in-string
+   | property-in-string
 
-// Explicitly specify the end of the variable name by enclosing the reference in braces.
-echo "He drank some juice made of {$juice}s.";
+offset-in-string::
+     [   name   ]
+   | [   variable-name   ]
+   | [   integer-literal   ]
 
-?>
+property-in-string::
+     ->  name
+
+variable-name::
+     $   name
+
+name::
+     [a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*
+
 ]]>
      </programlisting>
-     &example.outputs.82;
-     <screen>
-<![CDATA[
-Deprecated: Using ${var} in strings is deprecated, use {$var} instead in file on line 8
-
-Warning: Undefined variable $juices in file on line 5
-He drank some juice made of .
-He drank some juice made of apples.
-]]>
-     </screen>
-     &example.outputs.8;
-     <screen>
-<![CDATA[
-Warning: Undefined variable $juices in file on line 5
-He drank some juice made of .
-He drank some juice made of apples.
-]]>
-     </screen>
     </informalexample>
+
     <warning>
      <para>
-      This syntax is deprecated as of PHP 8.2.0, as it can be interpreted as
+      The <literal>${ expression }</literal> syntax is deprecated as of
+      PHP 8.2.0, as it can be interpreted as
       <link linkend="language.variables.variable">variable variables</link>:
       <informalexample>
        <programlisting role="php">
-  <![CDATA[
+<![CDATA[
 <?php
 const foo = 'bar';
 $foo = 'foo';
@@ -788,7 +778,7 @@ var_dump("${(foo)}");
        </programlisting>
        &example.outputs.82;
        <screen>
-  <![CDATA[
+<![CDATA[
 Deprecated: Using ${var} in strings is deprecated, use {$var} instead in file on line 6
 
 Deprecated: Using ${expr} (variable variables) in strings is deprecated, use {${expr}} instead in file on line 9
@@ -798,7 +788,7 @@ string(3) "bar"
        </screen>
        &example.outputs;
        <screen>
-  <![CDATA[
+<![CDATA[
 string(3) "foo"
 string(3) "bar"
 ]]>
@@ -812,7 +802,7 @@ string(3) "bar"
     <note>
      <simpara>
       If it is not possible to form a valid name the dollar sign remains
-      in the string:
+      as verbatim in the string:
      </simpara>
      <informalexample>
       <programlisting role="php">
@@ -836,14 +826,8 @@ No interpolation $2 has happened
      </informalexample>
     </note>
 
-    <simpara>
-     Moreover, the basic syntax permits access to the first, and only the first,
-     dimension of an array by using array indices (<literal>[]</literal>).
-     The key, must be an unquoted literal value.
-    </simpara>
-
     <example>
-     <title>Interpolating the value of the first dimension of an array with the basic syntax</title>
+     <title>Interpolating the value of the first dimension of an array or property</title>
      <programlisting role="php">
 <![CDATA[
 <?php
@@ -854,6 +838,15 @@ echo PHP_EOL;
 echo "He drank some $juices[1] juice.";
 echo PHP_EOL;
 echo "He drank some $juices[string_key] juice.";
+echo PHP_EOL;
+
+class A {
+    public $s = "string";
+}
+
+$o = new A();
+
+echo "Object value: $o->s.";
 ?>
 ]]>
      </programlisting>
@@ -863,40 +856,15 @@ echo "He drank some $juices[string_key] juice.";
 He drank some apple juice.
 He drank some orange juice.
 He drank some purple juice.
+Object value: string.
 ]]>
      </screen>
     </example>
 
-    <warning>
-     <para>
-      The basic syntax does not permit access to an array entry which has a key
-      containing a minus (<literal>-</literal>) sign.
-      Attempting to do will result in a parse error. The
-      <link linkend="language.types.string.parsing.advanced">advanced</link>
-      syntax must be used instead.
-      <informalexample>
-       <programlisting role="php">
-<![CDATA[
-<?php
-$a = ["string-key" => "value"];
-echo "Array value: $a[string-key]";
-?>
-]]>
-       </programlisting>
-       &example.outputs.similar;
-       <screen>
-<![CDATA[
-Parse error: syntax error, unexpected token "-", expecting "]" in file on line 3
-]]>
-       </screen>
-      </informalexample>
-     </para>
-    </warning>
-
     <note>
      <simpara>
-      Because the array key is unquoted, it is not possible to refer to a
-      constant with the basic syntax. Use the
+      The array key must be unquoted, and it is therefore not possible to
+      refer to a constant as a key with the basic syntax. Use the
       <link linkend="language.types.string.parsing.advanced">advanced</link>
       syntax instead.
      </simpara>
@@ -923,79 +891,6 @@ echo "Changing the character at index -3 to o gives $string.", PHP_EOL;
 <![CDATA[
 The character at index -2 is n.
 Changing the character at index -3 to o gives strong.
-]]>
-     </screen>
-    </example>
-
-    <simpara>
-     Similarly, it is possible to interpolate a non-static property of an
-     object. And it is impossible access a nested property.
-    </simpara>
-    <example>
-     <title>Interpolating the value of non-static property with the basic syntax</title>
-     <programlisting role="php">
-<![CDATA[
-<?php
-class A {
-    public $s = "string";
-}
-
-$o = new A();
-
-echo "Object value: $o->s.";
-?>
-]]>
-     </programlisting>
-     &example.outputs;
-     <screen>
-<![CDATA[
-Object value: string.
-]]>
-     </screen>
-    </example>
-
-    <example>
-     <title>Non-example demonstrating the impossibility to access nested or static properties</title>
-     <programlisting role="php">
-<![CDATA[
-<?php
-class A {
-    public static $bar = 'bar';
-}
-$a = new A();
-echo "Property $a::bar";
-?>
-]]>
-     </programlisting>
-     &example.outputs.similar;
-     <screen>
-<![CDATA[
-Fatal error: Uncaught Error: Object of class A could not be converted to string
-]]>
-     </screen>
-     <programlisting role="php">
-<![CDATA[
-<?php
-class A {
-    public $foo = 'foo';
-    public static $bar = 'bar';
-}
-class B {
-    public $o;
-}
-
-$a = new A();
-$b = new B();
-$b->o = $a;
-
-echo "Property $b->o->foo";
-?>
-]]>
-     </programlisting>
-     &example.outputs.similar;
-     <screen>
-<![CDATA[
-Fatal error: Uncaught Error: Object of class A could not be converted to string
 ]]>
      </screen>
     </example>

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -966,6 +966,10 @@ echo "This works: {$obj->values[3]->name}";
 
 echo "This works: {$obj->$staticProp}";
 
+// Won't work, outputs: C:\folder\{fantastic}.txt
+echo "C:\folder\{$great}.txt"
+// Works, outputs: C:\folder\fantastic.txt
+echo "C:\\folder\\{$great}.txt"
 ?>
 ]]>
      </programlisting>


### PR DESCRIPTION
This covers the PHP 8.2.0 deprecation of interpolation It also renames simple to basic and complex to advanced as those don't make a judgement on complexity.