### PR TITLE
Fix refpurpose of Imagick

### DIFF
--- a/reference/imagick/imagick/autolevelimage.xml
+++ b/reference/imagick/imagick/autolevelimage.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.autolevelimage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::autoLevelImage</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Adjusts the levels of a particular image channel</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/blueshiftimage.xml
+++ b/reference/imagick/imagick/blueshiftimage.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.blueshiftimage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::blueShiftImage</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Mutes the colors of the image</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/brightnesscontrastimage.xml
+++ b/reference/imagick/imagick/brightnesscontrastimage.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.brightnesscontrastimage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::brightnessContrastImage</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Change the brightness and/or contrast of an image</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/clampimage.xml
+++ b/reference/imagick/imagick/clampimage.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.clampimage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::clampImage</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Restricts the color range from 0 to the quantum depth.</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/clipimagepath.xml
+++ b/reference/imagick/imagick/clipimagepath.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.clipimagepath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::clipImagePath</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Clips along the named paths from the 8BIM profile, if present</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/colormatriximage.xml
+++ b/reference/imagick/imagick/colormatriximage.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.colormatriximage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::colorMatrixImage</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Apply color transformation to an image</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/deleteimageproperty.xml
+++ b/reference/imagick/imagick/deleteimageproperty.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.deleteimageproperty" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::deleteImageProperty</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Deletes an image property</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/filter.xml
+++ b/reference/imagick/imagick/filter.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.filter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::filter</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Applies a custom convolution kernel to the image</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>

--- a/reference/imagick/imagick/forwardfouriertransformimage.xml
+++ b/reference/imagick/imagick/forwardfouriertransformimage.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.forwardfouriertransformimage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::forwardFourierTransformImage</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Implements the discrete Fourier transform (DFT)</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/getimagemimetype.xml
+++ b/reference/imagick/imagick/getimagemimetype.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.getimagemimetype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::getImageMimeType</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Returns the image mime-type</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/getquantum.xml
+++ b/reference/imagick/imagick/getquantum.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.getquantum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::getQuantum</refname>
-  <refpurpose>Returns the ImageMagick quantum range as an integer</refpurpose>
+  <refpurpose>Returns the ImageMagick quantum range</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Returns the ImageMagick quantum range as an integer.
+   Returns the ImageMagick quantum range. If HDRI was enabled then the type is a float, if not it is an int.
   </para>
 
 

--- a/reference/imagick/imagick/getquantum.xml
+++ b/reference/imagick/imagick/getquantum.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.getquantum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::getQuantum</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Returns the ImageMagick quantum range as an integer</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/getregistry.xml
+++ b/reference/imagick/imagick/getregistry.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.getregistry" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::getRegistry</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Get the StringRegistry entry for the named key or false if not set</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/identifyformat.xml
+++ b/reference/imagick/imagick/identifyformat.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.identifyformat" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::identifyFormat</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Replaces any embedded formatting characters with the appropriate image property and returns the interpreted text</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/inversefouriertransformimage.xml
+++ b/reference/imagick/imagick/inversefouriertransformimage.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.inversefouriertransformimage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::inverseFourierTransformImage</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Implements the inverse discrete Fourier transform (DFT)</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/listregistry.xml
+++ b/reference/imagick/imagick/listregistry.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.listregistry" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::listRegistry</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>List all the registry settings</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/morphology.xml
+++ b/reference/imagick/imagick/morphology.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.morphology" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::morphology</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Applies a user supplied kernel to the image according to the given morphology method.</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/readimages.xml
+++ b/reference/imagick/imagick/readimages.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.readimages" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::readimages</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Reads image from an array of filenames</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/rotationalblurimage.xml
+++ b/reference/imagick/imagick/rotationalblurimage.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.rotationalblurimage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::rotationalBlurImage</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Rotational blurs an image</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/selectiveblurimage.xml
+++ b/reference/imagick/imagick/selectiveblurimage.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.selectiveblurimage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::selectiveBlurImage</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Selectively blur an image within a contrast threshold</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/setimageattribute.xml
+++ b/reference/imagick/imagick/setimageattribute.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.setimageattribute" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::setImageAttribute</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Sets the image attribute</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -19,10 +19,8 @@
    <methodparam><type>string</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
-
+   Sets the image attribute
   </para>
-
-  &warn.undocumented.func;
 
  </refsect1>
 

--- a/reference/imagick/imagick/setimagebiasquantum.xml
+++ b/reference/imagick/imagick/setimagebiasquantum.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.setimagebiasquantum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::setImageBiasQuantum</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Sets the image bias</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -15,13 +15,11 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>Imagick::setImageBiasQuantum</methodname>
-   <methodparam><type>string</type><parameter>bias</parameter></methodparam>
+   <methodparam><type>float</type><parameter>bias</parameter></methodparam>
   </methodsynopsis>
   <para>
-
+   Sets the image bias. Bias should be scaled with 0 = no adjustment, 1 = quantum value.
   </para>
-
-  &warn.undocumented.func;
 
  </refsect1>
 

--- a/reference/imagick/imagick/setprogressmonitor.xml
+++ b/reference/imagick/imagick/setprogressmonitor.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.setprogressmonitor" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::setProgressMonitor</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Set a callback that will be called during the processing of the Imagick image.</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/setregistry.xml
+++ b/reference/imagick/imagick/setregistry.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.setregistry" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::setRegistry</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Sets the ImageMagick registry entry named key to value</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/smushimages.xml
+++ b/reference/imagick/imagick/smushimages.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.smushimages" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::smushImages</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Takes all images from the current image pointer to the end of the image list and smushs them</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/statisticimage.xml
+++ b/reference/imagick/imagick/statisticimage.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.statisticimage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::statisticImage</refname>
-  <refpurpose>Replace each pixel with corresponding statistic from the neighborhood of the specified width and height.</refpurpose>
+  <refpurpose>Modifies image using a statistics function</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/statisticimage.xml
+++ b/reference/imagick/imagick/statisticimage.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.statisticimage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::statisticImage</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Replace each pixel with corresponding statistic from the neighborhood of the specified width and height.</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagick/subimagematch.xml
+++ b/reference/imagick/imagick/subimagematch.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagick.subimagematch" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::subImageMatch</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Searches for a subimage in the current image and returns a similarity image</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickdraw/getfontstretch.xml
+++ b/reference/imagick/imagickdraw/getfontstretch.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickdraw.getfontstretch" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickDraw::getFontStretch</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Gets the font stretch to use when annotating with text</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickdraw/gettextinterlinespacing.xml
+++ b/reference/imagick/imagickdraw/gettextinterlinespacing.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickdraw.gettextinterlinespacing" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickDraw::getTextInterlineSpacing</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Gets the text interword spacing</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickdraw/gettextinterwordspacing.xml
+++ b/reference/imagick/imagickdraw/gettextinterwordspacing.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickdraw.gettextinterwordspacing" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickDraw::getTextInterwordSpacing</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Gets the text interword spacing</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickdraw/gettextkerning.xml
+++ b/reference/imagick/imagickdraw/gettextkerning.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickdraw.gettextkerning" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickDraw::getTextKerning</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Gets the text kerning</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickdraw/resetvectorgraphics.xml
+++ b/reference/imagick/imagickdraw/resetvectorgraphics.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickdraw.resetvectorgraphics" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickDraw::resetVectorGraphics</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Resets the vector graphics</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickdraw/setresolution.xml
+++ b/reference/imagick/imagickdraw/setresolution.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickdraw.setresolution" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickDraw::setResolution</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Sets the resolution</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickdraw/settextinterlinespacing.xml
+++ b/reference/imagick/imagickdraw/settextinterlinespacing.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickdraw.settextinterlinespacing" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickDraw::setTextInterlineSpacing</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Sets the text interline spacing</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickdraw/settextinterwordspacing.xml
+++ b/reference/imagick/imagickdraw/settextinterwordspacing.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickdraw.settextinterwordspacing" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickDraw::setTextInterwordSpacing</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Sets the text interword spacing</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickdraw/settextkerning.xml
+++ b/reference/imagick/imagickdraw/settextkerning.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickdraw.settextkerning" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickDraw::setTextKerning</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Sets the text kerning</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickkernel/addkernel.xml
+++ b/reference/imagick/imagickkernel/addkernel.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickkernel.addkernel" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickKernel::addKernel</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Attach another kernel to this kernel to allow them to both be applied in a single morphology or filter function</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickkernel/addunitykernel.xml
+++ b/reference/imagick/imagickkernel/addunitykernel.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickkernel.addunitykernel" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickKernel::addUnityKernel</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Adds a given amount of the 'Unity' Convolution Kernel to the given pre-scaled and normalized Kernel</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickkernel/frombuiltin.xml
+++ b/reference/imagick/imagickkernel/frombuiltin.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickkernel.frombuiltin" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickKernel::fromBuiltIn</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Create a kernel from a builtin in kernel</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickkernel/frommatrix.xml
+++ b/reference/imagick/imagickkernel/frommatrix.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickkernel.frommatrix" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickKernel::fromMatrix</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Create a kernel from an 2d matrix of values</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickkernel/getmatrix.xml
+++ b/reference/imagick/imagickkernel/getmatrix.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickkernel.getmatrix" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickKernel::getMatrix</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Get the 2d matrix of values used in this kernel</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickkernel/scale.xml
+++ b/reference/imagick/imagickkernel/scale.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickkernel.scale" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickKernel::scale</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Scales the given kernel list by the given amount, with or without normalization of the sum of the kernel values (as per given flags).</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,14 +15,11 @@
    <methodparam choice="opt"><type>int</type><parameter>normalizeFlag</parameter></methodparam>
   </methodsynopsis>
   <para>
-   ScaleKernelInfo() scales the given kernel list by the given amount, with or without
+   Scales the given kernel list by the given amount, with or without
    normalization of the sum of the kernel values (as per given flags).
 
    The exact behaviour of this function depends on the normalization type being used
    please see http://www.imagemagick.org/api/morphology.php#ScaleKernelInfo for details.
-
-   Flag should be one of Imagick::NORMALIZE_KERNEL_VALUE, Imagick::NORMALIZE_KERNEL_CORRELATE,
-   Imagick::NORMALIZE_KERNEL_PERCENT or not set.
   </para>
 
 
@@ -30,7 +27,29 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  &no.function.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>scale</parameter></term>
+     <listitem>
+      <para>
+
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>normalizeFlag</parameter></term>
+     <listitem>
+      <para>
+       Imagick::NORMALIZE_KERNEL_NONE = 0
+       Imagick::NORMALIZE_KERNEL_VALUE = 8192
+       Imagick::NORMALIZE_KERNEL_CORRELATE = 65536
+       Imagick::NORMALIZE_KERNEL_PERCENT = 4096
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/imagick/imagickkernel/separate.xml
+++ b/reference/imagick/imagickkernel/separate.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickkernel.separate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickKernel::separate</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Separates a linked set of kernels and returns an array of ImagickKernels</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickpixel/getcolorquantum.xml
+++ b/reference/imagick/imagickpixel/getcolorquantum.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickpixel.getcolorquantum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickPixel::getColorQuantum</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Returns the color of the pixel in an array as Quantum values</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickpixel/getcolorvaluequantum.xml
+++ b/reference/imagick/imagickpixel/getcolorvaluequantum.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickpixel.getcolorvaluequantum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickPixel::getColorValueQuantum</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Gets the quantum value of a color in the ImagickPixel</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickpixel/getindex.xml
+++ b/reference/imagick/imagickpixel/getindex.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickpixel.getindex" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickPixel::getIndex</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Gets the colormap index of the pixel wand</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickpixel/ispixelsimilarquantum.xml
+++ b/reference/imagick/imagickpixel/ispixelsimilarquantum.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickpixel.ispixelsimilarquantum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickPixel::isPixelSimilarQuantum</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Returns true if the distance between two colors is less than the specified distance</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickpixel/setcolorcount.xml
+++ b/reference/imagick/imagickpixel/setcolorcount.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickpixel.setcolorcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickPixel::setColorCount</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Sets the color count associated with this color</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickpixel/setcolorvaluequantum.xml
+++ b/reference/imagick/imagickpixel/setcolorvaluequantum.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickpixel.setcolorvaluequantum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickPixel::setColorValueQuantum</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Sets the quantum value of a color element of the ImagickPixel</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/imagick/imagickpixel/setindex.xml
+++ b/reference/imagick/imagickpixel/setindex.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickpixel.setindex" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickPixel::setIndex</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>Sets the colormap index of the pixel wand</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">


### PR DESCRIPTION
**Changes:**
- Fix refpurpose of Imagick
- Update description and parameters: reference/imagick/imagickkernel/scale.xml
- Fix type and add description: reference/imagick/imagick/setimagebiasquantum.xml
- Add description: reference/imagick/imagick/setimageattribute.xml

**Doc-base result:**
All good. Saving .manual.xml... done.