### PR TITLE
added ReflectionClass::isReadOnly documentation.

### DIFF
--- a/reference/reflection/reflectionclass/isreadonly.xml
+++ b/reference/reflection/reflectionclass/isreadonly.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<refentry xml:id="reflectionclass.isreadonly" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionClass::isReadOnly</refname>
+  <refpurpose>Checks if class is readonly</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>ReflectionClass::isReadOnly</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Checks if a class is <link linkend="language.oop5.basic.class.readonly">readonly</link>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &true; if a class is readonly, &false; otherwise.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><methodname>ReflectionClass::isReadOnly</methodname> example</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+class       TestClass { }
+readonly class TestReadOnlyClass { }
+
+$normalClass = new ReflectionClass('TestClass');
+$readonlyClass  = new ReflectionClass('TestReadOnlyClass');
+
+var_dump($normalClass->isReadOnly());
+var_dump($readonlyClass->isReadOnly());
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+bool(false)
+bool(true)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ReflectionClass::isAbstract</methodname></member>
+    <member><link linkend="language.oop5.basic.class.readonly">Readonly classes</link></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionclass/isreadonly.xml
+++ b/reference/reflection/reflectionclass/isreadonly.xml
@@ -38,11 +38,11 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-class       TestClass { }
+class TestClass { }
 readonly class TestReadOnlyClass { }
 
 $normalClass = new ReflectionClass('TestClass');
-$readonlyClass  = new ReflectionClass('TestReadOnlyClass');
+$readonlyClass = new ReflectionClass('TestReadOnlyClass');
 
 var_dump($normalClass->isReadOnly());
 var_dump($readonlyClass->isReadOnly());

--- a/reference/reflection/versions.xml
+++ b/reference/reflection/versions.xml
@@ -186,6 +186,7 @@
  <function name="reflectionclass::isinterface" from="PHP 5, PHP 7, PHP 8"/>
  <function name="reflectionclass::isabstract" from="PHP 5, PHP 7, PHP 8"/>
  <function name="reflectionclass::isfinal" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="reflectionclass::isreadonly" from="PHP 8 &gt;= 8.2.0"/>
  <function name="reflectionclass::isanonymous" from="PHP 7, PHP 8"/>
  <function name="reflectionclass::getmodifiers" from="PHP 5, PHP 7, PHP 8"/>
  <function name="reflectionclass::isinstance" from="PHP 5, PHP 7, PHP 8"/>


### PR DESCRIPTION
We added readonly class documentation in #1996, but ReflectionClass::isReadOnly is missing.