### PR TITLE
random: Improve short descriptions for methods

### DIFF
--- a/reference/random/functions/random-bytes.xml
+++ b/reference/random/functions/random-bytes.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.random-bytes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>random_bytes</refname>
-  <refpurpose>Generates cryptographically secure pseudo-random bytes</refpurpose>
+  <refpurpose>Get cryptographically secure random bytes</refpurpose>
  </refnamediv>
 
  <refsect1 role="description"><!-- {{{ -->

--- a/reference/random/functions/random-int.xml
+++ b/reference/random/functions/random-int.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.random-int" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>random_int</refname>
-  <refpurpose>Get a cryptographically secure, uniformly selected integer from a closed interval</refpurpose>
+  <refpurpose>Get a cryptographically secure, uniformly selected integer</refpurpose>
  </refnamediv>
 
  <refsect1 role="description"><!-- {{{ -->

--- a/reference/random/functions/random-int.xml
+++ b/reference/random/functions/random-int.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.random-int" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>random_int</refname>
-  <refpurpose>Generates cryptographically secure pseudo-random integers</refpurpose>
+  <refpurpose>Get a cryptographically secure, uniformly selected integer from a closed interval</refpurpose>
  </refnamediv>
 
  <refsect1 role="description"><!-- {{{ -->

--- a/reference/random/random/engine/mt19937/generate.xml
+++ b/reference/random/random/engine/mt19937/generate.xml
@@ -2,7 +2,7 @@
 <refentry xml:id="random-engine-mt19937.generate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Random\Engine\Mt19937::generate</refname>
-  <refpurpose>Generates 32 bits of randomness</refpurpose>
+  <refpurpose>Generate 32 bits of randomness</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/random/random/engine/pcgoneseq128xslrr64/generate.xml
+++ b/reference/random/random/engine/pcgoneseq128xslrr64/generate.xml
@@ -2,7 +2,7 @@
 <refentry xml:id="random-engine-pcgoneseq128xslrr64.generate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Random\Engine\PcgOneseq128XslRr64::generate</refname>
-  <refpurpose>Generates 64 bits of randomness</refpurpose>
+  <refpurpose>Generate 64 bits of randomness</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/random/random/engine/pcgoneseq128xslrr64/jump.xml
+++ b/reference/random/random/engine/pcgoneseq128xslrr64/jump.xml
@@ -2,7 +2,7 @@
 <refentry xml:id="random-engine-pcgoneseq128xslrr64.jump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Random\Engine\PcgOneseq128XslRr64::jump</refname>
-  <refpurpose>Efficiently moves the engine ahead multiple steps</refpurpose>
+  <refpurpose>Efficiently move the engine ahead multiple steps</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/random/random/engine/secure/generate.xml
+++ b/reference/random/random/engine/secure/generate.xml
@@ -2,7 +2,7 @@
 <refentry xml:id="random-engine-secure.generate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Random\Engine\Secure::generate</refname>
-  <refpurpose>Generates cryptographically secure randomness</refpurpose>
+  <refpurpose>Generate cryptographically secure randomness</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/random/random/engine/xoshiro256starstar/generate.xml
+++ b/reference/random/random/engine/xoshiro256starstar/generate.xml
@@ -2,7 +2,7 @@
 <refentry xml:id="random-engine-xoshiro256starstar.generate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Random\Engine\Xoshiro256StarStar::generate</refname>
-  <refpurpose>Generates 64 bits of randomness</refpurpose>
+  <refpurpose>Generate 64 bits of randomness</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/random/random/engine/xoshiro256starstar/jump.xml
+++ b/reference/random/random/engine/xoshiro256starstar/jump.xml
@@ -2,7 +2,7 @@
 <refentry xml:id="random-engine-xoshiro256starstar.jump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Random\Engine\Xoshiro256StarStar::jump</refname>
-  <refpurpose>Efficiently moves the engine ahead by 2^128 steps</refpurpose>
+  <refpurpose>Efficiently move the engine ahead by 2^128 steps</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/random/random/engine/xoshiro256starstar/jumplong.xml
+++ b/reference/random/random/engine/xoshiro256starstar/jumplong.xml
@@ -2,7 +2,7 @@
 <refentry xml:id="random-engine-xoshiro256starstar.jumplong" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Random\Engine\Xoshiro256StarStar::jumpLong</refname>
-  <refpurpose>Efficiently moves the engine ahead by 2^192 steps</refpurpose>
+  <refpurpose>Efficiently move the engine ahead by 2^192 steps</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/random/random/randomizer/getint.xml
+++ b/reference/random/random/randomizer/getint.xml
@@ -2,7 +2,7 @@
 <refentry xml:id="random-randomizer.getint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Random\Randomizer::getInt</refname>
-  <refpurpose>Get a uniformly selected integer from a closed interval</refpurpose>
+  <refpurpose>Get a uniformly selected integer</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">


### PR DESCRIPTION
I intentionally didn't touch the function [we plan to deprecate with 8.3](https://wiki.php.net/rfc/deprecations_php_8_3#global_mersenne_twister) to not add unnecessary churn for the translators. 