### PR TITLE
random: Clean up cross-references for randomness related functions

### DIFF
--- a/reference/array/functions/array-rand.xml
+++ b/reference/array/functions/array-rand.xml
@@ -100,7 +100,8 @@ echo $input[$rand_keys[1]] . "\n";
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>shuffle</function></member>
+    <member><function>Random\Randomizer::pickArrayKeys</function></member>
+    <member><function>Random\Randomizer::shuffleArray</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/array/functions/shuffle.xml
+++ b/reference/array/functions/shuffle.xml
@@ -90,7 +90,9 @@ foreach ($numbers as $number) {
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>array_rand</function></member>
+    <member><function>Random\Randomizer::shuffleArray</function></member>
+    <member><function>Random\Randomizer::shuffleBytes</function></member>
+    <member><function>Random\Randomizer::pickArrayKeys</function></member>
     <member>&seealso.array.sorting;</member>
    </simplelist>
   </para>

--- a/reference/misc/functions/uniqid.xml
+++ b/reference/misc/functions/uniqid.xml
@@ -118,7 +118,12 @@ printf("uniqid('', true): %s\r\n", uniqid('', true));
   </note>
 
  </refsect1>
-
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>random_bytes</function></member>
+  </simplelist>
+ </refsect1>
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/openssl/functions/openssl-random-pseudo-bytes.xml
+++ b/reference/openssl/functions/openssl-random-pseudo-bytes.xml
@@ -144,7 +144,7 @@ bool(true)
    <member><function>random_bytes</function></member>
    <member><function>bin2hex</function></member>
    <member><function>crypt</function></member>
-   <member><function>mt_rand</function></member>
+   <member><function>random_int</function></member>
   </simplelist>
  </refsect1>
 </refentry>

--- a/reference/openssl/functions/openssl-random-pseudo-bytes.xml
+++ b/reference/openssl/functions/openssl-random-pseudo-bytes.xml
@@ -145,7 +145,6 @@ bool(true)
    <member><function>bin2hex</function></member>
    <member><function>crypt</function></member>
    <member><function>mt_rand</function></member>
-   <member><function>uniqid</function></member>
   </simplelist>
  </refsect1>
 </refentry>

--- a/reference/random/functions/random-bytes.xml
+++ b/reference/random/functions/random-bytes.xml
@@ -104,6 +104,7 @@ string(10) "385e33f741"
  <refsect1 role="seealso"><!-- {{{ -->
   &reftitle.seealso;
   <simplelist>
+   <member><function>Random\Randomizer::getBytes</function></member>
    <member><function>random_int</function></member>
    <member><function>bin2hex</function></member>
   </simplelist>

--- a/reference/random/functions/random-int.xml
+++ b/reference/random/functions/random-int.xml
@@ -119,6 +119,7 @@ int(-898)
  <refsect1 role="seealso"><!-- {{{ -->
   &reftitle.seealso;
   <simplelist>
+   <member><function>Random\Randomizer::getInt</function></member>
    <member><function>random_bytes</function></member>
   </simplelist>
  </refsect1><!-- }}} -->

--- a/reference/strings/functions/str-shuffle.xml
+++ b/reference/strings/functions/str-shuffle.xml
@@ -90,8 +90,8 @@ echo $shuffled;
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>shuffle</function></member>
-    <member><function>rand</function></member>
+    <member><function>Random\Randomizer::shuffleBytes</function></member>
+    <member><function>Random\Randomizer::shuffleArray</function></member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
Basically:

- Point to Randomizer where useful.
- Do not point from Randomizer to elsewhere (except random_int, random_bytes), developers should use the new API.