### PR TITLE
Update now instead of null in the example for DateTimeImmutable::__construct

### DIFF
--- a/reference/datetime/datetimeimmutable/construct.xml
+++ b/reference/datetime/datetimeimmutable/construct.xml
@@ -164,7 +164,7 @@ $date = new DateTimeImmutable();
 echo $date->format('Y-m-d H:i:sP') . "\n";
 
 // Current date/time in the specified time zone.
-$date = new DateTimeImmutable(null, new DateTimeZone('Pacific/Nauru'));
+$date = new DateTimeImmutable('now', new DateTimeZone('Pacific/Nauru'));
 echo $date->format('Y-m-d H:i:sP') . "\n";
 
 // Using a UNIX timestamp.  Notice the result is in the UTC time zone.


### PR DESCRIPTION
The first parameter for `DateTimeImmutable::__construct` is expected to be string. But in the **_Example `#2` Intricacies of DateTimeImmutable::__construct()_** for the example, 'Current date/time in the specified time zone' `null` is used instead of `now`.

**Current**

```php
// Current date/time in the specified time zone.
$date = new DateTimeImmutable(null, new DateTimeZone('Pacific/Nauru'));
echo $date->format('Y-m-d H:i:sP') . "\n";
```

**Expected**

```php
// Current date/time in the specified time zone.
$date = new DateTimeImmutable('now', new DateTimeZone('Pacific/Nauru'));
echo $date->format('Y-m-d H:i:sP') . "\n";
```