### PR TITLE
random: Add description to PcgOneseq128XslRr64::jump()

### DIFF
--- a/reference/random/random/engine/pcgoneseq128xslrr64/jump.xml
+++ b/reference/random/random/engine/pcgoneseq128xslrr64/jump.xml
@@ -12,11 +12,9 @@
    <methodparam><type>int</type><parameter>advance</parameter></methodparam>
   </methodsynopsis>
   <para>
-
+   Moves the algorithm’s state ahead by the number of steps given by <parameter>advance</parameter>, as if
+   <function>Random\Engine\PcgOneseq128XslRr64::generate</function> was called that many times.
   </para>
-
-  &warn.undocumented.func;
-
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Contrary to xoshiro256**’s `jump()` methods (https://www.php.net/manual/en/random-engine-xoshiro256starstar.jump.php) I was not able to think of a “prime use case”. While “splitting the engine” also works with PCG, it works less great due to the smaller overall state and the fact that jump distance is limited by `PHP_INT_MAX`, which is in the realm of collision for 32 Bit PHP at least.

So a simple description of the functionality it is, unless @zeriyoshi has some ideas of what could be added?