### PR TITLE
Ubuntu-latest workflows will use Ubuntu-22.04, temporary workaround

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -12,7 +12,7 @@ jobs:
   build:
     name: "Build"
 
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
 
     strategy:
       matrix:


### PR DESCRIPTION
Currently phpdoc github actions workflow fails in some locale, because we specify "runs-on: ubuntu-latest". `ubuntu-latest` is currently transitioning to ubuntu-22.04, so we take workarounds with `runs-on: ubuntu-20.04`.

----

ubuntu-latest is currently transitioning to ubuntu-22.04. During this time, you may experience some jobs running on either an ubuntu-20.04 or ubuntu-22.04 runner. You can specify `runs-on: ubuntu-20.04` in your workflow if you need the previous version.

https://github.com/actions/runner-images
https://github.com/actions/runner-images/issues/6399