### PR TITLE
Fix return value description of Imagick::getResourceLimit

### DIFF
--- a/reference/imagick/imagick/getresourcelimit.xml
+++ b/reference/imagick/imagick/getresourcelimit.xml
@@ -27,7 +27,6 @@
       <para>
        One of the <link 
        linkend="imagick.constants.resourcetypes">resourcetype constants</link>.
-       The unit depends on the type of the resource being limited.
       </para>
      </listitem>
     </varlistentry>
@@ -38,7 +37,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the specified resource limit in megabytes.
+   Returns the specified resource limit.
+   The unit depends on the type of the resource being limited.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Unit of Imagick::getResourceLimit returns value is following, not megabytes.

- bytes
  - disk
  - map
  - memory
- pixel
  - area
- count
  - file
  - thread
  - throttle
- seconds
  - time

## Sample

### Version of ImageMagick

ImageMagick 6.9.11-60 Q16 aarch64

### policy.xml

```xml
  <policy domain="resource" name="area" value="1MP"/>
  <policy domain="resource" name="disk" value="2GiB"/>
  <policy domain="resource" name="file" value="3"/>
  <policy domain="resource" name="map" value="4MiB"/>
  <policy domain="resource" name="memory" value="5MiB"/>
  <policy domain="resource" name="thread" value="1"/> 
  <policy domain="resource" name="time" value="7"/> 
  <policy domain="resource" name="throttle" value="8"/> 
```

### Test script

```php
echo "Area: " . Imagick::getResourceLimit(Imagick::RESOURCETYPE_AREA) . PHP_EOL;
echo "Disk: " . Imagick::getResourceLimit(Imagick::RESOURCETYPE_DISK) . PHP_EOL;
echo "File: " . Imagick::getResourceLimit(Imagick::RESOURCETYPE_FILE) . PHP_EOL;
echo "Map: " . Imagick::getResourceLimit(Imagick::RESOURCETYPE_MAP) . PHP_EOL;
echo "Memory: " . Imagick::getResourceLimit(Imagick::RESOURCETYPE_MEMORY) . PHP_EOL;
echo "Thread: " . Imagick::getResourceLimit(Imagick::RESOURCETYPE_THREAD) . PHP_EOL;
echo "Time: " . Imagick::getResourceLimit(Imagick::RESOURCETYPE_TIME) . PHP_EOL;
echo "Throttle: " . Imagick::getResourceLimit(Imagick::RESOURCETYPE_THROTTLE) . PHP_EOL;
```

### Output

```text
Area: 1000000
Disk: 2147483648
File: 3
Map: 4194304
Memory: 5242880
Thread: 1
Time: 7
Throttle: 8
```