### PR TITLE
Fix example of interpolation in parse_ini_file

### DIFF
--- a/reference/filesystem/functions/parse-ini-file.xml
+++ b/reference/filesystem/functions/parse-ini-file.xml
@@ -250,8 +250,11 @@ negative_two = ~1
 ; () is used for grouping
 seven = (8|7)&(6|5)
 
+; Interpolate the PATH environment variable
 path = ${PATH}
-also_five = ${five}
+
+; Interpolate the configuration option 'memory_limit'
+configured_memory_limit = ${memory_limit}
 
 ]]>
     </programlisting>


### PR DESCRIPTION
The `also_five` example does not work. The documentation was fixed in https://github.com/php/doc-en/commit/f8b0bb410016270b696b28d3d416672dd2f7e66b from a bug report at https://bugs.php.net/bug.php?id=81620 . However, the example value of `also_five` still existed. Now the example code demonstrates how to interpolate a configuration variable, which is what is supported.