### PR TITLE
array_keys(): fix incorrect parameter name

### DIFF
--- a/reference/array/functions/array-keys.xml
+++ b/reference/array/functions/array-keys.xml
@@ -15,7 +15,7 @@
   <methodsynopsis role="procedural">
    <type>array</type><methodname>array_keys</methodname>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
-   <methodparam><type>mixed</type><parameter>search_value</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>filter_value</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>strict</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <para>
@@ -23,7 +23,7 @@
    string, from the <parameter>array</parameter>.
   </para>
   <para>
-   If a <parameter>search_value</parameter> is specified,
+   If a <parameter>filter_value</parameter> is specified,
    then only the keys for that value are returned. Otherwise, all
    the keys from the <parameter>array</parameter> are returned.
   </para>
@@ -42,7 +42,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>search_value</parameter></term>
+     <term><parameter>filter_value</parameter></term>
      <listitem>
       <para>
        If specified, then only keys containing this value are returned.


### PR DESCRIPTION
... which would break function calls using named parameters. Demo: https://3v4l.org/7BNbJ

Ref: https://github.com/php/php-src/blob/11b612af6dbe9fdd60edb58d37e441c97bff79e0/ext/standard/basic_functions.stub.php#L1691

As a side-note: I was surprised to find this bug as I thought the parameter info in the docs was generated from the stub file ? (or in some other automated way kept updated)
If there is an automated way to update this, I'd highly recommend running it as if I found one, there's bound to be more parameter names being out of sync with the stubs...