### PR TITLE
Fix spelling

### DIFF
--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -329,7 +329,7 @@ $test->obj = new stdClass;
   <sect2 xml:id="language.oop5.properties.dynamic-properties">
    <title>Dynamic properties</title>
    <para>
-    If trying to assign to a non existent property on an &object;,
+    If trying to assign to a non-existent property on an &object;,
     PHP will automatically create a corresponding property.
     This dynamically created property will <emphasis>only</emphasis> be
     available on this class instance.

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -329,7 +329,7 @@ $test->obj = new stdClass;
   <sect2 xml:id="language.oop5.properties.dynamic-properties">
    <title>Dynamic properties</title>
    <para>
-    If trying to assign to a non existant property on an &object;,
+    If trying to assign to a non existent property on an &object;,
     PHP will automatically create a corresponding property.
     This dynamically created property will <emphasis>only</emphasis> be
     available on this class instance.


### PR DESCRIPTION
"Existant" is a common misspelling of "Existent". Also, 'non' should act as a prefix to the word, either being hyphenated or treated as a compound word ("nonexistent").  I'm leaving it alone for now.