### PR TITLE
Document that constant & defined work with enums

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -130,6 +130,13 @@ print Suit::Spades->name;
 ]]>
    </programlisting>
 
+   <para>
+    It is also possible to use the <function>defined</function> and <function>constant</function>
+    functions to check for the existence of or read an enum case if the name is obtained dynamically.
+    This is, however, discouraged as using <link linkend="language.enumerations.backed">Backed enums</link>
+    should work for most use cases.
+   </para>
+
   </sect1>
 
  <sect1 xml:id="language.enumerations.backed">

--- a/reference/misc/functions/constant.xml
+++ b/reference/misc/functions/constant.xml
@@ -23,7 +23,8 @@
   </simpara>
   <simpara>
    This function works also with <link
-   linkend="language.oop5.constants">class constants</link>.
+   linkend="language.oop5.constants">class constants</link> and <link
+   linkend="language.types.enumerations">enum cases</link>.
   </simpara>
  </refsect1>
 
@@ -86,7 +87,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title><function>constant</function> example</title>
+    <title>Using <function>constant</function> with Constants</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -109,6 +110,28 @@ $const = 'test';
 
 var_dump(constant('bar::'. $const)); // string(7) "foobar!"
 var_dump(constant('foo::'. $const)); // string(7) "foobar!"
+
+?>
+]]>
+    </programlisting>
+   </example>
+   <example>
+    <title>Using <function>constant</function> with Enum Cases (as of PHP 8.1.0)</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
+
+$case = 'Hearts';
+
+var_dump(constant('Suit::'. $case)); // enum(Suit::Hearts)
 
 ?>
 ]]>

--- a/reference/misc/functions/defined.xml
+++ b/reference/misc/functions/defined.xml
@@ -15,6 +15,11 @@
   <para>
    Checks whether the given constant exists and is defined.
   </para>
+  <para>
+   This function works also with <link
+   linkend="language.oop5.constants">class constants</link> and <link
+   linkend="language.types.enumerations">enum cases</link>.
+  </para>
   <note>
    <para>
     If you want to see if a variable exists, use <function>isset</function>
@@ -56,11 +61,45 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-/* Note the use of quotes, this is important.  This example is checking
+
+/* Note the use of quotes, this is important. This example is checking
  * if the string 'TEST' is the name of a constant named TEST */
 if (defined('TEST')) {
     echo TEST;
 }
+
+
+interface bar {
+    const test = 'foobar!';
+}
+
+class foo {
+    const test = 'foobar!';
+}
+
+var_dump(defined('bar::test')); // bool(true)
+var_dump(defined('foo::test')); // bool(true)
+
+?>
+]]>
+    </programlisting>
+   </example>
+   <example>
+    <title>Checking Enum Cases (as of PHP 8.1.0)</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
+
+var_dump(defined('Suit::Hearts')); // bool(true)
+
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
The `constant()` & `defined()` methods can be used with dynamic enum cases names, which doesn't seem to be documented anywhere at the moment.