### PR TITLE
Update when opcache_reset returns false

### DIFF
--- a/reference/opcache/functions/opcache-reset.xml
+++ b/reference/opcache/functions/opcache-reset.xml
@@ -30,7 +30,7 @@
   &reftitle.returnvalues;
   <para>
    Returns &true; if the opcode cache was reset, or &false; if the opcode
-   cache is disabled.
+   cache is disabled or the restart is pending or in progress (see <function>opcache_get_status</function>).
   </para>
  </refsect1>
 


### PR DESCRIPTION
The `opcache_reset()` function also returns `false` when the restart is pending or in progress.