### PR TITLE
Update FilesystemIterator::__construct doc for php 8.2

### DIFF
--- a/appendices/migration82/incompatible.xml
+++ b/appendices/migration82/incompatible.xml
@@ -51,7 +51,7 @@
   </para>
 
   <para>
-   <methodname>FilesystemIterator::__construct</methodname>, prior to PHP 8.2
+   <methodname>FilesystemIterator::__construct</methodname>: prior to PHP 8.2.0,
    <constant>FilesystemIterator::SKIP_DOTS</constant> constant was always set
    and couldn't be disabled. In order to maintain the previous behaviour the constant
    must be explicitly set when using the <parameter>flags</parameter> parameter.

--- a/appendices/migration82/incompatible.xml
+++ b/appendices/migration82/incompatible.xml
@@ -53,9 +53,9 @@
   <para>
    <methodname>FilesystemIterator::__construct</methodname>, prior to PHP 8.2
    <constant>FilesystemIterator::SKIP_DOTS</constant> constant was always set
-   and couldn't be disabled. In order to maintain previous behaviour you have to
-   explicitly add this constant if you are using <parameter>flags</parameter>
-   parameter. The default value from <parameter>flags</parameter> parameter has
+   and couldn't be disabled. In order to maintain the previous behaviour the constant
+   must be explicitly set when using the <parameter>flags</parameter> parameter.
+   The default value from <parameter>flags</parameter> parameter has
    not been modified.
   </para>
 

--- a/appendices/migration82/incompatible.xml
+++ b/appendices/migration82/incompatible.xml
@@ -51,6 +51,15 @@
   </para>
 
   <para>
+   <methodname>FilesystemIterator::__construct</methodname>, prior to PHP 8.2
+   <constant>FilesystemIterator::SKIP_DOTS</constant> constant was always set
+   and couldn't be disabled. In order to maintain previous behaviour you have to
+   explicitly add this constant if you are using <parameter>flags</parameter>
+   parameter. The default value from <parameter>flags</parameter> parameter has
+   not been modified.
+  </para>
+
+  <para>
    <function>strtolower</function>,
    <function>strtoupper</function>,
    <function>stristr</function>,

--- a/reference/spl/filesystemiterator/construct.xml
+++ b/reference/spl/filesystemiterator/construct.xml
@@ -98,14 +98,24 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$it = new FilesystemIterator(dirname(__FILE__));
+$it = new FilesystemIterator(dirname(__FILE__), FilesystemIterator::CURRENT_AS_FILEINFO);
 foreach ($it as $fileinfo) {
     echo $fileinfo->getFilename() . "\n";
 }
 ?>
 ]]>
     </programlisting>
-    &example.outputs;
+    &example.outputs.82.similar;
+    <screen>
+<![CDATA[
+.
+..
+apples.jpg
+banana.jpg
+example.php
+]]>
+    </screen>
+    <para>Output of the above example prior to PHP 8.2.0 is similar to:</para>
     <screen>
 <![CDATA[
 apples.jpg

--- a/reference/spl/filesystemiterator/construct.xml
+++ b/reference/spl/filesystemiterator/construct.xml
@@ -39,12 +39,6 @@
        A list of the flags can found under <link linkend="filesystemiterator.constants">FilesystemIterator predefined constants</link>. 
        They can also be set later with <methodname>FilesystemIterator::setFlags</methodname>
       </para>
-      <note>
-       <para>
-        <constant>FilesystemIterator::SKIP_DOTS</constant> is always set, and cannot
-        be removed.
-       </para>
-      </note>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -75,6 +69,13 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.2.0</entry>
+       <entry>
+        Prior to PHP 8.2 <constant>FilesystemIterator::SKIP_DOTS</constant> was
+        always set and could not be removed.
+       </entry>
+      </row>
       <row>
        <entry>8.0.0</entry>
        <entry>

--- a/reference/spl/filesystemiterator/construct.xml
+++ b/reference/spl/filesystemiterator/construct.xml
@@ -72,7 +72,7 @@
       <row>
        <entry>8.2.0</entry>
        <entry>
-        Prior to PHP 8.2 <constant>FilesystemIterator::SKIP_DOTS</constant> was
+        Prior to PHP 8.2.0, <constant>FilesystemIterator::SKIP_DOTS</constant> was
         always set and could not be removed.
        </entry>
       </row>

--- a/reference/spl/filesystemiterator/current.xml
+++ b/reference/spl/filesystemiterator/current.xml
@@ -49,7 +49,7 @@ foreach ($iterator as $fileinfo) {
 ?>
 ]]>
     </programlisting>
-    &example.outputs.similar;
+    &example.outputs.82.similar;
     <screen>
 <![CDATA[
 /www/examples/.

--- a/reference/spl/filesystemiterator/current.xml
+++ b/reference/spl/filesystemiterator/current.xml
@@ -52,6 +52,8 @@ foreach ($iterator as $fileinfo) {
     &example.outputs.similar;
     <screen>
 <![CDATA[
+/www/examples/.
+/www/examples/..
 /www/examples/apple.jpg
 /www/examples/banana.jpg
 /www/examples/example.php

--- a/reference/spl/filesystemiterator/key.xml
+++ b/reference/spl/filesystemiterator/key.xml
@@ -45,7 +45,7 @@ foreach ($iterator as $fileinfo) {
 ?>
 ]]>
     </programlisting>
-    &example.outputs.similar;
+    &example.outputs.82.similar;
     <screen>
 <![CDATA[
 .

--- a/reference/spl/filesystemiterator/key.xml
+++ b/reference/spl/filesystemiterator/key.xml
@@ -48,6 +48,8 @@ foreach ($iterator as $fileinfo) {
     &example.outputs.similar;
     <screen>
 <![CDATA[
+.
+..
 apple.jpg
 banana.jpg
 example.php

--- a/reference/spl/filesystemiterator/setflags.xml
+++ b/reference/spl/filesystemiterator/setflags.xml
@@ -69,7 +69,7 @@ foreach ($iterator as $key => $fileinfo) {
 ?>
 ]]>
     </programlisting>
-    &example.outputs.similar;
+    &example.outputs.82.similar;
     <screen>
 <![CDATA[
 Key as Pathname:

--- a/reference/spl/filesystemiterator/setflags.xml
+++ b/reference/spl/filesystemiterator/setflags.xml
@@ -73,11 +73,15 @@ foreach ($iterator as $key => $fileinfo) {
     <screen>
 <![CDATA[
 Key as Pathname:
+/www/examples/.
+/www/examples/..
 /www/examples/apple.jpg
 /www/examples/banana.jpg
 /www/examples/example.php
 
 Key as Filename:
+.
+..
 apple.jpg
 banana.jpg
 example.php


### PR DESCRIPTION
Hello, I'm updating documentation for [FilesystemIterator::__construct](https://www.php.net/manual/en/filesystemiterator.construct.php).

Before PHP 8.2 the `FilesystemIterator::SKIP_DOTS` was always set and couldn't be removed, this changed in PHP 8.2.
If you are using the default value for `flags` parameter then everything work as expected, but if you are using any other value you have to add `FilesystemIterator::SKIP_DOTS` to maintain old behavior. 

You can see an example in <https://3v4l.org/HrmZ2>.

This already provoked a bug (see https://github.com/phingofficial/phing/pull/1685), that's why I also updated documentation in "breaking changes" section.

This change was added in https://github.com/php/php-src/commit/088e5478029f7b3482a9c5ae2b06b77772b92480 and as far as I know it's not part of any pull request, I suppose that's the reason it hasn't been documented yet.