### PR TITLE
ldap: Document removal of ber_identifier param

### DIFF
--- a/reference/ldap/functions/ldap-first-attribute.xml
+++ b/reference/ldap/functions/ldap-first-attribute.xml
@@ -43,25 +43,6 @@
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry>
-     <term><parameter>ber_identifier</parameter></term>
-     <listitem>
-      <para>
-       <parameter>ber_identifier</parameter> is the identifier to internal
-       memory location pointer. It is passed by reference. The same
-       <parameter>ber_identifier</parameter> is passed to
-       <function>ldap_next_attribute</function> , which modifies that
-       pointer.
-      </para>
-      <note>
-       <para>
-        This parameter is no longer used as this is now handled automatically
-        by PHP. For backwards compatibility PHP will not throw an error if
-        this parameter is passed.
-       </para>
-      </note>
-     </listitem>
-    </varlistentry>
    </variablelist>
   </para>
  </refsect1>
@@ -87,6 +68,12 @@
     <tbody>
      &ldap.changelog.ldap-object;
      &ldap.changelog.entry-object;
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       The unused third parameter <parameter>ber_identifier</parameter> is no longer accepted.
+      </entry>
+     </row>
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/ldap/functions/ldap-next-attribute.xml
+++ b/reference/ldap/functions/ldap-next-attribute.xml
@@ -41,21 +41,6 @@
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry>
-     <term><parameter>ber_identifier</parameter></term>
-     <listitem>
-      <para>
-       The internal state of the pointer is maintained by this parameter.
-      </para>
-      <note>
-       <para>
-        This parameter is no longer used as this is now handled automatically
-        by PHP. For backwards compatibility PHP will not throw an error if
-        this parameter is passed.
-       </para>
-      </note>
-     </listitem>
-    </varlistentry>
    </variablelist>
   </para>
  </refsect1>
@@ -81,6 +66,12 @@
     <tbody>
      &ldap.changelog.ldap-object;
      &ldap.changelog.entry-object;
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       The unused third parameter <parameter>ber_identifier</parameter> is no longer accepted.
+      </entry>
+     </row>
     </tbody>
    </tgroup>
   </informaltable>


### PR DESCRIPTION
The docs for ldap_first_attribute and ldap_next_attribute note that PHP accepts a third, deprecated argument, `$ber_identifier` without raising an error.

In fact, passing 3 parameters to these functions has been an ArgumentCountError since PHP 8.0.0 (see php/php-src@eeec37d31d6aa4452d83e2640aee7c8c25349617).

For both functions, this change removes the argument from the list, removes the note indicating that a third argument can be passed, and adds the change at version 8.0.0 to the changelog.