### PR TITLE
Better crosslinks between str_replace and preg_replace

### DIFF
--- a/reference/pcre/functions/preg-replace.xml
+++ b/reference/pcre/functions/preg-replace.xml
@@ -21,6 +21,11 @@
    <parameter>pattern</parameter> and replaces them with
    <parameter>replacement</parameter>.
   </para>
+  <para>
+   To match an exact string, rather than a pattern,
+   consider using <function>str_replace</function> or
+   <function>str_ireplace</function> instead of this function.
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -335,6 +340,8 @@ print_r(preg_replace($p, $r, 'a'));
     <member><function>preg_replace_callback</function></member>
     <member><function>preg_split</function></member>
     <member><function>preg_last_error</function></member>
+    <member><function>preg_last_error</function></member>
+    <member><function>str_replace</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/strings/functions/str-ireplace.xml
+++ b/reference/strings/functions/str-ireplace.xml
@@ -19,9 +19,12 @@
    This function returns a string or an array with all occurrences of
    <parameter>search</parameter> in <parameter>subject</parameter>
    (ignoring case) replaced with the given <parameter>replace</parameter>
-   value.  If you don't need fancy replacing rules, you should generally
-   use this function instead of
-   <function>preg_replace</function> with the <literal>i</literal> modifier.
+   value.
+   </para>
+   <para>
+    To replace text based on a pattern rather than a fixed string,
+    use <function>preg_replace</function> with the <literal>i</literal>
+    <link linkend="reference.pcre.pattern.modifiers">pattern modifier</link>.
   </para>
  </refsect1>
 

--- a/reference/strings/functions/str-replace.xml
+++ b/reference/strings/functions/str-replace.xml
@@ -21,8 +21,8 @@
    replaced with the given <parameter>replace</parameter> value.
   </para>
   <para>
-   If you don't need fancy replacing rules (like regular expressions), you
-   should use this function instead of <function>preg_replace</function>.
+   To replace text based on a pattern rather than a fixed
+   string, use <function>preg_replace</function>.
   </para>
  </refsect1>
 


### PR DESCRIPTION
The str_replace page had a helpful note that if you'd somehow got here when you were looking for preg_replace, you didn't need to go there. But if you were actually on the page for preg_replace, there was no link to str_replace at all, not even in the See Also section.