### PR TITLE
Nits to the type juggling page

### DIFF
--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -150,7 +150,7 @@
    <!-- e.g. An object that implements __toString will pass a string type -->
    type, the value is convertable to a scalar type,
    and the coercive typing mode is active
-   (the default), the value may be converted to an accepted scalar valued.
+   (the default), the value may be converted to an accepted scalar value.
    See below for a description of this behaviour.
   </para>
 

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -146,8 +146,10 @@
    Two exceptions exist, the first one is: if the value is of type
    <type>int</type> and the declared type is <type>float</type>, then the
    integer is converted to a floating point number.
-   The second one is: if the value and the declared type are
-   <emphasis>scalar</emphasis> types, and the coercive typing mode is active
+   The second one is: if the declared type is a <emphasis>scalar</emphasis>
+   <!-- e.g. An object that implements __toString will pass a string type -->
+   type, the value is convertable to a scalar type,
+   and the coercive typing mode is active
    (the default), the value may be converted to an accepted scalar valued.
    See below for a description of this behaviour.
   </para>
@@ -230,7 +232,8 @@
     <para>
      As an exception, if the value is a string and both int and float are part
      of the union, the preferred type is determined by the existing
-     “numeric string” semantics.
+     <link linkend="language.types.numeric-strings">numeric string</link>
+     semantics.
      For example, for <literal>"42"</literal> <type>int</type> is chosen,
      while for <literal>"42.0"</literal> <type>float</type> is chosen.
     </para>
@@ -240,7 +243,8 @@
     <para>
      Types that are not part of the above preference list are not eligible
      targets for implicit coercion. In particular no implicit coercions to
-     the <literal>null</literal> and <literal>false</literal> types occur.
+     the <type>null</type>, <type>false</type>, and <type>true</type>
+     types occur.
     </para>
    </note>
 


### PR DESCRIPTION
The big one is the need to clarify the behaviour around the coercive typing mode, as the conversion of objects to strings is relatively straight forward but in theory internal objects that overload the cast handler can convert to other types too.