### PR TITLE
Fix typo in PHP 7.0 migration guide

### DIFF
--- a/appendices/migration70/incompatible/other.xml
+++ b/appendices/migration70/incompatible/other.xml
@@ -362,7 +362,7 @@ switch (1) {
  </sect3>
 
  <sect3 xml:id="migration70.incompatible.other.break-continue">
-  <title>Misplaced break and switch statements</title>
+  <title>Misplaced break and continue statements</title>
   <para>
    <literal>break</literal> and <literal>continue</literal> statements outside of
    a loop or <literal>switch</literal> control structure are now detected at


### PR DESCRIPTION
The title refers to "break and switch" when it means "break and continue".