### PR TITLE
Constant disallowed as break and continue argument as of PHP 7.0

### DIFF
--- a/appendices/migration70/incompatible/other.xml
+++ b/appendices/migration70/incompatible/other.xml
@@ -371,6 +371,15 @@ switch (1) {
   </para>
  </sect3>
 
+ <sect3 xml:id="migration70.incompatible.other.break-continue-constant">
+  <title>Constant disallowed as break and continue argument</title>
+  <para>
+   <literal>break</literal> and <literal>continue</literal> statements no longer
+   allow their argument to be a constant, and trigger a
+   <constant>E_COMPILE_ERROR</constant>.
+  </para>
+ </sect3>
+
  <sect3 xml:id="migration70.incompatible.other.mhash">
   <title>Mhash is not an extension anymore</title>
   <para>


### PR DESCRIPTION
This is no longer allowed ([3v4l.org](https://3v4l.org/MMuci)):
```php
while (true) {
    break E_ERROR;
}
```

It seems like this is a continuation of the change introduced in PHP 5.4, and was overlooked in the documentation.
> The break and continue statements no longer accept variable arguments (e.g., break 1 + foo() * $bar;).

Source: https://php-legacy-docs.zend.com/manual/php5/en/migration54.incompatible