### PR TITLE
Better example for usleep()

### DIFF
--- a/reference/misc/functions/usleep.xml
+++ b/reference/misc/functions/usleep.xml
@@ -63,13 +63,19 @@
 <?php
 
 // Current time
-echo date('h:i:s') . "\n";
+echo (new DateTime('now'))->format('H:i:s.v'), "\n";
 
-// wait for 2 seconds
-usleep(2000000);
+// wait for 2 milliseconds
+usleep(2000);
 
 // back!
-echo date('h:i:s') . "\n";
+echo (new DateTime('now'))->format('H:i:s.v'), "\n";
+
+// wait for 30 milliseconds
+usleep(30000);
+
+// back again!
+echo (new DateTime('now'))->format('H:i:s.v'), "\n";
 
 ?>
 ]]>
@@ -77,8 +83,9 @@ echo date('h:i:s') . "\n";
     &example.outputs;
     <screen>
 <![CDATA[
-11:13:28
-11:13:30
+11:13:28.005
+11:13:28.007
+11:13:28.037
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
It is unnatural that the only example exceeds that number even though <q>may not be supported by the operating system</q> is mentioned. Also, it makes sense to show that you can sleep with sub-second accuracy.

> Note: Values larger than 1000000 (i.e. sleeping for more than a second) may not be supported by the operating system. Use [sleep()](https://www.php.net/manual/en/function.sleep.php) instead.

Linux timers seem to work with this precision: https://3v4l.org/1GI6a