### PR TITLE
Duplicate note on microsecond precision from datetime.formats

### DIFF
--- a/reference/datetime/functions/date.xml
+++ b/reference/datetime/functions/date.xml
@@ -38,6 +38,15 @@
      <para>
       Format accepted by <methodname>DateTimeInterface::format</methodname>.
      </para>
+      <note>
+       <simpara>
+        <function>date</function> will always generate
+        <literal>000000</literal> as microseconds since it takes an <type>int</type>
+        parameter, whereas <methodname>DateTime::format</methodname> does
+        support microseconds if <classname>DateTime</classname> was
+        created with microseconds.
+       </simpara>
+      </note>
     </listitem>
    </varlistentry>
 


### PR DESCRIPTION
Duplicate the note because users who tried to use `date()` get confused about the format for microseconds.

refs https://github.com/php/doc-en/pull/2113