### PR TITLE
OOP5/Traits/Constants: fix example code

### DIFF
--- a/language/oop5/traits.xml
+++ b/language/oop5/traits.xml
@@ -510,11 +510,11 @@ trait ConstantsTrait {
 }
 
 class ConstantsExample {
-    use ConstantTrait;
+    use ConstantsTrait;
 }
 
-$example = new ConstantExample;
-$example::FLAG;
+$example = new ConstantsExample;
+echo $example::FLAG_MUTABLE; // 1
 ?>
 ]]>
    </programlisting>
@@ -535,7 +535,7 @@ trait ConstantsTrait {
 }
 
 class ConstantsExample {
-    use ConstantTrait;
+    use ConstantsTrait;
     public const FLAG_IMMUTABLE = 5; // Fatal error
 }
 ?>


### PR DESCRIPTION
The example code contained three errors:
* Reference to non-existent `ConstantTrait` trait (x2).
* Instantiation of non-existent `ConstantExample` class.
* Reference to an undefined constant.

Fixed now.