### PR TITLE
Update return value description for date()

### DIFF
--- a/reference/datetime/functions/date.xml
+++ b/reference/datetime/functions/date.xml
@@ -58,9 +58,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a formatted date string. If a non-numeric value is used for
-   <parameter>timestamp</parameter>, &false; is returned and an
-   <constant>E_WARNING</constant> level error is emitted.
+   Returns a formatted date string.
   </para>
  </refsect1>
 


### PR DESCRIPTION
The documentation hints that `timestamp` can be non-numeric, but that will cause a `TypeError` since PHP 8.0. 