### PR TITLE
ArgumentCountError is not limited to user-defined stuff.

### DIFF
--- a/language/predefined/argumentcounterror.xml
+++ b/language/predefined/argumentcounterror.xml
@@ -11,7 +11,7 @@
    &reftitle.intro;
    <para>
     <ooclass><classname>ArgumentCountError</classname></ooclass> is thrown
-    when too few arguments are passed to a user-defined function or method.
+    when too few arguments are passed to a function or method.
    </para>
   </section>
 <!-- }}} -->


### PR DESCRIPTION
For example strlen(); generates ArgumentCountError and is not a user-defined function.