### PR TITLE
Fix bcsqrt return type description

### DIFF
--- a/reference/bc/functions/bcsqrt.xml
+++ b/reference/bc/functions/bcsqrt.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the square root as a string. 
+   Returns the square root as a string.
   </para>
  </refsect1>
  

--- a/reference/bc/functions/bcsqrt.xml
+++ b/reference/bc/functions/bcsqrt.xml
@@ -38,8 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the square root as a string, or &null; if 
-   <parameter>num</parameter> is negative. 
+   Returns the square root as a string. 
   </para>
  </refsect1>
  


### PR DESCRIPTION
These functions thrown an error if the value is negative not return null. Changed to match bcpow.