### PR TITLE
Add void ternary note

### DIFF
--- a/language/operators.xml
+++ b/language/operators.xml
@@ -1864,7 +1864,7 @@ if (empty($_POST['action'])) {
        <programlisting role="php">
         <?php
         // Both functions are void, so no value assignment is needed.
-        isset($seed) ? mt_srand($seed) : mt_srand();        
+        isset($seed) ? mt_srand($seed) : mt_srand();
 
         // One side returns a value, so an assignment is needed unless the
         // the return value is to be ignored.

--- a/language/operators.xml
+++ b/language/operators.xml
@@ -98,17 +98,17 @@
        <row>
         <entry>(n/a)</entry>
         <entry>
-         <literal>+</literal> 
-         <literal>-</literal> 
-         <literal>++</literal> 
-         <literal>--</literal> 
-         <literal>~</literal> 
-         <literal>(int)</literal> 
-         <literal>(float)</literal> 
-         <literal>(string)</literal> 
+         <literal>+</literal>
+         <literal>-</literal>
+         <literal>++</literal>
+         <literal>--</literal>
+         <literal>~</literal>
+         <literal>(int)</literal>
+         <literal>(float)</literal>
+         <literal>(string)</literal>
          <literal>(array)</literal>
-         <literal>(object)</literal> 
-         <literal>(bool)</literal> 
+         <literal>(object)</literal>
+         <literal>(bool)</literal>
          <literal>@</literal>
         </entry>
         <entry>
@@ -147,8 +147,8 @@
        <row>
         <entry>left</entry>
         <entry>
-         <literal>+</literal> 
-         <literal>-</literal> 
+         <literal>+</literal>
+         <literal>-</literal>
          <literal>.</literal>
         </entry>
         <entry>
@@ -160,7 +160,7 @@
        <row>
         <entry>left</entry>
         <entry>
-         <literal>&lt;&lt;</literal> 
+         <literal>&lt;&lt;</literal>
          <literal>&gt;&gt;</literal>
         </entry>
         <entry>
@@ -177,9 +177,9 @@
        <row>
         <entry>non-associative</entry>
         <entry>
-         <literal>&lt;</literal> 
-         <literal>&lt;=</literal> 
-         <literal>&gt;</literal> 
+         <literal>&lt;</literal>
+         <literal>&lt;=</literal>
+         <literal>&gt;</literal>
          <literal>&gt;=</literal>
         </entry>
         <entry>
@@ -190,9 +190,9 @@
         <entry>non-associative</entry>
         <entry>
          <literal>==</literal>
-         <literal>!=</literal> 
-         <literal>===</literal> 
-         <literal>!==</literal> 
+         <literal>!=</literal>
+         <literal>===</literal>
+         <literal>!==</literal>
          <literal>&lt;&gt;</literal>
          <literal>&lt;=&gt;</literal>
         </entry>
@@ -253,18 +253,18 @@
        <row>
         <entry>right</entry>
         <entry>
-         <literal>=</literal> 
-         <literal>+=</literal> 
-         <literal>-=</literal> 
-         <literal>*=</literal> 
-         <literal>**=</literal> 
-         <literal>/=</literal> 
-         <literal>.=</literal> 
-         <literal>%=</literal> 
-         <literal>&amp;=</literal> 
-         <literal>|=</literal> 
-         <literal>^=</literal> 
-         <literal>&lt;&lt;=</literal> 
+         <literal>=</literal>
+         <literal>+=</literal>
+         <literal>-=</literal>
+         <literal>*=</literal>
+         <literal>**=</literal>
+         <literal>/=</literal>
+         <literal>.=</literal>
+         <literal>%=</literal>
+         <literal>&amp;=</literal>
+         <literal>|=</literal>
+         <literal>^=</literal>
+         <literal>&lt;&lt;=</literal>
          <literal>&gt;&gt;=</literal>
          <literal>??=</literal>
         </entry>
@@ -1596,7 +1596,7 @@ bool(true)
 bool(true)
 a
 ]]>
-      </screen>      
+      </screen>
      </informalexample>
     </para>
    </warning>
@@ -1605,53 +1605,53 @@ a
     <informalexample>
      <programlisting role="php">
 <![CDATA[
-<?php  
+<?php
 // Integers
 echo 1 <=> 1; // 0
 echo 1 <=> 2; // -1
 echo 2 <=> 1; // 1
- 
+
 // Floats
 echo 1.5 <=> 1.5; // 0
 echo 1.5 <=> 2.5; // -1
 echo 2.5 <=> 1.5; // 1
- 
+
 // Strings
 echo "a" <=> "a"; // 0
 echo "a" <=> "b"; // -1
 echo "b" <=> "a"; // 1
- 
+
 echo "a" <=> "aa"; // -1
 echo "zz" <=> "aa"; // 1
- 
+
 // Arrays
 echo [] <=> []; // 0
 echo [1, 2, 3] <=> [1, 2, 3]; // 0
 echo [1, 2, 3] <=> []; // 1
 echo [1, 2, 3] <=> [1, 2, 1]; // 1
 echo [1, 2, 3] <=> [1, 2, 4]; // -1
- 
+
 // Objects
-$a = (object) ["a" => "b"]; 
-$b = (object) ["a" => "b"]; 
+$a = (object) ["a" => "b"];
+$b = (object) ["a" => "b"];
 echo $a <=> $b; // 0
- 
-$a = (object) ["a" => "b"]; 
-$b = (object) ["a" => "c"]; 
+
+$a = (object) ["a" => "b"];
+$b = (object) ["a" => "c"];
 echo $a <=> $b; // -1
- 
-$a = (object) ["a" => "c"]; 
-$b = (object) ["a" => "b"]; 
+
+$a = (object) ["a" => "c"];
+$b = (object) ["a" => "b"];
 echo $a <=> $b; // 1
- 
+
 // not only values are compared; keys must match
-$a = (object) ["a" => "b"]; 
-$b = (object) ["b" => "b"]; 
+$a = (object) ["a" => "b"];
+$b = (object) ["b" => "b"];
 echo $a <=> $b; // 1
 
 ?>
 ]]>
-      
+
      </programlisting>
     </informalexample>
    </para>
@@ -1929,7 +1929,7 @@ echo 0 ?: 0 ?: 0 ?: 3, PHP_EOL; //3
      </para>
     </note>
    </sect2>
-   
+
    <sect2 xml:id="language.operators.comparison.coalesce">
     <title>Null Coalescing Operator</title>
     <para>
@@ -1941,7 +1941,6 @@ echo 0 ?: 0 ?: 0 ?: 3, PHP_EOL; //3
 <?php
 // Example usage for: Null Coalesce Operator
 $action = $_POST['action'] ?? 'default';
-
 // The above is identical to this if/else statement
 if (isset($_POST['action'])) {
     $action = $_POST['action'];
@@ -2002,7 +2001,6 @@ $foo = null;
 $bar = null;
 $baz = 1;
 $qux = 2;
-
 echo $foo ?? $bar ?? $baz ?? $qux; // outputs 1
 
 ?>
@@ -2011,9 +2009,8 @@ echo $foo ?? $bar ?? $baz ?? $qux; // outputs 1
       </example>
      </para>
     </note>
-   </sect2> 
+   </sect2>
   </sect1>
-
   <sect1 xml:id="language.operators.errorcontrol">
    <title>Error Control Operators</title>
    <simpara>
@@ -2029,8 +2026,8 @@ echo $foo ?? $bar ?? $baz ?? $qux; // outputs 1
 
    <warning>
     <para>
-     Prior to PHP 8.0.0, the <function>error_reporting</function> called inside the custom error handler 
-     always returned <literal>0</literal> if the error was suppressed by the <literal>@</literal> operator. 
+     Prior to PHP 8.0.0, the <function>error_reporting</function> called inside the custom error handler
+     always returned <literal>0</literal> if the error was suppressed by the <literal>@</literal> operator.
      As of PHP 8.0.0, it returns the value <literal>E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE</literal>.
     </para>
    </warning>

--- a/language/operators.xml
+++ b/language/operators.xml
@@ -1855,6 +1855,30 @@ if (empty($_POST['action'])) {
     </note>
     <note>
      <para>
+      Ternary expressions can include void-returning functions for either or
+      both of the conditional values. If the results are assigned to a
+      variable, the variable will be considered set if the ternary results in a
+      value or unset if the result is void.
+      <example>
+       <title>Void Ternaries</title>
+       <programlisting role="php">
+        <?php
+        // Both functions are void, so no value assignment is needed.
+        isset($seed) ? mt_srand($seed) : mt_srand();        
+
+        // One side returns a value, so an assignment is needed unless the
+        // the return value is to be ignored.
+        $initSrand = isset($seed) ? mt_srand($seed) : 'Seed was not specified!';
+        if (isset($initSrand)) {
+         echo $initSrand;
+        }
+        ?>
+       </programlisting>
+      </example>
+     </para>
+    </note>
+    <note>
+     <para>
       It is recommended to avoid "stacking" ternary expressions.
       PHP's behaviour when using more than one unparenthesized ternary operator within a single
       expression is non-obvious compared to other languages.

--- a/language/operators.xml
+++ b/language/operators.xml
@@ -1867,7 +1867,7 @@ if (empty($_POST['action'])) {
         isset($seed) ? mt_srand($seed) : mt_srand();
 
         // One side returns a value, so an assignment is needed unless the
-        // the return value is to be ignored.
+        // return value is to be ignored.
         $initSrand = isset($seed) ? mt_srand($seed) : 'Seed was not specified!';
         if (isset($initSrand)) {
          echo $initSrand;

--- a/reference/errorfunc/functions/set-error-handler.xml
+++ b/reference/errorfunc/functions/set-error-handler.xml
@@ -18,26 +18,26 @@
    errors in a script.
   </para>
   <para>
-   This function can be used for defining your own way of handling errors
-   during runtime, for example in applications in which you need to do
-   cleanup of data/files when a critical error happens, or when you need
-   to trigger an error under certain conditions (using
-   <function>trigger_error</function>).
+   This function can be used to define custom error handlers during runtime,
+   for example in applications which need to do file/data cleanup when a critical
+   error happens, or when triggering an error in response to certain conditions
+   (using <function>trigger_error</function>).
   </para>
   <para>
    It is important to remember that the standard PHP error handler is completely
    bypassed for the error types specified by <parameter>error_levels</parameter> 
    unless the callback function returns &false;.
-   <function>error_reporting</function> settings will have no effect and your
-   error handler will be called regardless - however you are still able to read 
-   the current value of 
+   <function>error_reporting</function> settings will have no effect and the
+   error handler will be called regardless - however, it's still possible to
+   read the current value of
    <link linkend="ini.error-reporting">error_reporting</link> and act
    appropriately.
   </para>
   <para>
-   Also note that it is your responsibility to <function>die</function> if
-   necessary. If the error-handler function returns, script execution
-   will continue with the next statement after the one that caused an error.
+   Also note that it is the handler's responsibility to call the
+   <function>die</function> function if necessary. If the error-handler
+   function returns, script execution will continue with the next statement
+   after the one that caused an error.
   </para>
   <para>
    The following error types cannot be handled with a user defined
@@ -126,7 +126,7 @@
           <warning xmlns="http://docbook.org/ns/docbook">
            <simpara>
             This parameter has been <emphasis>DEPRECATED</emphasis> as of PHP 7.2.0,
-            and <emphasis>REMOVED</emphasis> as of PHP 8.0.0. If your function defines
+            and <emphasis>REMOVED</emphasis> as of PHP 8.0.0. If the function defines
             this parameter without a default, an error of "too few arguments" will be
             raised when it is called.
            </simpara>


### PR DESCRIPTION
Unlike most languages, PHP supports both void and mixed void/value-returning ternaries. I've noted this in the ternary docs. I'm a little unclear if I'm using the correct terminology, though. Suggestions are welcome!