### PR TITLE
Use FQCN for native attributes

### DIFF
--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -121,7 +121,7 @@ ArgumentCountError - makeyogurt(): Argument #1 ($container) not passed
     inheritance validation.
     In case the return type cannot be declared for an overriding method due to
     PHP cross-version compatibility concerns,
-    a <code>#[ReturnTypeWillChange]</code> attribute can be added to silence
+    a <code>#[\ReturnTypeWillChange]</code> attribute can be added to silence
     the deprecation notice.
    </para>
   </sect3>

--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -143,7 +143,7 @@ Stack trace:
      <programlisting role="php">
 <![CDATA[
 <?php
-#[AllowDynamicProperties]
+#[\AllowDynamicProperties]
 readonly class Foo {
 }
 

--- a/language/oop5/inheritance.xml
+++ b/language/oop5/inheritance.xml
@@ -123,7 +123,7 @@ $bar->printPHP();       // Output: 'PHP is great'
  
    <para>
     If the return type cannot be declared for an overriding method due to PHP cross-version compatibility concerns,
-    a <code>#[ReturnTypeWillChange]</code> attribute can be added to silence the deprecation notice.
+    a <code>#[\ReturnTypeWillChange]</code> attribute can be added to silence the deprecation notice.
    </para>
  
    <example>
@@ -168,7 +168,7 @@ class MyDateTime extends DateTime
     /**
      * @return DateTime|false
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function modify(string $modifier) { return false; }
 }
  

--- a/language/predefined/attributes/allowdynamicproperties.xml
+++ b/language/predefined/attributes/allowdynamicproperties.xml
@@ -49,7 +49,7 @@
 <?php
 class DefaultBehaviour { }
 
-#[AllowDynamicProperties]
+#[\AllowDynamicProperties]
 class ClassAllowsDynamicProperties { }
 
 $o1 = new DefaultBehaviour();

--- a/language/predefined/attributes/returntypewillchange.xml
+++ b/language/predefined/attributes/returntypewillchange.xml
@@ -13,7 +13,7 @@
     inheritance validation.
     In case the return type cannot be declared for an overriding method due to
     PHP cross-version compatibility concerns,
-    a <code>#[ReturnTypeWillChange]</code> attribute can be added to silence
+    a <code>#[\ReturnTypeWillChange]</code> attribute can be added to silence
     the deprecation notice.
    </para>
   </section>

--- a/language/predefined/iterator.xml
+++ b/language/predefined/iterator.xml
@@ -82,13 +82,13 @@ class myIterator implements Iterator {
         $this->position = 0;
     }
 
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function current() {
         var_dump(__METHOD__);
         return $this->array[$this->position];
     }
 
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function key() {
         var_dump(__METHOD__);
         return $this->position;

--- a/reference/session/sessionhandlerinterface.xml
+++ b/reference/session/sessionhandlerinterface.xml
@@ -94,7 +94,7 @@ class MySessionHandler implements SessionHandlerInterface
         return true;
     }
 
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function read($id)
     {
         return (string)@file_get_contents("$this->savePath/sess_$id");
@@ -115,7 +115,7 @@ class MySessionHandler implements SessionHandlerInterface
         return true;
     }
 
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function gc($maxlifetime)
     {
         foreach (glob("$this->savePath/sess_*") as $file) {


### PR DESCRIPTION
For attributes it's non-obvious that they need to be imported with `use` or referenced with their FQCN, because applying a non-existant attribute is not an error.

Make the examples copy-and-paste safe by adding the leading backslash, as already done for `#[\SensitiveParameterValue]`.

--------------------

See also this user note: https://www.php.net/manual/en/class.allow-dynamic-properties.php#128019