### PR TITLE
Add note that Memcached::getAllKeys is for debugging

### DIFF
--- a/reference/memcached/memcached/getallkeys.xml
+++ b/reference/memcached/memcached/getallkeys.xml
@@ -20,6 +20,9 @@
    the keys at point in time. As memcache doesn't guarantee to return all keys
    you also cannot assume that all keys have been returned.
   </para>
+  <para>
+   This method is intended for debugging purposes and should not be used at scale!
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/memcached/memcached/getallkeys.xml
+++ b/reference/memcached/memcached/getallkeys.xml
@@ -20,9 +20,11 @@
    the keys at point in time. As memcache doesn't guarantee to return all keys
    you also cannot assume that all keys have been returned.
   </para>
-  <para>
-   This method is intended for debugging purposes and should not be used at scale!
-  </para>
+  <note>
+   <para>
+    This method is intended for debugging purposes and should not be used at scale!
+   </para>
+  </note> 
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
This comes up from time to time in tickets on the php-memcached repo, adding a doc note should help.

e.g. https://github.com/php-memcached-dev/php-memcached/issues/427