### PR TITLE
Remove outdated ReflectionClass::getTraitAliases() null return description

### DIFF
--- a/reference/reflection/reflectionclass/gettraitaliases.xml
+++ b/reference/reflection/reflectionclass/gettraitaliases.xml
@@ -30,7 +30,6 @@
   <para>
    Returns an array with new method names in keys and original names (in the
    format <literal>"TraitName::original"</literal>) in values.
-   Returns &null; in case of an error.
   </para>
  </refsect1>
 


### PR DESCRIPTION
This was dropped with the RETURN_THROWS conversions.