### PR TITLE
Remove outdated ReflectionClass::getTraitNames() null return description

### DIFF
--- a/reference/reflection/reflectionclass/gettraitnames.xml
+++ b/reference/reflection/reflectionclass/gettraitnames.xml
@@ -29,7 +29,6 @@
   &reftitle.returnvalues;
   <para>
    Returns an array with trait names in values.
-   Returns &null; in case of an error.
   </para>
  </refsect1>
 


### PR DESCRIPTION
This was dropped with the RETURN_THROWS conversions.