### PR TITLE
fix: true return type for return true always function

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -721,7 +721,7 @@ searched for within the <link xmlns="http://docbook.org/ns/docbook" linkend="ini
 <!ENTITY return.type.true '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.2.0</entry>
  <entry>
-  The return type is &true; now; previously, it was &bool;.
+  The return type is &true; now; previously, it was <type>bool</type>.
  </entry>
 </row>'>
 

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -718,6 +718,13 @@ searched for within the <link xmlns="http://docbook.org/ns/docbook" linkend="ini
 
 <!-- Returns -->
 
+<!ENTITY return.type.true '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.2.0</entry>
+ <entry>
+  The return type is &true; now; previously, it was &bool;
+ </entry>
+</row>'>
+
 <!ENTITY return.falseforfailure ' or &false; on failure'>
 <!ENTITY return.falseforfailure.style.procedural '&style.procedural; returns &false; on failure.'>
 

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -721,7 +721,7 @@ searched for within the <link xmlns="http://docbook.org/ns/docbook" linkend="ini
 <!ENTITY return.type.true '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.2.0</entry>
  <entry>
-  The return type is &true; now; previously, it was &bool;
+  The return type is &true; now; previously, it was &bool;.
  </entry>
 </row>'>
 

--- a/reference/array/functions/arsort.xml
+++ b/reference/array/functions/arsort.xml
@@ -48,6 +48,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/array/functions/arsort.xml
+++ b/reference/array/functions/arsort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>arsort</methodname>
+   <type>true</type><methodname>arsort</methodname>
    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>SORT_REGULAR</constant></initializer></methodparam>
   </methodsynopsis>

--- a/reference/array/functions/asort.xml
+++ b/reference/array/functions/asort.xml
@@ -49,6 +49,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/array/functions/asort.xml
+++ b/reference/array/functions/asort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>asort</methodname>
+   <type>true</type><methodname>asort</methodname>
    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>SORT_REGULAR</constant></initializer></methodparam>
   </methodsynopsis>

--- a/reference/array/functions/krsort.xml
+++ b/reference/array/functions/krsort.xml
@@ -44,6 +44,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/array/functions/krsort.xml
+++ b/reference/array/functions/krsort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>krsort</methodname>
+   <type>true</type><methodname>krsort</methodname>
    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>SORT_REGULAR</constant></initializer></methodparam>
   </methodsynopsis>

--- a/reference/array/functions/ksort.xml
+++ b/reference/array/functions/ksort.xml
@@ -44,6 +44,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/array/functions/ksort.xml
+++ b/reference/array/functions/ksort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>ksort</methodname>
+   <type>true</type><methodname>ksort</methodname>
    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>SORT_REGULAR</constant></initializer></methodparam>
   </methodsynopsis>

--- a/reference/array/functions/natcasesort.xml
+++ b/reference/array/functions/natcasesort.xml
@@ -46,6 +46,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/array/functions/natcasesort.xml
+++ b/reference/array/functions/natcasesort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>natcasesort</methodname>
+   <type>true</type><methodname>natcasesort</methodname>
    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/array/functions/natsort.xml
+++ b/reference/array/functions/natsort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>natsort</methodname>
+   <type>true</type><methodname>natsort</methodname>
    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/array/functions/natsort.xml
+++ b/reference/array/functions/natsort.xml
@@ -44,6 +44,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/array/functions/rsort.xml
+++ b/reference/array/functions/rsort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>rsort</methodname>
+   <type>true</type><methodname>rsort</methodname>
    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>SORT_REGULAR</constant></initializer></methodparam>
   </methodsynopsis>

--- a/reference/array/functions/rsort.xml
+++ b/reference/array/functions/rsort.xml
@@ -45,6 +45,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/array/functions/sort.xml
+++ b/reference/array/functions/sort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>sort</methodname>
+   <type>true</type><methodname>sort</methodname>
    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>SORT_REGULAR</constant></initializer></methodparam>
   </methodsynopsis>

--- a/reference/array/functions/sort.xml
+++ b/reference/array/functions/sort.xml
@@ -45,6 +45,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/array/functions/uasort.xml
+++ b/reference/array/functions/uasort.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>uasort</methodname>
+   <type>true</type><methodname>uasort</methodname>
    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>

--- a/reference/array/functions/uasort.xml
+++ b/reference/array/functions/uasort.xml
@@ -69,6 +69,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &array.changelog.by-ref;
     </tbody>
    </tgroup>

--- a/reference/array/functions/uksort.xml
+++ b/reference/array/functions/uksort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>uksort</methodname>
+   <type>true</type><methodname>uksort</methodname>
    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>

--- a/reference/array/functions/uksort.xml
+++ b/reference/array/functions/uksort.xml
@@ -63,6 +63,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &array.changelog.by-ref;
     </tbody>
    </tgroup>

--- a/reference/array/functions/usort.xml
+++ b/reference/array/functions/usort.xml
@@ -63,6 +63,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &array.changelog.by-ref;
     </tbody>
    </tgroup>

--- a/reference/array/functions/usort.xml
+++ b/reference/array/functions/usort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>usort</methodname>
+   <type>true</type><methodname>usort</methodname>
    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>

--- a/reference/intl/intlcalendar/clear.xml
+++ b/reference/intl/intlcalendar/clear.xml
@@ -12,14 +12,14 @@
    &style.oop;
   </para>
   <methodsynopsis role="IntlCalendar">
-   <modifier>public</modifier> <type>bool</type><methodname>IntlCalendar::clear</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>IntlCalendar::clear</methodname>
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>field</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    &style.procedural;
   </para>
   <methodsynopsis>
-   <type>bool</type><methodname>intlcal_clear</methodname>
+   <type>true</type><methodname>intlcal_clear</methodname>
    <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>field</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>

--- a/reference/intl/intlcalendar/clear.xml
+++ b/reference/intl/intlcalendar/clear.xml
@@ -58,6 +58,24 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/intl/intlcalendar/set.xml
+++ b/reference/intl/intlcalendar/set.xml
@@ -143,6 +143,24 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/intl/intlcalendar/set.xml
+++ b/reference/intl/intlcalendar/set.xml
@@ -13,12 +13,12 @@
    &style.oop;
   </para>
   <methodsynopsis role="IntlCalendar">
-   <modifier>public</modifier> <type>bool</type><methodname>IntlCalendar::set</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>IntlCalendar::set</methodname>
    <methodparam><type>int</type><parameter>field</parameter></methodparam>
    <methodparam><type>int</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <methodsynopsis role="IntlCalendar">
-   <modifier>public</modifier> <type>bool</type><methodname>IntlCalendar::set</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>IntlCalendar::set</methodname>
    <methodparam><type>int</type><parameter>year</parameter></methodparam>
    <methodparam><type>int</type><parameter>month</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>dayOfMonth</parameter><initializer>NULL</initializer></methodparam>
@@ -30,7 +30,7 @@
    &style.procedural;
   </para>
   <methodsynopsis>
-   <type>bool</type><methodname>intlcal_set</methodname>
+   <type>true</type><methodname>intlcal_set</methodname>
    <methodparam><type>IntlCalendar</type><parameter>cal</parameter></methodparam>
    <methodparam><type>int</type><parameter>field</parameter></methodparam>
    <methodparam><type>int</type><parameter>value</parameter></methodparam>

--- a/reference/intl/intlcalendar/setfirstdayofweek.xml
+++ b/reference/intl/intlcalendar/setfirstdayofweek.xml
@@ -60,6 +60,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/intl/intlcalendar/setfirstdayofweek.xml
+++ b/reference/intl/intlcalendar/setfirstdayofweek.xml
@@ -12,14 +12,14 @@
    &style.oop;
   </para>
   <methodsynopsis role="IntlCalendar">
-   <modifier>public</modifier> <type>bool</type><methodname>IntlCalendar::setFirstDayOfWeek</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>IntlCalendar::setFirstDayOfWeek</methodname>
    <methodparam><type>int</type><parameter>dayOfWeek</parameter></methodparam>
   </methodsynopsis>
   <para>
    &style.procedural;
   </para>
   <methodsynopsis>
-   <type>bool</type><methodname>intlcal_set_first_day_of_week</methodname>
+   <type>true</type><methodname>intlcal_set_first_day_of_week</methodname>
    <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
    <methodparam><type>int</type><parameter>dayOfWeek</parameter></methodparam>
   </methodsynopsis>

--- a/reference/intl/intlcalendar/setlenient.xml
+++ b/reference/intl/intlcalendar/setlenient.xml
@@ -59,6 +59,24 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/intl/intlcalendar/setlenient.xml
+++ b/reference/intl/intlcalendar/setlenient.xml
@@ -12,14 +12,14 @@
    &style.oop;
   </para>
   <methodsynopsis role="IntlCalendar">
-   <modifier>public</modifier> <type>bool</type><methodname>IntlCalendar::setLenient</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>IntlCalendar::setLenient</methodname>
    <methodparam><type>bool</type><parameter>lenient</parameter></methodparam>
   </methodsynopsis>
   <para>
    &style.procedural;
   </para>
   <methodsynopsis>
-   <type>bool</type><methodname>intlcal_set_lenient</methodname>
+   <type>true</type><methodname>intlcal_set_lenient</methodname>
    <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
    <methodparam><type>bool</type><parameter>lenient</parameter></methodparam>
   </methodsynopsis>

--- a/reference/intl/intlcalendar/setrepeatedwalltimeoption.xml
+++ b/reference/intl/intlcalendar/setrepeatedwalltimeoption.xml
@@ -81,6 +81,7 @@
     </tgroup>
    </informaltable>
   </para>
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/intl/intlcalendar/setrepeatedwalltimeoption.xml
+++ b/reference/intl/intlcalendar/setrepeatedwalltimeoption.xml
@@ -64,6 +64,24 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/intl/intlcalendar/setrepeatedwalltimeoption.xml
+++ b/reference/intl/intlcalendar/setrepeatedwalltimeoption.xml
@@ -12,14 +12,14 @@
    &style.oop;
   </para>
   <methodsynopsis role="IntlCalendar">
-   <modifier>public</modifier> <type>bool</type><methodname>IntlCalendar::setRepeatedWallTimeOption</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>IntlCalendar::setRepeatedWallTimeOption</methodname>
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
   </methodsynopsis>
   <para>
    &style.procedural;
   </para>
   <methodsynopsis>
-   <type>bool</type><methodname>intlcal_set_repeated_wall_time_option</methodname>
+   <type>true</type><methodname>intlcal_set_repeated_wall_time_option</methodname>
    <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
   </methodsynopsis>

--- a/reference/intl/intlcalendar/setskippedwalltimeoption.xml
+++ b/reference/intl/intlcalendar/setskippedwalltimeoption.xml
@@ -95,6 +95,7 @@
     </tgroup>
    </informaltable>
   </para>
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/intl/intlcalendar/setskippedwalltimeoption.xml
+++ b/reference/intl/intlcalendar/setskippedwalltimeoption.xml
@@ -78,6 +78,28 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.2.0</entry>
+       <entry>
+        return type is &true; now
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/intl/intlcalendar/setskippedwalltimeoption.xml
+++ b/reference/intl/intlcalendar/setskippedwalltimeoption.xml
@@ -12,14 +12,14 @@
    &style.oop;
   </para>
   <methodsynopsis role="IntlCalendar">
-   <modifier>public</modifier> <type>bool</type><methodname>IntlCalendar::setSkippedWallTimeOption</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>IntlCalendar::setSkippedWallTimeOption</methodname>
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
   </methodsynopsis>
   <para>
    &style.procedural;
   </para>
   <methodsynopsis>
-   <type>bool</type><methodname>intlcal_set_skipped_wall_time_option</methodname>
+   <type>true</type><methodname>intlcal_set_skipped_wall_time_option</methodname>
    <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
   </methodsynopsis>

--- a/reference/intl/intlcalendar/setskippedwalltimeoption.xml
+++ b/reference/intl/intlcalendar/setskippedwalltimeoption.xml
@@ -90,12 +90,7 @@
       </row>
      </thead>
      <tbody>
-      <row>
-       <entry>8.2.0</entry>
-       <entry>
-        return type is &true; now
-       </entry>
-      </row>
+      &return.type.true;
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/pgsql/functions/pg-close.xml
+++ b/reference/pgsql/functions/pg-close.xml
@@ -63,6 +63,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &pgsql.changelog.connection-object;
      <row>
       <entry>8.0.0</entry>

--- a/reference/pgsql/functions/pg-close.xml
+++ b/reference/pgsql/functions/pg-close.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>pg_close</methodname>
+   <type>true</type><methodname>pg_close</methodname>
    <methodparam choice="opt"><type class="union"><type>PgSql\Connection</type><type>null</type></type><parameter>connection</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/pgsql/functions/pg-untrace.xml
+++ b/reference/pgsql/functions/pg-untrace.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>pg_untrace</methodname>
+   <type>true</type><methodname>pg_untrace</methodname>
    <methodparam choice="opt"><type class="union"><type>PgSql\Connection</type><type>null</type></type><parameter>connection</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/pgsql/functions/pg-untrace.xml
+++ b/reference/pgsql/functions/pg-untrace.xml
@@ -50,6 +50,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &pgsql.changelog.connection-object;
      <row>
       <entry>8.0.0</entry>

--- a/reference/pthreads/collectable/isgarbage.xml
+++ b/reference/pthreads/collectable/isgarbage.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>bool</type><methodname>Collectable::isGarbage</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>Collectable::isGarbage</methodname>
    <void/>
   </methodsynopsis>
   <para>

--- a/reference/pthreads/collectable/isgarbage.xml
+++ b/reference/pthreads/collectable/isgarbage.xml
@@ -30,6 +30,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/snmp/functions/snmp-set-enum-print.xml
+++ b/reference/snmp/functions/snmp-set-enum-print.xml
@@ -40,6 +40,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/snmp/functions/snmp-set-enum-print.xml
+++ b/reference/snmp/functions/snmp-set-enum-print.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>snmp_set_enum_print</methodname>
+   <type>true</type><methodname>snmp_set_enum_print</methodname>
    <methodparam><type>bool</type><parameter>enable</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/snmp/functions/snmp-set-oid-output-format.xml
+++ b/reference/snmp/functions/snmp-set-oid-output-format.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>snmp_set_oid_output_format</methodname>
+   <type>true</type><methodname>snmp_set_oid_output_format</methodname>
    <methodparam><type>int</type><parameter>format</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/snmp/functions/snmp-set-oid-output-format.xml
+++ b/reference/snmp/functions/snmp-set-oid-output-format.xml
@@ -52,6 +52,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/snmp/functions/snmp-set-quick-print.xml
+++ b/reference/snmp/functions/snmp-set-quick-print.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>snmp_set_quick_print</methodname>
+   <type>true</type><methodname>snmp_set_quick_print</methodname>
    <methodparam><type>bool</type><parameter>enable</parameter></methodparam>
   </methodsynopsis>
 

--- a/reference/snmp/functions/snmp-set-quick-print.xml
+++ b/reference/snmp/functions/snmp-set-quick-print.xml
@@ -54,6 +54,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/snmp/functions/snmp-set-valueretrieval.xml
+++ b/reference/snmp/functions/snmp-set-valueretrieval.xml
@@ -62,6 +62,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/snmp/functions/snmp-set-valueretrieval.xml
+++ b/reference/snmp/functions/snmp-set-valueretrieval.xml
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>snmp_set_valueretrieval</methodname>
+   <type>true</type><methodname>snmp_set_valueretrieval</methodname>
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
   </methodsynopsis>
  </refsect1>

--- a/reference/spl/arrayiterator/asort.xml
+++ b/reference/spl/arrayiterator/asort.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ArrayIterator">
-   <modifier>public</modifier> <type>bool</type><methodname>ArrayIterator::asort</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>ArrayIterator::asort</methodname>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>SORT_REGULAR</constant></initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/spl/arrayiterator/asort.xml
+++ b/reference/spl/arrayiterator/asort.xml
@@ -32,6 +32,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/spl/arrayiterator/ksort.xml
+++ b/reference/spl/arrayiterator/ksort.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ArrayIterator">
-   <modifier>public</modifier> <type>bool</type><methodname>ArrayIterator::ksort</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>ArrayIterator::ksort</methodname>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>SORT_REGULAR</constant></initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/spl/arrayiterator/ksort.xml
+++ b/reference/spl/arrayiterator/ksort.xml
@@ -32,6 +32,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/spl/arrayiterator/natcasesort.xml
+++ b/reference/spl/arrayiterator/natcasesort.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ArrayIterator">
-   <modifier>public</modifier> <type>bool</type><methodname>ArrayIterator::natcasesort</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>ArrayIterator::natcasesort</methodname>
    <void/>
   </methodsynopsis>
   <para>

--- a/reference/spl/arrayiterator/natcasesort.xml
+++ b/reference/spl/arrayiterator/natcasesort.xml
@@ -30,6 +30,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/spl/arrayiterator/natsort.xml
+++ b/reference/spl/arrayiterator/natsort.xml
@@ -30,6 +30,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/spl/arrayiterator/natsort.xml
+++ b/reference/spl/arrayiterator/natsort.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ArrayIterator">
-   <modifier>public</modifier> <type>bool</type><methodname>ArrayIterator::natsort</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>ArrayIterator::natsort</methodname>
    <void/>
   </methodsynopsis>
   <para>

--- a/reference/spl/arrayiterator/uasort.xml
+++ b/reference/spl/arrayiterator/uasort.xml
@@ -44,6 +44,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/spl/arrayiterator/uasort.xml
+++ b/reference/spl/arrayiterator/uasort.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ArrayIterator">
-   <modifier>public</modifier> <type>bool</type><methodname>ArrayIterator::uasort</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>ArrayIterator::uasort</methodname>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/spl/arrayiterator/uksort.xml
+++ b/reference/spl/arrayiterator/uksort.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ArrayIterator">
-   <modifier>public</modifier> <type>bool</type><methodname>ArrayIterator::uksort</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>ArrayIterator::uksort</methodname>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/spl/arrayiterator/uksort.xml
+++ b/reference/spl/arrayiterator/uksort.xml
@@ -43,6 +43,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/spl/arrayobject/asort.xml
+++ b/reference/spl/arrayobject/asort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ArrayObject">
-   <modifier>public</modifier> <type>bool</type><methodname>ArrayObject::asort</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>ArrayObject::asort</methodname>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>SORT_REGULAR</constant></initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/spl/arrayobject/asort.xml
+++ b/reference/spl/arrayobject/asort.xml
@@ -37,6 +37,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/spl/arrayobject/ksort.xml
+++ b/reference/spl/arrayobject/ksort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ArrayObject">
-   <modifier>public</modifier> <type>bool</type><methodname>ArrayObject::ksort</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>ArrayObject::ksort</methodname>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>SORT_REGULAR</constant></initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/spl/arrayobject/ksort.xml
+++ b/reference/spl/arrayobject/ksort.xml
@@ -32,6 +32,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/spl/arrayobject/natcasesort.xml
+++ b/reference/spl/arrayobject/natcasesort.xml
@@ -35,6 +35,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/spl/arrayobject/natcasesort.xml
+++ b/reference/spl/arrayobject/natcasesort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ArrayObject">
-   <modifier>public</modifier> <type>bool</type><methodname>ArrayObject::natcasesort</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>ArrayObject::natcasesort</methodname>
    <void/>
   </methodsynopsis>
   <para>

--- a/reference/spl/arrayobject/natsort.xml
+++ b/reference/spl/arrayobject/natsort.xml
@@ -34,6 +34,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/spl/arrayobject/natsort.xml
+++ b/reference/spl/arrayobject/natsort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ArrayObject">
-   <modifier>public</modifier> <type>bool</type><methodname>ArrayObject::natsort</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>ArrayObject::natsort</methodname>
    <void/>
   </methodsynopsis>
   <para>

--- a/reference/spl/arrayobject/uasort.xml
+++ b/reference/spl/arrayobject/uasort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ArrayObject">
-   <modifier>public</modifier> <type>bool</type><methodname>ArrayObject::uasort</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>ArrayObject::uasort</methodname>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/spl/arrayobject/uasort.xml
+++ b/reference/spl/arrayobject/uasort.xml
@@ -47,6 +47,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/spl/arrayobject/uksort.xml
+++ b/reference/spl/arrayobject/uksort.xml
@@ -42,6 +42,25 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/spl/arrayobject/uksort.xml
+++ b/reference/spl/arrayobject/uksort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ArrayObject">
-   <modifier>public</modifier> <type>bool</type><methodname>ArrayObject::uksort</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>ArrayObject::uksort</methodname>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <para>


### PR DESCRIPTION
Hi, I'm not sure what I'm doing, I search for `&return.true.always;` in doc-en and try to replace `bool` with `true`, but what about other language..?

I suppose this is not the right place for this PR? We must have some system to synchronize between languages? Do we have a link for that (I'd close this PR and open new PR).