### PR TITLE
Fix GH-2156: stdClass is spelled in different cases: StdClass / stdclass

### DIFF
--- a/appendices/migration72/incompatible.xml
+++ b/appendices/migration72/incompatible.xml
@@ -135,7 +135,7 @@ var_dump(
     count(null), // NULL is not countable
     count(1), // integers are not countable
     count('abc'), // strings are not countable
-    count(new stdclass), // objects not implementing the Countable interface are not countable
+    count(new stdClass), // objects not implementing the Countable interface are not countable
     count([1,2]) // arrays are countable
 );
 ]]>

--- a/appendices/migration72/new-features.xml
+++ b/appendices/migration72/new-features.xml
@@ -23,7 +23,7 @@ function test(object $obj) : object
     return new SplQueue();
 }
 
-test(new StdClass());
+test(new stdClass());
 ]]>
    </programlisting>
   </informalexample>

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1401,7 +1401,7 @@ NULL
 $func = static function() {
     // function body
 };
-$func = $func->bindTo(new StdClass);
+$func = $func->bindTo(new stdClass);
 $func();
 
 ?>

--- a/language/predefined/weakmap.xml
+++ b/language/predefined/weakmap.xml
@@ -73,7 +73,7 @@
 <?php
 $wm = new WeakMap();
 
-$o = new StdClass;
+$o = new stdClass;
 
 class A {
     public function __destruct() {

--- a/language/references.xml
+++ b/language/references.xml
@@ -74,7 +74,7 @@ $b = array();
 foo($b['b']);
 var_dump(array_key_exists('b', $b)); // bool(true)
 
-$c = new StdClass;
+$c = new stdClass;
 foo($c->d);
 var_dump(property_exists($c, 'd')); // bool(true)
 ?>

--- a/language/variables.xml
+++ b/language/variables.xml
@@ -542,13 +542,13 @@ var_dump(Bar::counter()); // int(4), prior to PHP 8.1.0 int(2)
 <?php
 function test_global_ref() {
     global $obj;
-    $new = new stdclass;
+    $new = new stdClass;
     $obj = &$new;
 }
 
 function test_global_noref() {
     global $obj;
-    $new = new stdclass;
+    $new = new stdClass;
     $obj = $new;
 }
 
@@ -586,7 +586,7 @@ function &get_instance_ref() {
     echo 'Static object: ';
     var_dump($obj);
     if (!isset($obj)) {
-        $new = new stdclass;
+        $new = new stdClass;
         // Assign a reference to the static variable
         $obj = &$new;
     }
@@ -604,7 +604,7 @@ function &get_instance_noref() {
     echo 'Static object: ';
     var_dump($obj);
     if (!isset($obj)) {
-        $new = new stdclass;
+        $new = new stdClass;
         // Assign the object to the static variable
         $obj = $new;
     }

--- a/reference/array/functions/array-udiff.xml
+++ b/reference/array/functions/array-udiff.xml
@@ -70,12 +70,12 @@
 <![CDATA[
 <?php
 // Arrays to compare
-$array1 = array(new stdclass, new stdclass,
-                new stdclass, new stdclass,
+$array1 = array(new stdClass, new stdClass,
+                new stdClass, new stdClass,
                );
 
 $array2 = array(
-                new stdclass, new stdclass,
+                new stdClass, new stdClass,
                );
 
 // Set some properties for each object

--- a/reference/memcached/memcached/set.xml
+++ b/reference/memcached/memcached/set.xml
@@ -84,7 +84,7 @@ $m->set('int', 99);
 $m->set('string', 'a simple string');
 $m->set('array', array(11, 12));
 /* expire 'object' key in 5 minutes */
-$m->set('object', new stdclass, time() + 300);
+$m->set('object', new stdClass, time() + 300);
 
 
 var_dump($m->get('int'));

--- a/reference/pthreads/volatile.xml
+++ b/reference/pthreads/volatile.xml
@@ -73,7 +73,7 @@ class Task extends Threaded
         $this->data = new Threaded();
 
         // attempt to overwrite a Threaded property of a Threaded class (invalid)
-        $this->data = new StdClass();
+        $this->data = new stdClass();
     }
 }
 
@@ -100,7 +100,7 @@ class Task extends Volatile
         $this->data = new Threaded();
 
         // attempt to overwrite a Threaded property of a Volatile class (valid)
-        $this->data = new StdClass();
+        $this->data = new stdClass();
     }
 }
 

--- a/reference/reflection/reflectionnamedtype/isbuiltin.xml
+++ b/reference/reflection/reflectionnamedtype/isbuiltin.xml
@@ -40,7 +40,7 @@
 <?php
 class SomeClass {}
 
-function someFunction(string $param, SomeClass $param2, StdClass $param3) {}
+function someFunction(string $param, SomeClass $param2, stdClass $param3) {}
 
 $reflectionFunc = new ReflectionFunction('someFunction');
 $reflectionParams = $reflectionFunc->getParameters();

--- a/reference/reflection/reflectiontype/allowsnull.xml
+++ b/reference/reflection/reflectiontype/allowsnull.xml
@@ -37,7 +37,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-function someFunction(string $param, StdClass $param2 = null) {}
+function someFunction(string $param, stdClass $param2 = null) {}
 
 $reflectionFunc = new ReflectionFunction('someFunction');
 $reflectionParams = $reflectionFunc->getParameters();

--- a/reference/spl/splobjectstorage.xml
+++ b/reference/spl/splobjectstorage.xml
@@ -70,9 +70,9 @@
 // As an object set
 $s = new SplObjectStorage();
 
-$o1 = new StdClass;
-$o2 = new StdClass;
-$o3 = new StdClass;
+$o1 = new stdClass;
+$o2 = new stdClass;
+$o3 = new stdClass;
 
 $s->attach($o1);
 $s->attach($o2);
@@ -109,9 +109,9 @@ bool(false)
 // As a map from objects to data
 $s = new SplObjectStorage();
 
-$o1 = new StdClass;
-$o2 = new StdClass;
-$o3 = new StdClass;
+$o1 = new stdClass;
+$o2 = new stdClass;
+$o3 = new stdClass;
 
 $s[$o1] = "data for object 1";
 $s[$o2] = array(1,2,3);

--- a/reference/spl/splobjectstorage/addall.xml
+++ b/reference/spl/splobjectstorage/addall.xml
@@ -48,7 +48,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$o = new StdClass;
+$o = new stdClass;
 $a = new SplObjectStorage();
 $a[$o] = "hello";
 

--- a/reference/spl/splobjectstorage/attach.xml
+++ b/reference/spl/splobjectstorage/attach.xml
@@ -57,8 +57,8 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$o1 = new StdClass;
-$o2 = new StdClass;
+$o1 = new stdClass;
+$o2 = new stdClass;
 $s = new SplObjectStorage();
 $s->attach($o1); // similar to $s[$o1] = NULL;
 $s->attach($o2, "hello"); // similar to $s[$o2] = "hello";

--- a/reference/spl/splobjectstorage/contains.xml
+++ b/reference/spl/splobjectstorage/contains.xml
@@ -48,8 +48,8 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$o1 = new StdClass;
-$o2 = new StdClass;
+$o1 = new stdClass;
+$o2 = new stdClass;
 
 $s = new SplObjectStorage();
 

--- a/reference/spl/splobjectstorage/count.xml
+++ b/reference/spl/splobjectstorage/count.xml
@@ -51,8 +51,8 @@
 <![CDATA[
 <?php
 $s = new SplObjectStorage();
-$o1 = new StdClass;
-$o2 = new StdClass;
+$o1 = new stdClass;
+$o2 = new stdClass;
 
 $s->attach($o1);
 $s->attach($o2);

--- a/reference/spl/splobjectstorage/current.xml
+++ b/reference/spl/splobjectstorage/current.xml
@@ -62,8 +62,8 @@
 <?php
 $s = new SplObjectStorage();
 
-$o1 = new StdClass;
-$o2 = new StdClass;
+$o1 = new stdClass;
+$o2 = new stdClass;
 
 $s->attach($o1, "d1");
 $s->attach($o2, "d2");

--- a/reference/spl/splobjectstorage/detach.xml
+++ b/reference/spl/splobjectstorage/detach.xml
@@ -48,7 +48,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$o = new StdClass;
+$o = new stdClass;
 $s = new SplObjectStorage();
 $s->attach($o);
 var_dump(count($s));

--- a/reference/spl/splobjectstorage/getinfo.xml
+++ b/reference/spl/splobjectstorage/getinfo.xml
@@ -39,8 +39,8 @@
 <?php
 $s = new SplObjectStorage();
 
-$o1 = new StdClass;
-$o2 = new StdClass;
+$o1 = new stdClass;
+$o2 = new stdClass;
 
 $s->attach($o1, "d1");
 $s->attach($o2, "d2");

--- a/reference/spl/splobjectstorage/key.xml
+++ b/reference/spl/splobjectstorage/key.xml
@@ -39,8 +39,8 @@
 <?php
 $s = new SplObjectStorage();
 
-$o1 = new StdClass;
-$o2 = new StdClass;
+$o1 = new stdClass;
+$o2 = new stdClass;
 
 $s->attach($o1, "d1");
 $s->attach($o2, "d2");

--- a/reference/spl/splobjectstorage/next.xml
+++ b/reference/spl/splobjectstorage/next.xml
@@ -39,8 +39,8 @@
 <?php
 $s = new SplObjectStorage();
 
-$o1 = new StdClass;
-$o2 = new StdClass;
+$o1 = new stdClass;
+$o2 = new stdClass;
 
 $s->attach($o1, "d1");
 $s->attach($o2, "d2");

--- a/reference/spl/splobjectstorage/offsetexists.xml
+++ b/reference/spl/splobjectstorage/offsetexists.xml
@@ -55,8 +55,8 @@
 <![CDATA[
 <?php
 $s = new SplObjectStorage;
-$o1 = new StdClass;
-$o2 = new StdClass;
+$o1 = new stdClass;
+$o2 = new stdClass;
 
 $s->attach($o1);
 

--- a/reference/spl/splobjectstorage/offsetget.xml
+++ b/reference/spl/splobjectstorage/offsetget.xml
@@ -57,8 +57,8 @@
 <?php
 $s = new SplObjectStorage;
 
-$o1 = new StdClass;
-$o2 = new StdClass;
+$o1 = new stdClass;
+$o2 = new stdClass;
 
 $s[$o1] = "hello";
 $s->attach($o2);

--- a/reference/spl/splobjectstorage/offsetset.xml
+++ b/reference/spl/splobjectstorage/offsetset.xml
@@ -64,7 +64,7 @@
 <?php
 $s = new SplObjectStorage;
 
-$o1 = new StdClass;
+$o1 = new stdClass;
 
 $s->offsetSet($o1, "hello"); // Similar to $s[$o1] = "hello";
 

--- a/reference/spl/splobjectstorage/offsetunset.xml
+++ b/reference/spl/splobjectstorage/offsetunset.xml
@@ -53,7 +53,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$o = new StdClass;
+$o = new stdClass;
 $s = new SplObjectStorage();
 $s->attach($o);
 var_dump(count($s));

--- a/reference/spl/splobjectstorage/removeall.xml
+++ b/reference/spl/splobjectstorage/removeall.xml
@@ -48,8 +48,8 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$o1 = new StdClass;
-$o2 = new StdClass;
+$o1 = new stdClass;
+$o2 = new stdClass;
 $a = new SplObjectStorage();
 $a[$o1] = "foo";
 

--- a/reference/spl/splobjectstorage/rewind.xml
+++ b/reference/spl/splobjectstorage/rewind.xml
@@ -39,8 +39,8 @@
 <?php
 $s = new SplObjectStorage();
 
-$o1 = new StdClass;
-$o2 = new StdClass;
+$o1 = new stdClass;
+$o2 = new stdClass;
 
 $s->attach($o1, "d1");
 $s->attach($o2, "d2");

--- a/reference/spl/splobjectstorage/serialize.xml
+++ b/reference/spl/splobjectstorage/serialize.xml
@@ -38,7 +38,7 @@
 <![CDATA[
 <?php
 $s = new SplObjectStorage;
-$o = new StdClass;
+$o = new stdClass;
 $s[$o] = "data";
 
 echo $s->serialize()."\n";

--- a/reference/spl/splobjectstorage/setinfo.xml
+++ b/reference/spl/splobjectstorage/setinfo.xml
@@ -50,8 +50,8 @@
 <?php
 $s = new SplObjectStorage();
 
-$o1 = new StdClass;
-$o2 = new StdClass;
+$o1 = new stdClass;
+$o2 = new stdClass;
 
 $s->attach($o1, "d1");
 $s->attach($o2, "d2");

--- a/reference/spl/splobjectstorage/unserialize.xml
+++ b/reference/spl/splobjectstorage/unserialize.xml
@@ -50,7 +50,7 @@
 <?php
 $s1 = new SplObjectStorage;
 $s2 = new SplObjectStorage;
-$o = new StdClass;
+$o = new stdClass;
 $s1[$o] = "data";
 
 $s2->unserialize($s1->serialize());

--- a/reference/spl/splobjectstorage/valid.xml
+++ b/reference/spl/splobjectstorage/valid.xml
@@ -39,8 +39,8 @@
 <?php
 $s = new SplObjectStorage();
 
-$o1 = new StdClass;
-$o2 = new StdClass;
+$o1 = new stdClass;
+$o2 = new stdClass;
 
 $s->attach($o1, "d1");
 $s->attach($o2, "d2");


### PR DESCRIPTION
Not sure if this commit should be marked with `[skip-revcheck]`. @mumumu, @Girgias, @saundefined, what do you think?