### PR TITLE
Update array-walk.xml

### DIFF
--- a/reference/array/functions/array-walk.xml
+++ b/reference/array/functions/array-walk.xml
@@ -133,7 +133,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$fruits = array("d" => "lemon", "a" => "orange", "b" => "banana", "c" => "apple");
+$fruit = array("d" => "lemon", "a" => "orange", "b" => "banana", "c" => "apple");
 
 function test_alter(&$item1, $key, $prefix)
 {
@@ -146,12 +146,12 @@ function test_print($item2, $key)
 }
 
 echo "Before ...:\n";
-array_walk($fruits, 'test_print');
+array_walk($fruit, 'test_print');
 
-array_walk($fruits, 'test_alter', 'fruit');
+array_walk($fruit, 'test_alter', 'fruit');
 echo "... and after:\n";
 
-array_walk($fruits, 'test_print');
+array_walk($fruit, 'test_print');
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
Updated example to show $fruit instead of $fruits... even though it's an array grammatically fruit should not be plural