### PR TITLE
Remove ReflectionFunction::getClosure() null return description

### DIFF
--- a/reference/reflection/reflectionfunction/getclosure.xml
+++ b/reference/reflection/reflectionfunction/getclosure.xml
@@ -29,7 +29,6 @@
   &reftitle.returnvalues;
   <para>
    Returns <classname>Closure</classname>.
-   Returns &null; in case of an error.
   </para>
  </refsect1>
 


### PR DESCRIPTION
This now throws on error.