### PR TITLE
Drop SplFileObject::fgets() return false description

### DIFF
--- a/reference/spl/splfileobject/fgets.xml
+++ b/reference/spl/splfileobject/fgets.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a string containing the next line from the file, or &false; on error.
+   Returns a string containing the next line from the file.
   </para>
  </refsect1>
 


### PR DESCRIPTION
This was converted to an exception, but looks like that's already in the errors section.