### PR TITLE
Drop xml_get_current_byte_index() return false description

### DIFF
--- a/reference/xml/functions/xml-get-current-byte-index.xml
+++ b/reference/xml/functions/xml-get-current-byte-index.xml
@@ -36,8 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   This function returns &false; if <parameter>parser</parameter> does
-   not refer to a valid parser, or else it returns which byte index
+   Returns which byte index
    the parser is currently at in its data buffer (starting at 0).
   </para>
  </refsect1>


### PR DESCRIPTION
This was dropped during conversion to object in https://github.com/php/php-src/commit/e35a3cb28cd663489b27630e4dca2a5e61898f2e so no new exceptions were added that require a changelog.

