### PR TITLE
random: Drop the range constraints from getInt()/random_int()

### DIFF
--- a/reference/random/functions/random-int.xml
+++ b/reference/random/functions/random-int.xml
@@ -30,8 +30,7 @@
     <term><parameter>min</parameter></term>
     <listitem>
      <para>
-      The lowest value to be returned; must be
-      <constant>PHP_INT_MIN</constant> or greater.
+      The lowest value to be returned.
      </para>
     </listitem>
    </varlistentry>
@@ -39,8 +38,7 @@
     <term><parameter>max</parameter></term>
     <listitem>
      <para>
-      The highest value to be returned; must be
-      <constant>PHP_INT_MAX</constant> or less.
+      The highest value to be returned.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/random/random/randomizer/getint.xml
+++ b/reference/random/random/randomizer/getint.xml
@@ -27,8 +27,7 @@
     <term><parameter>min</parameter></term>
     <listitem>
      <para>
-      The lowest value to be returned; must be
-      <constant>PHP_INT_MIN</constant> or greater.
+      The lowest value to be returned.
      </para>
     </listitem>
    </varlistentry>
@@ -36,8 +35,7 @@
     <term><parameter>max</parameter></term>
     <listitem>
      <para>
-      The highest value to be returned; must be
-      <constant>PHP_INT_MAX</constant> or less.
+      The highest value to be returned.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
It’s impossible to pass an integer that does not fall into the documented range, making this useless information. Integers outside these ranges will be converted into floats, making those a TypeError.