### PR TITLE
Added changelog to reflect changed return type of spl_autoload_functions

### DIFF
--- a/reference/spl/functions/spl-autoload-functions.xml
+++ b/reference/spl/functions/spl-autoload-functions.xml
@@ -25,9 +25,32 @@
   &reftitle.returnvalues;
   <para>
    An <type>array</type> of all registered __autoload functions.
-   If the autoload queue is not activated then the return value is &false;.
-   If no function is registered the return value will be an empty array.
+   If no function is registered, or the autoload queue is not activated,
+   then the return value will be an empty array.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       Return value was updated to always be an &array;; previously this function returned
+       &false; if the autoload queue wasn't activated.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
I've updated the return description and added a changelog for `spl_autoload_functions` to reflect the changes made in php/php-src@5b59d49.

This closes php/doc-en#2185 and ollieread/php-doc-en#14.