### PR TITLE
Corrected description of negative offsets.

### DIFF
--- a/reference/strings/functions/strrpos.xml
+++ b/reference/strings/functions/strrpos.xml
@@ -47,14 +47,14 @@
        <parameter>haystack</parameter>.
       </para>
       <para>
-       If negative, the search is performed right to left skipping the
-       last <parameter>offset</parameter> bytes of the
+       If negative, the search is performed right to left beginning with the
+       <parameter>offset</parameter> byte from the right end of
        <parameter>haystack</parameter> and searching for the first occurrence
        of <parameter>needle</parameter>.
        <note>
         <para>
          This is effectively looking for the last occurrence of
-         <parameter>needle</parameter> before the last
+         <parameter>needle</parameter> at or before the last
          <parameter>offset</parameter> bytes.
         </para>
        </note>

--- a/reference/strings/functions/strrpos.xml
+++ b/reference/strings/functions/strrpos.xml
@@ -47,10 +47,10 @@
        <parameter>haystack</parameter>.
       </para>
       <para>
-       If negative, the search is performed right to left beginning with the
-       <parameter>offset</parameter> byte from the right end of
-       <parameter>haystack</parameter> and searching for the first occurrence
-       of <parameter>needle</parameter>.
+       If negative, the search starts <parameter>offset</parameter> bytes from
+       the right instead of from the beginning of <parameter>haystack</parameter>.
+       The search is performed right to left, searching for the first
+       occurrence of <parameter>needle</parameter> from the selected byte.
        <note>
         <para>
          This is effectively looking for the last occurrence of


### PR DESCRIPTION
Fixes #2220 

The negative value for `strrpos` offset is inclusive of those bytes as a starting point, but was previously described as skipping those bytes.