### PR TITLE
Automatic leading dot in setcookie.xml

### DIFF
--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -120,6 +120,9 @@
        name (<literal>'example.com'</literal>, in this case).
       </para>
       <para>
+       PHP will add a leading <literal>.</literal> when using a subdomain as domain.
+      </para>
+      <para>
        Older browsers still implementing the deprecated
        <link xlink:href="&url.rfc;2109">RFC 2109</link> may require a leading
        <literal>.</literal> to match all subdomains.


### PR DESCRIPTION
PHP adds a leading . when using a subdomain in setcookie