### PR TITLE
random: Update list of CSPRNG sources

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -3794,34 +3794,65 @@ local: {
 <!-- csprng snippets -->
 <!ENTITY csprng.sources '
 <para xmlns="http://docbook.org/ns/docbook">
- The sources of randomness used for this function are as follows:
+ The sources of randomness in the order of priority are as follows:
 </para>
 <itemizedlist xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <listitem>
+  <para>
+   Linux: <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
+  </para>
+ </listitem>
+ <listitem>
+  <para>
+   FreeBSD &gt;= 12 (PHP &gt;= 7.3): <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
+  </para>
+ </listitem>
+ <listitem>
+  <para>
+   Windows (PHP &gt;= 7.2): <link xlink:href="&url.csprng.cng-api;">CNG-API</link>
+  </para>
+  <para>
+   Windows: <link xlink:href="&url.csprng.crypt-gen-random;">CryptGenRandom</link>
+  </para>
+ </listitem>
+ <listitem>
+  <para>
+   macOS (PHP &gt;= 8.2; &gt;= 8.1.9; &gt;= 8.0.22 if CCRandomGenerateBytes is available at compile time): CCRandomGenerateBytes()
+  </para>
+  <para>
+   macOS (PHP &gt;= 8.1; &gt;= 8.0.2): arc4random_buf(), <filename>/dev/urandom</filename>
+  </para>
+ </listitem>
+ <listitem>
+  <para>
+   NetBSD &gt;= 7 (PHP &gt;= 7.1; &gt;= 7.0.1): arc4random_buf(), <filename>/dev/urandom</filename>
+  </para>
+ </listitem>
+ <listitem>
+  <para>
+   OpenBSD &gt;= 5.5 (PHP &gt;= 7.1; &gt;= 7.0.1): arc4random_buf(), <filename>/dev/urandom</filename>
+  </para>
+ </listitem>
+ <listitem>
+  <para>
+   DragonflyBSD (PHP &gt;= 8.1): <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
+  </para>
+ </listitem>
+ <listitem>
+  <para>
+   Solaris (PHP &gt;= 8.1): <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
+  </para>
+ </listitem>
+ <listitem>
   <simpara>
-   On Windows,
-   <link xlink:href="&url.csprng.crypt-gen-random;"><function>CryptGenRandom</function></link>
-   will always be used. As of PHP 7.2.0, the
-   <link xlink:href="&url.csprng.cng-api;">CNG-API</link>
-   will always be used instead.
+   Any combination of operating system and PHP version not previously mentioned: <filename>/dev/urandom</filename>
   </simpara>
  </listitem>
  <listitem>
   <simpara>
-   On Linux, the
-   <link xlink:href="&url.csprng.get-random-2;">getrandom(2)</link>
-   syscall will be used if available.
-  </simpara>
- </listitem>
- <listitem>
-  <simpara>
-   On other platforms, <filename>/dev/urandom</filename> will be used.
-  </simpara>
- </listitem>
- <listitem>
-  <simpara>
-   If none of the aforementioned sources are available, then a
-   <classname>Random\RandomException</classname> will be thrown.
+   If none of the sources are available or they all fail to generate
+   randomness, then a <classname>Random\RandomException</classname>
+   will be thrown.
   </simpara>
  </listitem>
 </itemizedlist>


### PR DESCRIPTION
The result is absolutely not pretty, but it should hopefully be accurate for all PHP versions supported by the manual (i.e. >= 7.0):

![image](https://user-images.githubusercontent.com/209270/214162891-4ba829a4-b1fd-4a55-aee4-16e1d48f4ba3.png)

It's a little messy, because new sources have often been added in patch versions. At least the NetBSD getrandom(2) support will only appear starting in 8.3.