### PR TITLE
random: Drop example section from the `generate()` method of the Engines

### DIFF
--- a/reference/random/random/engine/mt19937/generate.xml
+++ b/reference/random/random/engine/mt19937/generate.xml
@@ -31,28 +31,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="examples">
-  &reftitle.examples;
-  <example>
-   <title><function>Random\Engine\Mt19937::generate</function> example</title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-
-/* ... */
-
-?>
-]]>
-   </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-...
-]]>
-   </screen>
-  </example>
- </refsect1>
-
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/random/random/engine/pcgoneseq128xslrr64/generate.xml
+++ b/reference/random/random/engine/pcgoneseq128xslrr64/generate.xml
@@ -31,28 +31,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="examples">
-  &reftitle.examples;
-  <example>
-   <title><function>Random\Engine\PcgOneseq128XslRr64::generate</function> example</title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-
-/* ... */
-
-?>
-]]>
-   </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-...
-]]>
-   </screen>
-  </example>
- </refsect1>
-
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/random/random/engine/secure/generate.xml
+++ b/reference/random/random/engine/secure/generate.xml
@@ -37,28 +37,6 @@
   </itemizedlist>
  </refsect1>
 
- <refsect1 role="examples">
-  &reftitle.examples;
-  <example>
-   <title><function>Random\Engine\Secure::generate</function> example</title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-
-/* ... */
-
-?>
-]]>
-   </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-...
-]]>
-   </screen>
-  </example>
- </refsect1>
-
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/random/random/engine/xoshiro256starstar/generate.xml
+++ b/reference/random/random/engine/xoshiro256starstar/generate.xml
@@ -31,28 +31,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="examples">
-  &reftitle.examples;
-  <example>
-   <title><function>Random\Engine\Xoshiro256StarStar::generate</function> example</title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-
-/* ... */
-
-?>
-]]>
-   </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-...
-]]>
-   </screen>
-  </example>
- </refsect1>
-
 
 </refentry>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
This method is not meant to be used directly and showcasing some random bytes of fixed length does not provide a value-add for the reader.