### PR TITLE
random: Reorder engines documentation

### DIFF
--- a/reference/random/book.xml
+++ b/reference/random/book.xml
@@ -19,11 +19,12 @@
  &reference.random.random.randomizer;
 
  &reference.random.random.engine;
+ &reference.random.random.cryptosafeengine;
+
+ &reference.random.random.engine.secure;
  &reference.random.random.engine.mt19937;
  &reference.random.random.engine.pcgoneseq128xslrr64;
  &reference.random.random.engine.xoshiro256starstar;
- &reference.random.random.cryptosafeengine;
- &reference.random.random.engine.secure;
 
  &reference.random.random.randomerror;
  &reference.random.random.brokenrandomengineerror;


### PR DESCRIPTION
This patch reorders the engines in the overview to list the “Secure” engine first, as that is the preferred engine for the majority of use cases. As a side effect the CryptoSafeEngine interface is documented right after the Engine interface.

The other engines remain sorted alphabetically.