### PR TITLE
Constructor visibility can be restricted

### DIFF
--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -525,7 +525,8 @@ a default value
      <constant>E_WARNING</constant> level error is generated.
      A signature is compatible if it respects the
      <link linkend="language.oop5.variance">variance</link> rules, makes a
-     mandatory parameter optional, and if any new parameters are optional.
+     mandatory parameter optional, adds only optional new parameters and
+     doesn't restrict but only relaxes the visibility.
      This is known as the Liskov Substitution Principle, or LSP for short.
      The <link linkend="language.oop5.decon.constructor">constructor</link>,
      and <literal>private</literal> methods are exempt from these signature

--- a/language/oop5/inheritance.xml
+++ b/language/oop5/inheritance.xml
@@ -32,6 +32,9 @@
   <literal>protected</literal> method can be marked as
   <literal>public</literal>, but they cannot be restricted, e.g.
   marking a <literal>public</literal> property as <literal>private</literal>.
+  An exception are constructors, whose visibility can be restricted, e.g.
+  a <literal>public</literal> constructor can be marked as <literal>private</literal>
+  in a child class.
  </para>
 
   <note>


### PR DESCRIPTION
This doesn't seem to be explicitly mentioned anywhere as far as I can tell, but the visibility of constructors can be restricted.