### PR TITLE
Modernize note about session_unset

### DIFF
--- a/reference/session/functions/session-destroy.xml
+++ b/reference/session/functions/session-destroy.xml
@@ -105,16 +105,6 @@ session_destroy();
   </para>
  </refsect1>
 
- <refsect1 role="notes">
-  &reftitle.notes;
-  <note>
-   <para>
-    Only use <function>session_unset</function> for older deprecated code
-    that does not use <varname>$_SESSION</varname>.
-   </para>
-  </note>
- </refsect1>
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/session/functions/session-unset.xml
+++ b/reference/session/functions/session-unset.xml
@@ -74,6 +74,14 @@
     The use of <function>session_unset</function> is identical to <code>$_SESSION = []</code>.
    </para>
   </note>
+  <caution>
+   <para>
+    This function works only if a session is active. It will not clear the
+    <varname>$_SESSION</varname> array if the session has not been started yet
+    or has already been destroyed. Use <code>$_SESSION = []</code> to unset all
+    session variables even if the session is not active.
+   </para>
+  </caution>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
I believe this was written back when PHP 5.4 was released. The old note isn't very clear now unless someone remembers the old days. However, the note still makes sense on the `session_unset` page with a clear explanation of why using it may be problematic. 

P.S. Help wanted for a good example code for this page. 