### PR TITLE
Fix minor typo in cloning.xml leading paragraph

### DIFF
--- a/language/oop5/cloning.xml
+++ b/language/oop5/cloning.xml
@@ -5,14 +5,14 @@
   
   <para>
    Creating a copy of an object with fully replicated properties is not
-   always the wanted behavior. A good example of the need for copy
-   constructors, is if you have an object which represents a GTK window and the
-   object holds the resource of this GTK window, when you create a duplicate
-   you might want to create a new window with the same properties and have the
-   new object hold the resource of the new window. Another example is if your
-   object holds a reference to another object which it uses and when you
-   replicate the parent object you want to create a new instance of this other
-   object so that the replica has its own separate copy.
+   always the wanted behavior. A good example of the need to copy constructors,
+   is if you have an object which represents a GTK window and the object holds
+   the resource of this GTK window, when you create a duplicate you might want
+   to create a new window with the same properties and have the new object hold
+   the resource of the new window. Another example is if your object holds a
+   reference to another object which it uses and when you replicate the parent
+   object you want to create a new instance of this other object so that the
+   replica has its own separate copy.
   </para>
 
   <para>


### PR DESCRIPTION
The leading paragraph didn't quite read well due to the typo. This  patch fixes it.