### PR TITLE
Fix typo in php8 example

### DIFF
--- a/reference/strings/functions/substr.xml
+++ b/reference/strings/functions/substr.xml
@@ -230,7 +230,7 @@ var_dump(substr('a', 2));
     <screen>
 <![CDATA[
 string(0) ""
-]]>]
+]]>
     </screen>
     &example.outputs.7;
     <screen>


### PR DESCRIPTION
The php8 example contains an additional `]` at the end. Probably a mistake.

![afbeelding](https://user-images.githubusercontent.com/511245/216985542-b18d8495-5e7d-4ece-89a8-d3a844d0e465.png)
