### PR TITLE
Document `Spoofchecker::setRestrictionLevel`

### DIFF
--- a/reference/intl/spoofchecker/setrestrictionlevel.xml
+++ b/reference/intl/spoofchecker/setrestrictionlevel.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="spoofchecker.setrestrictionlevel" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Spoofchecker::setRestrictionLevel</refname>
+  <refpurpose>Set the restriction level</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Spoofchecker">
+   <modifier>public</modifier> <type>void</type><methodname>Spoofchecker::setRestrictionLevel</methodname>
+   <methodparam><type>int</type><parameter>restrictionLevel</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Sets the restriction level of <methodname>SpoofChecker::isSuspicious</methodname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>restrictionLevel</parameter></term>
+    <listitem>
+     <para>
+      The restriction level of <methodname>SpoofChecker::isSuspicious</methodname>.
+      One of
+      <constant>Spoofchecker::ASCII</constant>,
+      <constant>Spoofchecker::SINGLE_SCRIPT_RESTRICTIVE</constant>,
+      <constant>Spoofchecker::HIGHLY_RESTRICTIVE</constant>,
+      <constant>Spoofchecker::MODERATELY_RESTRICTIVE</constant>,
+      <constant>Spoofchecker::MINIMALLY_RESTRICTIVE</constant>, or
+      <constant>Spoofchecker::UNRESTRICTIVE</constant>.
+      Defaults to <constant>Spoofchecker::HIGHLY_RESTRICTIVE</constant>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/versions.xml
+++ b/reference/intl/versions.xml
@@ -308,6 +308,7 @@
  <function name="spoofchecker::issuspicious" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
  <function name="spoofchecker::setallowedlocales" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
  <function name="spoofchecker::setchecks" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="spoofchecker::setRestrictionLevel" from="PHP 7 &gt;= 7.3.0, PHP 8"/>
  <function name="transliterator" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
  <function name="transliterator::__construct" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
  <function name="transliterator::create" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>


### PR DESCRIPTION
Part of #2163

Stumbled upon this (amongst other things) while implementing [Symfony’s `NoSuspiciousCharacters` constraint](https://symfony.com/doc/current/reference/constraints/NoSuspiciousCharacters.html).