### PR TITLE
Plurality Grammar Correction

### DIFF
--- a/reference/array/functions/array.xml
+++ b/reference/array/functions/array.xml
@@ -30,7 +30,7 @@
        omitted, an integer index is automatically generated, starting
        at 0. If index is an integer, next generated index will
        be the biggest integer index + 1. Note that when two identical
-       index are defined, the last overwrite the first.
+       indices are defined, the last overwrites the first.
       </para>
       <para>
        Having a trailing comma after the last defined array entry, while


### PR DESCRIPTION
(Refering to the code differential)
2 indexes are indices.

Regarding "overwrites," below there's an assumed meaning/reference in this clause.   "the last (index/one) overwrites the first (index/one)."  And this is perfectly fine to write it with these assumed words, but since that assumed thing is **singular**, the verb needs to have an 's' at the end (not because the verb is plural, it's just the way English refers to verbs regarding singular things).