### PR TITLE
Fixes iterator_to_array parameter name

### DIFF
--- a/language/generators.xml
+++ b/language/generators.xml
@@ -388,7 +388,7 @@ foreach (gen_reference() as &$number) {
        A common case where this matters is <function>iterator_to_array</function>
        returning a keyed array by default, leading to possibly unexpected results.
        <function>iterator_to_array</function> has a second parameter
-       <parameter>use_keys</parameter> which can be set to &false; to collect
+       <parameter>preserve_keys</parameter> which can be set to &false; to collect
        all the values while ignoring the keys returned by the <classname>Generator</classname>.
       </para>
      


### PR DESCRIPTION
`iterator_to_array()` second parameter's name is `preserve_keys` and not `use_keys` as it is currently stated.

This is useful when using named parameters.