### PR TITLE
Fix broken method reference, `push` doesn't exist

### DIFF
--- a/reference/ds/ds/set/capacity.xml
+++ b/reference/ds/ds/set/capacity.xml
@@ -40,7 +40,7 @@
 $set = new \Ds\Set();
 var_dump($set->capacity());
 
-$set->push(...range(1, 50));
+$set->add(...range(1, 50));
 var_dump($set->capacity());
 ?>
 ]]>


### PR DESCRIPTION
There is no `push` method, `add` seems equivalent here.