### PR TITLE
Remove incorrect inflate_get_status() return false description

### DIFF
--- a/reference/zlib/functions/inflate-get-status.xml
+++ b/reference/zlib/functions/inflate-get-status.xml
@@ -35,7 +35,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns decompression status&return.falseforfailure;.
+   Returns decompression status.
   </para>
  </refsect1>
 


### PR DESCRIPTION
inflate_get_status() does not return false on error. Previously, it returned false on invalid resource parameters. Not sure if that needs a changelog since that's not normally done for parameter parsing errors.