### PR TITLE
Fix sort true return type

### DIFF
--- a/reference/array/functions/arsort.xml
+++ b/reference/array/functions/arsort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>arsort</methodname>
+   <type>true</type><methodname>arsort</methodname>
    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>SORT_REGULAR</constant></initializer></methodparam>
   </methodsynopsis>

--- a/reference/array/functions/krsort.xml
+++ b/reference/array/functions/krsort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>krsort</methodname>
+   <type>true</type><methodname>krsort</methodname>
    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>SORT_REGULAR</constant></initializer></methodparam>
   </methodsynopsis>

--- a/reference/array/functions/ksort.xml
+++ b/reference/array/functions/ksort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>ksort</methodname>
+   <type>true</type><methodname>ksort</methodname>
    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>SORT_REGULAR</constant></initializer></methodparam>
   </methodsynopsis>

--- a/reference/array/functions/sort.xml
+++ b/reference/array/functions/sort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>sort</methodname>
+   <type>true</type><methodname>sort</methodname>
    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>SORT_REGULAR</constant></initializer></methodparam>
   </methodsynopsis>

--- a/reference/array/functions/usort.xml
+++ b/reference/array/functions/usort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>usort</methodname>
+   <type>true</type><methodname>usort</methodname>
    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>


### PR DESCRIPTION
These were updated to the new `true`, they could have never returned false according to https://github.com/php/php-src/commit/e86cdce549c9e81847584d2caa2dff7f89eac682 