### PR TITLE
Fix dba_open changelog php version

### DIFF
--- a/reference/dba/functions/dba-open.xml
+++ b/reference/dba/functions/dba-open.xml
@@ -240,7 +240,7 @@
       </entry>
      </row>
      <row>
-      <entry>8.1.0</entry>
+      <entry>8.2.0</entry>
       <entry>
        <parameter>handler</parameter> is now nullable.
       </entry>


### PR DESCRIPTION
According to reflection, this change was in PHP 8.2 as well from https://github.com/php/php-src/commit/7db32add9be75421347af30b0ae9b908ea8944cf