### PR TITLE
Change error level for intval and floatval

### DIFF
--- a/reference/var/functions/floatval.xml
+++ b/reference/var/functions/floatval.xml
@@ -45,7 +45,7 @@
    apply.
   </para>
  </refsect1>
- 
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -67,7 +67,7 @@
    </tgroup>
   </informaltable>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/var/functions/floatval.xml
+++ b/reference/var/functions/floatval.xml
@@ -24,7 +24,7 @@
      <listitem>
       <para>
        May be any scalar type. <function>floatval</function> should not be used
-       on objects, as doing so will emit an <constant>E_NOTICE</constant> level
+       on objects, as doing so will emit an <constant>E_WARNING</constant> level
        error and return 1.
       </para>
      </listitem>
@@ -45,6 +45,29 @@
    apply.
   </para>
  </refsect1>
+ 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       The error level when converting from object was changed from <constant>E_NOTICE</constant> to <constant>E_WARNING</constant>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/var/functions/intval.xml
+++ b/reference/var/functions/intval.xml
@@ -17,7 +17,7 @@
    Returns the <type>int</type> value of <parameter>value</parameter>,
    using the specified <parameter>base</parameter> for the conversion 
    (the default is base 10). <function>intval</function> should not be used
-   on objects, as doing so will emit an <constant>E_NOTICE</constant> level
+   on objects, as doing so will emit an <constant>E_WARNING</constant> level
    error and return 1.
   </para>
  </refsect1>
@@ -92,6 +92,28 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       The error level when converting from object was changed from <constant>E_NOTICE</constant> to <constant>E_WARNING</constant>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/var/functions/intval.xml
+++ b/reference/var/functions/intval.xml
@@ -113,7 +113,7 @@
    </tgroup>
   </informaltable>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>


### PR DESCRIPTION
In 8.0.0 it was changed to warning.
Not sure of the correct wording/format tho. 