### PR TITLE
Add format RFC 7231 warning

### DIFF
--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -260,6 +260,11 @@
        <simpara>
         RFC 7231 (since PHP 7.0.19 and 7.1.5) (example: Sat, 30 Apr 2016 17:52:13 GMT)
        </simpara>
+      <note>
+       <simpara>
+        This format ignores the given timezone and always displays hardcoded GMT timezone designation.
+       </simpara>
+      </note>
       </listitem>
     </varlistentry>
 


### PR DESCRIPTION
Format RFC 7231 doesn't take into consideration the timezone of the DateTime object. It shows always `GMT` designation. It should be reflected in documentation.