### PR TITLE
fix: UnitEnum::cases() returns enums ordered by declaration

### DIFF
--- a/language/predefined/unitenum/cases.xml
+++ b/language/predefined/unitenum/cases.xml
@@ -12,7 +12,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   This method will return a packed array of all cases in an enumeration, in lexical order.
+   This method will return a packed array of all cases in an enumeration, in order of declaration.
   </para>
 
  </refsect1>
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An array of all defined cases of this enumeration, in lexical order.
+   An array of all defined cases of this enumeration, in order of declaration.
   </para>
  </refsect1>
 


### PR DESCRIPTION
as per the RFC, and example in the doc:
https://wiki.php.net/rfc/enumerations#value_listing

> cases() returns a packed array of all defined Cases in the order of declaration.