### PR TITLE
[ibm_db2] Update param and return type for `db2_autocommit()`

### DIFF
--- a/reference/ibm_db2/functions/db2-autocommit.xml
+++ b/reference/ibm_db2/functions/db2-autocommit.xml
@@ -11,9 +11,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>mixed</type><methodname>db2_autocommit</methodname>
+   <type class="union"><type>int</type><type>bool</type></type><methodname>db2_autocommit</methodname>
    <methodparam><type>resource</type><parameter>connection</parameter></methodparam>
-   <methodparam choice="opt"><type>bool</type><parameter>value</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
 
   <para>
@@ -75,7 +75,7 @@
   <para>
    When <function>db2_autocommit</function> receives both the
    <parameter>connection</parameter> parameter and
-   <parameter>autocommit</parameter> parameter, it attempts to set the
+   <parameter>value</parameter> parameter, it attempts to set the
    AUTOCOMMIT state of the requested connection to the corresponding state.
    &return.success;
   </para>


### PR DESCRIPTION
Prior to version ibm_db2 2.1, the `db2_autocommit()` function was expecting a boolean as argument 2.

See:
* https://bugs.php.net/bug.php?id=77591
* https://github.com/php/pecl-database-ibm_db2/commit/e9fb4b173046ab4fa1bb69125adf3de8d3818b97

Additionally, the return type of this function can be `int|bool` depending on the received arguments, so `mixed` was narrowed to `int|bool`.
