### PR TITLE
Don't mention sorting but comparison

### DIFF
--- a/reference/array/functions/array-unique.xml
+++ b/reference/array/functions/array-unique.xml
@@ -48,10 +48,10 @@
      <listitem>
       <para>
        The optional second parameter <parameter>flags</parameter>
-       may be used to modify the sorting behavior using these values:
+       may be used to modify the comparison behavior using these values:
       </para>
       <para>
-       Sorting type flags:
+       Comparison type flags:
        <itemizedlist>
         <listitem>
          <simpara><constant>SORT_REGULAR</constant> - compare items normally


### PR DESCRIPTION
The array_unique function doesn't sort, but compares. It uses the same constants but terms are mixed up. The text uses "sorting" while each constant uses "compare".

This is now streamlined in order to reduce friction while reading.