### PR TITLE
random: Remove examples for mt_srand() and srand()

### DIFF
--- a/reference/random/functions/mt-srand.xml
+++ b/reference/random/functions/mt-srand.xml
@@ -93,28 +93,6 @@
    </informaltable>
   </para>
  </refsect1>
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title><function>mt_srand</function> example</title>
-    <programlisting role="php">
-<![CDATA[
-<?php
-// seed with microseconds
-function make_seed()
-{
-  list($usec, $sec) = explode(' ', microtime());
-  return $sec + $usec * 1000000;
-}
-mt_srand(make_seed());
-$randval = mt_rand();
-?>
-]]>
-    </programlisting>
-   </example>
-  </para>
- </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/random/functions/srand.xml
+++ b/reference/random/functions/srand.xml
@@ -67,28 +67,6 @@
    </informaltable>
   </para>
  </refsect1>
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title><function>srand</function> example</title>
-    <programlisting role="php">
-<![CDATA[
-<?php
-// seed with microseconds
-function make_seed()
-{
-  list($usec, $sec) = explode(' ', microtime());
-  return $sec + $usec * 1000000;
-}
-srand(make_seed());
-$randval = rand();
-?>
-]]>
-    </programlisting>
-   </example>
-  </para>
- </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>


### PR DESCRIPTION
These examples teach the readers bad practices, because they indicate that seeding from the current time is reasonable (it is not). Users should ideally use the `random_int()` function. If that is not possible, the `Random\Randomizer` is the next best choice. If that's not an option either, then relying on the random seed of the global Mt19937 is better than any manual seeding that relies on the current time.