### PR TITLE
Clarify return value when array is inputted

### DIFF
--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -802,7 +802,8 @@ filter.default_flags = 0
        <entry>
        </entry>
        <entry>
-        Requires the value to be an array.
+        Requires the value to be an array. Filter given will be applied to each
+        scalar entry of the array.
        </entry>
       </row>
       <row>

--- a/reference/filter/functions/filter-var.xml
+++ b/reference/filter/functions/filter-var.xml
@@ -26,9 +26,12 @@
       <para>
        Value to filter. Note that scalar values are
        <link linkend="language.types.string.casting">converted to string</link>
-       internally before they are filtered. If value is an array, each scalar
-       entry found within it will have the inputted filter applied to them
-       recursively.
+       internally before they are filtered.
+      </para>
+      <para>
+       If value is an array together with <constant>FILTER_REQUIRE_ARRAY</constant>
+       as <parameter>options</parameter>, each scalar entry found within it will
+       have the inputted filter applied to them.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/filter/functions/filter-var.xml
+++ b/reference/filter/functions/filter-var.xml
@@ -24,14 +24,9 @@
      <term><parameter>value</parameter></term>
      <listitem>
       <para>
-       Value to filter. Note that scalar values are
-       <link linkend="language.types.string.casting">converted to string</link>
-       internally before they are filtered.
-      </para>
-      <para>
-       If value is an array together with <constant>FILTER_REQUIRE_ARRAY</constant>
-       as <parameter>options</parameter>, each scalar entry found within it will
-       have the inputted filter applied to them.
+       Value to filter. Note that scalar values are <link
+       linkend="language.types.string.casting">converted to
+       string</link> internally before they are filtered.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/filter/functions/filter-var.xml
+++ b/reference/filter/functions/filter-var.xml
@@ -90,7 +90,9 @@ $var = filter_var('Doe, Jane Sue', FILTER_CALLBACK, array('options' => 'foo'));
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the filtered data, or &false; if the filter fails.
+   Returns the filtered data, or &false; if the filter fails. If
+   <parameter>value</parameter> is an array, all scalar values found within it
+   will have <parameter>filter</parameter> applied to it recursively.
   </para>
  </refsect1>
 

--- a/reference/filter/functions/filter-var.xml
+++ b/reference/filter/functions/filter-var.xml
@@ -95,9 +95,7 @@ $var = filter_var('Doe, Jane Sue', FILTER_CALLBACK, array('options' => 'foo'));
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the filtered data, or &false; if the filter fails. If
-   <parameter>value</parameter> is an array, each scalar entry will
-   be returned filtered.
+   Returns the filtered data, or &false; if the filter fails.
   </para>
  </refsect1>
 

--- a/reference/filter/functions/filter-var.xml
+++ b/reference/filter/functions/filter-var.xml
@@ -123,6 +123,37 @@ bool(false)
     </screen>
    </example>
   </para>
+  <para>
+   <example>
+    <title>Filter an array example</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$emails = [
+    "bob@example.com",
+    "test@example.local",
+    "invalidemail"
+];
+
+var_dump(filter_var($emails, FILTER_VALIDATE_EMAIL, FILTER_REQUIRE_ARRAY));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+array(3) {
+  [0]=>
+  string(15) "bob@example.com"
+  [1]=>
+  string(18) "test@example.local"
+  [2]=>
+  bool(false)
+}
+]]>
+    </screen>
+   </example>
+  </para>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/filter/functions/filter-var.xml
+++ b/reference/filter/functions/filter-var.xml
@@ -24,9 +24,11 @@
      <term><parameter>value</parameter></term>
      <listitem>
       <para>
-       Value to filter. Note that scalar values are <link
-       linkend="language.types.string.casting">converted to
-       string</link> internally before they are filtered.
+       Value to filter. Note that scalar values are
+       <link linkend="language.types.string.casting">converted to string</link>
+       internally before they are filtered. If value is an array, each scalar
+       entry found within it will have the inputted filter applied to them
+       recursively.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/filter/functions/filter-var.xml
+++ b/reference/filter/functions/filter-var.xml
@@ -93,8 +93,8 @@ $var = filter_var('Doe, Jane Sue', FILTER_CALLBACK, array('options' => 'foo'));
   &reftitle.returnvalues;
   <para>
    Returns the filtered data, or &false; if the filter fails. If
-   <parameter>value</parameter> is an array, all scalar values found within it
-   will have <parameter>filter</parameter> applied to it recursively.
+   <parameter>value</parameter> is an array, each scalar entry will
+   be returned filtered.
   </para>
  </refsect1>
 


### PR DESCRIPTION
It's not made clear that inputting an array as `value` causes each entry to be filtered rather than the array itself.