### PR TITLE
random: Unify code style in examples

### DIFF
--- a/reference/random/functions/mt-rand.xml
+++ b/reference/random/functions/mt-rand.xml
@@ -111,10 +111,10 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-echo mt_rand() . "\n";
-echo mt_rand() . "\n";
+echo mt_rand(), "\n";
+echo mt_rand(), "\n";
 
-echo mt_rand(5, 15);
+echo mt_rand(5, 15), "\n";
 ?>
 ]]>
     </programlisting>

--- a/reference/random/functions/rand.xml
+++ b/reference/random/functions/rand.xml
@@ -108,10 +108,10 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-echo rand() . "\n";
-echo rand() . "\n";
+echo rand(), "\n";
+echo rand(), "\n";
 
-echo rand(5, 15);
+echo rand(5, 15), "\n";
 ?>
 ]]>
     </programlisting>

--- a/reference/random/random/engine/pcgoneseq128xslrr64/construct.xml
+++ b/reference/random/random/engine/pcgoneseq128xslrr64/construct.xml
@@ -116,10 +116,10 @@ $string = "My string seed";
 // to turn the $string into a 128 Bit seed. Using the same
 // string will result in the same sequence of randomness.
 $e = new \Random\Engine\PcgOneseq128XslRr64(
-    substr( hash( 'sha256', $string, binary: true ), 0, 16 )
+    substr(hash('sha256', $string, binary: true), 0, 16)
 );
 
-echo bin2hex( $e->generate() ), "\n";
+echo bin2hex($e->generate()), "\n";
 ?>
 ]]>
    </programlisting>

--- a/reference/random/random/engine/pcgoneseq128xslrr64/jump.xml
+++ b/reference/random/random/engine/pcgoneseq128xslrr64/jump.xml
@@ -65,8 +65,8 @@ for ($i = 0; $i < 1_000; $i++) {
 }
 $b->jump(1_000);
 
-echo "A: ", bin2hex( $a->generate() ), "\n";
-echo "B: ", bin2hex( $b->generate() ), "\n";
+echo "A: ", bin2hex($a->generate()), "\n";
+echo "B: ", bin2hex($b->generate()), "\n";
 ?>
 ]]>
    </programlisting>
@@ -93,11 +93,11 @@ $b->engine->jump(2);
 
 // Because the first call to ->getInt() called ->generate() twice
 // the engines do not match up after performing a ->jump(2).
-echo "A: ", bin2hex( $a->engine->generate() ), "\n";
-echo "B: ", bin2hex( $b->engine->generate() ), "\n";
+echo "A: ", bin2hex($a->engine->generate()), "\n";
+echo "B: ", bin2hex($b->engine->generate()), "\n";
 
 // Now the B engine matches the A engine.
-echo "B: ", bin2hex( $b->engine->generate() ), "\n";
+echo "B: ", bin2hex($b->engine->generate()), "\n";
 ?>
 ]]>
    </programlisting>

--- a/reference/random/random/engine/xoshiro256starstar/construct.xml
+++ b/reference/random/random/engine/xoshiro256starstar/construct.xml
@@ -122,10 +122,10 @@ $string = "My string seed";
 // $string into a 256 Bit seed. Using the same string will result
 // in the same sequence of randomness.
 $e = new \Random\Engine\Xoshiro256StarStar(
-    hash( 'sha256', $string, binary: true )
+    hash('sha256', $string, binary: true)
 );
 
-echo bin2hex( $e->generate() ), "\n";
+echo bin2hex($e->generate()), "\n";
 ?>
 ]]>
    </programlisting>

--- a/reference/random/random/engine/xoshiro256starstar/jump.xml
+++ b/reference/random/random/engine/xoshiro256starstar/jump.xml
@@ -59,7 +59,8 @@ for ($i = 0; $i < 8; $i++) {
 
         while (true) {
             Fiber::suspend();
-            echo "{$i}: " . $randomizer->getInt(0, 100), PHP_EOL;
+
+            echo "{$i}: ", $randomizer->getInt(0, 100), "\n";
         }
     });
     $fiber->start();

--- a/reference/random/random/engine/xoshiro256starstar/jumplong.xml
+++ b/reference/random/random/engine/xoshiro256starstar/jumplong.xml
@@ -70,10 +70,10 @@ $parent2->jump();
 $child2b = clone $parent2;
 $parent2->jump();
 
-echo "Child 1A: ", bin2hex( $child1a->generate() ), "\n";
-echo "Child 1B: ", bin2hex( $child1b->generate() ), "\n";
-echo "Child 2A: ", bin2hex( $child2a->generate() ), "\n";
-echo "Child 2B: ", bin2hex( $child2b->generate() ), "\n";
+echo "Child 1A: ", bin2hex($child1a->generate()), "\n";
+echo "Child 1B: ", bin2hex($child1b->generate()), "\n";
+echo "Child 2A: ", bin2hex($child2a->generate()), "\n";
+echo "Child 2B: ", bin2hex($child2b->generate()), "\n";
 ?>
 ]]>
    </programlisting>

--- a/reference/random/random/randomizer/getbytes.xml
+++ b/reference/random/random/randomizer/getbytes.xml
@@ -62,7 +62,7 @@
 <?php
 $r = new \Random\Randomizer();
 
-echo bin2hex( $r->getBytes( 8 ) ), "\n";
+echo bin2hex($r->getBytes(8)), "\n";
 ?>
 ]]>
    </programlisting>

--- a/reference/random/random/randomizer/pickarraykeys.xml
+++ b/reference/random/random/randomizer/pickarraykeys.xml
@@ -88,10 +88,10 @@ $r = new \Random\Randomizer();
 $fruits = [ 'red' => '🍎', 'green' => '🥝', 'yellow' => '🍌', 'pink' => '🍑', 'purple' => '🍇' ];
 
 // Pick 2 random array keys:
-echo "Keys: ", join( ', ', $r->pickArrayKeys( $fruits, 2 ) ), "\n";
+echo "Keys: ", implode(', ', $r->pickArrayKeys($fruits, 2)), "\n";
 
 // Pick another 3:
-echo "Keys: ", join( ', ', $r->pickArrayKeys( $fruits, 3 ) ), "\n";
+echo "Keys: ", implode(', ', $r->pickArrayKeys($fruits, 3)), "\n";
 ?>
 ]]>
    </programlisting>
@@ -119,7 +119,7 @@ $selection = array_map(
     $keys
 );
 
-echo "Values: ", join( ', ', $selection ), "\n";
+echo "Values: ", implode(', ', $selection), "\n";
 ?>
 ]]>
    </programlisting>

--- a/reference/random/random/randomizer/shufflearray.xml
+++ b/reference/random/random/randomizer/shufflearray.xml
@@ -67,10 +67,10 @@ $r = new \Random\Randomizer();
 $fruits = [ 'red' => '🍎', 'green' => '🥝', 'yellow' => '🍌', 'pink' => '🍑', 'purple' => '🍇' ];
 
 // Shuffle array:
-echo "Salad: ", join( ', ', $r->shuffleArray( $fruits ) ), "\n";
+echo "Salad: ", implode(', ', $r->shuffleArray($fruits)), "\n";
 
 // Shuffle again:
-echo "Another Salad: ", join( ', ', $r->shuffleArray( $fruits ) ), "\n";
+echo "Another Salad: ", implode(', ', $r->shuffleArray($fruits)), "\n";
 ?>
 ]]>
    </programlisting>

--- a/reference/random/random/randomizer/shufflebytes.xml
+++ b/reference/random/random/randomizer/shufflebytes.xml
@@ -61,7 +61,7 @@
 $r = new \Random\Randomizer();
 
 // Shuffle bytes in a string:
-echo '«', $r->shuffleBytes( "PHP is great!" ), "»\n";
+echo "«", $r->shuffleBytes("PHP is great!"), "»\n";
 ?>
 ]]>
    </programlisting>
@@ -86,9 +86,9 @@ $shuffled = $r->shuffleBytes( $unicode );
 // resulting in invalid sequences (indicated by the Unicode
 // replacement character) or even entirely different characters
 // appearing in the output.
-echo 'Original: ', $unicode, "\n";
-echo 'Shuffled: «', $shuffled, "»\n";
-echo 'Shuffled Bytes: ', bin2hex( $shuffled ), "\n";
+echo "Original: ", $unicode, "\n";
+echo "Shuffled: «", $shuffled, "»\n";
+echo "Shuffled Bytes: ", bin2hex($shuffled), "\n";
 ?>
 ]]>
    </programlisting>


### PR DESCRIPTION
I apologize to the translators in advance :see_no_evil: The changes should be able to be trivially copied over, though.

-------------------

The spaces within a function call have been introduced in ad458c5f01db4bed979d1623267738ccc7a31962 and I have been trying to emulate them, but failed due to muscle memory, resulting in very inconsistently formatted examples.

Adjust the code examples purely stylistically, without changing their output:

- Remove the extra spaces within the function calls to match the commonly accepted code style (e.g. PSR-12).
- Use `implode()` instead of the `join()` alias.
- Use comma instead of string concatenation when echo-ing.
- Consistently use "\n" to emit newlines, not `PHP_EOL`.
- Unify to double quotes.