### PR TITLE
Fix wording of openssl-pkey-get-details to be consistent with other functions

### DIFF
--- a/reference/openssl/functions/openssl-pkey-get-details.xml
+++ b/reference/openssl/functions/openssl-pkey-get-details.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an array with the key details in success or &false; in failure.
+   Returns an array with the key details on success or &false; on failure.
    Returned array has indexes <literal>bits</literal> (number of bits),
    <literal>key</literal> (string representation of the public key) and
    <literal>type</literal> (type of the key which is one of


### PR DESCRIPTION
Changed wording to use `on` instead of `in` to be consistent with other functions.