### PR TITLE
Fix wording in Phar::mungServer() variables description

### DIFF
--- a/reference/phar/Phar/mungServer.xml
+++ b/reference/phar/Phar/mungServer.xml
@@ -45,7 +45,7 @@
      <term><parameter>variables</parameter></term>
      <listitem>
       <para>
-       an array containing as string indices any of
+       An array of any of the strings
        <literal>REQUEST_URI</literal>, <literal>PHP_SELF</literal>,
        <literal>SCRIPT_NAME</literal> and <literal>SCRIPT_FILENAME</literal>.
        Other values trigger an exception, and <function>Phar::mungServer</function>


### PR DESCRIPTION
This should just be an array of strings. The string indices wording is confusing.