### PR TITLE
Remove incorrect Phar::webPhar() changelog for nullable parameter

### DIFF
--- a/reference/phar/Phar/webPhar.xml
+++ b/reference/phar/Phar/webPhar.xml
@@ -173,8 +173,7 @@ $mimes = array(
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <parameter>fileNotFoundScript</parameter>, <parameter>mimeTypes</parameter>
-       and <parameter>rewrite</parameter> are nullable now.
+       <parameter>fileNotFoundScript</parameter> and <parameter>rewrite</parameter> are nullable now.
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
This was not made nullable in PHP 8.0 and still expects an array.