### PR TITLE
Explicitly mention that spl_autoload_register will drop any leading backslash

### DIFF
--- a/reference/spl/functions/spl-autoload-register.xml
+++ b/reference/spl/functions/spl-autoload-register.xml
@@ -51,7 +51,7 @@
       </methodsynopsis>
       <para>
        The <parameter>class</parameter> will not contain the leading
-       backslash of a fully-qualified classname.
+       backslash of a fully-qualified identifier.
       </para>
      </listitem>
     </varlistentry>
@@ -168,7 +168,7 @@ Fatal error: Class 'Foobar\InexistentClass' not found in ...
     </screen>
    </example>
    <example>
-    <title>The classname will be provided without the leading backslash</title>
+    <title>The identifier will be provided without the leading backslash</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/spl/functions/spl-autoload-register.xml
+++ b/reference/spl/functions/spl-autoload-register.xml
@@ -47,10 +47,10 @@
       </para>
       <methodsynopsis>
        <type>void</type><methodname><replaceable>callback</replaceable></methodname>
-       <methodparam><type>string</type><parameter>class_name</parameter></methodparam>
+       <methodparam><type>string</type><parameter>class</parameter></methodparam>
       </methodsynopsis>
       <para>
-       The <parameter>class_name</parameter> will not contain the leading
+       The <parameter>class</parameter> will not contain the leading
        backslash of a fully-qualified classname.
       </para>
      </listitem>
@@ -147,8 +147,8 @@ spl_autoload_register(function ($class) {
 namespace Foobar;
 
 class Foo {
-    static public function test($name) {
-        print '[['. $name .']]';
+    static public function test($class) {
+        print '[['. $class .']]';
     }
 }
 
@@ -173,8 +173,8 @@ Fatal error: Class 'Foobar\InexistentClass' not found in ...
 <![CDATA[
 <?php
 
-spl_autoload_register(static function ($class_name) {
-    var_dump($class_name);
+spl_autoload_register(static function ($class) {
+    var_dump($class);
 });
 
 class_exists('RelativeName');

--- a/reference/spl/functions/spl-autoload-register.xml
+++ b/reference/spl/functions/spl-autoload-register.xml
@@ -49,6 +49,10 @@
        <type>void</type><methodname><replaceable>callback</replaceable></methodname>
        <methodparam><type>string</type><parameter>class_name</parameter></methodparam>
       </methodsynopsis>
+      <para>
+       The <parameter>class_name</parameter> will not contain the leading
+       backslash of a fully-qualified classname.
+      </para>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -160,6 +164,34 @@ new InexistentClass;
 <![CDATA[
 [[Foobar\InexistentClass]]
 Fatal error: Class 'Foobar\InexistentClass' not found in ...
+]]>
+    </screen>
+   </example>
+   <example>
+    <title>The classname will be provided without the leading backslash</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+spl_autoload_register(static function ($class_name) {
+    var_dump($class_name);
+});
+
+class_exists(RelativeName::class);
+class_exists(RelativeName\WithNamespace::class);
+class_exists(\AbsoluteName::class);
+class_exists(\AbsoluteName\WithNamespace::class);
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+string(12) "RelativeName"
+string(26) "RelativeName\WithNamespace"
+string(12) "AbsoluteName"
+string(26) "AbsoluteName\WithNamespace"
 ]]>
     </screen>
    </example>

--- a/reference/spl/functions/spl-autoload-register.xml
+++ b/reference/spl/functions/spl-autoload-register.xml
@@ -177,10 +177,10 @@ spl_autoload_register(static function ($class_name) {
     var_dump($class_name);
 });
 
-class_exists(RelativeName::class);
-class_exists(RelativeName\WithNamespace::class);
-class_exists(\AbsoluteName::class);
-class_exists(\AbsoluteName\WithNamespace::class);
+class_exists('RelativeName');
+class_exists('RelativeName\\WithNamespace');
+class_exists('\\AbsoluteName');
+class_exists('\\AbsoluteName\\WithNamespace');
 
 ?>
 ]]>


### PR DESCRIPTION
Due to this guarantee there is no need to perform this unnecessary check within the autoloader.