### PR TITLE
Fix function signature

### DIFF
--- a/reference/ftp/functions/ftp-nb-get.xml
+++ b/reference/ftp/functions/ftp-nb-get.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>int</type><methodname>ftp_nb_get</methodname>
+   <type class="union"><type>int</type><type>false</type></type><methodname>ftp_nb_get</methodname>
    <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>local_filename</parameter></methodparam>
    <methodparam><type>string</type><parameter>remote_filename</parameter></methodparam>
@@ -73,7 +73,7 @@
   &reftitle.returnvalues;
   <para>
    Returns <constant>FTP_FAILED</constant> or <constant>FTP_FINISHED</constant>
-   or <constant>FTP_MOREDATA</constant>.
+   or <constant>FTP_MOREDATA</constant>, or &false; on failure to open the local file.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Missed false on return in case of failure

https://github.com/php/php-src/blob/4177257178d6a1a44f0aa6d6b23d02b91e0a58d3/ext/ftp/php_ftp.c#L797