### PR TITLE
Add DOMNode::lookupPrefix() return null description

### DIFF
--- a/reference/dom/domnode/lookupprefix.xml
+++ b/reference/dom/domnode/lookupprefix.xml
@@ -35,7 +35,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The prefix of the namespace.
+   The prefix of the namespace or &null; on error.
   </para>
  </refsect1>
  <refsect1 role="seealso">


### PR DESCRIPTION
This method returns null on error.