### PR TITLE
Fix DOMElement::returnAttributeNS() return void description

### DIFF
--- a/reference/dom/domelement/removeattributens.xml
+++ b/reference/dom/domelement/removeattributens.xml
@@ -42,7 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.void;
   </para>
  </refsect1>
  <refsect1 role="errors">


### PR DESCRIPTION
This function does not return a value. The code always returns NULL which should be valid for return type `void`.