### PR TITLE
update length verbiage to differentiate behavior between BLOB bytes and CLOB characters

### DIFF
--- a/reference/oci8/ocilob/read.xml
+++ b/reference/oci8/ocilob/read.xml
@@ -13,13 +13,14 @@
    <methodparam><type>int</type><parameter>length</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Reads <parameter>length</parameter> bytes from the current position of
-   LOB's internal pointer.
+   Reads <parameter>length</parameter> of bytes (BLOB) or characters (CLOB)
+   from the current position of LOB's internal pointer.
   </para> 
   <para> 
-   Reading stops when <parameter>length</parameter> bytes have been read or
-   end of the large object is reached. Internal pointer of the large object
-   will be shifted on the amount of bytes read.
+   Reading stops when <parameter>length</parameter> of bytes have been read for a BLOB,
+   when <parameter>length</parameter> of characters have been read for a CLOB,
+   or when the end of the large object is reached. Internal pointer of the large object
+   will be shifted on the amount of bytes/characters read.
   </para>
  </refsect1>
 
@@ -31,7 +32,8 @@
      <term><parameter>length</parameter></term>
      <listitem>
       <para>
-       The length of data to read, in bytes.  Large values will be rounded down to 1 MB.
+       The length of data to read, in bytes (BLOB) or characters (CLOB).
+       Large values will be rounded down to 1 MB.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
This updates the doc verbiage based on @cjbj 's comments on https://bugs.php.net/bug.php?id=70700.