### PR TITLE
Update set-exception-handler.xml

### DIFF
--- a/reference/errorfunc/functions/set-exception-handler.xml
+++ b/reference/errorfunc/functions/set-exception-handler.xml
@@ -89,7 +89,7 @@ echo "Not Executed\n";
     <member><function>restore_exception_handler</function></member>
     <member><function>restore_error_handler</function></member>
     <member><function>error_reporting</function></member>
-    <member><link linkend="language.exceptions">PHP 5 Exceptions</link></member>
+    <member><link linkend="language.exceptions">Exceptions</link></member>
    </simplelist>
   </para>
  </refsect1><!-- }}} -->


### PR DESCRIPTION
PHP 5 Exceptions -> Exceptions

The linked URL is not only for PHP5 but also for upper versions.
I fixed it and I referred to another text, for example, https://github.com/php/doc-en/blob/master/reference/pdo/pdoexception.xml#L15.