### PR TITLE
`str-split`: precise behavior change for PHP 8.2.0

### DIFF
--- a/reference/strings/functions/str-split.xml
+++ b/reference/strings/functions/str-split.xml
@@ -73,6 +73,13 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.2.0</entry>
+      <entry>
+       If <parameter>string</parameter> is empty an empty &array; is now returned.
+       Previously an &array; containing a single empty string was returned.
+      </entry>
+     </row>
+     <row>
       <entry>8.0.0</entry>
       <entry>
        If <parameter>length</parameter> is less than <literal>1</literal>,


### PR DESCRIPTION
It looks like `str_split` behaviour's did change in PHP8.2.0: https://3v4l.org/mHMvb

This document the change. I am unsure about the wording, also an example may be clearer.