### PR TITLE
Fix: Remove class declaration

### DIFF
--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -335,8 +335,6 @@ try {
 <![CDATA[
 <?php
 
-class SpecificException extends Exception {}
-
 function test() {
     do_something_risky() or throw new Exception('It did not work');
 }


### PR DESCRIPTION
This pull request

- [x] removes a class declaration for a `SpecificException` that is not used in the example

See https://www.php.net/manual/en/language.exceptions.php#example-336:

![CleanShot 2023-03-16 at 23 55 29@2x](https://user-images.githubusercontent.com/605483/225770657-53855627-a5fd-4c2b-878c-834e7e9d2b30.png)

