### PR TITLE
added: Phar::count parameter documentation

### DIFF
--- a/reference/phar/Phar/count.xml
+++ b/reference/phar/Phar/count.xml
@@ -18,20 +18,20 @@
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-    <variablelist>
-      <varlistentry>
-        <term>
-          <parameter>mode</parameter>
-        </term>
-        <listitem>
-          <para>
-            <parameter>mode</parameter> is an integer value specifying the counting mode to be used. By default, it is set to <constant>COUNT_NORMAL</constant>, which counts only the number of items in the archive that have not been deleted or hidden. When set to <constant>COUNT_RECURSIVE</constant>, it counts all items in the archive, including those that have been deleted or hidden.
-          </para>
-        </listitem>
-      </varlistentry>
-    </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>mode</parameter></term>
+    <listitem>
+     <para>
+      <parameter>mode</parameter> is an integer value specifying the counting mode to be used.
+      By default, it is set to <constant>COUNT_NORMAL</constant>,
+      which counts only the number of items in the archive that have not been deleted or hidden.
+      When set to <constant>COUNT_RECURSIVE</constant>, it counts all items in the archive,
+      including those that have been deleted or hidden.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;

--- a/reference/phar/Phar/count.xml
+++ b/reference/phar/Phar/count.xml
@@ -19,6 +19,18 @@
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
+    <variablelist>
+      <varlistentry>
+        <term>
+          <parameter>mode</parameter>
+        </term>
+        <listitem>
+          <para>
+            <parameter>mode</parameter> is an integer value specifying the counting mode to be used. By default, it is set to <constant>COUNT_NORMAL</constant>, which counts only the number of items in the archive that have not been deleted or hidden. When set to <constant>COUNT_RECURSIVE</constant>, it counts all items in the archive, including those that have been deleted or hidden.
+          </para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
   </para>
  </refsect1>
  <refsect1 role="returnvalues">


### PR DESCRIPTION
I have updated the documentation for the Phar::count method to include information on its $mode parameter. This should fix issue #2362.