### PR TITLE
call_user_func_array $args need not be indexed

### DIFF
--- a/reference/funchand/functions/call-user-func-array.xml
+++ b/reference/funchand/functions/call-user-func-array.xml
@@ -35,7 +35,23 @@
      <term><parameter>args</parameter></term>
      <listitem>
       <para>
-       The parameters to be passed to the callback, as an indexed array.
+       The parameters to be passed to the callback, as an array.
+      </para>
+      <para>
+        If the keys of <parameter>args</parameter> are all numeric,
+        the keys are ignored and each element will be passed to
+        <parameter>callback</parameter> as a positional argument, in
+        order.
+      </para>
+      <para>
+        If any keys of <parameter>args</parameter> are strings,
+        those elements will be passed to <parameter>callback</parameter>
+        as named arguments, with the name given by the key.
+      </para>
+      <para>
+        It is a fatal error to have a numeric key in <parameter>args</parameter>
+        appear after a string key, or to have a string key that does not
+        match the name of any parameter of <parameter>callback</parameter>.
       </para>
      </listitem>
     </varlistentry>
@@ -182,6 +198,37 @@ echo "global \$bar=$bar\n";
 <![CDATA[
 function mega $a=55
 global $bar=55
+]]>
+    </screen>
+   </example>
+   <example>
+    <title><function>call_user_func_array</function> using named arguments</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+function foobar($first, $second) {
+    echo __FUNCTION__, " got $first and $second\n";
+}
+
+// Call the foobar() function with named arguments in non-positional order
+call_user_func_array("foobar", array("second" => "two", "first" => "one"));
+
+// Call the foobar() function with one named argument
+call_user_func_array("foobar", array("foo", "second" => "bar"));
+
+// Fatal error: Cannot use positional argument after named argument
+call_user_func_array("foobar", array("first" => "one", "bar"));
+
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+foobar got one and two
+foobar got foo and bar
+
+Fatal error: Uncaught Error: Cannot use positional argument after named argument
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
Since PHP 8.0, the keys can be used as argument names.