### PR TITLE
Add warning that GMP's random functions are not cryptographically secure

### DIFF
--- a/reference/gmp/functions/gmp-random.xml
+++ b/reference/gmp/functions/gmp-random.xml
@@ -26,6 +26,7 @@
    not static, and can vary from system to system. Generally, the number
    of bits in a limb is either 32 or 64, but this is not guaranteed.
   </para>
+  &caution.cryptographically-insecure;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/gmp/functions/gmp_random_bits.xml
+++ b/reference/gmp/functions/gmp_random_bits.xml
@@ -19,6 +19,7 @@
   <para>
    <parameter>bits</parameter> must greater than 0, and the maximum value is restricted by available memory.
   </para>
+  &caution.cryptographically-insecure;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/gmp/functions/gmp_random_range.xml
+++ b/reference/gmp/functions/gmp_random_range.xml
@@ -20,6 +20,7 @@
   <para>
    <parameter>min</parameter> and <parameter>max</parameter> can both be negative but <parameter>min</parameter> must always be less than <parameter>max</parameter>.
   </para>
+  &caution.cryptographically-insecure;
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Resolves php/doc-en#2384