### PR TITLE
Fix Imagick::profileImage() parameter type

### DIFF
--- a/reference/imagick/imagick/profileimage.xml
+++ b/reference/imagick/imagick/profileimage.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Imagick::profileImage</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam><type>string</type><parameter>profile</parameter></methodparam>
+   <methodparam><type>?string</type><parameter>profile</parameter></methodparam>
   </methodsynopsis>
   <para>
    Adds or removes a ICC, IPTC, or generic profile from an image.


### PR DESCRIPTION
Actually this parameter accepts `null` to remove the value.

The original stub is below:
https://github.com/Imagick/imagick/blob/28f27044e435a2b203e32675e942eb8de620ee58/Imagick.stub.php#L1050