### PR TITLE
Issue #2397: Bring reserved.xml in sync with RFC 

### DIFF
--- a/appendices/reserved.xml
+++ b/appendices/reserved.xml
@@ -508,6 +508,7 @@
    <title>List of other reserved words</title>
    <simpara>
     The following words cannot be used to name a class, interface or trait.
+    Prior to PHP 8.0, they are also prohibited from being used in namespaces.
    </simpara>
    <para>
     <table>

--- a/appendices/reserved.xml
+++ b/appendices/reserved.xml
@@ -507,8 +507,7 @@
   <sect1 xml:id="reserved.other-reserved-words">
    <title>List of other reserved words</title>
    <simpara>
-    The following words cannot be used to name a class, interface or trait, and
-    they are also prohibited from being used in namespaces.
+    The following words cannot be used to name a class, interface or trait.
    </simpara>
    <para>
     <table>
@@ -563,8 +562,8 @@
    </para>
    <para>
     The following list of words have had soft reservations placed on them.
-    Whilst they may still be used as class, interface, and trait names (as well
-    as in namespaces), usage of them is highly discouraged since they may be
+    Whilst they may still be used as class, interface, and trait names
+    usage of them is highly discouraged since they may be
     used in future versions of PHP.
    </para>
    <para>


### PR DESCRIPTION
Fixes #2397 and brings documentation in sync with the RFC on [namespaces as a single token](https://wiki.php.net/rfc/namespaced_names_as_token) which was [implemented in 8.0](https://github.com/php/php-src/milestone/1?closed=1).