### PR TITLE
array pointer functions: Clarify deprecated use on objects

### DIFF
--- a/appendices/migration81/deprecated.xml
+++ b/appendices/migration81/deprecated.xml
@@ -327,8 +327,9 @@ $arr[] = 2;
    <function>next</function>, <function>prev</function>,
    <function>reset</function>, or <function>end</function>
    on &object;s is deprecated.
-   Either use <function>get_mangled_object_vars</function> on the
-   object first, or use <classname>ArrayIterator</classname>.
+   Either convert the &object; to an &array; using <function>get_mangled_object_vars</function>
+   first, or use the methods provided by a class that implements
+   <interfacename>Iterator</interfacename>, such as <classname>ArrayIterator</classname>, instead.
   </para>
 
   <para>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -796,7 +796,7 @@ function.</simpara></warning>'>
 <row xmlns="http://docbook.org/ns/docbook">
  <entry>7.4.0</entry>
  <entry>
-  Calling this function on <link xmlns="http://docbook.org/ns/docbook" linkend="book.spl">SPL</link> classes is deprecated.
+  Instances of <link xmlns="http://docbook.org/ns/docbook" linkend="book.spl">SPL</link> classes are now treated like empty objects that have no properties instead of calling the <interfacename>Iterator</interfacename> method with the same name as this function.
  </entry>
 </row>
 '>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -789,7 +789,14 @@ function.</simpara></warning>'>
  <entry>8.1.0</entry>
  <entry>
   Calling this function on &object;s is deprecated.
-  Either use <function>get_mangled_object_vars</function> on the &object; first, or use <classname>ArrayIterator</classname>.
+  Either convert the &object; to an &array; using <function>get_mangled_object_vars</function> first, or use the methods
+  provided by a class that implements <interfacename>Iterator</interfacename>, such as <classname>ArrayIterator</classname>, instead.
+ </entry>
+</row>
+<row xmlns="http://docbook.org/ns/docbook">
+ <entry>7.4.0</entry>
+ <entry>
+  Calling this function on <link xmlns="http://docbook.org/ns/docbook" linkend="book.spl">SPL</link> classes is deprecated.
  </entry>
 </row>
 '>


### PR DESCRIPTION
As further described in the issue, it was not clear - to me and I believe others - that the suggestion to "use ArrayIterator" was actually a suggestion to "use ArrayIterator's method instead of these functions". I thought that, similar to the Countable interface which allows classes to work with `count()`, the ArrayIterator class could somehow work with these array functions.

In testing the ArrayIterator class and contrasting it with other classes, it was a surprise to learn that while non-SPL classes would still work with these array functions in PHP 7.4 and PHP 8.0, SPL classes stopped working with these array functions in PHP 7.4, with no mention on the function pages.

I have done my best to create this initial draft and mirrored as much as possible the format used in other places in the code. I hope this helps and please let me know if you have any questions.

Fixes #2394 