### PR TITLE
Fix example code throwing deprecation warning

### DIFF
--- a/language/variables.xml
+++ b/language/variables.xml
@@ -694,7 +694,7 @@ $$a = 'world';
     <programlisting role="php">
 <![CDATA[
 <?php
-echo "$a ${$a}";
+echo "$a {$$a}";
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
Using ${expr} (variable variables) in strings is deprecated in PHP 8.2