### PR TITLE
Drop outdated cautions in generator syntax examples

### DIFF
--- a/language/generators.xml
+++ b/language/generators.xml
@@ -89,8 +89,8 @@ foreach (xrange(1, 9, 2) as $number) {
    &example.outputs;
    <screen>
 <![CDATA[
-Single digit odd numbers from range():  1 3 5 7 9 
-Single digit odd numbers from xrange(): 1 3 5 7 9 
+Single digit odd numbers from range():  1 3 5 7 9
+Single digit odd numbers from xrange(): 1 3 5 7 9
 ]]>
    </screen>
   </example>
@@ -185,14 +185,6 @@ foreach ($generator as $value) {
     </para>
    </note>
 
-   <caution>
-    <para>
-     The value that will be assigned to <varname>$data</varname> is the value
-     passed to <methodname>Generator::send</methodname>, or &null; if 
-     <methodname>Generator::next</methodname> is called instead.
-    </para>
-   </caution>
-
    <sect3 xml:id="control-structures.yield.associative">
     <title>Yielding values with keys</title>
 
@@ -255,22 +247,6 @@ foreach (input_parser($input) as $id => $fields) {
 ]]>
      </screen>
     </example>
-
-    <caution>
-     <para>
-      As with the simple value yields shown earlier, yielding a key/value pair
-      in an expression context requires the yield statement to be
-      parenthesised:
-     </para>
-
-     <informalexample>
-      <programlisting role="php">
-<![CDATA[
-      $data = (yield $key => $value);
-]]>
-      </programlisting>
-     </informalexample>
-    </caution>
    </sect3>
 
    <sect3 xml:id="control-structures.yield.null">
@@ -318,7 +294,7 @@ array(3) {
     <para>
      Generator functions are able to yield values by reference as well as by
      value. This is done in the same way as
-     <link linkend="functions.returning-values">returning references from functions</link>: 
+     <link linkend="functions.returning-values">returning references from functions</link>:
      by prepending an ampersand to the function name.
     </para>
 
@@ -349,7 +325,7 @@ foreach (gen_reference() as &$number) {
      &example.outputs;
      <screen>
 <![CDATA[
-2... 1... 0... 
+2... 1... 0...
 ]]>
      </screen>
     </example>
@@ -372,7 +348,7 @@ foreach (gen_reference() as &$number) {
      <command>yield from</command> expression will also return any value
      returned by the inner generator.
     </para>
-    
+
     <caution>
      <title>Storing into an array (e.g. with <function>iterator_to_array</function>)</title>
 
@@ -391,7 +367,7 @@ foreach (gen_reference() as &$number) {
        <parameter>preserve_keys</parameter> which can be set to &false; to collect
        all the values while ignoring the keys returned by the <classname>Generator</classname>.
       </para>
-     
+
       <example>
        <title><command>yield from</command> with <function>iterator_to_array</function></title>
        <programlisting role="php">
@@ -461,7 +437,7 @@ foreach (count_to_ten() as $num) {
      &example.outputs;
      <screen>
 <![CDATA[
-1 2 3 4 5 6 7 8 9 10 
+1 2 3 4 5 6 7 8 9 10
 ]]>
      </screen>
     </example>
@@ -531,11 +507,11 @@ function getLinesFromFile($fileName) {
     if (!$fileHandle = fopen($fileName, 'r')) {
         return;
     }
- 
+
     while (false !== $line = fgets($fileHandle)) {
         yield $line;
     }
- 
+
     fclose($fileHandle);
 }
 
@@ -543,41 +519,41 @@ function getLinesFromFile($fileName) {
 
 class LineIterator implements Iterator {
     protected $fileHandle;
- 
+
     protected $line;
     protected $i;
- 
+
     public function __construct($fileName) {
         if (!$this->fileHandle = fopen($fileName, 'r')) {
             throw new RuntimeException('Couldn\'t open file "' . $fileName . '"');
         }
     }
- 
+
     public function rewind() {
         fseek($this->fileHandle, 0);
         $this->line = fgets($this->fileHandle);
         $this->i = 0;
     }
- 
+
     public function valid() {
         return false !== $this->line;
     }
- 
+
     public function current() {
         return $this->line;
     }
- 
+
     public function key() {
         return $this->i;
     }
- 
+
     public function next() {
         if (false !== $this->line) {
             $this->line = fgets($this->fileHandle);
             $this->i++;
         }
     }
- 
+
     public function __destruct() {
         fclose($this->fileHandle);
     }
@@ -605,7 +581,7 @@ class LineIterator implements Iterator {
 
  </sect1>
 </chapter>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
fixes https://github.com/php/doc-en/issues/696