### PR TITLE
Fix strlen page

### DIFF
--- a/reference/strings/functions/strlen.xml
+++ b/reference/strings/functions/strlen.xml
@@ -69,12 +69,6 @@ echo strlen($str); // 7
     of characters in a string.
    </para>
   </note>
-  <note>
-   <para>
-    <function>strlen</function> returns &null; when executed on arrays, and
-    an <constant>E_WARNING</constant> level error is emitted.
-   </para>
-  </note>  
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/strings/functions/strlen.xml
+++ b/reference/strings/functions/strlen.xml
@@ -36,8 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The length of the <parameter>string</parameter> on success, 
-   and <literal>0</literal> if the <parameter>string</parameter> is empty.
+   The length of the <parameter>string</parameter> in bytes.
   </para>
  </refsect1>
 


### PR DESCRIPTION
This also fixes #2332. We don't document undefined behaviour for every function. As this function is documented to accept only strings, passing any other type is an undefined behaviour. The return value cannot be relied upon and in fact changed many times over the years https://3v4l.org/ukOhg. The note mentioning arrays is out of place, because why would we mention arrays on this page?