### PR TITLE
spl_autoload_register ignores throw parameter

### DIFF
--- a/reference/spl/functions/spl-autoload-register.xml
+++ b/reference/spl/functions/spl-autoload-register.xml
@@ -64,6 +64,14 @@
        exceptions when the <parameter>callback</parameter>
        cannot be registered.
       </para>
+      <warning>
+        <para>
+          This parameter is ignored as of PHP 8.0.0, and a notice will be
+          emitted if set to &false;. <function>spl_autoload_register</function>
+          will now always throw a <classname>TypeError</classname> on invalid
+          arguments.
+        </para>
+      </warning>
      </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
I've added note about ignored parameter

https://github.com/php/php-src/commit/2302b14aab3bf01a9a87d2ee87951a13bc7752a0