### PR TITLE
Replace links to __autoload

### DIFF
--- a/reference/classobj/functions/class-alias.xml
+++ b/reference/classobj/functions/class-alias.xml
@@ -43,7 +43,8 @@
      <term><parameter>autoload</parameter></term>
      <listitem>
       <para>
-       Whether to autoload if the original class is not found.
+       Whether to <link linkend="language.oop5.autoload">autoload</link>
+       if the original class is not found.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/classobj/functions/class-exists.xml
+++ b/reference/classobj/functions/class-exists.xml
@@ -32,7 +32,8 @@
      <term><parameter>autoload</parameter></term>
      <listitem>
       <para>
-       Whether to call &link.autoload; by default.
+       Whether to <link linkend="language.oop5.autoload">autoload</link>
+       if not already loaded.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/classobj/functions/enum-exists.xml
+++ b/reference/classobj/functions/enum-exists.xml
@@ -32,7 +32,8 @@
      <term><parameter>autoload</parameter></term>
      <listitem>
       <para>
-       Whether to call &link.autoload; by default.
+       Whether to <link linkend="language.oop5.autoload">autoload</link>
+       if not already loaded.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/classobj/functions/interface-exists.xml
+++ b/reference/classobj/functions/interface-exists.xml
@@ -32,7 +32,8 @@
      <term><parameter>autoload</parameter></term>
      <listitem>
       <para>
-       Whether to call &link.autoload; or not by default.
+       Whether to <link linkend="language.oop5.autoload">autoload</link>
+       if not already loaded.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/classobj/functions/trait-exists.xml
+++ b/reference/classobj/functions/trait-exists.xml
@@ -33,9 +33,10 @@
    <varlistentry>
     <term><parameter>autoload</parameter></term>
     <listitem>
-     <para>
-      Whether to autoload if not already loaded.
-     </para>
+      <para>
+       Whether to <link linkend="language.oop5.autoload">autoload</link>
+       if not already loaded.
+      </para>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/spl/functions/class-implements.xml
+++ b/reference/spl/functions/class-implements.xml
@@ -36,7 +36,8 @@
      <term><parameter>autoload</parameter></term>
      <listitem>
       <para>
-       Whether to call &link.autoload; by default.
+       Whether to <link linkend="language.oop5.autoload">autoload</link>
+       if not already loaded.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/spl/functions/class-parents.xml
+++ b/reference/spl/functions/class-parents.xml
@@ -36,7 +36,8 @@
      <term><parameter>autoload</parameter></term>
      <listitem>
       <para>
-       Whether to call &link.autoload; by default.
+       Whether to <link linkend="language.oop5.autoload">autoload</link>
+       if not already loaded.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/spl/functions/class-uses.xml
+++ b/reference/spl/functions/class-uses.xml
@@ -37,7 +37,8 @@
      <term><parameter>autoload</parameter></term>
      <listitem>
       <para>
-       Whether to call &link.autoload; by default.
+       Whether to <link linkend="language.oop5.autoload">autoload</link>
+       if not already loaded.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
I've replaced some links to removed [__autoload](https://www.php.net/manual/en/function.autoload.php) with [autoloading classes](https://www.php.net/manual/en/language.oop5.autoload.php). There are also a few in SPL, but I've not updated these.

Fixes #1456