### PR TITLE
Update Mysqli::construct() docs for return value as of PHP 8.1

### DIFF
--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -128,8 +128,8 @@
    &return.falseforfailure;.
   </para>
   <para>
-   <methodname>mysqli::connect</methodname> returns &null; on success&return.falseforfailure;.
-   As of PHP 8.1.0, returns &true; on success.
+   <methodname>mysqli::connect</methodname> returns &true; on success&return.falseforfailure;.
+   Prior to PHP 8.1.0, returns &null; on success.
   </para>
  </refsect1>
 

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -124,10 +124,6 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <methodname>mysqli::__construct</methodname> always returns an object which represents the connection to a MySQL Server, 
-   regardless of it being successful or not.
-  </para>
-  <para>
    <function>mysqli_connect</function> returns an object which represents the connection to a MySQL Server,
    &return.falseforfailure;.
   </para>

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -132,7 +132,7 @@
    &return.falseforfailure;.
   </para>
   <para>
-   <methodname>mysqli::connect</methodname> returns &null; on success&return.falseforfailure;.
+   <methodname>mysqli::connect</methodname> returns &null; on success&return.falseforfailure;. As of PHP 8.1, returns true on success.
   </para>
  </refsect1>
 

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -155,15 +155,15 @@
      </thead>
      <tbody>
       <row>
-       <entry>7.4.0</entry>
-       <entry>
-        All parameters are now nullable.
-       </entry>
-      </row>
-      <row>
        <entry>8.1.0</entry>
        <entry>
         <methodname>mysqli::connect</methodname> now returns &true; instead of &null; on success.
+       </entry>
+      </row>
+      <row>
+       <entry>7.4.0</entry>
+       <entry>
+        All parameters are now nullable.
        </entry>
       </row>
      </tbody>

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -132,7 +132,8 @@
    &return.falseforfailure;.
   </para>
   <para>
-   <methodname>mysqli::connect</methodname> returns &null; on success&return.falseforfailure;. As of PHP 8.1, returns &true; on success.
+   <methodname>mysqli::connect</methodname> returns &null; on success&return.falseforfailure;.
+   As of PHP 8.1.0, returns &true; on success.
   </para>
  </refsect1>
 
@@ -157,6 +158,12 @@
        <entry>7.4.0</entry>
        <entry>
         All parameters are now nullable.
+       </entry>
+      </row>
+      <row>
+       <entry>8.1.0</entry>
+       <entry>
+        <methodname>mysqli::connect</methodname> now returns &true; instead of &null; on success.
        </entry>
       </row>
      </tbody>

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -132,7 +132,7 @@
    &return.falseforfailure;.
   </para>
   <para>
-   <methodname>mysqli::connect</methodname> returns &null; on success&return.falseforfailure;. As of PHP 8.1, returns true on success.
+   <methodname>mysqli::connect</methodname> returns &null; on success&return.falseforfailure;. As of PHP 8.1, returns &true; on success.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Docs need updating according to this:
https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.mysqli
