### PR TITLE
Corrected typo in language/attributes.xml

### DIFF
--- a/language/attributes.xml
+++ b/language/attributes.xml
@@ -29,7 +29,7 @@
 
     <para>
      A simple example of attribute usage is to convert an interface
-     that has optional methods to use attributes. Lets assume an
+     that has optional methods to use attributes. Let's assume an
      <literal>ActionHandler</literal>
       interface representing an operation in an application, where some
       implementations of an action handler require setup and others do not. Instead of requiring all classes


### PR DESCRIPTION
Line 32: "Lets assume an [...]" -> "Let's assume an [...]"

Hi there! This is my first contribution to the PHP documentation. I did read the contribution guidelines, specifically http://doc.php.net/tutorial/editing.php, but please let me know if there are any inadequacies with the current PR.

Thank you.