### PR TITLE
stream_get_contents: Note buffer of max length size will always be allocated

### DIFF
--- a/reference/stream/functions/stream-get-contents.xml
+++ b/reference/stream/functions/stream-get-contents.xml
@@ -119,6 +119,13 @@ if ($stream = fopen('http://www.example.net', 'r')) {
  <refsect1 role="notes">
   &reftitle.notes;
   &note.bin-safe;
+  <note>
+   <para>
+    When specifying a length value other than null, this function will
+    immediately allocate an internal buffer of that size even if the
+    actual contents are significantly shorter.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/stream/functions/stream-get-contents.xml
+++ b/reference/stream/functions/stream-get-contents.xml
@@ -121,7 +121,7 @@ if ($stream = fopen('http://www.example.net', 'r')) {
   &note.bin-safe;
   <note>
    <para>
-    When specifying a length value other than null, this function will
+    When specifying a length value other than &null;, this function will
     immediately allocate an internal buffer of that size even if the
     actual contents are significantly shorter.
    </para>


### PR DESCRIPTION
Clarify in a note that even if a stream's contents are much smaller a buffer of the maximum length will be allocated if a maximum length is provided. This may be surprising if you otherwise expect the function to dynamically grow a buffer depending on the actual stream contents, as it does with the default null value.