### PR TITLE
document removal of log_errors_max_len in PHP 8.1

### DIFF
--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -46,7 +46,7 @@
      <entry><link linkend="ini.log-errors-max-len">log_errors_max_len</link></entry>
      <entry>"1024"</entry>
      <entry>PHP_INI_ALL</entry>
-     <entry></entry>
+     <entry>Had no effect as of PHP 8.0.0, removed as of PHP 8.1.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.ignore-repeated-errors">ignore_repeated_errors</link></entry>


### PR DESCRIPTION
See https://www.php.net/manual/en/migration81.other-changes.php#migration81.other-changes.ini