### PR TITLE
Update assert() docs for PHP 8

### DIFF
--- a/reference/info/functions/assert-options.xml
+++ b/reference/info/functions/assert-options.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>mixed</type><methodname>assert_options</methodname>
-   <methodparam><type>int</type><parameter>what</parameter></methodparam>
+   <methodparam><type>int</type><parameter>option</parameter></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -33,7 +33,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>what</parameter></term>
+     <term><parameter>option</parameter></term>
      <listitem>
       <para>
        <table>
@@ -53,6 +53,12 @@
            <entry>assert.active</entry>
            <entry>1</entry>
            <entry>enable <function>assert</function> evaluation</entry>
+          </row>
+          <row>
+           <entry>ASSERT_EXCEPTION</entry>
+           <entry>assert.exception</entry>
+           <entry>1</entry>
+           <entry>throws a <classname>AssertionError</classname> for each failed assertions</entry>
           </row>
           <row>
            <entry>ASSERT_WARNING</entry>
@@ -151,7 +157,41 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the original setting of any option or &false; on errors.
+   Returns the original setting of any option.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   If <parameter>option</parameter> is not a valid option a
+   <classname>ValueError</classname> is thrown.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        If <parameter>option</parameter> is not a valid option,
+        a <classname>ValueError</classname> is now thrown.
+        Previously &false; was returned.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </para>
  </refsect1>
 

--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -3,113 +3,47 @@
 <refentry xml:id="function.assert" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>assert</refname>
-  <refpurpose>Checks if assertion is &false;</refpurpose>
+  <refpurpose>Checks an assertion</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>PHP 5 and 7</para>
   <methodsynopsis>
    <type>bool</type><methodname>assert</methodname>
    <methodparam><type>mixed</type><parameter>assertion</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>description</parameter></methodparam>
-  </methodsynopsis>
-  <para>PHP 7</para>
-  <methodsynopsis>
-   <type>bool</type><methodname>assert</methodname>
-   <methodparam><type>mixed</type><parameter>assertion</parameter></methodparam>
-   <methodparam choice="opt"><type>Throwable</type><parameter>exception</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>Throwable</type><type>string</type><type>null</type></type><parameter>description</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>assert</function> will check the given
-   <parameter>assertion</parameter> and take appropriate action if
-   its result is &false;.
+   <function>assert</function> is not a function but a language construct.
+   allowing for
+   the definition of expectations: assertions that take effect in development
+   and testing environments, but are optimised away to have zero cost in
+   production.
   </para>
-  <refsect2>
-   <title>Traditional assertions (PHP 5 and 7)</title>
-   <para>
-    If the <parameter>assertion</parameter> is given as a string it
-    will be evaluated as PHP code by <function>assert</function>.
-    If you pass a boolean condition as <parameter>assertion</parameter>,
-    this condition will not be passed as a parameter to the assertion callback
-    which you may have defined with <function>assert_options</function>.
-    Rather, the callback will receive an empty string.
-   </para>
-   <para>
-    Assertions should be used as a debugging feature only. You may
-    use them for sanity-checks that test for conditions that should
-    always be &true; and that indicate some programming errors if not
-    or to check for the presence of certain features like extension
-    functions or certain system limits and features.
-   </para>
-   <para>
-    Assertions should not be used for normal runtime operations like
-    input parameter checks. As a rule of thumb your code should
-    always be able to work correctly if assertion checking is not
-    activated.
-   </para>
-   <para>
-    The behavior of <function>assert</function> may be configured by
-    <function>assert_options</function> or by .ini-settings described
-    in that functions manual page.
-   </para>
-   <para>
-    The <function>assert_options</function> function and/or
-    <constant>ASSERT_CALLBACK</constant> configuration directive allow a
-    callback function to be set to handle failed assertions.
-   </para>
-   <para>
-    <function>assert</function> callbacks are particularly useful for
-    building automated test suites because they allow you to easily
-    capture the code passed to the assertion, along with information
-    on where the assertion was made. While this information can be
-    captured via other methods, using assertions makes it much faster
-    and easier!
-   </para>
-   <para>
-    The callback function should accept three arguments. The first
-    argument will contain the file the assertion failed in. The
-    second argument will contain the line the assertion failed on and
-    the third argument will contain the expression that failed (if
-    any &#x2014; literal values such as 1 or "two" will not be passed via
-    this argument). Users of PHP 5.4.8 and later may also provide a fourth
-    optional argument, which will contain the
-    <parameter>description</parameter> given to <function>assert</function>, if
-    it was set.
-   </para>
-  </refsect2>
-  <refsect2 xml:id="function.assert.expectations">
-   <title>Expectations (PHP 7 only)</title>
-   <para>
-    <function>assert</function> is a language construct in PHP 7, allowing for
-    the definition of expectations: assertions that take effect in development
-    and testing environments, but are optimised away to have zero cost in
-    production.
-   </para>
-   <para>
-    While <function>assert_options</function> can still be used to control
-    behaviour as described above for backward compatibility reasons, PHP 7
-    only code should use the two new configuration directives to control
-    the behaviour of <function>assert</function> and not call
-    <function>assert_options</function>.
-   </para>
+  <para>
+   <function>assert</function> will check that the expectation given in
+   <parameter>assertion</parameter> holds.
+   If not, and thus the result is &false;, it will take the appropriate action
+   depending on how <function>assert</function> was configured.
+  </para>
+  
+  <para>
+   The behaviour of <function>assert</function> is dictated by the
+   following INI settings:
    <table>
-    <title>
-     PHP 7 configuration directives for <function>assert</function>
-    </title>
-    <tgroup cols="3">
+    <title>Assert &ConfigureOptions;</title>
+    <tgroup cols="4">
      <thead>
       <row>
-       <entry>Directive</entry>
-       <entry>Default value</entry>
-       <entry>Possible values</entry>
+       <entry>&Name;</entry>
+       <entry>&Default;</entry>
+       <entry>&Description;</entry>
+       <entry>&Changelog;</entry>
       </row>
      </thead>
      <tbody>
       <row>
-       <entry>
-        <link linkend="ini.zend.assertions">zend.assertions</link>
-       </entry>
+       <entry><link linkend="ini.zend.assertions">zend.assertions</link></entry>
        <entry><literal>1</literal></entry>
        <entry>
         <simplelist>
@@ -125,32 +59,102 @@
          </member>
         </simplelist>
        </entry>
+       <entry/>
       </row>
       <row>
+       <entry><link linkend="ini.assert.active">assert.active</link></entry>
+       <entry>&true;</entry>
        <entry>
+        If &false;, <function>assert</function> does not check the expectation
+        and returns &true;.
+       </entry>
+       <entry/>
+      </row>
+      <row>
+       <entry><link linkend="ini.assert.callback">assert.callback</link></entry>
+       <entry>&null;</entry>
+       <entry>
+        A user defined function to call when an assertion fails.
+        It's signature should be:
+        <methodsynopsis role="procedural">
+         <type>void</type><methodname>assert_callback</methodname>
+         <methodparam><type>string</type><parameter>file</parameter></methodparam>
+         <methodparam><type>int</type><parameter>line</parameter></methodparam>
+         <methodparam><type>null</type><parameter>assertion</parameter></methodparam>
+         <methodparam choice="opt"><type>string</type><parameter>description</parameter></methodparam>
+        </methodsynopsis>
+       </entry>
+       <entry>
+        Prior to PHP 8.0.0, the signature of the callback should be:
+        <methodsynopsis role="procedural">
+         <type>void</type><methodname>assert_callback</methodname>
+         <methodparam><type>string</type><parameter>file</parameter></methodparam>
+         <methodparam><type>int</type><parameter>line</parameter></methodparam>
+         <methodparam><type>string</type><parameter>assertion</parameter></methodparam>
+         <methodparam choice="opt"><type>string</type><parameter>description</parameter></methodparam>
+        </methodsynopsis>
+       </entry>
+      </row>
+      <row>
+       <entry><link linkend="ini.assert.exception">assert.exception</link></entry>
+       <entry>&true;</entry>
+       <entry>
+        If &true; will throw a <classname>AssertionError</classname> if the
+        expectation isn't upheld.
+       </entry>
+       <entry/>
+      </row>
+      <row>
+       <entry><link linkend="ini.assert.bail">assert.bail</link></entry>
+       <entry>&false;</entry>
+       <entry>
+        If &true; will abort execution of the PHP script if the
+        expectation isn't upheld.
+       </entry>
+       <entry/>
+      </row>
+      <row>
+       <entry><link linkend="ini.assert.warning">assert.warning</link></entry>
+       <entry>&ture;</entry>
+       <entry>
+        If &true; will emit an <constant>E_WARNING</constant> if the
+        expectation isn't upheld. This INI setting is ineffective if
         <link linkend="ini.assert.exception">assert.exception</link>
+        is enabled.
        </entry>
-       <entry><literal>0</literal></entry>
-       <entry>
-        <simplelist>
-         <member>
-          <literal>1</literal>: throw when the assertion fails, either by
-          throwing the object provided as the <parameter>exception</parameter>
-          or by throwing a new <classname>AssertionError</classname> object if
-          <parameter>exception</parameter> wasn't provided
-         </member>
-         <member>
-          <literal>0</literal>: use or generate a
-          <classname>Throwable</classname> as described above, but only
-          generate a warning based on that object rather than throwing it
-          (compatible with PHP 5 behaviour)
-         </member>
-        </simplelist>
-       </entry>
+       <entry/>
       </row>
      </tbody>
     </tgroup>
    </table>
+   
+   Some of these option can be configured via <function>assert_options</function>.
+   However, this is not recommended.
+  </para>
+  
+  <!-- TODO Clean-up/integrate/delete -->
+  <refsect2>
+   <para>
+    Assertions should be used as a debugging feature only. You may
+    use them for sanity-checks that test for conditions that should
+    always be &true; and that indicate some programming errors if not
+    or to check for the presence of certain features like extension
+    functions or certain system limits and features.
+   </para>
+   <para>
+    Assertions should not be used for normal runtime operations like
+    input parameter checks. As a rule of thumb your code should
+    always be able to work correctly if assertion checking is not
+    activated.
+   </para>
+   <para>
+    <function>assert</function> callbacks are particularly useful for
+    building automated test suites because they allow you to easily
+    capture the code passed to the assertion, along with information
+    on where the assertion was made. While this information can be
+    captured via other methods, using assertions makes it much faster
+    and easier!
+   </para>
   </refsect2>
  </refsect1>
 
@@ -162,16 +166,18 @@
      <term><parameter>assertion</parameter></term>
      <listitem>
       <para>
-       The assertion. In PHP 5, this must be either a <type>string</type> to
-       be evaluated or a <type>bool</type> to be tested. In PHP 7, this may
-       also be any expression that returns a value, which will be executed and
-       the result used to indicate whether the assertion succeeded or failed.
+       This may be any expression that returns a value, which will be executed
+       and the result is used to indicate whether the assertion succeeded or failed.
       </para>
 
       <warning>
        <para>
-        Using <type>string</type> as the <parameter>assertion</parameter> is
-        <emphasis>DEPRECATED</emphasis> as of PHP 7.2.0 and <emphasis>REMOVED</emphasis> as of PHP 8.0.0.
+        Prior to PHP 8.0.0, if <parameter>assertion</parameter> was a
+        <type>string</type> it was interpreted as PHP code and executed via
+        <function>eval</function>.
+        This string would be passed to the callback as the third argument.
+        This behaviour was <emphasis>DEPRECATED</emphasis> in PHP 7.2.0,
+        and <emphasis>REMOVED</emphasis> in PHP 8.0.0.
        </para>
       </warning>
      </listitem>
@@ -180,23 +186,28 @@
      <term><parameter>description</parameter></term>
      <listitem>
       <para>
-       An optional description that will be included in the failure message if
-       the <parameter>assertion</parameter> fails. From PHP 7, if no
-       description is provided, a default description equal to the source code
-       for the invocation of <function>assert</function> is provided.
+       If <parameter>description</parameter> is an instance of
+       <classname>Throwable</classname>, it will be thrown if the
+       <parameter>assertion</parameter> fails.
+       This is done <emphasis>prior</emphasis> to calling the potentially
+       defined assertion callback.
+       As of PHP 8.0.0, the &object; will be thrown regardless of the configuration of
+       <link linkend="ini.assert.exception">assert.exception</link>.
+       As of PHP 8.0.0, the
+       <link linkend="ini.assert.bail">assert.bail</link>
+       setting has no effect in this case.
       </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>exception</parameter></term>
-     <listitem>
       <para>
-       In PHP 7, the second parameter can be a
-       <classname>Throwable</classname> object instead of a descriptive
-       <type>string</type>, in which case this is the object that will be
-       thrown if the assertion fails and the
-       <link linkend="ini.assert.exception">assert.exception</link>
-       configuration directive is enabled.
+       If <parameter>description</parameter> is a &string; this message
+       will be used if an exception or a warning is emitted.
+       An optional description that will be included in the failure message if
+       the <parameter>assertion</parameter> fails.
+      </para>
+      <para>
+       If <parameter>description</parameter> is omitted.
+       <!-- This does not happen if &null; is passed ... -->
+       A default description equal to the source code for the invocation of
+       <function>assert</function> is created at compile time.
       </para>
      </listitem>
     </varlistentry>
@@ -236,6 +247,23 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
+        If <parameter>description</parameter> is an instance of
+        <classname>Throwable</classname>, the object is thrown if the assertion
+        fails, regardless of the value of
+        <link linkend="ini.assert.exception">assert.exception</link>.
+       </entry>
+      </row>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        If <parameter>description</parameter> is an instance of
+        <classname>Throwable</classname>, no user callback is called even
+        if it set.
+       </entry>
+      </row>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
         Declaring a function called <literal>assert()</literal> inside a namespace is
         no longer allowed, and issues <constant>E_COMPILE_ERROR</constant>.
        </entry>
@@ -257,17 +285,6 @@
         to <literal>1</literal>.
        </entry>
       </row>
-      <row>
-       <entry>7.0.0</entry>
-       <entry>
-        <function>assert</function> is now a language construct and not a
-        function. <parameter>assertion</parameter> can now be an expression.
-        The second parameter is now interpreted either as an
-        <parameter>exception</parameter> (if a
-        <classname>Throwable</classname> object is given), or as the
-        <parameter>description</parameter> supported from PHP 5.4.8 onwards.
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>
@@ -277,81 +294,8 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <refsect2>
-   <title>Traditional assertions (PHP 5 and 7)</title>
-   <para>
-    <example>
-     <title>Handle a failed assertion with a custom handler</title>
-     <programlisting role="php">
-<![CDATA[
-<?php
-// Active assert and make it quiet
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 0);
-assert_options(ASSERT_QUIET_EVAL, 1);
-
-// Create a handler function
-function my_assert_handler($file, $line, $code)
-{
-    echo "<hr>Assertion Failed:
-        File '$file'<br />
-        Line '$line'<br />
-        Code '$code'<br /><hr />";
-}
-
-// Set up the callback
-assert_options(ASSERT_CALLBACK, 'my_assert_handler');
-
-// Make an assertion that should fail
-assert('mysql_query("")');
-?>
-]]>
-     </programlisting>
-    </example>
-   </para>
-   <para>
-    <example>
-     <title>Using a custom handler to print a description</title>
-     <programlisting role="php">
-<![CDATA[
-<?php
-// Active assert and make it quiet
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 0);
-assert_options(ASSERT_QUIET_EVAL, 1);
-
-// Create a handler function
-function my_assert_handler($file, $line, $code, $desc = null)
-{
-    echo "Assertion failed at $file:$line: $code";
-    if ($desc) {
-        echo ": $desc";
-    }
-    echo "\n";
-}
-
-// Set up the callback
-assert_options(ASSERT_CALLBACK, 'my_assert_handler');
-
-// Make an assertion that should fail
-assert('2 < 1');
-assert('2 < 1', 'Two is less than one');
-?>
-]]>
-     </programlisting>
-     &example.outputs;
-     <screen>
- <![CDATA[
- Assertion failed at test.php:21: 2 < 1
- Assertion failed at test.php:22: 2 < 1: Two is less than one
- ]]>
-     </screen>
-    </example>
-   </para>
-  </refsect2>
-  <refsect2>
-   <title>Expectations (PHP 7 only)</title>
+   <title>Expectations</title>
    <example>
-    <title>Expectations without a custom exception</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -443,6 +387,78 @@ Stack trace:
 ]]>
     </screen>
    </example>
+  </refsect2>
+  <refsect2>
+   <title>Evaluated code assertions (PHP 7 only)</title>
+   <para>
+    <example>
+     <title>Handle a failed assertion with a custom handler</title>
+     <programlisting role="php">
+      <![CDATA[
+<?php
+// Active assert and make it quiet
+assert_options(ASSERT_ACTIVE, 1);
+assert_options(ASSERT_WARNING, 0);
+assert_options(ASSERT_QUIET_EVAL, 1);
+
+// Create a handler function
+function my_assert_handler($file, $line, $code)
+{
+    echo "<hr>Assertion Failed:
+        File '$file'<br />
+        Line '$line'<br />
+        Code '$code'<br /><hr />";
+}
+
+// Set up the callback
+assert_options(ASSERT_CALLBACK, 'my_assert_handler');
+
+// Make an assertion that should fail
+assert('mysql_query("")');
+?>
+]]>
+     </programlisting>
+    </example>
+   </para>
+   <para>
+    <example>
+     <title>Using a custom handler to print a description</title>
+     <programlisting role="php">
+      <![CDATA[
+<?php
+// Active assert and make it quiet
+assert_options(ASSERT_ACTIVE, 1);
+assert_options(ASSERT_WARNING, 0);
+assert_options(ASSERT_QUIET_EVAL, 1);
+
+// Create a handler function
+function my_assert_handler($file, $line, $code, $desc = null)
+{
+    echo "Assertion failed at $file:$line: $code";
+    if ($desc) {
+        echo ": $desc";
+    }
+    echo "\n";
+}
+
+// Set up the callback
+assert_options(ASSERT_CALLBACK, 'my_assert_handler');
+
+// Make an assertion that should fail
+assert('2 < 1');
+assert('2 < 1', 'Two is less than one');
+?>
+]]>
+     </programlisting>
+     &example.outputs;
+     <screen>
+      <![CDATA[
+ Assertion failed at test.php:21: 2 < 1
+ Assertion failed at test.php:22: 2 < 1: Two is less than one
+ ]]>
+     </screen>
+    </example>
+   </para>
   </refsect2>
  </refsect1>
 

--- a/reference/info/ini.xml
+++ b/reference/info/ini.xml
@@ -44,13 +44,13 @@
      <entry><link linkend="ini.assert.quiet-eval">assert.quiet_eval</link></entry>
      <entry>"0"</entry>
      <entry>PHP_INI_ALL</entry>
-     <entry></entry>
+     <entry>Removed as of PHP 8.0.0</entry>
     </row>
     <row>
      <entry><link linkend="ini.assert.exception">assert.exception</link></entry>
      <entry>"0"</entry>
      <entry>PHP_INI_ALL</entry>
-     <entry>Available as of PHP 7.0.0.</entry>
+     <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.enable-dl">enable_dl</link></entry>


### PR DESCRIPTION
``assert()`` is pretty wild due to all those options and the behaviour was changed in-between 7 and 8.