### PR TITLE
Update intval docs for 64 bit and scientific notation

### DIFF
--- a/reference/var/functions/intval.xml
+++ b/reference/var/functions/intval.xml
@@ -120,7 +120,7 @@
    <example>
     <title><function>intval</function> examples</title>
     <para>
-     The following examples are based on a 32 bit system.
+     The following examples are based on a 64 bit system.
     </para>
     <programlisting role="php">
 <![CDATA[
@@ -132,12 +132,14 @@ echo intval('+42');                   // 42
 echo intval('-42');                   // -42
 echo intval(042);                     // 34
 echo intval('042');                   // 42
-echo intval(1e10);                    // 1410065408
-echo intval('1e10');                  // 1
+echo intval(1e10);                    // 10000000000
+echo intval('1e10');                  // 10000000000
 echo intval(0x1A);                    // 26
+echo intval('0x1A');                  // 0
+echo intval('0x1A', 0);               // 26
 echo intval(42000000);                // 42000000
-echo intval(420000000000000000000);   // 0
-echo intval('420000000000000000000'); // 2147483647
+echo intval(420000000000000000000);   // -4275113695319687168
+echo intval('420000000000000000000'); // 9223372036854775807
 echo intval(42, 8);                   // 42
 echo intval('42', 8);                 // 34
 echo intval(array());                 // 0


### PR DESCRIPTION
- Update example to be based on a 64 bit system
- Show that '1e10' evaluates using scientific notation
- Include an example with `0` as the base.

https://3v4l.org/gleJ0 shows that in:
- PHP 7.1+ converts scientific notation in numeric strings
- PHP 5.5+ converts large floats to negative integers / undefined results

These may not be relevant to `intval` though they don't seem to be called out anywhere else.

Thanks!