### PR TITLE
Mention the use of '*' in printf-formatting specifiers

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -3505,16 +3505,20 @@ local: {
   <formalpara>
    <title>Width</title>
    <para>
-    An integer that says how many characters (minimum)
-    this conversion should result in.
+    Either an integer that says how many characters (minimum)
+    this conversion should result in, or <literal>*</literal>.
+    If <literal>*</literal> is used, then the width is supplied
+    as an additional integer value preceding the one formatted
+    by the specifier.
    </para>
   </formalpara>
 
   <formalpara>
    <title>Precision</title>
    <para>
-    A period <literal>.</literal> followed by an integer
-    who&apos;s meaning depends on the specifier:
+    A period <literal>.</literal> optionally followed by
+    either an integer or <literal>*</literal>,
+    whose meaning depends on the specifier:
     <itemizedlist>
      <listitem>
       <simpara>
@@ -3542,7 +3546,9 @@ local: {
     <note>
      <simpara>
       If the period is specified without an explicit value for precision,
-      0 is assumed.
+      0 is assumed. If <literal>*</literal> is used, the precision is
+      supplied as an additional integer value preceding the one formatted
+      by the specifier.
      </simpara>
     </note>
    </para>

--- a/reference/strings/functions/printf.xml
+++ b/reference/strings/functions/printf.xml
@@ -109,13 +109,14 @@ printf("%%+d = '%+d'\n", $u); // sign specifier on a negative integer
 $s = 'monkey';
 $t = 'many monkeys';
 
-printf("[%s]\n",      $s); // standard string output
-printf("[%10s]\n",    $s); // right-justification with spaces
-printf("[%-10s]\n",   $s); // left-justification with spaces
-printf("[%010s]\n",   $s); // zero-padding works on strings too
-printf("[%'#10s]\n",  $s); // use the custom padding character '#'
-printf("[%10.9s]\n",  $t); // right-justification but with a cutoff of 8 characters
-printf("[%-10.9s]\n", $t); // left-justification but with a cutoff of 8 characters
+printf("[%s]\n",        $s); // standard string output
+printf("[%10s]\n",      $s); // right-justification with spaces
+printf("[%-10s]\n",     $s); // left-justification with spaces
+printf("[%010s]\n",     $s); // zero-padding works on strings too
+printf("[%'#10s]\n",    $s); // use the custom padding character '#'
+pritnf("[%'#*s]\n", 10, $s); // Provide the padding width as an additional argument
+printf("[%10.9s]\n",    $t); // right-justification but with a cutoff of 8 characters
+printf("[%-10.9s]\n",   $t); // left-justification but with a cutoff of 8 characters
 ?>
 ]]>
     </programlisting>
@@ -126,6 +127,7 @@ printf("[%-10.9s]\n", $t); // left-justification but with a cutoff of 8 characte
 [    monkey]
 [monkey    ]
 [0000monkey]
+[####monkey]
 [####monkey]
 [ many monk]
 [many monk ]


### PR DESCRIPTION
When '*' is used to indicate width or precision in a formatting specifier, an additional integer argument is to be supplied which will provide the width/precision to be used.

#2423 