### PR TITLE
parallel\Runtime methods descriptions were obviously wrong

### DIFF
--- a/reference/parallel/parallel.runtime.xml
+++ b/reference/parallel/parallel.runtime.xml
@@ -64,7 +64,7 @@
      <xi:fallback />
     </xi:include>
 
-    <classsynopsisinfo role="comment">Join</classsynopsisinfo>
+    <classsynopsisinfo role="comment">Shutdown</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-runtime')/db:refentry/db:refsect1[@audience='shutdown']/descendant::db:methodsynopsis[not(@role='procedural')])">
      <xi:fallback />
     </xi:include>

--- a/reference/parallel/parallel.runtime.xml
+++ b/reference/parallel/parallel.runtime.xml
@@ -65,7 +65,7 @@
     </xi:include>
 
     <classsynopsisinfo role="comment">Join</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-runtime')/db:refentry/db:refsect1[@audience='join']/descendant::db:methodsynopsis[not(@role='procedural')])">
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-runtime')/db:refentry/db:refsect1[@audience='shutdown']/descendant::db:methodsynopsis[not(@role='procedural')])">
      <xi:fallback />
     </xi:include>
    </classsynopsis>

--- a/reference/parallel/parallel/runtime/close.xml
+++ b/reference/parallel/parallel/runtime/close.xml
@@ -4,10 +4,10 @@
 <refentry xml:id="parallel-runtime.close" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>parallel\Runtime::close</refname>
-  <refpurpose>Runtime Graceful Join</refpurpose>
+  <refpurpose>Runtime Graceful Shutdown</refpurpose>
  </refnamediv>
 
- <refsect1 role="description" audience="join">
+ <refsect1 role="description" audience="shutdown">
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>parallel\Runtime::close</methodname>

--- a/reference/parallel/parallel/runtime/kill.xml
+++ b/reference/parallel/parallel/runtime/kill.xml
@@ -4,10 +4,10 @@
 <refentry xml:id="parallel-runtime.kill" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>parallel\Runtime::kill</refname>
-  <refpurpose>Runtime Join</refpurpose>
+  <refpurpose>Runtime Shutdown</refpurpose>
  </refnamediv>
 
- <refsect1 role="description" audience="join">
+ <refsect1 role="description" audience="shutdown">
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>parallel\Runtime::kill</methodname>


### PR DESCRIPTION
`parallel\Runtime::close` and `parallel\Runtime::kill` methods descriptions fixed ('join' => 'shutdown')