### PR TITLE
tutorial: Promote lowercase boolean to beginners

### DIFF
--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -232,14 +232,14 @@ echo $_SERVER['HTTP_USER_AGENT'];
      A sample output of this script may be:
     </para>
     <screen role="html">
-Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
+Mozilla/5.0 (Linux) Firefox/112.0
     </screen>
    </example>
    </para>
    <para>
     There are many <link linkend="language.types">types</link> of 
-    variables available in PHP.  In the above example we printed 
-    an <link linkend="language.types.array">Array</link> element.
+    variables available in PHP.  In the above example we printed an element
+    from an <link linkend="language.types.array">Array</link> variable.
     Arrays can be very useful.
    </para>
    <para>
@@ -253,7 +253,7 @@ Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
    <para>
     You can put multiple PHP statements inside a PHP tag and create
     little blocks of code that do more than just a single echo.
-    For example, if you want to check for Internet Explorer you
+    For example, if you want to check for Firefox you
     can do this:
    </para>
    <para>
@@ -263,8 +263,8 @@ Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
      <programlisting role="php">
 <![CDATA[
 <?php
-if (strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE') !== FALSE) {
-    echo 'You are using Internet Explorer.<br />';
+if (strpos($_SERVER['HTTP_USER_AGENT'], 'Firefox') !== false) {
+    echo 'You are using Firefox.<br />';
 }
 ?>
 ]]>
@@ -274,7 +274,7 @@ if (strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE') !== FALSE) {
      </para>
      <screen role="html">
 <![CDATA[
-You are using Internet Explorer.<br />
+You are using Firefox.<br />
 ]]>
      </screen>
     </example>
@@ -292,7 +292,7 @@ You are using Internet Explorer.<br />
     The second concept we introduced was the <function>strpos</function>
     function call. <function>strpos</function> is a function built into
     PHP which searches a string for another string. In this case we are
-    looking for <literal>'MSIE'</literal> (so-called needle) inside
+    looking for <literal>'Firefox'</literal> (so-called needle) inside
     <varname>$_SERVER['HTTP_USER_AGENT']</varname> (so-called haystack).  If
     the needle is found inside the haystack, the function returns the position
     of the needle relative to the start of the haystack.  Otherwise, it
@@ -319,15 +319,15 @@ You are using Internet Explorer.<br />
      <programlisting role="php">
 <![CDATA[
 <?php
-if (strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE') !== FALSE) {
+if (strpos($_SERVER['HTTP_USER_AGENT'], 'Firefox') !== false) {
 ?>
 <h3>strpos() must have returned non-false</h3>
-<p>You are using Internet Explorer</p>
+<p>You are using Firefox</p>
 <?php
 } else {
 ?>
 <h3>strpos() must have returned false</h3>
-<p>You are not using Internet Explorer</p>
+<p>You are not using Firefox</p>
 <?php
 }
 ?>
@@ -339,7 +339,7 @@ if (strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE') !== FALSE) {
      <screen role="html">
 <![CDATA[
 <h3>strpos() must have returned non-false</h3>
-<p>You are using Internet Explorer</p>
+<p>You are using Firefox</p>
 ]]>
      </screen>
     </example>
@@ -350,7 +350,7 @@ if (strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE') !== FALSE) {
     to note here is that the logical flow of the script remains intact. Only
     one of the HTML blocks will end up getting sent to the viewer depending on
     the result of <function>strpos</function>.  In other words, it depends on
-    whether the string <literal>MSIE</literal> was found or not.
+    whether the string <literal>Firefox</literal> was found or not.
    </para>
   </section>
    


### PR DESCRIPTION
Update the example to a browser that people can actually download and install from official websites on macOS, Linux, and Windows today.

MSIE is EOL and was Windows-only (apart from [IE 5.5 for Mac](https://www.versionmuseum.com/history-of/internet-explorer), back in the day). Note that even IE11 no longer identified as MSIE, it identified as Trident instead.