### PR TITLE
Clarify mktime and gmmktime without args

### DIFF
--- a/reference/datetime/functions/gmmktime.xml
+++ b/reference/datetime/functions/gmmktime.xml
@@ -23,14 +23,17 @@
    so only times valid in derived local time can be used.
   </para>
   <para>
-   Like <function>mktime</function>, arguments may be left out in order
+   Like <function>mktime</function>, any arguments (other than the first) may be left out in order
    from right to left, with any omitted arguments being set to the
    current corresponding GMT value.
   </para>
-  <simpara>
-   Calling <function>gmmktime</function> without arguments is deprecated.
-   <function>time</function> can be used to get the current timestamp.
-  </simpara>
+  <warning>
+   <simpara>
+    As of PHP 8.0.0, an <classname>ArgumentCountError</classname> is thrown if
+    the number of arguments is zero.
+    <function>time</function> can be used to get the current timestamp.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/datetime/functions/gmmktime.xml
+++ b/reference/datetime/functions/gmmktime.xml
@@ -29,8 +29,7 @@
   </para>
   <warning>
    <simpara>
-    As of PHP 8.0.0, an <classname>ArgumentCountError</classname> is thrown if
-    the number of arguments is zero.
+    As of PHP 8.0.0, <parameter>hour</parameter> is no longer optional.
     <function>time</function> can be used to get the current timestamp.
    </simpara>
   </warning>

--- a/reference/datetime/functions/gmmktime.xml
+++ b/reference/datetime/functions/gmmktime.xml
@@ -23,7 +23,7 @@
    so only times valid in derived local time can be used.
   </para>
   <para>
-   Like <function>mktime</function>, any arguments (other than the first) may be left out in order
+   Like <function>mktime</function>, arguments (other than the first) may be left out in order
    from right to left, with any omitted arguments being set to the
    current corresponding GMT value.
   </para>

--- a/reference/datetime/functions/mktime.xml
+++ b/reference/datetime/functions/mktime.xml
@@ -25,8 +25,8 @@
   </para>
   <para>
    Any
-   arguments omitted or &null; will be set to the current value according
-   to the local date and time.
+   arguments (other than the first) that are omitted or &null; will be set to
+   the current value according to the local date and time.
   </para>
   <warning>
    <para>
@@ -37,10 +37,13 @@
     <parameter>day</parameter>.
    </para>
   </warning>
-  <simpara>
-   Calling <function>mktime</function> without arguments is deprecated.
-   <function>time</function> can be used to get the current timestamp.
-  </simpara>
+  <warning>
+   <simpara>
+    As of PHP 8.0.0, an <classname>ArgumentCountError</classname> is thrown if
+    the number of arguments is zero.
+    <function>time</function> can be used to get the current timestamp.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/datetime/functions/mktime.xml
+++ b/reference/datetime/functions/mktime.xml
@@ -39,8 +39,7 @@
   </warning>
   <warning>
    <simpara>
-    As of PHP 8.0.0, an <classname>ArgumentCountError</classname> is thrown if
-    the number of arguments is zero.
+    As of PHP 8.0.0, <parameter>hour</parameter> is no longer optional.
     <function>time</function> can be used to get the current timestamp.
    </simpara>
   </warning>


### PR DESCRIPTION
This just adds some clarification for mktime and gmmktime about whether passing no arguments is still deprecated or not, and makes it obvious that as of PHP 8.0, it will throw an error.

