### PR TITLE
may also return DOMElement

### DIFF
--- a/reference/dom/domnodelist/item.xml
+++ b/reference/dom/domnodelist/item.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DOMNodeList">
-   <modifier>public</modifier> <type class="union"><type>DOMNode</type><type>DOMNameSpaceNode</type><type>null</type></type><methodname>DOMNodeList::item</methodname>
+   <modifier>public</modifier> <type class="union"><type>DOMElement</type><type>DOMNode</type><type>DOMNameSpaceNode</type><type>null</type></type><methodname>DOMNodeList::item</methodname>
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
   </methodsynopsis>
   <para>


### PR DESCRIPTION
Not explicitly documenting the possibility of returning DOMElement causes the Intelephense linter (a popular PHP linter with ~9 million downloads: https://marketplace.visualstudio.com/items?itemName=bmewburn.vscode-intelephense-client ) to think this code is bad:

$xp->query("whatever")->item(0)->getAttribute("foo");

because DOMNode does not have getAttribute (while DOMElement does). documenting the DOMElement return type should fix Intelephense's linter.