### PR TITLE
Add an example for str_getcsv with empty input

### DIFF
--- a/reference/strings/functions/str-getcsv.xml
+++ b/reference/strings/functions/str-getcsv.xml
@@ -152,6 +152,31 @@ array(5) {
     </screen>
    </example>
   </para>
+  <para>
+   <example>
+    <title><function>str_getcsv</function> example with empty input</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$string = '';
+$data = str_getcsv($string);
+
+var_dump($data);
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+array(1) {
+  [0]=>
+  NULL
+}
+]]>
+    </screen>
+   </example>
+  </para>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/strings/functions/str-getcsv.xml
+++ b/reference/strings/functions/str-getcsv.xml
@@ -154,7 +154,13 @@ array(5) {
   </para>
   <para>
    <example>
-    <title><function>str_getcsv</function> example with empty input</title>
+    <title><function>str_getcsv</function> example with an empty string</title>
+    <caution>
+     <simpara>
+      On an empty string this function returns the value <code>[null]</code>
+      instead of an empty array.
+     </simpara>
+    </caution>
     <programlisting role="php">
 <![CDATA[
 <?php


### PR DESCRIPTION
It's surprising that `str_getcsv("")` returns `[null]`. This adds an example to warn users of this behavior.