### PR TITLE
Update phrasing for consistency with dynamically generated text

### DIFF
--- a/reference/url/functions/http-build-query.xml
+++ b/reference/url/functions/http-build-query.xml
@@ -195,7 +195,7 @@ echo http_build_query($data, 'flags_');
 ]]>
    </programlisting>
    <para>
-    this will output : (word wrapped for readability)
+    The above example will output: (word wrapped for readability)
    </para>
    <screen>
 <![CDATA[


### PR DESCRIPTION
Change affects this page: https://www.php.net/manual/en/function.http-build-query.php

The line I am changing: https://github.com/php/doc-en/blob/master/reference/url/functions/http-build-query.xml#L198

This change updates the phrasing of that label to use what `&example.outputs;` generates.

I opted to not use `&example.outputs;` because I figure that the text should remain static, rather than doing something like
```xml
&example.outputs;
<para>(word wrapped for readability)</para>
```
but I'm not sure about this... because it could be the preference to use the dynamically generated text regardless of whether there's an addendum.