### PR TITLE
Link to `enable_post_data_reading` from the `php://input` documentation

### DIFF
--- a/language/wrappers/php.xml
+++ b/language/wrappers/php.xml
@@ -43,8 +43,11 @@
    <simpara>
     <filename>php://input</filename> is a read-only stream that allows you to
     read raw data from the request body.
-    <filename>php://input</filename> is not available with
+    <filename>php://input</filename> is not available in POST requests with
     <literal>enctype="multipart/form-data"</literal>.
+    <literal>enctype="multipart/form-data"</literal> if
+    <link linkend="ini.enable-post-data-reading">enable_post_data_reading</link>
+    option is enabled.
    </simpara>
   </refsect2>
 


### PR DESCRIPTION
I need to read `php://input` under any circumstances to implement a reverse proxy. After reading the current document, I thought that it would not be possible and it took me a long time to find the solution.