### PR TITLE
Reflection: fix some "undocumented" methods, and some other edits for consistency

### DIFF
--- a/reference/reflection/reflectionclass/getparentclass.xml
+++ b/reference/reflection/reflectionclass/getparentclass.xml
@@ -13,10 +13,8 @@
    <void/>
   </methodsynopsis>
   <para>
-   
+   Get the parent class.
   </para>
-
-  &warn.undocumented.func;
 
  </refsect1>
 

--- a/reference/reflection/reflectionclass/getstartline.xml
+++ b/reference/reflection/reflectionclass/getstartline.xml
@@ -16,8 +16,6 @@
    Get the starting line number.
   </para>
 
-  &warn.undocumented.func;
-
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/reflection/reflectionclass/getstaticproperties.xml
+++ b/reference/reflection/reflectionclass/getstaticproperties.xml
@@ -16,8 +16,6 @@
    Get the static properties.
   </para>
 
-  &warn.undocumented.func;
-
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/reflection/reflectionclass/gettraitaliases.xml
+++ b/reference/reflection/reflectionclass/gettraitaliases.xml
@@ -13,10 +13,8 @@
    <void/>
   </methodsynopsis>
   <para>
-
+   Get the array of trait method aliases defined in the current class.
   </para>
-
-  &warn.undocumented.func;
 
  </refsect1>
 

--- a/reference/reflection/reflectionclass/gettraitnames.xml
+++ b/reference/reflection/reflectionclass/gettraitnames.xml
@@ -13,10 +13,8 @@
    <void/>
   </methodsynopsis>
   <para>
-
+   Get the names of the traits used by this class.
   </para>
-
-  &warn.undocumented.func;
 
  </refsect1>
 

--- a/reference/reflection/reflectionclass/gettraits.xml
+++ b/reference/reflection/reflectionclass/gettraits.xml
@@ -13,10 +13,8 @@
    <void/>
   </methodsynopsis>
   <para>
-
+   Get the array of traits used by this class.
   </para>
-
-  &warn.undocumented.func;
 
  </refsect1>
 

--- a/reference/reflection/reflectionclass/istrait.xml
+++ b/reference/reflection/reflectionclass/istrait.xml
@@ -26,7 +26,6 @@
   &reftitle.returnvalues;
   <para>
    Returns &true; if this is a trait, &false; otherwise.
-   Returns &null; in case of an error.
   </para>
  </refsect1>
 

--- a/reference/reflection/reflectionclass/istrait.xml
+++ b/reference/reflection/reflectionclass/istrait.xml
@@ -13,11 +13,8 @@
    <void/>
   </methodsynopsis>
   <para>
-
+   Check whether this <type>ReflectionClass</type> refers to a trait.
   </para>
-
-  &warn.undocumented.func;
-
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/reflection/reflectionextension/construct.xml
+++ b/reference/reflection/reflectionextension/construct.xml
@@ -33,6 +33,13 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Throws <classname>ReflectionException</classname> if the extension to reflect does not exist.
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/reflection/reflectionextension/ispersistent.xml
+++ b/reference/reflection/reflectionextension/ispersistent.xml
@@ -13,10 +13,12 @@
    <void/>
   </methodsynopsis>
   <para>
-
+   Check whether the extension is persistent.
   </para>
-
-  &warn.undocumented.func;
+  <para>
+   An extension is persistent when it is loaded using &php.ini;.
+   An extension is temporary, not persistent, when it is loaded with <function>dl</function>.
+  </para>
 
  </refsect1>
 

--- a/reference/reflection/reflectionextension/istemporary.xml
+++ b/reference/reflection/reflectionextension/istemporary.xml
@@ -13,10 +13,11 @@
    <void/>
   </methodsynopsis>
   <para>
-
+   Check whether the extension is temporary.
   </para>
-
-  &warn.undocumented.func;
+  <para>
+   An extension is temporary when it is loaded with <function>dl</function>.
+  </para>
 
  </refsect1>
 

--- a/reference/reflection/reflectionfunction/getclosure.xml
+++ b/reference/reflection/reflectionfunction/getclosure.xml
@@ -13,10 +13,8 @@
    <void/>
   </methodsynopsis>
   <para>
-
+   Get a dynamically created closure for the function.
   </para>
-
-  &warn.undocumented.func;
 
  </refsect1>
 

--- a/reference/reflection/reflectionfunction/getclosure.xml
+++ b/reference/reflection/reflectionfunction/getclosure.xml
@@ -26,10 +26,16 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns <classname>Closure</classname>.
+   Returns the newly created <classname>Closure</classname>.
   </para>
  </refsect1>
 
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><link linkend="functions.first_class_callable_syntax">First class callable syntax</link></member>
+  </simplelist>
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/reflection/reflectionfunction/tostring.xml
+++ b/reference/reflection/reflectionfunction/tostring.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="reflectionfunction.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionFunction::__toString</refname>
-  <refpurpose>To string</refpurpose>
+  <refpurpose>Returns the string representation of the ReflectionFunction object</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,7 +13,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   To string.
+   Get a human-readable description of the function, its parameters and return values.
   </para>
  </refsect1>
 
@@ -25,8 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns <methodname>ReflectionFunction::export</methodname>-like output for 
-   the function.
+   The string.
   </para>
  </refsect1>
 

--- a/reference/reflection/reflectionfunctionabstract/getclosurescopeclass.xml
+++ b/reference/reflection/reflectionfunctionabstract/getclosurescopeclass.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="reflectionfunctionabstract.getclosurescopeclass" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionFunctionAbstract::getClosureScopeClass</refname>
-  <refpurpose>Returns the scope associated to the closure</refpurpose>
+  <refpurpose>Returns the scope class associated with the closure</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,10 +13,8 @@
    <void/>
   </methodsynopsis>
   <para>
-
+   Get the class enclosing the closure declaration.
   </para>
-
-  &warn.undocumented.func;
 
  </refsect1>
 
@@ -28,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the class on success or &null; on failure.
+   Returns the class, or &null; if the function is not a closure or if there was no enclosing class.
   </para>
  </refsect1>
 

--- a/reference/reflection/reflectionfunctionabstract/getclosurethis.xml
+++ b/reference/reflection/reflectionfunctionabstract/getclosurethis.xml
@@ -13,10 +13,8 @@
    <void/>
   </methodsynopsis>
   <para>
-
+   If the function is a non-static closure, get the object bound to <varname>$this</varname> inside the closure.
   </para>
-
-  &warn.undocumented.func;
 
  </refsect1>
 

--- a/reference/reflection/reflectionfunctionabstract/tostring.xml
+++ b/reference/reflection/reflectionfunctionabstract/tostring.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="reflectionfunctionabstract.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionFunctionAbstract::__toString</refname>
-  <refpurpose>To string</refpurpose>
+  <refpurpose>Returns the string representation of the ReflectionFunctionAbstract object</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,10 +14,8 @@
    <void />
   </methodsynopsis>
   <para>
-   To string.
+   Get a human-readable description of the function, its parameters and return values.
   </para>
-
-  &warn.undocumented.func;
 
  </refsect1>
 
@@ -37,7 +35,8 @@
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><methodname>ReflectionClass::clone</methodname></member>
+    <member><methodname>ReflectionFunction::__toString</methodname></member>
+    <member><methodname>ReflectionMethod::__toString</methodname></member>
     <member><link linkend="object.tostring">__toString()</link></member>
    </simplelist>
   </para>

--- a/reference/reflection/reflectionmethod/getclosure.xml
+++ b/reference/reflection/reflectionmethod/getclosure.xml
@@ -35,8 +35,17 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns <classname>Closure</classname>.
-   Returns &null; in case of an error.
+   Returns the newly created <classname>Closure</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Throws a <classname>ValueError</classname> if <parameter>object</parameter> is &null; but the method is non-static.
+  </para>
+  <para>
+   Throws a <classname>ReflectionException</classname> if <parameter>object</parameter> is not an instance of the class this method was declared in.
   </para>
  </refsect1>
 
@@ -61,6 +70,14 @@
    </tgroup>
   </informaltable>
  </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><link linkend="functions.first_class_callable_syntax">First class callable syntax</link></member>
+  </simplelist>
+ </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/reflection/reflectionmethod/getclosure.xml
+++ b/reference/reflection/reflectionmethod/getclosure.xml
@@ -13,10 +13,8 @@
    <methodparam choice="opt"><type class="union"><type>object</type><type>null</type></type><parameter>object</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-
+   Create a closure which will call the method.
   </para>
-
-  &warn.undocumented.func;
 
  </refsect1>
 

--- a/reference/reflection/reflectionparameter/getdeclaringfunction.xml
+++ b/reference/reflection/reflectionparameter/getdeclaringfunction.xml
@@ -16,8 +16,6 @@
    Gets the declaring function.
   </para>
 
-  &warn.undocumented.func;
-
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/reflection/reflectionparameter/tostring.xml
+++ b/reference/reflection/reflectionparameter/tostring.xml
@@ -37,7 +37,7 @@
     <title><methodname>ReflectionParameter::__toString</methodname> example</title>
     <programlisting role="php">
 <![CDATA[
-     <?php
+<?php
 echo new ReflectionParameter('substr', 0);
 ?>
 ]]>
@@ -51,7 +51,6 @@ Parameter #0 [ <required> string $string ]
    </example>
   </para>
  </refsect1>
-
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/reflection/reflectionparameter/tostring.xml
+++ b/reference/reflection/reflectionparameter/tostring.xml
@@ -13,10 +13,8 @@
    <void/>
   </methodsynopsis>
   <para>
-   To string.
+   Get a human-readable description of the parameter.
   </para>
-
-  &warn.undocumented.func;
 
  </refsect1>
 
@@ -28,15 +26,39 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   
+   The string.
   </para>
  </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><methodname>ReflectionParameter::__toString</methodname> example</title>
+    <programlisting role="php">
+<![CDATA[
+     <?php
+echo new ReflectionParameter('substr', 0);
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+Parameter #0 [ <required> string $string ]
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><methodname>ReflectionParameter::export</methodname></member>
+    <member><methodname>ReflectionFunction::__toString</methodname></member>
+    <member><methodname>ReflectionMethod::__toString</methodname></member>
     <member><link linkend="object.tostring">__toString()</link></member>
    </simplelist>
   </para>

--- a/reference/reflection/reflectionproperty/tostring.xml
+++ b/reference/reflection/reflectionproperty/tostring.xml
@@ -13,10 +13,8 @@
    <void/>
   </methodsynopsis>
   <para>
-   To string.
+   Returns the string representation of the property.
   </para>
-
-  &warn.undocumented.func;
 
  </refsect1>
 
@@ -28,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   
+   The string.
   </para>
  </refsect1>
 

--- a/reference/reflection/reflectionzendextension/construct.xml
+++ b/reference/reflection/reflectionzendextension/construct.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="reflectionzendextension.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionZendExtension::__construct</refname>
-  <refpurpose>Constructor</refpurpose>
+  <refpurpose>Constructs a ReflectionZendExtension object</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,10 +13,8 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </constructorsynopsis>
   <para>
-
+   Constructs a new <type>ReflectionZendExtension</type> object.
   </para>
-
-  &warn.undocumented.func;
 
  </refsect1>
 
@@ -27,20 +25,19 @@
     <term><parameter>name</parameter></term>
     <listitem>
      <para>
-      
+      The extension name.
      </para>
     </listitem>
    </varlistentry>
   </variablelist>
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
+ <refsect1 role="errors">
+  &reftitle.errors;
   <para>
-
+   Throws <classname>ReflectionException</classname> if the extension to reflect does not exist.
   </para>
  </refsect1>
-
 
 </refentry>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
* If a method has a refpurpose, description, parameters and return
  values, it's documented, there's no need for the warning box.
* Add description where there was none. It is usually very similar
  to the refpurpose.
* Document ReflectionZendExtension::__construct(), and update
  ReflectionExtension::__construct() for consistency.
* In ReflectionFunction::__toString()
* Remove some references to deprecated export() methods.
* Add example for ReflectionParameter::__toString().
