### PR TITLE
Add "iterable" to the list of built-in types within the Introduction

### DIFF
--- a/language/types.xml
+++ b/language/types.xml
@@ -18,6 +18,7 @@
     <listitem><simpara><type>array</type></simpara></listitem>
     <listitem><simpara><type>object</type></simpara></listitem>
     <listitem><simpara><type>callable</type></simpara></listitem>
+    <listitem><simpara><type>iterable</type></simpara></listitem>
     <listitem><simpara><type>resource</type></simpara></listitem>
    </itemizedlist>
   </para>


### PR DESCRIPTION
Hello,

I noticed `iterable` wasn't listed with the other built-ins at the top of this page, so I've added it.

Thanks!