### PR TITLE
docs: add a reference to array_map from array_combine

### DIFF
--- a/reference/array/functions/array-combine.xml
+++ b/reference/array/functions/array-combine.xml
@@ -128,6 +128,7 @@ Array
     <member><function>array_merge</function></member>
     <member><function>array_walk</function></member>
     <member><function>array_values</function></member>
+    <member><function>array_map</function></member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
Last time I searched how to zip up an array, and all I came up with was `array_combine`. Hence, I guess a link from `array_combine` to `array_map` would be helpful.
WDYT?