### PR TITLE
Improve str_pad documentation

### DIFF
--- a/reference/strings/functions/str-pad.xml
+++ b/reference/strings/functions/str-pad.xml
@@ -42,6 +42,7 @@
      <term><parameter>length</parameter></term>
      <listitem>
       <para>
+       This is the desired length of the final padded string.
        If the value of <parameter>length</parameter> is negative,
        less than, or equal to the length of the input string, no padding
        takes place, and <parameter>string</parameter> will be returned.

--- a/reference/strings/functions/str-pad.xml
+++ b/reference/strings/functions/str-pad.xml
@@ -42,7 +42,7 @@
      <term><parameter>length</parameter></term>
      <listitem>
       <para>
-       This is the desired length of the final padded string.
+       The desired length of the final padded string.
        If the value of <parameter>length</parameter> is negative,
        less than, or equal to the length of the input string, no padding
        takes place, and <parameter>string</parameter> will be returned.


### PR DESCRIPTION
IIMHO, we need to specify that `length` is the desired length of the final padded chain. In my case, it was unclear.