### PR TITLE
Fix session security docs markup and wording

### DIFF
--- a/reference/session/security.xml
+++ b/reference/session/security.xml
@@ -8,8 +8,8 @@
  </para>
  <para>
   HTTP session management represents the core of web security.
-  All possible mitigation measures SHOULD be adopted to ensure
-  sessions are secured.
+  All possible mitigation measures <emphasis>should</emphasis>
+  be adopted to ensure sessions are secured.
   Developers should also enable/use applicable security measures.
  </para>
 
@@ -30,8 +30,8 @@
      The importance of the data carried in the session needs to be
      assessed and further protection may be deployed; this typically
      comes at a price, such as reduced convenience for the user.
-     For example, to protect users from a simple social engineering
-     tactic, <literal>session.use_only_cookies</literal>
+     For example, to protect users from a simple social engineering tactic,
+     <link linkend="ini.session.use-only-cookies">session.use_only_cookies</link>
      needs to be enabled. In that case, cookies must be enabled
      unconditionally on the client side, or sessions will not work.
     </para>
@@ -64,7 +64,7 @@
   </sect2>
 
   <sect2 xml:id="features.session.security.management.non-adaptive-session">
-   <title>Nonadaptive Session Management</title>
+   <title>Non-adaptive Session Management</title>
 
    <para>
     PHP's session manager is adaptive by default currently.
@@ -128,7 +128,7 @@
     </simpara>
 
     <simpara>
-     When an access to an obsolete session occurs, developers should save all
+     When access to an obsolete session occurs, developers should save all
      active session data of the user. As this information will be relevant
      for an ensuing investigation. The user should be forcefully logged out
      of all sessions, i.e. require them to reauthenticate.
@@ -155,7 +155,8 @@
 
    <note>
     <simpara>
-     Users prior to PHP 7.1.0 SHOULD use CSPRNG, e.g. /dev/urandom, or
+     Users prior to PHP 7.1.0 <emphasis>should</emphasis> use
+     <acronym>CSPRNG</acronym>, e.g. <filename>/dev/urandom</filename>, or
      <function>random_bytes</function> and hash functions to generate
      a new session ID. <function>session_create_id</function> has
      collision detection and generates a session ID according to the
@@ -189,7 +190,7 @@
     Session IDs <emphasis>must</emphasis> be regenerated when user privileges
     are elevated, such as after authenticating.
     <function>session_regenerate_id</function> must be called prior to
-    setting the authentication information to $_SESSION. 
+    setting the authentication information to <varname>$_SESSION</varname>.
     (<function>session_regenerate_id</function> saves the current session data
     automatically in order to save timestamp/etc. to the current session.)
     Ensure only the new session contains the authenticated flag.
@@ -212,7 +213,7 @@
      this feature is not implemented. Old session data must be kept until GC.
      Simultaneously, developers must assure themselves obsolete session data
      is removed. However, developers must not remove active session data immediately.
-     I.e. <literal>session_regenerate_id(true);</literal> and
+     I.e. <code>session_regenerate_id(true);</code> and
      <function>session_destroy</function> must never be called together for an active session.
      This may sound contradictory, but this is a mandatory requirement.
     </simpara>
@@ -237,7 +238,7 @@
     </simpara>
     <simpara>
      Instead of deleting outdated sessions immediately, developers must set a
-     short-term expiration time (timestamp) in $_SESSION,
+     short-term expiration time (timestamp) in <varname>$_SESSION</varname>,
      and prohibit access to the session data by themselves.
     </simpara>
     <simpara>
@@ -264,9 +265,10 @@
 
    <warning>
     <simpara>
-     Do not misunderstand the DoS risk. <literal>use_strict_mode=On</literal>
-     is mandatory for general session ID security! All sites are advised
-     to enable <literal>use_strict_mode</literal>.
+     Do not misunderstand the DoS risk.
+     <link linkend="ini.session.use-strict-mode">session.use_strict_mode</link>=On
+     is mandatory for general session ID security! All sites are advised to enable
+     <link linkend="ini.session.use-strict-mode">session.use_strict_mode</link>.
     </simpara>
     <simpara>
      DoS can only happen when the account is under attack. A JavaScript injection
@@ -303,8 +305,8 @@
    <note>
     <simpara>
      Access to an obsolete session can also happen because of an unstable network
-     and/or concurrent access to the web site.
-     E.g the server tried to set a new session ID via a cookie, but the Set-Cookie
+     and/or concurrent access to the website.
+     E.g. the server tried to set a new session ID via a cookie, but the Set-Cookie
      packet may not have reached the client due to loss of connection.
      One connection may issue a new session ID by <function>session_regenerate_id</function>,
      but another concurrent connection may not have received the new session ID yet.
@@ -335,7 +337,7 @@
     To mitigate the risk of a DoS attack by session-locking, minimize locks.
     Use read only sessions when session data does not need to be updated.
     Use the 'read_and_close' option with <function>session_start</function>.
-    <literal>session_start(['read_and_close'=>1]);</literal>
+    <code>session_start(['read_and_close'=>1]);</code>
     Close the session as soon as possible after updating $_SESSION by
     using <function>session_commit</function>.
    </para>
@@ -387,7 +389,7 @@
     <simpara>
      Enabling <link linkend="ini.session.use-strict-mode">session.use_strict_mode</link>
      is mandatory for this setup. Ensure it is enabled.
-     Otherwise the active session database can be compromised.
+     Otherwise, the active session database can be compromised.
     </simpara>
    </warning>
 
@@ -413,7 +415,7 @@
     Use a secure one time hash key as an auto-login key using
     <function>setcookie</function>. Use a secure hash stronger than SHA-2.
     E.g. SHA-256 or greater with random data from <function>random_bytes</function>
-    or /dev/urandom.
+    or <filename>/dev/urandom</filename>.
    </para>
 
    <para>
@@ -513,9 +515,9 @@
       Most applications should use a cookie for the session ID.
      </para>
      <para>
-      If <literal>session.use_only_cookies</literal>=Off,
+      If <link linkend="ini.session.use-only-cookies">session.use_only_cookies</link>=Off,
       the session module will use the session ID values set by
-      GET/POST/URL provided the session ID cookie is uninitialized.
+      GET or POST provided the session ID cookie is uninitialized.
      </para>
     </listitem>
 
@@ -524,7 +526,8 @@
       <link linkend="ini.session.use-strict-mode">session.use_strict_mode</link>=On
      </para>
      <para>
-      Although, enabling <literal>session.use_strict_mode</literal>
+      Although, enabling
+      <link linkend="ini.session.use-strict-mode">session.use_strict_mode</link>
       is mandatory for secure sessions. It is disabled by default.
      </para>
      <para>
@@ -535,17 +538,19 @@
      </para>
      <para>
       Due to the cookie specification, attackers are capable to place
-      non removable session ID cookies by locally setting a cookie database
+      non-removable session ID cookies by locally setting a cookie database
       or JavaScript injections.
-      <literal>session.use_strict_mode</literal> can prevent an attacker
-      initialized session ID of being used.
+      <link linkend="ini.session.use-strict-mode">session.use_strict_mode</link>
+      can prevent an attacker initialized session ID of being used.
      </para>
      <note>
       <para>
        Attackers may initialize a session ID with their device and may set
        the session ID of the victim. They must keep the session ID active to abuse.
        Attackers require additional steps to perform an attack in this scenario.
-       Therefore, <literal>session.use_strict_mode</literal> works as a mitigation.
+       Therefore,
+       <link linkend="ini.session.use-strict-mode">session.use_strict_mode</link>
+       works as a mitigation.
       </para>
      </note>
     </listitem>
@@ -606,7 +611,7 @@
       <link linkend="ini.session.gc-maxlifetime">session.gc_maxlifetime</link>=[choose smallest possible]
      </para>
      <para>
-      <literal>session.gc_maxlifetime</literal>
+      <link linkend="ini.session.gc-maxlifetime">session.gc_maxlifetime</link>
       is a setting for deleting obsolete session ID.
       Reliance on this setting is <emphasis>not</emphasis> recommended.
       Developers should manage the lifetime of sessions with a timestamp by themselves.
@@ -690,7 +695,8 @@
       linkend="ini.session.use-trans-sid">session.use_trans_sid</link>
       is enabled.
       It reduces the risk of session ID injection.
-      If a website is http://example.com/, set http://example.com/ to it.
+      If a website is <literal>http://example.com/</literal>,
+      set <literal>http://example.com/</literal> to it.
       Note that with HTTPS browsers will not send the referrer header.
       Browsers may not send the referrer header by configuration.
       Therefore, this setting is not a reliable security measure.
@@ -705,10 +711,13 @@
      <para>
       Ensure HTTP content are uncached for authenticated sessions.
       Allow caching only when the content is not private.
-      Otherwise, content may be exposed. "private" may be employed if HTTP content does not
+      Otherwise, content may be exposed.
+      <literal>"private"</literal> may be employed if HTTP content does not
       include security sensitive data.
-      Note that "private" may transmit private data cached by shared clients.
-      "public" must only be used when HTTP content does not contain any private data at all.
+      Note that <literal>"private"</literal> may transmit private data
+      cached by shared clients.
+      <literal>"public"</literal> must only be used when HTTP content does
+      not contain any private data at all.
      </para>
     </listitem>
 

--- a/reference/session/security.xml
+++ b/reference/session/security.xml
@@ -541,7 +541,7 @@
       non-removable session ID cookies by locally setting a cookie database
       or JavaScript injections.
       <link linkend="ini.session.use-strict-mode">session.use_strict_mode</link>
-      can prevent an attacker initialized session ID of being used.
+      can prevent an attacker-initialized session ID of being used.
      </para>
      <note>
       <para>


### PR DESCRIPTION
@iluuu1994 there is unrelated markup change as I just did a drive by cleanup while fixing the docs for https://github.com/php/php-src/pull/11471