### PR TITLE
Add used rounding rule into the description of function number_format 

### DIFF
--- a/reference/strings/functions/number-format.xml
+++ b/reference/strings/functions/number-format.xml
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>thousands_separator</parameter><initializer>","</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Formats a number with grouped thousands and optionally decimal digits using rounding half up rule.
+   Formats a number with grouped thousands and optionally decimal digits using the rounding half up rule.
   </para>
  </refsect1>
 

--- a/reference/strings/functions/number-format.xml
+++ b/reference/strings/functions/number-format.xml
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>thousands_separator</parameter><initializer>","</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Formats a number with grouped thousands and optionally decimal digits.
+   Formats a number with grouped thousands and optionally decimal digits using rounding half up rule.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Function number_format uses only rounding half up rule. Others are not supported.

Line responsible for the rounding method used: https://github.com/php/php-src/blob/master/ext/standard/math.c#L1034