### PR TITLE
Added missing `FILE_NO_DEFAULT_CONTEXT` for file()

### DIFF
--- a/reference/filesystem/functions/file.xml
+++ b/reference/filesystem/functions/file.xml
@@ -76,6 +76,16 @@
           </simpara>
          </listitem>
         </varlistentry>
+        <varlistentry>
+         <term>
+          <constant>FILE_NO_DEFAULT_CONTEXT</constant>
+         </term>
+         <listitem>
+          <simpara>
+           Don't use the default context
+          </simpara>
+         </listitem>
+        </varlistentry>
        </variablelist>
       </para>
      </listitem>


### PR DESCRIPTION
it seems this flag is available but missing from the docs