### PR TITLE
Randomizer::nextInt return value and 32-bit note

### DIFF
--- a/reference/random/random/randomizer/nextint.xml
+++ b/reference/random/random/randomizer/nextint.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    Positive integer starting from 0, with maximum value depending on number of bytes
+    Positive integer starting from 0, with maximum value depending on the number of bytes
     returned from <methodname>Random\Engine::generate</methodname>.
     The exact value can be calculated as <code>2**($engine_bits - 1) - 1</code>.
   </para>
@@ -38,11 +38,11 @@
   <itemizedlist>
    <listitem>
     <simpara>
-      To avoid inconsistency, 32 bit PHP will throw <classname>Random\RandomException</classname>
+      To avoid inconsistencies, 32 bit PHP will throw <classname>Random\RandomException</classname>
       if the output size of <methodname>Random\Engine::generate</methodname> exceeds 32 bits,
       as the random value cannot be returned losslessly.
       This affects 64 bit engines: <classname>Random\Engine\PcgOneseq128XslRr64</classname> and
-      <classname>Random\Engine\Xoshiro256StarStar</classname>, as well as any userland engines
+      <classname>Random\Engine\Xoshiro256StarStar</classname>, as well for any userland engines
       returning more than 4 bytes of randomness.
     </simpara>
    </listitem>

--- a/reference/random/random/randomizer/nextint.xml
+++ b/reference/random/random/randomizer/nextint.xml
@@ -27,16 +27,27 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-
+    Positive integer starting from 0, with maximum value depending on number of bytes
+    returned from <methodname>Random\Engine::generate</methodname>.
+    The exact value can be calculated as <code>2**($engine_bits - 1) - 1</code>.
   </para>
+ </refsect1>
 
-  <caution>
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <itemizedlist>
+   <listitem>
     <simpara>
-      On 32-bit PHP compilation, this function will throw <classname>Random\RandomException</classname>
-      when used with 64-bit engines: <classname>Random\Engine\PcgOneseq128XslRr64</classname> and
-      <classname>Random\Engine\Xoshiro256StarStar</classname>.
+      To avoid inconsistency, 32 bit PHP will throw <classname>Random\RandomException</classname>
+      if the output size of <methodname>Random\Engine::generate</methodname> exceeds 32 bits,
+      as the random value cannot be returned losslessly.
+      This affects 64 bit engines: <classname>Random\Engine\PcgOneseq128XslRr64</classname> and
+      <classname>Random\Engine\Xoshiro256StarStar</classname>, as well as any userland engines
+      returning more than 4 bytes of randomness.
     </simpara>
-  </caution>
+   </listitem>
+   &random.engineErrors;
+  </itemizedlist>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/random/random/randomizer/nextint.xml
+++ b/reference/random/random/randomizer/nextint.xml
@@ -27,9 +27,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    Positive integer starting from 0, with maximum value depending on the number of bytes
+    A positive integer between 0 and a maximum value depending on the number of bytes
     returned from <methodname>Random\Engine::generate</methodname>.
-    The exact value can be calculated as <code>2**($engine_bits - 1) - 1</code>.
+    The exact maximum can be calculated as 2<superscript>$engine_bytes * 8 - 1</superscript> - 1.
   </para>
  </refsect1>
 
@@ -40,10 +40,10 @@
     <simpara>
       To avoid inconsistencies, 32 bit PHP will throw <classname>Random\RandomException</classname>
       if the output size of <methodname>Random\Engine::generate</methodname> exceeds 32 bits,
-      as the random value cannot be returned losslessly.
-      This affects 64 bit engines: <classname>Random\Engine\PcgOneseq128XslRr64</classname> and
-      <classname>Random\Engine\Xoshiro256StarStar</classname>, as well for any userland engines
-      returning more than 4 bytes of randomness.
+      as the selected integer cannot be returned losslessly.
+      This affects the native 64 bit engines <classname>Random\Engine\PcgOneseq128XslRr64</classname> and
+      <classname>Random\Engine\Xoshiro256StarStar</classname>. Any userland engine
+      returning more than 4 bytes of randomness is also affected.
     </simpara>
    </listitem>
    &random.engineErrors;

--- a/reference/random/random/randomizer/nextint.xml
+++ b/reference/random/random/randomizer/nextint.xml
@@ -29,6 +29,14 @@
   <para>
 
   </para>
+
+  <caution>
+    <simpara>
+      On 32-bit PHP compilation, this function will throw <classname>Random\RandomException</classname>
+      when used with 64-bit engines: <classname>Random\Engine\PcgOneseq128XslRr64</classname> and
+      <classname>Random\Engine\Xoshiro256StarStar</classname>.
+    </simpara>
+  </caution>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
> However, if ~~`Randomizer::getInt()` with no arguments~~ `Randomizer::nextInt()` is executed in a 32-bit environment using an Engine that generates values above 32-bit, a RuntimeException will be thrown to avoid incompatibility.
> https://wiki.php.net/rfc/rng_extension#final_class_random_randomizer

Also added return value description