### PR TITLE
Remove false return hint on `curl_share_errno`

### DIFF
--- a/reference/curl/functions/curl-share-errno.xml
+++ b/reference/curl/functions/curl-share-errno.xml
@@ -27,8 +27,7 @@
  <refsect1 role="returnvalues"><!-- {{{ -->
   &reftitle.returnvalues;
   <para>
-   Returns an integer containing the last share curl error number,
-   &return.falseforfailure;.
+   Returns an integer containing the last share curl error number.
   </para>
  </refsect1><!-- }}} -->
 


### PR DESCRIPTION
As stated in the changelog, this method no longer returns `false` on error.