### PR TITLE
Documented ZipArchive::open return values per file-upload.xml example

### DIFF
--- a/reference/zip/ziparchive/open.xml
+++ b/reference/zip/ziparchive/open.xml
@@ -77,55 +77,55 @@
     <varlistentry>
      <term><constant>ZipArchive::ER_EXISTS</constant></term>
      <listitem>
-      <simpara>File already exists.</simpara>
+      <simpara>Value: 10; File already exists.</simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><constant>ZipArchive::ER_INCONS</constant></term>
      <listitem>
-      <simpara>Zip archive inconsistent.</simpara>
+      <simpara>Value: 21; Zip archive inconsistent.</simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><constant>ZipArchive::ER_INVAL</constant></term>
      <listitem>
-      <simpara>Invalid argument.</simpara>
+      <simpara>Value: 18; Invalid argument.</simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><constant>ZipArchive::ER_MEMORY</constant></term>
      <listitem>
-      <simpara>Malloc failure.</simpara>
+      <simpara>Value: 14; Malloc failure.</simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><constant>ZipArchive::ER_NOENT</constant></term>
      <listitem>
-      <simpara>No such file.</simpara>
+      <simpara>Value: 9; No such file.</simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><constant>ZipArchive::ER_NOZIP</constant></term>
      <listitem>
-      <simpara>Not a zip archive.</simpara>
+      <simpara>Value: 19; Not a zip archive.</simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><constant>ZipArchive::ER_OPEN</constant></term>
      <listitem>
-      <simpara>Can't open file.</simpara>
+      <simpara>Value: 11; Can't open file.</simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><constant>ZipArchive::ER_READ</constant></term>
      <listitem>
-      <simpara>Read error.</simpara>
+      <simpara>Value: 5; Read error.</simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><constant>ZipArchive::ER_SEEK</constant></term>
      <listitem>
-      <simpara>Seek error.</simpara>
+      <simpara>Value: 4; Seek error.</simpara>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
It'd be nice to easily look up what a `ZipArchive::open` return value means.  I mirrored the first example I found of something similar ([Handling file uploads -> Error Messages Explained](https://www.php.net/manual/en/features.file-upload.errors.php)).  If you'd prefer this be done a different way, I'm happy to accommodate.