### PR TITLE
Add null as valid parameter type for strval

### DIFF
--- a/reference/var/functions/strval.xml
+++ b/reference/var/functions/strval.xml
@@ -35,8 +35,8 @@
        The variable that is being converted to a <type>string</type>.
       </para>
       <para>
-       <parameter>value</parameter> may be any scalar type or an object that
-       implements the <link linkend="object.tostring">__toString()</link>
+       <parameter>value</parameter> may be any scalar type, <type>null</type>,
+       or an <type>object</type> that implements the <link linkend="object.tostring">__toString()</link>
        method. You cannot use <function>strval</function> on arrays or on
        objects that do not implement the
        <link linkend="object.tostring">__toString()</link> method.


### PR DESCRIPTION
`null` is a valid type for `$value`, but it's not a scalar nor an `object`.
