### PR TITLE
Replace PECL <link> with entity &link.pecl;

### DIFF
--- a/extensions.ent
+++ b/extensions.ent
@@ -74,9 +74,11 @@ extensions are bundled with PHP.</para>'>
 <!ENTITY extcat.membership.external '<title xmlns="http://docbook.org/ns/docbook">External Extensions</title><para xmlns="http://docbook.org/ns/docbook">These
 extensions are bundled with PHP but in order to compile them, external libraries will be needed.</para>'>
 
-<!ENTITY extcat.membership.pecl '<title xmlns="http://docbook.org/ns/docbook">PECL Extensions</title><para xmlns="http://docbook.org/ns/docbook">These
-extensions are available from <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.pecl;">PECL</link>. They may require external libraries. More PECL
-extensions exist but they are not documented in the PHP manual yet.</para>'>
+<!ENTITY extcat.membership.pecl '<title xmlns="http://docbook.org/ns/docbook">
+PECL Extensions</title>
+<para xmlns="http://docbook.org/ns/docbook">These extensions are available from
+&link.pecl;. They may require external libraries. More PECL extensions exist but
+they are not documented in the PHP manual yet.</para>'>
 
 <!-- ======================================================================= -->
 

--- a/features/dtrace.xml
+++ b/features/dtrace.xml
@@ -44,11 +44,6 @@
   </para>
 
   <para>
-   DTrace static probes are included in PHP 5.4. Prior to this they were
-   available via a &link.pecl; extension, which is now obsolete.
-  </para>
-
-  <para>
    The static DTrace probes in PHP can alternatively be used with the
    SystemTap facility on some Linux distributions.
   </para>

--- a/features/dtrace.xml
+++ b/features/dtrace.xml
@@ -44,11 +44,8 @@
   </para>
 
   <para>
-   DTrace static probes are included in PHP 5.4.  Prior to this they
-   were available via a <link xmlns="http://docbook.org/ns/docbook"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xlink:href="&url.pecl;">PECL</link> extension, which is now
-   obsolete.
+   DTrace static probes are included in PHP 5.4. Prior to this they were
+   available via a &link.pecl; extension, which is now obsolete.
   </para>
 
   <para>

--- a/install/pecl.xml
+++ b/install/pecl.xml
@@ -246,7 +246,7 @@ drive:\path\to\php\executable\php.exe -i
     that the semicolon only needs to be removed to activate them.
    </para>
    <para>
-    Note that, on PHP version 7.2.0 and up, the extension name may be used
+    Note that, as of PHP 7.2.0, the extension name may be used
     instead of the extension's file name.
     As this is OS-independent and easier, especially for newcomers, it becomes
     the recommended way of specifying extensions to load.
@@ -264,7 +264,7 @@ extension=php_extname.dll
    </screen>
    <screen>
 <![CDATA[
-; On PHP version 7.2 and up, prefer :
+; As of PHP 7.2.0, prefer:
 extension=extname
 zend_extension=another_extension
 ]]>

--- a/install/pecl.xml
+++ b/install/pecl.xml
@@ -1,37 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<chapter xml:id="install.pecl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="install.pecl" xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Installation of PECL extensions</title>
 
  <sect1 xml:id="install.pecl.intro">
   <title>Introduction to PECL Installations</title>
   <simpara>
    &link.pecl; is a repository of PHP extensions that are made available via the
-   <link xlink:href="&url.php.pear;">PEAR</link> packaging system. This section
-   of the manual is intended to demonstrate how to obtain and install PECL
-   extensions.
+   <link xlink:href="&url.php.pear;">PEAR</link>
+   packaging system.
+   This section of the manual is intended to demonstrate how to obtain and
+   install PECL extensions.
   </simpara>
   <simpara>
    These instructions assume <literal>/path/to/php/src/dir/</literal> is the
    path to the PHP source distribution and that <literal>extname</literal> is
-   the name of the PECL extension. Adjust accordingly. These instructions also
-   assume a familiarity with the <link xlink:href="&url.php.pear.cli;">pear
-   command</link>. The information in the PEAR manual for the
-   <command>pear</command> command also applies to the <command>pecl</command>
+   the name of the PECL extension. Adjust accordingly.
+   These instructions also assume a familiarity with the
+   <link xlink:href="&url.php.pear.cli;">pear command</link>.
+   The information in the PEAR manual for the
+   <command>pear</command>
+   command also applies to the
+   <command>pecl</command>
    command.
   </simpara>
   <simpara>
-   A shared extension must be built, installed, and loaded to be useful. The
-   methods described below provide various instructions on how to build and
-   install the extensions, but they do not automatically load them. Extensions
-   can be loaded by adding an <link linkend="ini.extension">extension</link>
+   A shared extension must be built, installed, and loaded to be useful.
+   The methods described below provide various instructions on how to build and
+   install the extensions, but they do not automatically load them.
+   Extensions can be loaded by adding an
+   <link linkend="ini.extension">extension</link>
    directive to the &php.ini; file or through the use of the
-   <function>dl</function> function.
+   <function>dl</function>
+   function.
   </simpara>
   <simpara>
    When building PHP modules, it's important to have known-good versions of the
-   required tools (autoconf, automake, libtool, etc.). See the
+   required tools (autoconf, automake, libtool, etc.).
+   See the
    <link xlink:href="&url.php.anongit;">Anonymous Git Instructions</link>
    for details on the required tools and required versions.
   </simpara>
@@ -56,9 +64,9 @@
     </simpara>
     <simpara>
      The PECL website contains information about the different extensions that
-     are offered by the PHP Development Team. The information available here
-     includes: changelog, release notes, requirements, and other similar
-     details.
+     are offered by the PHP Development Team.
+     The information available here includes: changelog, release notes,
+     requirements, and other similar details.
     </simpara>
    </listitem>
    <listitem>
@@ -67,9 +75,9 @@
     </simpara>
     <simpara>
      PECL extensions that have releases listed on the PECL website are available
-     for download and installation using the <link
-     xlink:href="&url.php.pear.cli;">pecl command</link>. Specific revisions may
-     also be specified.
+     for download and installation using the
+     <link xlink:href="&url.php.pear.cli;">pecl command</link>.
+     Specific revisions may also be specified.
     </simpara>
    </listitem>
    <listitem>
@@ -86,11 +94,11 @@
      <acronym>SVN</acronym>
     </simpara>
     <simpara>
-     Some PECL extensions also reside in <acronym>SVN</acronym>. A web-based
-     view may be seen at <link
-     xlink:href="&url.php.svn;pecl/">&url.php.svn;pecl/</link>. To download
-     straight from <acronym>SVN</acronym>, the following sequence of commands
-     may be used:
+     Some PECL extensions also reside in <acronym>SVN</acronym>.
+     A web-based view may be seen at
+     <link xlink:href="&url.php.svn;pecl/">&url.php.svn;pecl/</link>.
+     To download straight from <acronym>SVN</acronym>, the following sequence of
+     commands may be used:
     </simpara>
     <para>
      <screen>
@@ -114,13 +122,15 @@ $ svn checkout https://svn.php.net/repository/pecl/extname/trunk extname
   <title>Installing a PHP extension on Windows</title>
   <para>
    There are two ways to load a PHP extension on Windows: either compile it into
-   PHP, or load the DLL. Loading a pre-compiled extension is the easiest and
-   preferred way.
+   PHP, or load the DLL.
+   Loading a pre-compiled extension is the easiest and preferred way.
   </para>
   <para>
-   To load an extension, it has to be available as a <filename>.dll</filename>
-   file on the system. All the extensions are automatically and periodically
-   compiled by the PHP Group (see next section for the download).
+   To load an extension, it has to be available as a
+   <filename>.dll</filename>
+   file on the system.
+   All the extensions are automatically and periodically compiled by the PHP
+   Group (see next section for the download).
   </para>
   <para>
    To compile an extension into PHP, please refer to the
@@ -130,35 +140,36 @@ $ svn checkout https://svn.php.net/repository/pecl/extname/trunk extname
   <para>
    To compile a standalone extension (aka a DLL file), please refer to the
    <link linkend="install.windows.building">building from source</link>
-   documentation. If the DLL file is available neither with the PHP distribution
-   nor in PECL, it may be necessary to compile it before the extension can be
-   used.
+   documentation.
+   If the DLL file is available neither with the PHP distribution nor in PECL,
+   it may be necessary to compile it before the extension can be used.
   </para>
   <sect2 xml:id="install.pecl.windows.find">
    <title>Where to find an extension?</title>
    <para>
     PHP extensions are usually called <filename>php_*.dll</filename> (where the
     star represents the name of the extension), and they are located under the
-    <filename>PHP\ext</filename> folder.
+    <filename>PHP\ext</filename>
+    folder.
    </para>
    <para>
     PHP ships with the extensions most useful to the majority of developers.
-    They are called "core" extensions.
+    They are called <emphasis>bundled</emphasis> extensions.
    </para>
    <para>
-    However, if functionality not provided by any core extension is required, it
-    may still be found in &link.pecl;. The PHP Extension Community Library
-    (PECL) is a repository for PHP Extensions, providing a directory of all
-    known extensions and hosting facilities for downloading and developing PHP
-    extensions.
+    However, if functionality not provided by any bundled extension is required,
+    it may still be found in &link.pecl;.
+    The PHP Extension Community Library (PECL) is a repository for PHP
+    Extensions, providing a directory of all known extensions and hosting
+    facilities for downloading and developing PHP extensions.
    </para>
    <para>
     If an extension has been developed for particular uses, it may be hosted on
-    PECL so that others with the same needs can benefit from it. A nice side
-    effect is that it's a good chance to receive feedback, (hopefully) thanks,
-    bug reports and even fixes/patches. Before submitting an extension for
-    hosting on PECL, please read <link xlink:href="&url.pecl.submit;">
-    PECL submit</link>.
+    PECL so that others with the same needs can benefit from it.
+    A nice side effect is that it's a good chance to receive feedback,
+    (hopefully) thanks, bug reports and even fixes/patches.
+    Before submitting an extension for hosting on PECL, please read
+    <link xlink:href="&url.pecl.submit;">PECL submit</link>.
    </para>
   </sect2>
 
@@ -198,12 +209,16 @@ $ svn checkout https://svn.php.net/repository/pecl/extname/trunk extname
    </para>
    <para>
     Keep in mind that the extension settings should match all the settings of
-    the PHP executable being used. The following PHP script will tell
-    <emphasis>all</emphasis> about the PHP settings:
+    the PHP executable being used.
+    The following PHP script will tell <emphasis>all</emphasis> about the PHP
+    settings:
    </para>
    <para>
     <example>
-     <title><function>phpinfo</function> call</title>
+     <title>
+      <function>phpinfo</function>
+      call
+     </title>
      <programlisting role="php">
 <![CDATA[
 <?php
@@ -217,7 +232,7 @@ phpinfo();
     Or from the command line, run:
     <screen>
 <![CDATA[
-drive:\\path\to\php\executable\php.exe -i
+drive:\path\to\php\executable\php.exe -i
 ]]>
     </screen>
    </para>
@@ -226,54 +241,55 @@ drive:\\path\to\php\executable\php.exe -i
   <sect2 xml:id="install.pecl.windows.loading">
    <title>Loading an extension</title>
    <para>
-    The most common way to load a PHP extension is to include it in the
-    &php.ini; configuration file. Please note that many extensions are already
-    present in the &php.ini; and that the semicolon only needs to be removed to
-    activate them.
+    The most common way to load a PHP extension is to include it in
+    the &php.ini; configuration file.
+    Please note that many extensions are already present in the &php.ini; and
+    that the semicolon only needs to be removed to activate them.
    </para>
    <para>
     Note that, on PHP version 7.2.0 and up, the extension name may be used
-    instead of the extension's file name. As this is OS-independent and easier,
-    especially for newcomers, it becomes the recommended way of specifying
-    extensions to load. File names remain supported for compatibility with prior
-    versions.
+    instead of the extension's file name.
+    As this is OS-independent and easier, especially for newcomers, it becomes
+    the recommended way of specifying extensions to load.
+    File names remain supported for compatibility with prior versions.
    </para>
-    <screen>
+   <screen>
 <![CDATA[
 ;extension=php_extname.dll
 ]]>
-    </screen>
-    <screen>
+   </screen>
+   <screen>
 <![CDATA[
 extension=php_extname.dll
 ]]>
-    </screen>
-    <screen>
+   </screen>
+   <screen>
 <![CDATA[
 ; On PHP version 7.2 and up, prefer :
 extension=extname
 zend_extension=another_extension
 ]]>
-    </screen>
+   </screen>
    <para>
-    However, some web servers are confusing because they do not use the
-    &php.ini; located alongside the PHP executable. To find out where the actual
-    &php.ini; resides, look for its path in <function>phpinfo</function>:
+    However, some web servers are confusing because they do not use
+    the &php.ini; located alongside the PHP executable.
+    To find out where the actual &php.ini; resides, look for its path
+    in <function>phpinfo</function>:
    </para>
-    <screen>
+   <screen>
 <![CDATA[
 Configuration File (php.ini) Path  C:\WINDOWS
 ]]>
-    </screen>
-    <screen>
+   </screen>
+   <screen>
 <![CDATA[
 Loaded Configuration File   C:\Program Files\PHP\8.2\php.ini
 ]]>
-    </screen>
+   </screen>
    <para>
     After activating an extension, save &php.ini;, restart the web server, and
-    check <function>phpinfo</function> again. The new extension should now have
-    its own section.
+    check <function>phpinfo</function> again.
+    The new extension should now have its own section.
    </para>
   </sect2>
 
@@ -289,8 +305,9 @@ Loaded Configuration File   C:\Program Files\PHP\8.2\php.ini
    </para>
    <para>
     If PHP is being used with a web server, the location and format of the logs
-    vary depending on the software. Please read the web server documentation to
-    locate the logs, as it has nothing to do with PHP itself.
+    vary depending on the software.
+    Please read the web server documentation to locate the logs, as it has
+    nothing to do with PHP itself.
    </para>
    <para>
     Common problems are the location of the DLL and the DLLs it depends on, the
@@ -299,9 +316,9 @@ Loaded Configuration File   C:\Program Files\PHP\8.2\php.ini
    </para>
    <para>
     If the problem lies in a compile-time setting mismatch, probably the DLL
-    downloaded is not the right one. Try downloading the extension again with
-    the proper settings. Again, <function>phpinfo</function> can be of great
-    help.
+    downloaded is not the right one.
+    Try downloading the extension again with the proper settings.
+    Again, <function>phpinfo</function> can be of great help.
    </para>
   </sect2>
 
@@ -310,8 +327,10 @@ Loaded Configuration File   C:\Program Files\PHP\8.2\php.ini
  <sect1 xml:id="install.pecl.pear">
   <title>Compiling shared PECL extensions with the pecl command</title>
   <simpara>
-   PECL makes it easy to create shared PHP extensions. Using the
-   <link xlink:href="&url.php.pear.cli;">pecl command</link>, do the following:
+   PECL makes it easy to create shared PHP extensions.
+   Using the
+   <link xlink:href="&url.php.pear.cli;">pecl command</link>,
+   do the following:
   </simpara>
   <para>
    <screen>
@@ -320,15 +339,18 @@ $ pecl install extname
   </para>
   <simpara>
    This will download the source for <emphasis>extname</emphasis>, compile, and
-   install <filename>extname.so</filename> into the <link
-   linkend="ini.extension-dir">extension_dir</link>.
-   <filename>extname.so</filename> may then be loaded via &php.ini;
+   install <filename>extname.so</filename> into the
+   <link linkend="ini.extension-dir">extension_dir</link>.
+   <filename>extname.so</filename>
+   may then be loaded via &php.ini;.
   </simpara>
   <simpara>
    By default, the <command>pecl</command> command will not install packages
-   that are marked with the <literal>alpha</literal> or <literal>beta</literal>
+   that are marked with the <literal>alpha</literal> or
+   <literal>beta</literal>
    state. If no <literal>stable</literal> packages are available, a
-   <literal>beta</literal> package may be installed using the following command:
+   <literal>beta</literal>
+   package may be installed using the following command:
   </simpara>
   <para>
    <screen>
@@ -354,16 +376,18 @@ $ pecl install extname-0.1
  <sect1 xml:id="install.pecl.phpize">
   <title>Compiling shared PECL extensions with phpize</title>
   <simpara>
-   Sometimes, using the <command>pecl</command> installer is not an option. This
-   could be because there is a firewall or because the extension being installed
-   is unavailable as a PECL-compatible package, such as unreleased extensions
-   from git. If such an extension needs to be built, the lower-level build tools
-   can be used to perform the build manually.
+   Sometimes, using the <command>pecl</command> installer is not an option.
+   This could be because there is a firewall or because the extension being
+   installed is unavailable as a PECL-compatible package, such as unreleased
+   extensions from git.
+   If such an extension needs to be built, the lower-level build tools can be
+   used to perform the build manually.
   </simpara>
   <simpara>
    The <command>phpize</command> command is used to prepare the build
-   environment for a PHP extension. In the following sample, the sources for an
-   extension are in a directory named <filename>extname</filename>:
+   environment for a PHP extension.
+   In the following sample, the sources for an extension are in a directory
+   named <filename>extname</filename>:
   </simpara>
   <para>
    <screen>
@@ -378,17 +402,18 @@ $ make
   </para>
   <simpara>
    A successful install will have created <filename>extname.so</filename> and
-   put it into the PHP <link linkend="ini.extension-dir">extensions
-   directory</link>. The &php.ini; will need to be adjusted, and an
-   <literal>extension=extname.so</literal> line will need to be added before the
-   extension can be used.
+   put it into the PHP
+   <link linkend="ini.extension-dir">extensions directory</link>.
+   The &php.ini; will need to be adjusted, and an
+   <literal>extension=extname.so</literal>
+   line will need to be added before the extension can be used.
   </simpara>
   <simpara>
    If the system is missing the <command>phpize</command> command, and
    precompiled packages (like RPM's) are used, be sure to install also the
    appropriate development version of the PHP package as they often include the
-   <command>phpize</command> command along with the proper header files to build
-   PHP and its extensions.
+   <command>phpize</command>
+   command along with the proper header files to build PHP and its extensions.
   </simpara>
   <simpara>
    Execute <command>phpize --help</command> to display additional usage
@@ -397,20 +422,28 @@ $ make
  </sect1>
 
  <sect1 xml:id="install.pecl.php-config">
-  <title>php-config</title>
+  <title>
+   <command>php-config</command>
+  </title>
   <para>
-   <command>php-config</command> is a simple shell script for obtaining
-   information about the installed PHP configuration.
+   <command>php-config</command>
+   is a simple shell script for obtaining information about the installed PHP
+   configuration.
   </para>
   <para>
    When the extensions are being compiled, if multiple PHP versions are
    installed, the installation for which to build can be specified by using the
-   <option role="configure">--with-php-config</option> option during
-   configuration, setting the path of the respective php-config script.
+   <option role="configure">--with-php-config</option>
+   option during configuration, setting the path of the respective
+   <command>php-config</command>
+   script.
   </para>
   <para>
-   The list of command line options provided by the php-config script can be
-   queried anytime by running php-config with the <option>-h</option> switch:
+   The list of command line options provided by the
+   <command>php-config</command>
+   script can be queried anytime by running
+   <command>php-config</command>
+   with the <option>-h</option> switch:
    <screen>
 <![CDATA[
 Usage: /usr/local/bin/php-config [OPTION]
@@ -452,7 +485,10 @@ Options:
       </row>
       <row>
        <entry>--ldflags</entry>
-       <entry><literal>LD</literal> flags which PHP was compiled with</entry>
+       <entry>
+        <literal>LD</literal>
+        flags which PHP was compiled with
+       </entry>
       </row>
       <row>
        <entry>--libs</entry>
@@ -501,8 +537,9 @@ Options:
   <simpara>
    It may be necessary to build a PECL extension statically into the PHP binary.
    To do this, the extension source will need to be placed under the
-   <filename>/path/to/php/src/dir/ext/</filename> directory, and the PHP build
-   system will be required to regenerate its configure script.
+   <filename>/path/to/php/src/dir/ext/</filename>
+   directory, and the PHP build system will be required to regenerate its
+   configure script.
   </simpara>
   <para>
    <screen>
@@ -540,17 +577,25 @@ $ make install
   <note>
    <simpara>
     To run the <command>buildconf</command> script, the
-    <command>autoconf</command> <literal>2.13</literal> and
-    <command>automake</command> <literal>1.4+</literal> will be needed. Newer
-    versions of <command>autoconf</command> may work but are not supported.
+    <command>autoconf</command>
+    <literal>2.13</literal>
+    and
+    <command>automake</command>
+    <literal>1.4+</literal>
+    will be needed.
+    Newer versions of <command>autoconf</command> may work but are not
+    supported.
    </simpara>
   </note>
   <simpara>
-   Whether <option role="configure">--enable-extname</option> or
-   <option role="configure">--with-extname</option> is used depends on the
-   extension. Typically, an extension that does not require external libraries
-   uses <option role="configure">--enable</option>. To be sure, run the
-   following after <command>buildconf</command>:
+   Whether
+   <option role="configure">--enable-extname</option>
+   or
+   <option role="configure">--with-extname</option>
+   is used depends on the extension.
+   Typically, an extension that does not require external libraries uses
+   <option role="configure">--enable</option>.
+   To be sure, run the following after <command>buildconf</command>:
   </simpara>
   <para>
    <screen>

--- a/install/pecl.xml
+++ b/install/pecl.xml
@@ -97,8 +97,8 @@
      Some PECL extensions also reside in <acronym>SVN</acronym>.
      A web-based view may be seen at
      <link xlink:href="&url.php.svn;pecl/">&url.php.svn;pecl/</link>.
-     To download straight from <acronym>SVN</acronym>, the following sequence of
-     commands may be used:
+     To download straight from <acronym>SVN</acronym>,
+     the following sequence of commands may be used:
     </simpara>
     <para>
      <screen>
@@ -296,8 +296,8 @@ Loaded Configuration File   C:\Program Files\PHP\8.2\php.ini
   <sect2 xml:id="install.pecl.windows.problemsolving">
    <title>Resolving problems</title>
    <para>
-    If the extension does not appear in <function>phpinfo</function>, the logs
-    should be checked to learn where the problem comes from.
+    If the extension does not appear in <function>phpinfo</function>,
+    the logs should be checked to learn where the problem comes from.
    </para>
    <para>
     If PHP is being used from the command line (CLI), the extension loading
@@ -338,8 +338,8 @@ $ pecl install extname
    </screen>
   </para>
   <simpara>
-   This will download the source for <emphasis>extname</emphasis>, compile, and
-   install <filename>extname.so</filename> into the
+   This will download the source for <emphasis>extname</emphasis>,
+   compile, and install <filename>extname.so</filename> into the
    <link linkend="ini.extension-dir">extension_dir</link>.
    <filename>extname.so</filename>
    may then be loaded via &php.ini;.
@@ -348,9 +348,10 @@ $ pecl install extname
    By default, the <command>pecl</command> command will not install packages
    that are marked with the <literal>alpha</literal> or
    <literal>beta</literal>
-   state. If no <literal>stable</literal> packages are available, a
-   <literal>beta</literal>
-   package may be installed using the following command:
+   state.
+   If no <literal>stable</literal> packages are available,
+   a <literal>beta</literal> package may be installed using the following
+   command:
   </simpara>
   <para>
    <screen>

--- a/install/pecl.xml
+++ b/install/pecl.xml
@@ -7,10 +7,10 @@
  <sect1 xml:id="install.pecl.intro">
   <title>Introduction to PECL Installations</title>
   <simpara>
-   <link xlink:href="&url.pecl;">PECL</link> is a repository of PHP extensions that
-   are made available to you via the <link xlink:href="&url.php.pear;">PEAR</link>
-   packaging system.  This section of the manual is intended to demonstrate
-   how to obtain and install PECL extensions.
+   &link.pecl; is a repository of PHP extensions that are made available to you
+   via the <link xlink:href="&url.php.pear;">PEAR</link> packaging system. This
+   section of the manual is intended to demonstrate how to obtain and install
+   PECL extensions.
   </simpara>
   <simpara>
    These instructions assume <literal>/your/phpsrcdir/</literal> is the path
@@ -140,10 +140,11 @@ $ svn checkout http://svn.php.net/repository/pecl/extname/trunk extname
     called "core" extensions.
    </para>
    <para>
-    However, if you need functionality not provided by any core extension, you may still be 
-    able to find one in <link xlink:href="&url.pecl;">PECL</link>. The PHP Extension Community Library (PECL) is a repository for 
-    PHP Extensions, providing a directory of all known extensions and hosting facilities for 
-    downloading and development of PHP extensions.
+    However, if you need functionality not provided by any core extension, you
+    may still be able to find one in &link.pecl;. The PHP Extension Community
+    Library (PECL) is a repository for PHP Extensions, providing a directory of
+    all known extensions and hosting facilities for downloading and development
+    of PHP extensions.
    </para>
    <para>
     If you have developed an extension for your own uses, you might want to think about hosting 

--- a/install/pecl.xml
+++ b/install/pecl.xml
@@ -583,7 +583,7 @@ $ make install
    <simpara>
     To run the <command>buildconf</command> script, the
     <command>autoconf</command>
-    <literal>2.13</literal>
+    <literal>2.68</literal>
     and
     <command>automake</command>
     <literal>1.4+</literal>

--- a/install/pecl.xml
+++ b/install/pecl.xml
@@ -426,11 +426,13 @@ $ make
   <title>
    <command>php-config</command>
   </title>
+  
   <para>
    <command>php-config</command>
    is a simple shell script for obtaining information about the installed PHP
    configuration.
   </para>
+  
   <para>
    When the extensions are being compiled, if multiple PHP versions are
    installed, the installation for which to build can be specified by using the
@@ -439,6 +441,7 @@ $ make
    <command>php-config</command>
    script.
   </para>
+  
   <para>
    The list of command line options provided by the
    <command>php-config</command>
@@ -463,6 +466,7 @@ Options:
 ]]>
    </screen>
   </para>
+  
   <para>
    <table>
     <title>Command line options</title>

--- a/install/pecl.xml
+++ b/install/pecl.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<chapter xml:id="install.pecl" xmlns="http://docbook.org/ns/docbook"
-         xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="install.pecl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Installation of PECL extensions</title>
 
  <sect1 xml:id="install.pecl.intro">

--- a/install/pecl.xml
+++ b/install/pecl.xml
@@ -7,32 +7,33 @@
  <sect1 xml:id="install.pecl.intro">
   <title>Introduction to PECL Installations</title>
   <simpara>
-   &link.pecl; is a repository of PHP extensions that are made available to you
-   via the <link xlink:href="&url.php.pear;">PEAR</link> packaging system. This
-   section of the manual is intended to demonstrate how to obtain and install
-   PECL extensions.
+   &link.pecl; is a repository of PHP extensions that are made available via the
+   <link xlink:href="&url.php.pear;">PEAR</link> packaging system. This section
+   of the manual is intended to demonstrate how to obtain and install PECL
+   extensions.
   </simpara>
   <simpara>
-   These instructions assume <literal>/your/phpsrcdir/</literal> is the path
-   to the PHP source distribution, and that <literal>extname</literal> is the name of the
-   PECL extension.  Adjust accordingly.  These instructions also assume a 
-   familiarity with the <link xlink:href="&url.php.pear.cli;">pear command</link>.
-   The information in the PEAR manual for the <literal>pear</literal> command also
-   applies to the <literal>pecl</literal> command.
+   These instructions assume <literal>/path/to/php/src/dir/</literal> is the
+   path to the PHP source distribution and that <literal>extname</literal> is
+   the name of the PECL extension. Adjust accordingly. These instructions also
+   assume a familiarity with the <link xlink:href="&url.php.pear.cli;">pear
+   command</link>. The information in the PEAR manual for the
+   <command>pear</command> command also applies to the <command>pecl</command>
+   command.
   </simpara>
   <simpara>
-   To be useful, a shared extension must be built, installed, and loaded.  The
-   methods described below provide you with various instructions on how to
-   build and install the extensions, but they do not automatically load them.
-   Extensions can be loaded by adding an <link
-   linkend="ini.extension">extension</link> directive to the &php.ini;
-   file, or through the use of the <function>dl</function> function.
+   A shared extension must be built, installed, and loaded to be useful. The
+   methods described below provide various instructions on how to build and
+   install the extensions, but they do not automatically load them. Extensions
+   can be loaded by adding an <link linkend="ini.extension">extension</link>
+   directive to the &php.ini; file or through the use of the
+   <function>dl</function> function.
   </simpara>
   <simpara>
-   When building PHP modules, it's important to have known-good versions 
-   of the required tools (autoconf, automake, libtool, etc.) See the 
-   <link xlink:href="&url.php.anongit;">Anonymous Git Instructions</link> for 
-   details on the required tools, and required versions.
+   When building PHP modules, it's important to have known-good versions of the
+   required tools (autoconf, automake, libtool, etc.). See the
+   <link xlink:href="&url.php.anongit;">Anonymous Git Instructions</link>
+   for details on the required tools and required versions.
   </simpara>
  </sect1>
 
@@ -44,9 +45,9 @@
   <itemizedlist>
    <listitem>
     <simpara>
-     The <literal>pecl install extname</literal> command downloads the
-     extensions code automatically, so in this case there is no need
-     for a separate download.
+     The <command>pecl install extname</command> command downloads the
+     extensions code automatically, so in this case, there is no need for a
+     separate download.
     </simpara>
    </listitem>
    <listitem>
@@ -54,21 +55,21 @@
      <link xlink:href="&url.pecl;">&url.pecl;</link>
     </simpara>
     <simpara>
-     The PECL web site contains information about the different extensions
-     that are offered by the PHP Development Team.  The information available
-     here includes: ChangeLog, release notes, requirements and other similar
+     The PECL website contains information about the different extensions that
+     are offered by the PHP Development Team. The information available here
+     includes: changelog, release notes, requirements, and other similar
      details.
     </simpara>
    </listitem>
    <listitem>
     <simpara>
-     <literal>pecl download extname</literal>
+     <command>pecl download extname</command>
     </simpara>
     <simpara>
-     PECL extensions that have releases listed on the PECL web site are
-     available for download and installation using the <link
-     xlink:href="&url.php.pear.cli;">pecl command</link>.
-     Specific revisions may also be specified.
+     PECL extensions that have releases listed on the PECL website are available
+     for download and installation using the <link
+     xlink:href="&url.php.pear.cli;">pecl command</link>. Specific revisions may
+     also be specified.
     </simpara>
    </listitem>
    <listitem>
@@ -85,14 +86,15 @@
      <acronym>SVN</acronym>
     </simpara>
     <simpara>
-     Some PECL extensions also reside in <acronym>SVN</acronym>.  A web-based view may
-     be seen at <link xlink:href="&url.php.svn;pecl/">&url.php.svn;pecl/</link>.  
-     To download straight from <acronym>SVN</acronym>, the following 
-     sequence of commands may be used:
+     Some PECL extensions also reside in <acronym>SVN</acronym>. A web-based
+     view may be seen at <link
+     xlink:href="&url.php.svn;pecl/">&url.php.svn;pecl/</link>. To download
+     straight from <acronym>SVN</acronym>, the following sequence of commands
+     may be used:
     </simpara>
     <para>
      <screen>
-$ svn checkout http://svn.php.net/repository/pecl/extname/trunk extname
+$ svn checkout https://svn.php.net/repository/pecl/extname/trunk extname
      </screen>
     </para>
    </listitem>
@@ -101,8 +103,8 @@ $ svn checkout http://svn.php.net/repository/pecl/extname/trunk extname
      Windows downloads
     </simpara>
     <simpara>
-     The PHP project compiles and offers Windows DLLs for most
-     PECL extensions on the respective package page.
+     The PHP project compiles and offers Windows DLLs for most PECL extensions
+     on the package page.
     </simpara>
    </listitem>
   </itemizedlist>
@@ -111,54 +113,61 @@ $ svn checkout http://svn.php.net/repository/pecl/extname/trunk extname
  <sect1 xml:id="install.pecl.windows">
   <title>Installing a PHP extension on Windows</title>
   <para>
-   On Windows, you have two ways to load a PHP extension: either compile it into PHP, or 
-   load the DLL. Loading a pre-compiled extension is the easiest and preferred way.
+   There are two ways to load a PHP extension on Windows: either compile it into
+   PHP, or load the DLL. Loading a pre-compiled extension is the easiest and
+   preferred way.
   </para>
   <para>
-   To load an extension, you need to have it available as a ".dll" file on your system. 
-   All the extensions are automatically and periodically compiled by the PHP Group 
-   (see next section for the download).
+   To load an extension, it has to be available as a <filename>.dll</filename>
+   file on the system. All the extensions are automatically and periodically
+   compiled by the PHP Group (see next section for the download).
   </para>
   <para>
-   To compile an extension into PHP, please refer to <link linkend="install.windows.building">
-   building from source</link> documentation.
+   To compile an extension into PHP, please refer to the
+   <link linkend="install.windows.building">building from source</link>
+   documentation.
   </para>
   <para>
-   To compile a standalone extension (aka a DLL file), please refer to <link linkend="install.windows.building">
-   building from source</link> documentation. If the DLL file is available neither with your 
-   PHP distribution nor in PECL, you may have to compile it before you can start using the 
-   extension.
+   To compile a standalone extension (aka a DLL file), please refer to the
+   <link linkend="install.windows.building">building from source</link>
+   documentation. If the DLL file is available neither with the PHP distribution
+   nor in PECL, it may be necessary to compile it before the extension can be
+   used.
   </para>
   <sect2 xml:id="install.pecl.windows.find">
    <title>Where to find an extension?</title>
    <para>
-    PHP extensions are usually called "php_*.dll" (where the star represents the name of 
-    the extension) and  they are located under the "PHP\ext" folder.
+    PHP extensions are usually called <filename>php_*.dll</filename> (where the
+    star represents the name of the extension), and they are located under the
+    <filename>PHP\ext</filename> folder.
    </para>
    <para>
-    PHP ships with the extensions most useful to the majority of developers. They are 
-    called "core" extensions.
+    PHP ships with the extensions most useful to the majority of developers.
+    They are called "core" extensions.
    </para>
    <para>
-    However, if you need functionality not provided by any core extension, you
-    may still be able to find one in &link.pecl;. The PHP Extension Community
-    Library (PECL) is a repository for PHP Extensions, providing a directory of
-    all known extensions and hosting facilities for downloading and development
-    of PHP extensions.
+    However, if functionality not provided by any core extension is required, it
+    may still be found in &link.pecl;. The PHP Extension Community Library
+    (PECL) is a repository for PHP Extensions, providing a directory of all
+    known extensions and hosting facilities for downloading and developing PHP
+    extensions.
    </para>
    <para>
-    If you have developed an extension for your own uses, you might want to think about hosting 
-    it on PECL so that others with the same needs can benefit from your time. A nice side effect 
-    is that you give them a good chance to give you feedback, (hopefully) thanks, bug reports 
-    and even fixes/patches. Before you submit your extension for hosting on PECL, please read 
-    <link xlink:href="&url.pecl.submit;">PECL submit</link>.
+    If an extension has been developed for particular uses, it may be hosted on
+    PECL so that others with the same needs can benefit from it. A nice side
+    effect is that it's a good chance to receive feedback, (hopefully) thanks,
+    bug reports and even fixes/patches. Before submitting an extension for
+    hosting on PECL, please read <link xlink:href="&url.pecl.submit;">
+    PECL submit</link>.
    </para>
   </sect2>
 
   <sect2 xml:id="install.pecl.windows.which">
    <title>Which extension to download?</title>
    <para>
-    <emphasis>Many times, you will find several versions of each DLL:</emphasis>
+    <emphasis>
+     Many times, there will be several versions of each DLL available:
+    </emphasis>
     <itemizedlist>
      <listitem>
       <simpara>
@@ -188,9 +197,9 @@ $ svn checkout http://svn.php.net/repository/pecl/extname/trunk extname
     </itemizedlist>
    </para>
    <para>
-    You should keep in mind that your extension settings should match all the 
-    settings of the PHP executable you are using. The following PHP script will 
-    tell you <emphasis>all</emphasis> about your PHP settings:
+    Keep in mind that the extension settings should match all the settings of
+    the PHP executable being used. The following PHP script will tell
+    <emphasis>all</emphasis> about the PHP settings:
    </para>
    <para>
     <example>
@@ -217,12 +226,17 @@ drive:\\path\to\php\executable\php.exe -i
   <sect2 xml:id="install.pecl.windows.loading">
    <title>Loading an extension</title>
    <para>
-    The most common way to load a PHP extension is to include it in your <filename>php.ini</filename> 
-    configuration file. Please note that many extensions are already present in your 
-    <filename>php.ini</filename> and that you only need to remove the semicolon to activate them.
+    The most common way to load a PHP extension is to include it in the
+    &php.ini; configuration file. Please note that many extensions are already
+    present in the &php.ini; and that the semicolon only needs to be removed to
+    activate them.
    </para>
    <para>
-    Note that, on PHP version 7.2.0 and up, the extension name may be used instead of the extension's file name. As this is OS-independent and easier, especially for newcomers, it becomes the recommended way of specifying extensions to load. File names remain supported for compatibility with prior versions.
+    Note that, on PHP version 7.2.0 and up, the extension name may be used
+    instead of the extension's file name. As this is OS-independent and easier,
+    especially for newcomers, it becomes the recommended way of specifying
+    extensions to load. File names remain supported for compatibility with prior
+    versions.
    </para>
     <screen>
 <![CDATA[
@@ -242,9 +256,9 @@ zend_extension=another_extension
 ]]>
     </screen>
    <para>
-    However, some web servers are confusing because they do not use the <filename>php.ini</filename> located alongside 
-    your PHP executable. To find out where your actual <filename>php.ini</filename> resides, look 
-    for its path in <function>phpinfo</function>:
+    However, some web servers are confusing because they do not use the
+    &php.ini; located alongside the PHP executable. To find out where the actual
+    &php.ini; resides, look for its path in <function>phpinfo</function>:
    </para>
     <screen>
 <![CDATA[
@@ -253,47 +267,50 @@ Configuration File (php.ini) Path  C:\WINDOWS
     </screen>
     <screen>
 <![CDATA[
-Loaded Configuration File   C:\Program Files\PHP\5.2\php.ini
+Loaded Configuration File   C:\Program Files\PHP\8.2\php.ini
 ]]>
     </screen>
    <para>
-    After activating an extension, save <filename>php.ini</filename>, restart the web server and check 
-    <function>phpinfo</function> again. The new extension should now have its own section.
+    After activating an extension, save &php.ini;, restart the web server, and
+    check <function>phpinfo</function> again. The new extension should now have
+    its own section.
    </para>
   </sect2>
 
   <sect2 xml:id="install.pecl.windows.problemsolving">
    <title>Resolving problems</title>
    <para>
-    If the extension does not appear in <function>phpinfo</function>, you should check your logs to 
-    learn where the problem comes from.
+    If the extension does not appear in <function>phpinfo</function>, the logs
+    should be checked to learn where the problem comes from.
    </para>
    <para>
-    If you are using PHP from the command line (CLI), the extension loading error can be read 
-    directly on screen.
+    If PHP is being used from the command line (CLI), the extension loading
+    error can be read directly on the screen.
    </para>
    <para>
-    If you are using PHP with a web server, the location and format of the logs vary depending on 
-    your software. Please read your web server documentation to locate the logs, as it does not 
-    have anything to do with PHP itself.
+    If PHP is being used with a web server, the location and format of the logs
+    vary depending on the software. Please read the web server documentation to
+    locate the logs, as it has nothing to do with PHP itself.
    </para>
    <para>
-    Common problems are the location of the DLL and the DLLs it depends on, the value of the "<link linkend="ini.extension-dir">
-    extension_dir</link>" setting inside <filename>php.ini</filename> and compile-time setting mismatches.
+    Common problems are the location of the DLL and the DLLs it depends on, the
+    value of the "<link linkend="ini.extension-dir">extension_dir</link>"
+    setting inside &php.ini; and compile-time setting mismatches.
    </para>
    <para>
-    If the problem lies in a compile-time setting mismatch, you probably didn't download the right DLL. 
-    Try downloading again the extension with the right settings. Again, <function>phpinfo</function> 
-    can be of great help.
+    If the problem lies in a compile-time setting mismatch, probably the DLL
+    downloaded is not the right one. Try downloading the extension again with
+    the proper settings. Again, <function>phpinfo</function> can be of great
+    help.
    </para>
   </sect2>
 
  </sect1>
- 
+
  <sect1 xml:id="install.pecl.pear">
   <title>Compiling shared PECL extensions with the pecl command</title>
   <simpara>
-   PECL makes it easy to create shared PHP extensions. Using the 
+   PECL makes it easy to create shared PHP extensions. Using the
    <link xlink:href="&url.php.pear.cli;">pecl command</link>, do the following:
   </simpara>
   <para>
@@ -302,17 +319,16 @@ $ pecl install extname
    </screen>
   </para>
   <simpara>
-   This will download the source for <emphasis>extname</emphasis>, 
-   compile, and install <filename>extname.so</filename> into your <link
-   linkend="ini.extension-dir">extension_dir</link>.  
+   This will download the source for <emphasis>extname</emphasis>, compile, and
+   install <filename>extname.so</filename> into the <link
+   linkend="ini.extension-dir">extension_dir</link>.
    <filename>extname.so</filename> may then be loaded via &php.ini;
   </simpara>
   <simpara>
-   By default, the <literal>pecl</literal> command will not install
-   packages that are marked with the <literal>alpha</literal> or
-   <literal>beta</literal> state.  If no <literal>stable</literal> packages
-   are available, you may install a <literal>beta</literal> package using the
-   following command:
+   By default, the <command>pecl</command> command will not install packages
+   that are marked with the <literal>alpha</literal> or <literal>beta</literal>
+   state. If no <literal>stable</literal> packages are available, a
+   <literal>beta</literal> package may be installed using the following command:
   </simpara>
   <para>
    <screen>
@@ -320,7 +336,7 @@ $ pecl install extname-beta
    </screen>
   </para>
   <para>
-   You may also install a specific version using this variant:
+   A specific version may also be installed using this variant:
   </para>
   <para>
    <screen>
@@ -338,17 +354,16 @@ $ pecl install extname-0.1
  <sect1 xml:id="install.pecl.phpize">
   <title>Compiling shared PECL extensions with phpize</title>
   <simpara>
-   Sometimes, using the <literal>pecl</literal> installer is not an option.
-   This could be because you're behind a firewall, or it could be because the
-   extension you want to install is not available as a PECL compatible
-   package, such as unreleased extensions from git.  If you need to build such
-   an extension, you can use the lower-level build tools to perform the build
-   manually.
+   Sometimes, using the <command>pecl</command> installer is not an option. This
+   could be because there is a firewall or because the extension being installed
+   is unavailable as a PECL-compatible package, such as unreleased extensions
+   from git. If such an extension needs to be built, the lower-level build tools
+   can be used to perform the build manually.
   </simpara>
   <simpara>
-   The <literal>phpize</literal> command is used to prepare the build
-   environment for a PHP extension.  In the following sample, the sources for
-   an extension are in a directory named <filename>extname</filename>:
+   The <command>phpize</command> command is used to prepare the build
+   environment for a PHP extension. In the following sample, the sources for an
+   extension are in a directory named <filename>extname</filename>:
   </simpara>
   <para>
    <screen>
@@ -362,42 +377,40 @@ $ make
    </screen>
   </para>
   <simpara>
-   A successful install will have created <filename>extname.so</filename> and put it 
-   into the PHP 
-   <link linkend="ini.extension-dir">extensions directory</link>.  You'll need
-   to adjust &php.ini; and add an <literal>extension=extname.so</literal>
-   line before you can use the extension.
+   A successful install will have created <filename>extname.so</filename> and
+   put it into the PHP <link linkend="ini.extension-dir">extensions
+   directory</link>. The &php.ini; will need to be adjusted, and an
+   <literal>extension=extname.so</literal> line will need to be added before the
+   extension can be used.
   </simpara>
   <simpara>
-   If the system is missing the <literal>phpize</literal> command, and precompiled
-   packages (like RPM's) are used, be sure to also install the appropriate 
-   devel version of the PHP package as they often include the 
-   <literal>phpize</literal> command along with the appropriate header files to 
-   build PHP and its extensions.
+   If the system is missing the <command>phpize</command> command, and
+   precompiled packages (like RPM's) are used, be sure to install also the
+   appropriate development version of the PHP package as they often include the
+   <command>phpize</command> command along with the proper header files to build
+   PHP and its extensions.
   </simpara>
   <simpara>
-   Execute <command>phpize --help</command> to display additional usage information.
+   Execute <command>phpize --help</command> to display additional usage
+   information.
   </simpara>
  </sect1>
- 
+
  <sect1 xml:id="install.pecl.php-config">
   <title>php-config</title>
-  
   <para>
-   php-config is a simple shell script for obtaining information about the
-   installed PHP configuration.
+   <command>php-config</command> is a simple shell script for obtaining
+   information about the installed PHP configuration.
   </para>
-  
   <para>
-   When compiling extensions, if you have multiple PHP versions installed, you
-   may specify for which installation you'd like to build by using the
-   <literal>--with-php-config</literal> option during configuration, specifying
-   the path of the respective php-config script.
+   When the extensions are being compiled, if multiple PHP versions are
+   installed, the installation for which to build can be specified by using the
+   <option role="configure">--with-php-config</option> option during
+   configuration, setting the path of the respective php-config script.
   </para>
-  
   <para>
-   The list of command line options provided by the php-config script can be queried
-   anytime by running php-config with the <option>-h</option> switch:
+   The list of command line options provided by the php-config script can be
+   queried anytime by running php-config with the <option>-h</option> switch:
    <screen>
 <![CDATA[
 Usage: /usr/local/bin/php-config [OPTION]
@@ -416,7 +429,6 @@ Options:
 ]]>
    </screen>
   </para>
-  
   <para>
    <table>
     <title>Command line options</title>
@@ -434,11 +446,13 @@ Options:
       </row>
       <row>
        <entry>--includes</entry>
-       <entry>List of -I options with all include files</entry>
+       <entry>
+        List of <literal>-I</literal> options with all include files
+       </entry>
       </row>
       <row>
        <entry>--ldflags</entry>
-       <entry>LD Flags which PHP was compiled with</entry>
+       <entry><literal>LD</literal> flags which PHP was compiled with</entry>
       </row>
       <row>
        <entry>--libs</entry>
@@ -450,7 +464,9 @@ Options:
       </row>
       <row>
        <entry>--include-dir</entry>
-       <entry>Directory prefix where header files are installed by default</entry>
+       <entry>
+        Directory prefix where header files are installed by default
+       </entry>
       </row>
       <row>
        <entry>--php-binary</entry>
@@ -462,7 +478,9 @@ Options:
       </row>
       <row>
        <entry>--configure-options</entry>
-       <entry>Configure options to recreate configuration of current PHP installation</entry>
+       <entry>
+        Configure options to recreate configuration of current PHP installation
+       </entry>
       </row>
       <row>
        <entry>--version</entry>
@@ -481,15 +499,15 @@ Options:
  <sect1 xml:id="install.pecl.static">
   <title>Compiling PECL extensions statically into PHP</title>
   <simpara>
-   You might find that you need to build a PECL extension statically into your
-   PHP binary.  To do this, you'll need to place the extension source under
-   the <filename>/your/phpsrcdir/ext/</filename> directory and tell the PHP build
-   system to regenerate its configure script.
+   It may be necessary to build a PECL extension statically into the PHP binary.
+   To do this, the extension source will need to be placed under the
+   <filename>/path/to/php/src/dir/ext/</filename> directory, and the PHP build
+   system will be required to regenerate its configure script.
   </simpara>
   <para>
    <screen>
 <![CDATA[
-$ cd /your/phpsrcdir/ext
+$ cd /path/to/php/src/dir/ext
 $ pecl download extname
 $ gzip -d < extname.tgz | tar -xvf -
 $ mv extname-x.x.x extname
@@ -501,15 +519,16 @@ $ mv extname-x.x.x extname
   </simpara>
   <para>
    <screen>
-    /your/phpsrcdir/ext/extname
+    /path/to/php/src/dir/ext/extname
    </screen>
   </para>
   <simpara>
-   From here, force PHP to rebuild the configure script, and then build PHP as normal:
+   From here, PHP needs to be forced to rebuild the configure script, and then
+   it can be built as normal:
   </simpara>
   <para>
    <screen>
-$ cd /your/phpsrcdir 
+$ cd /path/to/php/src/dir
 $ rm configure
 $ ./buildconf --force
 $ ./configure --help
@@ -520,15 +539,18 @@ $ make install
   </para>
   <note>
    <simpara>
-    To run the 'buildconf' script you need autoconf 2.13 and automake 1.4+
-    (newer versions of autoconf may work, but are not supported).
+    To run the <command>buildconf</command> script, the
+    <command>autoconf</command> <literal>2.13</literal> and
+    <command>automake</command> <literal>1.4+</literal> will be needed. Newer
+    versions of <command>autoconf</command> may work but are not supported.
    </simpara>
   </note>
   <simpara>
-   Whether <literal>--enable-extname</literal> or <literal>--with-extname
-   </literal> is used depends on the extension.  Typically an extension that 
-   does not require external libraries uses <literal>--enable</literal>.  To be
-   sure, run the following after buildconf:
+   Whether <option role="configure">--enable-extname</option> or
+   <option role="configure">--with-extname</option> is used depends on the
+   extension. Typically, an extension that does not require external libraries
+   uses <option role="configure">--enable</option>. To be sure, run the
+   following after <command>buildconf</command>:
   </simpara>
   <para>
    <screen>
@@ -536,7 +558,7 @@ $ ./configure --help | grep extname
    </screen>
   </para>
  </sect1>
-</chapter>   
+</chapter>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/install/pecl.xml
+++ b/install/pecl.xml
@@ -156,8 +156,8 @@ $ svn checkout https://svn.php.net/repository/pecl/extname/trunk extname
     They are called <emphasis>bundled</emphasis> extensions.
    </para>
    <para>
-    However, if functionality not provided by any bundled extension is required,
-    it may still be found in &link.pecl;.
+    However, if the bundled extensions do not provide the needed functionality,
+    one extension that does may still be found in &link.pecl;.
     The PHP Extension Community Library (PECL) is a repository for PHP
     Extensions, providing a directory of all known extensions and hosting
     facilities for downloading and developing PHP extensions.

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1882,11 +1882,9 @@ is set to <constant>PDO::ERRMODE_EXCEPTION</constant>.
 </para>'>
 
 <!-- PECL entities -->
-<!ENTITY pecl.moved 'This <link xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.pecl;">PECL</link> extension
-is not bundled with PHP.'>
+<!ENTITY pecl.moved 'This &link.pecl; extension is not bundled with PHP.'>
 
-<!ENTITY pecl.bundled 'This <link xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.pecl;">PECL</link> extension
-is bundled with PHP.'>
+<!ENTITY pecl.bundled 'This &link.pecl; extension is bundled with PHP.'>
 
 <!ENTITY pecl.info 'Information for installing this PECL extension may be
 found in the manual chapter titled <link xmlns="http://docbook.org/ns/docbook" linkend="install.pecl">Installation
@@ -1912,9 +1910,8 @@ for this <acronym xmlns="http://docbook.org/ns/docbook">PECL</acronym> extension
 
 <!ENTITY pecl.windows.download.unbundled '&pecl.windows.download;'>
 
-<!ENTITY pecl.moved-ver 'This extension has been moved to the
-<link xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.pecl;">PECL</link> repository and is no longer bundled with
-PHP as of PHP '>
+<!ENTITY pecl.moved-ver 'This extension has been moved to the &link.pecl;
+repository and is no longer bundled with PHP as of PHP '>
 
 <!-- PGSQL entities -->
 

--- a/language/wrappers/audio.xml
+++ b/language/wrappers/audio.xml
@@ -28,9 +28,10 @@
   <note>
    <title>This wrapper is not enabled by default</title>
    <simpara>
-    In order to use the <filename>ogg://</filename> wrapper you must install the
-    <link xlink:href="&url.pecl.package;oggvorbis">OGG/Vorbis</link> extension
-    available from &link.pecl;.
+    In order to use the <filename>ogg://</filename> wrapper,
+    the
+    <link xlink:href="&url.pecl.package;oggvorbis">OGG/Vorbis</link>
+    extension available from &link.pecl; must be installed.
    </simpara>
   </note>
  </refsect1><!-- }}} -->

--- a/language/wrappers/audio.xml
+++ b/language/wrappers/audio.xml
@@ -28,9 +28,9 @@
   <note>
    <title>This wrapper is not enabled by default</title>
    <simpara>
-    In order to use the <filename>ogg://</filename> wrapper you must install
-    the <link xlink:href="&url.pecl.package;oggvorbis">OGG/Vorbis</link> extension
-    available from <link xlink:href="&url.pecl;">PECL</link>.
+    In order to use the <filename>ogg://</filename> wrapper you must install the
+    <link xlink:href="&url.pecl.package;oggvorbis">OGG/Vorbis</link> extension
+    available from &link.pecl;.
    </simpara>
   </note>
  </refsect1><!-- }}} -->

--- a/language/wrappers/expect.xml
+++ b/language/wrappers/expect.xml
@@ -18,7 +18,7 @@
    <simpara>
     In order to use the <filename>expect://</filename> wrapper you must install
     the <link xlink:href="&url.pecl.package;expect">Expect</link> extension
-    available from <link xlink:href="&url.pecl;">PECL</link>.
+    available from &link.pecl;.
    </simpara>
   </note>
   <simpara><filename>expect://</filename> (PECL)</simpara>

--- a/language/wrappers/expect.xml
+++ b/language/wrappers/expect.xml
@@ -16,9 +16,10 @@
   <note>
    <title>This wrapper is not enabled by default</title>
    <simpara>
-    In order to use the <filename>expect://</filename> wrapper you must install
-    the <link xlink:href="&url.pecl.package;expect">Expect</link> extension
-    available from &link.pecl;.
+    In order to use the <filename>expect://</filename> wrapper,
+    the
+    <link xlink:href="&url.pecl.package;expect">Expect</link>
+    extension available from &link.pecl; must be installed.
    </simpara>
   </note>
   <simpara><filename>expect://</filename> (PECL)</simpara>

--- a/language/wrappers/rar.xml
+++ b/language/wrappers/rar.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <para>
    The wrapper takes the url encoded path to the RAR archive (relative or absolute),
-   an optional asterik (<literal>*</literal>), an optional number sign
+   an optional asterisk (<literal>*</literal>), an optional number sign
    (<literal>#</literal>) and an optional url encoded entry name, as stored in the
    archive. Specifying an entry name requires the number sign; a leading forward
    slash in the entry name is optional.
@@ -38,9 +38,10 @@
   <note>
    <title>This wrapper is not enabled by default</title>
    <simpara>
-    In order to use the <filename>rar://</filename> wrapper, you must install
-    the <link xlink:href="&url.pecl.package;rar">rar</link> extension available
-    from &link.pecl;.
+    In order to use the <filename>rar://</filename> wrapper,
+    the
+    <link xlink:href="&url.pecl.package;rar">rar</link>
+    extension available from &link.pecl; must be installed.
    </simpara>
   </note>
   <simpara>

--- a/language/wrappers/rar.xml
+++ b/language/wrappers/rar.xml
@@ -39,8 +39,8 @@
    <title>This wrapper is not enabled by default</title>
    <simpara>
     In order to use the <filename>rar://</filename> wrapper, you must install
-    the <link xlink:href="&url.pecl.package;rar">rar</link> extension
-    available from <link xlink:href="&url.pecl;">PECL</link>.
+    the <link xlink:href="&url.pecl.package;rar">rar</link> extension available
+    from &link.pecl;.
    </simpara>
   </note>
   <simpara>

--- a/language/wrappers/ssh2.xml
+++ b/language/wrappers/ssh2.xml
@@ -21,9 +21,10 @@
   <note>
    <title>This wrapper is not enabled by default</title>
    <simpara>
-    In order to use the <filename>ssh2.*://</filename> wrappers you must install
-    the <link xlink:href="&url.pecl.package;ssh2">SSH2</link> extension
-    available from &link.pecl;.
+    In order to use the <filename>ssh2.*://</filename> wrappers,
+    the
+    <link xlink:href="&url.pecl.package;ssh2">SSH2</link>
+    extension available from &link.pecl; must be installed.
    </simpara>
   </note>
 
@@ -249,9 +250,9 @@ $stream = fopen("ssh2.tunnel://$session/remote.example.com:1234", 'r');
   <example>
    <title>This <varname>$session</varname> variable must be kept available!</title>
    <simpara>
-    In order to use the <filename>ssh2.*://$session</filename> wrappers you must
-    keep the <varname>$session</varname> resource variable. The code below will not 
-    have the desired effect:
+    In order to use the <filename>ssh2.*://$session</filename> wrappers,
+    the <varname>$session</varname> resource variable must be kept.
+    The code below will not have the desired effect:
    </simpara>
    <programlisting role="php">
 <![CDATA[

--- a/language/wrappers/ssh2.xml
+++ b/language/wrappers/ssh2.xml
@@ -23,7 +23,7 @@
    <simpara>
     In order to use the <filename>ssh2.*://</filename> wrappers you must install
     the <link xlink:href="&url.pecl.package;ssh2">SSH2</link> extension
-    available from <link xlink:href="&url.pecl;">PECL</link>.
+    available from &link.pecl;.
    </simpara>
   </note>
 

--- a/reference/ibm_db2/configure.xml
+++ b/reference/ibm_db2/configure.xml
@@ -17,10 +17,10 @@
   links to the header files and libraries in your DB2 instances.
  </para>
  <para>
-  ibm_db2 is a  <link xlink:href="&url.pecl;">PECL</link> extension, so follow the
-  instructions in <xref linkend='install.pecl' /> to install the ibm_db2
-  extension for PHP. Issue the <command>configure</command> command to point
-  to the location of your DB2 header files and libraries as follows:
+  ibm_db2 is a &link.pecl; extension, so follow the instructions in
+  <xref linkend='install.pecl' /> to install the ibm_db2 extension for PHP.
+  Issue the <command>configure</command> command to point to the location of
+  your DB2 header files and libraries as follows:
   <screen>
 <![CDATA[
 bash$ ./configure --with-IBM_DB2=/path/to/DB2

--- a/reference/ibm_db2/configure.xml
+++ b/reference/ibm_db2/configure.xml
@@ -3,24 +3,25 @@
 <section xml:id="ibm-db2.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
  <para>
-  To build the ibm_db2 extension, the DB2 application development header
-  files and libraries must be installed on your system. DB2 does not install
-  these by default, so you may have to return to your DB2 installer and add
-  this option. The header files are included with the DB2 Application
-  Development Client freely available for download from the IBM DB2 Universal
-  Database <link xlink:href="&url.ibm.db2.client;">support site</link>.
+  To build the ibm_db2 extension, the DB2 application development header files
+  and libraries must be installed on the system.
+  DB2 does not install these by default, so it may be necessary to return to the
+  DB2 installer and add this option.
+  The DB2 Application Development Client includes the header files and is freely
+  available for download from the IBM DB2 Universal Database
+  <link xlink:href="&url.ibm.db2.client;">support site</link>.
  </para>
  <para>
-  If you add the DB2 application development header files and libraries to
-  a Linux or Unix operating system on which DB2 was already installed, you
-  must issue the command <command>db2iupdt -e</command> to update the symbolic
-  links to the header files and libraries in your DB2 instances.
+  If the DB2 application development header files and libraries are added to a
+  Linux or Unix operating system on which DB2 was already installed, the command
+  <command>db2iupdt -e</command> must be issued to update the symbolic links to
+  the header files and libraries in the DB2 instances.
  </para>
  <para>
   ibm_db2 is a &link.pecl; extension, so follow the instructions in
   <xref linkend='install.pecl' /> to install the ibm_db2 extension for PHP.
   Issue the <command>configure</command> command to point to the location of
-  your DB2 header files and libraries as follows:
+  the DB2 header files and libraries as follows:
   <screen>
 <![CDATA[
 bash$ ./configure --with-IBM_DB2=/path/to/DB2
@@ -33,8 +34,8 @@ bash$ ./configure --with-IBM_DB2=/path/to/DB2
   <note>
    <title>Note for IIS users</title>
    <para>
-    If you are using the ibm_db2 driver with Microsoft Internet Information Server (IIS) 
-    you may have to do the following:
+    If the ibm_db2 driver is being used with Microsoft Internet Information
+    Server (IIS), it may be necessary to do the following:
    </para>
    <para>
     <simplelist>

--- a/reference/oci8/setup.xml
+++ b/reference/oci8/setup.xml
@@ -8,13 +8,8 @@
  <section xml:id="oci8.requirements">
   &reftitle.required;
   <para>
-   OCI8 3.0 is included with PHP 8. It is also available
-   from <link xmlns="http://docbook.org/ns/docbook"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xlink:href="&url.pecl;">PECL</link>.  For PHP 7, use OCI8 2.2
-   from <link xmlns="http://docbook.org/ns/docbook"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xlink:href="&url.pecl;">PECL</link>.  OCI8 requires Oracle
+   OCI8 3.0 is included with PHP 8. It is also available from &link.pecl;. For
+   PHP 7, use OCI8 2.2 from &link.pecl;. OCI8 requires Oracle
    10<emphasis>g</emphasis> or later Oracle client libraries.
   </para>
   <para>

--- a/reference/pdo_cubrid/configure.xml
+++ b/reference/pdo_cubrid/configure.xml
@@ -6,10 +6,10 @@
   To build the PDO_CUBRID extension, the CUBRID DBMS must be installed on the
   same system as PHP.
 
-  PDO_CUBRID is a <link xlink:href="&url.pecl;">PECL</link> extension, so
-  follow the instructions in <xref linkend='install.pecl' /> to install the
-  PDO_CUBRID extension. Issue the <command>configure</command> command to
-  point to the location of your CUBRID base dir as follows:
+  PDO_CUBRID is a &link.pecl; extension, so follow the instructions in
+  <xref linkend='install.pecl' /> to install the PDO_CUBRID extension. Issue the
+  <command>configure</command> command to point to the location of your CUBRID
+  base dir as follows:
   <screen>
 <![CDATA[
    $ ./configure --with-pdo-cubrid=/path/to/CUBRID[,shared]

--- a/reference/pdo_cubrid/configure.xml
+++ b/reference/pdo_cubrid/configure.xml
@@ -7,22 +7,24 @@
   same system as PHP.
 
   PDO_CUBRID is a &link.pecl; extension, so follow the instructions in
-  <xref linkend='install.pecl' /> to install the PDO_CUBRID extension. Issue the
-  <command>configure</command> command to point to the location of your CUBRID
-  base dir as follows:
+  <xref linkend='install.pecl' />
+  to install the PDO_CUBRID extension.
+  Issue the <command>configure</command> command to point to the location of the
+  CUBRID base dir as follows:
   <screen>
 <![CDATA[
    $ ./configure --with-pdo-cubrid=/path/to/CUBRID[,shared]
 ]]>
   </screen>
   The <command>configure</command> command defaults to the value of the
-  <literal>CUBRID</literal> environment variable.
+  <envar>CUBRID</envar>
+  environment variable.
  </para>
  <para>
   &pecl.windows.download; Detailed information about installation on Linux and
   Windows manually, please read build-guide.html in PECL package CUBRID for
   reference.
-  </para>
+ </para>
 </section>
 
 <!-- Keep this comment at the end of the file

--- a/reference/pdo_ibm/configure.xml
+++ b/reference/pdo_ibm/configure.xml
@@ -21,10 +21,10 @@
    </para>
  </note>
  <para>
-  PDO_IBM is a <link xlink:href="&url.pecl;">PECL</link> extension, so follow the 
-  instructions in <xref linkend='install.pecl' /> to install the PDO_IBM 
-  extension. Issue the <command>configure</command> command to point to the 
-  location of your DB2 Client header files and libraries as follows:
+  PDO_IBM is a &link.pecl; extension, so follow the instructions in
+  <xref linkend='install.pecl' /> to install the PDO_IBM extension. Issue the
+  <command>configure</command> command to point to the location of your DB2
+  Client header files and libraries as follows:
   <screen>
 <![CDATA[
 bash$ ./configure --with-pdo-ibm=/path/to/sqllib[,shared]

--- a/reference/pdo_ibm/configure.xml
+++ b/reference/pdo_ibm/configure.xml
@@ -22,16 +22,16 @@
  </note>
  <para>
   PDO_IBM is a &link.pecl; extension, so follow the instructions in
-  <xref linkend='install.pecl' /> to install the PDO_IBM extension. Issue the
-  <command>configure</command> command to point to the location of your DB2
-  Client header files and libraries as follows:
+  <xref linkend='install.pecl' /> to install the PDO_IBM extension.
+  Issue the <command>configure</command> command to point to the location of the
+  DB2 Client header files and libraries as follows:
   <screen>
 <![CDATA[
 bash$ ./configure --with-pdo-ibm=/path/to/sqllib[,shared]
 ]]>
   </screen>
   The <command>configure</command> command defaults to the value of the 
-  <literal>DB2DIR</literal> environment variable. 
+  <envar>DB2DIR</envar> environment variable.
  </para>
 </section>
 

--- a/reference/pdo_informix/configure.xml
+++ b/reference/pdo_informix/configure.xml
@@ -10,8 +10,8 @@
  </para>
  <para>
   PDO_INFORMIX is a &link.pecl; extension, so follow the instructions in
-  <xref linkend='install.pecl' /> to install the PDO_INFORMIX extension. Issue
-  the <command>configure</command> command to point to the location of your
+  <xref linkend='install.pecl' /> to install the PDO_INFORMIX extension.
+  Issue the <command>configure</command> command to point to the location of the
   Informix Client SDK header files and libraries as follows:
   <screen>
 <![CDATA[
@@ -19,7 +19,7 @@
 ]]>
   </screen>
   The <command>configure</command> command defaults to the value of the
-  <literal>INFORMIXDIR</literal> environment variable.
+  <envar>INFORMIXDIR</envar> environment variable.
  </para>
 </section>
 

--- a/reference/pdo_informix/configure.xml
+++ b/reference/pdo_informix/configure.xml
@@ -9,11 +9,10 @@
   Support Site</link>.
  </para>
  <para>
-  PDO_INFORMIX is a <link xlink:href="&url.pecl;">PECL</link> extension, so
-  follow the instructions in <xref linkend='install.pecl' /> to install the
-  PDO_INFORMIX extension. Issue the <command>configure</command> command
-  to point to the location of your Informix Client SDK header files and
-  libraries as follows:
+  PDO_INFORMIX is a &link.pecl; extension, so follow the instructions in
+  <xref linkend='install.pecl' /> to install the PDO_INFORMIX extension. Issue
+  the <command>configure</command> command to point to the location of your
+  Informix Client SDK header files and libraries as follows:
   <screen>
 <![CDATA[
    bash$ ./configure --with-pdo-informix=/path/to/SDK[,shared]

--- a/reference/pdo_sqlsrv/configure.xml
+++ b/reference/pdo_sqlsrv/configure.xml
@@ -12,13 +12,15 @@
   <link xlink:href="&url.sqlsrv.system.requirements;">SQLSRV System Requirements</link>.
  </para>
  <para>
-  On Windows the PDO_SQLSRV extension is enabled by downloading and adding appropriate DLL files to your PHP
-  extension directory and the corresponding entry to the &php.ini; file.
+  On Windows the PDO_SQLSRV extension is enabled by downloading and adding
+  appropriate DLL files to the PHP extension directory and the corresponding
+  entry to the &php.ini; file.
  </para>
  <para>
   On Linux and macOS, the PDO_SQLSRV extension can be installed using
-  &link.pecl;. See the <link xlink:href="&url.sqlsrv.linux-mac;">installation
-  tutorial</link> for details.
+  &link.pecl;.
+  See the <link xlink:href="&url.sqlsrv.linux-mac;">installation tutorial</link>
+  for details.
  </para>
 </section>
 

--- a/reference/pdo_sqlsrv/configure.xml
+++ b/reference/pdo_sqlsrv/configure.xml
@@ -16,8 +16,9 @@
   extension directory and the corresponding entry to the &php.ini; file.
  </para>
  <para>
-  On Linux and macOS, the PDO_SQLSRV extension can be installed using <link xlink:href="&url.pecl;">PECL</link>.
-  See the <link xlink:href="&url.sqlsrv.linux-mac;">installation tutorial</link> for details.
+  On Linux and macOS, the PDO_SQLSRV extension can be installed using
+  &link.pecl;. See the <link xlink:href="&url.sqlsrv.linux-mac;">installation
+  tutorial</link> for details.
  </para>
 </section>
 


### PR DESCRIPTION
This PR replaces the tag `<link xlink:href="&url.pecl;">PECL</link>` and its more extended versions, like `<link xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.pecl;">PECL</link>`, with the entity `&link.pecl;`.