### PR TITLE
Update debugger.xml

### DIFF
--- a/appendices/debugger.xml
+++ b/appendices/debugger.xml
@@ -6,13 +6,13 @@
   <sect1 xml:id="debugger-about">
    <title>About debugging in PHP</title>
    <simpara>
-    PHP is shipped with the <link linkend="migration56.new-features.phpdbg">phpdbg</link> interactive debugger. 
-    External debuggers can also be used. The
-    <link xlink:href="&url.zend.ide;">Zend IDE</link> includes
-    a debugger, and there are also some free debugger extensions
-    like DBG at <link xlink:href="&url.dbg;">&url.dbg;</link>, the 
-    <link xlink:href="&url.apd;">Advanced PHP Debugger</link> (APD) or
-    <link xlink:href="&url.xdebug;">Xdebug</link>.
+    PHP is shipped with a basic command line interactive debugger,
+    <link linkend="migration56.new-features.phpdbg">phpdbg</link>. 
+   </simpara>
+   <simpara>
+    Most IDEs have support for <link xlink:href="&url.xdebug;">Xdebug</link>,
+    a free debug tool, which allows for single step debugging your PHP
+    applications.
    </simpara>
   </sect1>
 


### PR DESCRIPTION
Remove links to Zend IDE (no longer available), dbg (supportws until PHP 5.5) and apd (no releases since 2004).

This page could really be flashed out with how step debuggers like Xdebug are the way to comprehensively debug applications, but I don't think it's my place to write that documentation.