### PR TITLE
Remove non-working, outdated example

### DIFF
--- a/reference/dom/domdocument/loadxml.xml
+++ b/reference/dom/domdocument/loadxml.xml
@@ -75,20 +75,6 @@ echo $doc->saveXML();
     </programlisting>
    </example>
   </para>
-  <para>
-   <example>
-    <title>Static invocation of <literal>loadXML</literal></title>
-    <programlisting role="php">
-<![CDATA[
-<?php
-// Issues an E_DEPRECATED error
-$doc = DOMDocument::loadXML('<root><node/></root>');
-echo $doc->saveXML();
-?>
-]]>
-    </programlisting>
-   </example>
-  </para>
  </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;


### PR DESCRIPTION
Calling this statically has been made impossible since PHP 8.0.

Diff looks funky, but expand it in the webview to see it is right :P