### PR TITLE
curl_multi_init: fix return description

### DIFF
--- a/reference/curl/functions/curl-multi-init.xml
+++ b/reference/curl/functions/curl-multi-init.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a cURL multi handle object.
+   Returns a cURL multi handle.
   </para>
  </refsect1>
  

--- a/reference/curl/functions/curl-multi-init.xml
+++ b/reference/curl/functions/curl-multi-init.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a cURL multi handle on success, &false; on failure.
+   Returns a cURL multi handle object.
   </para>
  </refsect1>
  


### PR DESCRIPTION
ref.: https://github.com/php/php-src/blob/master/ext/curl/multi.c#L60 (stub: `function curl_multi_init(): CurlMultiHandle {}`)

⇒ "Stubs are the authoriative source of truth. The descriptions in the manual are sometimes buggy due to them not being syncronized with the stubs via automatic tooling (unlike signatures)." - Máté Kocsis (https://twitter.com/kocsismate90/status/1681912594024525824)