### PR TITLE
Document ReflectionProperty::setValue PHP 8.3 deprecation

### DIFF
--- a/reference/reflection/reflectionproperty/setvalue.xml
+++ b/reference/reflection/reflectionproperty/setvalue.xml
@@ -21,6 +21,11 @@
   <para>
    Sets (changes) the property's value.
   </para>
+  <note>
+   <simpara>
+    As of PHP 8.3.0, calling this method with a single argument is deprecated, use <methodname>ReflectionClass::setStaticPropertyValue</methodname> instead.
+   </simpara>
+  </note>
  </refsect1>
  
  <refsect1 role="parameters">
@@ -99,7 +104,8 @@ class Foo {
 
 $reflectionClass = new ReflectionClass('Foo');
 
-$reflectionClass->getProperty('staticProperty')->setValue('foo');
+// As of PHP 8.3, setValue should no longer be used to set static property value, use setStaticPropertyValue() instead
+$reflectionClass->setStaticPropertyValue('staticProperty', 'foo');
 var_dump(Foo::$staticProperty);
 
 $foo = new Foo;

--- a/reference/reflection/reflectionproperty/setvalue.xml
+++ b/reference/reflection/reflectionproperty/setvalue.xml
@@ -73,6 +73,14 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.3.0</entry>
+      <entry>
+       Calling this method with a single argument is deprecated,
+       <methodname>ReflectionClass::setStaticPropertyValue</methodname>
+       should be used instead to modify static properties.
+      </entry>
+     </row>
+     <row>
       <entry>8.1.0</entry>
       <entry>
        Private and protected properties can be accessed by


### PR DESCRIPTION
Document the consequence of [`11703`](https://github.com/php/php-src/pull/11703) for `ReflectionProperty::setValue`