### PR TITLE
[PHP 8.2] Added PCRE n (NO_AUTO_CAPTURE) modifier description.

### DIFF
--- a/reference/pcre/pattern.modifiers.xml
+++ b/reference/pcre/pattern.modifiers.xml
@@ -174,6 +174,18 @@
        </simpara>
       </listitem>
      </varlistentry>
+     <varlistentry>
+      <term><emphasis>n</emphasis> (<literal>PCRE_NO_AUTO_CAPTURE</literal>)</term>
+      <listitem>
+       <simpara>
+        This modifier makes simple <code>(xyz)</code> groups non-capturing.
+        Only named groups like <code>(?&lt;name&gt;xyz)</code> are capturing.
+        This only affects which groups are capturing, it is still possible to
+        use numbered subpattern references, and the matches array will still
+        contain numbered results.
+       </simpara>
+      </listitem>
+     </varlistentry>
     </variablelist>
    </blockquote>
   </para>


### PR DESCRIPTION
Almost copied and pasted from [PHP 8.2 migration guide](https://www.php.net/manual/en/migration82.new-features.php#migration82.new-features.pcre).
