### PR TITLE
Reworded json_decode return value paragraph to be more explicit about `true`, `false` and `null`

### DIFF
--- a/reference/json/functions/json-decode.xml
+++ b/reference/json/functions/json-decode.xml
@@ -80,11 +80,12 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the value encoded in <parameter>json</parameter> in appropriate
-   PHP type. Values <literal>true</literal>, <literal>false</literal> and
-   <literal>null</literal> are returned as &true;, &false; and &null;
-   respectively. &null; is returned if the <parameter>json</parameter> cannot
-   be decoded or if the encoded data is deeper than the nesting limit.
+   Returns the value encoded in <parameter>json</parameter> as an appropriate
+   PHP type. Unquoted values <literal>true</literal>, <literal>false</literal>
+   and <literal>null</literal> are returned as &true;,
+   &false; and &null; respectively. &null; is returned if the
+   <parameter>json</parameter> cannot be decoded or if the encoded data is
+   deeper than the nesting limit.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Fix https://github.com/php/doc-en/issues/2513