### PR TITLE
OPcache: clarify validate_timestamps considering other options

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -482,6 +482,10 @@
       manually via <function>opcache_reset</function>,
       <function>opcache_invalidate</function> or by restarting the Web server
       for changes to the filesystem to take effect.
+      Note that OPcache may still validate the timestamp of a file if
+      <link linkend="ini.opcache.file_update_protection">opcache.file_update_protection</link>
+      or <link linkend="ini.opcache.max-file-size">opcache.max_file_size</link>
+      options are set to non-zero values.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -482,10 +482,14 @@
       manually via <function>opcache_reset</function>,
       <function>opcache_invalidate</function> or by restarting the Web server
       for changes to the filesystem to take effect.
-      Note that OPcache may still validate the timestamp of a file if
-      <link linkend="ini.opcache.file_update_protection">opcache.file_update_protection</link>
-      or <link linkend="ini.opcache.max-file-size">opcache.max_file_size</link>
-      options are set to non-zero values.
+      <note>
+       <simpara>
+        OPcache may still validate the timestamp of a file if
+        <link linkend="ini.opcache.file_update_protection">opcache.file_update_protection</link>
+        or <link linkend="ini.opcache.max-file-size">opcache.max_file_size</link>
+        options are set to non-zero values.
+       </simpara>
+      </note>
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
The changes aim to clarify that disabling `opcache.validate_timestamps` doesn't mean timestamps will never be checked.

In scenarios where `opcache.file_update_protection` is non-zero (it is `2` by default) or `opcache.max_file_size` is set to a non-default value, OPcache may still validate file timestamps. This behavior was not clearly indicated in the original documentation and could lead to potential confusion for users (e.g., https://github.com/amnuts/opcache-gui/issues/92#issuecomment-1261958279)

I have confirmed this is the behavior here: https://github.com/php/php-src/blob/master/ext/opcache/ZendAccelerator.c#L1772C2-L1772C2