### PR TITLE
OPcache: explain why setting file_update_protection to 0 may improve performance

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -784,7 +784,9 @@
      <para>
       Prevents caching files that are less than this number of seconds old.
       It protects from caching of incompletely updated files. In case all file
-      updates on your site are atomic, you may increase performance by setting it to "0".
+      updates on your site are atomic, you may increase performance by setting
+      it to "0". This will allow files to be cached immediately, potentially
+      eliminating the need to validate timestamps.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -784,9 +784,8 @@
      <para>
       Prevents caching files that are less than this number of seconds old.
       It protects from caching of incompletely updated files. In case all file
-      updates on your site are atomic, you may increase performance by setting
-      it to "0". This will allow files to be cached immediately, potentially
-      eliminating the need to validate timestamps.
+      updates are atomic, performance can be increased by setting this to <literal>0</literal>.
+      This will allow files to be cached immediately, potentially eliminating the need to validate timestamps.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -785,7 +785,7 @@
       Prevents caching files that are less than this number of seconds old.
       It protects from caching of incompletely updated files. In case all file
       updates are atomic, performance can be increased by setting this to <literal>0</literal>.
-      This will allow files to be cached immediately, potentially eliminating the need to validate timestamps.
+      This will allow files to be cached immediately.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Related: https://github.com/php/doc-en/pull/2609