### PR TITLE
Add example for class properties type declaration

### DIFF
--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -93,6 +93,12 @@
       </entry>
      </row>
      <row>
+      <entry>7.4.0</entry>
+      <entry>
+       Support for class properties typing has been added.
+      </entry>
+     </row>
+     <row>
       <entry>7.2.0</entry>
       <entry>
        Support for <type>object</type> has been added.
@@ -600,6 +606,27 @@ function get_item(): ?string {
         return $_GET['item'];
     } else {
         return null;
+    }
+}
+?>
+]]>
+   </programlisting>
+  </example>
+
+  <example>
+   <title>Class property type declaration</title>
+   <programlisting role="php">
+    <![CDATA[
+<?php
+class User {
+    public static string $foo = 'foo';
+
+    public int $id;
+    public string $username;
+
+    public function __construct(int $id, string $username) {
+        $this->id = $id;
+        $this->username = $username;
     }
 }
 ?>

--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -616,7 +616,7 @@ function get_item(): ?string {
   <example>
    <title>Class property type declaration</title>
    <programlisting role="php">
-    <![CDATA[
+<![CDATA[
 <?php
 class User {
     public static string $foo = 'foo';


### PR DESCRIPTION
Fix https://github.com/php/doc-en/issues/2373