### PR TITLE
OPcache: clarify timestamps can be checked at compile-time

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -484,7 +484,7 @@
       for changes to the filesystem to take effect.
       <note>
        <simpara>
-        OPcache may still validate the timestamp of a file if
+        OPcache may still validate the timestamp of a file at compile-time if
         <link linkend="ini.opcache.file_update_protection">opcache.file_update_protection</link>
         or <link linkend="ini.opcache.max-file-size">opcache.max_file_size</link>
         options are set to non-zero values.


### PR DESCRIPTION
This is to clarify that `file_update_protection` and `max_file_size` settings affect validation of timestamps at compile-time only.

Context: https://github.com/php/doc-en/pull/2609#issuecomment-1655109927