### PR TITLE
Update operator precedence table

### DIFF
--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -258,6 +258,15 @@
      </row>
      <row>
       <entry>(n/a)</entry>
+      <entry><literal>=&gt;</literal></entry>
+      <entry>
+       <link linkend="language.types.array">array</link>,
+       <link linkend="control-structures.match">match</link>&listendand;
+       <link linkend="functions.arrow">fn</link>
+      </entry>
+     </row>
+     <row>
+      <entry>(n/a)</entry>
       <entry><literal>yield</literal></entry>
       <entry>
        <link linkend="control-structures.yield">yield</link>
@@ -288,6 +297,26 @@
       <entry>
        <link linkend="language.operators.logical">logical</link>
       </entry>
+     </row>
+     <row>
+      <entry>(n/a)</entry>
+      <entry>
+       <literal>include</literal>
+       <literal>include_once</literal>
+       <literal>require</literal>
+       <literal>require_once</literal>
+      </entry>
+      <entry>
+       <function>include</function>,
+       <function>include_once</function>,
+       <function>require</function>&listendand;
+       <function>require_once</function>
+      </entry>
+     </row>
+     <row>
+      <entry>(n/a)</entry>
+      <entry><literal>fn</literal></entry>
+      <entry><link linkend="functions.arrow">fn</link></entry>
      </row>
      <row>
       <entry>(n/a)</entry>

--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -260,9 +260,7 @@
       <entry>(n/a)</entry>
       <entry><literal>=&gt;</literal></entry>
       <entry>
-       <link linkend="language.types.array">array</link>,
-       <link linkend="control-structures.match">match</link>&listendand;
-       <link linkend="functions.arrow">fn</link>
+       <link linkend="language.generators.syntax">yield with keys</link>
       </entry>
      </row>
      <row>

--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -313,7 +313,7 @@
      </row>
      <row>
       <entry>(n/a)</entry>
-      <entry><literal>=&gt;</literal></entry>
+      <entry><literal>fn (...) =&gt;</literal></entry>
       <entry><link linkend="functions.arrow">fn arrow</link> disambiguity</entry>
      </row>
      <row>

--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -313,8 +313,8 @@
      </row>
      <row>
       <entry>(n/a)</entry>
-      <entry><literal>fn</literal></entry>
-      <entry><link linkend="functions.arrow">fn</link></entry>
+      <entry><literal>=&gt;</literal></entry>
+      <entry><link linkend="functions.arrow">fn arrow</link> disambiguity</entry>
      </row>
      <row>
       <entry>(n/a)</entry>


### PR DESCRIPTION
Updates the table to match the information per the parser.

This adds entries for:
* `=>`
* `include`, `include_once`, `require`, `require_once`
* `fn`
* ~~`throw`~~

~~Ref: https://github.com/php/php-src/blob/2e2416825d2270d256f7597904e14e386cc0d854/Zend/zend_language_parser.y#L54-L82~~
Ref: https://github.com/php/php-src/blob/82a15338e298142f52854b64d803695d4e5252df/Zend/zend_language_parser.y#L53-L82 (Sept 2026)

~~Fixes~~ ++Related to++ #2622