### PR TITLE
Constructors and Destructors: add note to promoted properties

### DIFF
--- a/language/oop5/decon.xml
+++ b/language/oop5/decon.xml
@@ -157,6 +157,12 @@ class Point {
     </note>
     <note>
      <para>
+      As promoted properties are desugared to both a property as well as a function parameter, any
+      and all naming restrictions for both properties as well as parameters apply.
+     </para>
+    </note>
+    <note>
+     <para>
       <link linkend="language.attributes">Attributes</link> placed on a
       promoted constructor argument will be replicated to both the property
       and argument.  Default values on a promoted constructor argument will be replicated only to the argument and not the property.


### PR DESCRIPTION
Point out naming restrictions for promoted properties.

Ref: https://www.php.net/manual/en/language.oop5.decon.php#language.oop5.decon.constructor.promotion

Fixes #2586