### PR TITLE
Add `zlib` requirement to GD

### DIFF
--- a/reference/image/setup.xml
+++ b/reference/image/setup.xml
@@ -22,6 +22,11 @@
      the bundled <acronym>GD</acronym> library that ships with PHP.
     </simpara>
    </note>
+   <note>
+    <simpara>
+     The <acronym>GD</acronym> library requires zlib &gt;= 1.2.0.4.
+    </simpara>
+   </note>
   </para>
   <para>
    You may wish to enhance <acronym>GD</acronym> to handle more image formats.


### PR DESCRIPTION
Fix https://github.com/php/doc-en/issues/1383

Got the [version info here](https://github.com/php/php-src/blob/655f116be57b46efe32221d7adfec6d6b81eeece/ext/zlib/config0.m4#L4), hope hat was the good place to get it :slightly_smiling_face: 
