### PR TITLE
[IntlDateFormatter] Add changelog entry about making `dateType` and `timeType` optional

### DIFF
--- a/reference/intl/dateformatter/create.xml
+++ b/reference/intl/dateformatter/create.xml
@@ -68,11 +68,10 @@
      <term><parameter>dateType</parameter></term>
      <listitem>
       <para>
-       Date type to use (<constant>none</constant>, <constant>short</constant>,
-       <constant>medium</constant>, <constant>long</constant>,
-       <constant>full</constant>).  This is one of the <link
-       linkend="intl.intldateformatter-constants">IntlDateFormatter
-       constants</link>.
+       Format of the date determined by one of the
+       <link linkend="intl.intldateformatter-constants">IntlDateFormatter
+       constants</link>. The default value is
+       <constant>IntlDateFormatter::FULL</constant>.
       </para>
      </listitem>
     </varlistentry>
@@ -80,11 +79,10 @@
      <term><parameter>timeType</parameter></term>
      <listitem>
       <para>
-       Time type to use (<constant>none</constant>, <constant>short</constant>,
-       <constant>medium</constant>, <constant>long</constant>,
-       <constant>full</constant>).  This is one of the <link
-       linkend="intl.intldateformatter-constants">IntlDateFormatter
-       constants</link>.
+       Format of the time determined by one of the
+       <link linkend="intl.intldateformatter-constants">IntlDateFormatter
+       constants</link>. The default value is
+       <constant>IntlDateFormatter::FULL</constant>.
       </para>
      </listitem>
     </varlistentry>
@@ -159,25 +157,11 @@
      </thead>
      <tbody>
       <row>
-       <entry>5.5.0/PECL 3.0.0</entry>
+       <entry>8.1.0</entry>
        <entry>
         <para>
-         An <classname>IntlCalendar</classname> object is allowed for
-         <parameter>calendar</parameter>.
-        </para>
-        <para>
-         Objects of type <classname>IntlTimeZone</classname> and
-         <classname>DateTimeZone</classname> are allowed for
-         <parameter>timezone</parameter>.
-        </para>
-        <para>
-         Invalid timezone identifiers (including empty strings) are no longer
-         allowed for <parameter>timezone</parameter>.
-        </para>
-        <para>
-         If &null; is given for <parameter>timezone</parameter>, the timezone
-         identifier given by <function>date_default_timezone_get</function> will
-         be used instead of ICUʼs default.
+         Parameters <parameter>dateType</parameter> and
+         <parameter>timeType</parameter> are now optional.
         </para>
        </entry>
       </row>


### PR DESCRIPTION
Fix https://github.com/php/doc-en/issues/2425