### PR TITLE
Create a docker container for a single-line setup and rendering

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,15 +1,15 @@
 FROM php:8.2-cli
 
-RUN apt-get update ; \
+RUN apt-get update && \
     apt-get install -y git
 
 WORKDIR /var/www
 
-RUN git clone https://github.com/php/phd.git ;  \
-    git clone https://github.com/php/doc-base.git ; \
+RUN git clone https://github.com/php/phd.git &&  \
+    git clone https://github.com/php/doc-base.git && \
     git -C phd checkout 5708881e233cd9979dd11bcbd9fd0bb8a714f9d5
 
 RUN echo 'memory_limit = 512M' >> /usr/local/etc/php/conf.d/local.ini
 
-CMD php doc-base/configure.php --disable-segfault-error ; \
+CMD php doc-base/configure.php --disable-segfault-error && \
     php phd/render.php --docbook doc-base/.manual.xml --output=/var/www/en/output --package PHP --format xhtml

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -5,6 +5,9 @@ RUN apt-get update && \
 
 WORKDIR /var/www
 
+ADD https://api.github.com/repos/php/phd/git/refs/heads/master version-phd.json
+ADD https://api.github.com/repos/php/doc-base/git/refs/heads/master version-doc-base.json
+
 RUN git clone --depth 1 https://github.com/php/phd.git &&  \
     git clone --depth 1 https://github.com/php/doc-base.git
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
 WORKDIR /var/www
 
 RUN git clone https://github.com/php/phd.git &&  \
-    git clone https://github.com/php/doc-base.git && \
+    git clone --depth 1 https://github.com/php/doc-base.git && \
     git -C phd checkout 5708881e233cd9979dd11bcbd9fd0bb8a714f9d5
 
 RUN echo 'memory_limit = 512M' >> /usr/local/etc/php/conf.d/local.ini

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM php:8.2-cli
+
+RUN apt-get update ; \
+    apt-get install -y git
+
+WORKDIR /var/www
+
+RUN git clone https://github.com/php/phd.git ;  \
+    git clone https://github.com/php/doc-base.git ; \
+    git -C phd checkout 5708881e233cd9979dd11bcbd9fd0bb8a714f9d5
+
+RUN echo 'memory_limit = 512M' >> /usr/local/etc/php/conf.d/local.ini
+
+CMD php doc-base/configure.php --disable-segfault-error ; \
+    php phd/render.php --docbook doc-base/.manual.xml --output=/var/www/en/output --package PHP --format xhtml

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -5,9 +5,8 @@ RUN apt-get update && \
 
 WORKDIR /var/www
 
-RUN git clone https://github.com/php/phd.git &&  \
-    git clone --depth 1 https://github.com/php/doc-base.git && \
-    git -C phd checkout 5708881e233cd9979dd11bcbd9fd0bb8a714f9d5
+RUN git clone --depth 1 https://github.com/php/phd.git &&  \
+    git clone --depth 1 https://github.com/php/doc-base.git
 
 RUN echo 'memory_limit = 512M' >> /usr/local/etc/php/conf.d/local.ini
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 entities.*.xml
+output

--- a/README
+++ b/README
@@ -7,3 +7,8 @@ Please refer to the README file within the [doc-base repository](https://github.
 For information related to creating this setup, see:
 
   http://doc.php.net/tutorial/local-setup.php
+
+Running With Docker
+
+- Rebuild the documentation using `docker-compose up`
+- Open output/php-chunked-xhtml/ in your browser.

--- a/README
+++ b/README
@@ -10,6 +10,6 @@ For information related to creating this setup, see:
 
 Running With Docker
 
-- Install Docker (https://docs.docker.com/get-docker/
+- Install Docker (https://docs.docker.com/get-docker/)
 - Rebuild the documentation using `docker-compose up`
 - Open output/php-chunked-xhtml/ in your browser.

--- a/README
+++ b/README
@@ -10,6 +10,6 @@ For information related to creating this setup, see:
 
 Running With Docker
 
-- Install [Docker](https://docs.docker.com/get-docker/).
+- Install Docker (https://docs.docker.com/get-docker/
 - Rebuild the documentation using `docker-compose up`
 - Open output/php-chunked-xhtml/ in your browser.

--- a/README
+++ b/README
@@ -10,5 +10,6 @@ For information related to creating this setup, see:
 
 Running With Docker
 
+- Install [Docker](https://docs.docker.com/get-docker/).
 - Rebuild the documentation using `docker-compose up`
 - Open output/php-chunked-xhtml/ in your browser.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  doc:
+    build: .docker
+    working_dir: /var/www
+    volumes:
+      - .:/var/www/en


### PR DESCRIPTION
Use case: a casual contributor who wants to preview their changes before opening a PR.

- There is currently no way to provide custom args to phd/render.php, because then we'd be back to complicated instructions.
- I tried not to make any assumptions about the host system, so I don't use make.
- This image is tied to an older commit of phd, since a (very) recent commit causes a crash on `assert($this->cchunk["classsynopsis"]["legacy"] === true);`. I'll just assume that it's a regression, since it fails on 2 machines and 2 PHP versions. I don't want to go down that rabbit hole today.

Fixes #2637