### PR TITLE
Updates the DS interfaces to use new syntax

### DIFF
--- a/reference/ds/ds.collection.xml
+++ b/reference/ds/ds.collection.xml
@@ -24,19 +24,18 @@
 
 <!-- {{{ Synopsis -->
    <classsynopsis class="interface">
-    <ooclass><classname>Ds\Collection</classname></ooclass>
+    <oointerface><interfacename>Ds\Collection</interfacename></oointerface>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-
-    <ooclass><classname>Ds\Collection</classname></ooclass>
-
-    <oointerface><interfacename>Countable</interfacename></oointerface>
-    <oointerface><interfacename>IteratorAggregate</interfacename></oointerface>
-    <oointerface><interfacename>JsonSerializable</interfacename></oointerface>
-
-    </classsynopsisinfo>
-<!-- }}} -->
+    <oointerface>
+     <modifier>extends</modifier>
+     <interfacename>Countable</interfacename>
+    </oointerface>
+    <oointerface>
+     <interfacename>IteratorAggregate</interfacename>
+    </oointerface>
+    <oointerface>
+     <interfacename>JsonSerializable</interfacename>
+    </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ds-collection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />

--- a/reference/ds/ds.hashable.xml
+++ b/reference/ds/ds.hashable.xml
@@ -38,15 +38,7 @@
 
 <!-- {{{ Synopsis -->
    <classsynopsis class="interface">
-    <ooclass><classname>Ds\Hashable</classname></ooclass>
-
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Ds\Hashable</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
+    <oointerface><interfacename>Ds\Hashable</interfacename></oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ds-hashable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />

--- a/reference/ds/ds.sequence.xml
+++ b/reference/ds/ds.sequence.xml
@@ -38,17 +38,15 @@
 
 <!-- {{{ Synopsis -->
    <classsynopsis class="interface">
-    <ooclass><classname>Ds\Sequence</classname></ooclass>
+    <oointerface><interfacename>Ds\Sequence</interfacename></oointerface>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-
-    <ooclass><classname>Ds\Sequence</classname></ooclass>
-    <oointerface><interfacename>Ds\Collection</interfacename></oointerface>
-    <oointerface><interfacename>ArrayAccess</interfacename></oointerface>
-
-    </classsynopsisinfo>
-<!-- }}} -->
+    <oointerface>
+     <modifier>extends</modifier>
+     <interfacename>Ds\Collection</interfacename>
+    </oointerface>
+    <oointerface>
+     <interfacename>ArrayAccess</interfacename>
+    </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ds-sequence')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />


### PR DESCRIPTION
per title, this fixes the current build issues.
this is accomplished by updating the Data Structures docs to match the examples from here: https://github.com/php/doc-en/pull/2563
once merged these interfaces will use the proper new syntax and fixes both the builds and the current render issues on php.net