### PR TITLE
Add missing inherited methods to DS extension docs

### DIFF
--- a/reference/ds/ds.collection.xml
+++ b/reference/ds/ds.collection.xml
@@ -44,6 +44,9 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.countable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])">
      <xi:fallback/>
     </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoraggregate')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])">
+     <xi:fallback/>
+    </xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.jsonserializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])">
      <xi:fallback/>
     </xi:include>

--- a/reference/ds/ds.sequence.xml
+++ b/reference/ds/ds.sequence.xml
@@ -55,6 +55,15 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ds-collection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
      <xi:fallback/>
     </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.countable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoraggregate')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.jsonserializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])">
+     <xi:fallback/>
+    </xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayaccess')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])">
      <xi:fallback/>
     </xi:include>


### PR DESCRIPTION
Per title, this fixes one thing I noticed after my quick PR to fix the broken builds.
So now DS Collection shows the method from IteratorAggregate.
And sequence shows all the ones it inherits from Collection too.