### PR TITLE
Fix minor spelling errors in the sodium_crypto_secretbox docs

### DIFF
--- a/reference/sodium/functions/sodium-crypto-secretbox-open.xml
+++ b/reference/sodium/functions/sodium-crypto-secretbox-open.xml
@@ -93,7 +93,7 @@ $key = random_bytes(SODIUM_CRYPTO_SECRETBOX_KEYBYTES);
 $nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
 $ciphertext = sodium_crypto_secretbox('message to be encrypted', $nonce, $key);
 
-// The same nouce and key are required to decrypt the $ciphertext
+// The same nonce and key are required to decrypt the $ciphertext
 $plaintext = sodium_crypto_secretbox_open($ciphertext, $nonce, $key);
 if ($plaintext !== false) {
     echo $plaintext . PHP_EOL;

--- a/reference/sodium/functions/sodium-crypto-secretbox.xml
+++ b/reference/sodium/functions/sodium-crypto-secretbox.xml
@@ -99,7 +99,7 @@ $plaintext = "message to be encrypted";
 $ciphertext = sodium_crypto_secretbox($plaintext, $nonce, $key);
 
 var_dump(bin2hex($ciphertext));
-// The same nouce and key are required to decrypt the $ciphertext
+// The same nonce and key are required to decrypt the $ciphertext
 var_dump(sodium_crypto_secretbox_open($ciphertext, $nonce, $key));
 ?>
 ]]>


### PR DESCRIPTION
This corrects 2 instances of the word _nonce_ misspelled as _nouce_ in the documentation for `sodium_crypto_secretbox()` and `sodium_crypto_secretbox_open()`