### PR TITLE
mb_convert_kana throws ValueError when impossible combination since PHP 8.2

### DIFF
--- a/reference/mbstring/functions/mb-convert-kana.xml
+++ b/reference/mbstring/functions/mb-convert-kana.xml
@@ -165,6 +165,15 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Throws a <classname>ValueError</classname> if
+   combination of <parameter>mode</parameter> is invalid. (ex: "s" and "S").
+  </para>
+ </refsect1>
+
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -178,7 +187,10 @@
     <tbody>
       <row>
         <entry>8.2.0</entry>
-        <entry>Throw ValueError when impossible combinations (ex: "sS" throws ValueError)</entry>
+        <entry>
+          <classname>ValueError</classname> is thrown if the 
+   combination of <parameter>mode</parameter> is invalid. (ex: "s" and "S")
+        </entry>
       </row>
      &mbstring.changelog.encoding-nullable;
     </tbody>

--- a/reference/mbstring/functions/mb-convert-kana.xml
+++ b/reference/mbstring/functions/mb-convert-kana.xml
@@ -176,6 +176,10 @@
      </row>
     </thead>
     <tbody>
+      <row>
+        <entry>8.2.0</entry>
+        <entry>Throw ValueError when impossible combinations (ex: "sS" throws ValueError)</entry>
+      </row>
      &mbstring.changelog.encoding-nullable;
     </tbody>
    </tgroup>

--- a/reference/mbstring/functions/mb-convert-kana.xml
+++ b/reference/mbstring/functions/mb-convert-kana.xml
@@ -188,7 +188,7 @@
       <row>
         <entry>8.2.0</entry>
         <entry>
-          <classname>ValueError</classname> is thrown if the 
+          <classname>ValueError</classname> is thrown if the
    combination of <parameter>mode</parameter> is invalid. (ex: "s" and "S")
         </entry>
       </row>


### PR DESCRIPTION
Throws ValueError since PHP 8.2.
I add ChangeLog section it.

```php
mb_convert_kana("abc", "sS", "UTF-8");

Fatal error: Uncaught ValueError: mb_convert_kana(): Argument #2 ($mode) must not combine 'S' and 's' flags in /in/gvk4D:3
Stack trace:
#0 /in/gvk4D(3): mb_convert_kana('abc', 'sS', 'UTF-8')
#1 {main}
  thrown in /in/gvk4D on line 3
```

3v4l <https://3v4l.org/gvk4D>
