### PR TITLE
Clarify `array_diff_(u)assoc` examples

### DIFF
--- a/reference/array/functions/array-diff-assoc.xml
+++ b/reference/array/functions/array-diff-assoc.xml
@@ -87,17 +87,19 @@
    <example>
     <title><function>array_diff_assoc</function> example</title>
     <para>
-     In this example you see the <literal>"a" =&gt; "green"</literal>
+     In this example the <literal>"a" =&gt; "green"</literal>
      pair is present in both arrays and thus it is not in the output from the
      function. Unlike this, the pair <literal>0 =&gt; "red"</literal>
-     is in the output because in the second argument <literal>"red"</literal>
-     has key which is <literal>1</literal>.
+     is in the output because the key of <literal>"red"</literal> is
+     automatically assigned to <literal>0</literal> in the first array,
+     whereas it is assigned to <literal>1</literal> in the second array as the
+     key <literal>0</literal> is already taken by <literal>yellow</literal>.
     </para>
     <programlisting role="php">
 <![CDATA[
 <?php
 $array1 = array("a" => "green", "b" => "brown", "c" => "blue", "red");
-$array2 = array("a" => "green", "yellow", 1 => "red");
+$array2 = array("a" => "green", "yellow", "red");
 $result = array_diff_assoc($array1, $array2);
 print_r($result);
 ?>
@@ -153,14 +155,14 @@ Array
   &reftitle.notes;
   <note>
    <simpara>
-    This function only checks one dimension of a n-dimensional
-    array. Of course you can check deeper dimensions by using, for example,
+    This function only checks one dimension of an n-dimensional
+    array. It is possible to check deeper dimensions by using, for example,
     <literal>array_diff_assoc($array1[0], $array2[0]);</literal>.
    </simpara>
   </note>
   <note>
    <simpara>
-    Ensure you pass arguments in the correct order when comparing similar 
+    Ensure arguments are passed in the correct order when comparing similar
     arrays with more keys. The new array should be the first in the list.
    </simpara>
   </note>

--- a/reference/array/functions/array-diff-uassoc.xml
+++ b/reference/array/functions/array-diff-uassoc.xml
@@ -80,25 +80,24 @@
    <example>
     <title><function>array_diff_uassoc</function> example</title>
     <para>
-     The <literal>"a" =&gt; "green"</literal>
+     In this example the <literal>"a" =&gt; "green"</literal>
      pair is present in both arrays and thus it is not in the output from the
      function. Unlike this, the pair <literal>0 =&gt; "red"</literal>
-     is in the output because in the second argument <literal>"red"</literal>
-     has key which is <literal>1</literal>.
+     is in the output because the key of <literal>"red"</literal> is
+     automatically assigned to <literal>0</literal> in the first array,
+     whereas it is assigned to <literal>1</literal> in the second array as the
+     key <literal>0</literal> is already taken by <literal>yellow</literal>.
     </para>
     <programlisting role="php">
 <![CDATA[
 <?php
 function key_compare_func($a, $b)
 {
-    if ($a === $b) {
-        return 0;
-    }
-    return ($a > $b)? 1:-1;
+    return $a <=> $b;
 }
 
 $array1 = array("a" => "green", "b" => "brown", "c" => "blue", "red");
-$array2 = array("a" => "green", "yellow", 1 => "red");
+$array2 = array("a" => "green", "yellow", "red");
 $result = array_diff_uassoc($array1, $array2, "key_compare_func");
 print_r($result);
 ?>
@@ -126,8 +125,8 @@ Array
   &reftitle.notes;
   <note>
    <para>
-    This function only checks one dimension of a n-dimensional
-    array. Of course you can check deeper dimensions by using, for example,
+    This function only checks one dimension of an n-dimensional
+    array. It is possible to check deeper dimensions by using, for example,
     <literal>array_diff_uassoc($array1[0], $array2[0], "key_compare_func");</literal>.
    </para>
   </note>


### PR DESCRIPTION
Fix https://github.com/php/doc-en/issues/2631

My last try to clarify this wasn't the good fix. I try here to clarify what happens with `array_diff_(u)assoc` and why `red` is present in the output.