### PR TITLE
Fix GH-2450: mention when ArgumentCountError being thrown by built-in functions

### DIFF
--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -306,6 +306,10 @@ function test(int $arg = null) {}
         Attempting to access unqualified constants which are undefined.
         Previously, unqualified constant accesses resulted in a warning and were interpreted as strings.
        </member>
+       <member>
+        Passing the wrong number of arguments to a non-variadic built-in
+        function will throw an <classname>ArgumentCountError</classname>.
+       </member>
       </simplelist>
      </para>
      <para>

--- a/language/predefined/argumentcounterror.xml
+++ b/language/predefined/argumentcounterror.xml
@@ -13,6 +13,10 @@
     <ooclass><classname>ArgumentCountError</classname></ooclass> is thrown
     when too few arguments are passed to a user-defined function or method.
    </para>
+   <para>
+    This error is also thrown when too many arguments are passed to a
+    non-variadic built-in function.
+   </para>
   </section>
 <!-- }}} -->
  


### PR DESCRIPTION
Fix https://github.com/php/doc-en/issues/2450