### PR TITLE
[skip-revcheck] Normalize entity usage on classsynopsisinfo.

### DIFF
--- a/reference/lua/lua.xml
+++ b/reference/lua/lua.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>string</type>

--- a/reference/zmq/zmqcontext.xml
+++ b/reference/zmq/zmqcontext.xml
@@ -32,7 +32,7 @@
     </classsynopsisinfo>
 <!-- }}} -->
     
-    <classsynopsisinfo role="comment">Methods</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqcontext')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/zmq/zmqcontextexception.xml
+++ b/reference/zmq/zmqcontextexception.xml
@@ -36,13 +36,13 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Properties</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
     
-    <classsynopsisinfo role="comment">Methods</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqcontextexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
     
-    <classsynopsisinfo role="comment">Inherited methods</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>

--- a/reference/zmq/zmqdevice.xml
+++ b/reference/zmq/zmqdevice.xml
@@ -32,7 +32,7 @@
     </classsynopsisinfo>
 <!-- }}} -->
     
-    <classsynopsisinfo role="comment">Methods</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqdevice')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/zmq/zmqdeviceexception.xml
+++ b/reference/zmq/zmqdeviceexception.xml
@@ -36,13 +36,13 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Properties</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
     
-    <classsynopsisinfo role="comment">Methods</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqdeviceexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
     
-    <classsynopsisinfo role="comment">Inherited methods</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>

--- a/reference/zmq/zmqexception.xml
+++ b/reference/zmq/zmqexception.xml
@@ -36,13 +36,13 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Properties</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
     
-    <classsynopsisinfo role="comment">Methods</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
     
-    <classsynopsisinfo role="comment">Inherited methods</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>

--- a/reference/zmq/zmqpoll.xml
+++ b/reference/zmq/zmqpoll.xml
@@ -32,7 +32,7 @@
     </classsynopsisinfo>
 <!-- }}} -->
     
-    <classsynopsisinfo role="comment">Methods</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqpoll')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/zmq/zmqpollexception.xml
+++ b/reference/zmq/zmqpollexception.xml
@@ -36,13 +36,13 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Properties</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
     
-    <classsynopsisinfo role="comment">Methods</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqpollexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
     
-    <classsynopsisinfo role="comment">Inherited methods</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>

--- a/reference/zmq/zmqsocket.xml
+++ b/reference/zmq/zmqsocket.xml
@@ -32,7 +32,7 @@
     </classsynopsisinfo>
 <!-- }}} -->
     
-    <classsynopsisinfo role="comment">Methods</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqsocket')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/zmq/zmqsocketexception.xml
+++ b/reference/zmq/zmqsocketexception.xml
@@ -36,13 +36,13 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Properties</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
-    
-    <classsynopsisinfo role="comment">Methods</classsynopsisinfo>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqsocketexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    
-    <classsynopsisinfo role="comment">Inherited methods</classsynopsisinfo>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>


### PR DESCRIPTION
These files are the last on English still using strings instead of entities on `<classsynopsisinfo>`.