### PR TITLE
remove unnecessary operation in code example

### DIFF
--- a/language/variables.xml
+++ b/language/variables.xml
@@ -455,7 +455,6 @@ function test()
     if ($count < 10) {
         test();
     }
-    $count--;
 }
 ?>
 ]]>


### PR DESCRIPTION
in this example, `$count--` at the end of the function helps with nothing. Its existence also does not harm anything. But because in the same file, in "Example # 4 Example demonstrating need for static variables" we were talking about how useless `$a++` is in that example, putting a useless `$count--` can be misleading in this example, because the reader may look for the philosophy/reason behind existence of this statement.