### PR TITLE
Better phrasing and code example for PDO connection management

### DIFF
--- a/reference/pdo/connections.xml
+++ b/reference/pdo/connections.xml
@@ -46,7 +46,7 @@ try {
  <warning>
   <para>
    If a <literal>PDOException</literal> object thrown from the PDO constructor
-   is not caught either explicitly (via a <literal>catch</literal> statement)
+   is not caught either explicitly (via a &catch; statement)
    or implicitly via <function>set_exception_handler</function>.
    Otherwise, the default behaviour of converting an uncaught exception to a
    <constant>E_FATAL_ERROR</constant> will occur.

--- a/reference/pdo/connections.xml
+++ b/reference/pdo/connections.xml
@@ -47,12 +47,13 @@ try {
   <para>
    If a <literal>PDOException</literal> object thrown from the PDO constructor
    is not caught either explicitly (via a <literal>catch</literal> statement)
-   or implicitly via <function>set_exception_handler</function>, the default
-   action taken by the zend engine is to convert the exception into a fatal error
-   that contains a back trace. This back trace will likely reveal database
-   connection details. It is your responsibility to set the &php.ini; option
+   or implicitly via <function>set_exception_handler</function>.
+   Otherwise, the default behaviour of converting an uncaught exception to a
+   <constant>E_FATAL_ERROR</constant> will occur.
+   The fatal error will contain a back trace that can leak connection details.
+   As such, the &php.ini; option
    <link linkend="ini.display-errors"><parameter>display_errors</parameter></link>
-   to 0 on a live server as not to reveal this information.
+   should be set to <literal>0</literal> on a production server.
   </para>
  </warning>
  <para>

--- a/reference/pdo/connections.xml
+++ b/reference/pdo/connections.xml
@@ -45,9 +45,9 @@ try {
  </para>
  <warning>
   <para>
-   If a <literal>PDOException</literal> object thrown from the PDO constructor
-   is not caught either explicitly (via a &catch; statement)
-   or implicitly via <function>set_exception_handler</function>.
+   Just like any other <link linkend="language.exceptions">exception</link>,
+   <literal>PDOException</literal> could be caught either explicitly, via
+   a &catch; statement, or implicitly via <function>set_exception_handler</function>.
    Otherwise, the default behaviour of converting an uncaught exception to a
    <constant>E_FATAL_ERROR</constant> will occur.
    The fatal error will contain a back trace that can leak connection details.

--- a/reference/pdo/connections.xml
+++ b/reference/pdo/connections.xml
@@ -46,13 +46,13 @@ try {
  <warning>
   <para>
    Just like any other <link linkend="language.exceptions">exception</link>,
-   <literal>PDOException</literal> could be caught either explicitly, via
+   <classname>PDOException</classname> could be caught either explicitly, via
    a &catch; statement, or implicitly via <function>set_exception_handler</function>.
    Otherwise, the default behaviour of converting an uncaught exception to a
    <constant>E_FATAL_ERROR</constant> will occur.
-   The fatal error will contain a back trace that can leak connection details.
+   The fatal error will contain a backtrace that can leak connection details.
    As such, the &php.ini; option
-   <link linkend="ini.display-errors"><parameter>display_errors</parameter></link>
+   <link linkend="ini.display-errors"><literal>display_errors</literal></link>
    should be set to <literal>0</literal> on a production server.
   </para>
  </warning>

--- a/reference/pdo/connections.xml
+++ b/reference/pdo/connections.xml
@@ -36,28 +36,23 @@ $dbh = new PDO('mysql:host=localhost;dbname=test', $user, $pass);
 <?php
 try {
     $dbh = new PDO('mysql:host=localhost;dbname=test', $user, $pass);
-    foreach($dbh->query('SELECT * from FOO') as $row) {
-        print_r($row);
-    }
-    $dbh = null;
 } catch (PDOException $e) {
-    print "Error!: " . $e->getMessage() . "<br/>";
-    die();
+    // attempt to retry the connection after some timeout for example
 }
-?>
 ]]>
    </programlisting>
   </example>
  </para>
  <warning>
   <para>
-   If your application does not catch the exception thrown from the PDO
-   constructor, the default action taken by the zend engine is to terminate
-   the script and display a back trace.  This back trace will likely reveal
-   the full database connection details, including the username and
-   password.  It is your responsibility to catch this exception, either
-   explicitly (via a <literal>catch</literal> statement) or implicitly via
-   <function>set_exception_handler</function>.
+   If a <literal>PDOException</literal> object thrown from the PDO constructor
+   is not caught either explicitly (via a <literal>catch</literal> statement)
+   or implicitly via <function>set_exception_handler</function>, the default
+   action taken by the zend engine is to convert the exception into a fatal error
+   that contains a back trace. This back trace will likely reveal database
+   connection details. It is your responsibility to set the &php.ini; option
+   <link linkend="ini.display-errors"><parameter>display_errors</parameter></link>
+   to 0 on a live server as not to reveal this information.
   </para>
  </warning>
  <para>


### PR DESCRIPTION
The current phrasing appears to be incorrect. The Zend engine doesn't necessarily display the error and back trace. And catching exception is not required in order to hide the sensitive information.