### PR TITLE
datetime modify: add examples with other formats

### DIFF
--- a/reference/datetime/datetime/modify.xml
+++ b/reference/datetime/datetime/modify.xml
@@ -100,6 +100,33 @@ echo $date->format('Y-m-d') . "\n";
 ]]>
    </screen>
   </example>
+  <example>
+   <title>All formats of Date and Time are supported</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$date = new DateTime('2020-12-31');
+
+$date->modify('July 1st, 2023');
+echo $date->format('Y-m-d H:i') . "\n";
+
+$date->modify('Monday next week');
+echo $date->format('Y-m-d H:i') . "\n";
+
+$date->modify('17:30');
+echo $date->format('Y-m-d H:i') . "\n";
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+2023-07-01 00:00
+2023-07-03 00:00
+2023-07-03 17:30
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
The current page only shows examples that use the relative formats: https://www.php.net/manual/en/datetime.modify.php

I added examples with other formats so that users can see that not only the relative format is supported.


See also:

- #2674