### PR TITLE
Improve tag semantic usage

### DIFF
--- a/features/file-upload.xml
+++ b/features/file-upload.xml
@@ -371,7 +371,7 @@ foreach ($_FILES["pictures"]["error"] as $key => $error) {
      <link linkend="ini.max-input-time">max_input_time</link> sets the maximum
      time, in seconds, the script is allowed to receive input; this includes
      file uploads.  For large or multiple files, or users on slower connections,
-     the default of <literal>60 seconds</literal> may be exceeded.
+     the default of <literal>60</literal> seconds may be exceeded.
     </simpara>
    </warning>
    <simpara>

--- a/features/xforms.xml
+++ b/features/xforms.xml
@@ -9,7 +9,7 @@
  </para>
  <para>
   The first key difference in XForms is how the form is sent to the client.
-  <link xlink:href="&url.xforms.htmlauthors;"><literal>XForms for HTML Authors</literal></link>
+  <link xlink:href="&url.xforms.htmlauthors;">XForms for HTML Authors</link>
   contains a detailed description of how to create XForms, for the purpose
   of this tutorial we'll only be looking at a simple example.
  </para>

--- a/language/oop5/constants.xml
+++ b/language/oop5/constants.xml
@@ -15,7 +15,7 @@
   </para>
  </note>
  <para>
-  It's also possible for interfaces to have <literal>constants</literal>. Look
+  It's also possible for interfaces to have constants. Look
   at the <link linkend="language.oop5.interfaces">interface documentation</link>
   for examples.
  </para>

--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -179,8 +179,8 @@ Stack trace:
      because such a function is contradictory.
      Previously, it already emitted the following
      <constant>E_NOTICE</constant> when called:
-     <literal>Only variable references should be returned by reference</literal>.
-
+     <emphasis role="strong">Only variable references should be returned by
+     reference</emphasis>.
      <informalexample>
       <programlisting role="php">
 <![CDATA[

--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -179,8 +179,7 @@ Stack trace:
      because such a function is contradictory.
      Previously, it already emitted the following
      <constant>E_NOTICE</constant> when called:
-     <emphasis role="strong">Only variable references should be returned by
-     reference</emphasis>.
+     <computeroutput>Only variable references should be returned by reference</computeroutput>.
      <informalexample>
       <programlisting role="php">
 <![CDATA[

--- a/reference/math/functions/pow.xml
+++ b/reference/math/functions/pow.xml
@@ -81,7 +81,7 @@ echo pow(-1, 5.5); // NAN
   <note>
    <para>
     This function will convert all input to a number, even non-scalar values,
-    which could lead to <literal>weird</literal> results.
+    which could lead to <emphasis>weird</emphasis> results.
    </para>
   </note>
  </refsect1>

--- a/reference/mysqli/mysqli/real-escape-string.xml
+++ b/reference/mysqli/mysqli/real-escape-string.xml
@@ -49,8 +49,9 @@
        The string to be escaped.
       </para>
       <para>
-       Characters encoded are <literal>NUL (ASCII 0), \n, \r, \, ', ", and
-       Control-Z</literal>.
+       Characters encoded are <literal>NUL (ASCII 0)</literal>,
+       <literal>\n</literal>, <literal>\r</literal>, <literal>\</literal>,
+       <literal>'</literal>, <literal>"</literal> and <literal>Control-Z</literal>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mysqli/mysqli/real-escape-string.xml
+++ b/reference/mysqli/mysqli/real-escape-string.xml
@@ -51,7 +51,8 @@
       <para>
        Characters encoded are <literal>NUL (ASCII 0)</literal>,
        <literal>\n</literal>, <literal>\r</literal>, <literal>\</literal>,
-       <literal>'</literal>, <literal>"</literal> and <literal>Control-Z</literal>.
+       <literal>'</literal>, <literal>"</literal>, and
+       <keycombo action='simul'><keycap>CTRL</keycap><keycap>Z</keycap></keycombo>.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
This commit changes tag usage without changing text contents. I'm in doubt to submit it with or without `[skip-revcheck]`.