### PR TITLE
Clarify the output of example code

### DIFF
--- a/language/variables.xml
+++ b/language/variables.xml
@@ -266,7 +266,7 @@ test();
 
    <simpara>
     As of PHP 8, this script will generate an undefined variable warning and will not produce 
-    any output if the display_errors directive is set to hide warnings, because the echo statement
+    any output if the <link linkend="ini.display-errors">display_errors</link> directive of the &php.ini; file is set to hide warnings, because the echo statement
     refers to a local version of the <varname>$a</varname> variable,
     and it has not been assigned a value within this scope.  You may
     notice that this is a little bit different from the C language in

--- a/language/variables.xml
+++ b/language/variables.xml
@@ -265,8 +265,12 @@ test();
    </informalexample>
 
    <simpara>
-    As of PHP 8, this script will generate an undefined variable warning and will not produce 
-    any output if the <link linkend="ini.display-errors">display_errors</link> directive of the &php.ini; file is set to hide warnings, because the echo statement
+    This script will generate an undefined variable <constant>E_WARNING</constant>
+    (or a <constant>E_NOTICE</constant> prior to PHP 8.0.0)
+    diagnostic. However, if the
+    <link linkend="ini.display-errors">display_errors</link> INI setting is set to hide
+    such diagnostics then nothing at all will be outputted.
+    This is because the echo statement
     refers to a local version of the <varname>$a</varname> variable,
     and it has not been assigned a value within this scope.  You may
     notice that this is a little bit different from the C language in

--- a/language/variables.xml
+++ b/language/variables.xml
@@ -265,7 +265,8 @@ test();
    </informalexample>
 
    <simpara>
-    This script will not produce any output because the echo statement
+    As of PHP 8, this script will generate an undefined variable warning and will not produce 
+    any output if the display_errors directive is set to hide warnings, because the echo statement
     refers to a local version of the <varname>$a</varname> variable,
     and it has not been assigned a value within this scope.  You may
     notice that this is a little bit different from the C language in


### PR DESCRIPTION
Accessing undefined variables generate an E_WARNING since PHP 8 (and will result in error exceptions being thrown in PHP 9).