### PR TITLE
update intval doc with explicit binary numeral notation

### DIFF
--- a/reference/var/functions/intval.xml
+++ b/reference/var/functions/intval.xml
@@ -53,6 +53,12 @@
          </listitem>
          <listitem>
           <simpara>
+           if string starts with a "0b" (or "0B"), the base is taken
+           as 2 (binary); otherwise,
+          </simpara>
+         </listitem>
+         <listitem>
+          <simpara>
            if string starts with "0", the base is taken as 8 (octal);
            otherwise,
           </simpara>


### PR DESCRIPTION
In `intval` function, the `base` parameter allows to set the desired base to convert a string to int.

The base "0" works as "automatic base", the base will be detected:

```php
echo intval('101', 0);   // 101
echo intval('0x101', 0); // 257
echo intval('0X101', 0); // 257
echo intval('0b101', 0); // 5
echo intval('0B101', 0); // 5
echo intval('0101', 0);  // 65
```

I updated the documentation to include binary `0b` and `0B` prefixes.

I would have liked to do the same for octal numeral notation, but `0o` and `0O` seems to not be implemented yet, only `0` works.