### PR TITLE
Revert "Fix GH-2635: Fix switch alternative syntax (#2648)"

### DIFF
--- a/language/control-structures/alternative-syntax.xml
+++ b/language/control-structures/alternative-syntax.xml
@@ -67,10 +67,9 @@ endif;
    <programlisting role="php">
 <![CDATA[
 <?php switch ($foo): ?>
-
     <?php case 1: ?>
     ...
-<?php endswitch; ?>
+<?php endswitch ?>
 ]]>
    </programlisting>
   </informalexample>
@@ -86,7 +85,7 @@ endif;
 <?php switch ($foo): ?>
 <?php case 1: ?>
     ...
-<?php endswitch; ?>
+<?php endswitch ?>
 ]]>
    </programlisting>
   </informalexample>


### PR DESCRIPTION
As per the discussion in php/doc-en#2648, the part that might actually be unexpected is that leading indentation also causes problems.  The addition of the empty line distracts from that. Now that the CSS for PHP.net is fixed, this can be reverted.

This reverts commit 1d73d6e34f2963c42456dbb8384bc15f5fa5642a.

see php/web-php#801