### PR TITLE
Re-add the semicolon after `endswitch` in alternative-syntax.xml

### DIFF
--- a/language/control-structures/alternative-syntax.xml
+++ b/language/control-structures/alternative-syntax.xml
@@ -69,7 +69,7 @@ endif;
 <?php switch ($foo): ?>
     <?php case 1: ?>
     ...
-<?php endswitch ?>
+<?php endswitch; ?>
 ]]>
    </programlisting>
   </informalexample>
@@ -85,7 +85,7 @@ endif;
 <?php switch ($foo): ?>
 <?php case 1: ?>
     ...
-<?php endswitch ?>
+<?php endswitch; ?>
 ]]>
    </programlisting>
   </informalexample>


### PR DESCRIPTION
This was part of an unrelated commit and is now re-added in a dedicated single-purpose commit.

see #2648
see #2693