### PR TITLE
[skip-revcheck] Normalize &Constants; and &Methods; usage

### DIFF
--- a/reference/cmark/commonmark.interfaces.ivisitor.xml
+++ b/reference/cmark/commonmark.interfaces.ivisitor.xml
@@ -32,7 +32,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/ds/ds.deque.xml
+++ b/reference/ds/ds.deque.xml
@@ -83,7 +83,7 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/ds/ds.map.xml
+++ b/reference/ds/ds.map.xml
@@ -64,7 +64,7 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/ds/ds.priorityqueue.xml
+++ b/reference/ds/ds.priorityqueue.xml
@@ -50,7 +50,7 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/ds/ds.queue.xml
+++ b/reference/ds/ds.queue.xml
@@ -40,7 +40,7 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/ds/ds.set.xml
+++ b/reference/ds/ds.set.xml
@@ -77,7 +77,7 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/ds/ds.vector.xml
+++ b/reference/ds/ds.vector.xml
@@ -71,7 +71,7 @@
 
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/ev/ev.xml
+++ b/reference/ev/ev.xml
@@ -29,7 +29,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
 <!--{{{-->
     <fieldsynopsis>
      <modifier>const</modifier>

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -55,7 +55,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/event/eventbase.xml
+++ b/reference/event/eventbase.xml
@@ -69,7 +69,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/event/eventbuffer.xml
+++ b/reference/event/eventbuffer.xml
@@ -33,7 +33,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/event/eventbufferevent.xml
+++ b/reference/event/eventbufferevent.xml
@@ -65,7 +65,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/event/eventconfig.xml
+++ b/reference/event/eventconfig.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/event/eventdnsbase.xml
+++ b/reference/event/eventdnsbase.xml
@@ -29,7 +29,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/event/eventhttprequest.xml
+++ b/reference/event/eventhttprequest.xml
@@ -27,7 +27,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/event/eventlistener.xml
+++ b/reference/event/eventlistener.xml
@@ -28,7 +28,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/event/eventsslcontext.xml
+++ b/reference/event/eventsslcontext.xml
@@ -30,7 +30,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/event/eventutil.xml
+++ b/reference/event/eventutil.xml
@@ -29,7 +29,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/gender/gender.xml
+++ b/reference/gender/gender.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -404,7 +404,7 @@
      <varname linkend="gender.constants.korea">Gender\Gender::KOREA</varname>
      <initializer>53</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gender')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
      <xi:fallback/>
@@ -416,7 +416,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ Gender\Gender constants -->
   <section xml:id="gender.constants">
    &reftitle.constants;

--- a/reference/hrtime/hrtime.unit.xml
+++ b/reference/hrtime/hrtime.unit.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -56,7 +56,7 @@
      <varname linkend="hrtime-unit.constants.nanosecond">HRTime\Unit::NANOSECOND</varname>
      <initializer>3</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook)
     xpointer(id('class.hrtime-unit')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"
@@ -65,7 +65,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ HRTime\Unit constants -->
   <section xml:id="hrtime-unit.constants">
    &reftitle.constants;

--- a/reference/luasandbox/luasandbox.xml
+++ b/reference/luasandbox/luasandbox.xml
@@ -32,7 +32,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/luasandbox/luasandboxerror.xml
+++ b/reference/luasandbox/luasandboxerror.xml
@@ -36,7 +36,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/mongodb/bson/binary.xml
+++ b/reference/mongodb/bson/binary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-bson-binary" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -55,7 +55,7 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -110,14 +110,14 @@
      <varname linkend="mongodb-bson-binary.constants.type-user-defined">MongoDB\BSON\Binary::TYPE_USER_DEFINED</varname>
      <initializer>128</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-binary')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ MongoDB\BSON\Binary constants -->
   <section xml:id="mongodb-bson-binary.constants">
    &reftitle.constants;

--- a/reference/mongodb/mongodb/driver/clientencryption.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption.xml
@@ -36,7 +36,7 @@
     <!-- }}} -->
 
     <!-- {{{ MongoDB\Driver\ReadPreference constants -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>string</type>

--- a/reference/mongodb/mongodb/driver/readconcern.xml
+++ b/reference/mongodb/mongodb/driver/readconcern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-driver-readconcern" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -42,7 +42,7 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>string</type>
@@ -73,14 +73,14 @@
      <varname linkend="mongodb-driver-readconcern.constants.snapshot">MongoDB\Driver\ReadConcern::SNAPSHOT</varname>
      <initializer>"snapshot"</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-readconcern')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ MongoDB\Driver\ReadConcern constants -->
   <section xml:id="mongodb-driver-readconcern.constants">
    &reftitle.constants;

--- a/reference/mongodb/mongodb/driver/readpreference.xml
+++ b/reference/mongodb/mongodb/driver/readpreference.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-driver-readpreference" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -40,7 +40,7 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -120,7 +120,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ MongoDB\Driver\ReadPreference constants -->
   <section xml:id="mongodb-driver-readpreference.constants">
    &reftitle.constants;

--- a/reference/mongodb/mongodb/driver/server.xml
+++ b/reference/mongodb/mongodb/driver/server.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-driver-server" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -32,7 +32,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -100,7 +100,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ MongoDB\Driver\Server constants -->
   <section xml:id="mongodb-driver-server.constants">
    &reftitle.constants;

--- a/reference/mongodb/mongodb/driver/serverapi.xml
+++ b/reference/mongodb/mongodb/driver/serverapi.xml
@@ -39,7 +39,7 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>string</type>

--- a/reference/mongodb/mongodb/driver/serverdescription.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-driver-serverdescription" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -36,7 +36,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>string</type>
@@ -104,7 +104,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ MongoDB\Driver\ServerDescription constants -->
   <section xml:id="mongodb-driver-serverdescription.constants">
    &reftitle.constants;

--- a/reference/mongodb/mongodb/driver/session.xml
+++ b/reference/mongodb/mongodb/driver/session.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-driver-session" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -36,7 +36,7 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>string</type>

--- a/reference/mongodb/mongodb/driver/topologydescription.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-driver-topologydescription" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -36,7 +36,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>string</type>
@@ -80,7 +80,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ MongoDB\Driver\TopologyDescription constants -->
   <section xml:id="mongodb-driver-topologydescription.constants">
    &reftitle.constants;

--- a/reference/mongodb/mongodb/driver/writeconcern.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-driver-writeconcern" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -44,21 +44,21 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>string</type>
      <varname linkend="mongodb-driver-writeconcern.constants.majority">MongoDB\Driver\WriteConcern::MAJORITY</varname>
      <initializer>"majority"</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-writeconcern')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ MongoDB\Driver\WriteConcern constants -->
   <section xml:id="mongodb-driver-writeconcern.constants">
    &reftitle.constants;

--- a/reference/mysql_xdevapi/mysql-xdevapi.driver.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.driver.xml
@@ -31,21 +31,21 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>string</type>
      <varname linkend="mysql-xdevapi-driver.constants.version">mysql_xdevapi\Driver::version</varname>
      <initializer>8.0.3</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysql-xdevapi-driver')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ mysql_xdevapi\Driver constants -->
   <section xml:id="mysql-xdevapi-driver.constants">
    &reftitle.constants;

--- a/reference/mysql_xdevapi/mysql-xdevapi.sqlstatement.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.sqlstatement.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -51,7 +51,7 @@
      <varname linkend="mysql-xdevapi-sqlstatement.props.statement">statement</varname>
     </fieldsynopsis>
 
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysql-xdevapi-sqlstatement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
@@ -59,7 +59,7 @@
 
   </section>
 
-  
+
 <!-- {{{ mysql_xdevapi\SqlStatement properties -->
   <section xml:id="mysql-xdevapi-sqlstatement.props">
    &reftitle.properties;
@@ -74,7 +74,7 @@
   </section>
 <!-- }}} -->
 
-  
+
 <!-- {{{ mysql_xdevapi\SqlStatement constants -->
   <section xml:id="mysql-xdevapi-sqlstatement.constants">
    &reftitle.constants;

--- a/reference/mysql_xdevapi/mysql-xdevapi.statement.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.statement.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -44,14 +44,14 @@
      <varname linkend="mysql-xdevapi-statement.constants.buffered">mysql_xdevapi\Statement::BUFFERED</varname>
      <initializer>2</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysql-xdevapi-statement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ mysql_xdevapi\Statement constants -->
   <section xml:id="mysql-xdevapi-statement.constants">
    &reftitle.constants;

--- a/reference/parle/parle.lexer.xml
+++ b/reference/parle/parle.lexer.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -62,7 +62,7 @@
      <varname linkend="parle-lexer.constants.flag-regex-match-zero-len">Parle\Lexer::MATCH_ZERO_LEN</varname>
      <initializer>16</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>public</modifier>
@@ -101,7 +101,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ Parle\Lexer constants -->
   <section xml:id="parle-lexer.constants">
    &reftitle.constants;

--- a/reference/parle/parle.parser.xml
+++ b/reference/parle/parle.parser.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -80,7 +80,7 @@
      <varname linkend="parle-parser.constants.error-unknown-token">Parle\Parser::ERROR_UNKNOWN_TOKEN</varname>
      <initializer>2</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>public</modifier>
@@ -101,7 +101,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ Parle\Parser constants -->
   <section xml:id="parle-parser.constants">
    &reftitle.constants;

--- a/reference/parle/parle.rlexer.xml
+++ b/reference/parle/parle.rlexer.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -62,7 +62,7 @@
      <varname linkend="parle-rlexer.constants.flag-regex-match-zero-len">Parle\RLexer::MATCH_ZERO_LEN</varname>
      <initializer>16</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>public</modifier>
@@ -101,7 +101,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ Parle\RLexer constants -->
   <section xml:id="parle-rlexer.constants">
    &reftitle.constants;

--- a/reference/parle/parle.rparser.xml
+++ b/reference/parle/parle.rparser.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -80,7 +80,7 @@
      <varname linkend="parle-rparser.constants.error-unknown-token">Parle\RParser::ERROR_UNKNOWN_TOKEN</varname>
      <initializer>2</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>public</modifier>
@@ -101,7 +101,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ Parle\RParser constants -->
   <section xml:id="parle-rparser.constants">
    &reftitle.constants;

--- a/reference/parle/parle.token.xml
+++ b/reference/parle/parle.token.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -63,7 +63,7 @@
      <varname linkend="parle-token.props.value">value</varname>
     </fieldsynopsis>
 
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <!-- Uncomment if there are some methods, same for the entities item down there. -->
     <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parle-token')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />-->
@@ -72,7 +72,7 @@
 
   </section>
 
-  
+
 <!-- {{{ Parle\Token properties -->
   <section xml:id="parle-token.props">
    &reftitle.properties;
@@ -93,7 +93,7 @@
   </section>
 <!-- }}} -->
 
-  
+
 <!-- {{{ Parle\Token constants -->
   <section xml:id="parle-token.constants">
    &reftitle.constants;

--- a/reference/solr/solrcollapsefunction.xml
+++ b/reference/solr/solrcollapsefunction.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>string</type>
@@ -50,7 +50,7 @@
      <varname linkend="solrcollapsefunction.constants.nullpolicy-collapse">SolrCollapseFunction::NULLPOLICY_COLLAPSE</varname>
      <initializer>collapse</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.solrcollapsefunction')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
      <xi:fallback />
@@ -60,7 +60,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ SolrCollapseFunction constants -->
   <section xml:id="solrcollapsefunction.constants">
    &reftitle.constants;

--- a/reference/svm/svm.xml
+++ b/reference/svm/svm.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -164,7 +164,7 @@
      <varname linkend="svm.constants.opt-cache-size">SVM::OPT_CACHE_SIZE</varname>
      <initializer>207</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.svm')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
      <xi:fallback/>
@@ -176,7 +176,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ svm constants -->
   <section xml:id="svm.constants">
    &reftitle.constants;

--- a/reference/svm/svmmodel.xml
+++ b/reference/svm/svmmodel.xml
@@ -32,8 +32,8 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    
-    <classsynopsisinfo role="comment">Methods</classsynopsisinfo>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.svmmodel')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
      <xi:fallback/>
     </xi:include>

--- a/reference/swoole/swoole.client.xml
+++ b/reference/swoole/swoole.client.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -75,7 +75,7 @@
      <varname linkend="swoole-client.props.reusecount">reuseCount</varname>
     </fieldsynopsis>
 
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.swoole-client')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
@@ -83,7 +83,7 @@
 
   </section>
 
-  
+
 <!-- {{{ Swoole\Client properties -->
   <section xml:id="swoole-client.props">
    &reftitle.properties;
@@ -116,7 +116,7 @@
   </section>
 <!-- }}} -->
 
-  
+
 <!-- {{{ Swoole\Client constants -->
   <section xml:id="swoole-client.constants">
    &reftitle.constants;

--- a/reference/swoole/swoole.coroutine.client.xml
+++ b/reference/swoole/swoole.coroutine.client.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -67,14 +67,14 @@
      <varname linkend="swoole-coroutine-client.props.sock">sock</varname>
     </fieldsynopsis>
 
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
    </classsynopsis>
 <!-- }}} -->
 
   </section>
 
-  
+
 <!-- {{{ Swoole\Coroutine\Client properties -->
   <section xml:id="swoole-coroutine-client.props">
    &reftitle.properties;
@@ -95,7 +95,7 @@
   </section>
 <!-- }}} -->
 
-  
+
 <!-- {{{ Swoole\Coroutine\Client constants -->
   <section xml:id="swoole-coroutine-client.constants">
    &reftitle.constants;

--- a/reference/swoole/swoole.process.xml
+++ b/reference/swoole/swoole.process.xml
@@ -31,21 +31,21 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
      <varname linkend="swoole-process.constants.ipc-nowait">Swoole\Process::IPC_NOWAIT</varname>
      <initializer>256</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.swoole-process')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ Swoole\Process constants -->
   <section xml:id="swoole-process.constants">
    &reftitle.constants;

--- a/reference/swoole/swoole.redis.server.xml
+++ b/reference/swoole/swoole.redis.server.xml
@@ -29,14 +29,14 @@
      <ooclass>
       <classname>Swoole\Redis\Server</classname>
      </ooclass>
-     
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>Swoole\Server</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -79,10 +79,10 @@
      <varname linkend="swoole-redis-server.constants.map">Swoole\Redis\Server::MAP</varname>
      <initializer>6</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.swoole-redis-server')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
-    
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.swoole-server')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
 
@@ -90,7 +90,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ Swoole\Redis\Server constants -->
   <section xml:id="swoole-redis-server.constants">
    &reftitle.constants;

--- a/reference/swoole/swoole.table.xml
+++ b/reference/swoole/swoole.table.xml
@@ -29,7 +29,7 @@
      <ooclass>
       <classname>Swoole\Table</classname>
      </ooclass>
-     
+
      <oointerface>
       <interfacename>Iterator</interfacename>
      </oointerface>
@@ -39,7 +39,7 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -58,14 +58,14 @@
      <varname linkend="swoole-table.constants.type-float">Swoole\Table::TYPE_FLOAT</varname>
      <initializer>6</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.swoole-table')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ Swoole\Table constants -->
   <section xml:id="swoole-table.constants">
    &reftitle.constants;

--- a/reference/ui/ui.area.xml
+++ b/reference/ui/ui.area.xml
@@ -29,14 +29,14 @@
      <ooclass>
       <classname>UI\Area</classname>
      </ooclass>
-     
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>UI\Control</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -70,7 +70,7 @@
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-area')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
-    
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-control')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
 
@@ -78,7 +78,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ UI\Area constants -->
   <section xml:id="ui-area.constants">
    &reftitle.constants;

--- a/reference/ui/ui.controls.box.xml
+++ b/reference/ui/ui.controls.box.xml
@@ -29,7 +29,7 @@
      <ooclass>
       <classname>UI\Controls\Box</classname>
      </ooclass>
-     
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>UI\Control</classname>
@@ -37,7 +37,7 @@
     </classsynopsisinfo>
 
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -57,10 +57,10 @@
 
     <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-controls-box')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-controls-box')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
-    
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-control')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
 
@@ -84,7 +84,7 @@
    </variablelist>
   </section>
 <!-- }}} -->
-  
+
 <!-- {{{ UI\Controls\Box constants -->
   <section xml:id="ui-controls-box.constants">
    &reftitle.constants;

--- a/reference/ui/ui.controls.entry.xml
+++ b/reference/ui/ui.controls.entry.xml
@@ -29,14 +29,14 @@
      <ooclass>
       <classname>UI\Controls\Entry</classname>
      </ooclass>
-     
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>UI\Control</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -55,10 +55,10 @@
 
     <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-controls-entry')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-controls-entry')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
-    
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-control')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
 
@@ -66,7 +66,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ UI\Controls\Entry constants -->
   <section xml:id="ui-controls-entry.constants">
    &reftitle.constants;

--- a/reference/ui/ui.controls.grid.xml
+++ b/reference/ui/ui.controls.grid.xml
@@ -29,14 +29,14 @@
      <ooclass>
       <classname>UI\Controls\Grid</classname>
      </ooclass>
-     
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>UI\Control</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -83,10 +83,10 @@
      <modifier>protected</modifier>
      <varname linkend="ui-controls-grid.props.controls">controls</varname>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-controls-grid')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
-    
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-control')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
 
@@ -94,7 +94,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ UI\Controls\Grid constants -->
   <section xml:id="ui-controls-grid.constants">
    &reftitle.constants;

--- a/reference/ui/ui.controls.multilineentry.xml
+++ b/reference/ui/ui.controls.multilineentry.xml
@@ -29,14 +29,14 @@
      <ooclass>
       <classname>UI\Controls\MultilineEntry</classname>
      </ooclass>
-     
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>UI\Control</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -50,10 +50,10 @@
 
     <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-controls-multilineentry')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-controls-multilineentry')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
-    
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-control')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
 
@@ -61,7 +61,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ UI\Controls\MultilineEntry constants -->
   <section xml:id="ui-controls-multilineentry.constants">
    &reftitle.constants;

--- a/reference/ui/ui.controls.picker.xml
+++ b/reference/ui/ui.controls.picker.xml
@@ -29,14 +29,14 @@
      <ooclass>
       <classname>UI\Controls\Picker</classname>
      </ooclass>
-     
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>UI\Control</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -52,10 +52,10 @@
      <type>int</type>
      <varname linkend="ui-controls-picker.constants.datetime">UI\Controls\Picker::DateTime</varname>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-controls-picker')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
-    
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-control')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
 
@@ -63,7 +63,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ UI\Controls\Picker constants -->
   <section xml:id="ui-controls-picker.constants">
    &reftitle.constants;

--- a/reference/ui/ui.controls.separator.xml
+++ b/reference/ui/ui.controls.separator.xml
@@ -29,14 +29,14 @@
      <ooclass>
       <classname>UI\Controls\Separator</classname>
      </ooclass>
-     
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>UI\Control</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -47,10 +47,10 @@
      <type>int</type>
      <varname linkend="ui-controls-separator.constants.vertical">UI\Controls\Separator::Vertical</varname>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-controls-separator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
-    
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-control')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
 
@@ -58,7 +58,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ UI\Controls\Separator constants -->
   <section xml:id="ui-controls-separator.constants">
    &reftitle.constants;

--- a/reference/ui/ui.draw.color.xml
+++ b/reference/ui/ui.draw.color.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -73,7 +73,7 @@
 
     <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-draw-color')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-draw-color')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
@@ -81,7 +81,7 @@
 
   </section>
 
-  
+
 <!-- {{{ UI\Draw\Color properties -->
   <section xml:id="ui-draw-color.props">
    &reftitle.properties;
@@ -114,7 +114,7 @@
   </section>
 <!-- }}} -->
 
-  
+
 <!-- {{{ UI\Draw\Color constants -->
   <section xml:id="ui-draw-color.constants">
    &reftitle.constants;

--- a/reference/ui/ui.draw.line.cap.xml
+++ b/reference/ui/ui.draw.line.cap.xml
@@ -32,7 +32,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -48,7 +48,7 @@
      <type>int</type>
      <varname>UI\Draw\Line\Cap::Square</varname>
     </fieldsynopsis>
-    
+
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/ui/ui.draw.line.join.xml
+++ b/reference/ui/ui.draw.line.join.xml
@@ -32,7 +32,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/ui/ui.draw.path.xml
+++ b/reference/ui/ui.draw.path.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -45,14 +45,14 @@
 
     <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-draw-path')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-draw-path')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ UI\Draw\Path constants -->
   <section xml:id="ui-draw-path.constants">
    &reftitle.constants;

--- a/reference/ui/ui.draw.text.font.italic.xml
+++ b/reference/ui/ui.draw.text.font.italic.xml
@@ -32,7 +32,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -51,7 +51,7 @@
      <varname>UI\Draw\Text\Font\Italic::Italic</varname>
      <initializer>2</initializer>
     </fieldsynopsis>
-    
+
     </classsynopsis>
 <!-- }}} -->
 

--- a/reference/ui/ui.draw.text.font.stretch.xml
+++ b/reference/ui/ui.draw.text.font.stretch.xml
@@ -32,7 +32,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/ui/ui.draw.text.font.weight.xml
+++ b/reference/ui/ui.draw.text.font.weight.xml
@@ -32,7 +32,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/ui/ui.key.xml
+++ b/reference/ui/ui.key.xml
@@ -32,7 +32,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -228,7 +228,7 @@
      <type>int</type>
      <varname>UI\Key::NDivide</varname>
     </fieldsynopsis>
-    
+
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/v8js/v8js.xml
+++ b/reference/v8js/v8js.xml
@@ -35,7 +35,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>string</type>
@@ -53,7 +53,7 @@
      <varname linkend="v8js.constants.flag-force-array">V8Js::FLAG_FORCE_ARRAY</varname>
      <initializer>2</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.v8js')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
      <xi:fallback/>
@@ -65,7 +65,7 @@
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ V8Js constants -->
   <section xml:id="v8js.constants">
    &reftitle.constants;

--- a/reference/varnish/varnishlog.xml
+++ b/reference/varnish/varnishlog.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -344,14 +344,14 @@
      <varname linkend="varnishlog.constants.tag-gzip">VarnishLog::TAG_Gzip</varname>
      <initializer>51</initializer>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.varnishlog')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ VarnishLog constants -->
   <section xml:id="varnishlog.constants">
    &reftitle.constants;

--- a/reference/win32service/win32serviceexception.xml
+++ b/reference/win32service/win32serviceexception.xml
@@ -15,9 +15,9 @@
   <section xml:id="win32serviceexception.intro">
    &reftitle.intro;
    <para>
-    The exception replaces the old mechanism where the error value needed to be 
-    compared to constants to detect which error was emitted. The Exception code 
-    is equal to the value of the error value and the exception message is based 
+    The exception replaces the old mechanism where the error value needed to be
+    compared to constants to detect which error was emitted. The Exception code
+    is equal to the value of the error value and the exception message is based
     on the corresponding constant name.
    </para>
   </section>
@@ -50,7 +50,7 @@
 
 <!-- Comment this section out if the exception does not contain any methods -->
 <!--
-    <classsynopsisinfo role="comment">Methods</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.win32serviceexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 -->
 <!-- If the exception extends another exception use this -->

--- a/reference/xlswriter/xlsx-format.xml
+++ b/reference/xlswriter/xlsx-format.xml
@@ -32,7 +32,7 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/yaf/yaf-request-abstract.xml
+++ b/reference/yaf/yaf-request-abstract.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>string</type>
@@ -91,7 +91,7 @@
      <varname linkend="yaf-request-abstract.props.routed">routed</varname>
     </fieldsynopsis>
 
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yaf-request-abstract')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
@@ -99,7 +99,7 @@
 
   </section>
 
-  
+
 <!-- {{{ Yaf_Request_Abstract properties -->
   <section xml:id="yaf-request-abstract.props">
    &reftitle.properties;
@@ -174,7 +174,7 @@
   </section>
 <!-- }}} -->
 
-  
+
 <!-- {{{ Yaf_Request_Abstract constants -->
   <section xml:id="yaf-request-abstract.constants">
    &reftitle.constants;

--- a/reference/yaf/yaf-request-simple.xml
+++ b/reference/yaf/yaf-request-simple.xml
@@ -30,14 +30,14 @@
      <ooclass>
       <classname>Yaf_Request_Simple</classname>
      </ooclass>
-     
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>Yaf_Request_Abstract</classname>
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>string</type>
@@ -53,11 +53,11 @@
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yaf-request-simple')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yaf-request-simple')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yaf-request-abstract')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
@@ -66,7 +66,7 @@
 
   </section>
 
-  
+
 <!-- {{{ Yaf_Request_Simple properties -->
   <section xml:id="yaf-request-simple.props">
    &reftitle.properties;
@@ -141,7 +141,7 @@
   </section>
 <!-- }}} -->
 
-  
+
 <!-- {{{ Yaf_Request_Simple constants -->
   <section xml:id="yaf-request-simple.constants">
    &reftitle.constants;

--- a/reference/yaf/yaf-response-abstract.xml
+++ b/reference/yaf/yaf-response-abstract.xml
@@ -31,13 +31,13 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo> 
-    <fieldsynopsis> 
-     <modifier>const</modifier> 
-     <type>string</type> 
-     <varname>Yaf_Response_Abstract::DEFAULT_BODY</varname> 
-     <initializer>"content"</initializer> 
-    </fieldsynopsis> 
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>string</type>
+     <varname>Yaf_Response_Abstract::DEFAULT_BODY</varname>
+     <initializer>"content"</initializer>
+    </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -53,7 +53,7 @@
      <varname linkend="yaf-response-abstract.props.sendheader">_sendheader</varname>
     </fieldsynopsis>
 
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yaf-response-abstract')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yaf-response-abstract')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
@@ -63,7 +63,7 @@
 
   </section>
 
-  
+
 <!-- {{{ Yaf_Response_Abstract properties -->
   <section xml:id="yaf-response-abstract.props">
    &reftitle.properties;

--- a/reference/zmq/zmq.xml
+++ b/reference/zmq/zmq.xml
@@ -31,7 +31,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -106,7 +106,7 @@
      <modifier>const</modifier>
      <type>int</type>
      <varname linkend="zmq.constants.sockopt-hwm">ZMQ::SOCKOPT_HWM</varname>
-    </fieldsynopsis>    
+    </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -116,7 +116,7 @@
      <modifier>const</modifier>
      <type>int</type>
      <varname linkend="zmq.constants.sockopt-rcvhwm">ZMQ::SOCKOPT_RCVHWM</varname>
-    </fieldsynopsis>    
+    </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -186,7 +186,7 @@
      <modifier>const</modifier>
      <type>int</type>
      <varname linkend="zmq.constants.sockopt-linger">ZMQ::SOCKOPT_LINGER</varname>
-    </fieldsynopsis>  
+    </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -286,7 +286,7 @@
      <modifier>const</modifier>
      <type>int</type>
      <varname linkend="zmq.constants.mode-dontwait">ZMQ::MODE_DONTWAIT</varname>
-    </fieldsynopsis>    
+    </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -317,14 +317,14 @@
      <type>int</type>
      <varname linkend="zmq.constants.err-eterm">ZMQ::ERR_ETERM</varname>
     </fieldsynopsis>
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmq')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
    </classsynopsis>
 <!-- }}} -->
 
   </section>
-  
+
 <!-- {{{ ZMQ constants -->
   <section xml:id="zmq.constants">
    &reftitle.constants;
@@ -394,7 +394,7 @@
        <para>Pipeline downstream pull socket</para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="zmq.constants.socket-router">
       <term><constant>ZMQ::SOCKET_ROUTER</constant></term>
       <listitem>
@@ -437,14 +437,14 @@
        <para>The high water mark for inbound and outbound messages is a hard limit on the maximum number of outstanding messages ØMQ shall queue in memory for any single peer that the specified socket is communicating with. Setting this option on a socket will only affect connections made after the option has been set. On ZeroMQ 3.x this is a wrapper for setting both SNDHWM and RCVHWM. (Value: &integer;).</para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="zmq.constants.sockopt-sndhwm">
       <term><constant>ZMQ::SOCKOPT_SNDHWM</constant></term>
       <listitem>
        <para>The ZMQ_SNDHWM option shall set the high water mark for outbound messages on the specified socket. Available if compiled against ZeroMQ 3.x or higher (Value: &integer;).</para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="zmq.constants.sockopt-rcvhwm">
       <term><constant>ZMQ::SOCKOPT_RCVHWM</constant></term>
       <listitem>
@@ -542,7 +542,7 @@
        <para>Get the socket type. Valid for getSockOpt (Value: &integer;)</para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="zmq.constants.sockopt-linger">
       <term><constant>ZMQ::SOCKOPT_LINGER</constant></term>
       <listitem>
@@ -550,14 +550,14 @@
              trying flush messages after it has been closed (Value: &integer;)</para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="zmq.constants.sockopt-backlog">
       <term><constant>ZMQ::SOCKOPT_BACKLOG</constant></term>
       <listitem>
        <para>The SOCKOPT_BACKLOG option shall set the maximum length of the queue of outstanding peer connections for the specified socket; this only applies to connection-oriented transports. (Value: &integer;)</para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="zmq.constants.sockopt-maxmsgsize">
       <term><constant>ZMQ::SOCKOPT_MAXMSGSIZE</constant></term>
       <listitem>
@@ -584,7 +584,7 @@
       <listitem>
        <para>Disable IPV6 support if 1. Available if compiled against ZeroMQ 3.x (Value: &integer;)</para>
       </listitem>
-     </varlistentry>    
+     </varlistentry>
 
      <varlistentry xml:id="zmq.constants.sockopt-last-endpoint">
       <term><constant>ZMQ::SOCKOPT_LAST_ENDPOINT</constant></term>
@@ -670,14 +670,14 @@
        <para>Poll for outgoing data</para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="zmq.constants.mode-noblock">
       <term><constant>ZMQ::MODE_NOBLOCK</constant></term>
       <listitem>
        <para>Non-blocking operation. Deprecated, use ZMQ::MODE_DONTWAIT instead</para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="zmq.constants.mode-dontwait">
       <term><constant>ZMQ::MODE_DONTWAIT</constant></term>
       <listitem>
@@ -691,7 +691,7 @@
        <para>Send multi-part message</para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="zmq.constants.device-forwarder">
       <term><constant>ZMQ::DEVICE_FORWARDER</constant></term>
       <listitem>
@@ -712,7 +712,7 @@
        <para>Streamer device</para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="zmq.constants.err-internal">
       <term><constant>ZMQ::ERR_INTERNAL</constant></term>
       <listitem>


### PR DESCRIPTION
As discussed on https://github.com/php/doc-en/pull/2700 , replaces autogenerated text with entities, in tandem with gen_stub.