### PR TITLE
Update string.xml to remove old string interpolation

### DIFF
--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -721,10 +721,10 @@ EOT;
 $juice = "apple";
 
 echo "He drank some $juice juice.".PHP_EOL;
-// Invalid. "s" is a valid character for a variable name, but the variable is $juice.
+// Unintended. "s" is a valid character for a variable name, so this refers to $juices, not $juice.
 echo "He drank some juice made of $juices.";
-// Valid. Explicitly specify the end of the variable name by enclosing it in braces:
-echo "He drank some juice made of ${juice}s.";
+// Explicitly specify the end of the variable name by enclosing the reference in braces.
+echo "He drank some juice made of {$juice}s.";
 ?>
 ]]>
      </programlisting>


### PR DESCRIPTION
An example used the deprecated `${varname}` syntax; fix it.