### PR TITLE
Standardise Getting Started example indentation

### DIFF
--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -371,9 +371,9 @@ if (strpos($_SERVER['HTTP_USER_AGENT'], 'Firefox') !== false) {
      <programlisting role="html">
 <![CDATA[
 <form action="action.php" method="post">
- <p>Your name: <input type="text" name="name" /></p>
- <p>Your age: <input type="text" name="age" /></p>
- <p><input type="submit" /></p>
+    <p>Your name: <input type="text" name="name" /></p>
+    <p>Your age: <input type="text" name="age" /></p>
+    <p><input type="submit" /></p>
 </form>
 ]]>
      </programlisting>

--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -74,7 +74,7 @@
         <title>PHP Test</title>
     </head>
     <body>
-        <?php echo '<p>Hello World</p>'; ?> 
+        <?php echo '<p>Hello World</p>'; ?>
     </body>
 </html>
 ]]>

--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -70,12 +70,12 @@
      <programlisting role="php">
 <![CDATA[
 <html>
- <head>
-  <title>PHP Test</title>
- </head>
- <body>
- <?php echo '<p>Hello World</p>'; ?> 
- </body>
+    <head>
+        <title>PHP Test</title>
+    </head>
+    <body>
+        <?php echo '<p>Hello World</p>'; ?> 
+    </body>
 </html>
 ]]>
      </programlisting>
@@ -91,12 +91,12 @@
      <screen role="html">
 <![CDATA[
 <html>
- <head>
-  <title>PHP Test</title>
- </head>
- <body>
- <p>Hello World</p>
- </body>
+    <head>
+        <title>PHP Test</title>
+    </head>
+    <body>
+        <p>Hello World</p>
+    </body>
 </html>
 ]]>
      </screen>


### PR DESCRIPTION
There is inconsistent indentation within the "Getting started" section of the docs including the same example across different pages.

I feel that using 4 spaces is pretty established indentation in the PHP community and should be our standard within the docs.

[This example](https://www.php.net/manual/en/intro-whatis.php
):

<img width="868" alt="Screen Shot 2023-08-27 at 7 33 48 am" src="https://github.com/php/doc-en/assets/24803032/61ae94da-0e8c-4953-a8a4-eccd1af49252">

is then repeated on [different pages](https://www.php.net/manual/en/tutorial.firstpage.php) in the same section with different indentation.

<img width="526" alt="Screen Shot 2023-08-27 at 7 35 00 am" src="https://github.com/php/doc-en/assets/24803032/2fe0c4b1-584c-4b27-82cb-ffa780f9a976">

## Result

<img width="465" alt="Screen Shot 2023-08-27 at 7 40 02 am" src="https://github.com/php/doc-en/assets/24803032/f115fa1c-629c-49ad-9660-bd0866b0a5fe">
