### PR TITLE
Use semantic HTML tags for tutorial `form` example

### DIFF
--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -371,9 +371,9 @@ if (strpos($_SERVER['HTTP_USER_AGENT'], 'Firefox') !== false) {
      <programlisting role="html">
 <![CDATA[
 <form action="action.php" method="post">
- <p>Your name: <input type="text" name="name" /></p>
- <p>Your age: <input type="text" name="age" /></p>
- <p><input type="submit" /></p>
+    <p>Your name: <input type="text" name="name" /></p>
+    <p>Your age: <input type="text" name="age" /></p>
+    <p><input type="submit" /></p>
 </form>
 ]]>
      </programlisting>

--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -372,12 +372,12 @@ if (strpos($_SERVER['HTTP_USER_AGENT'], 'Firefox') !== false) {
 <![CDATA[
 <form action="action.php" method="post">
     <label for="name">Your name:</label>
-    <input name="name" id="name">
+    <input name="name" id="name" type="text">
 
     <label for="age">Your age:</label>
-    <input name="age" id="age">
+    <input name="age" id="age" type="number">
 
-    <button>Submit</button>
+    <button type="submit">Submit</button>
 </form>
 ]]>
      </programlisting>

--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -371,9 +371,13 @@ if (strpos($_SERVER['HTTP_USER_AGENT'], 'Firefox') !== false) {
      <programlisting role="html">
 <![CDATA[
 <form action="action.php" method="post">
-    <p>Your name: <input type="text" name="name" /></p>
-    <p>Your age: <input type="text" name="age" /></p>
-    <p><input type="submit" /></p>
+    <label for="name">Your name:</label>
+    <input name="name" id="name">
+
+    <label for="age">Your age:</label>
+    <input name="age" id="age">
+
+    <button>Submit</button>
 </form>
 ]]>
      </programlisting>


### PR DESCRIPTION
This PR improves the form example by:

1. Using `label` tags, rather than generic inaccessible `<p>` tags.
2. Removes the redundant `type` attribute from input tags.

> If this attribute is not specified, the default type adopted is text [source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types)

3. Adds an `id` tag to the `input` so that `label` tags can reference them with their `for` attibute.
3. Use a submit `button` and provide custom text. Adding custom text between an HTML tag feels much more familiar than doing it within an attribute. This also matches how the `label` works.
4. Added some spacing to ease the flow to reading the `label` / `input` pairs.
5. Removed the "closing" slash on the inputs. We've already shown the doctype in the opening example of the PHP docs showing that we aren't using "quirks mode" or an XML type that requires closing.

I can only assume that `<p>` tags were used for formatting. I don't think that a horizontal form is an issue and something we need to "format". I also don't think wrapping things in `<p>` or `<div>` is the way we should promote formatting in HTML, over CSS

## Docs before

<img width="1074" alt="Screenshot 2023-08-28 at 9 05 40 am" src="https://github.com/php/doc-en/assets/24803032/efb6c75c-5e27-4d04-be71-15586ffc9098">

## Docs after

<img width="1076" alt="Screenshot 2023-08-28 at 9 05 31 am" src="https://github.com/php/doc-en/assets/24803032/912341d0-ec6d-4425-aad6-099703360267">

## Rendered HTML before

<img width="348" alt="Screenshot 2023-08-28 at 8 50 14 am" src="https://github.com/php/doc-en/assets/24803032/114d60b3-511c-471c-8310-931a86994c8e">

## Rendered HTML after

<img width="637" alt="Screenshot 2023-08-28 at 8 55 29 am" src="https://github.com/php/doc-en/assets/24803032/89d3de60-b3d4-404c-b17f-5a49b6b1df80">

This PR contains the same commit to indent the form seen in https://github.com/php/doc-en/pull/2713. This should allow both to merged / rejected independently without causing conflicts...that is if I know how git works lol 🤞