### PR TITLE
Use `str_contains` over `strpos` for tutorial example

### DIFF
--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -263,8 +263,8 @@ Mozilla/5.0 (Linux) Firefox/112.0
      <programlisting role="php">
 <![CDATA[
 <?php
-if (strpos($_SERVER['HTTP_USER_AGENT'], 'Firefox') !== false) {
-    echo 'You are using Firefox.<br />';
+if (str_contains($_SERVER['HTTP_USER_AGENT'], 'Firefox')) {
+    echo 'You are using Firefox.';
 }
 ?>
 ]]>
@@ -274,7 +274,7 @@ if (strpos($_SERVER['HTTP_USER_AGENT'], 'Firefox') !== false) {
      </para>
      <screen role="html">
 <![CDATA[
-You are using Firefox.<br />
+You are using Firefox.
 ]]>
      </screen>
     </example>
@@ -289,14 +289,13 @@ You are using Firefox.<br />
     Reference</link> part of the manual.
    </para>
    <para>
-    The second concept we introduced was the <function>strpos</function>
-    function call. <function>strpos</function> is a function built into
-    PHP which searches a string for another string. In this case we are
+    The second concept we introduced was the <function>str_contains</function>
+    function call. <function>str_contains</function> is a function built into
+    PHP which determines is given a string contains another string. In this case we are
     looking for <literal>'Firefox'</literal> (so-called needle) inside
     <varname>$_SERVER['HTTP_USER_AGENT']</varname> (so-called haystack).  If
-    the needle is found inside the haystack, the function returns the position
-    of the needle relative to the start of the haystack.  Otherwise, it
-    returns &false;.  If it does not return &false;, the <link
+    the needle is found inside the haystack, the function returns true. Otherwise, it
+    returns &false;. If it returns &true;, the <link
     linkend="control-structures.if">if</link> expression evaluates to &true;
     and the code within its {braces} is executed. Otherwise, the code is not
     run. Feel free to create similar examples, 
@@ -319,14 +318,14 @@ You are using Firefox.<br />
      <programlisting role="php">
 <![CDATA[
 <?php
-if (strpos($_SERVER['HTTP_USER_AGENT'], 'Firefox') !== false) {
+if (str_contains($_SERVER['HTTP_USER_AGENT'], 'Firefox')) {
 ?>
-<h3>strpos() must have returned non-false</h3>
+<h3>str_contains() returned true</h3>
 <p>You are using Firefox</p>
 <?php
 } else {
 ?>
-<h3>strpos() must have returned false</h3>
+<h3>str_contains() returned false</h3>
 <p>You are not using Firefox</p>
 <?php
 }
@@ -338,7 +337,7 @@ if (strpos($_SERVER['HTTP_USER_AGENT'], 'Firefox') !== false) {
      </para>
      <screen role="html">
 <![CDATA[
-<h3>strpos() must have returned non-false</h3>
+<h3>str_contains() returned true</h3>
 <p>You are using Firefox</p>
 ]]>
      </screen>
@@ -349,7 +348,7 @@ if (strpos($_SERVER['HTTP_USER_AGENT'], 'Firefox') !== false) {
     of PHP mode and just sent straight HTML. The important and powerful point
     to note here is that the logical flow of the script remains intact. Only
     one of the HTML blocks will end up getting sent to the viewer depending on
-    the result of <function>strpos</function>.  In other words, it depends on
+    the result of <function>str_contains</function>.  In other words, it depends on
     whether the string <literal>Firefox</literal> was found or not.
    </para>
   </section>


### PR DESCRIPTION
The first example on the PHP documentation that isn't a "hello world" is searching the `User-Agent` for the string `"Firefox"`.

This example currently uses [`strpos`](https://www.php.net/manual/en/function.strpos.php). I believe we should be using [`str_contains`](https://www.php.net/manual/en/function.str-contains).

I believe this for a few reasons, but to start with I'll let the function descriptions do the talking:

> Find the position of the first occurrence of a substring in a string

vs.

> Determine if a string contains a given substring

`str_contains` matches the semantics of what we are doing and eases the overhead of understanding what is happening.

When using `strpos` we are also introducing the reader to:

1. "Truthiness"
2. Boolean literals
3. PHP's "return `false` as a flag to indicate something" behaviour

Which is all additional overhead.

The current example also has double negatives that are hare to read left to right. The `str_contains` example feels much easier to comprehend, i.e.,

> If strpos is not equal to `false`

versus

> If str_contains

and...

> returned non-false

vs

> returned true


I understand that `str_contain` is a "newer" PHP function, however these are the documentation for the current PHP language - so we should take advantage and promote it's newer features, when it makes sense.

The `str_contains` function is available in all currently supported PHP versions.

Lastly, I removed the `<br />` from the example as it serves no purpose to introducing the reader to "control structures and functions". The next example handles mixing in HTML in the "Mixing both HTML and PHP modes". The later examples also don't reference the `<br />` anyway, so kinda feels like unneeded noise we ca drop.