### PR TITLE
Standardise casting spacing

### DIFF
--- a/appendices/migration72/incompatible.xml
+++ b/appendices/migration72/incompatible.xml
@@ -46,7 +46,7 @@ var_dump(number_format(-0.01)); // now outputs string(1) "0" instead of string(2
 
 // array to object
 $arr = [0 => 1];
-$obj = (object)$arr;
+$obj = (object) $arr;
 var_dump(
     $obj,
     $obj->{'0'}, // now accessible
@@ -84,7 +84,7 @@ $obj = new class {
         $this->{0} = 1;
     }
 };
-$arr = (array)$obj;
+$arr = (array) $obj;
 var_dump(
     $arr,
     $arr[0], // now accessible

--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -398,7 +398,7 @@ if (str_contains($_SERVER['HTTP_USER_AGENT'], 'Firefox')) {
      <programlisting role="php">
 <![CDATA[
 Hi <?php echo htmlspecialchars($_POST['name']); ?>.
-You are <?php echo (int)$_POST['age']; ?> years old.
+You are <?php echo (int) $_POST['age']; ?> years old.
 ]]>
      </programlisting>
      <para>

--- a/language/operators/bitwise.xml
+++ b/language/operators/bitwise.xml
@@ -243,10 +243,10 @@ echo "hallo" ^ "hello"; // Outputs the ascii values #0 #4 #0 #0 #0
                         // 'a' ^ 'e' = #4
 
 echo 2 ^ "3"; // Outputs 1
-              // 2 ^ ((int)"3") == 1
+              // 2 ^ ((int) "3") == 1
 
 echo "2" ^ 3; // Outputs 1
-              // ((int)"2") ^ 3 == 1
+              // ((int) "2") ^ 3 == 1
 ?>
 ]]>
    </programlisting>

--- a/language/operators/comparison.xml
+++ b/language/operators/comparison.xml
@@ -266,11 +266,11 @@ echo $a <=> $b; // 1
 <![CDATA[
 <?php
 // Bool and null are compared as bool always
-var_dump(1 == TRUE);  // TRUE - same as (bool)1 == TRUE
-var_dump(0 == FALSE); // TRUE - same as (bool)0 == FALSE
-var_dump(100 < TRUE); // FALSE - same as (bool)100 < TRUE
-var_dump(-10 < FALSE);// FALSE - same as (bool)-10 < FALSE
-var_dump(min(-100, -10, NULL, 10, 100)); // NULL - (bool)NULL < (bool)-100 is FALSE < TRUE
+var_dump(1 == TRUE);  // TRUE - same as (bool) 1 == TRUE
+var_dump(0 == FALSE); // TRUE - same as (bool) 0 == FALSE
+var_dump(100 < TRUE); // FALSE - same as (bool) 100 < TRUE
+var_dump(-10 < FALSE);// FALSE - same as (bool) -10 < FALSE
+var_dump(min(-100, -10, NULL, 10, 100)); // NULL - (bool) NULL < (bool) -100 is FALSE < TRUE
 ?>
 ]]>
    </programlisting>
@@ -421,7 +421,7 @@ echo (true ? 'true' : false ? 't' : 'f');
 echo ((true ? 'true' : false) ? 't' : 'f');
 
 // here, one can see that the first expression is evaluated to 'true', which
-// in turn evaluates to (bool)true, thus returning the true branch of the
+// in turn evaluates to (bool) true, thus returning the true branch of the
 // second ternary expression.
 ?>
 ]]>

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -965,7 +965,7 @@ $error_descriptions[8] = "This is just an informal notice";
    <type>string</type>, <type>bool</type> and <type>resource</type>,
    converting a value to an <type>array</type> results in an array with a single
    element with index zero and the value of the scalar which was converted. In
-   other words, <literal>(array)$scalarValue</literal> is exactly the same as
+   other words, <literal>(array) $scalarValue</literal> is exactly the same as
    <literal>array($scalarValue)</literal>.
   </para>
   

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -965,7 +965,7 @@ $error_descriptions[8] = "This is just an informal notice";
    <type>string</type>, <type>bool</type> and <type>resource</type>,
    converting a value to an <type>array</type> results in an array with a single
    element with index zero and the value of the scalar which was converted. In
-   other words, <literal>(array) $scalarValue</literal> is exactly the same as
+   other words, <code>(array) $scalarValue</code> is exactly the same as
    <literal>array($scalarValue)</literal>.
   </para>
   

--- a/language/types/integer.xml
+++ b/language/types/integer.xml
@@ -200,7 +200,7 @@ var_dump(foo(8.1)); // "Deprecated: Implicit conversion from float 8.1 to int lo
 var_dump(foo(8.1)); // 8 prior to PHP 8.1.0
 var_dump(foo(8.0)); // 8 in both cases
 
-var_dump((int)8.1); // 8 in both cases
+var_dump((int) 8.1); // 8 in both cases
 var_dump(intval(8.1)); // 8 in both cases
 ?>
 ]]>

--- a/reference/array/functions/array-merge.xml
+++ b/reference/array/functions/array-merge.xml
@@ -179,7 +179,7 @@ array(5) {
 <?php
 $beginning = 'foo';
 $end = array(1 => 'bar');
-$result = array_merge((array)$beginning, (array)$end);
+$result = array_merge((array) $beginning, (array) $end);
 print_r($result);
 ?>
 ]]>

--- a/reference/datetime/datetimeinterface/gettimestamp.xml
+++ b/reference/datetime/datetimeinterface/gettimestamp.xml
@@ -129,8 +129,8 @@ echo date_timestamp_get($date);
 <![CDATA[
 <?php
 $date = new DateTimeImmutable();
-$milli = (int)$date->format('Uv'); // Timestamp in milliseconds
-$micro = (int)$date->format('Uu'); // Timestamp in microseconds
+$milli = (int) $date->format('Uv'); // Timestamp in milliseconds
+$micro = (int) $date->format('Uu'); // Timestamp in microseconds
 
 echo $milli, "\n", $micro, "\n";
 ?>

--- a/reference/ffi/examples.xml
+++ b/reference/ffi/examples.xml
@@ -303,7 +303,7 @@ final class Dummy {
         }
     }
     function printf($format, ...$args) {
-       return (int)self::$ffi->printf($format, ...$args);
+       return (int) self::$ffi->printf($format, ...$args);
     }
 }
 ?>

--- a/reference/mongodb/mongodb/driver/command.xml
+++ b/reference/mongodb/mongodb/driver/command.xml
@@ -56,14 +56,14 @@ class CreateCollection {
     protected $cmd = array();
 
     function __construct($collectionName) {
-        $this->cmd["create"] = (string)$collectionName;
+        $this->cmd["create"] = (string) $collectionName;
     }
     function setCappedCollection($maxBytes, $maxDocuments = false) {
         $this->cmd["capped"] = true;
-        $this->cmd["size"]   = (int)$maxBytes;
+        $this->cmd["size"]   = (int) $maxBytes;
 
         if ($maxDocuments) {
-            $this->cmd["max"] = (int)$maxDocuments;
+            $this->cmd["max"] = (int) $maxDocuments;
         }
     }
     function usePowerOf2Sizes($bool) {
@@ -74,7 +74,7 @@ class CreateCollection {
         }
     }
     function setFlags($flags) {
-        $this->cmd["flags"] = (int)$flags;
+        $this->cmd["flags"] = (int) $flags;
     }
     function getCommand() {
         return new MongoDB\Driver\Command($this->cmd);

--- a/reference/rar/examples.xml
+++ b/reference/rar/examples.xml
@@ -56,7 +56,7 @@ function detectUserAgent() {
     if (preg_match("@Chrome/@", $uas))
         return "Chrome";
     if (preg_match("@MSIE ([0-9.]+);@", $uas, $matches)) {
-        if (((float)$matches[1]) >= 7.0)
+        if (((float) $matches[1]) >= 7.0)
             return "IE";
     }
     

--- a/reference/reflection/reflectionenum/getbackingtype.xml
+++ b/reference/reflection/reflectionenum/getbackingtype.xml
@@ -75,7 +75,7 @@ $rEnum = new ReflectionEnum(Suit::class);
 
 $rBackingType = $rEnum->getBackingType();
 
-var_dump((string)$rBackingType);
+var_dump((string) $rBackingType);
 ?>
 ]]>
     </programlisting>

--- a/reference/session/sessionhandlerinterface.xml
+++ b/reference/session/sessionhandlerinterface.xml
@@ -92,7 +92,7 @@ class MySessionHandler implements SessionHandlerInterface
     #[\ReturnTypeWillChange]
     public function read($id)
     {
-        return (string)@file_get_contents("$this->savePath/sess_$id");
+        return (string) @file_get_contents("$this->savePath/sess_$id");
     }
 
     public function write($id, $data): bool

--- a/reference/stream/functions/stream-notification-callback.xml
+++ b/reference/stream/functions/stream-notification-callback.xml
@@ -222,7 +222,7 @@ function stream_notification_callback($notification_code, $severity, $message, $
             if (!isset($filesize)) {
                 printf("\rUnknown filesize.. %2d kb done..", $bytes_transferred/1024);
             } else {
-                $length = (int)(($bytes_transferred/$filesize)*100);
+                $length = (int) (($bytes_transferred/$filesize)*100);
                 printf("\r[%-100s] %d%% (%2d/%2d kb)", str_repeat("=", $length). ">", $length, ($bytes_transferred/1024), $filesize/1024);
             }
         }


### PR DESCRIPTION
This PR standardises the spacing of casting in PHP via `(bool) $value` style casts.

We currently have an inconsistent usage. I feel that we should standardise on a single space, which is commonly used in the community and also helps separate the "cast" from the "value".