### PR TITLE
Update fopen.xml for 'n' flag

### DIFF
--- a/reference/filesystem/functions/fopen.xml
+++ b/reference/filesystem/functions/fopen.xml
@@ -190,7 +190,14 @@ $handle = fopen("c:\\folder\\resource.txt", "r");
            <entry><literal>'e'</literal></entry>
            <entry>
             Set close-on-exec flag on the opened file descriptor. Only
-            available in PHP compiled on POSIX.1-2008 conform systems.
+            available in PHP compiled on POSIX.1-2008 conformant systems.
+           </entry>
+          </row>
+          <row>
+           <entry><literal>'n'</literal></entry>
+           <entry>
+            Set non-blocking flag on the opened file descriptor. Only
+            available in PHP compiled on POSIX.1-2008 conformant systems.
            </entry>
           </row>
          </tbody>


### PR DESCRIPTION
PHP has supported fopen with `'n'` since 2013. Document this.
(Source: main/streams/plain_wrapper.c)