### PR TITLE
Document new `$before_needle` argument of `strrchr()`

### DIFF
--- a/reference/strings/functions/strrchr.xml
+++ b/reference/strings/functions/strrchr.xml
@@ -12,6 +12,7 @@
    <type class="union"><type>string</type><type>false</type></type><methodname>strrchr</methodname>
    <methodparam><type>string</type><parameter>haystack</parameter></methodparam>
    <methodparam><type>string</type><parameter>needle</parameter></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>before_needle</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <para>
    This function returns the portion of <parameter>haystack</parameter> which
@@ -43,6 +44,16 @@
       &strings.parameter.needle.non-string;
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term><parameter>before_needle</parameter></term>
+     <listitem>
+      <para>
+       If &true;, <function>strrchr</function>
+       returns the part of the <parameter>haystack</parameter> before the
+       first occurrence of the <parameter>needle</parameter> (excluding needle).
+      </para>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
  </refsect1>
@@ -66,6 +77,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       The <parameter>before_needle</parameter> parameter was added.
+      </entry>
+     </row>
      &strings.changelog.needle-empty;
      <row>
       <entry>8.0.0</entry>


### PR DESCRIPTION
Documents the new `$before_needle` argument of `strrchr()` add in https://github.com/php/php-src/pull/11430.