### PR TITLE
PDO::lastInsertId of pdo_pgsql no longer requires sequence name

### DIFF
--- a/reference/pdo/pdo/lastinsertid.xml
+++ b/reference/pdo/pdo/lastinsertid.xml
@@ -16,9 +16,7 @@
 
   <para>
    Returns the ID of the last inserted row, or the last value from a
-   sequence object, depending on the underlying driver. For example,
-   <link linkend="ref.pdo-pgsql">PDO_PGSQL</link> requires you to specify the name of
-   a sequence object for the <parameter>name</parameter> parameter.
+   sequence object, depending on the underlying driver.
   </para>
   <note>
    <para>


### PR DESCRIPTION
`name` parameter is not mandatory since 7.0.11.
https://bugs.php.net/bug.php?id=72633