### PR TITLE
Fixed $before_needle argument of strrchr() description

### DIFF
--- a/reference/strings/functions/strrchr.xml
+++ b/reference/strings/functions/strrchr.xml
@@ -50,7 +50,7 @@
       <para>
        If &true;, <function>strrchr</function>
        returns the part of the <parameter>haystack</parameter> before the
-       last occurrence of the <parameter>needle</parameter> (excluding needle).
+       last occurrence of the <parameter>needle</parameter> (excluding the needle).
       </para>
      </listitem>
     </varlistentry>

--- a/reference/strings/functions/strrchr.xml
+++ b/reference/strings/functions/strrchr.xml
@@ -50,7 +50,7 @@
       <para>
        If &true;, <function>strrchr</function>
        returns the part of the <parameter>haystack</parameter> before the
-       first occurrence of the <parameter>needle</parameter> (excluding needle).
+       last occurrence of the <parameter>needle</parameter> (excluding needle).
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
New parameter `$before_needle` outputs result based on the **last** occurances of needle.

```
$ sapi/cli/php --version | head -n 1
PHP 8.4.0-dev (cli) (built: Aug 30 2023 22:08:33) (NTS)

$ sapi/cli/php -r '$text = "Line 1:Line 2:Line 3"; var_dump(strrchr($text, ":", false));'
string(7) ":Line 3"

$ sapi/cli/php -r '$text = "Line 1:Line 2:Line 3"; var_dump(strrchr($text, ":", true));'
string(13) "Line 1:Line 2"
```
