### PR TITLE
Update the default value for memcached.store_retry_count

### DIFF
--- a/reference/memcached/ini.xml
+++ b/reference/memcached/ini.xml
@@ -189,7 +189,11 @@
       <entry><link linkend="ini.memcached.store-retry-count">memcached.store_retry_count</link></entry>
       <entry>0</entry>
       <entry>PHP_INI_ALL</entry>
-      <entry>Available as of memcached 2.2.0. Default value 0 as of memcached 3.2.0 (previously 2).</entry>
+      <entry>
+       Available as of memcached 2.2.0.
+       Default value <literal>0</literal> as of memcached 3.2.0
+       (previously <literal>2</literal>).
+      </entry>
      </row>
     </tbody>
    </tgroup>

--- a/reference/memcached/ini.xml
+++ b/reference/memcached/ini.xml
@@ -187,9 +187,9 @@
      </row>
      <row>
       <entry><link linkend="ini.memcached.store-retry-count">memcached.store_retry_count</link></entry>
-      <entry>2</entry>
+      <entry>0</entry>
       <entry>PHP_INI_ALL</entry>
-      <entry>Available as of memcached 2.2.0.</entry>
+      <entry>Available as of memcached 2.2.0. Default value 0 as of memcached 3.2.0 (previously 2).</entry>
      </row>
     </tbody>
    </tgroup>


### PR DESCRIPTION
The default was changed in 3.2.0 - Fixes https://github.com/php/doc-en/issues/2727