### PR TITLE
Standardise "open source" capitalisation

### DIFF
--- a/preface.xml
+++ b/preface.xml
@@ -6,7 +6,7 @@
  <abstract>
   <simpara>
    <acronym>PHP</acronym>, which stands for &quot;<literal>PHP: Hypertext
-   Preprocessor</literal>&quot; is a widely-used Open Source general-purpose
+   Preprocessor</literal>&quot; is a widely-used open source general-purpose
    scripting language that is especially suited for web
    development and can be embedded into HTML. Its syntax draws
    upon C, Java, and Perl, and is easy to learn. The main goal of

--- a/reference/pgsql/book.xml
+++ b/reference/pgsql/book.xml
@@ -9,7 +9,7 @@
  <preface xml:id="intro.pgsql">
   &reftitle.intro;
   <para>
-   PostgreSQL database is an Open Source product and available without
+   PostgreSQL database is an open source product and available without
    cost. Postgres, developed originally in the UC Berkeley Computer
    Science Department, pioneered many of the object-relational concepts
    now becoming available in some commercial databases. It provides


### PR DESCRIPTION
I don't  have strong feelings on if this should be capitalised or not, but I do think we should reference it consistently.

I appears 8 times throughout the docs. Only two are capitalised.

Additionally, a similar sentence on the Preface and Getting Started pages uses differing casing.

<img width="827" alt="Screen Shot 2023-09-02 at 1 13 30 pm" src="https://github.com/php/doc-en/assets/24803032/dd60fac2-d420-472d-aeac-dd6e2ac09b3e">

<img width="870" alt="Screen Shot 2023-09-02 at 1 13 40 pm" src="https://github.com/php/doc-en/assets/24803032/93975787-1e3f-4ae1-89f1-78a4903d1282">