### PR TITLE
Remove reference to generating "Flash" movies

### DIFF
--- a/chapters/intro.xml
+++ b/chapters/intro.xml
@@ -145,7 +145,7 @@
     With PHP you are not limited to output HTML. PHP's abilities include
     outputting rich file types, such as images or PDF files, encrypting data,
     and sending emails. You can also output easily any text, such as JSON
-    or XML files. PHP can autogenerate these files, and save them in the
+    or XML. PHP can autogenerate these files, and save them in the
     file system, instead of printing it out, forming a server-side cache for
     your dynamic content.
    </para>

--- a/chapters/intro.xml
+++ b/chapters/intro.xml
@@ -144,8 +144,8 @@
    <para>
     With PHP you are not limited to output HTML. PHP's abilities include
     outputting rich file types, such as images or PDF files, encrypting data,
-    and sending emails. You can also output easily any text, such as XHTML and
-    any other XML file. PHP can autogenerate these files, and save them in the
+    and sending emails. You can also output easily any text, such as JSON
+    or XML files. PHP can autogenerate these files, and save them in the
     file system, instead of printing it out, forming a server-side cache for
     your dynamic content.
    </para>

--- a/chapters/intro.xml
+++ b/chapters/intro.xml
@@ -142,13 +142,12 @@
     programming (OOP), or a mixture of them both.
    </para>
    <para>
-    With PHP you are not limited to output HTML. PHP's abilities
-    includes outputting images, PDF files and even Flash movies
-    (using libswf and Ming) generated on the fly. You can also
-    output easily any text, such as XHTML and any other XML file.
-    PHP can autogenerate these files, and save them in the file
-    system, instead of printing it out, forming a server-side
-    cache for your dynamic content.
+    With PHP you are not limited to output HTML. PHP's abilities include
+    outputting rich file types, such as images or PDF files, encrypting data,
+    and sending emails. You can also output easily any text, such as XHTML and
+    any other XML file. PHP can autogenerate these files, and save them in the
+    file system, instead of printing it out, forming a server-side cache for
+    your dynamic content.
    </para>
    <para>
     One of the strongest and most significant features in PHP is its


### PR DESCRIPTION
With the demise of Flash, I think we should remove the reference to it from the "what can PHP do" section.

Sure, it continues to be able to do this (I assume), but I think we would be better off highlighting some other features.

I've opted to highlight encryption and sending emails. These feel like very practical things for modern web development.