### PR TITLE
Add doctype to full HTML document

### DIFF
--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -69,6 +69,7 @@
      <info><title>Our first PHP script: <filename>hello.php</filename></title></info>
      <programlisting role="php">
 <![CDATA[
+<!DOCTYPE html>
 <html>
     <head>
         <title>PHP Test</title>
@@ -90,6 +91,7 @@
      </simpara>
      <screen role="html">
 <![CDATA[
+<!DOCTYPE html>
 <html>
     <head>
         <title>PHP Test</title>


### PR DESCRIPTION
Proposing that for **full HTML document** examples, we include a doctype.

The section's initial example includes a doctype, but then we don't include it on the subsequent examples.

Has doctype: https://www.php.net/manual/en/intro-whatis.php

<img width="510" alt="Screen Shot 2023-09-02 at 4 36 03 pm" src="https://github.com/php/doc-en/assets/24803032/18582a93-e9b8-4a60-83ca-bbac98c470fb">

Missing doctype: https://www.php.net/manual/en/tutorial.firstpage.php

<img width="517" alt="Screen Shot 2023-09-02 at 4 35 50 pm" src="https://github.com/php/doc-en/assets/24803032/76828f3e-ef4b-4476-8776-add23e0b2911">
