### PR TITLE
Incorrect regex for floating point numbers

### DIFF
--- a/language/types/float.xml
+++ b/language/types/float.xml
@@ -29,7 +29,7 @@ $d = 1_234.567; // as of PHP 7.4.0
   <programlisting>
 <![CDATA[
 LNUM          [0-9]+(_[0-9]+)*
-DNUM          ([0-9]*(_[0-9]+)*[\.]{LNUM}) | ({LNUM}[\.][0-9]*(_[0-9]+)*)
+DNUM          (([0-9]+(_[0-9]+)*)?\.{LNUM}) | ({LNUM}\.([0-9]+(_[0-9]+)*)?)
 EXPONENT_DNUM (({LNUM} | {DNUM}) [eE][+-]? {LNUM})
 ]]>
   </programlisting>


### PR DESCRIPTION
Fixed Issue #2711

Above issue talks about replacing the DNUM regex:

```DNUM          ([0-9]*(_[0-9]+)*[\.]{LNUM}) | ({LNUM}[\.][0-9]*(_[0-9]+)*)```

with:

```DNUM          (([0-9]+(_[0-9]+)*)?\.{LNUM}) | ({LNUM}\.([0-9]+(_[0-9]+)*)?)```

In this PR required changes are done.