### PR TITLE
Wrap example output in CDATA

### DIFF
--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -232,7 +232,9 @@ echo $_SERVER['HTTP_USER_AGENT'];
      A sample output of this script may be:
     </para>
     <screen role="html">
+<![CDATA[
 Mozilla/5.0 (Linux) Firefox/112.0
+]]>
     </screen>
    </example>
    </para>


### PR DESCRIPTION
https://www.php.net/manual/en/tutorial.useful.php

The output of the first example includes an initial new line.

<img width="422" alt="Screen Shot 2023-09-02 at 5 06 48 pm" src="https://github.com/php/doc-en/assets/24803032/0316c8c1-222b-4b43-b426-6030900e4a02">


The script to generate this output will not generate a newline. Here is the output of the given script:

<img width="755" alt="Screen Shot 2023-09-02 at 4 59 55 pm" src="https://github.com/php/doc-en/assets/24803032/97c1f70e-cf5d-4d49-b7f7-f42b613a994d">

Wrapping in CDATA, which seems to be the pattern used for `screen` tags, fixes this.

<img width="468" alt="Screen Shot 2023-09-02 at 5 00 17 pm" src="https://github.com/php/doc-en/assets/24803032/b171eb04-0d8f-466c-b6fe-a46b99f061a5">
