### PR TITLE
Added syntax highlighting for currentdirectory in 'Using Namespace' page

### DIFF
--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -291,7 +291,7 @@ echo MyProject\Connection::start();
     <listitem>
      <simpara>
       Relative file name like <literal>foo.txt</literal>.  This resolves to
-      <literal>currentdirectory/foo.txt</literal> where currentdirectory is the
+      <literal>currentdirectory/foo.txt</literal> where <literal>currentdirectory</literal> is the
       directory currently occupied.  So if the current directory is
       <literal>/home/foo</literal>, the name resolves to <literal>/home/foo/foo.txt</literal>.
      </simpara>


### PR DESCRIPTION
I was reading the documentation on the namespace and got confused when I saw the word currentdirectory, I thought it was a typo error but noticed that it is referencing a part of an initially highlighted part of the text <literal>currentdirectory/foo.txt</literal>.

Since this is used as an example, it has to be highlighted as well, I added the highlight