### PR TITLE
Synchronize predefined constants with stubs - part 3

### DIFF
--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -376,7 +376,7 @@
   <varlistentry xml:id="constant.curlopt-altsvc">
    <term>
     <constant>CURLOPT_ALTSVC</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -1340,7 +1340,7 @@
   <varlistentry xml:id="constant.curlopt-ssl-ec-curves">
    <term>
     <constant>CURLOPT_SSL_EC_CURVES</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -2428,7 +2428,7 @@
   <varlistentry xml:id="constant.curlinfo-redirect-url">
    <term>
     <constant>CURLINFO_REDIRECT_URL</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -2439,7 +2439,7 @@
   <varlistentry xml:id="constant.curlinfo-primary-ip">
    <term>
     <constant>CURLINFO_PRIMARY_IP</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -2461,7 +2461,7 @@
   <varlistentry xml:id="constant.curlinfo-local-ip">
    <term>
     <constant>CURLINFO_LOCAL_IP</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>

--- a/reference/ftp/constants.xml
+++ b/reference/ftp/constants.xml
@@ -110,7 +110,7 @@
   <varlistentry xml:id="constant.ftp-usepasvaddress">
    <term>
     <constant>FTP_USEPASVADDRESS</constant>
-    (<type>bool</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <para>

--- a/reference/ldap/constants.xml
+++ b/reference/ldap/constants.xml
@@ -266,7 +266,7 @@
   <varlistentry xml:id="constant.ldap-opt-x-tls-cacertdir">
    <term>
     <constant>LDAP_OPT_X_TLS_CACERTDIR</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -277,7 +277,7 @@
   <varlistentry xml:id="constant.ldap-opt-x-tls-cacertfile">
    <term>
     <constant>LDAP_OPT_X_TLS_CACERTFILE</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -288,7 +288,7 @@
   <varlistentry xml:id="constant.ldap-opt-x-tls-certfile">
    <term>
     <constant>LDAP_OPT_X_TLS_CERTFILE</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -299,7 +299,7 @@
   <varlistentry xml:id="constant.ldap-opt-x-tls-cipher-suite">
    <term>
     <constant>LDAP_OPT_X_TLS_CIPHER_SUITE</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -326,7 +326,7 @@
   <varlistentry xml:id="constant.ldap-opt-x-tls-crlfile">
    <term>
     <constant>LDAP_OPT_X_TLS_CRLFILE</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -342,7 +342,7 @@
   <varlistentry xml:id="constant.ldap-opt-x-tls-dhfile">
    <term>
     <constant>LDAP_OPT_X_TLS_DHFILE</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -358,7 +358,7 @@
   <varlistentry xml:id="constant.ldap-opt-x-tls-keyfile">
    <term>
     <constant>LDAP_OPT_X_TLS_KEYFILE</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -380,7 +380,7 @@
   <varlistentry xml:id="constant.ldap-opt-x-tls-random-file">
    <term>
     <constant>LDAP_OPT_X_TLS_RANDOM_FILE</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -805,7 +805,6 @@
   </varlistentry>
  </variablelist>
 </appendix>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -636,7 +636,7 @@
     <varlistentry xml:id="constant.openssl-tlsext-server-name">
       <term>
        <constant>OPENSSL_TLSEXT_SERVER_NAME</constant>
-       (<type>string</type>)
+       (<type>int</type>)
       </term>
       <listitem>
         <simpara>
@@ -659,7 +659,7 @@
     <varlistentry xml:id="constant.openssl-raw-data">
       <term>
        <constant>OPENSSL_RAW_DATA</constant>
-       (<type>bool</type>)
+       (<type>int</type>)
       </term>
       <listitem>
         <simpara>
@@ -673,7 +673,7 @@
     <varlistentry xml:id="constant.openssl-zero-padding">
       <term>
        <constant>OPENSSL_ZERO_PADDING</constant>
-       (<type>bool</type>)
+       (<type>int</type>)
       </term>
       <listitem>
         <simpara>

--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -487,7 +487,7 @@
   <varlistentry xml:id="pdo.constants.attr-driver-name">
    <term>
     <constant>PDO::ATTR_DRIVER_NAME</constant>
-     (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -522,7 +522,7 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
   <varlistentry xml:id="pdo.constants.attr-persistent">
    <term>
     <constant>PDO::ATTR_PERSISTENT</constant>
-     (<type>mixed</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara> 

--- a/reference/pgsql/constants.xml
+++ b/reference/pgsql/constants.xml
@@ -538,7 +538,7 @@
   <varlistentry xml:id="constant.pgsql-diag-schema-name">
    <term>
     <constant>PGSQL_DIAG_SCHEMA_NAME</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -549,7 +549,7 @@
   <varlistentry xml:id="constant.pgsql-diag-table-name">
    <term>
     <constant>PGSQL_DIAG_TABLE_NAME</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -560,7 +560,7 @@
   <varlistentry xml:id="constant.pgsql-diag-column-name">
    <term>
     <constant>PGSQL_DIAG_COLUMN_NAME</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -571,7 +571,7 @@
   <varlistentry xml:id="constant.pgsql-diag-datatype-name">
    <term>
     <constant>PGSQL_DIAG_DATATYPE_NAME</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -582,7 +582,7 @@
   <varlistentry xml:id="constant.pgsql-diag-constraint-name">
    <term>
     <constant>PGSQL_DIAG_CONSTRAINT_NAME</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>

--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -460,7 +460,7 @@
   <varlistentry xml:id="constant.so-acceptfilter">
    <term>
     <constant>SO_ACCEPTFILTER</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -559,7 +559,7 @@
   <varlistentry xml:id="constant.tcp-congestion">
    <term>
     <constant>TCP_CONGESTION</constant>
-    (<type>string</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>

--- a/reference/uodbc/constants.xml
+++ b/reference/uodbc/constants.xml
@@ -7,7 +7,7 @@
   <varlistentry xml:id="constant.odbc-type">
    <term>
     <constant>ODBC_TYPE</constant>
-    (<type>int</type>)
+    (<type>string</type>)
    </term>
    <listitem>
     <simpara>


### PR DESCRIPTION
Fix wrong constant types. Apparently, in some cases, the type of the relevant option is documented as the constant type.