### PR TITLE
Remove `session_register` references

### DIFF
--- a/language/oop5/serialization.xml
+++ b/language/oop5/serialization.xml
@@ -77,7 +77,7 @@
   
   <para>
    So if in the example above <varname>$a</varname> became part of a session
-   by running <literal>session_register("a")</literal>, you should include the
+   by adding a new key to the <varname>$_SESSION</varname> superglobal array, you should include the
    file <literal>classa.inc</literal> on all of your pages, not only <filename>page1.php</filename>
    and <filename>page2.php</filename>.
   </para>

--- a/reference/session/book.xml
+++ b/reference/session/book.xml
@@ -65,8 +65,7 @@
   <note>
    <para>
     Please note when working with sessions that a record of a session
-    is not created until a variable has been registered using the
-    <function>session_register</function> function or by adding a new
+    is not created until a variable has been registered by adding a new
     key to the <varname>$_SESSION</varname> superglobal array. This
     holds true regardless of if a session has been started using the
     <function>session_start</function> function.


### PR DESCRIPTION
re: #2730 

Removes references to the `session_register` function removed in PHP 5.4