### PR TITLE
[gnupg] Fix return type hints

### DIFF
--- a/reference/gnupg/functions/gnupg-decrypt.xml
+++ b/reference/gnupg/functions/gnupg-decrypt.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>gnupg_decrypt</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>gnupg_decrypt</methodname>
    <methodparam><type>resource</type><parameter>identifier</parameter></methodparam>
    <methodparam><type>string</type><parameter>text</parameter></methodparam>
   </methodsynopsis>

--- a/reference/gnupg/functions/gnupg-decryptverify.xml
+++ b/reference/gnupg/functions/gnupg-decryptverify.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>gnupg_decryptverify</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>gnupg_decryptverify</methodname>
    <methodparam><type>resource</type><parameter>identifier</parameter></methodparam>
    <methodparam><type>string</type><parameter>text</parameter></methodparam>
    <methodparam><type>string</type><parameter role="reference">plaintext</parameter></methodparam>

--- a/reference/gnupg/functions/gnupg-encrypt.xml
+++ b/reference/gnupg/functions/gnupg-encrypt.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>gnupg_encrypt</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>gnupg_encrypt</methodname>
    <methodparam><type>resource</type><parameter>identifier</parameter></methodparam>
    <methodparam><type>string</type><parameter>plaintext</parameter></methodparam>
   </methodsynopsis>

--- a/reference/gnupg/functions/gnupg-encryptsign.xml
+++ b/reference/gnupg/functions/gnupg-encryptsign.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>gnupg_encryptsign</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>gnupg_encryptsign</methodname>
    <methodparam><type>resource</type><parameter>identifier</parameter></methodparam>
    <methodparam><type>string</type><parameter>plaintext</parameter></methodparam>
   </methodsynopsis>

--- a/reference/gnupg/functions/gnupg-export.xml
+++ b/reference/gnupg/functions/gnupg-export.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>gnupg_export</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>gnupg_export</methodname>
    <methodparam><type>resource</type><parameter>identifier</parameter></methodparam>
    <methodparam><type>string</type><parameter>fingerprint</parameter></methodparam>
   </methodsynopsis>

--- a/reference/gnupg/functions/gnupg-geterror.xml
+++ b/reference/gnupg/functions/gnupg-geterror.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>gnupg_geterror</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>gnupg_geterror</methodname>
    <methodparam><type>resource</type><parameter>identifier</parameter></methodparam>
   </methodsynopsis>
  </refsect1>

--- a/reference/gnupg/functions/gnupg-gettrustlist.xml
+++ b/reference/gnupg/functions/gnupg-gettrustlist.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>gnupg_gettrustlist</methodname>
+   <type class="union"><type>array</type><type>null</type></type><methodname>gnupg_gettrustlist</methodname>
    <methodparam><type>resource</type><parameter>identifier</parameter></methodparam>
    <methodparam><type>string</type><parameter>pattern</parameter></methodparam>
   </methodsynopsis>

--- a/reference/gnupg/functions/gnupg-import.xml
+++ b/reference/gnupg/functions/gnupg-import.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>gnupg_import</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>gnupg_import</methodname>
    <methodparam><type>resource</type><parameter>identifier</parameter></methodparam>
    <methodparam><type>string</type><parameter>keydata</parameter></methodparam>
   </methodsynopsis>

--- a/reference/gnupg/functions/gnupg-keyinfo.xml
+++ b/reference/gnupg/functions/gnupg-keyinfo.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>gnupg_keyinfo</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>gnupg_keyinfo</methodname>
    <methodparam><type>resource</type><parameter>identifier</parameter></methodparam>
    <methodparam><type>string</type><parameter>pattern</parameter></methodparam>
   </methodsynopsis>

--- a/reference/gnupg/functions/gnupg-listsignatures.xml
+++ b/reference/gnupg/functions/gnupg-listsignatures.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>gnupg_listsignatures</methodname>
+   <type class="union"><type>array</type><type>null</type></type><methodname>gnupg_listsignatures</methodname>
    <methodparam><type>resource</type><parameter>identifier</parameter></methodparam>
    <methodparam><type>string</type><parameter>keyid</parameter></methodparam>
   </methodsynopsis>

--- a/reference/gnupg/functions/gnupg-sign.xml
+++ b/reference/gnupg/functions/gnupg-sign.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>gnupg_sign</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>gnupg_sign</methodname>
    <methodparam><type>resource</type><parameter>identifier</parameter></methodparam>
    <methodparam><type>string</type><parameter>plaintext</parameter></methodparam>
   </methodsynopsis>

--- a/reference/gnupg/functions/gnupg-verify.xml
+++ b/reference/gnupg/functions/gnupg-verify.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>gnupg_verify</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>gnupg_verify</methodname>
    <methodparam><type>resource</type><parameter>identifier</parameter></methodparam>
    <methodparam><type>string</type><parameter>signed_text</parameter></methodparam>
    <methodparam><type>string</type><parameter>signature</parameter></methodparam>


### PR DESCRIPTION
This PR fixes return type hints for gnupg extension functions.