### PR TITLE
Sort mis-ordered modifier in code example #2

### DIFF
--- a/reference/funchand/functions/call-user-func-array.xml
+++ b/reference/funchand/functions/call-user-func-array.xml
@@ -134,7 +134,7 @@ foo::bar got three and four
 namespace Foobar;
 
 class Foo {
-    static public function test($name) {
+    public static function test($name) {
         print "Hello {$name}!\n";
     }
 }


### PR DESCRIPTION
This patch proposes a fix to something that looks like a typo, supposed to be `public static ...` and not the other way around.