### PR TITLE
Clarify constructor property promotion modifiers

### DIFF
--- a/language/oop5/decon.xml
+++ b/language/oop5/decon.xml
@@ -138,7 +138,7 @@ class Point {
      </programlisting>
     </example>
     <para>
-     When a constructor argument includes a visibility modifier, PHP will interpret it as
+     When a constructor argument includes a modifier, PHP will interpret it as
      both an object property and a constructor argument, and assign the argument value to
      the property.  The constructor body may then be empty or may contain other statements.
      Any additional statements will be executed after the argument values have been assigned
@@ -148,6 +148,13 @@ class Point {
      Not all arguments need to be promoted. It is possible to mix and match promoted and not-promoted
      arguments, in any order.  Promoted arguments have no impact on code calling the constructor.
     </para>
+    <note>
+     <para>
+      Using a <link linkend="language.oop5.visibility">visibility modifier</link> (<literal>public</literal>,
+      <literal>protected</literal> or <literal>private</literal>) is the most likely way to apply property 
+      promotion, but any other single modifier (such as <literal>readonly</literal>) will have the same effect.
+     </para>
+    </note>
     <note>
      <para>
       Object properties may not be typed <type>callable</type> due to engine ambiguity that would

--- a/language/oop5/decon.xml
+++ b/language/oop5/decon.xml
@@ -151,7 +151,7 @@ class Point {
     <note>
      <para>
       Using a <link linkend="language.oop5.visibility">visibility modifier</link> (<literal>public</literal>,
-      <literal>protected</literal> or <literal>private</literal>) is the most likely way to apply property 
+      <literal>protected</literal> or <literal>private</literal>) is the most likely way to apply property
       promotion, but any other single modifier (such as <literal>readonly</literal>) will have the same effect.
      </para>
     </note>


### PR DESCRIPTION
I was recently made aware that any modifier can be used to apply constructor property promotion, instead of just visibility modifiers:
https://github.com/php/php-src/issues/12122

This PR aims to clarify this in the docs.