### PR TITLE
typo(intl): comma instead of point

### DIFF
--- a/reference/intl/book.xml
+++ b/reference/intl/book.xml
@@ -15,7 +15,7 @@
    library, enabling PHP programmers to perform various locale-aware operations including
    but not limited to formatting, transliteration, encoding conversion, calendar operations,
    <link xlink:href="&url.icu.uca;">UCA</link>-conformant collation, locating
-   text boundaries and working with locale identifiers, timezones and graphemes,
+   text boundaries and working with locale identifiers, timezones and graphemes.
   </para>
 
   <para>


### PR DESCRIPTION
Replace a comma by a point in the Introduction of intl