### PR TITLE
Fix SimpleXMLElement::current() example

### DIFF
--- a/reference/simplexml/simplexmlelement/current.xml
+++ b/reference/simplexml/simplexmlelement/current.xml
@@ -76,9 +76,8 @@
 <![CDATA[
 <?php
 $xmlElement = new SimpleXMLElement('<books><book>PHP basics</book><book>XML basics</book></books>');
-var_dump($xmlIElement->current());
 
-$xmlElement->rewind(); // rewind to first element
+$xmlElement->rewind(); // rewind to first element, otherwise current() won't work
 var_dump($xmlElement->current());
 ?>
 ]]>
@@ -86,7 +85,6 @@ var_dump($xmlElement->current());
     &example.outputs;
     <screen>
 <![CDATA[
-NULL
 object(SimpleXMLElement)#2 (1) {
   [0]=>
   string(10) "PHP basics"


### PR DESCRIPTION
1) There's a typo in the variable name
2) The call returned NULL in PHP < 8.1. It throws an exception starting
   in 8.1. To keep the example simple and not introduce different
   variants based on the version, just remove the faulty call and
   expand upon the comment.