### PR TITLE
$message in stream_notification_callback() is nullable

### DIFF
--- a/reference/stream/functions/stream-notification-callback.xml
+++ b/reference/stream/functions/stream-notification-callback.xml
@@ -13,7 +13,7 @@
    <type>void</type><methodname><replaceable>stream_notification_callback</replaceable></methodname>
    <methodparam><type>int</type><parameter>notification_code</parameter></methodparam>
    <methodparam><type>int</type><parameter>severity</parameter></methodparam>
-   <methodparam><type>string</type><parameter>message</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>message</parameter></methodparam>
    <methodparam><type>int</type><parameter>message_code</parameter></methodparam>
    <methodparam><type>int</type><parameter>bytes_transferred</parameter></methodparam>
    <methodparam><type>int</type><parameter>bytes_max</parameter></methodparam>


### PR DESCRIPTION
At least for HTTP streams, the `$message` parameter of `stream_notification_callback()` is nullable, let's document it.

See https://onlinephp.io/c/f0a2fc for a simple script to get the types.