### PR TITLE
`compact()` now issues an E_WARNING error.(PHP8.0)

### DIFF
--- a/reference/array/functions/compact.xml
+++ b/reference/array/functions/compact.xml
@@ -58,7 +58,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   <function>compact</function> issues an E_NOTICE level error if a given string
+   <function>compact</function> issues an E_WARNING level error if a given string
    refers to an unset variable.
   </para>
  </refsect1>
@@ -74,6 +74,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       If a given string references an unset variable, an E_WARNING level error is now issued.
+      </entry>
+     </row>
      <row>
       <entry>7.3.0</entry>
       <entry>

--- a/reference/array/functions/compact.xml
+++ b/reference/array/functions/compact.xml
@@ -58,7 +58,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   <function>compact</function> issues an E_WARNING level error if a given string
+   <function>compact</function> issues an <constant>E_WARNING</constant> level error if a given string
    refers to an unset variable.
   </para>
  </refsect1>
@@ -77,13 +77,13 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       If a given string references an unset variable, an E_WARNING level error is now issued.
+       If a given string references an unset variable, an <constant>E_WARNING</constant> level error is now issued.
       </entry>
      </row>
      <row>
       <entry>7.3.0</entry>
       <entry>
-       <function>compact</function> now issues an E_NOTICE level error if a given string
+       <function>compact</function> now issues an <constant>E_NOTICE</constant> level error if a given string
        refers to an unset variable. Formerly, such strings have been silently skipped.
       </entry>
      </row>


### PR DESCRIPTION
Since PHP 8.0: "[A number of notices have been converted into warnings](https://www.php.net/manual/en/migration80.incompatible.php)"

Usually, in the PHP manual, even if the error level is raised from E_NOTICE to E_WARNING, a changelog isn't kept within individual function pages.
However, on the compact() page, there's already an entry in the changelog regarding the previous change to 'now issues an E_NOTICE'. Therefore, I believe that adding a note explicitly indicating the recent change in the issued error might prevent confusion.