### PR TITLE
Corrections to xml_parser_[gs]et_option

### DIFF
--- a/reference/xml/functions/xml-parser-get-option.xml
+++ b/reference/xml/functions/xml-parser-get-option.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type class="union"><type>string</type><type>int</type></type><methodname>xml_parser_get_option</methodname>
+   <type class="union"><type>string</type><type>int</type><type>bool</type></type><methodname>xml_parser_get_option</methodname>
    <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
   </methodsynopsis>
@@ -48,8 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   This function returns &false; if <parameter>parser</parameter> does
-   not refer to a valid parser. Else the option's value is returned.
+   Returns the option's value.
   </para>
  </refsect1>
 
@@ -77,6 +76,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       The function now returns a boolean for boolean options.
+      </entry>
+     </row>
      &xml.changelog.parser-param;
      <row>
       <entry>8.0.0</entry>

--- a/reference/xml/functions/xml-parser-set-option.xml
+++ b/reference/xml/functions/xml-parser-set-option.xml
@@ -12,7 +12,7 @@
    <type>bool</type><methodname>xml_parser_set_option</methodname>
    <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
-   <methodparam><type class="union"><type>string</type><type>int</type></type><parameter>value</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>int</type><type>bool</type></type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
    Sets an option in an XML parser.
@@ -52,7 +52,7 @@
          <tbody>
           <row>
            <entry><constant>XML_OPTION_CASE_FOLDING</constant></entry>
-           <entry>integer</entry>
+           <entry>bool</entry>
            <entry>
             Controls whether <link
             linkend="xml.case-folding">case-folding</link> is enabled for this
@@ -69,7 +69,7 @@
           </row>
           <row>
            <entry><constant>XML_OPTION_SKIP_WHITE</constant></entry>
-           <entry>integer</entry> 
+           <entry>bool</entry>
            <entry>
             Whether to skip values consisting of whitespace characters.
            </entry>
@@ -106,8 +106,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   This function returns &false; if <parameter>parser</parameter> does not
-   refer to a valid parser. Else the option's is set and &true; is returned.
+   Returns &true; on success or &false; on failure.
   </para>
  </refsect1>
 
@@ -136,6 +135,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       The <parameter>value</parameter> parameter now also accepts booleans.
+       The options <constant>XML_OPTION_CASE_FOLDING</constant> and <constant>XML_OPTION_SKIP_WHITE</constant>
+       are now boolean options.
+      </entry>
+     </row>
      &xml.changelog.parser-param;
      <row>
       <entry>8.0.0</entry>


### PR DESCRIPTION
Reference: https://github.com/php/php-src/commit/81e59c64979c458b658695aac85fb8dbaad4a7ef
Came across this by coincidence and noticed the manpage is not yet up-to-date for 8.3 and there was no PR, so here we go.