### PR TITLE
PHP 8.3 migration guide.

### DIFF
--- a/appendices/migration83.xml
+++ b/appendices/migration83.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appendix xml:id="migration83" xmlns="http://docbook.org/ns/docbook" xmlns:phd="http://www.php.net/ns/phd">
+ <title>Migrating from PHP 8.2.x to PHP 8.3.x</title>
+
+ &appendices.migration83.new-features;
+ &appendices.migration83.new-classes;
+ &appendices.migration83.new-functions;
+ &appendices.migration83.constants;
+ &appendices.migration83.incompatible;
+ &appendices.migration83.deprecated;
+ <!--
+ &appendices.migration83.other-changes;
+ -->
+ &appendices.migration83.windows-support;
+
+ <sect1 phd:chunk="false" xml:id="migration83.intro">
+  <para>
+   This new minor version brings with it a number of
+   <link linkend="migration83.new-features">new features</link> and a
+   <link linkend="migration83.incompatible">few incompatibilities</link>
+   that should be tested for before switching PHP versions in production
+   environments.
+  </para>
+
+  <para>
+   &manual.migration.seealso;
+   <link linkend="migration71">7.1.x</link>,
+   <link linkend="migration72">7.2.x</link>,
+   <link linkend="migration73">7.3.x</link>,
+   <link linkend="migration74">7.4.x</link>,
+   <link linkend="migration80">8.0.x</link>,
+   <link linkend="migration81">8.1.x</link>.
+   <link linkend="migration82">8.2.x</link>.
+  </para>
+ </sect1>
+</appendix>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration83.xml
+++ b/appendices/migration83.xml
@@ -8,9 +8,7 @@
  &appendices.migration83.constants;
  &appendices.migration83.incompatible;
  &appendices.migration83.deprecated;
- <!--
  &appendices.migration83.other-changes;
- -->
  &appendices.migration83.windows-support;
 
  <sect1 phd:chunk="false" xml:id="migration83.intro">

--- a/appendices/migration83/constants.xml
+++ b/appendices/migration83/constants.xml
@@ -1,0 +1,332 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration83.constants" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>New Global Constants</title>
+
+ <sect2 xml:id="migration83.constants.curl">
+  <title>cURL</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <constant>CURLINFO_CAPATH</constant> (libcurl >= 7.84.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLINFO_CAINFO</constant> (libcurl >= 7.84.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_MIME_OPTIONS</constant> (libcurl >= 7.81.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLMIMEOPT_FORMESCAPE</constant> (libcurl >= 7.81.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_WS_OPTIONS</constant> (libcurl >= 7.86.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLWS_RAW_MODE</constant> (libcurl >= 7.86.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_SSH_HOSTKEYFUNCTION</constant> (libcurl >= 7.84.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_PROTOCOLS_STR</constant> (libcurl >= 7.85.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_REDIR_PROTOCOLS_STR</constant> (libcurl >= 7.85.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_CA_CACHE_TIMEOUT</constant> (libcurl >= 7.87.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLOPT_QUICK_EXIT</constant> (libcurl >= 7.87.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLKHMATCH_OK</constant> (libcurl >= 7.84.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLKHMATCH_MISMATCH</constant> (libcurl >= 7.84.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLKHMATCH_MISSING</constant> (libcurl >= 7.84.0)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>CURLKHMATCH_LAST</constant> (libcurl >= 7.84.0)
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration83.constants.intl">
+  <title>Intl</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>MIXED_NUMBERS</constant> (<classname>Spoofchecker</classname>)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>HIDDEN_OVERLAY</constant> (<classname>Spoofchecker</classname>)</simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration83.constants.openssl">
+  <title>OpenSSL</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>OPENSSL_CMS_OLDMIMETYPE</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>PKCS7_NOOLDMIMETYPE</constant></simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration83.constants.pcntl">
+  <title>PCNTL</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>SIGINFO</constant></simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration83.constants.pdo-odbc">
+  <title>PDO_ODBC</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>PDO_ODBC_TYPE</constant></simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration83.constants.posix">
+  <title>Posix</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>POSIX_SC_ARG_MAX</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>POSIX_SC_PAGESIZE</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>POSIX_SC_NPROCESSORS_CONF</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>POSIX_SC_NPROCESSORS_ONLN</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>POSIX_PC_LINK_MAX</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>POSIX_PC_MAX_CANON</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>POSIX_PC_MAX_INPUT</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>POSIX_PC_NAME_MAX</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>POSIX_PC_PATH_MAX</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>POSIX_PC_PIPE_BUF</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>POSIX_PC_CHOWN_RESTRICTED</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>POSIX_PC_NO_TRUNC</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>POSIX_PC_ALLOC_SIZE_MIN</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>POSIX_PC_SYMLINK_MAX</constant></simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration83.constants.sockets">
+  <title>Sockets</title>
+
+  <para>
+   The following socket options are now defined if they are supported:
+  </para>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>SO_ATTACH_REUSEPORT_CBPF</constant> (Linux)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_DETACH_BPF</constant> (Linux)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_DETACH_FILTER</constant> (Linux)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>TCP_QUICKACK</constant> (Linux)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>IP_DONTFRAG</constant> (FreeBSD)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>IP_MTU_DISCOVER</constant> (Linux)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>IP_PMTUDISC_DO</constant> (Linux)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>IP_PMTUDISC_DONT</constant> (Linux)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>IP_PMTUDISC_WANT</constant> (Linux)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>IP_PMTUDISC_PROBE</constant> (Linux)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>IP_PMTUDISC_INTERFACE</constant> (Linux)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>IP_PMTUDISC_OMIT</constant> (Linux)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>AF_DIVERT</constant> (FreeBSD)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SOL_UDPLITE</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>UDPLITE_RECV_CSCOV</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>UDPLITE_SEND_CSCOV</constant></simpara>
+   </listitem>
+
+   <listitem>
+    <simpara><constant>SO_RERROR</constant> (NetBSD)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_ZEROIZE</constant> (OpenBSD)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_SPLICE</constant> (OpenBSD)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>TCP_REPAIR</constant> (Linux)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_REUSEPORT_LB</constant> (FreeBSD)</simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>IP_BIND_ADDRESS_NO_PORT</constant> (Linux)</simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration83.constants.zip">
+  <title>Zip</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <constant>ZipArchive::ER_DATA_LENGTH</constant> (libzip >= 1.10)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>ZipArchive::ER_NOT_ALLOWED</constant> (libzip >= 1.10)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>ZipArchive::AFL_RDONLY</constant> (libzip >= 1.10)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>ZipArchive::AFL_IS_TORRENTZIP</constant> (libzip >= 1.10)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>ZipArchive::AFL_WANT_TORRENTZIP</constant> (libzip >= 1.10)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant> (libzip >= 1.10)
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>ZipArchive::FL_OPEN_FILE_NOW</constant>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>ZipArchive::LENGTH_TO_END</constant> as default value for <function>ZipArchive::addFile</function> and <function>ZipArchive::replaceFile</function>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>ZipArchive::LENGTH_UNCHECKED</constant> (libzip >= 1.10)
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+</sect1>
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/appendices/migration83/constants.xml
+++ b/appendices/migration83/constants.xml
@@ -89,10 +89,12 @@
 
   <itemizedlist>
    <listitem>
-    <simpara><constant>MIXED_NUMBERS</constant> (<classname>Spoofchecker</classname>)</simpara>
+    <simpara><constant>MIXED_NUMBERS</constant>
+    (<classname>Spoofchecker</classname>)</simpara>
    </listitem>
    <listitem>
-    <simpara><constant>HIDDEN_OVERLAY</constant> (<classname>Spoofchecker</classname>)</simpara>
+    <simpara><constant>HIDDEN_OVERLAY</constant>
+    (<classname>Spoofchecker</classname>)</simpara>
    </listitem>
   </itemizedlist>
  </sect2>
@@ -288,7 +290,8 @@
    </listitem>
    <listitem>
     <simpara>
-     <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant> (libzip >= 1.10)
+     <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
+     (libzip >= 1.10)
     </simpara>
    </listitem>
    <listitem>
@@ -298,7 +301,9 @@
    </listitem>
    <listitem>
     <simpara>
-     <constant>ZipArchive::LENGTH_TO_END</constant> as default value for <function>ZipArchive::addFile</function> and <function>ZipArchive::replaceFile</function>
+     <constant>ZipArchive::LENGTH_TO_END</constant> as default value for
+     <function>ZipArchive::addFile</function> and
+     <function>ZipArchive::replaceFile</function>
     </simpara>
    </listitem>
    <listitem>

--- a/appendices/migration83/constants.xml
+++ b/appendices/migration83/constants.xml
@@ -63,22 +63,22 @@
    </listitem>
    <listitem>
     <simpara>
-     <constant>CURLKHMATCH_OK</constant> (libcurl >= 7.84.0)
+     <constant>CURLKHMATCH_OK</constant> (libcurl >= 7.19.6)
     </simpara>
    </listitem>
    <listitem>
     <simpara>
-     <constant>CURLKHMATCH_MISMATCH</constant> (libcurl >= 7.84.0)
+     <constant>CURLKHMATCH_MISMATCH</constant> (libcurl >= 7.19.6)
     </simpara>
    </listitem>
    <listitem>
     <simpara>
-     <constant>CURLKHMATCH_MISSING</constant> (libcurl >= 7.84.0)
+     <constant>CURLKHMATCH_MISSING</constant> (libcurl >= 7.19.6)
     </simpara>
    </listitem>
    <listitem>
     <simpara>
-     <constant>CURLKHMATCH_LAST</constant> (libcurl >= 7.84.0)
+     <constant>CURLKHMATCH_LAST</constant> (libcurl >= 7.19.6)
     </simpara>
    </listitem>
   </itemizedlist>

--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration83.deprecated">
+ <title>Deprecated Features</title>
+
+ <sect2 xml:id="migration83.deprecated.core">
+  <title>PHP Core</title>
+
+  <sect3 xml:id="migration83.deprecated.core.saner-inc-dec-operators">
+   <title>Saner Increment/Decrement operators</title>
+
+   <para>
+    Using the ++ operator on empty, non-numeric, or non-alphanumeric strings
+    is now deprecated. Moreover, incrementing non-numeric strings is soft
+    deprecated and the new <function>str_increment</function> function should be used instead.
+   </para>
+
+   <para>
+    Using the -- operator on empty or non-numeric strings is now deprecated.
+   </para>
+   <!-- RFC: https://wiki.php.net/rfc/saner-inc-dec-operators -->
+  </sect3>
+
+  <sect3 xml:id="migration83.deprecated.core.get-class">
+   <title>get_class()/get_parent_class() call without arguments</title>
+
+   <para>
+    Calling <function>get_class</function> and <function>get_parent_class</function> without arguments is now
+    deprecated.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.deprecated.core.dba">
+   <title>DBA</title>
+
+   <para>
+    Calling <function>dba_fetch</function> with $dba as the 3rd argument is now deprecated.
+   </para>
+  </sect3>
+
+ </sect2>
+
+ <sect2 xml:id="migration83.deprecated.ffi">
+  <title>FFI</title>
+
+  <para>
+   Calling <methodname>FFI::cast</methodname>, <methodname>FFI::new</methodname>, and <methodname>FFI::type</methodname> statically is now
+   deprecated.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration83.deprecated.intl">
+  <title>Intl</title>
+
+  <para>
+   The <constant>U_MULTIPLE_DECIMAL_SEP*E*RATORS</constant> constant had been deprecated, using
+   the <constant>U_MULTIPLE_DECIMAL_SEP*A*RATORS</constant> instead is recommended.
+  </para>
+  <para>
+   The <constant>NumberFormatter::TYPE_CURRENCY</constant> has been deprecated.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration83.deprecated.ldap">
+  <title>LDAP</title>
+
+  <para>
+   Calling <function>ldap_connect</function> with separate hostname and port is deprecated.
+   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_3#deprecate_calling_ldap_connect_with_2_parameters -->
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration83.deprecated.mbstring">
+  <title>MBString</title>
+
+  <para>
+   Passing a negative $width to <function>mb_strimwidth</function> is now deprecated.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration83.deprecated.phar">
+  <title>Phar</title>
+
+  <para>
+   Calling <methodname>Phar::setStub</methodname> with a resource and a length is now deprecated.
+   Such calls should be replaced by:
+   <code>$phar->setStub(stream_get_contents($resource));</code>
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration83.deprecated.random">
+  <title>Random</title>
+
+  <para>
+   The <constant>MT_RAND_PHP</constant> Mt19937 variant is deprecated.
+   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_3#mt_rand_php -->
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration83.deprecated.standard">
+  <title>Standard</title>
+
+  <para>
+   The <function>assert_options</function> function is now deprecated.
+  </para>
+  <para>
+   The <constant>ASSERT_ACTIVE</constant>, <constant>ASSERT_BAIL</constant>, <constant>ASSERT_CALLBACK</constant>, <constant>ASSERT_EXCEPTION</constant>, and
+   <constant>ASSERT_WARNING</constant> constants have been deprecated.
+  </para>
+  <!-- RFC: https://wiki.php.net/rfc/assert-string-eval-cleanup -->
+ </sect2>
+
+ <sect2 xml:id="migration83.deprecated.sqlite3">
+  <title>SQLite3</title>
+
+  <para>
+   Using exceptions is now preferred, warnings will be removed in the future.
+   Calling <code>SQLite3::enableExceptions(false)</code> will trigger a depreciation
+   warning in this version.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration83.deprecated.zip">
+  <title>Zip</title>
+
+  <para>
+   The <constant>ZipArchive::FL_RECOMPRESS</constant> constant is deprecated and will be removed
+   in a future version of libzip.
+  </para>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -96,6 +96,15 @@
   </para>
  </sect2>
 
+ <sect2 xml:id="migration83.deprecated.reflection">
+  <title>Reflection</title>
+
+  <para>
+   Calling <methodname>ReflectionProperty::setValue</methodname> with only one parameter is deprecated.
+   To set static properties, pass null as the first parameter.
+  </para>
+ </sect2>
+
  <sect2 xml:id="migration83.deprecated.standard">
   <title>Standard</title>
 

--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -33,7 +33,7 @@
    <title>DBA</title>
 
    <para>
-    Calling <function>dba_fetch</function> with $dba as the 3rd argument is now deprecated.
+    Calling <function>dba_fetch</function> with <parameter>$dba</parameter> as the 3rd argument is now deprecated.
    </para>
   </sect3>
 
@@ -52,8 +52,10 @@
   <title>Intl</title>
 
   <para>
-   The <constant>U_MULTIPLE_DECIMAL_SEP*E*RATORS</constant> constant had been deprecated, using
-   the <constant>U_MULTIPLE_DECIMAL_SEP*A*RATORS</constant> instead is recommended.
+   The <constant>U_MULTIPLE_DECIMAL_SEP*E*RATORS</constant>
+   constant had been deprecated, using the
+   <constant>U_MULTIPLE_DECIMAL_SEP*A*RATORS</constant>
+   constant instead is recommended.
   </para>
   <para>
    The <constant>NumberFormatter::TYPE_CURRENCY</constant> has been deprecated.
@@ -73,7 +75,7 @@
   <title>MBString</title>
 
   <para>
-   Passing a negative $width to <function>mb_strimwidth</function> is now deprecated.
+   Passing a negative <parameter>$width</parameter> to <function>mb_strimwidth</function> is now deprecated.
   </para>
  </sect2>
 
@@ -101,7 +103,7 @@
 
   <para>
    Calling <methodname>ReflectionProperty::setValue</methodname> with only one parameter is deprecated.
-   To set static properties, pass null as the first parameter.
+   To set static properties, pass &null; as the first parameter.
   </para>
  </sect2>
 
@@ -123,7 +125,7 @@
 
   <para>
    Using exceptions is now preferred, warnings will be removed in the future.
-   Calling <code>SQLite3::enableExceptions(false)</code> will trigger a depreciation
+   Calling <code>SQLite3::enableExceptions(false)</code> will trigger a deprecation
    warning in this version.
   </para>
  </sect2>

--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -86,7 +86,8 @@
   <title>Phar</title>
 
   <para>
-   Calling <methodname>Phar::setStub</methodname> with a resource and a length
+   Calling <methodname>Phar::setStub</methodname> with a
+   <parameter>$resource</parameter> and a <parameter>$length</parameter>
    is now deprecated. Such calls should be replaced by:
    <code>$phar->setStub(stream_get_contents($resource));</code>
   </para>

--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -11,7 +11,8 @@
    <para>
     Using the ++ operator on empty, non-numeric, or non-alphanumeric strings
     is now deprecated. Moreover, incrementing non-numeric strings is soft
-    deprecated and the new <function>str_increment</function> function should be used instead.
+    deprecated and the new <function>str_increment</function> function should
+    be used instead.
    </para>
 
    <para>
@@ -24,8 +25,8 @@
    <title>get_class()/get_parent_class() call without arguments</title>
 
    <para>
-    Calling <function>get_class</function> and <function>get_parent_class</function> without arguments is now
-    deprecated.
+    Calling <function>get_class</function> and <function>get_parent_class</function>
+    without arguments is now deprecated.
    </para>
   </sect3>
  </sect2>
@@ -34,7 +35,8 @@
   <title>DBA</title>
 
   <para>
-   Calling <function>dba_fetch</function> with <parameter>$dba</parameter> as the 3rd argument is now deprecated.
+   Calling <function>dba_fetch</function> with <parameter>$dba</parameter> as
+   the 3rd argument is now deprecated.
   </para>
  </sect2>
 
@@ -42,8 +44,8 @@
   <title>FFI</title>
 
   <para>
-   Calling <methodname>FFI::cast</methodname>, <methodname>FFI::new</methodname>, and <methodname>FFI::type</methodname> statically is now
-   deprecated.
+   Calling <methodname>FFI::cast</methodname>, <methodname>FFI::new</methodname>,
+   and <methodname>FFI::type</methodname> statically is now deprecated.
   </para>
  </sect2>
 
@@ -65,7 +67,8 @@
   <title>LDAP</title>
 
   <para>
-   Calling <function>ldap_connect</function> with separate hostname and port is deprecated.
+   Calling <function>ldap_connect</function> with separate hostname and port is
+   deprecated.
    <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_3#deprecate_calling_ldap_connect_with_2_parameters -->
   </para>
  </sect2>
@@ -74,7 +77,8 @@
   <title>MBString</title>
 
   <para>
-   Passing a negative <parameter>$width</parameter> to <function>mb_strimwidth</function> is now deprecated.
+   Passing a negative <parameter>$width</parameter> to
+   <function>mb_strimwidth</function> is now deprecated.
   </para>
  </sect2>
 
@@ -82,8 +86,8 @@
   <title>Phar</title>
 
   <para>
-   Calling <methodname>Phar::setStub</methodname> with a resource and a length is now deprecated.
-   Such calls should be replaced by:
+   Calling <methodname>Phar::setStub</methodname> with a resource and a length
+   is now deprecated. Such calls should be replaced by:
    <code>$phar->setStub(stream_get_contents($resource));</code>
   </para>
  </sect2>
@@ -101,7 +105,8 @@
   <title>Reflection</title>
 
   <para>
-   Calling <methodname>ReflectionProperty::setValue</methodname> with only one parameter is deprecated.
+   Calling <methodname>ReflectionProperty::setValue</methodname> with only one
+   parameter is deprecated.
    To set static properties, pass &null; as the first parameter.
   </para>
  </sect2>
@@ -113,13 +118,16 @@
    The <function>assert_options</function> function is now deprecated.
   </para>
   <para>
-   The <constant>ASSERT_ACTIVE</constant>, <constant>ASSERT_BAIL</constant>, <constant>ASSERT_CALLBACK</constant>, <constant>ASSERT_EXCEPTION</constant>, and
-   <constant>ASSERT_WARNING</constant> constants have been deprecated.
+   The <constant>ASSERT_ACTIVE</constant>, <constant>ASSERT_BAIL</constant>,
+   <constant>ASSERT_CALLBACK</constant>, <constant>ASSERT_EXCEPTION</constant>,
+   and <constant>ASSERT_WARNING</constant> constants have been deprecated.
   </para>
 
   <para>
    The <literal>assert.*</literal> INI settings have been deprecated.
-    See the <link linkend="migration83.other-changes.ini">Changes to INI File Handling</link> page for further details.
+   See the
+   <link linkend="migration83.other-changes.ini">Changes to INI File Handling</link>
+   page for further details.
   </para>
   <!-- RFC: https://wiki.php.net/rfc/assert-string-eval-cleanup -->
  </sect2>
@@ -129,8 +137,8 @@
 
   <para>
    Using exceptions is now preferred, warnings will be removed in the future.
-   Calling <code>SQLite3::enableExceptions(false)</code> will trigger a deprecation
-   warning in this version.
+   Calling <code>SQLite3::enableExceptions(false)</code> will trigger a
+   deprecation warning in this version.
   </para>
  </sect2>
 
@@ -138,8 +146,8 @@
   <title>Zip</title>
 
   <para>
-   The <constant>ZipArchive::FL_RECOMPRESS</constant> constant is deprecated and will be removed
-   in a future version of libzip.
+   The <constant>ZipArchive::FL_RECOMPRESS</constant> constant is deprecated
+   and will be removed in a future version of libzip.
   </para>
  </sect2>
 

--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -28,15 +28,14 @@
     deprecated.
    </para>
   </sect3>
+ </sect2>
 
-  <sect3 xml:id="migration83.deprecated.core.dba">
-   <title>DBA</title>
+ <sect2 xml:id="migration83.deprecated.core.dba">
+  <title>DBA</title>
 
-   <para>
-    Calling <function>dba_fetch</function> with <parameter>$dba</parameter> as the 3rd argument is now deprecated.
-   </para>
-  </sect3>
-
+  <para>
+   Calling <function>dba_fetch</function> with <parameter>$dba</parameter> as the 3rd argument is now deprecated.
+  </para>
  </sect2>
 
  <sect2 xml:id="migration83.deprecated.ffi">
@@ -116,6 +115,11 @@
   <para>
    The <constant>ASSERT_ACTIVE</constant>, <constant>ASSERT_BAIL</constant>, <constant>ASSERT_CALLBACK</constant>, <constant>ASSERT_EXCEPTION</constant>, and
    <constant>ASSERT_WARNING</constant> constants have been deprecated.
+  </para>
+
+  <para>
+   The <literal>assert.*</literal> INI settings have been deprecated.
+    See the <link linkend="migration83.other-changes.ini">Changes to INI File Handling</link> page for further details.
   </para>
   <!-- RFC: https://wiki.php.net/rfc/assert-string-eval-cleanup -->
  </sect2>

--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -59,7 +59,7 @@
    constant instead is recommended.
   </para>
   <para>
-   The <constant>NumberFormatter::TYPE_CURRENCY</constant> has been deprecated.
+   The <constant>NumberFormatter::TYPE_CURRENCY</constant> constant has been deprecated.
   </para>
  </sect2>
 

--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -9,14 +9,16 @@
    <title>Saner Increment/Decrement operators</title>
 
    <para>
-    Using the ++ operator on empty, non-numeric, or non-alphanumeric strings
-    is now deprecated. Moreover, incrementing non-numeric strings is soft
-    deprecated and the new <function>str_increment</function> function should
-    be used instead.
+    Using the <link linkend="language.operators.increment">increment</link>
+    operator (<literal>++</literal>) on empty, non-numeric,
+    or non-alphanumeric strings is now deprecated.
+    Moreover, incrementing non-numeric strings is soft deprecated and the
+    new <function>str_increment</function> function should be used instead.
    </para>
 
    <para>
-    Using the -- operator on empty or non-numeric strings is now deprecated.
+    Using the <link linkend="language.operators.increment">decrement</link>
+    operator (<literal>--</literal>) on empty or non-numeric strings is now deprecated.
    </para>
    <!-- RFC: https://wiki.php.net/rfc/saner-inc-dec-operators -->
   </sect3>

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -186,8 +186,19 @@
     <code>range('5', '9', 0.5);</code> does not produce a warning).</member>
     <member><function>range</function> now produce a list of characters if one
     of the boundary inputs is a string digit instead of casting the other input
-    to int (e.g. <code>range('5', 'z');</code>).</member>
+    to int (e.g. <code>range('9', 'A');</code>).</member>
    </simplelist>
+
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+range('9', 'A');  // ["9", ":", ";", "<", "=", ">", "?", "@", "A"], as of PHP 8.3.0
+range('9', 'A');  // [9, 8, 7, 6, 5, 4, 3, 2, 1, 0], prior to PHP 8.3.0
+?>
+]]>
+    </programlisting>
+   </informalexample>
   </para>
 
   <para>

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -117,7 +117,7 @@
   <title>Phar</title>
 
   <para>
-   The type of Phar class constants are now declared.
+   The type of <classname>Phar</classname> class constants are now declared.
   </para>
  </sect2>
 
@@ -127,16 +127,16 @@
   <para>
    The <function>range</function> function has had various changes:
    <simplelist>
-    <member>A TypeError is now thrown when passing objects, resources, or arrays
+    <member>A <classname>TypeError</classname> is now thrown when passing objects, resources, or arrays
       as the boundary inputs.</member>
-    <member>A more descriptive ValueError is thrown when passing 0 for $step.</member>
-    <member>A ValueError is now thrown when using a negative $step for increasing ranges.</member>
-    <member>If $step is a float that can be interpreted as an int, it is now done so.</member>
-    <member>A ValueError is now thrown if any argument is infinity or NAN.</member>
-    <member>An E_WARNING is now emitted if $start or $end is the empty string. The value continues to be cast to the value 0.</member>
-    <member>An E_WARNING is now emitted if $start or $end has more than one byte, only if it is a non-numeric string.</member>
-    <member>An E_WARNING is now emitted if $start or $end is cast to an integer because the other boundary input is a number. (e.g. <code>range(5, 'z');</code>).</member>
-    <member>An E_WARNING is now emitted if $step is a float when trying to generate a range of characters, except if both boundary inputs are numeric strings (e.g. <code>range('5', '9', 0.5);</code> does not produce a warning).</member>
+    <member>A more descriptive <classname>ValueError</classname> is thrown when passing <literal>0</literal> for <parameter>$step</parameter>.</member>
+    <member>A <classname>ValueError</classname> is now thrown when using a negative <parameter>$step</parameter> for increasing ranges.</member>
+    <member>If <parameter>$step</parameter> is a float that can be interpreted as an int, it is now done so.</member>
+    <member>A <classname>ValueError</classname> is now thrown if any argument is infinity or NAN.</member>
+    <member>An <constant>E_WARNING</constant> is now emitted if <parameter>$start</parameter> or <parameter>$end</parameter> is the empty string. The value continues to be cast to the value <literal>0</literal>.</member>
+    <member>An <constant>E_WARNING</constant> is now emitted if <parameter>$start</parameter> or <parameter>$end</parameter> has more than one byte, only if it is a non-numeric string.</member>
+    <member>An <constant>E_WARNING</constant> is now emitted if <parameter>$start</parameter> or <parameter>$end</parameter> is cast to an integer because the other boundary input is a number. (e.g. <code>range(5, 'z');</code>).</member>
+    <member>An <constant>E_WARNING</constant> is now emitted if <parameter>$step</parameter> is a float when trying to generate a range of characters, except if both boundary inputs are numeric strings (e.g. <code>range('5', '9', 0.5);</code> does not produce a warning).</member>
     <member><function>range</function> now produce a list of characters if one of the boundary inputs is a string digit instead of casting the other input to int (e.g. <code>range('5', 'z');</code>).</member>
    </simplelist>
   </para>
@@ -150,7 +150,7 @@
   <title>SNMP</title>
 
   <para>
-   The type of SNMP class constants are now declared.
+   The type of <classname>SNMP</classname> class constants are now declared.
   </para>
  </sect2>
 

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -20,13 +20,14 @@
    <title>Executing proc_get_status() multiple times</title>
    <para>
     Executing <function>proc_get_status</function> multiple times will now always
-    return the right value on posix systems. Previously, only the first call
+    return the right value on POSIX systems. Previously, only the first call
     of the function returned the right value. Executing
     <function>proc_close</function> after <function>proc_get_status</function>
     will now also return the right exit code. Previously this would return
     <literal>-1</literal>.
-    Internally, this works by caching the result on posix systems. If you want
-    the old behaviour, you can check the "cached" key in the array returned by
+    Internally, this works by caching the result on POSIX systems.
+    If the previous behaviour is required, it is possible to check the
+    <literal>"cached"</literal> key in the array returned by
     <function>proc_get_status</function> to check whether the result was cached.
    </para>
   </sect3>
@@ -85,7 +86,7 @@
    <methodname>DOMChildNode::before</methodname>,
    <methodname>DOMChildNode::replaceWith</methodname>
    on a node that has no parent is now a no-op instead of a hierarchy
-   exception, which is the behaviour spec demands.
+   exception, which is the behaviour demanded by the DOM specification.
   </para>
 
   <para>
@@ -93,7 +94,7 @@
    and <classname>DOMChildNode</classname> methods without a document now
    works instead of throwing a <constant>DOM_HIERARCHY_REQUEST_ERR</constant>
    <classname>DOMException</classname>.
-   This is in line with the behaviour spec demands.
+   This is in line with the behaviour demanded by the DOM specification.
   </para>
 
   <para>
@@ -111,9 +112,10 @@
   </para>
 
   <para>
-   New methods and properties were added to some DOM classes. If you inherit
-   from these and you happen to have a method or property with the same name,
-   you might encounter errors if the declaration is incompatible.
+   New methods and properties were added to some DOM classes.
+   If a userland class inherits from these classes and declare a method or property
+   with the same name, the declarations must be compatible. Otherwise, a typical
+   compile error about incompatible declarations will be thrown.
    See the <link linkend="migration83.new-features.dom">list of new features</link>
    and <link linkend="migration83.new-functions.dom">few functions</link> for
    a list of the newly implemented methods and properties.
@@ -158,8 +160,8 @@
   <para>
    The <function>range</function> function has had various changes:
    <simplelist>
-    <member>A <classname>TypeError</classname> is now thrown when passing objects,
-    resources, or arrays as the boundary inputs.</member>
+    <member>A <classname>TypeError</classname> is now thrown when passing <type>object</type>s,
+    <type>resource</type>s, or <type>array</type>s as the boundary inputs.</member>
     <member>A more descriptive <classname>ValueError</classname> is thrown when
     passing <literal>0</literal> for <parameter>$step</parameter>.</member>
     <member>A <classname>ValueError</classname> is now thrown when using a

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -117,7 +117,7 @@
    with the same name, the declarations must be compatible. Otherwise, a typical
    compile error about incompatible declarations will be thrown.
    See the <link linkend="migration83.new-features.dom">list of new features</link>
-   and <link linkend="migration83.new-functions.dom">few functions</link> for
+   and <link linkend="migration83.new-functions.dom">new functions</link> for
    a list of the newly implemented methods and properties.
   </para>
  </sect2>

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -37,8 +37,8 @@
   </para>
 
   <para>
-   Assigning a negative index n to an empty array will now make sure that the
-   next index is n+1 instead of 0.
+   Assigning a negative index <varname>$n</varname> to an empty array will now make sure that the
+   next index is <code>n+1</code> instead of <literal>0</literal>.
   </para>
 
   <para>
@@ -102,7 +102,7 @@
   <title>FFI</title>
 
   <para>
-   C functions that have a return type of void now return null instead of
+   C functions that have a return type of <type>void</type> now return &null; instead of
    returning the following object <literal>object(FFI\CData:void) { }</literal>
   </para>
  </sect2>

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -76,7 +76,7 @@
 
   <para>
    <methodname>DOMDocument::createAttributeNS</methodname> would previously incorrectly throw a NAMESPACE_ERR
-   when the prefix was already used for a different uri. It now correctly
+   when the prefix was already used for a different URI. It now correctly
    chooses a different prefix when there's a prefix name conflict.
   </para>
 

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -7,7 +7,7 @@
 
   <para>
    Programs that were very close to overflowing the call stack may now throw an
-   Error when using more than
+   <classname>Error</classname> when using more than
    <!-- link linkend="zend.max_allowed_stack_size-zend.reserved_stack_size" -->zend.max_allowed_stack_size-zend.reserved_stack_size<!-- </link>--> bytes of stack
    (<!-- link linkend="fiber.stack_size-zend.reserved_stack_size" -->fiber.stack_size-zend.reserved_stack_size<!-- </link>--> for fibers).
   </para>
@@ -60,7 +60,7 @@
   <title>DOM</title>
 
   <para>
-   <methodname>DOMChildNode::after</methodname>,
+   Calling <methodname>DOMChildNode::after</methodname>,
    <methodname>DOMChildNode::before</methodname>,
    <methodname>DOMChildNode::replaceWith</methodname>
    on a node that has no parent is now a no-op instead of a hierarchy
@@ -76,7 +76,7 @@
   </para>
 
   <para>
-   <methodname>DOMDocument::createAttributeNS</methodname> without specifying
+   Calling <methodname>DOMDocument::createAttributeNS</methodname> without specifying
    a prefix would incorrectly create a default namespace, placing the element
    inside the namespace instead of the attribute. This bug is now fixed.
   </para>

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -70,7 +70,7 @@
   <para>
    Using the <classname>DOMParentNode</classname>
    and <classname>DOMChildNode</classname> methods without a document now
-   works instead of throwing a HIERARCHY_REQUEST_ERR
+   works instead of throwing a <constant>DOM_HIERARCHY_REQUEST_ERR</constant>
    <classname>DOMException</classname>.
    This is in line with the behaviour spec demands.
   </para>
@@ -83,7 +83,8 @@
 
   <para>
    <methodname>DOMDocument::createAttributeNS</methodname> would previously
-   incorrectly throw a NAMESPACE_ERR when the prefix was already used for a
+   incorrectly throw a <constant>DOM_NAMESPACE_ERRNAMESPACE_ERR</constant>
+   <classname>DOMException</classname> when the prefix was already used for a
    different URI. It now correctly chooses a different prefix when there's a
    prefix name conflict.
   </para>

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -38,7 +38,7 @@
 
   <para>
    Assigning a negative index <varname>$n</varname> to an empty array will now make sure that the
-   next index is <code>n+1</code> instead of <literal>0</literal>.
+   next index is <code>$n+1</code> instead of <literal>0</literal>.
   </para>
 
   <para>

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -84,7 +84,7 @@
    New methods and properties were added to some DOM classes. If you inherit
    from these and you happen to have a method or property with the same name,
    you might encounter errors if the declaration is incompatible.
-   <link linkend="migration83.new-features.dom">New Features</link> and <link linkend="migration83.new-functions.dom">New Functions</link> for a list of
+   See the <link linkend="migration83.new-features.dom">list of new features</link> and <link linkend="migration83.new-functions.dom">few functions</link> for a list of the
    newly implemented methods and properties.
 
   </para>

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -3,57 +3,78 @@
  <title>Backward Incompatible Changes</title>
 
  <sect2 xml:id="migration83.incompatible.core">
-  <title>Core</title>
+  <title>PHP Core</title>
 
-  <para>
-   Programs that were very close to overflowing the call stack may now throw an
-   <classname>Error</classname> when using more than
-   <!-- link linkend="zend.max_allowed_stack_size-zend.reserved_stack_size" -->zend.max_allowed_stack_size-zend.reserved_stack_size<!-- </link>--> bytes of stack
-   (<!-- link linkend="fiber.stack_size-zend.reserved_stack_size" -->fiber.stack_size-zend.reserved_stack_size<!-- </link>--> for fibers).
-  </para>
+  <sect3 xml:id="migration83.incompatible.core.overflowing-call-stack">
 
-  <para>
-   Executing <function>proc_get_status</function> multiple times will now always
-   return the right value on posix systems. Previously, only the first call
-   of the function returned the right value. Executing
-   <function>proc_close</function> after <function>proc_get_status</function>
-   will now also return the right exit code. Previously this would return
-   <literal>-1</literal>.
-   Internally, this works by caching the result on posix systems. If you want
-   the old behaviour, you can check the "cached" key in the array returned by
-   <function>proc_get_status</function> to check whether the result was cached.
-  </para>
+   <title>Programs that were very close to overflowing the call stack</title>
+   <para>
+    Programs that were very close to overflowing the call stack may now throw an
+    <classname>Error</classname> when using more than
+    <!-- link linkend="zend.max_allowed_stack_size-zend.reserved_stack_size" -->zend.max_allowed_stack_size-zend.reserved_stack_size<!-- </link>--> bytes of stack
+    (<!-- link linkend="fiber.stack_size-zend.reserved_stack_size" -->fiber.stack_size-zend.reserved_stack_size<!-- </link>--> for fibers).
+   </para>
+  </sect3>
 
-  <para>
-   Zend Max Execution Timers is now enabled by default for ZTS builds on
-   Linux.
-  </para>
+  <sect3 xml:id="migration83.incompatible.core.proc-get-status-multiple-times">
+   <title>Executing proc_get_status() multiple times</title>
+   <para>
+    Executing <function>proc_get_status</function> multiple times will now always
+    return the right value on posix systems. Previously, only the first call
+    of the function returned the right value. Executing
+    <function>proc_close</function> after <function>proc_get_status</function>
+    will now also return the right exit code. Previously this would return
+    <literal>-1</literal>.
+    Internally, this works by caching the result on posix systems. If you want
+    the old behaviour, you can check the "cached" key in the array returned by
+    <function>proc_get_status</function> to check whether the result was cached.
+   </para>
+  </sect3>
 
-  <para>
-   Uses of traits with static properties will now redeclare static properties
-   inherited from the parent class. This will create a separate static
-   property storage for the current class. This is analogous to adding the
-   static property to the class directly without traits.
-  </para>
+  <sect3 xml:id="migration83.incompatible.core.zend-max-execution-timers">
+   <title>Zend Max Execution Timers</title>
+   <para>
+    Zend Max Execution Timers is now enabled by default for ZTS builds on
+    Linux.
+   </para>
+  </sect3>
 
-  <para>
-   Assigning a negative index <varname>$n</varname> to an empty array will now make sure that the
-   next index is <code>$n+1</code> instead of <literal>0</literal>.
-  </para>
+  <sect3 xml:id="migration83.incompatible.core.traits-with-static-properties">
+   <title>Uses of traits with static properties</title>
+   <para>
+    Uses of traits with static properties will now redeclare static properties
+    inherited from the parent class. This will create a separate static
+    property storage for the current class. This is analogous to adding the
+    static property to the class directly without traits.
+   </para>
+  </sect3>
 
-  <para>
-   Class constant visibility variance is now correctly checked when inherited
-   from interfaces.
-  </para>
+  <sect3 xml:id="migration83.incompatible.core.negative-index-to-empty-array">
+   <title>Assigning a negative index to an empty array</title>
+   <para>
+    Assigning a negative index <varname>$n</varname> to an empty array will now make sure that the
+    next index is <code>$n+1</code> instead of <literal>0</literal>.
+   </para>
+  </sect3>
 
-  <para>
-   <classname>WeakMap</classname> entries whose key maps to itself (possibly
-   transitively) may now be removed during cycle collection if the key is not
-   reachable except by iterating over the WeakMap (reachability via iteration is
-   considered weak).
-   Previously, such entries would never be automatically removed.
-  </para>
+  <sect3 xml:id="migration83.incompatible.core.class-constant-visibility-check">
+   <title>Class constant visibility variance check</title>
+   <para>
+    Class constant visibility variance is now correctly checked when inherited
+    from interfaces.
+   </para>
+  </sect3>
 
+  <sect3 xml:id="migration83.incompatible.core.weakmap-entries-maps-to-itself">
+   <title>WeakMap entries whose key maps to itself</title>
+   <para>
+    <classname>WeakMap</classname> entries whose key maps to itself (possibly
+    transitively) may now be removed during cycle collection if the key is not
+    reachable except by iterating over the WeakMap (reachability via iteration is
+    considered weak).
+    Previously, such entries would never be automatically removed.
+   </para>
+  </sect3>
  </sect2>
 
  <sect2 xml:id="migration83.incompatible.dom">

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -13,10 +13,12 @@
   </para>
 
   <para>
-   Executing <function>proc_get_status</function> multiple times will now always return the right
-   value on posix systems. Previously, only the first call of the function
-   returned the right value. Executing <function>proc_close</function> after <function>proc_get_status</function>
-   will now also return the right exit code. Previously this would return <literal>-1</literal>.
+   Executing <function>proc_get_status</function> multiple times will now always
+   return the right value on posix systems. Previously, only the first call
+   of the function returned the right value. Executing
+   <function>proc_close</function> after <function>proc_get_status</function>
+   will now also return the right exit code. Previously this would return
+   <literal>-1</literal>.
    Internally, this works by caching the result on posix systems. If you want
    the old behaviour, you can check the "cached" key in the array returned by
    <function>proc_get_status</function> to check whether the result was cached.
@@ -45,9 +47,10 @@
   </para>
 
   <para>
-   <classname>WeakMap</classname> entries whose key maps to itself (possibly transitively) may now
-   be removed during cycle collection if the key is not reachable except by
-   iterating over the WeakMap (reachability via iteration is considered weak).
+   <classname>WeakMap</classname> entries whose key maps to itself (possibly
+   transitively) may now be removed during cycle collection if the key is not
+   reachable except by iterating over the WeakMap (reachability via iteration is
+   considered weak).
    Previously, such entries would never be automatically removed.
   </para>
 
@@ -57,36 +60,41 @@
   <title>DOM</title>
 
   <para>
-   <methodname>DOMChildNode::after</methodname>, <methodname>DOMChildNode::before</methodname>, <methodname>DOMChildNode::replaceWith</methodname>
+   <methodname>DOMChildNode::after</methodname>,
+   <methodname>DOMChildNode::before</methodname>,
+   <methodname>DOMChildNode::replaceWith</methodname>
    on a node that has no parent is now a no-op instead of a hierarchy
    exception, which is the behaviour spec demands.
   </para>
 
   <para>
-   Using the <classname>DOMParentNode</classname> and <classname>DOMChildNode</classname> methods without a document now
-   works instead of throwing a HIERARCHY_REQUEST_ERR <classname>DOMException</classname>. This is in
-    line with the behaviour spec demands.
+   Using the <classname>DOMParentNode</classname>
+   and <classname>DOMChildNode</classname> methods without a document now
+   works instead of throwing a HIERARCHY_REQUEST_ERR
+   <classname>DOMException</classname>.
+   This is in line with the behaviour spec demands.
   </para>
 
   <para>
-   <methodname>DOMDocument::createAttributeNS</methodname> without specifying a prefix would incorrectly create
-   a default namespace, placing the element inside the namespace instead of
-   the attribute. This bug is now fixed.
+   <methodname>DOMDocument::createAttributeNS</methodname> without specifying
+   a prefix would incorrectly create a default namespace, placing the element
+   inside the namespace instead of the attribute. This bug is now fixed.
   </para>
 
   <para>
-   <methodname>DOMDocument::createAttributeNS</methodname> would previously incorrectly throw a NAMESPACE_ERR
-   when the prefix was already used for a different URI. It now correctly
-   chooses a different prefix when there's a prefix name conflict.
+   <methodname>DOMDocument::createAttributeNS</methodname> would previously
+   incorrectly throw a NAMESPACE_ERR when the prefix was already used for a
+   different URI. It now correctly chooses a different prefix when there's a
+   prefix name conflict.
   </para>
 
   <para>
    New methods and properties were added to some DOM classes. If you inherit
    from these and you happen to have a method or property with the same name,
    you might encounter errors if the declaration is incompatible.
-   See the <link linkend="migration83.new-features.dom">list of new features</link> and <link linkend="migration83.new-functions.dom">few functions</link> for a list of the
-   newly implemented methods and properties.
-
+   See the <link linkend="migration83.new-features.dom">list of new features</link>
+   and <link linkend="migration83.new-functions.dom">few functions</link> for
+   a list of the newly implemented methods and properties.
   </para>
  </sect2>
 
@@ -103,9 +111,10 @@
   <title>Opcache</title>
 
   <para>
-   The <link linkend="ini.opcache.consistency-checks">opcache.consistency_checks</link> INI directive was removed. This feature was
-   broken with the tracing JIT, as well as with inheritance cache, and has
-   been disabled without a way to enable it since PHP 8.1.18 and PHP 8.2.5.
+   The <link linkend="ini.opcache.consistency-checks">opcache.consistency_checks</link>
+   INI directive was removed. This feature was broken with the tracing JIT,
+   as well as with inheritance cache, and has been disabled without a way to
+   enable it since PHP 8.1.18 and PHP 8.2.5.
    Both the tracing JIT and inheritance cache may modify shm after the script
    has been persisted by invalidating its checksum. The attempted fix skipped
    over the modifiable pointers but was rejected due to complexity. For this
@@ -127,22 +136,39 @@
   <para>
    The <function>range</function> function has had various changes:
    <simplelist>
-    <member>A <classname>TypeError</classname> is now thrown when passing objects, resources, or arrays
-      as the boundary inputs.</member>
-    <member>A more descriptive <classname>ValueError</classname> is thrown when passing <literal>0</literal> for <parameter>$step</parameter>.</member>
-    <member>A <classname>ValueError</classname> is now thrown when using a negative <parameter>$step</parameter> for increasing ranges.</member>
-    <member>If <parameter>$step</parameter> is a float that can be interpreted as an int, it is now done so.</member>
-    <member>A <classname>ValueError</classname> is now thrown if any argument is infinity or NAN.</member>
-    <member>An <constant>E_WARNING</constant> is now emitted if <parameter>$start</parameter> or <parameter>$end</parameter> is the empty string. The value continues to be cast to the value <literal>0</literal>.</member>
-    <member>An <constant>E_WARNING</constant> is now emitted if <parameter>$start</parameter> or <parameter>$end</parameter> has more than one byte, only if it is a non-numeric string.</member>
-    <member>An <constant>E_WARNING</constant> is now emitted if <parameter>$start</parameter> or <parameter>$end</parameter> is cast to an integer because the other boundary input is a number. (e.g. <code>range(5, 'z');</code>).</member>
-    <member>An <constant>E_WARNING</constant> is now emitted if <parameter>$step</parameter> is a float when trying to generate a range of characters, except if both boundary inputs are numeric strings (e.g. <code>range('5', '9', 0.5);</code> does not produce a warning).</member>
-    <member><function>range</function> now produce a list of characters if one of the boundary inputs is a string digit instead of casting the other input to int (e.g. <code>range('5', 'z');</code>).</member>
+    <member>A <classname>TypeError</classname> is now thrown when passing objects,
+    resources, or arrays as the boundary inputs.</member>
+    <member>A more descriptive <classname>ValueError</classname> is thrown when
+    passing <literal>0</literal> for <parameter>$step</parameter>.</member>
+    <member>A <classname>ValueError</classname> is now thrown when using a
+    negative <parameter>$step</parameter> for increasing ranges.</member>
+    <member>If <parameter>$step</parameter> is a float that can be interpreted
+    as an int, it is now done so.</member>
+    <member>A <classname>ValueError</classname> is now thrown if any argument
+    is infinity or NAN.</member>
+    <member>An <constant>E_WARNING</constant> is now emitted if
+    <parameter>$start</parameter> or <parameter>$end</parameter> is the empty
+    string. The value continues to be cast to the value <literal>0</literal>.</member>
+    <member>An <constant>E_WARNING</constant> is now emitted if
+    <parameter>$start</parameter> or <parameter>$end</parameter> has more than
+    one byte, only if it is a non-numeric string.</member>
+    <member>An <constant>E_WARNING</constant> is now emitted if
+    <parameter>$start</parameter> or <parameter>$end</parameter> is cast to an
+    integer because the other boundary input is a number.
+    (e.g. <code>range(5, 'z');</code>).</member>
+    <member>An <constant>E_WARNING</constant> is now emitted if
+    <parameter>$step</parameter> is a float when trying to generate a range of
+    characters, except if both boundary inputs are numeric strings (e.g.
+    <code>range('5', '9', 0.5);</code> does not produce a warning).</member>
+    <member><function>range</function> now produce a list of characters if one
+    of the boundary inputs is a string digit instead of casting the other input
+    to int (e.g. <code>range('5', 'z');</code>).</member>
    </simplelist>
   </para>
 
   <para>
-   The <function>file</function> flags error check now catches all invalid flags. Notably <constant>FILE_APPEND</constant> was previously silently accepted.
+   The <function>file</function> flags error check now catches all invalid flags.
+   Notably <constant>FILE_APPEND</constant> was previously silently accepted.
   </para>
  </sect2>
 

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration83.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Backward Incompatible Changes</title>
+
+ <sect2 xml:id="migration83.incompatible.core">
+  <title>Core</title>
+
+  <para>
+   Programs that were very close to overflowing the call stack may now throw an
+   Error when using more than
+   <!-- link linkend="zend.max_allowed_stack_size-zend.reserved_stack_size" -->zend.max_allowed_stack_size-zend.reserved_stack_size<!-- </link>--> bytes of stack
+   (<!-- link linkend="fiber.stack_size-zend.reserved_stack_size" -->fiber.stack_size-zend.reserved_stack_size<!-- </link>--> for fibers).
+  </para>
+
+  <para>
+   Executing <function>proc_get_status</function> multiple times will now always return the right
+   value on posix systems. Previously, only the first call of the function
+   returned the right value. Executing <function>proc_close</function> after <function>proc_get_status</function>
+   will now also return the right exit code. Previously this would return <literal>-1</literal>.
+   Internally, this works by caching the result on posix systems. If you want
+   the old behaviour, you can check the "cached" key in the array returned by
+   <function>proc_get_status</function> to check whether the result was cached.
+  </para>
+
+  <para>
+   Zend Max Execution Timers is now enabled by default for ZTS builds on
+   Linux.
+  </para>
+
+  <para>
+   Uses of traits with static properties will now redeclare static properties
+   inherited from the parent class. This will create a separate static
+   property storage for the current class. This is analogous to adding the
+   static property to the class directly without traits.
+  </para>
+
+  <para>
+   Assigning a negative index n to an empty array will now make sure that the
+   next index is n+1 instead of 0.
+  </para>
+
+  <para>
+   Class constant visibility variance is now correctly checked when inherited
+   from interfaces.
+  </para>
+
+  <para>
+   <classname>WeakMap</classname> entries whose key maps to itself (possibly transitively) may now
+   be removed during cycle collection if the key is not reachable except by
+   iterating over the WeakMap (reachability via iteration is considered weak).
+   Previously, such entries would never be automatically removed.
+  </para>
+
+ </sect2>
+
+ <sect2 xml:id="migration83.incompatible.dom">
+  <title>DOM</title>
+
+  <para>
+   <methodname>DOMChildNode::after</methodname>, <methodname>DOMChildNode::before</methodname>, <methodname>DOMChildNode::replaceWith</methodname>
+   on a node that has no parent is now a no-op instead of a hierarchy
+   exception, which is the behaviour spec demands.
+  </para>
+
+  <para>
+   Using the <classname>DOMParentNode</classname> and <classname>DOMChildNode</classname> methods without a document now
+   works instead of throwing a HIERARCHY_REQUEST_ERR <classname>DOMException</classname>. This is in
+    line with the behaviour spec demands.
+  </para>
+
+  <para>
+   <methodname>DOMDocument::createAttributeNS</methodname> without specifying a prefix would incorrectly create
+   a default namespace, placing the element inside the namespace instead of
+   the attribute. This bug is now fixed.
+  </para>
+
+  <para>
+   <methodname>DOMDocument::createAttributeNS</methodname> would previously incorrectly throw a NAMESPACE_ERR
+   when the prefix was already used for a different uri. It now correctly
+   chooses a different prefix when there's a prefix name conflict.
+  </para>
+
+  <para>
+   New methods and properties were added to some DOM classes. If you inherit
+   from these and you happen to have a method or property with the same name,
+   you might encounter errors if the declaration is incompatible.
+   <link linkend="migration83.new-features.dom">New Features</link> and <link linkend="migration83.new-functions.dom">New Functions</link> for a list of
+   newly implemented methods and properties.
+
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration83.incompatible.ffi">
+  <title>FFI</title>
+
+  <para>
+   C functions that have a return type of void now return null instead of
+   returning the following object <literal>object(FFI\CData:void) { }</literal>
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration83.incompatible.opcache">
+  <title>Opcache</title>
+
+  <para>
+   The <link linkend="ini.opcache.consistency-checks">opcache.consistency_checks</link> INI directive was removed. This feature was
+   broken with the tracing JIT, as well as with inheritance cache, and has
+   been disabled without a way to enable it since PHP 8.1.18 and PHP 8.2.5.
+   Both the tracing JIT and inheritance cache may modify shm after the script
+   has been persisted by invalidating its checksum. The attempted fix skipped
+   over the modifiable pointers but was rejected due to complexity. For this
+   reason, it was decided to remove the feature instead.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration83.incompatible.phar">
+  <title>Phar</title>
+
+  <para>
+   The type of Phar class constants are now declared.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration83.incompatible.standard">
+  <title>Standard</title>
+
+  <para>
+   The <function>range</function> function has had various changes:
+   <simplelist>
+    <member>A TypeError is now thrown when passing objects, resources, or arrays
+      as the boundary inputs.</member>
+    <member>A more descriptive ValueError is thrown when passing 0 for $step.</member>
+    <member>A ValueError is now thrown when using a negative $step for increasing ranges.</member>
+    <member>If $step is a float that can be interpreted as an int, it is now done so.</member>
+    <member>A ValueError is now thrown if any argument is infinity or NAN.</member>
+    <member>An E_WARNING is now emitted if $start or $end is the empty string. The value continues to be cast to the value 0.</member>
+    <member>An E_WARNING is now emitted if $start or $end has more than one byte, only if it is a non-numeric string.</member>
+    <member>An E_WARNING is now emitted if $start or $end is cast to an integer because the other boundary input is a number. (e.g. <code>range(5, 'z');</code>).</member>
+    <member>An E_WARNING is now emitted if $step is a float when trying to generate a range of characters, except if both boundary inputs are numeric strings (e.g. <code>range('5', '9', 0.5);</code> does not produce a warning).</member>
+    <member><function>range</function> now produce a list of characters if one of the boundary inputs is a string digit instead of casting the other input to int (e.g. <code>range('5', 'z');</code>).</member>
+   </simplelist>
+  </para>
+
+  <para>
+   The <function>file</function> flags error check now catches all invalid flags. Notably <constant>FILE_APPEND</constant> was previously silently accepted.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration83.incompatible.SNMP">
+  <title>SNMP</title>
+
+  <para>
+   The type of SNMP class constants are now declared.
+  </para>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration83/new-classes.xml
+++ b/appendices/migration83/new-classes.xml
@@ -10,7 +10,7 @@
   <itemizedlist>
    <listitem>
     <simpara>
-     <classname>IntervalBoundary</classname>
+     <classname>Random\IntervalBoundary</classname>
     </simpara>
    </listitem>
   </itemizedlist>

--- a/appendices/migration83/new-classes.xml
+++ b/appendices/migration83/new-classes.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<sect1 xml:id="migration83.new-classes" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>New Classes and Interfaces</title>
+
+ <sect2 xml:id="migration83.new-classes.random">
+  <title>Random</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>IntervalBoundary</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+</sect1>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -47,7 +47,8 @@
    <title>Override Attribute</title>
 
    <para>
-    Added the #[\Override] attribute to check that a method exists in a parent class or implemented interface.
+    Added the #[\Override] attribute to check that a method exists in a parent
+    class or implemented interface.
     <!-- RFC: https://wiki.php.net/rfc/marking_overriden_methods -->
    </para>
   </sect3>
@@ -56,8 +57,8 @@
    <title>Fetch class constant dynamically syntax</title>
 
    <para>
-    Class constants can now be accessed dynamically using the <code>C::{$name}</code>
-    syntax.
+    Class constants can now be accessed dynamically using the
+    <code>C::{$name}</code> syntax.
     <!-- RFC: https://wiki.php.net/rfc/dynamic_class_constant_fetch -->
    </para>
   </sect3>
@@ -86,7 +87,8 @@
 
   <para>
    Added properties DOMElement::$className and DOMElement::$id.
-   These are not binary-safe at the moment because of underlying limitations of libxml2.
+   These are not binary-safe at the moment because of underlying limitations
+   of libxml2.
    This means that the property values will be cut off at a NUL byte.
   </para>
  </sect2>
@@ -95,7 +97,8 @@
   <title>FFI</title>
 
   <para>
-   It is now possible to assign FFI/CData to other FFI/CData. This means you can now assign CData to structs and fields.
+   It is now possible to assign FFI/CData to other FFI/CData. This means you
+   can now assign CData to structs and fields.
   </para>
  </sect2>
 
@@ -103,7 +106,11 @@
   <title>Opcache</title>
 
   <para>
-   <code>opcache_get_status()['scripts'][n]['revalidate']</code> now contains a Unix timestamp of when the next revalidation of the scripts timestamp is due,dictated by the <link linkend="ini.opcache.revalidate-freq">opcache.revalidate_freq</link> INI directive.
+   <code>opcache_get_status()['scripts'][n]['revalidate']</code> now contains
+   a Unix timestamp of when the next revalidation of the scripts timestamp is
+   due, dictated by the
+   <link linkend="ini.opcache.revalidate-freq">opcache.revalidate_freq</link>
+   INI directive.
   </para>
  </sect2>
 
@@ -111,15 +118,19 @@
   <title>POSIX</title>
 
   <para>
-   <function>posix_getrlimit</function> now takes an optional $res parameter to allow fetching a single resource limit.
+   <function>posix_getrlimit</function> now takes an optional
+   <parameter>$res</parameter> parameter to allow fetching a single resource limit.
   </para>
 
   <para>
-   <function>posix_isatty</function> now raises type warnings for integers following the usual ZPP semantics.
+   <function>posix_isatty</function> now raises type warnings for integers
+   following the usual ZPP semantics.
   </para>
 
   <para>
-   <function>posix_ttyname</function> now raises type warnings for integers following the usual ZPP semantics and value warnings for invalid file descriptor integers.
+   <function>posix_ttyname</function> now raises type warnings for integers
+   following the usual ZPP semantics and value warnings for invalid file
+   descriptor integers.
   </para>
  </sect2>
 
@@ -127,7 +138,8 @@
   <title>Streams</title>
 
   <para>
-   Streams can now emit the <constant>STREAM_NOTIFY_COMPLETED</constant> notification. This was previously not implemented.
+   Streams can now emit the <constant>STREAM_NOTIFY_COMPLETED</constant>
+   notification. This was previously not implemented.
   </para>
  </sect2>
 

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -97,7 +97,7 @@
   </para>
 
   <para>
-   Added properties DOMNode::parentElement and DOMNameSpaceNode::parentElement.
+   Added properties DOMNode::$parentElement and DOMNameSpaceNode::$parentElement.
   </para>
  </sect2>
 

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -63,8 +63,8 @@
    </para>
   </sect3>
 
-  <sect3 xml:id="migration83.new-features.core.static-variable-initializer">
-   <title>Static variable Initializer</title>
+  <sect3 xml:id="migration83.new-features.core.static-variable-initializers">
+   <title>Static variable Initializers</title>
 
    <para>
     Static variable initializers can now contain arbitrary expressions.
@@ -97,7 +97,7 @@
   <title>FFI</title>
 
   <para>
-   It is now possible to assign FFI/CData to other FFI/CData. This means you
+   It is now possible to assign <classname>FFI\CData</classname> to other FFI\CData. This means you
    can now assign CData to structs and fields.
   </para>
  </sect2>

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -91,6 +91,14 @@
    of libxml2.
    This means that the property values will be cut off at a NUL byte.
   </para>
+
+  <para>
+   Added properties DOMNode::isConnected and DOMNameSpaceNode::isConnected.
+  </para>
+
+  <para>
+   Added properties DOMNode::parentElement and DOMNameSpaceNode::parentElement.
+  </para>
  </sect2>
 
  <sect2 xml:id="migration83.new-features.ffi">

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -86,18 +86,21 @@
   <title>DOM</title>
 
   <para>
-   Added properties DOMElement::$className and DOMElement::$id.
+   Added properties <property>DOMElement::$className</property>
+   and <property>DOMElement::$id</property>.
    These are not binary-safe at the moment because of underlying limitations
    of libxml2.
    This means that the property values will be cut off at a NUL byte.
   </para>
 
   <para>
-   Added properties DOMNode::$isConnected and DOMNameSpaceNode::$isConnected.
+   Added properties <property>DOMNode::$isConnected</property>
+   and <property>DOMNameSpaceNode::$isConnected</property>.
   </para>
 
   <para>
-   Added properties DOMNode::$parentElement and DOMNameSpaceNode::$parentElement.
+   Added properties <property>DOMNode::$parentElement</property>
+   and <property>DOMNameSpaceNode::$parentElement</property>.
   </para>
  </sect2>
 
@@ -105,8 +108,8 @@
   <title>FFI</title>
 
   <para>
-   It is now possible to assign <classname>FFI\CData</classname> to other FFI\CData. This means you
-   can now assign CData to structs and fields.
+   It is now possible to assign <classname>FFI\CData</classname> to other FFI\CData.
+   Meaning CData can now be assigned to structs and fields.
   </para>
  </sect2>
 

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -85,7 +85,7 @@
   <title>DOM</title>
 
   <para>
-   Added properties DOMElement::className and DOMElement::id.
+   Added properties DOMElement::$className and DOMElement::$id.
    These are not binary-safe at the moment because of underlying limitations of libxml2.
    This means that the property values will be cut off at a NUL byte.
   </para>

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration83.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>New Features</title>
+
+ <sect2 xml:id="migration83.new-features.core">
+  <title>PHP Core</title>
+
+  <sect3 xml:id="migration83.new-features.core.readonly-modifier-improvements">
+   <title>Readonly Amendments</title>
+
+   <para>
+    Anonymous classes may now be marked as readonly.
+   </para>
+
+   <para>
+    Readonly properties can now be reinitialized during cloning.
+    <!-- RFC: https://wiki.php.net/rfc/readonly_amendments -->
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.new-features.core.typed-class-constants">
+   <title>Typed Class Constants</title>
+
+   <para>
+    Class, interface, trait, and enum constants now support type declarations.
+    <!-- RFC: https://wiki.php.net/rfc/typed_class_constants -->
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.new-features.core.closures-created-from-magic-methods">
+   <title>Closures created from magic methods</title>
+
+   <para>
+    Closures created from magic methods can now accept named arguments.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.new-features.core.final-modifier-method-from-trait">
+   <title>The final modifier with a method from a trait</title>
+
+   <para>
+    The final modifier may now be used when using a method from a trait.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.new-features.core.override-attribute">
+   <title>Override Attribute</title>
+
+   <para>
+    Added the #[\Override] attribute to check that a method exists in a parent class or implemented interface.
+    <!-- RFC: https://wiki.php.net/rfc/marking_overriden_methods -->
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.new-features.core.fetch-class-constant-dynamically-syntax">
+   <title>Fetch class constant dynamically syntax</title>
+
+   <para>
+    Class constants can now be accessed dynamically using the <code>C::{$name}</code>
+    syntax.
+    <!-- RFC: https://wiki.php.net/rfc/dynamic_class_constant_fetch -->
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.new-features.core.static-variable-initializer">
+   <title>Static variable Initializer</title>
+
+   <para>
+    Static variable initializers can now contain arbitrary expressions.
+    <!-- RFC: RFC: https://wiki.php.net/rfc/arbitrary_static_variable_initializers -->
+   </para>
+  </sect3>
+
+ </sect2>
+
+ <sect2 xml:id="migration83.new-features.cli">
+  <title>CLI</title>
+
+  <para>
+   It is now possible to lint multiple files.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration83.new-features.dom">
+  <title>DOM</title>
+
+  <para>
+   Added properties DOMElement::className and DOMElement::id.
+   These are not binary-safe at the moment because of underlying limitations of libxml2.
+   This means that the property values will be cut off at a NUL byte.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration83.new-features.ffi">
+  <title>FFI</title>
+
+  <para>
+   It is now possible to assign FFI/CData to other FFI/CData. This means you can now assign CData to structs and fields.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration83.new-features.opcache">
+  <title>Opcache</title>
+
+  <para>
+   <code>opcache_get_status()['scripts'][n]['revalidate']</code> now contains a Unix timestamp of when the next revalidation of the scripts timestamp is due,dictated by the <link linkend="ini.opcache.revalidate-freq">opcache.revalidate_freq</link> INI directive.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration83.new-features.posix">
+  <title>POSIX</title>
+
+  <para>
+   <function>posix_getrlimit</function> now takes an optional $res parameter to allow fetching a single resource limit.
+  </para>
+
+  <para>
+   <function>posix_isatty</function> now raises type warnings for integers following the usual ZPP semantics.
+  </para>
+
+  <para>
+   <function>posix_ttyname</function> now raises type warnings for integers following the usual ZPP semantics and value warnings for invalid file descriptor integers.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration83.new-features.streams">
+  <title>Streams</title>
+
+  <para>
+   Streams can now emit the <constant>STREAM_NOTIFY_COMPLETED</constant> notification. This was previously not implemented.
+  </para>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -93,7 +93,7 @@
   </para>
 
   <para>
-   Added properties DOMNode::isConnected and DOMNameSpaceNode::isConnected.
+   Added properties DOMNode::$isConnected and DOMNameSpaceNode::$isConnected.
   </para>
 
   <para>

--- a/appendices/migration83/new-functions.xml
+++ b/appendices/migration83/new-functions.xml
@@ -93,7 +93,8 @@
  <sect2 xml:id="migration83.new-functions.pgsql">
   <title>PostgreSQL</title>
   <simplelist>
-    <member><function>pg_set_error_context_visibility</function> (libpq >= 9.6)</member>
+    <member><function>pg_set_error_context_visibility</function>
+    (libpq >= 9.6)</member>
     <member><function>pg_enter_pipeline_mode</function> </member>
     <member><function>pg_exit_pipeline_mode</function></member>
     <member><function>pg_pipeline_sync</function></member>

--- a/appendices/migration83/new-functions.xml
+++ b/appendices/migration83/new-functions.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration83.new-functions">
+ <title>New Functions</title>
+
+ <sect2 xml:id="migration83.new-functions.date">
+  <title>Date</title>
+  <simplelist>
+    <member>
+     <methodname>DatePeriod::createFromISO8601String</methodname></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration83.new-functions.dom">
+  <title>DOM</title>
+  <simplelist>
+    <member>
+     <methodname>DOMElement::getAttributeNames</methodname></member>
+    <member>
+     <methodname>DOMElement::insertAdjacentElement</methodname></member>
+    <member>
+     <methodname>DOMElement::insertAdjacentText</methodname></member>
+    <member>
+     <methodname>DOMElement::toggleAttribute</methodname></member>
+    <member>
+     <methodname>DOMNode::contains</methodname></member>
+    <member>
+     <methodname>DOMNode::getRootNode</methodname></member>
+    <member>
+     <methodname>DOMNode::isConnected</methodname></member>
+    <member>
+     <methodname>DOMNode::isEqualNode</methodname></member>
+    <member>
+     <methodname>DOMNode::parentElement</methodname></member>
+    <member>
+     <methodname>DOMNameSpaceNode::contains</methodname></member>
+    <member>
+     <methodname>DOMNameSpaceNode::isConnected</methodname></member>
+    <member>
+     <methodname>DOMNameSpaceNode::parentElement</methodname></member>
+    <member>
+     <methodname>DOMParentNode::replaceChildren</methodname></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration83.new-functions.intl">
+  <title>Intl</title>
+  <simplelist>
+    <member>
+     <methodname>IntlCalendar::setDate</methodname></member>
+    <member>
+     <methodname>IntlCalendar::setDateTime</methodname></member>
+    <member>
+     <methodname>IntlGregorianCalendar::createFromDate</methodname></member>
+    <member>
+     <methodname>IntlGregorianCalendar::createFromDateTime</methodname></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration83.new-functions.json">
+  <title>JSON</title>
+  <simplelist>
+    <member><function>json_validate</function></member>
+    <!-- RFC: https://wiki.php.net/rfc/json_validate -->
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration83.new-functions.ldap">
+  <title>LDAP</title>
+  <simplelist>
+    <member><function>ldap_connect_wallet</function></member>
+    <member><function>ldap_exop_sync</function></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration83.new-functions.mbstring">
+  <title>MBString</title>
+  <simplelist>
+    <member><function>mb_str_pad</function></member>
+    <!-- RFC:https://wiki.php.net/rfc/mb_str_pad -->
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration83.new-functions.posix">
+  <title>Posix</title>
+  <simplelist>
+    <member><function>posix_sysconf</function></member>
+    <member><function>posix_pathconf</function></member>
+    <member><function>posix_fpathconf</function></member>
+    <member><function>posix_eaccess</function></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration83.new-functions.pgsql">
+  <title>PostgreSQL</title>
+  <simplelist>
+    <member><function>pg_set_error_context_visibility</function> (libpq >= 9.6)</member>
+    <member><function>pg_enter_pipeline_mode</function> </member>
+    <member><function>pg_exit_pipeline_mode</function></member>
+    <member><function>pg_pipeline_sync</function></member>
+    <member><function>pg_pipeline_status</function></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration83.new-functions.random">
+  <title>Random</title>
+  <!-- RFC: https://wiki.php.net/rfc/randomizer_additions -->
+  <simplelist>
+    <member>
+     <methodname>Randomizer::getBytesFromString</methodname></member>
+    <member>
+     <methodname>Randomizer::nextFloat</methodname></member>
+    <member>
+     <methodname>Randomizer::getFloat</methodname></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration83.new-functions.reflection">
+  <title>Reflection</title>
+  <simplelist>
+    <member>
+     <methodname>ReflectionMethod::createFromMethodName</methodname></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration83.new-functions.sockets">
+  <title>Sockets</title>
+  <simplelist>
+    <member><function>socket_atmark</function></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration83.new-functions.standard">
+  <title>Standard</title>
+  <simplelist>
+    <member><function>str_increment</function></member>
+    <member><function>str_decrement</function></member>
+    <!-- RFC: https://wiki.php.net/rfc/saner-inc-dec-operators -->
+    <member><function>stream_context_set_options</function></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration83.new-functions.zip">
+  <title>Zip</title>
+  <simplelist>
+    <member>
+     <methodname>ZipArchive::getArchiveFlag</methodname></member>
+  </simplelist>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration83/new-functions.xml
+++ b/appendices/migration83/new-functions.xml
@@ -26,17 +26,9 @@
     <member>
      <methodname>DOMNode::getRootNode</methodname></member>
     <member>
-     <methodname>DOMNode::isConnected</methodname></member>
-    <member>
      <methodname>DOMNode::isEqualNode</methodname></member>
     <member>
-     <methodname>DOMNode::parentElement</methodname></member>
-    <member>
      <methodname>DOMNameSpaceNode::contains</methodname></member>
-    <member>
-     <methodname>DOMNameSpaceNode::isConnected</methodname></member>
-    <member>
-     <methodname>DOMNameSpaceNode::parentElement</methodname></member>
     <member>
      <methodname>DOMParentNode::replaceChildren</methodname></member>
   </simplelist>

--- a/appendices/migration83/new-functions.xml
+++ b/appendices/migration83/new-functions.xml
@@ -107,11 +107,11 @@
   <!-- RFC: https://wiki.php.net/rfc/randomizer_additions -->
   <simplelist>
     <member>
-     <methodname>Randomizer::getBytesFromString</methodname></member>
+     <methodname>Random\Randomizer::getBytesFromString</methodname></member>
     <member>
-     <methodname>Randomizer::nextFloat</methodname></member>
+     <methodname>Random\Randomizer::nextFloat</methodname></member>
     <member>
-     <methodname>Randomizer::getFloat</methodname></member>
+     <methodname>Random\Randomizer::getFloat</methodname></member>
   </simplelist>
  </sect2>
 

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -496,7 +496,7 @@
     <link linkend="object.tostring">__toString()</link>,
     <link linkend="object.clone">__clone()</link>,
     <link linkend="object.sleep">__sleep()</link>,
-    <link linkend="object.destruct">__destruct()</link>. 
+    <link linkend="object.destruct">__destruct()</link>.
     This is not related to stack buffer overflows, and is not a security feature.
     </para>
    </listitem>

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -125,9 +125,9 @@
     The resultant HTML of <function>highlight_string</function> and
     <function>highlight_file</function> has changed.
     Whitespace between outer HTML tags is removed. Newlines and spaces
-    are no longer converted to HTML entities. The whole HTML is now wrapped in
+    are no longer converted to HTML entities. The whole HTML is now wrapped in a
     <literal>&lt;pre&gt;</literal> tag. The outer <literal>&lt;span&gt;</literal>
-    has been merged with <literal>&lt;code&gt;</literal>.
+    tag has been merged with the <literal>&lt;code&gt;</literal> tag.
    </para>
 
   </sect3>
@@ -159,7 +159,7 @@
 
    <para>
     Changed <methodname>DOMCharacterData::appendData</methodname> tentative
-    return type to true.
+    return type to <type>true</type>.
    </para>
 
    <para>
@@ -167,9 +167,10 @@
     <methodname>DOMDocument::loadHTMLFile</methodname>,
     <methodname>DOMDocument::loadXML</methodname> and
     <methodname>DOMDocument::loadXMLFile</methodname> now have a tentative
-    return type of bool. Previously, this was documented as having a return
-    type of <code>DOMDocument|bool</code>, but <classname>DOMDocument</classname>
-    cannot be returned since PHP 8.0 as it is no longer statically callable.
+    return type of <type>bool</type>. Previously, this was documented as having a return
+    type of <code>DOMDocument|bool</code>, but, as of PHP 8.0.0,
+    <classname>DOMDocument</classname>
+    cannot be returned as it is no longer statically callable.
    </para>
 
   </sect3>
@@ -178,9 +179,9 @@
    <title>Gd</title>
 
    <para>
-    Changed <function>imagerotate</function> signature, removed the
-    <parameter>ignore_transparent</parameter> argument as it was not used
-    internally anyway from PHP 7.x.
+    The signature of <function>imagerotate</function> has changed.
+    The <parameter>ignore_transparent</parameter> parameter has been removed,
+    as it was ignored since PHP 5.5.0.
    </para>
   </sect3>
 
@@ -267,14 +268,14 @@
 
    <para>
     <function>mysqli_poll</function> now raises a <classname>ValueError</classname>
-    when the <parameter>read</parameter> nor <parameter>error</parameter> arguments
-    are passed.
+    when the neither the <parameter>read</parameter>
+    nor the <parameter>error</parameter> arguments are passed.
    </para>
 
    <para>
     <function>mysqli_field_seek</function> and
-    <methodname>mysqli_result::field_seek</methodname> now specify return type
-    as true instead of bool.
+    <methodname>mysqli_result::field_seek</methodname> now specify the return
+    type as <type>true</type> instead of <type>bool</type>.
    </para>
   </sect3>
 
@@ -312,8 +313,9 @@
    </para>
 
    <para>
-    The $row param of <function>pg_fetch_result</function>,
-    <function>pg_field_prtlen</function> and
+    The <parameter>$row</parameter> parameter of
+    <function>pg_fetch_result</function>,
+    <function>pg_field_prtlen</function>, and
     <function>pg_field_is_null</function> is now nullable.
    </para>
   </sect3>
@@ -369,13 +371,15 @@
    <para>
     <function>password_hash</function> will now chain the underlying
     <classname>Random\RandomException</classname>
-    as the <classname>ValueError</classname>’s <literal>$previous</literal>
+    as the <classname>ValueError</classname>’s <parameter>$previous</parameter>
     <classname>Exception</classname> when salt generation fails.
    </para>
 
    <para>
-    <function>proc_open</function> $command array must now have at least one
-    non empty element.
+    If using an array as the <parameter>$command</parameter>
+    for <function>proc_open</function>, it must now have at least one
+    non empty element. Otherwise a <classname>ValueError</classname>
+    is thrown.
    </para>
 
    <para>
@@ -396,15 +400,15 @@
    </para>
 
    <para>
-    The <parameter>$before_needle</parameter> argument added to
-    <function>strrchr</function> which works in the same way like its counterpart
-    in <function>strstr</function> or <function>stristr</function>.
+    A new <parameter>$before_needle</parameter> argument has been added to
+    <function>strrchr</function>. It behaves like its counterpart in the
+    <function>strstr</function> or <function>stristr</function> functions.
    </para>
 
    <para>
-    <function>str_getcsv</function> and <function>fgetcsv</function> return empty
-    string instead of a string with a single zero byte for the last field which
-    contains only unterminated enclosure.
+    <function>str_getcsv</function> and <function>fgetcsv</function> now return
+    an empty string instead of a string with a single null byte for the last field
+    which only contains an unterminated enclosure.
    </para>
   </sect3>
 
@@ -473,27 +477,35 @@
    <listitem>
     <para>
      <!--<link linkend="ini.zend.max_allowed_stack_size">-->zend.max_allowed_stack_size<!--</link>-->
-    is a new INI directive to set the maximum allowed stack size. Possible
-    values are <literal>0</literal> (detect the process or thread maximum stack size), <literal>-1</literal>
-    (no limit), or a positive number of bytes. The default is <literal>0</literal>.
+    is a new INI directive to set the maximum allowed stack size.
+    Possible values are <literal>0</literal> (detect the process or thread maximum stack size),
+    <literal>-1</literal> (no limit), or a positive number of bytes.
+    The default is <literal>0</literal>.
     When it is not possible to detect the the process or thread maximum stack
-    size, a known system default is used. Setting this value too high has the
-    same effect as disabling the stack size limit. Fibers use fiber.stack_size
-    as maximum allowed stack size. An Error is thrown when the process call
-    stack exceeds `zend.max_allowed_stack_size-zend.reserved_stack_size`
+    size, a known system default is used.
+    Setting this value too high has the same effect as disabling the stack size limit.
+    Fibers use
+    <!-- link TODO -->fiber.stack_size<!-- /link -->
+    as maximum allowed stack size.
+    An <classname>Error</classname> is thrown when the process call stack exceeds
+    <!-- link TODO -->zend.max_allowed_stack_size-zend.reserved_stack_size<!-- /link-->
     bytes, to prevent stack-overflow-induced segmentation faults, with
-    the goal of making debugging easier. The stack size increases during
-    uncontrolled recursions involving internal functions or the magic methods
-    __toString, __clone, __sleep, __destruct.  This is not related to stack
-    buffer overflows, and is not a security feature.
+    the goal of making debugging easier.
+    The stack size increases during uncontrolled recursions involving internal functions
+    or the magic methods
+    <link linkend="object.tostring">__toString()</link>,
+    <link linkend="object.clone">__clone()</link>,
+    <link linkend="object.sleep">__sleep()</link>,
+    <link linkend="object.destruct">__destruct()</link>. 
+    This is not related to stack buffer overflows, and is not a security feature.
     </para>
    </listitem>
    <listitem>
     <para>
      <!--<link linkend="ini.zend.reserved_stack_size">-->zend.reserved_stack_size<!--</link>-->
-     is a new INI directive to set the reserved stack size, in bytes. This is
-    subtracted from the max allowed stack size, as a buffer, when checking the
-    stack size.
+     is a new INI directive to set the reserved stack size, in bytes.
+     This is subtracted from the max allowed stack size,
+     as a buffer, when checking the stack size.
     </para>
    </listitem>
    </itemizedlist>

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -9,9 +9,11 @@
    <title>CLI</title>
 
    <para>
-    The <constant>STDOUT</constant>, <constant>STDERR</constant> and <constant>STDIN</constant> streams are no longer closed on resource destruction
-    which is mostly when the CLI finishes. It is however still possible to
-    explicitly close those streams using <function>fclose</function> and similar.
+    The <constant>STDOUT</constant>, <constant>STDERR</constant> and
+    <constant>STDIN</constant> streams are no longer closed on resource
+    destruction which is mostly when the CLI finishes.
+    It is however still possible to explicitly close those streams using
+    <function>fclose</function> and similar.
    </para>
   </sect3>
  </sect2>
@@ -30,22 +32,28 @@
      <member><literal>"protected"</literal> => bool</member>
      <member><literal>"full"</literal> => bool</member>
      <member><literal>"buffer_size"</literal> => int</member>
-     <member><literal>"application_time"</literal> => float: Total application time, in seconds (including collector_time)</member>
-     <member><literal>"collector_time"</literal> => float: Time spent collecting cycles, in seconds (including destructor_time and free_time)</member>
-     <member><literal>"destructor_time"</literal> => float: Time spent executing destructors during cycle collection, in seconds</member>
-     <member><literal>"free_time"</literal> => float: Time spent freeing values during cycle collection, in seconds</member>
+     <member><literal>"application_time"</literal> => float: Total application
+     time, in seconds (including collector_time)</member>
+     <member><literal>"collector_time"</literal> => float: Time spent collecting
+     cycles, in seconds (including destructor_time and free_time)</member>
+     <member><literal>"destructor_time"</literal> => float: Time spent executing
+     destructors during cycle collection, in seconds</member>
+     <member><literal>"free_time"</literal> => float: Time spent freeing values
+     during cycle collection, in seconds</member>
     </simplelist>
    </para>
 
    <para>
-    <function>class_alias</function> now supports creating an alias of an internal class.
+    <function>class_alias</function> now supports creating an alias of an
+    internal class.
    </para>
 
    <para>
-    Setting <link linkend="ini.open-basedir">open_basedir</link> at runtime using <code>ini_set('open_basedir', ...);</code> no
-    longer accepts paths containing the parent directory (<literal>..</literal>). Previously,
-    only paths starting with <literal>..</literal> were disallowed. This could easily be
-    circumvented by prepending <literal>./</literal> to the path.
+    Setting <link linkend="ini.open-basedir">open_basedir</link> at runtime
+    using <code>ini_set('open_basedir', ...);</code> no longer accepts paths
+    containing the parent directory (<literal>..</literal>). Previously,
+    only paths starting with <literal>..</literal> were disallowed. This could
+    easily be circumvented by prepending <literal>./</literal> to the path.
    </para>
 
    <para>
@@ -53,10 +61,12 @@
    </para>
 
    <para>
-    The resultant HTML of <function>highlight_string</function> and <function>highlight_file</function> has changed.
+    The resultant HTML of <function>highlight_string</function> and
+    <function>highlight_file</function> has changed.
     Whitespace between outer HTML tags is removed. Newlines and spaces
     are no longer converted to HTML entities. The whole HTML is now wrapped in
-    <literal>&lt;pre&gt;</literal> tag. The outer <literal>&lt;span&gt;</literal> has been merged with <literal>&lt;code&gt;</literal>.
+    <literal>&lt;pre&gt;</literal> tag. The outer <literal>&lt;span&gt;</literal>
+    has been merged with <literal>&lt;code&gt;</literal>.
    </para>
 
   </sect3>
@@ -65,8 +75,9 @@
    <title>Calendar</title>
 
    <para>
-    <function>easter_date</function> now supports years from 1970 to 2,000,000,000 on 64-bit
-    systems, previously it only supported years in the range from 1970 to 2037.
+    <function>easter_date</function> now supports years from 1970 to
+    2,000,000,000 on 64-bit systems, previously it only supported years in the
+    range from 1970 to 2037.
    </para>
   </sect3>
 
@@ -74,9 +85,11 @@
    <title>Curl</title>
 
    <para>
-    <function>curl_getinfo</function> now supports two new constants: <constant>CURLINFO_CAPATH</constant> and
-    <constant>CURLINFO_CAINFO</constant>. If option is &null;, the following two additional keys are
-    present: <literal>"capath"</literal> and <literal>"cainfo"</literal>.
+    <function>curl_getinfo</function> now supports two new constants:
+    <constant>CURLINFO_CAPATH</constant> and
+    <constant>CURLINFO_CAINFO</constant>. If option is &null;, the following
+    two additional keys are present:
+    <literal>"capath"</literal> and <literal>"cainfo"</literal>.
    </para>
   </sect3>
 
@@ -84,15 +97,18 @@
    <title>DOM</title>
 
    <para>
-    Changed <methodname>DOMCharacterData::appendData</methodname> tentative return type to true.
+    Changed <methodname>DOMCharacterData::appendData</methodname> tentative
+    return type to true.
    </para>
 
    <para>
-    <methodname>DOMDocument::loadHTML</methodname>, <methodname>DOMDocument::loadHTMLFile</methodname>,
-    <methodname>DOMDocument::loadXML</methodname> and <methodname>DOMDocument::loadXMLFile</methodname> now have a tentative
+    <methodname>DOMDocument::loadHTML</methodname>,
+    <methodname>DOMDocument::loadHTMLFile</methodname>,
+    <methodname>DOMDocument::loadXML</methodname> and
+    <methodname>DOMDocument::loadXMLFile</methodname> now have a tentative
     return type of bool. Previously, this was documented as having a return
-    type of <code>DOMDocument|bool</code>, but <classname>DOMDocument</classname> cannot be returned since PHP 8.0
-    as it is no longer statically callable.
+    type of <code>DOMDocument|bool</code>, but <classname>DOMDocument</classname>
+    cannot be returned since PHP 8.0 as it is no longer statically callable.
    </para>
 
   </sect3>
@@ -101,8 +117,9 @@
    <title>Gd</title>
 
    <para>
-    Changed <function>imagerotate</function> signature, removed the <parameter>ignore_transparent</parameter> argument
-    as it was not used internally anyway from PHP 7.x.
+    Changed <function>imagerotate</function> signature, removed the
+    <parameter>ignore_transparent</parameter> argument as it was not used
+    internally anyway from PHP 7.x.
    </para>
   </sect3>
 
@@ -110,13 +127,14 @@
    <title>Intl</title>
 
    <para>
-    <function>datefmt_set_timezone</function> (and its alias <methodname>IntlDateformatter::setTimeZone</methodname>)
+    <function>datefmt_set_timezone</function> (and its alias
+    <methodname>IntlDateformatter::setTimeZone</methodname>)
     now returns &true; on success, previously &null; was returned.
    </para>
 
    <para>
-    <methodname>IntlBreakiterator::setText</methodname> now returns &false; on failure, previously
-    &null; was returned.
+    <methodname>IntlBreakiterator::setText</methodname> now returns &false;
+    on failure, previously &null; was returned.
     now returns &true; on success, previously &null; was returned.
    </para>
 
@@ -130,43 +148,49 @@
    <title>MBString</title>
 
    <para>
-    <function>mb_strtolower</function>, <function>mb_strtotitle</function>, and <function>mb_convert_case</function> implement conditional
-    casing rules for the Greek letter sigma. For <function>mb_convert_case</function>, conditional
-    casing only applies to <constant>MB_CASE_LOWER</constant> and <constant>MB_CASE_TITLE</constant> modes, not to
-    <constant>MB_CASE_LOWER_SIMPLE</constant> and <constant>MB_CASE_TITLE_SIMPLE</constant>.
+    <function>mb_strtolower</function>, <function>mb_strtotitle</function>,
+    and <function>mb_convert_case</function> implement conditional casing rules
+    for the Greek letter sigma. For <function>mb_convert_case</function>,
+    conditional casing only applies to <constant>MB_CASE_LOWER</constant>
+    and <constant>MB_CASE_TITLE</constant> modes, not to
+    <constant>MB_CASE_LOWER_SIMPLE</constant> and
+    <constant>MB_CASE_TITLE_SIMPLE</constant>.
    </para>
 
    <para>
-    <function>mb_decode_mimeheader</function> interprets underscores in QPrint-encoded MIME
-    encoded words as required by RFC 2047; they are converted to spaces.
-    Underscores must be encoded as <literal>"=5F"</literal> in such MIME encoded words.
+    <function>mb_decode_mimeheader</function> interprets underscores in
+    QPrint-encoded MIME encoded words as required by RFC 2047; they are
+    converted to spaces.
+    Underscores must be encoded as <literal>"=5F"</literal> in such MIME
+    encoded words.
    </para>
 
    <para>
-    In rare cases, <function>mb_encode_mimeheader</function> will transfer-encode its input
-    string where it would pass it through as raw ASCII in PHP 8.2.
+    In rare cases, <function>mb_encode_mimeheader</function> will transfer-encode
+    its input string where it would pass it through as raw ASCII in PHP 8.2.
    </para>
 
    <para>
-    <function>mb_encode_mimeheader</function> no longer drops NUL (zero) bytes when
-    QPrint-encoding the input string. This previously caused strings in
-    certain text encodings, especially UTF-16 and UTF-32, to be
-    corrupted by mb_encode_mimeheader.
+    <function>mb_encode_mimeheader</function> no longer drops NUL (zero)
+    bytes when QPrint-encoding the input string.
+    This previously caused strings in certain text encodings, especially
+    UTF-16 and UTF-32, to be corrupted by mb_encode_mimeheader.
    </para>
 
    <para>
-    <function>mb_detect_encoding</function>'s "non-strict" mode now behaves as described in the
-    documentation. Previously, it would return false if the same byte
-    (for example, the first byte) of the input string was invalid in all
-    candidate encodings. More generally, it would eliminate candidate
-    encodings from consideration when an invalid byte was seen, and if the
-    same input byte eliminated all remaining encodings still under
-    consideration, it would return false. On the other hand, if all candidate
-    encodings but one were eliminated from consideration, it would return the
-    last remaining one without regard for how many encoding errors might be
-    encountered later in the string. This is different from the behavior
-    described in the documentation, which says: "If strict is set to false,
-    the closest matching encoding will be returned."
+    <function>mb_detect_encoding</function>'s "non-strict" mode now behaves
+    as described in the documentation.
+    Previously, it would return false if the same byte (for example, the first
+    byte) of the input string was invalid in all candidate encodings.
+    More generally, it would eliminate candidate encodings from consideration
+    when an invalid byte was seen, and if the same input byte eliminated all
+    remaining encodings still under consideration, it would return false.
+    On the other hand, if all candidate encodings but one were eliminated
+    from consideration, it would return the last remaining one without regard
+    for how many encoding errors might be encountered later in the string.
+    This is different from the behavior described in the documentation, which
+    says: "If strict is set to false, the closest matching encoding will be
+    returned."
    </para>
   </sect3>
 
@@ -174,18 +198,21 @@
    <title>mysqli</title>
 
    <para>
-    <function>mysqli_fetch_object</function> now raises a <classname>ValueError</classname> instead of an <classname>Exception</classname> when
-    the <parameter>constructor_args</parameter> argument is non empty with the class not having
-    constructor.
+    <function>mysqli_fetch_object</function> now raises a
+    <classname>ValueError</classname> instead of an <classname>Exception</classname>
+    when the <parameter>constructor_args</parameter> argument is non empty with
+    the class not having constructor.
    </para>
 
    <para>
-    <function>mysqli_poll</function> now raises a <classname>ValueError</classname> when the <parameter>read</parameter> nor <parameter>error</parameter> arguments are
-    passed.
+    <function>mysqli_poll</function> now raises a <classname>ValueError</classname>
+    when the <parameter>read</parameter> nor <parameter>error</parameter> arguments
+    are passed.
    </para>
 
    <para>
-    <function>mysqli_field_seek</function> and <methodname>mysqli_result::field_seek</methodname> now specify return type
+    <function>mysqli_field_seek</function> and
+    <methodname>mysqli_result::field_seek</methodname> now specify return type
     as true instead of bool.
    </para>
   </sect3>
@@ -194,7 +221,8 @@
    <title>ODBC</title>
 
    <para>
-    <function>odbc_autocommit</function> now accepts &null; for the <parameter>$enable</parameter> parameter.
+    <function>odbc_autocommit</function> now accepts &null; for the
+    <parameter>$enable</parameter> parameter.
     Passing &null; has the same behaviour as passing only 1 parameter,
     namely indicating if the autocommit feature is enabled or not.
    </para>
@@ -204,24 +232,27 @@
    <title>PGSQL</title>
 
    <para>
-    <function>pg_fetch_object</function> now raises a <classname>ValueError</classname> instead of an <classname>Exception</classname> when the
-    constructor_args argument is non empty with the class not having
-    constructor.
+    <function>pg_fetch_object</function> now raises a
+    <classname>ValueError</classname> instead of an <classname>Exception</classname>
+    when the <parameter>constructor_args</parameter> argument is non empty with
+    the class not having constructor.
    </para>
 
    <para>
-    <function>pg_insert</function> now raises a <classname>ValueError</classname> instead of a <constant>E_WARNING</constant> when the table
-    specified is invalid.
+    <function>pg_insert</function> now raises a <classname>ValueError</classname>
+    instead of a <constant>E_WARNING</constant> when the table specified is invalid.
    </para>
 
    <para>
-    <function>pg_insert</function> and <function>pg_convert</function> raises a <classname>ValueError</classname> or a <classname>TypeError</classname> instead of a
-    <constant>E_WARNING</constant> when the value/type of a field does not match properly with a
-    PostgreSQL's type.
+    <function>pg_insert</function> and <function>pg_convert</function> raises
+    a <classname>ValueError</classname> or a <classname>TypeError</classname>
+    instead of a <constant>E_WARNING</constant> when the value/type of a field
+    does not match properly with a PostgreSQL's type.
    </para>
 
    <para>
-    The $row param of <function>pg_fetch_result</function>, <function>pg_field_prtlen</function> and
+    The $row param of <function>pg_fetch_result</function>,
+    <function>pg_field_prtlen</function> and
     <function>pg_field_is_null</function> is now nullable.
    </para>
   </sect3>
@@ -230,10 +261,11 @@
    <title>Random</title>
 
    <para>
-    Changed <function>mt_srand</function> and <function>srand</function> to not check the number of arguments to
-    determine whether a random seed should be used. Passing &null; will generate
-    a random seed, <literal>0</literal> will use zero as the seed. The functions are now
-    consistent with <methodname>Random\Engine\Mt19937::__construct</methodname>.
+    Changed <function>mt_srand</function> and <function>srand</function> to
+    not check the number of arguments to determine whether a random seed should
+    be used. Passing &null; will generate a random seed, <literal>0</literal>
+    will use zero as the seed. The functions are now consistent with
+    <methodname>Random\Engine\Mt19937::__construct</methodname>.
    </para>
 
   </sect3>
@@ -242,7 +274,8 @@
    <title>Reflection</title>
 
    <para>
-    Return type of <methodname>ReflectionClass::getStaticProperties</methodname> is no longer nullable.
+    Return type of <methodname>ReflectionClass::getStaticProperties</methodname>
+    is no longer nullable.
    </para>
   </sect3>
 
@@ -250,60 +283,67 @@
    <title>Standard</title>
 
    <para>
-    <constant>E_NOTICE</constant>s emitted by <function>unserialize</function> have been promoted to <constant>E_WARNING</constant>.
+    <constant>E_NOTICE</constant>s emitted by <function>unserialize</function>
+    have been promoted to <constant>E_WARNING</constant>.
     <!-- RFC: https://wiki.php.net/rfc/improve_unserialize_error_handling -->
    </para>
 
    <para>
-    <function>unserialize</function> now emits a new <constant>E_WARNING</constant> if the input contains unconsumed
-    bytes.
+    <function>unserialize</function> now emits a new <constant>E_WARNING</constant>
+    if the input contains unconsumed bytes.
     <!-- RFC: https://wiki.php.net/rfc/unserialize_warn_on_trailing_data -->
    </para>
 
    <para>
-    <function>array_pad</function> is now only limited by the maximum number of elements an array
-    can have. Before, it was only possible to add at most 1048576 elements at a
-    time.
+    <function>array_pad</function> is now only limited by the maximum number of
+    elements an array can have. Before, it was only possible to add at most 1048576
+    elements at a time.
    </para>
 
    <para>
-    <function>strtok</function> raises an <constant>E_WARNING</constant> in the case token is not provided when starting
-    tokenization.
+    <function>strtok</function> raises an <constant>E_WARNING</constant> in the
+    case token is not provided when starting tokenization.
    </para>
 
    <para>
-    <function>password_hash</function> will now chain the underlying <classname>Random\RandomException</classname>
-    as the <classname>ValueError</classname>’s <literal>$previous</literal> <classname>Exception</classname> when salt generation fails.
+    <function>password_hash</function> will now chain the underlying
+    <classname>Random\RandomException</classname>
+    as the <classname>ValueError</classname>’s <literal>$previous</literal>
+    <classname>Exception</classname> when salt generation fails.
    </para>
 
    <para>
-    <function>proc_open</function> $command array must now have at least one non empty element.
+    <function>proc_open</function> $command array must now have at least one
+    non empty element.
    </para>
 
    <para>
-    <function>array_sum</function> and <function>array_product</function> now warn when values in the array cannot
-    be converted to int/float. Previously arrays and objects where ignored
-    whilst every other value was cast to int. Moreover, objects that define
-    a numeric cast (e.g. GMP) are now casted instead of ignored.
+    <function>array_sum</function> and <function>array_product</function> now
+    warn when values in the array cannot be converted to int/float.
+    Previously arrays and objects where ignored whilst every other value was
+    cast to int. Moreover, objects that define a numeric cast (e.g. GMP) are
+    now casted instead of ignored.
     <!-- RFC: https://wiki.php.net/rfc/saner-array-sum-product -->
    </para>
 
    <para>
-    <function>number_format</function> $decimal parameter handles rounding to negative places. It
-    means that when $decimals is negative, $num is rounded to $decimals
-    significant digits before the decimal point. Previously negative $decimals
-    got silently ignored and the number got rounded to zero decimal places.
+    <function>number_format</function> $decimal parameter handles rounding to
+    negative places. It means that when $decimals is negative, $num is rounded
+    to <parameter>$decimals</parameter> significant digits before the decimal
+    point. Previously negative <parameter>$decimals</parameter> got silently
+    ignored and the number got rounded to zero decimal places.
    </para>
 
    <para>
-    The $before_needle argument added to <function>strrchr</function> which works in the same way
-    like its counterpart in <function>strstr</function> or <function>stristr</function>.
+    The <parameter>$before_needle</parameter> argument added to
+    <function>strrchr</function> which works in the same way like its counterpart
+    in <function>strstr</function> or <function>stristr</function>.
    </para>
 
    <para>
-    <function>str_getcsv</function> and <function>fgetcsv</function> return empty string instead of a string with
-    a single zero byte for the last field which contains only unterminated
-    enclosure.
+    <function>str_getcsv</function> and <function>fgetcsv</function> return empty
+    string instead of a string with a single zero byte for the last field which
+    contains only unterminated enclosure.
    </para>
   </sect3>
 
@@ -335,8 +375,9 @@
    <title>SQLite3</title>
 
    <para>
-    The <classname>SQLite3</classname> class now throws <classname>SQLite3Exception</classname> (extends <classname>Exception</classname>) instead
-    of <classname>Exception</classname>.
+    The <classname>SQLite3</classname> class now throws
+    <classname>SQLite3Exception</classname> (extends
+    <classname>Exception</classname>) instead of <classname>Exception</classname>.
    </para>
 
    <para>
@@ -364,7 +405,8 @@
      </simplelist>
      If the value of the setting is equal to the default value, no deprecation
      notice is emitted.
-     The <link linkend="ini.zend.assertions">zend.assertions</link> INI setting should be used instead.
+     The <link linkend="ini.zend.assertions">zend.assertions</link> INI setting
+     should be used instead.
     </para>
    </listitem>
    <listitem>
@@ -372,10 +414,10 @@
      <!--<link linkend="ini.zend.max_allowed_stack_size">-->zend.max_allowed_stack_size<!--</link>-->
     is a new INI directive to set the maximum allowed stack size. Possible
     values are <literal>0</literal> (detect the process or thread maximum stack size), <literal>-1</literal>
-    (no limit), or a positive number of bytes. The default is <literal>0</literal>. When it
-    is not possible to detect the the process or thread maximum stack size,
-    a known system default is used. Setting this value too high has the same
-    effect as disabling the stack size limit. Fibers use fiber.stack_size
+    (no limit), or a positive number of bytes. The default is <literal>0</literal>.
+    When it is not possible to detect the the process or thread maximum stack
+    size, a known system default is used. Setting this value too high has the
+    same effect as disabling the stack size limit. Fibers use fiber.stack_size
     as maximum allowed stack size. An Error is thrown when the process call
     stack exceeds `zend.max_allowed_stack_size-zend.reserved_stack_size`
     bytes, to prevent stack-overflow-induced segmentation faults, with
@@ -403,8 +445,8 @@
    <title>DOM</title>
 
    <para>
-    Looping over a <classname>DOMNodeList</classname> now uses caching. Therefore requesting items no
-    longer takes quadratic time by default.
+    Looping over a <classname>DOMNodeList</classname> now uses caching. Therefore
+    requesting items no longer takes quadratic time by default.
    </para>
 
    <para>
@@ -429,8 +471,8 @@
    <title>SPL</title>
 
    <para>
-    <classname>RecursiveDirectoryIterator</classname> now performs less I/O when looping over a
-    directory.
+    <classname>RecursiveDirectoryIterator</classname> now performs less I/O
+    when looping over a directory.
    </para>
   </sect3>
  </sect2>

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -2,6 +2,67 @@
 <sect1 xml:id="migration83.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Other Changes</title>
 
+ <sect2 xml:id="migration83.other-changes.core">
+  <title>Core changes</title>
+
+  <sect3 xml:id="migration83.other-changes.core.ffi">
+   <title>FFI</title>
+
+   <para>
+    <methodname>FFI::load</methodname> is now allowed during preloading
+    when <link linkend="ini.opcache.preload-user">opcache.preload_user</link>
+    is the current system user. Previously,
+    calling <methodname>FFI::load</methodname> was not possible
+    during preloading if the
+    <link linkend="ini.opcache.preload-user">opcache.preload_user</link>
+    directive was set.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.core.fpm">
+   <title>FPM</title>
+
+   <para>
+    FPM CLI test now fails if the socket path is longer than supported by OS.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.core.opcache">
+   <title>Opcache</title>
+
+   <para>
+    In the CLI and phpdbg SAPIs, preloading does not require the
+    <link linkend="ini.opcache.preload-user">opcache.preload_user</link>
+    directive to be set anymore when running as root.
+    In other SAPIs, this directive is required when running as root because
+    preloading is done before the SAPI switches to an unprivileged user.
+    FPM CLI test now fails if the socket path is longer than supported by OS.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.core.streams">
+   <title>Streams</title>
+
+   <para>
+    Blocking <function>fread</function> on socket connection returns
+    immediately if there are any buffered data instead of waiting for more data.
+   </para>
+
+   <para>
+    Memory stream no longer fails if seek offset is past the end. Instead
+    the memory is increase on the next write and date between the old end and
+    offset is filled with zero bytes in the same way how it works for files.
+   </para>
+
+   <para>
+    <function>stat</function> access operations like
+    <function>file_exists</function> and similar will now use real
+    path instead of the actual stream path. This is consistent with stream
+    opening.
+   </para>
+  </sect3>
+ </sect2>
+
  <sect2 xml:id="migration83.other-changes.sapi">
   <title>Changes in SAPI Modules</title>
 

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -26,14 +26,14 @@
     <function>gc_status</function> has added the following 8 fields:
 
     <simplelist>
-     <member>"running" => bool</member>
-     <member>"protected" => bool</member>
-     <member>"full" => bool</member>
-     <member>"buffer_size" => int</member>
-     <member>"application_time" => float: Total application time, in seconds (including collector_time)</member>
-     <member>"collector_time" => float: Time spent collecting cycles, in seconds (including destructor_time and free_time)</member>
-     <member>"destructor_time" => float: Time spent executing destructors during cycle collection, in seconds</member>
-     <member>"free_time" => float: Time spent freeing values during cycle collection, in seconds</member>
+     <member><literal>"running"</literal> => bool</member>
+     <member><literal>"protected"</literal> => bool</member>
+     <member><literal>"full"</literal> => bool</member>
+     <member><literal>"buffer_size"</literal> => int</member>
+     <member><literal>"application_time"</literal> => float: Total application time, in seconds (including collector_time)</member>
+     <member><literal>"collector_time"</literal> => float: Time spent collecting cycles, in seconds (including destructor_time and free_time)</member>
+     <member><literal>"destructor_time"</literal> => float: Time spent executing destructors during cycle collection, in seconds</member>
+     <member><literal>"free_time"</literal> => float: Time spent freeing values during cycle collection, in seconds</member>
     </simplelist>
    </para>
 
@@ -56,7 +56,7 @@
     The resultant HTML of <function>highlight_string</function> and <function>highlight_file</function> has changed.
     Whitespace between outer HTML tags is removed. Newlines and spaces
     are no longer converted to HTML entities. The whole HTML is now wrapped in
-    &lt;pre&gt; tag. The outer &lt;span&gt; has been merged with &lt;code&gt;.
+    <literal>&lt;pre&gt;</literal> tag. The outer <literal>&lt;span&gt;</literal> has been merged with <literal>&lt;code&gt;</literal>.
    </para>
 
   </sect3>

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -91,7 +91,7 @@
     <methodname>DOMDocument::loadHTML</methodname>, <methodname>DOMDocument::loadHTMLFile</methodname>,
     <methodname>DOMDocument::loadXML</methodname> and <methodname>DOMDocument::loadXMLFile</methodname> now have a tentative
     return type of bool. Previously, this was documented as having a return
-    type of DOMDocument|bool, but DOMDocument cannot be returned since PHP 8.0
+    type of <code>DOMDocument|bool</code>, but <classname>DOMDocument</classname> cannot be returned since PHP 8.0
     as it is no longer statically callable.
    </para>
 
@@ -194,7 +194,7 @@
    <title>ODBC</title>
 
    <para>
-    <function>odbc_autocommit</function> now accepts null for the $enable parameter.
+    <function>odbc_autocommit</function> now accepts &null; for the <parameter>$enable</parameter> parameter.
     Passing &null; has the same behaviour as passing only 1 parameter,
     namely indicating if the autocommit feature is enabled or not.
    </para>
@@ -231,8 +231,8 @@
 
    <para>
     Changed <function>mt_srand</function> and <function>srand</function> to not check the number of arguments to
-    determine whether a random seed should be used. Passing null will generate
-    a random seed, 0 will use zero as the seed. The functions are now
+    determine whether a random seed should be used. Passing &null; will generate
+    a random seed, <literal>0</literal> will use zero as the seed. The functions are now
     consistent with <methodname>Mt19937::__construct</methodname>.
    </para>
 
@@ -250,12 +250,12 @@
    <title>Standard</title>
 
    <para>
-    E_NOTICEs emitted by <function>unserialize</function> have been promoted to E_WARNING.
+    <constant>E_NOTICE</constant>s emitted by <function>unserialize</function> have been promoted to <constant>E_WARNING</constant>.
     <!-- RFC: https://wiki.php.net/rfc/improve_unserialize_error_handling -->
    </para>
 
    <para>
-    <function>unserialize</function> now emits a new E_WARNING if the input contains unconsumed
+    <function>unserialize</function> now emits a new <constant>E_WARNING</constant> if the input contains unconsumed
     bytes.
     <!-- RFC: https://wiki.php.net/rfc/unserialize_warn_on_trailing_data -->
    </para>
@@ -267,13 +267,13 @@
    </para>
 
    <para>
-    <function>strtok</function> raises a warning in the case token is not provided when starting
+    <function>strtok</function> raises an <constant>E_WARNING</constant> in the case token is not provided when starting
     tokenization.
    </para>
 
    <para>
-    <function>password_hash</function> will now chain the underlying Random\RandomException
-    as the ValueError’s $previous Exception when salt generation fails.
+    <function>password_hash</function> will now chain the underlying <classname>Random\RandomException</classname>
+    as the <classname>ValueError</classname>’s <literal>$previous</literal> <classname>Exception</classname> when salt generation fails.
    </para>
 
    <para>
@@ -335,8 +335,8 @@
    <title>SQLite3</title>
 
    <para>
-    The SQLite3 class now throws \SQLite3Exception (extends \Exception) instead
-    of \Exception.
+    The <classname>SQLite3</classname> class now throws <classname>SQLite3Exception</classname> (extends <classname>Exception</classname>) instead
+    of <classname>Exception</classname>.
    </para>
 
    <para>
@@ -353,7 +353,7 @@
   <itemizedlist>
    <listitem>
     <para>
-     The assert.* INI settings have been deprecated.
+     The <literal>assert.*</literal> INI settings have been deprecated.
      This comprises the following INI settings:
      <simplelist>
       <member>assert.active</member>

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -43,9 +43,9 @@
 
    <para>
     Setting <link linkend="ini.open-basedir">open_basedir</link> at runtime using <code>ini_set('open_basedir', ...);</code> no
-    longer accepts paths containing the parent directory (`..`). Previously,
-    only paths starting with `..` were disallowed. This could easily be
-    circumvented by prepending `./` to the path.
+    longer accepts paths containing the parent directory (<literal>..</literal>). Previously,
+    only paths starting with <literal>..</literal> were disallowed. This could easily be
+    circumvented by prepending <literal>./</literal> to the path.
    </para>
 
    <para>
@@ -53,7 +53,7 @@
    </para>
 
    <para>
-    The resultant HTML of highlight_string and highlight_file has changed.
+    The resultant HTML of <function>highlight_string</function> and <function>highlight_file</function> has changed.
     Whitespace between outer HTML tags is removed. Newlines and spaces
     are no longer converted to HTML entities. The whole HTML is now wrapped in
     &lt;pre&gt; tag. The outer &lt;span&gt; has been merged with &lt;code&gt;.
@@ -101,7 +101,7 @@
    <title>Gd</title>
 
    <para>
-    Changed <function>imagerotate</function> signature, removed the `ignore_transparent` argument
+    Changed <function>imagerotate</function> signature, removed the <parameter>ignore_transparent</parameter> argument
     as it was not used internally anyway from PHP 7.x.
    </para>
   </sect3>
@@ -174,13 +174,13 @@
    <title>mysqli</title>
 
    <para>
-    <function>mysqli_fetch_object</function> now raises a ValueError instead of an Exception when
-    the constructor_args argument is non empty with the class not having
+    <function>mysqli_fetch_object</function> now raises a <classname>ValueError</classname> instead of an <classname>Exception</classname> when
+    the <parameter>constructor_args</parameter> argument is non empty with the class not having
     constructor.
    </para>
 
    <para>
-    <function>mysqli_poll</function> now raises a ValueError when the read nor error arguments are
+    <function>mysqli_poll</function> now raises a <classname>ValueError</classname> when the <parameter>read</parameter> nor <parameter>error</parameter> arguments are
     passed.
    </para>
 
@@ -204,19 +204,19 @@
    <title>PGSQL</title>
 
    <para>
-    <function>pg_fetch_object</function> now raises a ValueError instead of an Exception when the
+    <function>pg_fetch_object</function> now raises a <classname>ValueError</classname> instead of an <classname>Exception</classname> when the
     constructor_args argument is non empty with the class not having
     constructor.
    </para>
 
    <para>
-    <function>pg_insert</function> now raises a ValueError instead of a WARNING when the table
+    <function>pg_insert</function> now raises a <classname>ValueError</classname> instead of a <constant>E_WARNING</constant> when the table
     specified is invalid.
    </para>
 
    <para>
-    <function>pg_insert</function> and <function>pg_convert</function> raises a ValueError or a TypeError instead of a
-    WARNING when the value/type of a field does not match properly with a
+    <function>pg_insert</function> and <function>pg_convert</function> raises a <classname>ValueError</classname> or a <classname>TypeError</classname> instead of a
+    <constant>E_WARNING</constant> when the value/type of a field does not match properly with a
     PostgreSQL's type.
    </para>
 
@@ -233,7 +233,7 @@
     Changed <function>mt_srand</function> and <function>srand</function> to not check the number of arguments to
     determine whether a random seed should be used. Passing &null; will generate
     a random seed, <literal>0</literal> will use zero as the seed. The functions are now
-    consistent with <methodname>Mt19937::__construct</methodname>.
+    consistent with <methodname>Random\Engine\Mt19937::__construct</methodname>.
    </para>
 
   </sect3>
@@ -318,7 +318,7 @@
    <para>
     Internal objects that implement an _IS_NUMBER cast but not a do_operator
     handler that overrides addition and subtraction now can be incremented
-    and decrement as if one would do $o += 1 or $o -= 1
+    and decrement as if one would do <code>$o += 1</code> or <code>$o -= 1</code>
    </para>
   </sect3>
 
@@ -371,7 +371,7 @@
     <para>
      <!--<link linkend="ini.zend.max_allowed_stack_size">-->zend.max_allowed_stack_size<!--</link>-->
     is a new INI directive to set the maximum allowed stack size. Possible
-    values are <literal>0</literal> (detect the process or thread maximum stack size), `-1`
+    values are <literal>0</literal> (detect the process or thread maximum stack size), <literal>-1</literal>
     (no limit), or a positive number of bytes. The default is <literal>0</literal>. When it
     is not possible to detect the the process or thread maximum stack size,
     a known system default is used. Setting this value too high has the same

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -165,7 +165,7 @@
    <para>
     <methodname>DOMDocument::loadHTML</methodname>,
     <methodname>DOMDocument::loadHTMLFile</methodname>,
-    <methodname>DOMDocument::loadXML</methodname> and
+    <methodname>DOMDocument::loadXML</methodname>, and
     <methodname>DOMDocument::loadXMLFile</methodname> now have a tentative
     return type of <type>bool</type>. Previously, this was documented as having a return
     type of <code>DOMDocument|bool</code>, but, as of PHP 8.0.0,
@@ -268,7 +268,7 @@
 
    <para>
     <function>mysqli_poll</function> now raises a <classname>ValueError</classname>
-    when the neither the <parameter>read</parameter>
+    when neither the <parameter>read</parameter>
     nor the <parameter>error</parameter> arguments are passed.
    </para>
 
@@ -371,7 +371,7 @@
    <para>
     <function>password_hash</function> will now chain the underlying
     <classname>Random\RandomException</classname>
-    as the <classname>ValueError</classname>’s <parameter>$previous</parameter>
+    as the <classname>ValueError</classname>'s <parameter>$previous</parameter>
     <classname>Exception</classname> when salt generation fails.
    </para>
 
@@ -392,10 +392,12 @@
    </para>
 
    <para>
-    <function>number_format</function> $decimal parameter handles rounding to
-    negative places. It means that when $decimals is negative, $num is rounded
-    to <parameter>$decimals</parameter> significant digits before the decimal
-    point. Previously negative <parameter>$decimals</parameter> got silently
+    The <parameter>$decimal</parameter> of <function>number_format</function>
+    now properly handles negative integers.
+    Rounding with a negative value for <parameter>$decimal</parameter> means
+    that <parameter>$num</parameter> is rounded to <parameter>$decimals</parameter>
+    significant digits before the decimal point.
+    Previously negative <parameter>$decimals</parameter> were silently
     ignored and the number got rounded to zero decimal places.
    </para>
 

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -356,11 +356,11 @@
      The <literal>assert.*</literal> INI settings have been deprecated.
      This comprises the following INI settings:
      <simplelist>
-      <member>assert.active</member>
-      <member>assert.bail</member>
-      <member>assert.callback</member>
-      <member>assert.exception</member>
-      <member>assert.warning</member>
+      <member><link linkend="ini.assert.active">assert.active</link></member>
+      <member><link linkend="ini.assert.bail">assert.bail</link></member>
+      <member><link linkend="ini.assert.callback">assert.callback</link></member>
+      <member><link linkend="ini.assert.exception">assert.exception</link></member>
+      <member><link linkend="ini.assert.warning">assert.warning</link></member>
      </simplelist>
      If the value of the setting is equal to the default value, no deprecation
      notice is emitted.

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -122,7 +122,7 @@
 
    <para>
     <methodname>IntlChar::enumCharNames</methodname> is now returning a boolean.
-    Previously it returned &null; on success and &false; on failure. 
+    Previously it returned &null; on success and &false; on failure.
    </para>
   </sect3>
 

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -1,0 +1,458 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration83.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Other Changes</title>
+
+ <sect2 xml:id="migration83.other-changes.sapi">
+  <title>Changes in SAPI Modules</title>
+
+  <sect3 xml:id="migration83.other-changes.sapi.cli">
+   <title>CLI</title>
+
+   <para>
+    The <constant>STDOUT</constant>, <constant>STDERR</constant> and <constant>STDIN</constant> streams are no longer closed on resource destruction
+    which is mostly when the CLI finishes. It is however still possible to
+    explicitly close those streams using <function>fclose</function> and similar.
+   </para>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration83.other-changes.functions">
+  <title>Changed Functions</title>
+
+  <sect3 xml:id="migration83.other-changes.functions.core">
+   <title>Core</title>
+
+   <para>
+    <function>gc_status</function> has added the following 8 fields:
+
+    <simplelist>
+     <member>"running" => bool</member>
+     <member>"protected" => bool</member>
+     <member>"full" => bool</member>
+     <member>"buffer_size" => int</member>
+     <member>"application_time" => float: Total application time, in seconds (including collector_time)</member>
+     <member>"collector_time" => float: Time spent collecting cycles, in seconds (including destructor_time and free_time)</member>
+     <member>"destructor_time" => float: Time spent executing destructors during cycle collection, in seconds</member>
+     <member>"free_time" => float: Time spent freeing values during cycle collection, in seconds</member>
+    </simplelist>
+   </para>
+
+   <para>
+    <function>class_alias</function> now supports creating an alias of an internal class.
+   </para>
+
+   <para>
+    Setting <link linkend="ini.open-basedir">open_basedir</link> at runtime using <code>ini_set('open_basedir', ...);</code> no
+    longer accepts paths containing the parent directory (`..`). Previously,
+    only paths starting with `..` were disallowed. This could easily be
+    circumvented by prepending `./` to the path.
+   </para>
+
+   <para>
+    User exception handlers now catch exceptions during shutdown.
+   </para>
+
+   <para>
+    The resultant HTML of highlight_string and highlight_file has changed.
+    Whitespace between outer HTML tags is removed. Newlines and spaces
+    are no longer converted to HTML entities. The whole HTML is now wrapped in
+    &lt;pre&gt; tag. The outer &lt;span&gt; has been merged with &lt;code&gt;.
+   </para>
+
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.functions.calendar">
+   <title>Calendar</title>
+
+   <para>
+    <function>easter_date</function> now supports years from 1970 to 2,000,000,000 on 64-bit
+    systems, previously it only supported years in the range from 1970 to 2037.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.functions.curl">
+   <title>Curl</title>
+
+   <para>
+    <function>curl_getinfo</function> now supports two new constants: <constant>CURLINFO_CAPATH</constant> and
+    <constant>CURLINFO_CAINFO</constant>. If option is &null;, the following two additional keys are
+    present: <literal>"capath"</literal> and <literal>"cainfo"</literal>.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.functions.dom">
+   <title>DOM</title>
+
+   <para>
+    Changed <methodname>DOMCharacterData::appendData</methodname> tentative return type to true.
+   </para>
+
+   <para>
+    <methodname>DOMDocument::loadHTML</methodname>, <methodname>DOMDocument::loadHTMLFile</methodname>,
+    <methodname>DOMDocument::loadXML</methodname> and <methodname>DOMDocument::loadXMLFile</methodname> now have a tentative
+    return type of bool. Previously, this was documented as having a return
+    type of DOMDocument|bool, but DOMDocument cannot be returned since PHP 8.0
+    as it is no longer statically callable.
+   </para>
+
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.functions.gd">
+   <title>Gd</title>
+
+   <para>
+    Changed <function>imagerotate</function> signature, removed the `ignore_transparent` argument
+    as it was not used internally anyway from PHP 7.x.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.functions.intl">
+   <title>Intl</title>
+
+   <para>
+    <function>datefmt_set_timezone</function> (and its alias <methodname>IntlDateformatter::setTimeZone</methodname>)
+    now returns &true; on success, previously &null; was returned.
+   </para>
+
+   <para>
+    <methodname>IntlBreakiterator::setText</methodname> now returns &false; on failure, previously
+    &null; was returned.
+    now returns &true; on success, previously &null; was returned.
+   </para>
+
+   <para>
+    <methodname>IntlChar::enumCharNames</methodname> is now returning a boolean.
+    Previously it returned &null; on success and &false; on failure. 
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.functions.mbstring">
+   <title>MBString</title>
+
+   <para>
+    <function>mb_strtolower</function>, <function>mb_strtotitle</function>, and <function>mb_convert_case</function> implement conditional
+    casing rules for the Greek letter sigma. For <function>mb_convert_case</function>, conditional
+    casing only applies to <constant>MB_CASE_LOWER</constant> and <constant>MB_CASE_TITLE</constant> modes, not to
+    <constant>MB_CASE_LOWER_SIMPLE</constant> and <constant>MB_CASE_TITLE_SIMPLE</constant>.
+   </para>
+
+   <para>
+    <function>mb_decode_mimeheader</function> interprets underscores in QPrint-encoded MIME
+    encoded words as required by RFC 2047; they are converted to spaces.
+    Underscores must be encoded as <literal>"=5F"</literal> in such MIME encoded words.
+   </para>
+
+   <para>
+    In rare cases, <function>mb_encode_mimeheader</function> will transfer-encode its input
+    string where it would pass it through as raw ASCII in PHP 8.2.
+   </para>
+
+   <para>
+    <function>mb_encode_mimeheader</function> no longer drops NUL (zero) bytes when
+    QPrint-encoding the input string. This previously caused strings in
+    certain text encodings, especially UTF-16 and UTF-32, to be
+    corrupted by mb_encode_mimeheader.
+   </para>
+
+   <para>
+    <function>mb_detect_encoding</function>'s "non-strict" mode now behaves as described in the
+    documentation. Previously, it would return false if the same byte
+    (for example, the first byte) of the input string was invalid in all
+    candidate encodings. More generally, it would eliminate candidate
+    encodings from consideration when an invalid byte was seen, and if the
+    same input byte eliminated all remaining encodings still under
+    consideration, it would return false. On the other hand, if all candidate
+    encodings but one were eliminated from consideration, it would return the
+    last remaining one without regard for how many encoding errors might be
+    encountered later in the string. This is different from the behavior
+    described in the documentation, which says: "If strict is set to false,
+    the closest matching encoding will be returned."
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.functions.mysqli">
+   <title>mysqli</title>
+
+   <para>
+    <function>mysqli_fetch_object</function> now raises a ValueError instead of an Exception when
+    the constructor_args argument is non empty with the class not having
+    constructor.
+   </para>
+
+   <para>
+    <function>mysqli_poll</function> now raises a ValueError when the read nor error arguments are
+    passed.
+   </para>
+
+   <para>
+    <function>mysqli_field_seek</function> and <methodname>mysqli_result::field_seek</methodname> now specify return type
+    as true instead of bool.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.functions.odbc">
+   <title>ODBC</title>
+
+   <para>
+    <function>odbc_autocommit</function> now accepts null for the $enable parameter.
+    Passing &null; has the same behaviour as passing only 1 parameter,
+    namely indicating if the autocommit feature is enabled or not.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.functions.pgsql">
+   <title>PGSQL</title>
+
+   <para>
+    <function>pg_fetch_object</function> now raises a ValueError instead of an Exception when the
+    constructor_args argument is non empty with the class not having
+    constructor.
+   </para>
+
+   <para>
+    <function>pg_insert</function> now raises a ValueError instead of a WARNING when the table
+    specified is invalid.
+   </para>
+
+   <para>
+    <function>pg_insert</function> and <function>pg_convert</function> raises a ValueError or a TypeError instead of a
+    WARNING when the value/type of a field does not match properly with a
+    PostgreSQL's type.
+   </para>
+
+   <para>
+    The $row param of <function>pg_fetch_result</function>, <function>pg_field_prtlen</function> and
+    <function>pg_field_is_null</function> is now nullable.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.functions.random">
+   <title>Random</title>
+
+   <para>
+    Changed <function>mt_srand</function> and <function>srand</function> to not check the number of arguments to
+    determine whether a random seed should be used. Passing null will generate
+    a random seed, 0 will use zero as the seed. The functions are now
+    consistent with <methodname>Mt19937::__construct</methodname>.
+   </para>
+
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.functions.reflection">
+   <title>Reflection</title>
+
+   <para>
+    Return type of <methodname>ReflectionClass::getStaticProperties</methodname> is no longer nullable.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.functions.standard">
+   <title>Standard</title>
+
+   <para>
+    E_NOTICEs emitted by <function>unserialize</function> have been promoted to E_WARNING.
+    <!-- RFC: https://wiki.php.net/rfc/improve_unserialize_error_handling -->
+   </para>
+
+   <para>
+    <function>unserialize</function> now emits a new E_WARNING if the input contains unconsumed
+    bytes.
+    <!-- RFC: https://wiki.php.net/rfc/unserialize_warn_on_trailing_data -->
+   </para>
+
+   <para>
+    <function>array_pad</function> is now only limited by the maximum number of elements an array
+    can have. Before, it was only possible to add at most 1048576 elements at a
+    time.
+   </para>
+
+   <para>
+    <function>strtok</function> raises a warning in the case token is not provided when starting
+    tokenization.
+   </para>
+
+   <para>
+    <function>password_hash</function> will now chain the underlying Random\RandomException
+    as the ValueError’s $previous Exception when salt generation fails.
+   </para>
+
+   <para>
+    <function>proc_open</function> $command array must now have at least one non empty element.
+   </para>
+
+   <para>
+    <function>array_sum</function> and <function>array_product</function> now warn when values in the array cannot
+    be converted to int/float. Previously arrays and objects where ignored
+    whilst every other value was cast to int. Moreover, objects that define
+    a numeric cast (e.g. GMP) are now casted instead of ignored.
+    <!-- RFC: https://wiki.php.net/rfc/saner-array-sum-product -->
+   </para>
+
+   <para>
+    <function>number_format</function> $decimal parameter handles rounding to negative places. It
+    means that when $decimals is negative, $num is rounded to $decimals
+    significant digits before the decimal point. Previously negative $decimals
+    got silently ignored and the number got rounded to zero decimal places.
+   </para>
+
+   <para>
+    The $before_needle argument added to <function>strrchr</function> which works in the same way
+    like its counterpart in <function>strstr</function> or <function>stristr</function>.
+   </para>
+
+   <para>
+    <function>str_getcsv</function> and <function>fgetcsv</function> return empty string instead of a string with
+    a single zero byte for the last field which contains only unterminated
+    enclosure.
+   </para>
+  </sect3>
+
+ </sect2>
+
+ <sect2 xml:id="migration83.other-changes.extensions">
+  <title>Other Changes to Extensions</title>
+
+  <sect3 xml:id="migration83.other-changes.extensions.core">
+   <title>Core</title>
+
+   <para>
+    Internal objects that implement an _IS_NUMBER cast but not a do_operator
+    handler that overrides addition and subtraction now can be incremented
+    and decrement as if one would do $o += 1 or $o -= 1
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.extensions.dom">
+   <title>DOM</title>
+
+   <para>
+    The DOM lifetime mechanism has been reworked such that implicitly removed
+    nodes can still be fetched. Previously this resulted in an exception.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.extensions.sqlite3">
+   <title>SQLite3</title>
+
+   <para>
+    The SQLite3 class now throws \SQLite3Exception (extends \Exception) instead
+    of \Exception.
+   </para>
+
+   <para>
+    The SQLite error code is now passed in the exception error code instead of
+    being included in the error message.
+   </para>
+
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration83.other-changes.ini">
+  <title>Changes to INI File Handling</title>
+
+  <itemizedlist>
+   <listitem>
+    <para>
+     The assert.* INI settings have been deprecated.
+     This comprises the following INI settings:
+     <simplelist>
+      <member>assert.active</member>
+      <member>assert.bail</member>
+      <member>assert.callback</member>
+      <member>assert.exception</member>
+      <member>assert.warning</member>
+     </simplelist>
+     If the value of the setting is equal to the default value, no deprecation
+     notice is emitted.
+     The <link linkend="ini.zend.assertions">zend.assertions</link> INI setting should be used instead.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <!--<link linkend="ini.zend.max_allowed_stack_size">-->zend.max_allowed_stack_size<!--</link>-->
+    is a new INI directive to set the maximum allowed stack size. Possible
+    values are <literal>0</literal> (detect the process or thread maximum stack size), `-1`
+    (no limit), or a positive number of bytes. The default is <literal>0</literal>. When it
+    is not possible to detect the the process or thread maximum stack size,
+    a known system default is used. Setting this value too high has the same
+    effect as disabling the stack size limit. Fibers use fiber.stack_size
+    as maximum allowed stack size. An Error is thrown when the process call
+    stack exceeds `zend.max_allowed_stack_size-zend.reserved_stack_size`
+    bytes, to prevent stack-overflow-induced segmentation faults, with
+    the goal of making debugging easier. The stack size increases during
+    uncontrolled recursions involving internal functions or the magic methods
+    __toString, __clone, __sleep, __destruct.  This is not related to stack
+    buffer overflows, and is not a security feature.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <!--<link linkend="ini.zend.reserved_stack_size">-->zend.reserved_stack_size<!--</link>-->
+     is a new INI directive to set the reserved stack size, in bytes. This is
+    subtracted from the max allowed stack size, as a buffer, when checking the
+    stack size.
+    </para>
+   </listitem>
+   </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration83.other-changes.performance">
+  <title>Performance</title>
+
+  <sect3 xml:id="migration83.other-changes.performance.dom">
+   <title>DOM</title>
+
+   <para>
+    Looping over a <classname>DOMNodeList</classname> now uses caching. Therefore requesting items no
+    longer takes quadratic time by default.
+   </para>
+
+   <para>
+    Getting text content from nodes now avoids an allocation, resulting in a
+    performance gain.
+   </para>
+
+   <para>
+    <methodname>DOMChildNode::remove</methodname> now runs in O(1) performance.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.performance.standard">
+   <title>Standard</title>
+
+   <para>
+    The <function>file</function> flags error check is now about 7% faster.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.other-changes.performance.spl">
+   <title>SPL</title>
+
+   <para>
+    <classname>RecursiveDirectoryIterator</classname> now performs less I/O when looping over a
+    directory.
+   </para>
+  </sect3>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -321,8 +321,8 @@
     <function>array_sum</function> and <function>array_product</function> now
     warn when values in the array cannot be converted to int/float.
     Previously arrays and objects where ignored whilst every other value was
-    cast to int. Moreover, objects that define a numeric cast (e.g. GMP) are
-    now casted instead of ignored.
+    cast to int. Moreover, objects that define a numeric cast (e.g.
+    <link linkend="book.gmp">GMP</link>) are now casted instead of ignored.
     <!-- RFC: https://wiki.php.net/rfc/saner-array-sum-product -->
    </para>
 

--- a/appendices/migration83/windows-support.xml
+++ b/appendices/migration83/windows-support.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration83.windows-support" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Windows Support</title>
+
+ <sect2 xml:id="migration83.windows-support.core">
+  <title>Core</title>
+
+  <para>
+   Minimum supported Windows version has been bumped to Windows 8 or
+   Windows Server 2012
+  </para>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Based on [PHP 8.3 UPGRADE NOTES](https://github.com/php/php-src/blob/PHP-8.3/UPGRADING) and past migration guides.

- TODO
  * [x] New Features
  * [x] New Classes and Interfaces
  * [x] New Functions
  * [x] New Global Constants
  * [x] Backward Incompatible Changes
  * [x] Deprecated Features
  * [x] Windows Support
  * [x] Other Changes
  * [x] libcurl version check
  * [x] doc-base/manual.xml.in change
    - https://github.com/php/doc-base/pull/101
 
closes: #2774 