### PR TITLE
Fix bug #61907: XML Error Codes constants should list integer value

### DIFF
--- a/reference/xml/error-codes.xml
+++ b/reference/xml/error-codes.xml
@@ -5,30 +5,107 @@
  <para>
   The following constants are defined for XML error codes (as
   returned by <function>xml_parse</function>):
-  <simplelist>
-   <member><constant>XML_ERROR_NONE</constant></member>
-   <member><constant>XML_ERROR_NO_MEMORY</constant></member>
-   <member><constant>XML_ERROR_SYNTAX</constant></member>
-   <member><constant>XML_ERROR_NO_ELEMENTS</constant></member>
-   <member><constant>XML_ERROR_INVALID_TOKEN</constant></member>
-   <member><constant>XML_ERROR_UNCLOSED_TOKEN</constant></member>
-   <member><constant>XML_ERROR_PARTIAL_CHAR</constant></member>
-   <member><constant>XML_ERROR_TAG_MISMATCH</constant></member>
-   <member><constant>XML_ERROR_DUPLICATE_ATTRIBUTE</constant></member>
-   <member><constant>XML_ERROR_JUNK_AFTER_DOC_ELEMENT</constant></member>
-   <member><constant>XML_ERROR_PARAM_ENTITY_REF</constant></member>
-   <member><constant>XML_ERROR_UNDEFINED_ENTITY</constant></member>
-   <member><constant>XML_ERROR_RECURSIVE_ENTITY_REF</constant></member>
-   <member><constant>XML_ERROR_ASYNC_ENTITY</constant></member>
-   <member><constant>XML_ERROR_BAD_CHAR_REF</constant></member>
-   <member><constant>XML_ERROR_BINARY_ENTITY_REF</constant></member>
-   <member><constant>XML_ERROR_ATTRIBUTE_EXTERNAL_ENTITY_REF</constant></member>
-   <member><constant>XML_ERROR_MISPLACED_XML_PI</constant></member>
-   <member><constant>XML_ERROR_UNKNOWN_ENCODING</constant></member>
-   <member><constant>XML_ERROR_INCORRECT_ENCODING</constant></member>
-   <member><constant>XML_ERROR_UNCLOSED_CDATA_SECTION</constant></member>
-   <member><constant>XML_ERROR_EXTERNAL_ENTITY_HANDLING</constant></member>
-  </simplelist>
+  <table>
+   <title>XML error code constants</title>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>Value</entry>
+      <entry>Constant</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>0</entry>
+      <entry><constant>XML_ERROR_NONE</constant></entry>
+     </row>
+     <row>
+      <entry>1</entry>
+      <entry><constant>XML_ERROR_NO_MEMORY</constant></entry>
+     </row>
+     <row>
+      <entry>2</entry>
+      <entry><constant>XML_ERROR_SYNTAX</constant></entry>
+     </row>
+     <row>
+      <entry>3</entry>
+      <entry><constant>XML_ERROR_NO_ELEMENTS</constant></entry>
+     </row>
+     <row>
+      <entry>4</entry>
+      <entry><constant>XML_ERROR_INVALID_TOKEN</constant></entry>
+     </row>
+     <row>
+      <entry>5</entry>
+      <entry><constant>XML_ERROR_UNCLOSED_TOKEN</constant></entry>
+     </row>
+     <row>
+      <entry>6</entry>
+      <entry><constant>XML_ERROR_PARTIAL_CHAR</constant></entry>
+     </row>
+     <row>
+      <entry>7</entry>
+      <entry><constant>XML_ERROR_TAG_MISMATCH</constant></entry>
+     </row>
+     <row>
+      <entry>8</entry>
+      <entry><constant>XML_ERROR_DUPLICATE_ATTRIBUTE</constant></entry>
+     </row>
+     <row>
+      <entry>9</entry>
+      <entry><constant>XML_ERROR_JUNK_AFTER_DOC_ELEMENT</constant></entry>
+     </row>
+     <row>
+      <entry>10</entry>
+      <entry><constant>XML_ERROR_PARAM_ENTITY_REF</constant></entry>
+     </row>
+     <row>
+      <entry>11</entry>
+      <entry><constant>XML_ERROR_UNDEFINED_ENTITY</constant></entry>
+     </row>
+     <row>
+      <entry>12</entry>
+      <entry><constant>XML_ERROR_RECURSIVE_ENTITY_REF</constant></entry>
+     </row>
+     <row>
+      <entry>13</entry>
+      <entry><constant>XML_ERROR_ASYNC_ENTITY</constant></entry>
+     </row>
+     <row>
+      <entry>14</entry>
+      <entry><constant>XML_ERROR_BAD_CHAR_REF</constant></entry>
+     </row>
+     <row>
+      <entry>15</entry>
+      <entry><constant>XML_ERROR_BINARY_ENTITY_REF</constant></entry>
+     </row>
+     <row>
+      <entry>16</entry>
+      <entry><constant>XML_ERROR_ATTRIBUTE_EXTERNAL_ENTITY_REF</constant></entry>
+     </row>
+     <row>
+      <entry>17</entry>
+      <entry><constant>XML_ERROR_MISPLACED_XML_PI</constant></entry>
+     </row>
+     <row>
+      <entry>18</entry>
+      <entry><constant>XML_ERROR_UNKNOWN_ENCODING</constant></entry>
+     </row>
+     <row>
+      <entry>19</entry>
+      <entry><constant>XML_ERROR_INCORRECT_ENCODING</constant></entry>
+     </row>
+     <row>
+      <entry>20</entry>
+      <entry><constant>XML_ERROR_UNCLOSED_CDATA_SECTION</constant></entry>
+     </row>
+     <row>
+      <entry>21</entry>
+      <entry><constant>XML_ERROR_EXTERNAL_ENTITY_HANDLING</constant></entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
  </para>
 </article>
 
@@ -52,4 +129,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-


### PR DESCRIPTION
Fixes https://bugs.php.net/bug.php?id=61907.
Stole the table from exif image types page and adapted for ext/xml.