### PR TITLE
modernize ErrorException example code

### DIFF
--- a/language/predefined/errorexception.xml
+++ b/language/predefined/errorexception.xml
@@ -89,7 +89,7 @@ function exception_error_handler(int $errno, string $errstr, ?string $errfile, i
     throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
 }
 set_error_handler(__NAMESPACE__ . "\\exception_error_handler");
-// or in PHP>=8.1: set_error_handler(exception_error_handler(...));
+// PHP>=8.1: set_error_handler(exception_error_handler(...));
 
 /* Trigger exception */
 strpos();

--- a/language/predefined/errorexception.xml
+++ b/language/predefined/errorexception.xml
@@ -86,7 +86,7 @@ function exception_error_handler(int $errno, string $errstr, string $errfile, in
         // This error code is not included in error_reporting
         return;
     }
-    throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+    throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
 }
 set_error_handler(exception_error_handler(...));
 

--- a/language/predefined/errorexception.xml
+++ b/language/predefined/errorexception.xml
@@ -81,7 +81,7 @@
      <programlisting role="php">
  <![CDATA[
 <?php
-function exception_error_handler(int $errno, string $errstr, string $errfile == null, int $errline) {
+function exception_error_handler(int $errno, string $errstr, string $errfile = null, int $errline) {
     if (!(error_reporting() & $errno)) {
         // This error code is not included in error_reporting
         return;
@@ -89,7 +89,7 @@ function exception_error_handler(int $errno, string $errstr, string $errfile == 
     throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
 }
 set_error_handler(exception_error_handler(...));
-// Prior to PHP 8.1.0 and the introduction of the first class callable syntax, the following call must be used to 
+// Prior to PHP 8.1.0 and the introduction of the first class callable syntax, the following call must be used instead 
 // set_error_handler(__NAMESPACE__ . "\\exception_error_handler");
 
 /* Trigger exception */

--- a/language/predefined/errorexception.xml
+++ b/language/predefined/errorexception.xml
@@ -81,14 +81,14 @@
      <programlisting role="php">
  <![CDATA[
 <?php
-function exception_error_handler($severity, $message, $file, $line) {
-    if (!(error_reporting() & $severity)) {
+function exception_error_handler(int $errno, string $errstr, string $errfile, int $errline) {
+    if (!(error_reporting() & $errno)) {
         // This error code is not included in error_reporting
         return;
     }
-    throw new ErrorException($message, 0, $severity, $file, $line);
+    throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
 }
-set_error_handler("exception_error_handler");
+set_error_handler(exception_error_handler(...));
 
 /* Trigger exception */
 strpos();

--- a/language/predefined/errorexception.xml
+++ b/language/predefined/errorexception.xml
@@ -89,7 +89,7 @@ function exception_error_handler(int $errno, string $errstr, string $errfile = n
     throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
 }
 set_error_handler(exception_error_handler(...));
-// Prior to PHP 8.1.0 and the introduction of the first class callable syntax, the following call must be used instead 
+// Prior to PHP 8.1.0 and the introduction of the first class callable syntax, the following call must be used instead
 // set_error_handler(__NAMESPACE__ . "\\exception_error_handler");
 
 /* Trigger exception */

--- a/language/predefined/errorexception.xml
+++ b/language/predefined/errorexception.xml
@@ -81,7 +81,7 @@
      <programlisting role="php">
  <![CDATA[
 <?php
-function exception_error_handler(int $errno, string $errstr, string $errfile, int $errline) {
+function exception_error_handler(int $errno, string $errstr, ?string $errfile, int $errline) {
     if (!(error_reporting() & $errno)) {
         // This error code is not included in error_reporting
         return;

--- a/language/predefined/errorexception.xml
+++ b/language/predefined/errorexception.xml
@@ -81,15 +81,16 @@
      <programlisting role="php">
  <![CDATA[
 <?php
-function exception_error_handler(int $errno, string $errstr, ?string $errfile, int $errline) {
+function exception_error_handler(int $errno, string $errstr, string $errfile == null, int $errline) {
     if (!(error_reporting() & $errno)) {
         // This error code is not included in error_reporting
         return;
     }
     throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
 }
-set_error_handler(__NAMESPACE__ . "\\exception_error_handler");
-// PHP>=8.1: set_error_handler(exception_error_handler(...));
+set_error_handler(exception_error_handler(...));
+// Prior to PHP 8.1.0 and the introduction of the first class callable syntax, the following call must be used to 
+// set_error_handler(__NAMESPACE__ . "\\exception_error_handler");
 
 /* Trigger exception */
 strpos();

--- a/language/predefined/errorexception.xml
+++ b/language/predefined/errorexception.xml
@@ -88,7 +88,8 @@ function exception_error_handler(int $errno, string $errstr, ?string $errfile, i
     }
     throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
 }
-set_error_handler(exception_error_handler(...));
+set_error_handler(__NAMESPACE__ . "\\exception_error_handler");
+// or in PHP>=8.1: set_error_handler(exception_error_handler(...));
 
 /* Trigger exception */
 strpos();


### PR DESCRIPTION
IMO the old example should have been 
```
set_error_handler(__NAMESPACE__ . "\\exception_error_handler");
```
so it would work in any namespace, because the old example just worked in the global namespace, and crashed-at-runtime if used in any other namespace,  but as of PHP8.1.0 we have an even better way to do it: set_error_handler(exception_error_handler(...));