### PR TITLE
password_hash: Update script to generate cost recommendations

### DIFF
--- a/reference/password/functions/password-hash.xml
+++ b/reference/password/functions/password-hash.xml
@@ -295,13 +295,13 @@ $2y$12$QjSH496pcT5CEbzjD/vtVeH03tfHKFy36d4J0Ltp3lRtee9HDxY3K
 /**
  * This code will benchmark your server to determine how high of a cost you can
  * afford. You want to set the highest cost that you can without slowing down
- * you server too much. 8-10 is a good baseline, and more is good if your servers
- * are fast enough. The code below aims for ≤ 50 milliseconds stretching time,
- * which is a good baseline for systems handling interactive logins.
+ * you server too much. 10 is a good baseline, and more is good if your servers
+ * are fast enough. The code below aims for ≤ 350 milliseconds stretching time,
+ * which is an appropriate delay for systems handling interactive logins.
  */
-$timeTarget = 0.05; // 50 milliseconds 
+$timeTarget = 0.350; // 350 milliseconds
 
-$cost = 8;
+$cost = 10;
 do {
     $cost++;
     $start = microtime(true);
@@ -316,7 +316,7 @@ echo "Appropriate Cost Found: " . $cost;
     &example.outputs.similar;
     <screen>
 <![CDATA[
-Appropriate Cost Found: 10
+Appropriate Cost Found: 12
 ]]>
     </screen>
    </example>
@@ -358,7 +358,7 @@ Argon2i hash: $argon2i$v=19$m=1024,t=2,p=2$YzJBSzV4TUhkMzc3d3laeg$zqU/1IN0/AogfP
   <note>
    <para>
     It is recommended that you test this function on your servers, and adjust the cost parameter 
-    so that execution of the function takes less than 100 milliseconds on interactive systems. 
+    so that execution of the function takes less than 350 milliseconds on interactive systems.
     The script in the above example will help you choose a good cost value for your hardware.
    </para>
   </note>


### PR DESCRIPTION
50 ms is way to short to generate actually secure hashes. Update the recommendation to 350 ms with a starting cost of 10 (the current default) and example output of 12.

see https://wiki.php.net/rfc/bcrypt_cost_2023

/cc @roycewilliams