### PR TITLE
password_needs_rehash: Fix example

### DIFF
--- a/reference/password/functions/password-needs-rehash.xml
+++ b/reference/password/functions/password-needs-rehash.xml
@@ -98,19 +98,21 @@
 $password = 'rasmuslerdorf';
 $hash = '$2y$10$YCFsG6elYca568hBi2pZ0.3LDL5wjgxct1N8w/oLR/jfHsiQwCqTS';
 
-// The cost parameter can change over time as hardware improves
-$options = array('cost' => 11);
+$algorithm = PASSWORD_BCRYPT;
+// bcrypt's cost parameter can change over time as hardware improves
+$options = ['cost' => 12];
 
 // Verify stored hash against plain-text password
 if (password_verify($password, $hash)) {
-    // Check if a newer hashing algorithm is available
-    // or the cost has changed
-    if (password_needs_rehash($hash, PASSWORD_DEFAULT, $options)) {
+    // Check if either the algorithm or the options have changed
+    if (password_needs_rehash($hash, $algorithm, $options)) {
         // If so, create a new hash, and replace the old one
-        $newHash = password_hash($password, PASSWORD_DEFAULT, $options);
+        $newHash = password_hash($password, algorithm, $options);
+
+        // Update the user record with the $newHash
     }
 
-    // Log user in
+    // Perform the login.
 }
 ?>
 ]]>


### PR DESCRIPTION
The old example was broken, because the `cost` option is only valid for bcrypt, but not for argon2. Thus in case the default algorithm actually changes, the example would be broken.

Also update the example costs with 12 as per #2784.