### PR TITLE
crypt: Remove examples showcasing bad practices

### DIFF
--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -187,78 +187,17 @@
     <programlisting role="php">
 <![CDATA[
 <?php
- // let the salt be automatically generated; not recommended
-$hashed_password = crypt('mypassword');
 
-/* You should pass the entire results of crypt() as the salt for comparing a
-   password, to avoid problems when different hashing algorithms are used. (As
-   it says above, standard DES-based password hashing uses a 2-character salt,
-   but MD5-based hashing uses 12.) */
+$user_input = 'rasmuslerdorf';
+$hashed_password = '$6$rounds=1000000$NJy4rIPjpOaU$0ACEYGg/aKCY3v8O8AfyiO7CTfZQ8/W231Qfh2tRLmfdvFD6XfHk12u6hMr9cYIA4hnpjLNSTRtUwYr9km9Ij/';
+
+// Validate an existing crypt() hash for compatibility with non-PHP software.
 if (hash_equals($hashed_password, crypt($user_input, $hashed_password))) {
    echo "Password verified!";
 }
 ?>
 ]]>
     </programlisting>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title>Using <function>crypt</function> with htpasswd</title>
-    <programlisting role="php">
-<![CDATA[
-<?php
-// Set the password
-$password = 'mypassword';
-
-// Get the hash, letting the salt be automatically generated; not recommended
-$hash = crypt($password);
-?>
-]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title>Using <function>crypt</function> with different hash types</title>
-    <programlisting role="php">
-<![CDATA[
-<?php
-/* These salts are examples only, and should not be used verbatim in your code.
-   You should generate a distinct, correctly-formatted salt for each password.
-*/
-echo 'Standard DES: ',
-    crypt('rasmuslerdorf', 'rl'),
-    "\n";
-echo 'Extended DES: ',
-    crypt('rasmuslerdorf', '_J9..rasm'),
-    "\n";
-echo 'MD5:          ',
-    crypt('rasmuslerdorf', '$1$rasmusle$'),
-    "\n";
-echo 'Blowfish:     ',
-    crypt('rasmuslerdorf', '$2a$07$usesomesillystringforsalt$'),
-    "\n";
-echo 'SHA-256:      ',
-    crypt('rasmuslerdorf', '$5$rounds=5000$usesomesillystringforsalt$'),
-    "\n";
-echo 'SHA-512:      ',
-    crypt('rasmuslerdorf', '$6$rounds=5000$usesomesillystringforsalt$'),
-    "\n";
-?>
-]]>
-    </programlisting>
-    &example.outputs.similar;
-    <screen>
-<![CDATA[
-Standard DES: rl.3StKT.4T8M
-Extended DES: _J9..rasmBYk8r9AiWNc
-MD5:          $1$rasmusle$rISCgZzpwk3UhDidwXvin0
-Blowfish:     $2y$07$usesomesillystringfore2uDLvp1Ii2e./U9C8sBjqp8I90dH6hi
-SHA-256:      $5$rounds=5000$usesomesillystri$KqJWpanXZHKq2BOB43TSaYhEWsQ1Lr5QNyPCDH/Tp.6
-SHA-512:      $6$rounds=5000$usesomesillystri$D4IrlXatmP7rx3P3InaxBeoomnAihCKRVQP22JZ6EY47Wc6BkroIuUUBOov1i.S5KPgErtP/EN5mcO.ChWQW21
-]]>
-    </screen>
    </example>
   </para>
  </refsect1>


### PR DESCRIPTION
The existing examples showcased constant salts and the use of DES-based hashing. Showcase a simple example of validating an existing SHA-512 crypt hash with `1000000` rounds for compatibility with non-PHP software that relies on libc's crypt (commonly mail servers or the OS's /etc/shadow).