### PR TITLE
crypt: Do not reference `md5()`

### DIFF
--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -279,7 +279,6 @@ SHA-512:      $6$rounds=5000$usesomesillystri$D4IrlXatmP7rx3P3InaxBeoomnAihCKRVQ
    <simplelist>
     <member><function>hash_equals</function></member>
     <member><function>password_hash</function></member>
-    <member><function>md5</function></member>
     <member>The Unix man page for your crypt function for more information</member>
    </simplelist>
   </para>


### PR DESCRIPTION
`md5()` should not be referenced anywhere, especially not anywhere near a function that is suitable for hashing passwords.