### PR TITLE
Update descriptions of octal, hex and unicode escape sequences

### DIFF
--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -166,24 +166,25 @@ echo 'Variables do not $expand $either';
       <row>
        <entry><literal>\[0-7]{1,3}</literal></entry>
        <entry>
-        the sequence of characters matching the regular expression is a
-        character in octal notation, which silently overflows to fit in a byte
-        (e.g. "\400" === "\000")
+        Octal: the sequence of characters matching the regular expression <literal>[0-7]{1,3}</literal> 
+        is a character in octal notation (e.g. <literal>"\101" === "A"</literal>),
+        which silently overflows to fit in a byte (e.g. <literal>"\400" === "\000"</literal>)
        </entry>
       </row>
       <row>
        <entry><literal>\x[0-9A-Fa-f]{1,2}</literal></entry>
        <entry>
-        the sequence of characters matching the regular expression is a
-        character in hexadecimal notation
+        Hexadecimal: the sequence of characters matching the regular expression
+        <literal>[0-9A-Fa-f]{1,2}</literal> is a character in hexadecimal notation
+        (e.g. <literal>"\x41" === "A"</literal>)
        </entry>
       </row>
       <row>
        <entry><literal>\u{[0-9A-Fa-f]+}</literal></entry>
        <entry>
-        the sequence of characters matching the regular expression is a
-        Unicode codepoint, which will be output to the string as that
-        codepoint's UTF-8 representation
+        Unicode: the sequence of characters matching the regular expression <literal>[0-9A-Fa-f]+</literal>
+        is a Unicode codepoint, which will be output to the string as that codepoint's UTF-8 representation.
+        The braces are required in the sequence. E.g. <literal>"\u{41}" === "A"</literal>
        </entry>
       </row>
      </tbody>

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -166,7 +166,7 @@ echo 'Variables do not $expand $either';
       <row>
        <entry><literal>\[0-7]{1,3}</literal></entry>
        <entry>
-        Octal: the sequence of characters matching the regular expression <literal>[0-7]{1,3}</literal> 
+        Octal: the sequence of characters matching the regular expression <literal>[0-7]{1,3}</literal>
         is a character in octal notation (e.g. <literal>"\101" === "A"</literal>),
         which silently overflows to fit in a byte (e.g. <literal>"\400" === "\000"</literal>)
        </entry>


### PR DESCRIPTION
Clarify which part of each sequence is the regular expression by repeating it in the description, and give examples of each. Before this change, the curly braces are confusing due to having two different meanings in these sequences.