### PR TITLE
Update type system documentation

### DIFF
--- a/language/types.xml
+++ b/language/types.xml
@@ -129,7 +129,7 @@ int(16)
  &language.types.void;
  &language.types.never;
  &language.types.relative-class-types;
- &language.types.literal;
+ &language.types.value;
  &language.types.iterable;
  &language.types.declarations;
  &language.types.type-juggling;

--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -39,6 +39,12 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.3.0</entry>
+      <entry>
+       Support for class, interface, and trait constant typing has been added.
+      </entry>
+     </row>
+     <row>
       <entry>8.2.0</entry>
       <entry>
        Support for <acronym>DNF</acronym> types has been added.
@@ -128,10 +134,10 @@
  </sect2>
 
  <sect2 xml:id="language.types.declarations.base">
-  <title>Base Types Usage Notes</title>
+  <title>Atomic Types Usage Notes</title>
 
   <simpara>
-   Base types have straight forward behaviour with some minor caveats which
+   Atomic types have straight forward behaviour with some minor caveats which
    are described in this section.
   </simpara>
 
@@ -265,7 +271,7 @@ Stack trace:
    <title>Union types</title>
    <warning>
     <simpara>
-     It is not possible to combine the two literal types <type>false</type>
+     It is not possible to combine the two value types <type>false</type>
      and <type>true</type> together in a union type.
      Use <type>bool</type> instead.
     </simpara>

--- a/language/types/type-system.xml
+++ b/language/types/type-system.xml
@@ -9,15 +9,15 @@
  </para>
 
  <para>
-  PHP's type system supports various base types that can be composed together
+  PHP's type system supports various atomic types that can be composed together
   to create more complex types. Some of these types can be written as
   <link linkend="language.types.declarations">type declarations</link>.
  </para>
 
- <sect2 xml:id="language.types.type-system.base">
-  <title>Base types</title>
+ <sect2 xml:id="language.types.type-system.atomic">
+  <title>Atomic types</title>
   <para>
-   Some base types are built-in types which are tightly integrated with the
+   Some atomic types are built-in types which are tightly integrated with the
    language and cannot be reproduced with user defined types.
   </para>
 
@@ -74,7 +74,7 @@
     </listitem>
     <listitem>
      <simpara>
-      <link linkend="language.types.literal">Literal types</link>
+      <link linkend="language.types.value">Value types</link>
      </simpara>
      <itemizedlist>
       <listitem>
@@ -111,7 +111,7 @@
  <sect2 xml:id="language.types.type-system.composite">
   <title>Composite types</title>
   <para>
-   It is possible to combine simple types into composite types.
+   It is possible to combine multiple atomic types into composite types.
    PHP allows types to be combined in the following ways:
   </para>
 

--- a/language/types/value.xml
+++ b/language/types/value.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<sect1 xml:id="language.types.literal">
- <title>Literal types</title>
+<sect1 xml:id="language.types.value">
+ <title>Value types</title>
 
  <para>
-  Literal types are those which not only check the type of a value but also
-  the value itself. PHP has support for two literal types:
+  Value types are those which not only check the type of a value but also
+  the value itself. PHP has support for two value types:
   <type>false</type> as of PHP 8.0.0, and <type>true</type>
   as of PHP 8.2.0.
  </para>
@@ -18,7 +18,7 @@
 
  <note>
   <simpara>
-   It is not possible to define custom literal types. Consider using an
+   It is not possible to define custom value types. Consider using an
    <link linkend="language.types.enumerations">enumerations</link> instead.
   </simpara>
  </note>


### PR DESCRIPTION
Use 'atomic type' instead of simple or base types
Replace 'literal' types by 'value' types
Mention that class, interface, and trait constants can have a type declaration as of PHP 8.3