### PR TITLE
Use entity installation.enabled.disable on installation section

### DIFF
--- a/reference/ctype/configure.xml
+++ b/reference/ctype/configure.xml
@@ -3,7 +3,8 @@
 <section xml:id="ctype.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
  <para>
-  ctype support can be disabled with <option role="configure">--disable-ctype</option>.
+  &installation.enabled.disable;
+  <option role="configure">--disable-ctype</option>
  </para>
  &windows.builtin;
 </section>

--- a/reference/filter/configure.xml
+++ b/reference/filter/configure.xml
@@ -3,8 +3,8 @@
 <section xml:id="filter.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
  <para>
-  The filter extension is enabled by default.
-  To disable the filter extension, use <option role="configure">--disable-filter</option>.
+  &installation.enabled.disable;
+  <option role="configure">--disable-filter</option>
  </para>
 </section>
 

--- a/reference/posix/configure.xml
+++ b/reference/posix/configure.xml
@@ -3,8 +3,8 @@
 <section xml:id="posix.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
  <para>
-  POSIX functions are enabled by default. You can disable POSIX-like
-  functions with <option role="configure">--disable-posix</option>.
+  &installation.enabled.disable;
+  <option role="configure">--disable-posix</option>
  </para>
 </section>
 

--- a/reference/session/configure.xml
+++ b/reference/session/configure.xml
@@ -3,11 +3,12 @@
 <section xml:id="session.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
  <para>
-  Session support is enabled in PHP by default. If you would
-  not like to build your PHP with session support, you should
-  specify the <option role="configure">--disable-session</option>
-  option to configure. To use shared memory allocation (mm) for session
-  storage configure PHP <option role="configure">--with-mm[=DIR] </option>.
+  &installation.enabled.disable;
+  <option role="configure">--disable-session</option>
+ </para>
+ <para>
+  To use shared memory allocation (mm) for session storage configure PHP
+  <option role="configure">--with-mm[=DIR]</option>.
  </para>
  &windows.builtin;
  <note>

--- a/reference/tokenizer/configure.xml
+++ b/reference/tokenizer/configure.xml
@@ -3,8 +3,8 @@
 <section xml:id="tokenizer.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
  <para>
-  These functions are enabled by default. You can disable
-  tokenizer support with <option role="configure">--disable-tokenizer</option>.
+  &installation.enabled.disable;
+  <option role="configure">--disable-tokenizer</option>
  </para>
  &windows.builtin;
 </section>


### PR DESCRIPTION
Replaces the text about disabling extensions enabled by default with the entity `installation.enabled.disable`.