### PR TITLE
Fix example of XSLTProcessor::registerPHPFunctions()

### DIFF
--- a/reference/xsl/xsltprocessor/registerphpfunctions.xml
+++ b/reference/xsl/xsltprocessor/registerphpfunctions.xml
@@ -79,8 +79,10 @@ $xsl = <<<EOB
  </xsl:template>
 </xsl:stylesheet>
 EOB;
-$xmldoc = DOMDocument::loadXML($xml);
-$xsldoc = DOMDocument::loadXML($xsl);
+$xmldoc = new DOMDocument();
+$xmldoc->loadXML($xml);
+$xsldoc = new DOMDocument();
+$xsldoc->loadXML($xsl);
 
 $proc = new XSLTProcessor();
 $proc->registerPHPFunctions();


### PR DESCRIPTION
You can't call these DOMDocument functions statically anymore.