### PR TITLE
Update transformToDoc description

### DIFF
--- a/reference/xsl/xsltprocessor/transformtodoc.xml
+++ b/reference/xsl/xsltprocessor/transformtodoc.xml
@@ -3,17 +3,17 @@
 <refentry xml:id="xsltprocessor.transformtodoc" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>XSLTProcessor::transformToDoc</refname>
-  <refpurpose>Transform to a DOMDocument</refpurpose>
+  <refpurpose>Transform to a document</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="XSLTProcessor">
-   <modifier>public</modifier> <type class="union"><type>DOMDocument</type><type>false</type></type><methodname>XSLTProcessor::transformToDoc</methodname>
+   <modifier>public</modifier> <type class="union"><type>object</type><type>false</type></type><methodname>XSLTProcessor::transformToDoc</methodname>
    <methodparam><type>object</type><parameter>document</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>returnClass</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Transforms the source node to a <classname>DOMDocument</classname> applying
+   Transforms the source node to a document (e.g. <classname>DOMDocument</classname>) applying
    the stylesheet given by the
    <function>XSLTProcessor::importStylesheet</function> method.
   </para>
@@ -26,8 +26,17 @@
      <term><parameter>document</parameter></term>
      <listitem>
       <para>
-       The <classname>DOMDocument</classname> or <classname>SimpleXMLElement</classname> object to
-       be transformed.
+       The <classname>DOMDocument</classname> or <classname>SimpleXMLElement</classname> or libxml-compatible
+       object to be transformed.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>returnClass</parameter></term>
+     <listitem>
+      <para>
+       This optional parameter may be used so that <function>transformToDoc</function> will return an object of the specified class.
+       That class should either extend or be the same class as <parameter>document</parameter>'s class.
       </para>
      </listitem>
     </varlistentry>
@@ -37,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The resulting <classname>DOMDocument</classname> or &false; on error.
+   The resulting document or &false; on error.
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/xsl/xsltprocessor/transformtodoc.xml
+++ b/reference/xsl/xsltprocessor/transformtodoc.xml
@@ -35,7 +35,9 @@
      <term><parameter>returnClass</parameter></term>
      <listitem>
       <para>
-       This optional parameter may be used so that <function>transformToDoc</function> will return an object of the specified class.
+       This optional parameter may be used so that
+       <methodname>XSLTProcessor::transformToDoc</methodname>
+       will return an object of the specified class.
        That class should either extend or be the same class as <parameter>document</parameter>'s class.
       </para>
      </listitem>


### PR DESCRIPTION
Mainly, this is to fix https://bugs.php.net/bug.php?id=53693, which is about the undocumented returnClass argument.
However, I found that the description on this page was in general suboptimal, so this patch fixes that.