### PR TITLE
Cleanup options parameter description

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1571,6 +1571,11 @@ it is inserted with (e.g.) <function xmlns="http://docbook.org/ns/docbook">DOMNo
 </books>
 ]]></programlisting>'>
 
+<!-- Dom entities -->
+<!ENTITY dom.parameter.options '<para xmlns="http://docbook.org/ns/docbook">
+  <link linkend="language.operators.bitwise">Bitwise <literal>OR</literal></link>
+  of the <link linkend="libxml.constants">libxml option constants</link>.
+</para>'>
 
 <!-- FileSystem entities -->
 <!ENTITY fs.emits.warning.on.failure '<para xmlns="http://docbook.org/ns/docbook">

--- a/reference/dom/domdocument/loadhtml.xml
+++ b/reference/dom/domdocument/loadhtml.xml
@@ -34,10 +34,7 @@
     <varlistentry>
      <term><parameter>options</parameter></term>
      <listitem>
-      <para>
-       Since Libxml 2.6.0, you may also use the
-       <parameter>options</parameter> parameter to specify <link linkend="libxml.constants">additional Libxml parameters</link>.
-      </para>
+      &dom.parameter.options;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/dom/domdocument/loadhtmlfile.xml
+++ b/reference/dom/domdocument/loadhtmlfile.xml
@@ -35,10 +35,7 @@
     <varlistentry>
      <term><parameter>options</parameter></term>
      <listitem>
-      <para>
-       Since Libxml 2.6.0, you may also use the
-       <parameter>options</parameter> parameter to specify <link linkend="libxml.constants">additional Libxml parameters</link>.
-      </para>
+      &dom.parameter.options;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/dom/domdocument/xinclude.xml
+++ b/reference/dom/domdocument/xinclude.xml
@@ -30,10 +30,7 @@
     <varlistentry>
      <term><parameter>options</parameter></term>
      <listitem>
-      <para>
-       <link linkend="libxml.constants">libxml parameters</link>. Available
-       since Libxml 2.6.7.
-      </para>
+      &dom.parameter.options;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/simplexml/functions/simplexml-load-file.xml
+++ b/reference/simplexml/functions/simplexml-load-file.xml
@@ -48,10 +48,7 @@
     <varlistentry>
      <term><parameter>options</parameter></term>
      <listitem>
-      <para>
-       Since Libxml 2.6.0, you may also use the
-       <parameter>options</parameter> parameter to specify <link linkend="libxml.constants">additional Libxml parameters</link>.
-      </para>
+      &dom.parameter.options;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/simplexml/functions/simplexml-load-string.xml
+++ b/reference/simplexml/functions/simplexml-load-string.xml
@@ -48,10 +48,7 @@
     <varlistentry>
      <term><parameter>options</parameter></term>
      <listitem>
-      <para>
-       Since Libxml 2.6.0, you may also use the
-       <parameter>options</parameter> parameter to specify <link linkend="libxml.constants">additional Libxml parameters</link>.
-      </para>
+      &dom.parameter.options;
      </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
PHP 7.0 requires at least libxml2 2.6.11. So any note about an older version is simply irrelevant.

Use an entity to use consistent, more useful wording.

This patch also gets rid of some personification.