### PR TITLE
PHP 8.3 gen_stub.php --replace-classsynopses

### DIFF
--- a/reference/gmp/gmp.xml
+++ b/reference/gmp/gmp.xml
@@ -30,6 +30,9 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GMP'])">
+     <xi:fallback/>
+    </xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GMP'])">
      <xi:fallback/>
     </xi:include>

--- a/reference/intl/spoofchecker.xml
+++ b/reference/intl/spoofchecker.xml
@@ -112,6 +112,18 @@
      <type>int</type>
      <varname linkend="spoofchecker.constants.single-script-restrictive">Spoofchecker::SINGLE_SCRIPT_RESTRICTIVE</varname>
     </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="spoofchecker.constants.mixed-numbers">Spoofchecker::MIXED_NUMBERS</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="spoofchecker.constants.hidden-overlay">Spoofchecker::HIDDEN_OVERLAY</varname>
+    </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spoofchecker')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Spoofchecker'])">
@@ -215,6 +227,20 @@
 
     <varlistentry xml:id="spoofchecker.constants.single-script-restrictive">
      <term><constant>Spoofchecker::SINGLE_SCRIPT_RESTRICTIVE</constant></term>
+     <listitem>
+      <para/>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="spoofchecker.constants.mixed-numbers">
+     <term><constant>Spoofchecker::MIXED_NUMBERS</constant></term>
+     <listitem>
+      <para/>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="spoofchecker.constants.hidden-overlay">
+     <term><constant>Spoofchecker::HIDDEN_OVERLAY</constant></term>
      <listitem>
       <para/>
      </listitem>

--- a/reference/zip/ziparchive.xml
+++ b/reference/zip/ziparchive.xml
@@ -148,6 +148,12 @@
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
+     <varname linkend="ziparchive.constants.fl-open-file-now">ZipArchive::FL_OPEN_FILE_NOW</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
      <varname linkend="ziparchive.constants.cm-default">ZipArchive::CM_DEFAULT</varname>
     </fieldsynopsis>
     <fieldsynopsis>
@@ -466,6 +472,42 @@
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
+     <varname linkend="ziparchive.constants.er-data-length">ZipArchive::ER_DATA_LENGTH</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="ziparchive.constants.er-not-allowed">ZipArchive::ER_NOT_ALLOWED</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="ziparchive.constants.afl-rdonly">ZipArchive::AFL_RDONLY</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="ziparchive.constants.afl-is-torrentzip">ZipArchive::AFL_IS_TORRENTZIP</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="ziparchive.constants.afl-want-torrentzip">ZipArchive::AFL_WANT_TORRENTZIP</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="ziparchive.constants.afl-create-or-keep-file-for-empty-archive">ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
      <varname linkend="ziparchive.constants.opsys">ZipArchive::OPSYS_DOS</varname>
     </fieldsynopsis>
     <fieldsynopsis>
@@ -629,6 +671,18 @@
      <modifier>const</modifier>
      <type>string</type>
      <varname linkend="ziparchive.constants.libzip-version">ZipArchive::LIBZIP_VERSION</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="ziparchive.constants.length-to-end">ZipArchive::LENGTH_TO_END</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="ziparchive.constants.length-unchecked">ZipArchive::LENGTH_UNCHECKED</varname>
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>


### PR DESCRIPTION
Created by ``./build/gen_stub.php --replace-classsynopses ./ ./../docs-php/en/`` with some omissions due to false positives in DateTime.