### PR TITLE
deleted non-existent mb_strtotitle description

### DIFF
--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -209,9 +209,9 @@
    <title>MBString</title>
 
    <para>
-    <function>mb_strtolower</function>, <function>mb_strtotitle</function>,
-    and <function>mb_convert_case</function> implement conditional casing rules
-    for the Greek letter sigma. For <function>mb_convert_case</function>,
+    <function>mb_strtolower</function> and <function>mb_convert_case</function>
+    implement conditional casing rules for the Greek letter sigma.
+    For <function>mb_convert_case</function>,
     conditional casing only applies to <constant>MB_CASE_LOWER</constant>
     and <constant>MB_CASE_TITLE</constant> modes, not to
     <constant>MB_CASE_LOWER_SIMPLE</constant> and


### PR DESCRIPTION
It seems that `mb_strtotitle` function does not exist in the latest php-src, and the past implementation.