### PR TITLE
hash_*: Rewrite examples

### DIFF
--- a/reference/hash/functions/hash-file.xml
+++ b/reference/hash/functions/hash-file.xml
@@ -101,14 +101,14 @@
 /* Create a file to calculate hash of */
 file_put_contents('example.txt', 'The quick brown fox jumped over the lazy dog.');
 
-echo hash_file('md5', 'example.txt');
+echo hash_file('sha256', 'example.txt');
 ?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-5c6ffbdd40d9556b73a21e63c3e0e904
+68b1282b91de2c054c36629cb8dd447f12f096d3e3c587978dc2248444633483
 ]]>
     </screen>
    </example>

--- a/reference/hash/functions/hash-final.xml
+++ b/reference/hash/functions/hash-final.xml
@@ -71,30 +71,6 @@
    </informaltable>
   </para>
  </refsect1>
- 
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title><function>hash_final</function> example</title>
-    <programlisting role="php">
-<![CDATA[
-<?php
-$ctx = hash_init('sha1');
-hash_update($ctx, 'The quick brown fox jumped over the lazy dog.');
-echo hash_final($ctx);
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-c0854fb9fb03c41cce3802cb0d220529e6eef94e
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/hash/functions/hash-hmac.xml
+++ b/reference/hash/functions/hash-hmac.xml
@@ -113,14 +113,14 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-echo hash_hmac('ripemd160', 'The quick brown fox jumped over the lazy dog.', 'secret');
+echo hash_hmac('sha256', 'The quick brown fox jumped over the lazy dog.', 'secret');
 ?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-b8e7ae12510bdfb1812e463a7f086122cf37e4f7
+9c5c42422b03f0ee32949920649445e417b2c634050833c5165704b825c2a53b
 ]]>
     </screen>
    </example>

--- a/reference/hash/functions/hash-init.xml
+++ b/reference/hash/functions/hash-init.xml
@@ -130,17 +130,23 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$ctx = hash_init('md5');
+$hash = hash('sha256', 'The quick brown fox jumped over the lazy dog.');
+
+$ctx = hash_init('sha256');
 hash_update($ctx, 'The quick brown fox ');
 hash_update($ctx, 'jumped over the lazy dog.');
-echo hash_final($ctx);
+$incremental_hash = hash_final($ctx);
+
+echo $incremental_hash, PHP_EOL;
+var_dump($hash === $incremental_hash);
 ?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-5c6ffbdd40d9556b73a21e63c3e0e904
+68b1282b91de2c054c36629cb8dd447f12f096d3e3c587978dc2248444633483
+bool(true)
 ]]>
     </screen>
    </example>

--- a/reference/hash/functions/hash-update-stream.xml
+++ b/reference/hash/functions/hash-update-stream.xml
@@ -88,10 +88,11 @@
 <![CDATA[
 <?php
 $fp = tmpfile();
-fwrite($fp, 'The quick brown fox jumped over the lazy dog.');
+fwrite($fp, 'jumped over the lazy dog.');
 rewind($fp);
 
-$ctx = hash_init('md5');
+$ctx = hash_init('sha256');
+hash_update($ctx, 'The quick brown fox ');
 hash_update_stream($ctx, $fp);
 echo hash_final($ctx);
 ?>
@@ -100,7 +101,7 @@ echo hash_final($ctx);
     &example.outputs;
     <screen>
 <![CDATA[
-5c6ffbdd40d9556b73a21e63c3e0e904
+68b1282b91de2c054c36629cb8dd447f12f096d3e3c587978dc2248444633483
 ]]>
     </screen>
    </example>

--- a/reference/hash/functions/hash.xml
+++ b/reference/hash/functions/hash.xml
@@ -104,14 +104,14 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-echo hash('ripemd160', 'The quick brown fox jumped over the lazy dog.');
+echo hash('sha256', 'The quick brown fox jumped over the lazy dog.');
 ?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-ec457d0a974c48d5685a7efa03d137dc8bbde7e3
+68b1282b91de2c054c36629cb8dd447f12f096d3e3c587978dc2248444633483
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
- Consistently use `sha256` in the examples, as sha256 is the right choice if all things are equal.
- Improve the `hash_init()` example by showcasing that incremental hashing is equivalent to hashing the contents in full.