### PR TITLE
mt_rand: Remove rand() from the see also section

### DIFF
--- a/reference/random/functions/mt-rand.xml
+++ b/reference/random/functions/mt-rand.xml
@@ -149,7 +149,6 @@ echo mt_rand(5, 15), "\n";
     <member><function>mt_getrandmax</function></member>
     <member><function>random_int</function></member>
     <member><function>random_bytes</function></member>
-    <member><function>rand</function></member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
Nowadays it's the same function and in older version it's the worse alternative.