### PR TITLE
Overhaul XML handler docs

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -4258,6 +4258,32 @@ xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
 <emphasis>REMOVED</emphasis> in PECL uopz 5.0.0.</simpara></warning>'>
 
 <!-- XML snippets -->
+<!ENTITY xml.parser.param '<varlistentry xmlns="http://docbook.org/ns/docbook">
+ <term><parameter>parser</parameter></term>
+ <listitem>
+  <para>
+   The XML parser.
+  </para>
+ </listitem>
+</varlistentry>'>
+
+<!ENTITY xml.handler.description '<para xmlns="http://docbook.org/ns/docbook">
+ If &null; or an empty string is passed, the handler is reset to its default state.
+</para>
+<para xmlns="http://docbook.org/ns/docbook">
+ If <parameter>handler</parameter> is a <type>string</type>,
+ it can be the name of a method of an object set with
+ <function>xml_set_object</function>.
+</para>'>
+
+<!ENTITY xml.handler.parser.param '<varlistentry xmlns="http://docbook.org/ns/docbook">
+ <term><parameter>parser</parameter></term>
+ <listitem>
+  <simpara>
+   The XML parser calling the handler.
+  </simpara>
+ </listitem>
+</varlistentry>'>
 
 <!ENTITY xml.changelog.parser-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -4271,6 +4271,10 @@ xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
  If &null; or an empty string is passed, the handler is reset to its default state.
 </para>
 <para xmlns="http://docbook.org/ns/docbook">
+ If <parameter>handler</parameter> is a <type>callable</type>,
+ the callable is set as the handler.
+</para>
+<para xmlns="http://docbook.org/ns/docbook">
  If <parameter>handler</parameter> is a <type>string</type>,
  it can be the name of a method of an object set with
  <function>xml_set_object</function>.

--- a/reference/xml/functions/xml-set-character-data-handler.xml
+++ b/reference/xml/functions/xml-set-character-data-handler.xml
@@ -33,7 +33,7 @@
        <methodsynopsis>
         <type>void</type><methodname><replaceable>handler</replaceable></methodname>
         <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
-        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>data</parameter></methodparam>
+        <methodparam><type>string</type><parameter>data</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
         &xml.handler.parser.param;

--- a/reference/xml/functions/xml-set-character-data-handler.xml
+++ b/reference/xml/functions/xml-set-character-data-handler.xml
@@ -23,46 +23,25 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    <varlistentry>
-     <term><parameter>parser</parameter></term>
-     <listitem>
-      <para>
-       A reference to the XML parser to set up character data handler function.
-      </para>
-     </listitem>
-    </varlistentry>
+    &xml.parser.param;
     <varlistentry>
      <term><parameter>handler</parameter></term>
      <listitem>
+      &xml.handler.description;
       <para>
-       <parameter>handler</parameter> is a string containing the name of a
-       function that must exist when <function>xml_parse</function> is called
-       for <parameter>parser</parameter>.
-      </para>
-      <para>
-       The function named by <parameter>handler</parameter> must accept
-       two parameters:
+       The signature of the handler must be:
        <methodsynopsis>
-        <methodname><replaceable>handler</replaceable></methodname>
+        <type>void</type><methodname><replaceable>handler</replaceable></methodname>
         <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
-        <methodparam><type>string</type><parameter>data</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>data</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
-        <varlistentry>
-         <term><parameter>parser</parameter></term>
-         <listitem>
-          <simpara>
-           The first parameter, <replaceable>parser</replaceable>, is a
-           reference to the XML parser calling the handler.
-          </simpara>
-         </listitem>
-        </varlistentry>
+        &xml.handler.parser.param;
         <varlistentry>
          <term><parameter>data</parameter></term>
          <listitem>
           <simpara>
-           The second parameter, <parameter>data</parameter>, contains
-           the character data as a string.
+           Character data as a string.
           </simpara>
          </listitem>
         </varlistentry>
@@ -73,11 +52,6 @@
        document. It can be called multiple times inside each fragment (e.g.
        for non-ASCII strings).
       </para>
-      <para>
-       If a handler function is set to an empty string, or &false;, the handler
-       in question is disabled.
-      </para>
-      &note.func-callback;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/xml/functions/xml-set-default-handler.xml
+++ b/reference/xml/functions/xml-set-default-handler.xml
@@ -23,62 +23,34 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    <varlistentry>
-     <term><parameter>parser</parameter></term>
-     <listitem>
-      <para>
-       A reference to the XML parser to set up default handler function.
-      </para>
-     </listitem>
-    </varlistentry>
+    &xml.parser.param;
     <varlistentry>
      <term><parameter>handler</parameter></term>
      <listitem>
+      &xml.handler.description;
       <para>
-       <parameter>handler</parameter> is a string containing the name of a
-       function that must exist when <function>xml_parse</function> is called
-       for <parameter>parser</parameter>.
-      </para>
-      <para>
-       The function named by <parameter>handler</parameter> must accept
-       two parameters:
+       The signature of the handler must be:
        <methodsynopsis>
-        <methodname><replaceable>handler</replaceable></methodname>
+        <type>void</type><methodname><replaceable>handler</replaceable></methodname>
         <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
-        <methodparam><type>string</type><parameter>data</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>data</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
-        <varlistentry>
-         <term>
-          <parameter>parser</parameter>
-         </term> 
-         <listitem>
-          <simpara>
-           The first parameter, <replaceable>parser</replaceable>, is a
-           reference to the XML parser calling the handler.
-          </simpara>
-         </listitem>
-        </varlistentry>
+        &xml.handler.parser.param;
         <varlistentry>
          <term>
           <parameter>data</parameter>
          </term>
          <listitem>
           <simpara>
-           The second parameter, <parameter>data</parameter>, contains
-           the character data.This may be the XML declaration,
-           document type declaration, entities or other data for which
-           no other handler exists.
+           <parameter>data</parameter> contains the character data.
+           This may be the XML declaration, document type declaration,
+           entities or other data for which no other handler exists.
           </simpara>
          </listitem>
         </varlistentry>
        </variablelist>
       </para>
-      <para>
-       If a handler function is set to an empty string, or &false;, the handler
-       in question is disabled.
-      </para>
-      &note.func-callback;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/xml/functions/xml-set-default-handler.xml
+++ b/reference/xml/functions/xml-set-default-handler.xml
@@ -33,7 +33,7 @@
        <methodsynopsis>
         <type>void</type><methodname><replaceable>handler</replaceable></methodname>
         <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
-        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>data</parameter></methodparam>
+        <methodparam><type>string</type><parameter>data</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
         &xml.handler.parser.param;

--- a/reference/xml/functions/xml-set-element-handler.xml
+++ b/reference/xml/functions/xml-set-element-handler.xml
@@ -16,6 +16,8 @@
   </methodsynopsis>
   <para>
    Sets the element handler functions for the XML <parameter>parser</parameter>.
+  </para>
+  <para>
    <parameter>start_handler</parameter> is called when a new XML element is
    opened. <parameter>end_handler</parameter> is called when an XML element
    is closed.

--- a/reference/xml/functions/xml-set-element-handler.xml
+++ b/reference/xml/functions/xml-set-element-handler.xml
@@ -16,10 +16,9 @@
   </methodsynopsis>
   <para>
    Sets the element handler functions for the XML <parameter>parser</parameter>.
-   <parameter>start_handler</parameter> and
-   <parameter>end_handler</parameter> are strings containing
-   the names of functions that must exist when <function>xml_parse</function>
-   is called for <parameter>parser</parameter>.
+   <parameter>start_handler</parameter> is called when a new XML element is
+   opened. <parameter>end_handler</parameter> is called when an XML element
+   is closed.
   </para>
  </refsect1>
 
@@ -27,106 +26,78 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    <varlistentry>
-     <term><parameter>parser</parameter></term>
-     <listitem>
-      <para>
-       A reference to the XML parser to set up start and end element handler functions.
-      </para>
-     </listitem>
-    </varlistentry>
+    &xml.parser.param;
     <varlistentry>
      <term><parameter>start_handler</parameter></term>
      <listitem>
+      &xml.handler.description;
       <para>
-       The function named by <parameter>start_handler</parameter>
-       must accept three parameters:
+       The signature of the handler must be:
        <methodsynopsis>
-        <methodname><replaceable>start_element_handler</replaceable></methodname>
+        <type>void</type><methodname><replaceable>start_element_handler</replaceable></methodname>
         <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
         <methodparam><type>string</type><parameter>name</parameter></methodparam>
-        <methodparam><type>array</type><parameter>attribs</parameter></methodparam>
+        <methodparam><type>array</type><parameter>attributes</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
-        <varlistentry>
-         <term><parameter>parser</parameter></term> 
-         <listitem>
-          <simpara>
-           The first parameter, <replaceable>parser</replaceable>, is a
-           reference to the XML parser calling the handler.
-          </simpara>
-         </listitem>
-        </varlistentry>
+        &xml.handler.parser.param;
         <varlistentry>
          <term><parameter>name</parameter></term>
          <listitem>
           <simpara>
-           The second parameter, <parameter>name</parameter>, contains the name
-           of the element for which this handler is called.If <link linkend="xml.case-folding">case-folding</link> is in effect for this
-           parser, the element name will be in uppercase letters.
+           Contains the name of the element for which this handler is called.
+           If <link linkend="xml.case-folding">case-folding</link> is in effect
+           for this parser, the element name will be in uppercase letters.
           </simpara>
          </listitem>
         </varlistentry>
         <varlistentry>
-         <term><parameter>attribs</parameter></term>
+         <term><parameter>attributes</parameter></term>
          <listitem>
           <simpara>
-           The third parameter, <parameter>attribs</parameter>, contains an
-           associative array with the element's attributes (if any).The keys
-           of this array are the attribute names, the values are the attribute
-           values.Attribute names are <link linkend="xml.case-folding">case-folded</link> on the same criteria as
-           element names.Attribute values are <emphasis>not</emphasis>
-           case-folded.
+           An associative array with the element's attributes.
+           The array is empty if the element has no attributes.
+           The keys of this array are the attribute names,
+           the values are the attribute values.
+           Attribute names are
+           <link linkend="xml.case-folding">case-folded</link>
+           on the same criteria as element names.
+           Attribute values are <emphasis>not</emphasis> case-folded.
           </simpara>
           <simpara>
-           The original order of the attributes can be retrieved by walking
-           through <parameter>attribs</parameter> the normal way, using
-           <function>each</function>.The first key in the array was the first
-           attribute, and so on.
+           The order in which <parameter>attributes</parameter> is traversed
+           is identical to the order in which the attributes were declared.
           </simpara>
          </listitem>
         </varlistentry>
        </variablelist>
       </para>
-      &note.func-callback;
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>end_handler</parameter></term>
      <listitem>
+      &xml.handler.description;
       <para>
-       The function named by <parameter>end_handler</parameter>
-       must accept two parameters:
+       The signature of the handler must be:
        <methodsynopsis>
-        <methodname><replaceable>end_element_handler</replaceable></methodname>
+        <type>void</type><methodname><replaceable>end_element_handler</replaceable></methodname>
         <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
         <methodparam><type>string</type><parameter>name</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
-        <varlistentry>
-         <term><parameter>parser</parameter></term> 
-         <listitem>
-          <simpara>
-           The first parameter, <replaceable>parser</replaceable>, is a
-           reference to the XML parser calling the handler.
-          </simpara>
-         </listitem>
-        </varlistentry>
+        &xml.handler.parser.param;
         <varlistentry>
          <term><parameter>name</parameter></term>
          <listitem>
           <simpara>
-           The second parameter, <parameter>name</parameter>, contains the name
-           of the element for which this handler is called.If <link linkend="xml.case-folding">case-folding</link> is in effect for this
-           parser, the element name will be in uppercase letters.
+           Contains the name of the element for which this handler is called.
+           If <link linkend="xml.case-folding">case-folding</link> is in effect
+           for this parser, the element name will be in uppercase letters.
           </simpara>
          </listitem>
         </varlistentry>
        </variablelist>
-      </para>
-      <para>
-       If a handler function is set to an empty string, or &false;, the handler
-       in question is disabled.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/xml/functions/xml-set-end-namespace-decl-handler.xml
+++ b/reference/xml/functions/xml-set-end-namespace-decl-handler.xml
@@ -50,6 +50,7 @@
          <listitem>
           <simpara>
            The prefix is a string used to reference the namespace within an XML object.
+           &false; if no prefix exists.
           </simpara>
          </listitem>
         </varlistentry>

--- a/reference/xml/functions/xml-set-end-namespace-decl-handler.xml
+++ b/reference/xml/functions/xml-set-end-namespace-decl-handler.xml
@@ -31,44 +31,20 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    <varlistentry>
-     <term><parameter>parser</parameter></term>
-     <listitem>
-      <para>
-       A reference to the XML parser.
-      </para>
-     </listitem>
-    </varlistentry>
+    &xml.parser.param;
     <varlistentry>
      <term><parameter>handler</parameter></term>
      <listitem>
+      &xml.handler.description;
       <para>
-       <parameter>handler</parameter> is a string containing the name of a
-       function that must exist when <function>xml_parse</function> is called
-       for <parameter>parser</parameter>.
-      </para>
-      <para>
-       The function named by <parameter>handler</parameter> must accept
-       two parameters, and should return an integer value. If the
-       value returned from the handler is &false; (which it will be if no
-       value is returned), the XML parser will stop parsing and
-       <function>xml_get_error_code</function> will return
-       <constant>XML_ERROR_EXTERNAL_ENTITY_HANDLING</constant>.
+       The signature of the handler must be:
        <methodsynopsis>
         <methodname><replaceable>handler</replaceable></methodname>
         <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
-        <methodparam><type>string</type><parameter>prefix</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>prefix</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
-        <varlistentry>
-         <term><parameter>parser</parameter></term>
-         <listitem>
-          <simpara>
-           The first parameter, <replaceable>parser</replaceable>, is a
-           reference to the XML parser calling the handler.
-          </simpara>
-         </listitem>
-        </varlistentry>
+        &xml.handler.parser.param;
         <varlistentry>
          <term><parameter>prefix</parameter></term>
          <listitem>
@@ -79,11 +55,6 @@
         </varlistentry>
        </variablelist>
       </para>
-      <para>
-       If a handler function is set to an empty string, or &false;, the handler
-       in question is disabled.
-      </para>
-      &note.func-callback;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/xml/functions/xml-set-external-entity-ref-handler.xml
+++ b/reference/xml/functions/xml-set-external-entity-ref-handler.xml
@@ -33,9 +33,9 @@
        <methodsynopsis>
         <type>bool</type><methodname><replaceable>handler</replaceable></methodname>
         <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
-        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>open_entity_names</parameter></methodparam>
+        <methodparam><type>string</type><parameter>open_entity_names</parameter></methodparam>
         <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>base</parameter></methodparam>
-        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>system_id</parameter></methodparam>
+        <methodparam><type>string</type><parameter>system_id</parameter></methodparam>
         <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>public_id</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
@@ -44,8 +44,7 @@
          <term><parameter>open_entity_names</parameter></term>
          <listitem>
           <simpara>
-           The second parameter, <parameter>open_entity_names</parameter>, is a
-           space-separated list of the names of the entities that are open for
+           A space-separated list of the names of the entities that are open for
            the parse of this entity (including the name of the referenced
            entity).
           </simpara>

--- a/reference/xml/functions/xml-set-external-entity-ref-handler.xml
+++ b/reference/xml/functions/xml-set-external-entity-ref-handler.xml
@@ -23,47 +23,23 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    <varlistentry>
-     <term><parameter>parser</parameter></term>
-     <listitem>
-      <para>
-       A reference to the XML parser to set up external entity reference handler function.
-      </para>
-     </listitem>
-    </varlistentry>
+    &xml.parser.param;
     <varlistentry>
      <term><parameter>handler</parameter></term>
      <listitem>
+      &xml.handler.description;
       <para>
-       <parameter>handler</parameter> is a string containing the name of a
-       function that must exist when <function>xml_parse</function> is called
-       for <parameter>parser</parameter>.
-      </para>
-      <para>
-       The function named by <parameter>handler</parameter> must accept
-       five parameters, and should return an integer value.If the
-       value returned from the handler is &false; (which it will be if no
-       value is returned), the XML parser will stop parsing and
-       <function>xml_get_error_code</function> will return
-       <constant>XML_ERROR_EXTERNAL_ENTITY_HANDLING</constant>.
+       The signature of the handler must be:
        <methodsynopsis>
-        <methodname><replaceable>handler</replaceable></methodname>
+        <type>bool</type><methodname><replaceable>handler</replaceable></methodname>
         <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
-        <methodparam><type>string</type><parameter>open_entity_names</parameter></methodparam>
-        <methodparam><type>string</type><parameter>base</parameter></methodparam>
-        <methodparam><type>string</type><parameter>system_id</parameter></methodparam>
-        <methodparam><type>string</type><parameter>public_id</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>open_entity_names</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>base</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>system_id</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>public_id</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
-        <varlistentry>
-         <term><parameter>parser</parameter></term>
-         <listitem>
-          <simpara>
-           The first parameter, <replaceable>parser</replaceable>, is a
-           reference to the XML parser calling the handler.
-          </simpara>
-         </listitem>
-        </varlistentry>
+        &xml.handler.parser.param;
         <varlistentry>
          <term><parameter>open_entity_names</parameter></term>
          <listitem>
@@ -80,8 +56,7 @@
          <listitem>
           <simpara>
            This is the base for resolving the system identifier
-           (<parameter>system_id</parameter>) of the external entity.Currently
-           this parameter will always be set to an empty string.
+           (<parameter>system_id</parameter>) of the external entity.
           </simpara>
          </listitem>
         </varlistentry>
@@ -89,8 +64,7 @@
          <term><parameter>system_id</parameter></term>
          <listitem>
           <simpara>
-           The fourth parameter, <parameter>system_id</parameter>, is the
-           system identifier as specified in the entity declaration.
+           The system identifier as specified in the entity declaration.
           </simpara>
          </listitem>
         </varlistentry>
@@ -98,8 +72,7 @@
          <term><parameter>public_id</parameter></term>
          <listitem>
           <simpara>
-           The fifth parameter, <parameter>public_id</parameter>, is the
-           public identifier as specified in the entity declaration, or
+           The public identifier as specified in the entity declaration, or
            an empty string if none was specified; the whitespace in the
            public identifier will have been normalized as required by
            the XML spec.
@@ -109,10 +82,12 @@
        </variablelist>
       </para>
       <para>
-       If a handler function is set to an empty string, or &false;, the handler
-       in question is disabled.
+       The handler should return &true; if the entity was handled,
+       &false; otherwise.
+       When returning &false; the XML parser will stop parsing and
+       <function>xml_get_error_code</function> will return
+       <constant>XML_ERROR_EXTERNAL_ENTITY_HANDLING</constant>.
       </para>
-      &note.func-callback;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/xml/functions/xml-set-notation-decl-handler.xml
+++ b/reference/xml/functions/xml-set-notation-decl-handler.xml
@@ -45,9 +45,9 @@
        <methodsynopsis>
         <type>void</type><methodname><replaceable>handler</replaceable></methodname>
         <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
-        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>notation_name</parameter></methodparam>
+        <methodparam><type>string</type><parameter>notation_name</parameter></methodparam>
         <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>base</parameter></methodparam>
-        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>system_id</parameter></methodparam>
+        <methodparam><type>string</type><parameter>system_id</parameter></methodparam>
         <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>public_id</parameter></methodparam>
        </methodsynopsis>
        <variablelist>

--- a/reference/xml/functions/xml-set-notation-decl-handler.xml
+++ b/reference/xml/functions/xml-set-notation-decl-handler.xml
@@ -35,50 +35,28 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    <varlistentry>
-     <term><parameter>parser</parameter></term>
-     <listitem>
-      <para>
-       A reference to the XML parser to set up notation declaration handler function.
-      </para>
-     </listitem>
-    </varlistentry>
+    &xml.parser.param;
     <varlistentry>
      <term><parameter>handler</parameter></term>
      <listitem>
+      &xml.handler.description;
       <para>
-       <parameter>handler</parameter> is a string containing the name of a
-       function that must exist when <function>xml_parse</function> is called
-       for <parameter>parser</parameter>.
-      </para>
-      <para>
-       The function named by <parameter>handler</parameter> must accept
-       five parameters:
+       The signature of the handler must be:
        <methodsynopsis>
-        <methodname><replaceable>handler</replaceable></methodname>
+        <type>void</type><methodname><replaceable>handler</replaceable></methodname>
         <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
-        <methodparam><type>string</type><parameter>notation_name</parameter></methodparam>
-        <methodparam><type>string</type><parameter>base</parameter></methodparam>
-        <methodparam><type>string</type><parameter>system_id</parameter></methodparam>
-        <methodparam><type>string</type><parameter>public_id</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>notation_name</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>base</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>system_id</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>public_id</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
-        <varlistentry>
-         <term>
-          <parameter>parser</parameter>
-         </term> 
-         <listitem>
-          <simpara>
-           The first parameter, <replaceable>parser</replaceable>, is a
-           reference to the XML parser calling the handler.
-          </simpara>
-         </listitem>
-        </varlistentry>
+        &xml.handler.parser.param;
         <varlistentry>
          <term><parameter>notation_name</parameter></term>
          <listitem>
           <simpara>
-           This is the notation's <parameter>name</parameter>, as per
+           This is the notation's name, as per
            the notation format described above.
           </simpara>
          </listitem>
@@ -90,8 +68,7 @@
          <listitem>
           <simpara>
            This is the base for resolving the system identifier
-           (<parameter>system_id</parameter>) of the notation declaration.
-           Currently this parameter will always be set to an empty string.
+           (<literal>system_id</literal>) of the notation declaration.
           </simpara>
          </listitem>
         </varlistentry>
@@ -115,11 +92,6 @@
         </varlistentry>
        </variablelist>
       </para>
-      <para>
-       If a handler function is set to an empty string, or &false;, the handler
-       in question is disabled.
-      </para>
-      &note.func-callback;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/xml/functions/xml-set-object.xml
+++ b/reference/xml/functions/xml-set-object.xml
@@ -90,12 +90,6 @@ class CustomXMLParser
         xml_set_character_data_handler($this->parser, "cdata");
     }
 
-    function __destruct()
-    {
-        xml_parser_free($this->parser);
-        unset($this->parser);
-    }
-
     function parse($data) 
     {
         xml_parse($this->parser, $data);

--- a/reference/xml/functions/xml-set-object.xml
+++ b/reference/xml/functions/xml-set-object.xml
@@ -77,7 +77,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-class XMLParser
+class CustomXMLParser
 {
     private $parser;
 
@@ -117,7 +117,7 @@ class XMLParser
     }
 }
 
-$xml_parser = new XMLParser();
+$xml_parser = new CustomXMLParser();
 $xml_parser->parse("<A ID='hallo'>PHP</A>");
 ?>
 ]]>

--- a/reference/xml/functions/xml-set-processing-instruction-handler.xml
+++ b/reference/xml/functions/xml-set-processing-instruction-handler.xml
@@ -21,64 +21,52 @@
   </para>
   <para>
    A processing instruction has the following format:
-   <informalexample>
-    <programlisting>&lt;?<replaceable>target</replaceable> 
-     <replaceable>data</replaceable>?&gt;
-    </programlisting>
-   </informalexample>
-   You can put PHP code into such a tag, but be aware of one limitation: in
-   an XML PI, the PI end tag (<literal>?&gt;</literal>) can not be quoted,
-   so this character sequence should not appear in the PHP code you embed
-   with PIs in XML documents.If it does, the rest of the PHP code, as well
-   as the "real" PI end tag, will be treated as character data.
+   <programlisting role="xml">
+<![CDATA[
+<?target
+data
+?>
+]]>
+   </programlisting>
   </para>
+  <caution>
+   <para>
+    PHP code is delimited by the <literal>&lt;?php</literal>
+    processing instruction.
+    As such it is possible to have PHP code within an XML document.
+    However, the PI end tag (<literal>?&gt;</literal>) must not be part of
+    the data.
+    If a PI end tag exists as part of the embedded PHP code,
+    the rest of the PHP code and the "real" PI end tag, will be treated
+    as character data.
+   </para>
+  </caution>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
    <variablelist>
-    <varlistentry>
-     <term><parameter>parser</parameter></term>
-     <listitem>
-      <para>
-       A reference to the XML parser to set up processing instruction (PI) handler function.
-      </para>
-     </listitem>
-    </varlistentry>
+    &xml.parser.param;
     <varlistentry>
      <term><parameter>handler</parameter></term>
      <listitem>
+      &xml.handler.description;
       <para>
-       <parameter>handler</parameter> is a string containing the name of a
-       function that must exist when <function>xml_parse</function> is called
-       for <parameter>parser</parameter>.
-      </para>
-      <para>
-       The function named by <parameter>handler</parameter> must accept
-       three parameters:
+       The signature of the handler must be:
        <methodsynopsis>
-        <methodname><replaceable>handler</replaceable></methodname>
+        <type>void</type><methodname><replaceable>handler</replaceable></methodname>
         <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
-        <methodparam><type>string</type><parameter>target</parameter></methodparam>
-        <methodparam><type>string</type><parameter>data</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>target</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>data</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
-        <varlistentry>
-         <term><parameter>parser</parameter></term>
-         <listitem>
-          <simpara>
-           The first parameter, <replaceable>parser</replaceable>, is a
-           reference to the XML parser calling the handler.
-          </simpara>
-         </listitem>
-        </varlistentry>
+        &xml.handler.parser.param;
         <varlistentry>
          <term><parameter>target</parameter></term>
          <listitem>
           <simpara>
-           The second parameter, <parameter>target</parameter>, contains the PI
-           target.
+           The processing instruction target.
           </simpara>
          </listitem>
         </varlistentry>
@@ -86,18 +74,12 @@
          <term><parameter>data</parameter></term>
          <listitem>
           <simpara>
-           The third parameter, <parameter>data</parameter>, contains the PI
-           data.
+           The processing instruction data.
           </simpara>
          </listitem>
         </varlistentry>
        </variablelist>
       </para>
-      <para>
-       If a handler function is set to an empty string, or &false;, the handler
-       in question is disabled.
-      </para>
-      &note.func-callback;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/xml/functions/xml-set-processing-instruction-handler.xml
+++ b/reference/xml/functions/xml-set-processing-instruction-handler.xml
@@ -57,8 +57,8 @@ data
        <methodsynopsis>
         <type>void</type><methodname><replaceable>handler</replaceable></methodname>
         <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
-        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>target</parameter></methodparam>
-        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>data</parameter></methodparam>
+        <methodparam><type>string</type><parameter>target</parameter></methodparam>
+        <methodparam><type>string</type><parameter>data</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
         &xml.handler.parser.param;

--- a/reference/xml/functions/xml-set-start-namespace-decl-handler.xml
+++ b/reference/xml/functions/xml-set-start-namespace-decl-handler.xml
@@ -27,45 +27,21 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    <varlistentry>
-     <term><parameter>parser</parameter></term>
-     <listitem>
-      <para>
-       A reference to the XML parser.
-      </para>
-     </listitem>
-    </varlistentry>
+    &xml.parser.param;
     <varlistentry>
      <term><parameter>handler</parameter></term>
      <listitem>
+      &xml.handler.description;
       <para>
-       <parameter>handler</parameter> is a string containing the name of a
-       function that must exist when <function>xml_parse</function> is called
-       for <parameter>parser</parameter>.
-      </para>
-      <para>
-       The function named by <parameter>handler</parameter> must accept
-       three parameters, and should return an integer value. If the
-       value returned from the handler is &false; (which it will be if no
-       value is returned), the XML parser will stop parsing and
-       <function>xml_get_error_code</function> will return
-       <constant>XML_ERROR_EXTERNAL_ENTITY_HANDLING</constant>.
+       The signature of the handler must be:
        <methodsynopsis>
-        <methodname><replaceable>handler</replaceable></methodname>
+        <type>void</type><methodname><replaceable>handler</replaceable></methodname>
         <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
-        <methodparam><type>string</type><parameter>prefix</parameter></methodparam>
-        <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>prefix</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>uri</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
-        <varlistentry>
-         <term><parameter>parser</parameter></term>
-         <listitem>
-          <simpara>
-           The first parameter, <replaceable>parser</replaceable>, is a
-           reference to the XML parser calling the handler.
-          </simpara>
-         </listitem>
-        </varlistentry>
+        &xml.handler.parser.param;
         <varlistentry>
          <term><parameter>prefix</parameter></term>
          <listitem>
@@ -84,11 +60,6 @@
         </varlistentry>
        </variablelist>
       </para>
-      <para>
-       If a handler function is set to an empty string, or &false;, the handler
-       in question is disabled.
-      </para>
-      &note.func-callback;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/xml/functions/xml-set-start-namespace-decl-handler.xml
+++ b/reference/xml/functions/xml-set-start-namespace-decl-handler.xml
@@ -38,7 +38,7 @@
         <type>void</type><methodname><replaceable>handler</replaceable></methodname>
         <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
         <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>prefix</parameter></methodparam>
-        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>uri</parameter></methodparam>
+        <methodparam><type>string</type><parameter>uri</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
         &xml.handler.parser.param;
@@ -47,6 +47,7 @@
          <listitem>
           <simpara>
            The prefix is a string used to reference the namespace within an XML object.
+           &false; if no prefix exists.
           </simpara>
          </listitem>
         </varlistentry>

--- a/reference/xml/functions/xml-set-unparsed-entity-decl-handler.xml
+++ b/reference/xml/functions/xml-set-unparsed-entity-decl-handler.xml
@@ -51,9 +51,9 @@
        <methodsynopsis>
         <type>void</type><methodname><replaceable>handler</replaceable></methodname>
         <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
-        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>entity_name</parameter></methodparam>
+        <methodparam><type>string</type><parameter>entity_name</parameter></methodparam>
         <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>base</parameter></methodparam>
-        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>system_id</parameter></methodparam>
+        <methodparam><type>string</type><parameter>system_id</parameter></methodparam>
         <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>public_id</parameter></methodparam>
         <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>notation_name</parameter></methodparam>
        </methodsynopsis>

--- a/reference/xml/functions/xml-set-unparsed-entity-decl-handler.xml
+++ b/reference/xml/functions/xml-set-unparsed-entity-decl-handler.xml
@@ -41,45 +41,24 @@
   &reftitle.parameters;
   <para>
    <variablelist>
-    <varlistentry>
-     <term><parameter>parser</parameter></term>
-     <listitem>
-      <para>
-       A reference to the XML parser to set up unparsed entity declaration handler function.
-      </para>
-     </listitem>
-    </varlistentry>
+    &xml.parser.param;
     <varlistentry>
      <term><parameter>handler</parameter></term>
      <listitem>
+      &xml.handler.description;
       <para>
-       <parameter>handler</parameter> is a string containing the name of a
-       function that must exist when <function>xml_parse</function> is called
-       for <parameter>parser</parameter>.
-      </para>
-      <para>
-       The function named by <parameter>handler</parameter> must accept six
-       parameters:
+       The signature of the handler must be:
        <methodsynopsis>
-        <methodname><replaceable>handler</replaceable></methodname>
+        <type>void</type><methodname><replaceable>handler</replaceable></methodname>
         <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
-        <methodparam><type>string</type><parameter>entity_name</parameter></methodparam>
-        <methodparam><type>string</type><parameter>base</parameter></methodparam>
-        <methodparam><type>string</type><parameter>system_id</parameter></methodparam>
-        <methodparam><type>string</type><parameter>public_id</parameter></methodparam>
-        <methodparam><type>string</type><parameter>notation_name</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>entity_name</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>base</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>system_id</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>public_id</parameter></methodparam>
+        <methodparam><type class="union"><type>string</type><type>false</type></type><parameter>notation_name</parameter></methodparam>
        </methodsynopsis>
        <variablelist>
-        <varlistentry>
-         <term><parameter>parser</parameter></term>
-         <listitem>
-          <simpara>
-           The first parameter, <replaceable>parser</replaceable>, is a
-           reference to the XML parser calling the
-           handler.
-          </simpara>
-         </listitem>
-        </varlistentry>
+        &xml.handler.parser.param;
         <varlistentry>
          <term><parameter>entity_name</parameter></term>
          <listitem>
@@ -93,8 +72,7 @@
          <listitem>
           <simpara>
            This is the base for resolving the system identifier
-           (<parameter>systemId</parameter>) of the external entity.Currently
-           this parameter will always be set to an empty string.
+           (<parameter>systemId</parameter>) of the external entity.
           </simpara>
          </listitem>
         </varlistentry>
@@ -125,11 +103,6 @@
         </varlistentry>
        </variablelist>
       </para>
-      <para>
-       If a handler function is set to an empty string, or &false;, the handler
-       in question is disabled.
-      </para>
-      &note.func-callback;
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
This also removes the last remaining usage of the ``&note.func-callback;`` language snippet.