### PR TITLE
lcg_value: Include the caution from Randomizer::nextFloat()

### DIFF
--- a/reference/random/functions/lcg-value.xml
+++ b/reference/random/functions/lcg-value.xml
@@ -18,6 +18,21 @@
    to the product of both primes.
   </para>
   &caution.cryptographically-insecure;
+  <caution>
+   <para>
+    Scaling the return value to a different interval using multiplication
+    or addition (a so-called affine transformation) might result in a bias
+    in the resulting value as floats are not equally dense across the number
+    line. As not all values can be exactly represented by a float, the
+    result of the affine transformation might also result in values outside
+    of the requested interval.
+   </para>
+   <para>
+    Use <methodname>Random\Randomizer::getFloat</methodname> to generate a
+    random float within an arbitrary interval. Use <methodname>Random\Randomizer::getInt</methodname>
+    to generate a random integer within an arbitrary interval.
+   </para>
+  </caution>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
This is only appearing twice in the entire documentation, copying is probably preferable to creating an entity.

---------------

see php/doc-en#2825