### PR TITLE
mt_getrandmax: Remove example

### DIFF
--- a/reference/random/functions/mt-getrandmax.xml
+++ b/reference/random/functions/mt-getrandmax.xml
@@ -31,32 +31,6 @@
    result being scaled up (and therefore less random).
   </para>
  </refsect1>
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example><title>Calculate a random floating-point number</title>
-    <programlisting role="php">
-<![CDATA[
-<?php
-function randomFloat($min = 0, $max = 1) {
-    return $min + mt_rand() / mt_getrandmax() * ($max - $min);
-}
-
-var_dump(randomFloat());
-var_dump(randomFloat(2, 20));
-?>
-]]>
-    </programlisting>
-    &example.outputs.similar;
-    <screen>
-<![CDATA[
-float(0.91601131712832)
-float(16.511210331931)
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>


### PR DESCRIPTION
This affine transformation results in a bias and `Randomizer::getFloat()` must be used.