### PR TITLE
hash_hmac_file: Sync example with hash_hmac

### DIFF
--- a/reference/hash/functions/hash-hmac-file.xml
+++ b/reference/hash/functions/hash-hmac-file.xml
@@ -116,14 +116,14 @@
 /* Create a file to calculate hash of */
 file_put_contents('example.txt', 'The quick brown fox jumped over the lazy dog.');
 
-echo hash_hmac_file('md5', 'example.txt', 'secret');
+echo hash_hmac_file('sha256', 'example.txt', 'secret');
 ?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-7eb2b5c37443418fc77c136dd20e859c
+9c5c42422b03f0ee32949920649445e417b2c634050833c5165704b825c2a53b
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
This was missed in 20dcfbb0dd7150cbe5dfd7903a3001229295c549.