### PR TITLE
PHP 8.3: legacy assertion have been deprecated

### DIFF
--- a/reference/info/constants.xml
+++ b/reference/info/constants.xml
@@ -205,7 +205,6 @@
      <entry>&Description;</entry>
     </row>
    </thead>
-
    <tbody>
     <row xml:id="constant.assert-active">
      <entry><constant>ASSERT_ACTIVE</constant></entry>

--- a/reference/info/constants.xml
+++ b/reference/info/constants.xml
@@ -192,68 +192,6 @@
  </table>
 
  <simpara>
-  Assert constants, these values are used to set 
-  the assertion options in <function>assert_options</function>.
- </simpara>
- <table>
-  <title><function>assert</function> constants</title>
-  <tgroup cols="3">
-   <thead>
-    <row>
-     <entry>&Constants;</entry>
-     <entry>INI Setting</entry>
-     <entry>&Description;</entry>
-    </row>
-   </thead>
-   <tbody>
-    <row xml:id="constant.assert-active">
-     <entry><constant>ASSERT_ACTIVE</constant></entry>
-     <entry><link linkend="ini.assert.active">assert.active</link></entry>
-     <entry>
-      Enable <function>assert</function> evaluation.
-     </entry>
-    </row>
-    <row xml:id="constant.assert-callback">
-     <entry><constant>ASSERT_CALLBACK</constant></entry>
-     <entry><link linkend="ini.assert.callback">assert.callback</link></entry>
-     <entry>
-      Callback to call on failed assertions.
-     </entry>
-    </row>
-    <row xml:id="constant.assert-bail">
-     <entry><constant>ASSERT_BAIL</constant></entry>
-     <entry><link linkend="ini.assert.bail">assert.bail</link></entry>
-     <entry>
-      Terminate execution on failed assertions.
-     </entry>
-    </row>
-    <row xml:id="constant.assert-exception">
-     <entry><constant>ASSERT_EXCEPTION</constant></entry>
-     <entry><link linkend="ini.assert.exception">assert.exception</link></entry>
-     <entry>
-      Issues a PHP warning for each failed assertion
-     </entry>
-    </row>
-    <row xml:id="constant.assert-warning">
-     <entry><constant>ASSERT_WARNING</constant></entry>
-     <entry><link linkend="ini.assert.warning">assert.warning</link></entry>
-     <entry>
-      Issues a PHP warning for each failed assertion
-     </entry>
-    </row>
-    <row xml:id="constant.assert-quiet-eval">
-     <entry><constant>ASSERT_QUIET_EVAL</constant></entry>
-     <entry><link linkend="ini.assert.quiet-eval">assert.quiet_eval</link></entry>
-     <entry>
-      Disable <literal>error_reporting</literal> during assertion expression evaluation.
-      Removed as of PHP 8.0.0.
-     </entry>
-    </row>
-   </tbody>
-  </tgroup>
- </table>
-
- <simpara>
   The following constants are only available if the host operating 
   system is Windows, and can tell different versioning information 
   so its possible to detect various features and make use of them. 
@@ -434,6 +372,97 @@
    </tbody>
   </tgroup>
  </table>
+
+ <section>
+  <title><function>assert</function> constants</title>
+  <simpara>
+   Assert constants, these values are used to set
+   the assertion options in <function>assert_options</function>.
+  </simpara>
+
+  <variablelist>
+   <varlistentry xml:id="constant.assert-active">
+    <term>
+     <constant>ASSERT_ACTIVE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Option for <function>assert</function>. See also
+      <link linkend="ini.assert.active">assert.active</link>.
+     </simpara>
+     &warn.deprecated.feature-8-3-0;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+  <variablelist>
+   <varlistentry xml:id="constant.assert-callback">
+    <term>
+     <constant>ASSERT_CALLBACK</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Option for <function>assert</function>. See also
+      <link linkend="ini.assert.callback">assert.callback</link>.
+     </simpara>
+     &warn.deprecated.feature-8-3-0;
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.assert-bail">
+    <term>
+     <constant>ASSERT_BAIL</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Option for <function>assert</function>. See also
+      <link linkend="ini.assert.bail">assert.bail</link>.
+     </simpara>
+     &warn.deprecated.feature-8-3-0;
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.assert-exception">
+    <term>
+     <constant>ASSERT_EXCEPTION</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Option for <function>assert</function>. See also
+      <link linkend="ini.assert.exception">assert.exception</link>.
+     </simpara>
+     &warn.deprecated.feature-8-3-0;
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.assert-warning">
+    <term>
+     <constant>ASSERT_WARNING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Option for <function>assert</function>. See also
+      <link linkend="ini.assert.warning">assert.warning</link>.
+     </simpara>
+     &warn.deprecated.feature-8-3-0;
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.assert-quiet-eval">
+    <term>
+     <constant>ASSERT_QUIET_EVAL</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Option for <function>assert</function>. See also
+      <link linkend="ini.assert.quiet-eval">assert.quiet_eval</link>.
+     </simpara>
+     &warn.feature.removed-8-0-0;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </section>
 </appendix>
 
 <!-- Keep this comment at the end of the file

--- a/reference/info/constants.xml
+++ b/reference/info/constants.xml
@@ -192,6 +192,74 @@
  </table>
 
  <simpara>
+  Assert constants, these values are used to set
+  the assertion options in <function>assert_options</function>.
+ </simpara>
+ <table>
+  <title><function>assert</function> constants</title>
+  <tgroup cols="3">
+   <thead>
+    <row>
+     <entry>&Constants;</entry>
+     <entry>INI Setting</entry>
+     <entry>&Description;</entry>
+    </row>
+   </thead>
+
+   <tbody>
+    <row xml:id="constant.assert-active">
+     <entry><constant>ASSERT_ACTIVE</constant></entry>
+     <entry><link linkend="ini.assert.active">assert.active</link></entry>
+     <entry>
+      Enable <function>assert</function> evaluation.
+      &warn.deprecated.feature-8-3-0;
+     </entry>
+    </row>
+    <row xml:id="constant.assert-callback">
+     <entry><constant>ASSERT_CALLBACK</constant></entry>
+     <entry><link linkend="ini.assert.callback">assert.callback</link></entry>
+     <entry>
+      Callback to call on failed assertions.
+      &warn.deprecated.feature-8-3-0;
+     </entry>
+    </row>
+    <row xml:id="constant.assert-bail">
+     <entry><constant>ASSERT_BAIL</constant></entry>
+     <entry><link linkend="ini.assert.bail">assert.bail</link></entry>
+     <entry>
+      Terminate execution on failed assertions.
+      &warn.deprecated.feature-8-3-0;
+     </entry>
+    </row>
+    <row xml:id="constant.assert-exception">
+     <entry><constant>ASSERT_EXCEPTION</constant></entry>
+     <entry><link linkend="ini.assert.exception">assert.exception</link></entry>
+     <entry>
+      Issues a PHP warning for each failed assertion
+      &warn.deprecated.feature-8-3-0;
+     </entry>
+    </row>
+    <row xml:id="constant.assert-warning">
+     <entry><constant>ASSERT_WARNING</constant></entry>
+     <entry><link linkend="ini.assert.warning">assert.warning</link></entry>
+     <entry>
+      Issues a PHP warning for each failed assertion
+      &warn.deprecated.feature-8-3-0;
+     </entry>
+    </row>
+    <row xml:id="constant.assert-quiet-eval">
+     <entry><constant>ASSERT_QUIET_EVAL</constant></entry>
+     <entry><link linkend="ini.assert.quiet-eval">assert.quiet_eval</link></entry>
+     <entry>
+      Disable <literal>error_reporting</literal> during assertion expression evaluation.
+      &warn.feature.removed-8-0-0;
+     </entry>
+    </row>
+   </tbody>
+  </tgroup>
+ </table>
+
+ <simpara>
   The following constants are only available if the host operating 
   system is Windows, and can tell different versioning information 
   so its possible to detect various features and make use of them. 
@@ -372,97 +440,6 @@
    </tbody>
   </tgroup>
  </table>
-
- <section>
-  <title><function>assert</function> constants</title>
-  <simpara>
-   Assert constants, these values are used to set
-   the assertion options in <function>assert_options</function>.
-  </simpara>
-
-  <variablelist>
-   <varlistentry xml:id="constant.assert-active">
-    <term>
-     <constant>ASSERT_ACTIVE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Option for <function>assert</function>. See also
-      <link linkend="ini.assert.active">assert.active</link>.
-     </simpara>
-     &warn.deprecated.feature-8-3-0;
-    </listitem>
-   </varlistentry>
-  </variablelist>
-  <variablelist>
-   <varlistentry xml:id="constant.assert-callback">
-    <term>
-     <constant>ASSERT_CALLBACK</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Option for <function>assert</function>. See also
-      <link linkend="ini.assert.callback">assert.callback</link>.
-     </simpara>
-     &warn.deprecated.feature-8-3-0;
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.assert-bail">
-    <term>
-     <constant>ASSERT_BAIL</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Option for <function>assert</function>. See also
-      <link linkend="ini.assert.bail">assert.bail</link>.
-     </simpara>
-     &warn.deprecated.feature-8-3-0;
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.assert-exception">
-    <term>
-     <constant>ASSERT_EXCEPTION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Option for <function>assert</function>. See also
-      <link linkend="ini.assert.exception">assert.exception</link>.
-     </simpara>
-     &warn.deprecated.feature-8-3-0;
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.assert-warning">
-    <term>
-     <constant>ASSERT_WARNING</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Option for <function>assert</function>. See also
-      <link linkend="ini.assert.warning">assert.warning</link>.
-     </simpara>
-     &warn.deprecated.feature-8-3-0;
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.assert-quiet-eval">
-    <term>
-     <constant>ASSERT_QUIET_EVAL</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Option for <function>assert</function>. See also
-      <link linkend="ini.assert.quiet-eval">assert.quiet_eval</link>.
-     </simpara>
-     &warn.feature.removed-8-0-0;
-    </listitem>
-   </varlistentry>
-  </variablelist>
- </section>
 </appendix>
 
 <!-- Keep this comment at the end of the file

--- a/reference/info/functions/assert-options.xml
+++ b/reference/info/functions/assert-options.xml
@@ -5,6 +5,10 @@
   <refname>assert_options</refname>
   <refpurpose>Set/get the various assert flags</refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-3-0;
+ </refsynopsisdiv>
  
  <refsect1 role="description">
   &reftitle.description;
@@ -182,6 +186,12 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.3.0</entry>
+       <entry>
+        <function>assert_option</function> is now deprecated.
+       </entry>
+      </row>
       <row>
        <entry>8.0.0</entry>
        <entry>

--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -81,7 +81,9 @@
         If &false;, <function>assert</function> does not check the expectation
         and returns &true;, unconditionally.
        </entry>
-       <entry/>
+       <entry>
+        Deprecated as of PHP 8.3.0.
+       </entry>
       </row>
       <row>
        <entry><link linkend="ini.assert.callback">assert.callback</link></entry>
@@ -106,6 +108,7 @@
          <methodparam><type>string</type><parameter>assertion</parameter></methodparam>
          <methodparam choice="opt"><type>string</type><parameter>description</parameter></methodparam>
         </methodsynopsis>
+        Deprecated as of PHP 8.3.0.
        </entry>
       </row>
       <row>
@@ -115,7 +118,9 @@
         If &true; will throw an <classname>AssertionError</classname> if the
         expectation isn't upheld.
        </entry>
-       <entry/>
+       <entry>
+        Deprecated as of PHP 8.3.0.
+       </entry>
       </row>
       <row>
        <entry><link linkend="ini.assert.bail">assert.bail</link></entry>
@@ -124,7 +129,9 @@
         If &true; will abort execution of the PHP script if the
         expectation isn't upheld.
        </entry>
-       <entry/>
+       <entry>
+        Deprecated as of PHP 8.3.0.
+       </entry>
       </row>
       <row>
        <entry><link linkend="ini.assert.warning">assert.warning</link></entry>
@@ -135,7 +142,9 @@
         <link linkend="ini.assert.exception">assert.exception</link>
         is enabled.
        </entry>
-       <entry/>
+       <entry>
+        Deprecated as of PHP 8.3.0.
+       </entry>
       </row>
      </tbody>
     </tgroup>
@@ -234,6 +243,12 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.3.0</entry>
+       <entry>
+        All <literal>assert.</literal> INI settings have been deprecated.
+       </entry>
+      </row>
       <row>
        <entry>8.0.0</entry>
        <entry>

--- a/reference/info/ini.xml
+++ b/reference/info/ini.xml
@@ -20,25 +20,33 @@
      <entry><link linkend="ini.assert.active">assert.active</link></entry>
      <entry>"1"</entry>
      <entry>PHP_INI_ALL</entry>
-     <entry></entry>
+     <entry>
+      Deprecated as of PHP 8.3.0
+     </entry>
     </row>
     <row>
      <entry><link linkend="ini.assert.bail">assert.bail</link></entry>
      <entry>"0"</entry>
      <entry>PHP_INI_ALL</entry>
-     <entry></entry>
+     <entry>
+      Deprecated as of PHP 8.3.0
+     </entry>
     </row>
     <row>
      <entry><link linkend="ini.assert.warning">assert.warning</link></entry>
      <entry>"1"</entry>
      <entry>PHP_INI_ALL</entry>
-     <entry></entry>
+     <entry>
+      Deprecated as of PHP 8.3.0
+     </entry>
     </row>
     <row>
      <entry><link linkend="ini.assert.callback">assert.callback</link></entry>
      <entry>NULL</entry>
      <entry>PHP_INI_ALL</entry>
-     <entry></entry>
+     <entry>
+      Deprecated as of PHP 8.3.0
+     </entry>
     </row>
     <row>
      <entry><link linkend="ini.assert.quiet-eval">assert.quiet_eval</link></entry>
@@ -50,7 +58,10 @@
      <entry><link linkend="ini.assert.exception">assert.exception</link></entry>
      <entry>"1"</entry>
      <entry>PHP_INI_ALL</entry>
-     <entry>Prior to PHP 8.0.0, defaults to <literal>"0"</literal></entry>
+     <entry>
+      Prior to PHP 8.0.0, defaults to <literal>"0"</literal>.
+      Deprecated as of PHP 8.3.0
+     </entry>
     </row>
     <row>
      <entry><link linkend="ini.enable-dl">enable_dl</link></entry>
@@ -109,6 +120,7 @@
       <link linkend="ini.zend.assertions">zend.assertions</link> should be
       used instead to control the behaviour of <function>assert</function>.
      </para>
+     &warn.deprecated.feature-8-3-0;
     </listitem>
    </varlistentry>
 
@@ -121,6 +133,7 @@
      <para>
       Terminate script execution on failed assertions.
      </para>
+     &warn.deprecated.feature-8-3-0;
     </listitem>
    </varlistentry>
 
@@ -133,6 +146,7 @@
      <para>
       Issue a PHP warning for each failed assertion.
      </para>
+     &warn.deprecated.feature-8-3-0;
     </listitem>
    </varlistentry>
 
@@ -145,6 +159,7 @@
      <para>
       User function to call on failed assertions.
      </para>
+     &warn.deprecated.feature-8-3-0;
     </listitem>
    </varlistentry>
 
@@ -174,6 +189,7 @@
       Issue an <classname>AssertionError</classname> exception for the failed
       assertion.
      </para>
+     &warn.deprecated.feature-8-3-0;
     </listitem>
    </varlistentry>
 

--- a/reference/info/versions.xml
+++ b/reference/info/versions.xml
@@ -5,7 +5,7 @@
 -->
 <versions>
  <function name="assert" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
- <function name="assert_options" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="assert_options" from="PHP 4, PHP 5, PHP 7, PHP 8" deprecated="PHP 8.3.0" />
  <function name="cli_get_process_title" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="cli_set_process_title" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="dl" from="PHP 4, PHP 5, PHP 7, PHP 8"/>


### PR DESCRIPTION
Yanked the table markup for the constants just for assert and shoved it in a ``<section>`` tag.

This requires it moving it to the end to comply with the DTD.