### PR TITLE
Stringable can't be passed to argument expecting string, when strict types enabled

### DIFF
--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -273,7 +273,9 @@ class Connection
      As of PHP 8.0.0, the return value follows standard PHP type semantics,
      meaning it will be coerced into a <type>string</type> if possible and if
      <link linkend="language.types.declarations.strict">strict typing</link>
-     is disabled.
+     is disabled. If strict typing is enabled, a stringable object cannot be 
+     passed to a method that expects only a string, the argument must be 
+     typed as <interfacename>Stringable</interfacename>.
     </para>
     <para>
      As of PHP 8.0.0, any class that contains a <link linkend="object.tostring">__toString()</link>

--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -273,9 +273,14 @@ class Connection
      As of PHP 8.0.0, the return value follows standard PHP type semantics,
      meaning it will be coerced into a <type>string</type> if possible and if
      <link linkend="language.types.declarations.strict">strict typing</link>
-     is disabled. If strict typing is enabled, a stringable object cannot be 
-     passed to a method that expects only a string, the argument must be 
-     typed as <interfacename>Stringable</interfacename>.
+     is disabled.
+    </para>
+    <para>
+     A <interfacename>Stringable</interfacename> object will
+     <emphasis>not</emphasis> be accepted by a <type>string</type> type declaration if
+     <link linkend="language.types.declarations.strict">strict typing</link>
+     is enabled. If such behaviour is wanted the type declaration must accept
+     <interfacename>Stringable</interfacename> and <type>string</type> via a union type.
     </para>
     <para>
      As of PHP 8.0.0, any class that contains a <link linkend="object.tostring">__toString()</link>


### PR DESCRIPTION
A method that expects a `string` type argument will not allow a `stringable` object to be passed. This behaviour surprised me today and recently someone else here https://github.com/php/php-src/issues/12097

I tend to think that PHP should have an exception here, but I also understand the arguments against it. So, since the behaviour is what it is, I would like to propose making it clearer in the docs.