### PR TITLE
follow the changes of migration83 guide about constant typing

### DIFF
--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -41,7 +41,7 @@
      <row>
       <entry>8.3.0</entry>
       <entry>
-       Support for class, interface, and trait constant typing has been added.
+       Support for class, interface, trait, and enum constant typing has been added.
       </entry>
      </row>
      <row>


### PR DESCRIPTION
refs: https://github.com/php/doc-en/blob/c3b9bcfbee1f77830cfa086e88de6c0742cfb8ad/appendices/migration83/new-features.xml#L21-L28