### PR TITLE
Fix example of get_headers() usage with context

### DIFF
--- a/reference/url/functions/get-headers.xml
+++ b/reference/url/functions/get-headers.xml
@@ -155,7 +155,7 @@ $context = stream_context_create(
         )
     ]
 );
-$headers = get_headers('http://example.com', $context);
+$headers = get_headers('http://example.com', false, $context);
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
Function get_headers() called with wrong signature in example of usage with context. Add missing $associative argument.