### PR TITLE
Randomizer::getFloat(): Add documentation

### DIFF
--- a/reference/random/random/randomizer/getfloat.xml
+++ b/reference/random/random/randomizer/getfloat.xml
@@ -34,16 +34,17 @@
    <methodname>Random\Randomizer::getFloat</methodname> implements an algorithm that will
    return a uniformly selected float from the largest possible set of exactly representable
    and equidistributed floats within the requested interval. The distance between the selectable
-   floats matches the distance between the floats with the lowest density, i.e. the distance
-   between floats for the interval boundary with the larger absolute value. This means that
+   floats (“step size”) matches the distance between the floats with the lowest density, i.e. the distance
+   between floats at interval boundary with the larger absolute value. This means that
    not all representable floats within a given interval may be returned if the interval crosses
-   a power of two.
+   one or more powers of two. Stepping will start from the interval boundary with the larger absolute value
+   to ensure the steps align with the exactly representable floats.
   </para>
   <para>
-   The interval boundaries will always be included in the set of selectable floats. Thus, if
-   the size of the interval is not an exact multiple of the distance between each float,
-   the distance between <emphasis>one</emphasis> of the boundary values to its nearest value
-   will be smaller than the distance between all the other values.
+   Closed interval boundaries will always be included in the set of selectable floats. Thus,
+   if the size of the interval is not an exact multiple of the step size
+   and the boundary with the smaller absolute value is a closed boundary, the distance between
+   that boundary and its nearest selectable float will be smaller than the step size.
   </para>
 
   <caution>

--- a/reference/random/random/randomizer/getfloat.xml
+++ b/reference/random/random/randomizer/getfloat.xml
@@ -19,7 +19,7 @@
   <para>
    Due to the limited precision, not all real numbers can be exactly represented as
    a floating point number. If a number cannot be represented exactly, it is rounded to
-   the nearest representable exact value. Furthermore float are not equally dense across
+   the nearest representable exact value. Furthermore, floats are not equally dense across
    the whole number line. At each power of two, the distance between two neighboring
    floats doubles. In other words: There are the same number of floats between 1 and 2
    as they are between 2 and 4, 4 and 8, 8 and 16, and so on.
@@ -40,7 +40,7 @@
    a power of two.
   </para>
   <para>
-   The interval boundaries will always be included in the set of selectable floats. Thus if
+   The interval boundaries will always be included in the set of selectable floats. Thus, if
    the size of the interval is not an exact multiple of the distance between each float,
    the distance between <emphasis>one</emphasis> of the boundary values to its nearest value
    will be smaller than the distance between all the other values.

--- a/reference/random/random/randomizer/getfloat.xml
+++ b/reference/random/random/randomizer/getfloat.xml
@@ -21,7 +21,7 @@
    a floating point number. If a number cannot be represented exactly, it is rounded to
    the nearest representable exact value. Furthermore, floats are not equally dense across
    the whole number line. At each power of two, the distance between two neighboring
-   floats doubles. In other words: There are the same number of floats between 1 and 2
+   floats doubles. In other words: There are the same number of representable floats between 1 and 2
    as they are between 2 and 4, 4 and 8, 8 and 16, and so on.
   </para>
   <para>

--- a/reference/random/random/randomizer/getfloat.xml
+++ b/reference/random/random/randomizer/getfloat.xml
@@ -14,11 +14,47 @@
    <methodparam choice="opt"><type>Random\IntervalBoundary</type><parameter>boundary</parameter><initializer>Random\IntervalBoundary::ClosedOpen</initializer></methodparam>
   </methodsynopsis>
   <para>
-
+   Returns a uniformly selected, equidistributed float from a requested interval.
+  </para>
+  <para>
+   Due to the limited precision, not all real numbers can be exactly represented as
+   a floating point number. If a number cannot be represented exactly, it is rounded to
+   the nearest representable exact value. Furthermore float are not equally dense across
+   the whole number line. At each power of two, the distance between two neighboring
+   floats doubles. In other words: There are the same number of floats between 1 and 2
+   as they are between 2 and 4, 4 and 8, 8 and 16, and so on.
+  </para>
+  <para>
+   Randomly sampling an arbitrary number within the requested interval, for example by
+   dividing two integers, might result in a biased distribution for this reason. The
+   necessary rounding will cause some floats to be returned more often than others,
+   especially around powers of two when the density of floats changes.
+  </para>
+  <para>
+   <methodname>Random\Randomizer::getFloat</methodname> implements an algorithm that will
+   return a uniformly selected float from the largest possible set of exactly representable
+   and equidistributed floats within the requested interval. The distance between the selectable
+   floats matches the distance between the floats with the lowest density, i.e. the distance
+   between floats for the interval boundary with the larger absolute value. This means that
+   not all representable floats within a given interval may be returned if the interval crosses
+   a power of two.
+  </para>
+  <para>
+   The interval boundaries will always be included in the set of selectable floats. Thus if
+   the size of the interval is not an exact multiple of the distance between each float,
+   the distance between <emphasis>one</emphasis> of the boundary values to its nearest value
+   will be smaller than the distance between all the other values.
   </para>
 
-  &warn.undocumented.func;
-
+  <caution>
+   <para>
+    Post-processing the returned floats is likely going to break the uniform equidistribution,
+    because the intermediate floats within a mathematical operation are experiencing implicit
+    rounding. The requested interval should match the desired interval as closely as possible
+    and rounding should only be performed as an explicit operation right before displaying the
+    selected number to a user.
+   </para>
+  </caution>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -45,7 +81,7 @@
      <term><parameter>boundary</parameter></term>
      <listitem>
       <para>
-       Specifies if the interval boundaries are possible return values.
+       Specifies whether the interval boundaries are possible return values.
       </para>
      </listitem>
     </varlistentry>
@@ -56,9 +92,11 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   A uniformly selected float from the interval specified by <parameter>min</parameter>, <parameter>max</parameter>,
-   and <parameter>boundary</parameter>. Whether <parameter>min</parameter> and <parameter>max</parameter>
-   are possible return values depends on the value of <parameter>boundary</parameter>.
+   A uniformly selected, equidistributed float from the interval specified by <parameter>min</parameter>,
+   <parameter>max</parameter>, and <parameter>boundary</parameter>.
+
+   Whether <parameter>min</parameter> and <parameter>max</parameter> are possible return values depends
+   on the value of <parameter>boundary</parameter>.
   </para>
  </refsect1>
 
@@ -67,13 +105,13 @@
   <itemizedlist>
    <listitem>
     <simpara>
-     If the value of <parameter>$min</parameter> is not finite,
+     If the value of <parameter>$min</parameter> is not finite (<function>is_finite</function>),
      a <classname>ValueError</classname> will be thrown.
     </simpara>
    </listitem>
    <listitem>
     <simpara>
-     If the value of <parameter>$max</parameter> is not finite,
+     If the value of <parameter>$max</parameter> is not finite (<function>is_finite</function>),
      a <classname>ValueError</classname> will be thrown.
     </simpara>
    </listitem>

--- a/reference/random/random/randomizer/getfloat.xml
+++ b/reference/random/random/randomizer/getfloat.xml
@@ -20,8 +20,8 @@
    Due to the limited precision, not all real numbers can be exactly represented as
    a floating point number. If a number cannot be represented exactly, it is rounded to
    the nearest representable exact value. Furthermore, floats are not equally dense across
-   the whole number line. At each power of two, the distance between two neighboring
-   floats doubles. In other words: There are the same number of representable floats between 1 and 2
+   the whole number line. Because floats use a binary exponent, the distance between two neighboring floats doubles at each power of two.
+   In other words: There are the same number of representable floats between 1 and 2
    as they are between 2 and 4, 4 and 8, 8 and 16, and so on.
   </para>
   <para>

--- a/reference/random/random/randomizer/getfloat.xml
+++ b/reference/random/random/randomizer/getfloat.xml
@@ -18,42 +18,60 @@
   </para>
   <para>
    Due to the limited precision, not all real numbers can be exactly represented as
-   a floating point number. If a number cannot be represented exactly, it is rounded to
-   the nearest representable exact value. Furthermore, floats are not equally dense across
-   the whole number line. Because floats use a binary exponent, the distance between two neighboring floats doubles at each power of two.
+   a floating point number.
+
+   If a number cannot be represented exactly, it is rounded to the nearest
+   representable exact value.
+
+   Furthermore, floats are not equally dense across the whole number line.
+
+   Because floats use a binary exponent, the distance between two neighboring
+   floats doubles at each power of two.
+
    In other words: There are the same number of representable floats between 1 and 2
    as they are between 2 and 4, 4 and 8, 8 and 16, and so on.
   </para>
   <para>
-   Randomly sampling an arbitrary number within the requested interval, for example by
-   dividing two integers, might result in a biased distribution for this reason. The
-   necessary rounding will cause some floats to be returned more often than others,
-   especially around powers of two when the density of floats changes.
+   Randomly sampling an arbitrary number within the requested interval, for example
+   by dividing two integers, might result in a biased distribution for this reason.
+
+   The necessary rounding will cause some floats to be returned more often than
+   others, especially around powers of two when the density of floats changes.
   </para>
   <para>
-   <methodname>Random\Randomizer::getFloat</methodname> implements an algorithm that will
-   return a uniformly selected float from the largest possible set of exactly representable
-   and equidistributed floats within the requested interval. The distance between the selectable
-   floats (“step size”) matches the distance between the floats with the lowest density, i.e. the distance
-   between floats at interval boundary with the larger absolute value. This means that
-   not all representable floats within a given interval may be returned if the interval crosses
-   one or more powers of two. Stepping will start from the interval boundary with the larger absolute value
+   <methodname>Random\Randomizer::getFloat</methodname> implements an algorithm that
+   will return a uniformly selected float from the largest possible set of exactly
+   representable and equidistributed floats within the requested interval.
+
+   The distance between the selectable floats (“step size”) matches the distance
+   between the floats with the lowest density, i.e. the distance between floats
+   at interval boundary with the larger absolute value.
+
+   This means that not all representable floats within a given interval may be
+   returned if the interval crosses one or more powers of two.
+
+   Stepping will start from the interval boundary with the larger absolute value
    to ensure the steps align with the exactly representable floats.
   </para>
   <para>
-   Closed interval boundaries will always be included in the set of selectable floats. Thus,
-   if the size of the interval is not an exact multiple of the step size
-   and the boundary with the smaller absolute value is a closed boundary, the distance between
-   that boundary and its nearest selectable float will be smaller than the step size.
+   Closed interval boundaries will always be included in the set of selectable
+   floats.
+
+   Thus, if the size of the interval is not an exact multiple of the step size and
+   the boundary with the smaller absolute value is a closed boundary, the distance
+   between that boundary and its nearest selectable float will be smaller than the
+   step size.
   </para>
 
   <caution>
    <para>
-    Post-processing the returned floats is likely going to break the uniform equidistribution,
-    because the intermediate floats within a mathematical operation are experiencing implicit
-    rounding. The requested interval should match the desired interval as closely as possible
-    and rounding should only be performed as an explicit operation right before displaying the
-    selected number to a user.
+    Post-processing the returned floats is likely going to break the uniform
+    equidistribution, because the intermediate floats within a mathematical
+    operation are experiencing implicit rounding.
+
+    The requested interval should match the desired interval as closely as possible
+    and rounding should only be performed as an explicit operation right before
+    displaying the selected number to a user.
    </para>
   </caution>
  </refsect1>


### PR DESCRIPTION
Some first words explaining the problems of selecting a random float within a given interval and how `getFloat()` does it correctly. I plan to expand the explanation a little more in a second iteration, but wanted to put up for review what I already have to make sure that it is any good and not completely incomprehensible before spending more time on it. It was hard enough to write these words :grin: 