### PR TITLE
Regenerate gearman doc to fix #2859

### DIFF
--- a/reference/gearman/gearmanclient.xml
+++ b/reference/gearman/gearmanclient.xml
@@ -34,9 +34,6 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanclient')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GearmanClient'])">
      <xi:fallback/>
     </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanclient')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='GearmanClient'])">
-     <xi:fallback/>
-    </xi:include>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/gearman/gearmanclient.xml
+++ b/reference/gearman/gearmanclient.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <phpdoc:classref xml:id="class.gearmanclient" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>The GearmanClient class</title>
@@ -23,19 +22,21 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>GearmanClient</classname></ooclass>
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>GearmanClient</classname>
+    </ooclass>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>GearmanClient</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanclient')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanclient')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GearmanClient'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanclient')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GearmanClient'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanclient')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='GearmanClient'])">
+     <xi:fallback/>
+    </xi:include>
    </classsynopsis>
 <!-- }}} -->
 
@@ -46,7 +47,6 @@
  &reference.gearman.entities.gearmanclient;
 
 </phpdoc:classref>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/addoptions.xml
+++ b/reference/gearman/gearmanclient/addoptions.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.addoptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::addOptions</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::addOptions</methodname>
-   <methodparam><type>int</type><parameter>options</parameter></methodparam>
+   <methodparam><type>int</type><parameter>option</parameter></methodparam>
   </methodsynopsis>
   <para>
    Adds one or more options to those already set.
@@ -23,7 +22,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>options</parameter></term>
+     <term><parameter>option</parameter></term>
      <listitem>
       <para>
        The options to add.
@@ -48,7 +47,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/addserver.xml
+++ b/reference/gearman/gearmanclient/addserver.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.addserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::addServer</refname>
@@ -9,10 +8,11 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::addServer</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>host</parameter><initializer>127.0.0.1</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>port</parameter><initializer>4730</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>host</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>port</parameter><initializer>0</initializer></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>setupExceptionHandler</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Adds a job server to a list of servers that can be used to run a task.  No socket
@@ -85,7 +85,6 @@ $gmclient->addServer("10.0.0.2", 7003);
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/addservers.xml
+++ b/reference/gearman/gearmanclient/addservers.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.addservers" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::addServers</refname>
@@ -9,9 +8,10 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::addServers</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>servers</parameter><initializer>127.0.0.1:4730</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>servers</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>setupExceptionHandler</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Adds a list of job servers that can be used to run a task.  No socket I/O happens here;
@@ -75,7 +75,6 @@ $gmclient->addServers("10.0.0.1,10.0.0.2:7003");
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/addtask.xml
+++ b/reference/gearman/gearmanclient/addtask.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.addtask" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::addTask</refname>
@@ -9,12 +8,12 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>GearmanTask</type><methodname>GearmanClient::addTask</methodname>
+  <methodsynopsis role="GearmanClient">
+   <modifier>public</modifier> <type class="union"><type>GearmanTask</type><type>false</type></type><methodname>GearmanClient::addTask</methodname>
    <methodparam><type>string</type><parameter>function_name</parameter></methodparam>
-   <methodparam><type>string</type><parameter>workload</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter role="reference">context</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>unique</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>int</type><type>float</type></type><parameter>workload</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>context</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>unique_key</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Adds a task to be run in parallel with other tasks.  Call this method for all the tasks
@@ -53,7 +52,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>unique</parameter></term>
+     <term><parameter>unique_key</parameter></term>
      <listitem>
       <para>
        &gearman.parameter.unique;
@@ -172,7 +171,6 @@ t1: H:foo:22, !dlroW olleH
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/addtaskbackground.xml
+++ b/reference/gearman/gearmanclient/addtaskbackground.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.addtaskbackground" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::addTaskBackground</refname>
@@ -9,12 +8,12 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>GearmanTask</type><methodname>GearmanClient::addTaskBackground</methodname>
+  <methodsynopsis role="GearmanClient">
+   <modifier>public</modifier> <type class="union"><type>GearmanTask</type><type>false</type></type><methodname>GearmanClient::addTaskBackground</methodname>
    <methodparam><type>string</type><parameter>function_name</parameter></methodparam>
-   <methodparam><type>string</type><parameter>workload</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter role="reference">context</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>unique</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>int</type><type>float</type></type><parameter>workload</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>context</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>unique_key</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Adds a background task to be run in parallel with other tasks.  Call this method for all the tasks
@@ -52,7 +51,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>unique</parameter></term>
+     <term><parameter>unique_key</parameter></term>
      <listitem>
       <para>
        &gearman.parameter.unique;
@@ -260,7 +259,6 @@ DONE
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/addtaskhigh.xml
+++ b/reference/gearman/gearmanclient/addtaskhigh.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.addtaskhigh" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::addTaskHigh</refname>
@@ -9,12 +8,12 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>GearmanTask</type><methodname>GearmanClient::addTaskHigh</methodname>
+  <methodsynopsis role="GearmanClient">
+   <modifier>public</modifier> <type class="union"><type>GearmanTask</type><type>false</type></type><methodname>GearmanClient::addTaskHigh</methodname>
    <methodparam><type>string</type><parameter>function_name</parameter></methodparam>
-   <methodparam><type>string</type><parameter>workload</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter role="reference">context</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>unique</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>int</type><type>float</type></type><parameter>workload</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>context</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>unique_key</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Adds a high priority task to be run in parallel with other tasks.  Call this method for all
@@ -53,7 +52,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>unique</parameter></term>
+     <term><parameter>unique_key</parameter></term>
      <listitem>
       <para>
        &gearman.parameter.unique;
@@ -142,7 +141,6 @@ DONE
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/addtaskhighbackground.xml
+++ b/reference/gearman/gearmanclient/addtaskhighbackground.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.addtaskhighbackground" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::addTaskHighBackground</refname>
@@ -9,12 +8,12 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>GearmanTask</type><methodname>GearmanClient::addTaskHighBackground</methodname>
+  <methodsynopsis role="GearmanClient">
+   <modifier>public</modifier> <type class="union"><type>GearmanTask</type><type>false</type></type><methodname>GearmanClient::addTaskHighBackground</methodname>
    <methodparam><type>string</type><parameter>function_name</parameter></methodparam>
-   <methodparam><type>string</type><parameter>workload</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter role="reference">context</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>unique</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>int</type><type>float</type></type><parameter>workload</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>context</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>unique_key</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Adds a high priority background task to be run in parallel with other tasks.
@@ -53,7 +52,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>unique</parameter></term>
+     <term><parameter>unique_key</parameter></term>
      <listitem>
       <para>
        &gearman.parameter.unique;
@@ -86,7 +85,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/addtasklow.xml
+++ b/reference/gearman/gearmanclient/addtasklow.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.addtasklow" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::addTaskLow</refname>
@@ -9,12 +8,12 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>GearmanTask</type><methodname>GearmanClient::addTaskLow</methodname>
+  <methodsynopsis role="GearmanClient">
+   <modifier>public</modifier> <type class="union"><type>GearmanTask</type><type>false</type></type><methodname>GearmanClient::addTaskLow</methodname>
    <methodparam><type>string</type><parameter>function_name</parameter></methodparam>
-   <methodparam><type>string</type><parameter>workload</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter role="reference">context</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>unique</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>int</type><type>float</type></type><parameter>workload</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>context</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>unique_key</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Adds a low priority background task to be run in parallel with other tasks.
@@ -53,7 +52,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>unique</parameter></term>
+     <term><parameter>unique_key</parameter></term>
      <listitem>
       <para>
        &gearman.parameter.unique;
@@ -142,7 +141,6 @@ DONE
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/addtasklowbackground.xml
+++ b/reference/gearman/gearmanclient/addtasklowbackground.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.addtasklowbackground" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::addTaskLowBackground</refname>
@@ -9,12 +8,12 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>GearmanTask</type><methodname>GearmanClient::addTaskLowBackground</methodname>
+  <methodsynopsis role="GearmanClient">
+   <modifier>public</modifier> <type class="union"><type>GearmanTask</type><type>false</type></type><methodname>GearmanClient::addTaskLowBackground</methodname>
    <methodparam><type>string</type><parameter>function_name</parameter></methodparam>
-   <methodparam><type>string</type><parameter>workload</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter role="reference">context</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>unique</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>int</type><type>float</type></type><parameter>workload</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>context</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>unique_key</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Adds a low priority background task to be run in parallel with other tasks.
@@ -53,7 +52,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>unique</parameter></term>
+     <term><parameter>unique_key</parameter></term>
      <listitem>
       <para>
        &gearman.parameter.unique;
@@ -86,7 +85,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/addtaskstatus.xml
+++ b/reference/gearman/gearmanclient/addtaskstatus.xml
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   A <classname>GearmanTask</classname> object.
+   A <classname>GearmanTask</classname> object or &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/gearman/gearmanclient/addtaskstatus.xml
+++ b/reference/gearman/gearmanclient/addtaskstatus.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.addtaskstatus" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::addTaskStatus</refname>
@@ -9,10 +8,10 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>GearmanTask</type><methodname>GearmanClient::addTaskStatus</methodname>
+  <methodsynopsis role="GearmanClient">
+   <modifier>public</modifier> <type class="union"><type>GearmanTask</type><type>false</type></type><methodname>GearmanClient::addTaskStatus</methodname>
    <methodparam><type>string</type><parameter>job_handle</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter role="reference">context</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>context</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Used to request status information from the Gearman server, which will call the specified
@@ -144,7 +143,6 @@ Done: 2
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/clearcallbacks.xml
+++ b/reference/gearman/gearmanclient/clearcallbacks.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.clearcallbacks" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::clearCallbacks</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::clearCallbacks</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Clears all the task callback functions that have previously been set.
@@ -47,7 +46,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/construct.xml
+++ b/reference/gearman/gearmanclient/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::__construct</refname>
@@ -9,10 +8,10 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis role="GearmanClient">
    <modifier>public</modifier> <methodname>GearmanClient::__construct</methodname>
-   <void />
-  </methodsynopsis>
+   <void/>
+  </constructorsynopsis>
   <para>
    Creates a <classname>GearmanClient</classname> instance representing a client that connects to the
    job server and submits tasks to complete.
@@ -41,7 +40,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/context.xml
+++ b/reference/gearman/gearmanclient/context.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.context" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::context</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>string</type><methodname>GearmanClient::context</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Get the application context previously set with <methodname>GearmanClient::setContext</methodname>.
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/dobackground.xml
+++ b/reference/gearman/gearmanclient/dobackground.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.dobackground" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::doBackground</refname>
@@ -9,11 +8,11 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>string</type><methodname>GearmanClient::doBackground</methodname>
-   <methodparam><type>string</type><parameter>function_name</parameter></methodparam>
+   <methodparam><type>string</type><parameter>function</parameter></methodparam>
    <methodparam><type>string</type><parameter>workload</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>unique</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>unique</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Runs a task in the background, returning a job handle which can be used
@@ -26,7 +25,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>function_name</parameter></term>
+     <term><parameter>function</parameter></term>
      <listitem>
       <para>
        &gearman.parameter.functionname;
@@ -134,7 +133,6 @@ done!
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/dohigh.xml
+++ b/reference/gearman/gearmanclient/dohigh.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.dohigh" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::doHigh</refname>
@@ -9,11 +8,11 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>string</type><methodname>GearmanClient::doHigh</methodname>
-   <methodparam><type>string</type><parameter>function_name</parameter></methodparam>
+   <methodparam><type>string</type><parameter>function</parameter></methodparam>
    <methodparam><type>string</type><parameter>workload</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>unique</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>unique</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Runs a single high priority task and returns a string representation of the result.  It is up to
@@ -28,7 +27,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>function_name</parameter></term>
+     <term><parameter>function</parameter></term>
      <listitem>
       <para>
        &gearman.parameter.functionname;
@@ -76,7 +75,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/dohighbackground.xml
+++ b/reference/gearman/gearmanclient/dohighbackground.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.dohighbackground" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::doHighBackground</refname>
@@ -9,11 +8,11 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>string</type><methodname>GearmanClient::doHighBackground</methodname>
-   <methodparam><type>string</type><parameter>function_name</parameter></methodparam>
+   <methodparam><type>string</type><parameter>function</parameter></methodparam>
    <methodparam><type>string</type><parameter>workload</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>unique</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>unique</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Runs a high priority task in the background, returning a job handle which can be used
@@ -27,7 +26,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>function_name</parameter></term>
+     <term><parameter>function</parameter></term>
      <listitem>
       <para>
        &gearman.parameter.functionname;
@@ -75,7 +74,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/dojobhandle.xml
+++ b/reference/gearman/gearmanclient/dojobhandle.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.dojobhandle" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::doJobHandle</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>string</type><methodname>GearmanClient::doJobHandle</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Gets that job handle for a running task.  This should be used between repeated
@@ -42,7 +41,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/dolow.xml
+++ b/reference/gearman/gearmanclient/dolow.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.dolow" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::doLow</refname>
@@ -9,11 +8,11 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>string</type><methodname>GearmanClient::doLow</methodname>
-   <methodparam><type>string</type><parameter>function_name</parameter></methodparam>
+   <methodparam><type>string</type><parameter>function</parameter></methodparam>
    <methodparam><type>string</type><parameter>workload</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>unique</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>unique</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Runs a single low priority task and returns a string representation of the result.  It is up to
@@ -28,7 +27,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>function_name</parameter></term>
+     <term><parameter>function</parameter></term>
      <listitem>
       <para>
        &gearman.parameter.functionname;
@@ -76,7 +75,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/dolowbackground.xml
+++ b/reference/gearman/gearmanclient/dolowbackground.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.dolowbackground" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::doLowBackground</refname>
@@ -9,11 +8,11 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>string</type><methodname>GearmanClient::doLowBackground</methodname>
-   <methodparam><type>string</type><parameter>function_name</parameter></methodparam>
+   <methodparam><type>string</type><parameter>function</parameter></methodparam>
    <methodparam><type>string</type><parameter>workload</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>unique</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>unique</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Runs a low priority task in the background, returning a job handle which can be used
@@ -27,7 +26,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>function_name</parameter></term>
+     <term><parameter>function</parameter></term>
      <listitem>
       <para>
        &gearman.parameter.functionname;
@@ -75,7 +74,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/donormal.xml
+++ b/reference/gearman/gearmanclient/donormal.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.donormal" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::doNormal</refname>
@@ -9,11 +8,11 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>string</type><methodname>GearmanClient::doNormal</methodname>
-   <methodparam><type>string</type><parameter>function_name</parameter></methodparam>
+   <methodparam><type>string</type><parameter>function</parameter></methodparam>
    <methodparam><type>string</type><parameter>workload</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>unique</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>unique</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Runs a single task and returns a string representation of the result.  It is up to
@@ -27,7 +26,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>function_name</parameter></term>
+     <term><parameter>function</parameter></term>
      <listitem>
       <para>
        &gearman.parameter.functionname;
@@ -310,7 +309,6 @@ Success: !olleH
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/dostatus.xml
+++ b/reference/gearman/gearmanclient/dostatus.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.dostatus" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::doStatus</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>array</type><methodname>GearmanClient::doStatus</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Returns the status for the running task.  This should be used between repeated
@@ -117,7 +116,6 @@ Success: !olleH
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/error.xml
+++ b/reference/gearman/gearmanclient/error.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   A human readable error string.
+   A human readable error string, or &false; if there is no error message available.
   </para>
  </refsect1>
 

--- a/reference/gearman/gearmanclient/error.xml
+++ b/reference/gearman/gearmanclient/error.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.error" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::error</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>string</type><methodname>GearmanClient::error</methodname>
-   <void />
+  <methodsynopsis role="GearmanClient">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>GearmanClient::error</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns an error string for the last error encountered.
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/geterrno.xml
+++ b/reference/gearman/gearmanclient/geterrno.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.geterrno" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::getErrno</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>int</type><methodname>GearmanClient::getErrno</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Value of errno in the case of a GEARMAN_ERRNO return value.
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/jobstatus.xml
+++ b/reference/gearman/gearmanclient/jobstatus.xml
@@ -11,9 +11,9 @@
   &reftitle.description;
   <para>&style.oop; (method):</para>
    <methodsynopsis role="GearmanClient">
-   <modifier>public</modifier> <type>array</type><methodname>GearmanClient::jobStatus</methodname>
-   <methodparam><type>string</type><parameter>job_handle</parameter></methodparam>
-  </methodsynopsis>
+    <modifier>public</modifier> <type>array</type><methodname>GearmanClient::jobStatus</methodname>
+    <methodparam><type>string</type><parameter>job_handle</parameter></methodparam>
+   </methodsynopsis>
    <para>
     Gets the status for a background job given a job handle.  The status information will
     specify whether the job is known, whether the job is currently running, and

--- a/reference/gearman/gearmanclient/jobstatus.xml
+++ b/reference/gearman/gearmanclient/jobstatus.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.jobstatus" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::jobStatus</refname>
@@ -11,10 +10,10 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop; (method):</para>
-   <methodsynopsis>
+   <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>array</type><methodname>GearmanClient::jobStatus</methodname>
    <methodparam><type>string</type><parameter>job_handle</parameter></methodparam>
-   </methodsynopsis>
+  </methodsynopsis>
    <para>
     Gets the status for a background job given a job handle.  The status information will
     specify whether the job is known, whether the job is currently running, and
@@ -114,7 +113,6 @@ done!
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/ping.xml
+++ b/reference/gearman/gearmanclient/ping.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.ping" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::ping</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::ping</methodname>
    <methodparam><type>string</type><parameter>workload</parameter></methodparam>
   </methodsynopsis>
@@ -43,7 +42,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/removeoptions.xml
+++ b/reference/gearman/gearmanclient/removeoptions.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.removeoptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::removeOptions</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::removeOptions</methodname>
-   <methodparam><type>int</type><parameter>options</parameter></methodparam>
+   <methodparam><type>int</type><parameter>option</parameter></methodparam>
   </methodsynopsis>
   <para>
    Removes (unsets) one or more options.
@@ -23,7 +22,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>options</parameter></term>
+     <term><parameter>option</parameter></term>
      <listitem>
       <para>
        The options to be removed (unset)
@@ -42,7 +41,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/returncode.xml
+++ b/reference/gearman/gearmanclient/returncode.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.returncode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::returnCode</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>int</type><methodname>GearmanClient::returnCode</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Returns the last Gearman return code.
@@ -31,7 +30,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/runtasks.xml
+++ b/reference/gearman/gearmanclient/runtasks.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.runtasks" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::runTasks</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::runTasks</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    For a set of tasks previously added with <methodname>GearmanClient::addTask</methodname>,
@@ -44,7 +43,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/setcompletecallback.xml
+++ b/reference/gearman/gearmanclient/setcompletecallback.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.setcompletecallback" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::setCompleteCallback</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setCompleteCallback</methodname>
-   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>function</parameter></methodparam>
   </methodsynopsis>
   <para>
    Use to set a function to be called when a <classname>GearmanTask</classname> is completed, or
@@ -29,7 +28,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>callback</parameter></term>
+     <term><parameter>function</parameter></term>
      <listitem>
       <para>
        A function to be called
@@ -63,7 +62,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/setcontext.xml
+++ b/reference/gearman/gearmanclient/setcontext.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.setcontext" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::setContext</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setContext</methodname>
-   <methodparam><type>string</type><parameter>context</parameter></methodparam>
+   <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
   <para>
    Sets an arbitrary string to provide application context that can
@@ -24,7 +23,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>context</parameter></term>
+     <term><parameter>data</parameter></term>
      <listitem>
       <para>
        Arbitrary context data
@@ -52,7 +51,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/setcreatedcallback.xml
+++ b/reference/gearman/gearmanclient/setcreatedcallback.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.setcreatedcallback" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::setCreatedCallback</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setCreatedCallback</methodname>
-   <methodparam><type>string</type><parameter>callback</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>function</parameter></methodparam>
   </methodsynopsis>
   <para>
    Sets a function to be called when a task is received and queued by the Gearman job server.
@@ -24,7 +23,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>callback</parameter></term>
+     <term><parameter>function</parameter></term>
      <listitem>
       <para>
        A function to call
@@ -58,7 +57,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/setdatacallback.xml
+++ b/reference/gearman/gearmanclient/setdatacallback.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.setdatacallback" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::setDataCallback</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setDataCallback</methodname>
-   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>function</parameter></methodparam>
   </methodsynopsis>
   <para>
    Sets the callback function for accepting data packets for a task. The callback function should
@@ -24,7 +23,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>callback</parameter></term>
+     <term><parameter>function</parameter></term>
      <listitem>
       <para>
        A function or method to call
@@ -58,7 +57,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/setexceptioncallback.xml
+++ b/reference/gearman/gearmanclient/setexceptioncallback.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.setexceptioncallback" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::setExceptionCallback</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setExceptionCallback</methodname>
-   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>function</parameter></methodparam>
   </methodsynopsis>
   <para>
    Specifies a function to call when a worker for a task sends an exception.
@@ -23,7 +22,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>callback</parameter></term>
+     <term><parameter>function</parameter></term>
      <listitem>
       <para>
        Function to call when the worker throws an exception
@@ -57,7 +56,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/setfailcallback.xml
+++ b/reference/gearman/gearmanclient/setfailcallback.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.setfailcallback" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::setFailCallback</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setFailCallback</methodname>
-   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>function</parameter></methodparam>
   </methodsynopsis>
   <para>
    Sets the callback function to be used when a task does not complete successfully.  The function
@@ -24,7 +23,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>callback</parameter></term>
+     <term><parameter>function</parameter></term>
      <listitem>
       <para>
        A function to call
@@ -58,7 +57,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/setoptions.xml
+++ b/reference/gearman/gearmanclient/setoptions.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.setoptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::setOptions</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setOptions</methodname>
-   <methodparam><type>int</type><parameter>options</parameter></methodparam>
+   <methodparam><type>int</type><parameter>option</parameter></methodparam>
   </methodsynopsis>
   <para>
    Sets one or more client options.
@@ -23,7 +22,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>options</parameter></term>
+     <term><parameter>option</parameter></term>
      <listitem>
       <para>
        The options to be set
@@ -42,7 +41,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/setstatuscallback.xml
+++ b/reference/gearman/gearmanclient/setstatuscallback.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.setstatuscallback" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::setStatusCallback</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setStatusCallback</methodname>
-   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>function</parameter></methodparam>
   </methodsynopsis>
   <para>
    Sets a callback function used for getting updated status information from a worker.  The function
@@ -24,7 +23,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>callback</parameter></term>
+     <term><parameter>function</parameter></term>
      <listitem>
       <para>
        A function to call
@@ -58,7 +57,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/settimeout.xml
+++ b/reference/gearman/gearmanclient/settimeout.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.settimeout" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::setTimeout</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setTimeout</methodname>
    <methodparam><type>int</type><parameter>timeout</parameter></methodparam>
   </methodsynopsis>
@@ -42,7 +41,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/setwarningcallback.xml
+++ b/reference/gearman/gearmanclient/setwarningcallback.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.setwarningcallback" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::setWarningCallback</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setWarningCallback</methodname>
-   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>function</parameter></methodparam>
   </methodsynopsis>
   <para>
    Sets a function to be called when a worker sends a warning.  The callback should accept
@@ -24,7 +23,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>callback</parameter></term>
+     <term><parameter>function</parameter></term>
      <listitem>
       <para>
        A function to call
@@ -58,7 +57,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/setworkloadcallback.xml
+++ b/reference/gearman/gearmanclient/setworkloadcallback.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.setworkloadcallback" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::setWorkloadCallback</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setWorkloadCallback</methodname>
-   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>function</parameter></methodparam>
   </methodsynopsis>
   <para>
    Sets a function to be called when a worker needs to send back data prior to job completion.
@@ -26,7 +25,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>callback</parameter></term>
+     <term><parameter>function</parameter></term>
      <listitem>
       <para>
        A function to call
@@ -60,7 +59,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/timeout.xml
+++ b/reference/gearman/gearmanclient/timeout.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.timeout" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::timeout</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>int</type><methodname>GearmanClient::timeout</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Returns the timeout in milliseconds to wait for I/O activity.
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanclient/wait.xml
+++ b/reference/gearman/gearmanclient/wait.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanclient.wait" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanClient::wait</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::wait</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    This waits for activity from any one of the connected servers.
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanexception.xml
+++ b/reference/gearman/gearmanexception.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <phpdoc:classref xml:id="class.gearmanexception" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>The GearmanException class</title>
@@ -22,20 +21,9 @@
 
 <!-- {{{ Synopsis -->
    <classsynopsis>
-    <ooclass><classname>GearmanException</classname></ooclass>
-
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>GearmanException</classname>
-     </ooclass>
-     
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
+    <ooclass>
+     <classname>GearmanException</classname>
+    </ooclass>
     
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)" />
@@ -48,7 +36,7 @@
     -->
     
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GearmanException'])" />
 
    </classsynopsis>
 <!-- }}} -->

--- a/reference/gearman/gearmanexception.xml
+++ b/reference/gearman/gearmanexception.xml
@@ -36,7 +36,7 @@
     -->
     
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GearmanException'])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])" />
 
    </classsynopsis>
 <!-- }}} -->

--- a/reference/gearman/gearmanjob.xml
+++ b/reference/gearman/gearmanjob.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <phpdoc:classref xml:id="class.gearmanjob" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>The GearmanJob class</title>
@@ -21,19 +20,18 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>GearmanJob</classname></ooclass>
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>GearmanJob</classname>
+    </ooclass>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>GearmanJob</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanjob')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanjob')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GearmanJob'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanjob')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='GearmanJob'])">
+     <xi:fallback/>
+    </xi:include>
    </classsynopsis>
 <!-- }}} -->
 
@@ -44,7 +42,6 @@
  &reference.gearman.entities.gearmanjob;
 
 </phpdoc:classref>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanjob.xml
+++ b/reference/gearman/gearmanjob.xml
@@ -29,9 +29,6 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanjob')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GearmanJob'])">
      <xi:fallback/>
     </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanjob')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='GearmanJob'])">
-     <xi:fallback/>
-    </xi:include>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/gearman/gearmanjob/functionname.xml
+++ b/reference/gearman/gearmanjob/functionname.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanjob.functionname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanJob::functionName</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>string</type><methodname>GearmanJob::functionName</methodname>
-   <void />
+  <methodsynopsis role="GearmanJob">
+   <modifier>public</modifier> <type class="union"><type>false</type><type>string</type></type><methodname>GearmanJob::functionName</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns the function name for this job.  This is the function the work will execute to
@@ -41,7 +40,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanjob/functionname.xml
+++ b/reference/gearman/gearmanjob/functionname.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The name of a function.
+   The name of a function, or &false; if the job has not yet been initialized.
   </para>
  </refsect1>
 

--- a/reference/gearman/gearmanjob/handle.xml
+++ b/reference/gearman/gearmanjob/handle.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An opaque job handle.
+   An opaque job handle, or &false; if the job has not yet been initialized.
   </para>
  </refsect1>
 

--- a/reference/gearman/gearmanjob/handle.xml
+++ b/reference/gearman/gearmanjob/handle.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanjob.handle" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanJob::handle</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>string</type><methodname>GearmanJob::handle</methodname>
-   <void />
+  <methodsynopsis role="GearmanJob">
+   <modifier>public</modifier> <type class="union"><type>false</type><type>string</type></type><methodname>GearmanJob::handle</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns the opaque job handle assigned by the job server.
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanjob/returncode.xml
+++ b/reference/gearman/gearmanjob/returncode.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanjob.returncode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanJob::returnCode</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanJob">
    <modifier>public</modifier> <type>int</type><methodname>GearmanJob::returnCode</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Returns the last return code issued by the job server.
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanjob/sendcomplete.xml
+++ b/reference/gearman/gearmanjob/sendcomplete.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanjob.sendcomplete" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanJob::sendComplete</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanJob">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanJob::sendComplete</methodname>
    <methodparam><type>string</type><parameter>result</parameter></methodparam>
   </methodsynopsis>
@@ -52,7 +51,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanjob/senddata.xml
+++ b/reference/gearman/gearmanjob/senddata.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanjob.senddata" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanJob::sendData</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanJob">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanJob::sendData</methodname>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
@@ -52,7 +51,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanjob/sendexception.xml
+++ b/reference/gearman/gearmanjob/sendexception.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanjob.sendexception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanJob::sendException</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanJob">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanJob::sendException</methodname>
    <methodparam><type>string</type><parameter>exception</parameter></methodparam>
   </methodsynopsis>
@@ -53,7 +52,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanjob/sendfail.xml
+++ b/reference/gearman/gearmanjob/sendfail.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanjob.sendfail" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanJob::sendFail</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanJob">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanJob::sendFail</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Sends failure status for this job, indicating that the job failed in a known way (as
@@ -44,7 +43,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanjob/sendstatus.xml
+++ b/reference/gearman/gearmanjob/sendstatus.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanjob.sendstatus" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanJob::sendStatus</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanJob">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanJob::sendStatus</methodname>
    <methodparam><type>int</type><parameter>numerator</parameter></methodparam>
    <methodparam><type>int</type><parameter>denominator</parameter></methodparam>
@@ -63,7 +62,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanjob/sendwarning.xml
+++ b/reference/gearman/gearmanjob/sendwarning.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanjob.sendwarning" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanJob::sendWarning</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanJob">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanJob::sendWarning</methodname>
    <methodparam><type>string</type><parameter>warning</parameter></methodparam>
   </methodsynopsis>
@@ -53,7 +52,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanjob/setreturn.xml
+++ b/reference/gearman/gearmanjob/setreturn.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanjob.setreturn" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanJob::setReturn</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanJob">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanJob::setReturn</methodname>
    <methodparam><type>int</type><parameter>gearman_return_t</parameter></methodparam>
   </methodsynopsis>
@@ -42,7 +41,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanjob/unique.xml
+++ b/reference/gearman/gearmanjob/unique.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An opaque unique identifier.
+   An opaque unique identifier, or &false; if the job has not yet been initialized.
   </para>
  </refsect1>
 

--- a/reference/gearman/gearmanjob/unique.xml
+++ b/reference/gearman/gearmanjob/unique.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanjob.unique" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanJob::unique</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>string</type><methodname>GearmanJob::unique</methodname>
-   <void />
+  <methodsynopsis role="GearmanJob">
+   <modifier>public</modifier> <type class="union"><type>false</type><type>string</type></type><methodname>GearmanJob::unique</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns the unique identifier for this job.  The identifier is assigned by the client.
@@ -41,7 +40,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanjob/workload.xml
+++ b/reference/gearman/gearmanjob/workload.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanjob.workload" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanJob::workload</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanJob">
    <modifier>public</modifier> <type>string</type><methodname>GearmanJob::workload</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Returns the workload for the job.  This is serialized data that is to be processed by the worker.
@@ -41,7 +40,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanjob/workloadsize.xml
+++ b/reference/gearman/gearmanjob/workloadsize.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanjob.workloadsize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanJob::workloadSize</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanJob">
    <modifier>public</modifier> <type>int</type><methodname>GearmanJob::workloadSize</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Returns the size of the job's work load (the data the worker is to process) in bytes.
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmantask.xml
+++ b/reference/gearman/gearmantask.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <phpdoc:classref xml:id="class.gearmantask" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>The GearmanTask class</title>
@@ -21,19 +20,18 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>GearmanTask</classname></ooclass>
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>GearmanTask</classname>
+    </ooclass>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>GearmanTask</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmantask')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmantask')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GearmanTask'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmantask')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GearmanTask'])">
+     <xi:fallback/>
+    </xi:include>
    </classsynopsis>
 <!-- }}} -->
 
@@ -44,7 +42,6 @@
  &reference.gearman.entities.gearmantask;
 
 </phpdoc:classref>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmantask/construct.xml
+++ b/reference/gearman/gearmantask/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmantask.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanTask::__construct</refname>
@@ -9,10 +8,10 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis role="GearmanTask">
    <modifier>public</modifier> <methodname>GearmanTask::__construct</methodname>
-   <void />
-  </methodsynopsis>
+   <void/>
+  </constructorsynopsis>
   <para>
    Creates a <classname>GearmanTask</classname> instance representing a task to be submitted to a job server.
   </para>
@@ -31,7 +30,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmantask/data.xml
+++ b/reference/gearman/gearmantask/data.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmantask.data" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanTask::data</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>string</type><methodname>GearmanTask::data</methodname>
-   <void />
+  <methodsynopsis role="GearmanTask">
+   <modifier>public</modifier> <type class="union"><type>false</type><type>string</type></type><methodname>GearmanTask::data</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns data being returned for a task by a worker.
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmantask/datasize.xml
+++ b/reference/gearman/gearmantask/datasize.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmantask.datasize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanTask::dataSize</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>int</type><methodname>GearmanTask::dataSize</methodname>
-   <void />
+  <methodsynopsis role="GearmanTask">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>GearmanTask::dataSize</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns the size of the data being returned for a task.
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmantask/functionname.xml
+++ b/reference/gearman/gearmantask/functionname.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmantask.functionname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanTask::functionName</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>string</type><methodname>GearmanTask::functionName</methodname>
-   <void />
+  <methodsynopsis role="GearmanTask">
+   <modifier>public</modifier> <type class="union"><type>false</type><type>string</type></type><methodname>GearmanTask::functionName</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns the name of the function this task is associated with, i.e., the function
@@ -32,7 +31,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmantask/functionname.xml
+++ b/reference/gearman/gearmantask/functionname.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   A function name.
+   A function name, or &false; if the task has not yet been created.
   </para>
  </refsect1>
 

--- a/reference/gearman/gearmantask/isknown.xml
+++ b/reference/gearman/gearmantask/isknown.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmantask.isknown" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanTask::isKnown</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanTask">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanTask::isKnown</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Gets the status information for whether or not this task is known to the job server.
@@ -31,7 +30,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmantask/isrunning.xml
+++ b/reference/gearman/gearmantask/isrunning.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmantask.isrunning" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanTask::isRunning</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanTask">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanTask::isRunning</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Indicates whether or not this task is currently running.
@@ -31,7 +30,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmantask/jobhandle.xml
+++ b/reference/gearman/gearmantask/jobhandle.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The opaque job handle.
+   The opaque job handle, or &false; if the task has not yet been created.
   </para>
  </refsect1>
 

--- a/reference/gearman/gearmantask/jobhandle.xml
+++ b/reference/gearman/gearmantask/jobhandle.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmantask.jobhandle" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanTask::jobHandle</refname>
@@ -10,10 +9,10 @@
 
  <refsect1 role="description">
   &reftitle.description;
-   <methodsynopsis>
-   <modifier>public</modifier> <type>string</type><methodname>GearmanTask::jobHandle</methodname>
-   <void />
-   </methodsynopsis>
+   <methodsynopsis role="GearmanTask">
+   <modifier>public</modifier> <type class="union"><type>false</type><type>string</type></type><methodname>GearmanTask::jobHandle</methodname>
+   <void/>
+  </methodsynopsis>
   <para>
    Returns the job handle for this task.
   </para>
@@ -41,7 +40,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmantask/recvdata.xml
+++ b/reference/gearman/gearmantask/recvdata.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmantask.recvdata" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanTask::recvData</refname>
@@ -9,8 +8,8 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>array</type><methodname>GearmanTask::recvData</methodname>
+  <methodsynopsis role="GearmanTask">
+   <modifier>public</modifier> <type class="union"><type>false</type><type>array</type></type><methodname>GearmanTask::recvData</methodname>
    <methodparam><type>int</type><parameter>data_len</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -52,7 +51,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmantask/returncode.xml
+++ b/reference/gearman/gearmantask/returncode.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmantask.returncode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanTask::returnCode</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanTask">
    <modifier>public</modifier> <type>int</type><methodname>GearmanTask::returnCode</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Returns the last Gearman return code for this task.
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmantask/sendworkload.xml
+++ b/reference/gearman/gearmantask/sendworkload.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmantask.sendworkload" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanTask::sendWorkload</refname>
@@ -9,8 +8,8 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>int</type><methodname>GearmanTask::sendWorkload</methodname>
+  <methodsynopsis role="GearmanTask">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>GearmanTask::sendWorkload</methodname>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -52,7 +51,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmantask/taskdenominator.xml
+++ b/reference/gearman/gearmantask/taskdenominator.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmantask.taskdenominator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanTask::taskDenominator</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>int</type><methodname>GearmanTask::taskDenominator</methodname>
-   <void />
+  <methodsynopsis role="GearmanTask">
+   <modifier>public</modifier> <type class="union"><type>false</type><type>int</type></type><methodname>GearmanTask::taskDenominator</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns the denominator of the percentage of the task that is complete expressed as a fraction.
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmantask/tasknumerator.xml
+++ b/reference/gearman/gearmantask/tasknumerator.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmantask.tasknumerator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanTask::taskNumerator</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>int</type><methodname>GearmanTask::taskNumerator</methodname>
-   <void />
+  <methodsynopsis role="GearmanTask">
+   <modifier>public</modifier> <type class="union"><type>false</type><type>int</type></type><methodname>GearmanTask::taskNumerator</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns the numerator of the percentage of the task that is complete expressed as a fraction.
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmantask/unique.xml
+++ b/reference/gearman/gearmantask/unique.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmantask.unique" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanTask::unique</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>string</type><methodname>GearmanTask::unique</methodname>
-   <void />
+  <methodsynopsis role="GearmanTask">
+   <modifier>public</modifier> <type class="union"><type>false</type><type>string</type></type><methodname>GearmanTask::unique</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns the unique identifier for this task.  This is assigned by the <classname>GearmanClient</classname>,
@@ -42,7 +41,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker.xml
+++ b/reference/gearman/gearmanworker.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <phpdoc:classref xml:id="class.gearmanworker" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>The GearmanWorker class</title>
@@ -21,19 +20,21 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>GearmanWorker</classname></ooclass>
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>GearmanWorker</classname>
+    </ooclass>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>GearmanWorker</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanworker')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanworker')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GearmanWorker'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanworker')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GearmanWorker'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanworker')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='GearmanWorker'])">
+     <xi:fallback/>
+    </xi:include>
    </classsynopsis>
 <!-- }}} -->
 
@@ -44,7 +45,6 @@
  &reference.gearman.entities.gearmanworker;
 
 </phpdoc:classref>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker.xml
+++ b/reference/gearman/gearmanworker.xml
@@ -32,9 +32,6 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanworker')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GearmanWorker'])">
      <xi:fallback/>
     </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanworker')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='GearmanWorker'])">
-     <xi:fallback/>
-    </xi:include>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/gearman/gearmanworker/addfunction.xml
+++ b/reference/gearman/gearmanworker/addfunction.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.addfunction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::addFunction</refname>
@@ -9,12 +8,12 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanWorker">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanWorker::addFunction</methodname>
    <methodparam><type>string</type><parameter>function_name</parameter></methodparam>
    <methodparam><type>callable</type><parameter>function</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter role="reference">context</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>timeout</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>context</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>timeout</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
    Registers a function name with the job server and specifies a callback corresponding to that
@@ -127,7 +126,6 @@ function reverse_cb($job, &$count)
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker/addoptions.xml
+++ b/reference/gearman/gearmanworker/addoptions.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Always returns &true;.
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/gearman/gearmanworker/addoptions.xml
+++ b/reference/gearman/gearmanworker/addoptions.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.addoptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::addOptions</refname>
@@ -9,8 +8,8 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>bool</type><methodname>GearmanWorker::addOptions</methodname>
+  <methodsynopsis role="GearmanWorker">
+   <modifier>public</modifier> <type>true</type><methodname>GearmanWorker::addOptions</methodname>
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -53,7 +52,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker/addserver.xml
+++ b/reference/gearman/gearmanworker/addserver.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.addserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::addServer</refname>
@@ -9,10 +8,11 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanWorker">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanWorker::addServer</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>host</parameter><initializer>127.0.0.1</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>port</parameter><initializer>4730</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>host</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>port</parameter><initializer>0</initializer></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>setupExceptionHandler</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Adds a job server to this worker.  This goes into a list of servers than can be used to run jobs.
@@ -79,7 +79,6 @@ $worker->addServer("10.0.0.2", 7003);
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker/addservers.xml
+++ b/reference/gearman/gearmanworker/addservers.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.addservers" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::addServers</refname>
@@ -9,9 +8,10 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanWorker">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanWorker::addServers</methodname>
-   <methodparam><type>string</type><parameter>servers</parameter><initializer>127.0.0.1:4730</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>servers</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>setupExceptionHandler</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Adds one or more job servers to this worker.  These go into a list of servers that can be used
@@ -72,7 +72,6 @@ $worker->addServers("10.0.0.1,10.0.0.2:7003");
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker/construct.xml
+++ b/reference/gearman/gearmanworker/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::__construct</refname>
@@ -9,10 +8,10 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis role="GearmanWorker">
    <modifier>public</modifier> <methodname>GearmanWorker::__construct</methodname>
-   <void />
-  </methodsynopsis>
+   <void/>
+  </constructorsynopsis>
   <para>
    Creates a <classname>GearmanWorker</classname> instance representing a worker that connects to the job server and accepts tasks to run.
   </para>
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker/error.xml
+++ b/reference/gearman/gearmanworker/error.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.error" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::error</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>string</type><methodname>GearmanWorker::error</methodname>
-   <void />
+  <methodsynopsis role="GearmanWorker">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>GearmanWorker::error</methodname>
+   <void/>
   </methodsynopsis>
   <para>
    Returns an error string for the last error encountered.
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker/error.xml
+++ b/reference/gearman/gearmanworker/error.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An error string.
+   A human readable error string, or &false; if there is no error message available.
   </para>
  </refsect1>
 

--- a/reference/gearman/gearmanworker/geterrno.xml
+++ b/reference/gearman/gearmanworker/geterrno.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.geterrno" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::getErrno</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanWorker">
    <modifier>public</modifier> <type>int</type><methodname>GearmanWorker::getErrno</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Returns the value of errno in the case of a GEARMAN_ERRNO return value.
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker/options.xml
+++ b/reference/gearman/gearmanworker/options.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.options" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::options</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanWorker">
    <modifier>public</modifier> <type>int</type><methodname>GearmanWorker::options</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Gets the options previously set for the worker.
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker/register.xml
+++ b/reference/gearman/gearmanworker/register.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.register" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::register</refname>
@@ -9,10 +8,10 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanWorker">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanWorker::register</methodname>
    <methodparam><type>string</type><parameter>function_name</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>timeout</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>timeout</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
    Registers a function name with the job server with an optional timeout.  The timeout
@@ -63,7 +62,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker/removeoptions.xml
+++ b/reference/gearman/gearmanworker/removeoptions.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Always returns &true;.
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/gearman/gearmanworker/removeoptions.xml
+++ b/reference/gearman/gearmanworker/removeoptions.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.removeoptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::removeOptions</refname>
@@ -9,8 +8,8 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>bool</type><methodname>GearmanWorker::removeOptions</methodname>
+  <methodsynopsis role="GearmanWorker">
+   <modifier>public</modifier> <type>true</type><methodname>GearmanWorker::removeOptions</methodname>
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -53,7 +52,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker/returncode.xml
+++ b/reference/gearman/gearmanworker/returncode.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.returncode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::returnCode</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanWorker">
    <modifier>public</modifier> <type>int</type><methodname>GearmanWorker::returnCode</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Returns the last Gearman return code.
@@ -41,7 +40,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker/setid.xml
+++ b/reference/gearman/gearmanworker/setid.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.setid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::setId</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanWorker">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanWorker::setId</methodname>
    <methodparam><type>string</type><parameter>id</parameter></methodparam>
   </methodsynopsis>
@@ -69,7 +68,6 @@ Output:
 
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker/setoptions.xml
+++ b/reference/gearman/gearmanworker/setoptions.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Always returns &true;.
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/gearman/gearmanworker/setoptions.xml
+++ b/reference/gearman/gearmanworker/setoptions.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.setoptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::setOptions</refname>
@@ -9,8 +8,8 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>bool</type><methodname>GearmanWorker::setOptions</methodname>
+  <methodsynopsis role="GearmanWorker">
+   <modifier>public</modifier> <type>true</type><methodname>GearmanWorker::setOptions</methodname>
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -54,7 +53,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker/settimeout.xml
+++ b/reference/gearman/gearmanworker/settimeout.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Always returns &true;.
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/gearman/gearmanworker/settimeout.xml
+++ b/reference/gearman/gearmanworker/settimeout.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.settimeout" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::setTimeout</refname>
@@ -9,8 +8,8 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>bool</type><methodname>GearmanWorker::setTimeout</methodname>
+  <methodsynopsis role="GearmanWorker">
+   <modifier>public</modifier> <type>true</type><methodname>GearmanWorker::setTimeout</methodname>
    <methodparam><type>int</type><parameter>timeout</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -117,7 +116,6 @@ Timeout. Waiting for next job...
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker/timeout.xml
+++ b/reference/gearman/gearmanworker/timeout.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.timeout" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::timeout</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanWorker">
    <modifier>public</modifier> <type>int</type><methodname>GearmanWorker::timeout</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Returns the current time to wait, in milliseconds, for socket I/O activity.
@@ -40,7 +39,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker/unregister.xml
+++ b/reference/gearman/gearmanworker/unregister.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.unregister" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::unregister</refname>
@@ -9,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanWorker">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanWorker::unregister</methodname>
    <methodparam><type>string</type><parameter>function_name</parameter></methodparam>
   </methodsynopsis>
@@ -53,7 +52,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker/unregisterall.xml
+++ b/reference/gearman/gearmanworker/unregisterall.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.unregisterall" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::unregisterAll</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanWorker">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanWorker::unregisterAll</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Unregisters all previously registered functions, ensuring that no more jobs are
@@ -42,7 +41,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker/wait.xml
+++ b/reference/gearman/gearmanworker/wait.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.wait" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::wait</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanWorker">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanWorker::wait</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Causes the worker to wait for activity from one of the Gearman job servers when operating
@@ -102,7 +101,6 @@ function reverse_fn($job)
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gearman/gearmanworker/work.xml
+++ b/reference/gearman/gearmanworker/work.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="gearmanworker.work" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanWorker::work</refname>
@@ -9,9 +8,9 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="GearmanWorker">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanWorker::work</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Waits for a job to be assigned and then calls the appropriate callback function.
@@ -76,7 +75,6 @@ function my_reverse_function($job)
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
Fixes #2859 
See also [php/pecl-networking-gearman PR#24](https://github.com/php/pecl-networking-gearman/pull/24)

Regenerated gearman doc based on PR#24 in pecl-networking-gearman to fix some return types in PHP manual pages. I ran exactly this command with the PR cloned:

`../php-src/build/gen_stub.php --replace-methodsynopses ../path/to/pecl-networking-gearman/ reference/gearman/`

@Girgias 