### PR TITLE
assert: Rewrite examples

### DIFF
--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -311,94 +311,95 @@
   <refsect2>
    <title>Expectations</title>
    <example>
+    <title><function>assert</function> example</title>
     <programlisting role="php">
 <![CDATA[
 <?php
-assert(true == false);
+assert(1 > 2);
 echo 'Hi!';
-?>
 ]]>
     </programlisting>
     <para>
-     With <link linkend="ini.zend.assertions">zend.assertions</link> set to 0,
+     If assertions are enabled (<link linkend="ini.zend.assertions"><literal>zend.assertions=1</literal></link>)
      the above example will output:
     </para>
     <screen>
 <![CDATA[
-Hi!
-]]>
-    </screen>
-    <para>
-     With <link linkend="ini.zend.assertions">zend.assertions</link> set to 1
-     and <link linkend="ini.assert.exception">assert.exception</link> set to 0,
-     the above example will output:
-    </para>
-    <screen>
-<![CDATA[
-Warning: assert(): assert(true == false) failed in - on line 2
-Hi!
-]]>
-    </screen>
-    <para>
-     With <link linkend="ini.zend.assertions">zend.assertions</link> set to 1
-     and <link linkend="ini.assert.exception">assert.exception</link> set to 1,
-     the above example will output:
-    </para>
-    <screen>
-<![CDATA[
-Fatal error: Uncaught AssertionError: assert(true == false) in -:2
+Fatal error: Uncaught AssertionError: assert(1 > 2) in example.php:2
 Stack trace:
-#0 -(2): assert(false, 'assert(true == ...')
+#0 example.php(2): assert(false, 'assert(1 > 2)')
 #1 {main}
-  thrown in - on line 2
+  thrown in example.php on line 2
+]]>
+    </screen>
+    <para>
+     If assertions are disabled (<literal>zend.assertions=0</literal> or <literal>zend.assertions=-1</literal>)
+     the above example will output:
+    </para>
+    <screen>
+<![CDATA[
+Hi!
 ]]>
     </screen>
    </example>
    <example>
-    <title>Expectations with a custom exception</title>
+    <title>Using a custom message</title>
     <programlisting role="php">
 <![CDATA[
 <?php
-class CustomError extends AssertionError {}
-
-assert(true == false, new CustomError('True is not false!'));
+assert(1 > 2, "Expected one to be greater than two");
 echo 'Hi!';
-?>
 ]]>
     </programlisting>
     <para>
-     With <link linkend="ini.zend.assertions">zend.assertions</link> set to 0,
-     the above example will output:
+     If assertions are enabled the above example will output:
     </para>
     <screen>
 <![CDATA[
-Hi!
-]]>
-    </screen>
-    <para>
-     With <link linkend="ini.zend.assertions">zend.assertions</link> set to 1
-     and <link linkend="ini.assert.exception">assert.exception</link> set to 0,
-     the above example will output:
-    </para>
-    <screen>
-<![CDATA[
-Warning: assert(): CustomError: True is not false! in -:4
+Fatal error: Uncaught AssertionError: Expected one to be greater than two in example.php:2
 Stack trace:
-#0 {main} failed in - on line 4
-Hi!
+#0 example.php(2): assert(false, 'Expected one to...')
+#1 {main}
+  thrown in example.php on line 2
 ]]>
     </screen>
     <para>
-     With <link linkend="ini.zend.assertions">zend.assertions</link> set to 1
-     and <link linkend="ini.assert.exception">assert.exception</link> set to 1,
-     the above example will output:
+     If assertions are disabled the above example will output:
     </para>
     <screen>
 <![CDATA[
-Fatal error: Uncaught CustomError: True is not false! in -:4
+Hi!
+]]>
+    </screen>
+   </example>
+   <example>
+    <title>Using a custom exception class</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+class ArithmeticAssertionError extends AssertionError {}
+
+assert(1 > 2, new ArithmeticAssertionError("Expected one to be greater than two"));
+echo 'Hi!';
+]]>
+    </programlisting>
+    <para>
+     If assertions are enabled the above example will output:
+    </para>
+    <screen>
+<![CDATA[
+Fatal error: Uncaught ArithmeticAssertionError: Expected one to be greater than two in example.php:4
 Stack trace:
 #0 {main}
-  thrown in - on line 4
+  thrown in example.php on line 4
+]]>
+    </screen>
+    <para>
+     If assertions are disabled the above example will output:
+    </para>
+    <screen>
+<![CDATA[
+Hi!
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
- Drop the assert.exception=0 case, because that is deprecated.
- Showcase the output for enabled assertions first.
- Add example with a custom message