### PR TITLE
assert: Drop examples for legacy string-based assertions

### DIFF
--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -308,8 +308,6 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <refsect2>
-   <title>Expectations</title>
    <example>
     <programlisting role="php">
 <![CDATA[
@@ -402,115 +400,6 @@ Stack trace:
 ]]>
     </screen>
    </example>
-  </refsect2>
-  <refsect2>
-   <title>Evaluated code assertions (PHP 7 only)</title>
-
-   <para>
-    With evaluated code assertions, <function>assert</function> callbacks
-    can be particularly useful as the code used for the assertion is passed
-    to the callback alongside information on where the assertion was done.
-   </para>
-   <para>
-    <example>
-     <title>Handle a failed assertion with a custom handler</title>
-     <programlisting role="php">
-<![CDATA[
-<?php
-// Activate assert and make it quiet
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 0);
-assert_options(ASSERT_QUIET_EVAL, 1);
-
-// Create a handler function
-function my_assert_handler($file, $line, $code)
-{
-    echo "<hr>Assertion Failed:
-        File '$file'<br />
-        Line '$line'<br />
-        Code '$code'<br /><hr />";
-}
-
-// Set up the callback
-assert_options(ASSERT_CALLBACK, 'my_assert_handler');
-
-// Make an assertion that should fail
-$array = [];
-assert('count($array);');
-?>
-]]>
-     </programlisting>
-     &example.outputs.72;
-     <screen>
-<![CDATA[
-Deprecated: assert(): Calling assert() with a string argument is deprecated in test.php on line 21
-<hr>Assertion Failed:
-        File 'test.php'<br />
-        Line '21'<br />
-        Code 'count($array);'<br /><hr />
-]]>
-     </screen>
-     &example.outputs.71;
-     <screen>
-<![CDATA[
-<hr>Assertion Failed:
-        File 'test.php'<br />
-        Line '21'<br />
-        Code 'count($array);'<br /><hr />
-]]>
-     </screen>
-    </example>
-   </para>
-   <para>
-    <example>
-     <title>Using a custom handler to print a description</title>
-     <programlisting role="php">
-<![CDATA[
-<?php
-// Activate assert and make it quiet
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 0);
-assert_options(ASSERT_QUIET_EVAL, 1);
-
-// Create a handler function
-function my_assert_handler($file, $line, $code, $desc = null)
-{
-    echo "Assertion failed at $file:$line: $code";
-    if ($desc) {
-        echo ": $desc";
-    }
-    echo "\n";
-}
-
-// Set up the callback
-assert_options(ASSERT_CALLBACK, 'my_assert_handler');
-
-// Make an assertion that should fail
-assert('2 < 1');
-assert('2 < 1', 'Two is less than one');
-?>
-]]>
-     </programlisting>
-     &example.outputs.72;
-     <screen>
-<![CDATA[
-Deprecated: assert(): Calling assert() with a string argument is deprecated in test.php on line 21
-Assertion failed at test.php:21: 2 < 1
-
-Deprecated: assert(): Calling assert() with a string argument is deprecated in test.php on line 22
-Assertion failed at test.php:22: 2 < 1: Two is less than one
-]]>
-     </screen>
-     &example.outputs.71;
-     <screen>
-<![CDATA[
-Assertion failed at test.php:21: 2 < 1
-Assertion failed at test.php:22: 2 < 1: Two is less than one
-]]>
-     </screen>
-    </example>
-   </para>
-  </refsect2>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
They are no longer supported as of PHP 8 and only serve to cause confusion for a feature that is already complex enough by itself.

In fact the examples will silently misbehave in PHP 8, because a non-empty string is truthy and no warning is emitted.