### PR TITLE
assert: Fix return value explanation

### DIFF
--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -237,7 +237,7 @@
    <member>A custom exception object is passed to <parameter>description</parameter>.</member>
   </simplelist>
   <para>
-   If none of the conditions is true <function>assert</function> will return &true; if
+   If none of the conditions are true <function>assert</function> will return &true; if
    <parameter>assertion</parameter> is truthy and &false; otherwise.
   </para>
  </refsect1>

--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -227,7 +227,18 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &false; if <parameter>assertion</parameter> is false, &true; otherwise.
+   <function>assert</function> will always return &true; if at least one of the following is true:
+  </para>
+  <simplelist>
+   <member><literal>zend.assertions=0</literal></member>
+   <member><literal>zend.assertions=-1</literal></member>
+   <member><literal>assert.exception=1</literal></member>
+   <member><literal>assert.bail=1</literal></member>
+   <member>A custom exception object is passed to <parameter>description</parameter>.</member>
+  </simplelist>
+  <para>
+   If none of the conditions is true <function>assert</function> will return &true; if
+   <parameter>assertion</parameter> is truthy and &false; otherwise.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Specifically `assert()` will always return `true` if assertions are disabled. Ideally the return value would never be used anyway …