### PR TITLE
Drop usage of phd:args XML attribute usage

### DIFF
--- a/reference/mysql/functions/mysql-fetch-assoc.xml
+++ b/reference/mysql/functions/mysql-fetch-assoc.xml
@@ -11,7 +11,10 @@
    &mysql.alternative.note;
    <simplelist role="alternatives">
     <member><function>mysqli_fetch_assoc</function></member>
-    <member><methodname phd:args="PDO::FETCH_ASSOC">PDOStatement::fetch</methodname></member>
+    <member>
+     <methodname>PDOStatement::fetch</methodname>
+     with <parameter>mode</parameter> as <constant>PDO::FETCH_ASSOC</constant>
+    </member>
    </simplelist>
   </warning>
  </refsynopsisdiv>

--- a/reference/mysql/functions/mysql-fetch-object.xml
+++ b/reference/mysql/functions/mysql-fetch-object.xml
@@ -11,7 +11,10 @@
    &mysql.alternative.note;
    <simplelist role="alternatives">
     <member><function>mysqli_fetch_object</function></member>
-    <member><methodname phd:args="PDO::FETCH_OBJ">PDOStatement::fetch</methodname></member>
+    <member>
+     <methodname>PDOStatement::fetch</methodname>
+     with <parameter>mode</parameter> as <constant>PDO::FETCH_OBJ</constant>
+    </member>
    </simplelist>
   </warning>
  </refsynopsisdiv>

--- a/reference/mysql/functions/mysql-fetch-row.xml
+++ b/reference/mysql/functions/mysql-fetch-row.xml
@@ -11,7 +11,10 @@
    &mysql.alternative.note;
    <simplelist role="alternatives">
     <member><function>mysqli_fetch_row</function></member>
-    <member><methodname phd:args="PDO::FETCH_NUM">PDOStatement::fetch</methodname></member>
+    <member>
+     <methodname>PDOStatement::fetch</methodname>
+     with <parameter>mode</parameter> as <constant>PDO::FETCH_NUM</constant>
+    </member>
    </simplelist>
   </warning>
  </refsynopsisdiv>

--- a/reference/mysql/functions/mysql-get-client-info.xml
+++ b/reference/mysql/functions/mysql-get-client-info.xml
@@ -11,7 +11,10 @@
    &mysql.alternative.note;
    <simplelist role="alternatives">
     <member><function>mysqli_get_client_info</function></member>
-    <member><methodname phd:args="PDO::ATTR_CLIENT_VERSION">PDO::getAttribute</methodname></member>
+    <member>
+     <methodname>PDO::getAttribute</methodname>
+     with <parameter>attribute</parameter> as <constant>PDO::ATTR_CLIENT_VERSION</constant>
+    </member>
    </simplelist>
   </warning>
  </refsynopsisdiv>

--- a/reference/mysql/functions/mysql-get-host-info.xml
+++ b/reference/mysql/functions/mysql-get-host-info.xml
@@ -11,7 +11,10 @@
    &mysql.alternative.note;
    <simplelist role="alternatives">
     <member><function>mysqli_get_host_info</function></member>
-    <member><methodname phd:args="PDO::ATTR_CONNECTION_STATUS">PDO::getAttribute</methodname></member>
+    <member>
+     <methodname>PDO::getAttribute</methodname>
+     with <parameter>attribute</parameter> as <constant>PDO::ATTR_CONNECTION_STATUS</constant>
+    </member>
    </simplelist>
   </warning>
  </refsynopsisdiv>

--- a/reference/mysql/functions/mysql-get-server-info.xml
+++ b/reference/mysql/functions/mysql-get-server-info.xml
@@ -11,7 +11,10 @@
    &mysql.alternative.note;
    <simplelist role="alternatives">
     <member><function>mysqli_get_server_info</function></member>
-    <member><methodname phd:args="PDO::ATTR_SERVER_VERSION">PDO::getAttribute</methodname></member>
+    <member>
+     <methodname>PDO::getAttribute</methodname>
+     with <parameter>attribute</parameter> as <constant>PDO::ATTR_SERVER_VERSION</constant>
+    </member>
    </simplelist>
   </warning>
  </refsynopsisdiv>

--- a/reference/mysql/functions/mysql-stat.xml
+++ b/reference/mysql/functions/mysql-stat.xml
@@ -11,7 +11,10 @@
    &mysql.alternative.note;
    <simplelist role="alternatives">
     <member><function>mysqli_stat</function></member>
-    <member><methodname phd:args="PDO::ATTR_SERVER_INFO">PDO::getAttribute</methodname></member>
+    <member>
+     <methodname>PDO::getAttribute</methodname>
+     with <parameter>attribute</parameter> as <constant>PDO::ATTR_SERVER_INFO</constant>
+    </member>
    </simplelist>
   </warning>
  </refsynopsisdiv>


### PR DESCRIPTION
This is to make the documentation more comformant to the Docbook standard