### PR TITLE
docs: fix constants names U_MULTIPLE_DECIMAL_SEP*

### DIFF
--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -57,9 +57,9 @@
   <title>Intl</title>
 
   <para>
-   The <constant>U_MULTIPLE_DECIMAL_SEP*E*RATORS</constant>
+   The <constant>U_MULTIPLE_DECIMAL_SEPERATORS</constant>
    constant had been deprecated, using the
-   <constant>U_MULTIPLE_DECIMAL_SEP*A*RATORS</constant>
+   <constant>U_MULTIPLE_DECIMAL_SEPARATORS</constant>
    constant instead is recommended.
   </para>
   <para>


### PR DESCRIPTION
Hello,

I was translating the documentation and came across these constants.

Was it intentional to use *E* and *A* to show the small change in name?

For me it was more confusing than if it was written correctly.

Just in case, I uploaded this MR to check whether it was intentional or not.

If it was and is maintained, just ignore it.

https://github.com/php/php-src/blob/221b4fe246e62c5d59f617ee4cbe6fd4c614fb5a/ext/intl/common/common_arginfo.h#L117