### PR TITLE
assert: Remove “not recommended” reference to `assert_options()`

### DIFF
--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -149,9 +149,6 @@
      </tbody>
     </tgroup>
    </table>
-
-   The options starting with <literal>assert.</literal> can be configured via
-   <function>assert_options</function>. However, this is not recommended.
   </para>
  </refsect1>
 


### PR DESCRIPTION
The reference itself says that this is not recommended and `assert_options()` itself is deprecated in PHP 8.3. Remove the reference to slim down the docs.