### PR TITLE
function.arguments: Remove explanation of legacy variadics

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -478,17 +478,6 @@ Making a bowl of raspberry natural yogurt.
      user-defined functions by using the
      <literal>...</literal> token.
     </simpara>
-    
-    <note>
-     <simpara>
-      It is also possible to achieve variable-length arguments by using
-      <function>func_num_args</function>,
-      <function>func_get_arg</function>, and
-      <function>func_get_args</function> functions.
-      This technique is not recommended as it was used prior to the introduction
-      of the <literal>...</literal> token.
-     </simpara>
-    </note>
 
     <para>
      Argument lists may include the
@@ -604,46 +593,6 @@ Catchable fatal error: Argument 2 passed to total_intervals() must be an instanc
      prefixing the <literal>...</literal> with an ampersand
      (<literal>&amp;</literal>).
     </para>
-
-    <sect3 xml:id="functions.variable-arg-list.old">
-     <title>Older versions of PHP</title>
-
-     <para>
-      No special syntax is required to note that a function is variadic;
-      however access to the function's arguments must use
-      <function>func_num_args</function>, <function>func_get_arg</function>
-      and <function>func_get_args</function>.
-     </para>
-
-     <para>
-      The first example above would be implemented as follows in old versions of PHP:
-
-      <example>
-       <title>Accessing variable arguments in old PHP versions</title>
-       <programlisting role="php">
-<![CDATA[
-<?php
-function sum() {
-    $acc = 0;
-    foreach (func_get_args() as $n) {
-        $acc += $n;
-    }
-    return $acc;
-}
-
-echo sum(1, 2, 3, 4);
-?>
-]]>
-       </programlisting>
-       &example.outputs;
-       <screen>
-<![CDATA[
-10
-]]>
-       </screen>
-      </example>
-     </para>
-    </sect3>
 
    </sect2>
 


### PR DESCRIPTION
Proper variadics were introduced in PHP 5.6, legacy variadics are explicitly noted as “not recommended”. Remove the examples from this part of the documentation, which effectively is starter documentation.

Folks that see the legacy variadics being used in legacy code can simply refer to the reference manual for the respective functions to understand how they work.

In fact the documentation caused some confusion as per #2875.