### PR TITLE
assert: Remove note about it being a language construct

### DIFF
--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -14,8 +14,8 @@
    <methodparam choice="opt"><type class="union"><type>Throwable</type><type>string</type><type>null</type></type><parameter>description</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>assert</function> is not a function but a language construct.
-   allowing for the definition of expectations: assertions that take effect
+   <function>assert</function>
+   allows for the definition of expectations: assertions that take effect
    in development and testing environments, but are optimised away to have
    zero cost in production.
   </para>


### PR DESCRIPTION
`assert()` behaves like a regular function for all intents and purposes. It can even be used as a string callable. The only special thing about is that the `$description`'s default parameter is dynamic.