### PR TITLE
Add `IMAGETYPE_AVIF` constant to documentation

### DIFF
--- a/reference/exif/functions/exif-imagetype.xml
+++ b/reference/exif/functions/exif-imagetype.xml
@@ -133,6 +133,10 @@
         <entry>18</entry>
         <entry><constant>IMAGETYPE_WEBP</constant></entry>
        </row>
+       <row>
+        <entry>19</entry>
+        <entry><constant>IMAGETYPE_AVIF</constant></entry>
+       </row>
       </tbody>
      </tgroup>     
     </table>       
@@ -165,6 +169,12 @@
         <entry>7.1.0</entry>
         <entry>
          Added WebP support.
+        </entry>
+       </row>
+       <row>
+        <entry>8.1.0</entry>
+        <entry>
+         Added AVIF support.
         </entry>
        </row>
       </tbody>

--- a/reference/image/functions/image-type-to-mime-type.xml
+++ b/reference/image/functions/image-type-to-mime-type.xml
@@ -117,9 +117,13 @@
        <entry><constant>IMAGETYPE_ICO</constant></entry>
        <entry><literal>image/vnd.microsoft.icon</literal></entry>
       </row>
-       <row>
+      <row>
        <entry><constant>IMAGETYPE_WEBP</constant></entry>
        <entry><literal>image/webp</literal></entry>
+      </row>
+      <row>
+       <entry><constant>IMAGETYPE_AVIF</constant></entry>
+       <entry><literal>image/avif</literal></entry>
       </row>
      </tbody>
     </tgroup>


### PR DESCRIPTION
This constant is introduced with PHP 8.1 and is not documented yet.

For reference: php/doc-de#163