### PR TITLE
Improve clarity of igbinary_serialize() documentation

### DIFF
--- a/reference/igbinary/functions/igbinary-serialize.xml
+++ b/reference/igbinary/functions/igbinary-serialize.xml
@@ -33,7 +33,7 @@
       <para>
        The value to be serialized. <function>igbinary_serialize</function>
        handles all types, except the <type>resource</type>-type and some <type>object</type>s (see note below).
-       Even &array;s that contain references to itself can be <function>igbinary_serialize</function>d.
+       Even &array;s that contain references to itself can be processed by <function>igbinary_serialize</function>.
        Circular references inside the &array; or &object; that is being serializend will also be stored.
        Any other reference will be lost.
       </para>


### PR DESCRIPTION
The current description renders oddly and somewhat looks like a typo, I rephrased it to make it less of a stumbler.