### PR TITLE
Update boolean.xml

### DIFF
--- a/language/types/boolean.xml
+++ b/language/types/boolean.xml
@@ -19,7 +19,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$foo = True; // assign the value TRUE to $foo
+$foo = true; // assign the value TRUE to $foo
 ?>
 ]]>
    </programlisting>


### PR DESCRIPTION
A typo fixed.
```php
<?php
$foo = True; // assign the value TRUE to $foo
?>
```
It seems to me a typo occurred here.
It should be:–
```php
<?php
$foo = true; // assign the value TRUE to $foo
?>
```
As the [Manual](https://www.php.net/manual/en/language.types.boolean.php) suggests `true` and `false` are case-sensitive