### PR TITLE
Followed PHP-8.3 changes about IntlDateFormatter::construct exception

### DIFF
--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -203,6 +203,11 @@
     <methodname>IntlChar::enumCharNames</methodname> is now returning a boolean.
     Previously it returned &null; on success and &false; on failure.
    </para>
+
+   <para>
+    <methodname>IntlDateFormatter::construct</methodname> throws an <constant>U_ILLEGAL_ARGUMENT_ERROR</constant>
+    exception when an invalid locale had been set.
+   </para>
   </sect3>
 
   <sect3 xml:id="migration83.other-changes.functions.mbstring">


### PR DESCRIPTION
refs: https://github.com/php/php-src/commit/d4183c2c91ccbbf2d561e7839503ca6dfd471916