### PR TITLE
Add note about __get() & __set() being called on unset object properties

### DIFF
--- a/reference/var/functions/unset.xml
+++ b/reference/var/functions/unset.xml
@@ -239,7 +239,7 @@ string(6) "Felipe"
   &note.language-construct;
   <note>
    <para>
-    It is possible to unset object properties visible in the current context. 
+    It is possible to unset object properties visible in the current context.
    </para>
    <para>
      If declared,

--- a/reference/var/functions/unset.xml
+++ b/reference/var/functions/unset.xml
@@ -239,7 +239,10 @@ string(6) "Felipe"
   &note.language-construct;
   <note>
    <para>
-    It is possible to unset even object properties visible in current context.
+    It is possible to unset object properties visible in the current context. 
+   </para>
+   <para>
+     If declared, <link linkend="object.get">__get()</link> is called when accessing an unset property, and <link linkend="object.set">__set()</link> is called when setting an unset property.
    </para>
   </note>
   <note>

--- a/reference/var/functions/unset.xml
+++ b/reference/var/functions/unset.xml
@@ -242,7 +242,11 @@ string(6) "Felipe"
     It is possible to unset object properties visible in the current context. 
    </para>
    <para>
-     If declared, <link linkend="object.get">__get()</link> is called when accessing an unset property, and <link linkend="object.set">__set()</link> is called when setting an unset property.
+     If declared,
+     <link linkend="object.get">__get()</link>
+     is called when accessing an unset property, and
+     <link linkend="object.set">__set()</link>
+     is called when setting an unset property.
    </para>
   </note>
   <note>


### PR DESCRIPTION
If I `unset($this->property)`, and `__get()` is declared, then `$this->__get()` is called when accessing `$this->property`

If I `unset($this->property`, and `__set()` is declared, then `$this->__set()` is called when setting `$this->property`

Tested in php 8.2

This functionality was not clearly documented, and I did not expect this behavior, so I added a note describing this.

I also updated the existing note with slightly different language, because I think it reads better.

I think I did the `<link>` bits correctly, but idk.