### PR TITLE
add link to multibyte version of str_pad

### DIFF
--- a/reference/strings/functions/str-pad.xml
+++ b/reference/strings/functions/str-pad.xml
@@ -106,6 +106,15 @@ echo str_pad($input,  3, "*");                 // produces "Alien"
   </para>
  </refsect1>
 
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>mb_str_pad</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
`mb_str_pad` is a new function added in PHP 8.3, so I added a link in `str_pad` page.