### PR TITLE
Correct LDAP paging example

### DIFF
--- a/reference/ldap/examples.xml
+++ b/reference/ldap/examples.xml
@@ -198,7 +198,7 @@ do {
         $cookie = '';
     }
     // Empty cookie means last page
-} while (!empty($cookie));
+} while (strlen($cookie) > 0);
 ?>
 ]]>
    </programlisting>


### PR DESCRIPTION
As I've noted below the documentation, `empty('0')` is true in PHP, but `$cookie` is an opaque string and can legitimately be `'0'` (e.g. python-ldapserver returns this for the first response to every query).

I think `strlen` should work in all the same places, and also for `'0'`.