### PR TITLE
[PHP 8.3] The NumberFormatter::TYPE_CURRENCY constant has been deprecated.

### DIFF
--- a/reference/intl/numberformatter-constants.xml
+++ b/reference/intl/numberformatter-constants.xml
@@ -174,7 +174,7 @@
       <constant>NumberFormatter::TYPE_CURRENCY</constant>
      </term>
      <listitem>
-      <simpara>Format/parse as currency value</simpara>
+      <simpara>Format/parse as currency value. Deprecated as of PHP 8.3.0</simpara>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
refs: https://www.php.net/manual/en/migration83.deprecated.php#migration83.deprecated.intl