### PR TITLE
[PHP 8.3] Removed opcache.consistency_checks INI directive

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -129,7 +129,7 @@
       <entry><link linkend="ini.opcache.consistency-checks">opcache.consistency_checks</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_ALL</entry>
-      <entry>Disabled since 8.1.18 and 8.2.5. Removed as of PHP 8.3.0.</entry>
+      <entry>Disabled as of 8.1.18 and 8.2.5. Removed as of PHP 8.3.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.force-restart-timeout">opcache.force_restart_timeout</link></entry>

--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -129,7 +129,7 @@
       <entry><link linkend="ini.opcache.consistency-checks">opcache.consistency_checks</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_ALL</entry>
-      <entry></entry>
+      <entry>Disabled since 8.1.18 and 8.2.5. Removed as of PHP 8.3.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.force-restart-timeout">opcache.force_restart_timeout</link></entry>
@@ -665,6 +665,11 @@
       where N is the value of this configuration directive. This should only
       be enabled when debugging, as it will impair performance.
      </para>
+     <note>
+      <para>
+       Disabled as of 8.1.18 and 8.2.5. Removed as of PHP 8.3.0.
+      </para>
+     </note>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="ini.opcache.force-restart-timeout">


### PR DESCRIPTION
refs: https://www.php.net/manual/en/migration83.incompatible.php#migration83.incompatible.opcache