### PR TITLE
[PHP 8.3] Calling Phar::setStub() with a resource and a $length is now deprecated.

### DIFF
--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -92,7 +92,7 @@
 
   <para>
    Calling <methodname>Phar::setStub</methodname> with a
-   <parameter>$resource</parameter> and a <parameter>$length</parameter>
+   <type>resource</type> and a <parameter>$length</parameter>
    is now deprecated. Such calls should be replaced by:
    <code>$phar->setStub(stream_get_contents($resource));</code>
   </para>

--- a/reference/phar/Phar/setStub.xml
+++ b/reference/phar/Phar/setStub.xml
@@ -9,8 +9,8 @@
   &reftitle.description;
   <methodsynopsis role="Phar">
    <modifier>public</modifier> <type>bool</type><methodname>Phar::setStub</methodname>
-   <methodparam><type>string</type><parameter>stub</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>len</parameter><initializer>-1</initializer></methodparam>
+   <methodparam><type class="union"><type>resource</type><type>string</type></type><parameter>stub</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
   &phar.write;
 
@@ -58,7 +58,7 @@ include 'phar://myphar.phar/somefile.php';
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>len</parameter></term>
+     <term><parameter>length</parameter></term>
      <listitem>
       <para>
        
@@ -85,6 +85,31 @@ include 'phar://myphar.phar/somefile.php';
    <classname>PharException</classname> is thrown if any problems are encountered
    flushing changes to disk.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       Calling <methodname>Phar::setStub</methodname> with a
+       <type>resource</type> and a <parameter>length</parameter>
+       is now deprecated. Such calls should be replaced by:
+       <code>$phar->setStub(stream_get_contents($resource));</code>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
based on [Other Changes](https://www.php.net/manual/en/migration83.deprecated.php#migration83.deprecated.phar) and [Phar object stub](https://github.com/php/php-src/blob/PHP-8.3/ext/phar/phar_object.stub.php#L201-L205).
