### PR TITLE
[PHP 8.3] Return type of ReflectionClass::getStaticProperties() is no longer nullable.

### DIFF
--- a/reference/reflection/reflectionclass/getstaticproperties.xml
+++ b/reference/reflection/reflectionclass/getstaticproperties.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ReflectionClass">
-   <modifier>public</modifier> <type class="union"><type>array</type><type>null</type></type><methodname>ReflectionClass::getStaticProperties</methodname>
+   <modifier>public</modifier> <type>array</type><methodname>ReflectionClass::getStaticProperties</methodname>
    <void/>
   </methodsynopsis>
   <para>
@@ -26,8 +26,31 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The static properties, as an <type>array</type>, or &null; on failure.
+   The static properties, as an <type>array</type>.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+        Return type of <methodname>ReflectionClass::getStaticProperties</methodname>
+        is no longer nullable.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/reflection/reflectionclass/getstaticproperties.xml
+++ b/reference/reflection/reflectionclass/getstaticproperties.xml
@@ -44,8 +44,8 @@
      <row>
       <entry>8.3.0</entry>
       <entry>
-        Return type of <methodname>ReflectionClass::getStaticProperties</methodname>
-        is no longer nullable.
+       The return type of <methodname>ReflectionClass::getStaticProperties</methodname>
+       has been changed to <type>array</type> from <literal>?array</literal>.
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
refs: [php-src](https://github.com/php/php-src/blob/PHP-8.3/ext/reflection/php_reflection.stub.php#L408-L409) and [other changes](https://www.php.net/manual/en/migration83.other-changes.php#migration83.other-changes.functions.reflection)