### PR TITLE
[PHP 8.3] odbc_autocommit $enable parameter is now nullable.

### DIFF
--- a/reference/uodbc/functions/odbc-autocommit.xml
+++ b/reference/uodbc/functions/odbc-autocommit.xml
@@ -10,7 +10,7 @@
   <methodsynopsis>
    <type class="union"><type>int</type><type>bool</type></type><methodname>odbc_autocommit</methodname>
    <methodparam><type>resource</type><parameter>odbc</parameter></methodparam>
-   <methodparam choice="opt"><type>bool</type><parameter>enable</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>enable</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Toggles autocommit behaviour.

--- a/reference/uodbc/functions/odbc-autocommit.xml
+++ b/reference/uodbc/functions/odbc-autocommit.xml
@@ -10,7 +10,7 @@
   <methodsynopsis>
    <type class="union"><type>int</type><type>bool</type></type><methodname>odbc_autocommit</methodname>
    <methodparam><type>resource</type><parameter>odbc</parameter></methodparam>
-   <methodparam choice="opt"><type>bool</type><parameter>enable</parameter><initializer>&false;</initializer></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>enable</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Toggles autocommit behaviour.
@@ -35,7 +35,8 @@
      <listitem>
       <para>
        If <parameter>enable</parameter> is &true;, auto-commit is enabled, if
-       it is &false; auto-commit is disabled.
+       it is &false; auto-commit is disabled. If &null; is passed, this function
+       returns auto-commit status for <parameter>odbc</parameter>.
       </para>
      </listitem>
     </varlistentry>
@@ -55,6 +56,29 @@
    success and &false; on failure.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       <parameter>enable</parameter> is now nullable.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/uodbc/functions/odbc-autocommit.xml
+++ b/reference/uodbc/functions/odbc-autocommit.xml
@@ -35,8 +35,9 @@
      <listitem>
       <para>
        If <parameter>enable</parameter> is &true;, auto-commit is enabled, if
-       it is &false; auto-commit is disabled. If &null; is passed, this function
-       returns auto-commit status for <parameter>odbc</parameter>.
+       it is &false; auto-commit is disabled.
+       If &null; is passed, this function returns the auto-commit status for
+       <parameter>odbc</parameter>.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
- refs
  * [php-src stubs](https://github.com/php/php-src/blob/PHP-8.3/ext/odbc/odbc.stub.php#L427-L428)
  * [other changes](https://www.php.net/manual/en/migration83.other-changes.php#migration83.other-changes.functions.odbc)
  * [odbc_autocommit source code](https://github.com/php/php-src/blob/PHP-8.3/ext/odbc/php_odbc.c#L2551-L2587)