### PR TITLE
[PHP 8.3]: The ReflectionProperty::setValue $object is now required.

### DIFF
--- a/reference/reflection/reflectionproperty/setvalue.xml
+++ b/reference/reflection/reflectionproperty/setvalue.xml
@@ -37,8 +37,7 @@
      <listitem>
       <para>
        If the property is non-static an object must be provided to change
-       the property on. If the property is static this parameter is left
-       out and only <parameter>value</parameter> needs to be provided.
+       the property on. If the property is static a value of &null; should be to be provided.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/reflection/reflectionproperty/setvalue.xml
+++ b/reference/reflection/reflectionproperty/setvalue.xml
@@ -37,7 +37,8 @@
      <listitem>
       <para>
        If the property is non-static an object must be provided to change
-       the property on. If the property is static a value of &null; should be to be provided.
+       the property on.
+       If the property is static a value of &null; <emphasis>must</emphasis> be to be provided.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
I noticed this while updating code for 8.3.

Whilst the deprecation ins referenced as a Note, it was not reflected in the parameter descriptions.

Whilst `$object` is _optional_ before 8.3, it has supported a `null` value to have the same meaning for a long time (probably always). I felt it better to not suggest the alternative as it will lead to future compatability issues.