### PR TITLE
Changelog for return type of DOMCharacterData::appendData

### DIFF
--- a/reference/dom/domcharacterdata/appenddata.xml
+++ b/reference/dom/domcharacterdata/appenddata.xml
@@ -38,6 +38,27 @@
    &return.true.always;
   </para>
  </refsect1>
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       This function now has a tentative <type>true</type> return type.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>


### PR DESCRIPTION
Corresponds to `Changed DOMCharacterData::appendData() tentative return type to true.` of https://github.com/php/doc-en/issues/2796.