### PR TITLE
Fix `debug_backtrace` argument description

### DIFF
--- a/reference/errorfunc/functions/debug-backtrace.xml
+++ b/reference/errorfunc/functions/debug-backtrace.xml
@@ -57,7 +57,7 @@
             <row>
              <entry><code>debug_backtrace()</code></entry>
              <entry morerows="2" valign="middle">
-              Populates both indexes
+              Omits index <literal>"object"</literal> and populates index <literal>"args"</literal>.
              </entry>
             </row>
             <row>
@@ -69,7 +69,7 @@
             <row>
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS &amp; DEBUG_BACKTRACE_PROVIDE_OBJECT)</code></entry>
              <entry morerows="1" valign="middle">
-              Omits index <literal>"object"</literal>.
+              Populates both indexes
              </entry>
             </row>
             <row>

--- a/reference/errorfunc/functions/debug-backtrace.xml
+++ b/reference/errorfunc/functions/debug-backtrace.xml
@@ -57,7 +57,7 @@
             <row>
              <entry><code>debug_backtrace()</code></entry>
              <entry morerows="2" valign="middle">
-              Omits index <literal>"object"</literal> and populates index <literal>"args"</literal>.
+              Populates both indexes
              </entry>
             </row>
             <row>
@@ -67,13 +67,10 @@
              <entry><code>debug_backtrace(1)</code></entry>
             </row>
             <row>
-             <entry><code>debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS &amp; DEBUG_BACKTRACE_PROVIDE_OBJECT)</code></entry>
-             <entry morerows="1" valign="middle">
-              Populates both indexes
-             </entry>
-            </row>
-            <row>
              <entry><code>debug_backtrace(0)</code></entry>
+             <entry valign="middle">
+              Omits index <literal>"object"</literal> and populates index <literal>"args"</literal>.
+             </entry>
             </row>
             <row>
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
@@ -83,6 +80,15 @@
             </row>
             <row>
              <entry><code>debug_backtrace(2)</code></entry>
+            </row>
+            <row>
+             <entry><code>debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT|DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
+             <entry morerows="1" valign="middle">
+              Populate index <literal>"object"</literal> <emphasis>and</emphasis> omit index <literal>"args"</literal>.
+             </entry>
+            </row>
+            <row>
+             <entry><code>debug_backtrace(3)</code></entry>
             </row>
            </tbody>
           </tgroup>


### PR DESCRIPTION
Fix the documentation introduced by #1630

Demonstration: https://3v4l.org/9kCpQ
```
debug_backtrace()
args:   true
object: true

debug_backtrace(0)
$options = 0
args:   true
object: false

debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT)
$options = 1
args:   true
object: true

debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)
$options = 2
args:   false
object: false

debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT|DEBUG_BACKTRACE_IGNORE_ARGS)
$options = 3
args:   false
object: true
```
