### PR TITLE
Correct sentence grammar

### DIFF
--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -104,7 +104,7 @@
   <title>Integral and string contexts</title>
 
   <simpara>
-   This is the context when using a
+   This is the context when using
    <link linkend="language.operators.bitwise">bitwise operators</link>.
   </simpara>
 


### PR DESCRIPTION
Remove "a" before a plural subject.