### PR TITLE
Fix typo of Section 'Errors/Exceptions' in DateTime construct

### DIFF
--- a/reference/datetime/datetime/construct.xml
+++ b/reference/datetime/datetime/construct.xml
@@ -74,7 +74,7 @@
   <para>
     If an invalid Date/Time string is passed,
     <exceptionname>DateMalformedStringException</exceptionname> is thrown.
-    Previous to PHP 8.3, this was <exceptionname>Еxception</exceptionname>.
+    Previous to PHP 8.3, this was <exceptionname>Exception</exceptionname>.
   </para>
  </refsect1>
 

--- a/reference/datetime/datetimeimmutable/construct.xml
+++ b/reference/datetime/datetimeimmutable/construct.xml
@@ -78,7 +78,7 @@
   <para>
     If an invalid Date/Time string is passed,
     <exceptionname>DateMalformedStringException</exceptionname> is thrown.
-    Previous to PHP 8.3, this was <exceptionname>Еxception</exceptionname>.
+    Previous to PHP 8.3, this was <exceptionname>Exception</exceptionname>.
   </para>
  </refsect1>
 


### PR DESCRIPTION
a 'Е'(&amp;#1045;) of `Exception` was a multibyte character. fixed typo to 'E'(&amp;#69;).