### PR TITLE
cURL: A curl_close() call will not write the cookies out to the file …

### DIFF
--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -1479,8 +1479,10 @@
           <row>
            <entry valign="top"><constant>CURLOPT_COOKIEJAR</constant></entry>
            <entry valign="top">
-            The name of a file to save all internal cookies to when the handle is closed, 
-            e.g. after a call to curl_close.
+            The name of a file to save all internal cookies to when the handle's 
+            destructor is called.  Note that curl_close will not do this as of 
+            PHP 8.0.  If you need the cookies written before the handle goes 
+            out of scope, call <function>unset</function> on the handle.
            </entry>
            <entry valign="top">
            </entry>

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -1480,9 +1480,15 @@
            <entry valign="top"><constant>CURLOPT_COOKIEJAR</constant></entry>
            <entry valign="top">
             The name of a file to save all internal cookies to when the handle's 
-            destructor is called.  Note that curl_close will not do this as of 
-            PHP 8.0.  If you need the cookies written before the handle goes 
-            out of scope, call <function>unset</function> on the handle.
+            destructor is called.
+            <warning>
+             <simpara>
+              As of PHP 8.0.0, <function>curl_close</function> is a no-op
+              and does <emphasis>not</emphasis> destroy the handle.
+              If cookies need to be written prior to the handle being automatically
+              destroyed, call <function>unset</function> on the handle.
+             </simpara>
+            </warning>
            </entry>
            <entry valign="top">
            </entry>

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -1479,7 +1479,7 @@
           <row>
            <entry valign="top"><constant>CURLOPT_COOKIEJAR</constant></entry>
            <entry valign="top">
-            The name of a file to save all internal cookies to when the handle's 
+            The name of a file to save all internal cookies to when the handle's
             destructor is called.
             <warning>
              <simpara>


### PR DESCRIPTION
…specified by CURLOPT_COOKIEJAR as of PHP 8.0.  Updating the CURLOPT_COOKIEJAR description to recommend calling unset on the handle if the user needs the cookies written.