### PR TITLE
Update command line features

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -546,6 +546,9 @@ string(15) "doesntmakesense"
          This option won't find fatal errors (like undefined functions). Use
          the <option>-f</option> to test for fatal errors too.
         </para>
+        <para>
+         In PHP 8.3 and later multiple filenames can be specified
+        </para>
         <note>
          <para>
           This option does not work together with the <option>-r</option>


### PR DESCRIPTION
Add a note to indicate that multiple files can be linted at once in >=8.3