### PR TITLE
Removed pgsql pipeline related functions from migration83

### DIFF
--- a/appendices/migration83/new-functions.xml
+++ b/appendices/migration83/new-functions.xml
@@ -87,10 +87,6 @@
   <simplelist>
     <member><function>pg_set_error_context_visibility</function>
     (libpq >= 9.6)</member>
-    <member><function>pg_enter_pipeline_mode</function> </member>
-    <member><function>pg_exit_pipeline_mode</function></member>
-    <member><function>pg_pipeline_sync</function></member>
-    <member><function>pg_pipeline_status</function></member>
   </simplelist>
  </sect2>
 


### PR DESCRIPTION
refs: https://github.com/php/php-src/pull/12735 and https://github.com/php/doc-en/pull/2953