### PR TITLE
Minor grammar correction to RecursiveArrayIterator docs

### DIFF
--- a/reference/spl/recursivearrayiterator.xml
+++ b/reference/spl/recursivearrayiterator.xml
@@ -10,8 +10,8 @@
   <section xml:id="recursivearrayiterator.intro">
    &reftitle.intro;
    <para>
-    This iterator allows to unset and modify values and keys while iterating over Arrays and Objects
-    in the same way as the <type>ArrayIterator</type>. Additionally it is possible to iterate
+    This iterator allows for unsetting and modifying values and keys while iterating over arrays and objects,
+    in the same way as the <type>ArrayIterator</type>. Additionally, it is possible to iterate
     over the current iterator entry.
    </para>
   </section>


### PR DESCRIPTION
This change makes a couple of minor grammar fixes to the RecursiveArrayIterator docs, which I found on reading through the respective documentation, recently.