### PR TITLE
deleted DOMDocument::loadXMLFile() reference from migration83

### DIFF
--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -163,9 +163,8 @@
 
    <para>
     <methodname>DOMDocument::loadHTML</methodname>,
-    <methodname>DOMDocument::loadHTMLFile</methodname>,
-    <methodname>DOMDocument::loadXML</methodname>, and
-    <methodname>DOMDocument::loadXMLFile</methodname> now have a tentative
+    <methodname>DOMDocument::loadHTMLFile</methodname>, and
+    <methodname>DOMDocument::loadXML</methodname> now have a tentative
     return type of <type>bool</type>. Previously, this was documented as having a return
     type of <code>DOMDocument|bool</code>, but, as of PHP 8.0.0,
     <classname>DOMDocument</classname>


### PR DESCRIPTION
refs: https://github.com/php/php-src/blob/PHP-8.3/ext/dom/php_dom.stub.php