### PR TITLE
ZipArchive:extractTo do not restore perm

### DIFF
--- a/reference/zip/ziparchive/extractto.xml
+++ b/reference/zip/ziparchive/extractto.xml
@@ -26,7 +26,8 @@
    <para>
     For security reasons, the original permissions are not restored.
     For an example of how to restore them, see the code sample on the
-    <methodname>ZipArchive::getExternalAttributesIndex</methodname> page.
+    <link linkend="ziparchive.getexternalattributesindex.examples.perms">
+    <methodname>ZipArchive::getExternalAttributesIndex</methodname></link> page.
    </para>
   </warning>
  </refsect1>

--- a/reference/zip/ziparchive/extractto.xml
+++ b/reference/zip/ziparchive/extractto.xml
@@ -25,9 +25,9 @@
    </para>
    <para>
     For security reasons, the original permissions are not restored.
-    For an example of how to restore them, see the code sample on the
-    <link linkend="ziparchive.getexternalattributesindex.examples.perms">
-    <methodname>ZipArchive::getExternalAttributesIndex</methodname></link> page.
+    For an example of how to restore them, see the
+    <link linkend="ziparchive.getexternalattributesindex.examples.perms">code sample</link>
+    on the <methodname>ZipArchive::getExternalAttributesIndex</methodname> page.
    </para>
   </warning>
  </refsect1>

--- a/reference/zip/ziparchive/extractto.xml
+++ b/reference/zip/ziparchive/extractto.xml
@@ -24,8 +24,8 @@
     <function>umask</function>.
    </para>
    <para>
-    For security reasons, original permissions are not restored.
-    For example of how to restore them, see the code sample on the
+    For security reasons, the original permissions are not restored.
+    For an example of how to restore them, see the code sample on the
     <methodname>ZipArchive::getExternalAttributesIndex</methodname> page.
    </para>
   </warning>

--- a/reference/zip/ziparchive/extractto.xml
+++ b/reference/zip/ziparchive/extractto.xml
@@ -23,6 +23,11 @@
     by setting the current umask, which can be changed using
     <function>umask</function>.
    </para>
+   <para>
+    For security reasons, original permissions are not restored.
+    For example of how to restore them, see the code sample on the
+    <methodname>ZipArchive::getExternalAttributesIndex</methodname> page.
+   </para>
   </warning>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/zip/ziparchive/getexternalattributesindex.xml
+++ b/reference/zip/ziparchive/getexternalattributesindex.xml
@@ -71,7 +71,7 @@
       archive <filename>test.zip</filename> and 
       set the Unix rights from external attributes.
     </para>
-    <example>
+    <example xml:id="ziparchive.getexternalattributesindex.examples.perms">
      <title>Extract all entries with Unix rights</title>
      <programlisting role="php">
 <![CDATA[


### PR DESCRIPTION
After discussion about https://github.com/php/php-src/issues/12730
it was chosen to not restore original permissions.

Add a note in doc about this
as we have an example about how to do it
