### PR TITLE
Removed references to deprecated mysqli_init function

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2082,7 +2082,7 @@ object returned by <function>mysqli_query</function>, <function>mysqli_store_res
 <function>mysqli_use_result</function> or <function>mysqli_stmt_get_result</function>.</para></listitem></varlistentry>'>
 <!ENTITY mysqli.link.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
 <parameter>mysql</parameter></term><listitem><para>Procedural style only: A <classname>mysqli</classname> object
-returned by <function>mysqli_connect</function> or <function>mysqli_init</function>
+returned by <function>mysqli_connect</function>
 </para></listitem></varlistentry>'>
 <!ENTITY mysqli.stmt.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
 <parameter>statement</parameter></term><listitem><para>Procedural style only: A <classname>mysqli_stmt</classname> object
@@ -2093,7 +2093,7 @@ linkend="book.mysqlnd">mysqlnd</link>.'>
 <para>MySQLnd always assumes the server default charset. This charset is sent during connection
 hand-shake/authentication, which mysqlnd will use.</para><para>Libmysqlclient uses the default charset set in the
 <filename>my.cnf</filename> or by an explicit call to <function>mysqli_options</function> prior to
-calling <function>mysqli_real_connect</function>, but after <function>mysqli_init</function>.</para></note>'>
+calling <function>mysqli_real_connect</function>, but after <function>mysqli_connect</function>.</para></note>'>
 <!ENTITY mysqli.integer.overflow.as.string.note '<note xmlns="http://docbook.org/ns/docbook">
 <para>If the number of rows is greater than <constant>PHP_INT_MAX</constant>,
 the number will be returned as a &string;.</para></note>'>

--- a/reference/mysqli/mysqli/real-connect.xml
+++ b/reference/mysqli/mysqli/real-connect.xml
@@ -41,8 +41,8 @@
   <itemizedlist>
    <listitem>
     <para>
-     <function>mysqli_real_connect</function> needs a valid object which has
-     to be created by function <function>mysqli_init</function>.
+     <function>mysqli_real_connect</function> needs an instance of the <classname>mysqli</classname> object. 
+     This can be obtained by calling <methodname>mysqli::__construct</methodname> or <function>mysqli_connect</function> with no arguments
     </para>
    </listitem>
    <listitem>
@@ -236,9 +236,9 @@
 <![CDATA[
 <?php
 
-$mysqli = mysqli_init();
+$mysqli = new mysqli();
 if (!$mysqli) {
-    die('mysqli_init failed');
+    die('mysqli connection failed');
 }
 
 if (!$mysqli->options(MYSQLI_INIT_COMMAND, 'SET AUTOCOMMIT = 0')) {
@@ -267,7 +267,8 @@ $mysqli->close();
 
 class foo_mysqli extends mysqli {
     public function __construct($host, $user, $pass, $db) {
-        parent::init();
+        // The parent constructor must be called directly, or an E_FATAL error will be generated
+        parent::__construct();
 
         if (!parent::options(MYSQLI_INIT_COMMAND, 'SET AUTOCOMMIT = 0')) {
             die('Setting MYSQLI_INIT_COMMAND failed');
@@ -297,9 +298,9 @@ $db->close();
 <![CDATA[
 <?php
 
-$link = mysqli_init();
+$link = mysqli_connect();
 if (!$link) {
-    die('mysqli_init failed');
+    die('mysqli_connect failed');
 }
 
 if (!mysqli_options($link, MYSQLI_INIT_COMMAND, 'SET AUTOCOMMIT = 0')) {
@@ -340,7 +341,6 @@ Success... MySQL host info: localhost via TCP/IP
   <para>
    <simplelist>
     <member><function>mysqli_connect</function></member>
-    <member><function>mysqli_init</function></member>
     <member><function>mysqli_options</function></member>
     <member><function>mysqli_ssl_set</function></member>
     <member><function>mysqli_close</function></member>


### PR DESCRIPTION
[mysqli_init](https://www.php.net/manual/en/mysqli.init.php) was [deprecated in 8.1](https://wiki.php.net/rfc/deprecations_php_8_1) and will generate deprecated notices. While the function page shows it was deprecated, the rest of the manual still recommended it. Removed it from both the procedural notes (where `mysqli_connect` is preferred) and updated examples for [mysqli_real_connect](https://www.php.net/manual/en/mysqli.real-connect.php)