### PR TITLE
fix(pdo): In line with the latest specifications

### DIFF
--- a/reference/pdo/pdo/lastinsertid.xml
+++ b/reference/pdo/pdo/lastinsertid.xml
@@ -17,8 +17,8 @@
   <para>
    Returns the ID of the last inserted row, or the last value from a
    sequence object, depending on the underlying driver. For example,
-   <link linkend="ref.pdo-pgsql">PDO_PGSQL</link> allows you to specify the name of
-   any sequence object for the <parameter>name</parameter> parameter.
+   <link linkend="ref.pdo-pgsql">PDO_PGSQL</link> allows the name of any
+   sequence object to be specified for the <parameter>name</parameter> parameter.
   </para>
   <note>
    <para>


### PR DESCRIPTION
Fixed the outdated description when using `PDO::lastInsertId()` from PostgreSQL.

This feature was first committed at https://github.com/php/php-src/commit/1a10666b08bee5aee7b59b39362172776dc1803c. At this point we certainly needed to specify the sequence name to get the ID. The active versions of PostgreSQL at this point are 7.3-8.0.

After this feature was implemented, his LASTVAL() function was implemented as PostgreSQL 8.1.

https://www.postgresql.org/docs/8.1/release-8-1.html#AEN74978

> * Add a function lastval() (Dennis Björklund)  
>  
>   lastval() is a simplified version of currval(). It automatically determines the proper sequence name based on the most recent nextval() or setval() call performed by the current session.

Using this feature, we can get the ID of the last sequence numbered within the current session without specifying the sequence name.

Correspondingly, the following improvements have been made to pdo-pgsql: https://github.com/php/php-src/commit/12628e9a46b91a0aa92fd0619cdd545c409d25a6.

Traditional retrieval by sequence name is also available, but is less common. (I don't think many people know that PostgreSQL automatically names the sequence named for the primary key `id` of table `t` as `t_id_seq`.)

Therefore, I believe that the current manual's description is outdated based on past specifications, and I propose that the document be revised.