### PR TITLE
Change attribute from action to method

### DIFF
--- a/reference/outcontrol/examples.xml
+++ b/reference/outcontrol/examples.xml
@@ -61,7 +61,7 @@ var_dump(ini_get('url_rewriter.tags'));
 output_add_rewrite_var('test', 'value');
 ?>
 <a href="//php.net/index.php?bug=1234">bug1234</a>
-<form action="https://php.net/?bug=1234&edit=1" action="post">
+<form action="https://php.net/?bug=1234&edit=1" method="post">
  <input type="text" name="title" />
 </form>
 ]]>


### PR DESCRIPTION
This PR corrects the attribute of the `form` tag in the output control rewriting example described in Issue #2978 