### PR TITLE
Add Override Attribute stub

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -621,6 +621,10 @@ is highly discouraged.</simpara></warning>
 
 <!ENTITY example.outputs.82.similar '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.2 is similar to:</para>'>
 
+<!ENTITY example.outputs.83 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.3:</para>'>
+
+<!ENTITY example.outputs.83.similar '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.3 is similar to:</para>'>
+
 <!ENTITY example.outputs.32bit '<para xmlns="http://docbook.org/ns/docbook">Output of the above example on 32 bit machines:</para>'>
 
 <!ENTITY example.outputs.64bit '<para xmlns="http://docbook.org/ns/docbook">Output of the above example on 64 bit machines:</para>'>

--- a/language/predefined/attributes.xml
+++ b/language/predefined/attributes.xml
@@ -10,6 +10,7 @@
 
  &language.predefined.attributes.attribute;
  &language.predefined.attributes.allowdynamicproperties;
+ &language.predefined.attributes.override;
  &language.predefined.attributes.returntypewillchange;
  &language.predefined.attributes.sensitiveparameter;
 </part>

--- a/language/predefined/attributes/override.xml
+++ b/language/predefined/attributes/override.xml
@@ -28,6 +28,34 @@
 
   </section>
 
+  <section>
+   &reftitle.examples;
+   <example>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+class Base {
+    protected function foo(): void {}
+}
+
+final class Extended extends Base {
+    #[\Override]
+    protected function boo(): void {}
+}
+
+?>
+]]>
+    </programlisting>
+    &example.outputs.83.similar;
+    <screen>
+<![CDATA[
+Fatal error: Extended::boo() has #[\Override] attribute, but no matching parent method exists
+]]>
+    </screen>
+   </example>
+  </section>
+
   <section xml:id="override.seealso">
    &reftitle.seealso;
    <para>

--- a/language/predefined/attributes/override.xml
+++ b/language/predefined/attributes/override.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpdoc:classref xml:id="class.override" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Override class</title>
+ <titleabbrev>Override</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="override.intro">
+   &reftitle.intro;
+   <para>
+   </para>
+  </section>
+
+  <section xml:id="override.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier>final</modifier>
+     <classname>Override</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.override')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Override'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+
+  </section>
+
+  <section xml:id="override.seealso">
+   &reftitle.seealso;
+   <para>
+    <simplelist>
+     <member><link linkend="language.attributes">Attributes overview</link></member>
+    </simplelist>
+   </para>
+  </section>
+
+ </partintro>
+
+ &language.predefined.attributes.override.construct;
+
+</phpdoc:classref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/predefined/attributes/override/construct.xml
+++ b/language/predefined/attributes/override/construct.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="override.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Override::__construct</refname>
+  <refpurpose>Construct a new Override attribute instance</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="Override">
+   <modifier>public</modifier> <methodname>Override::__construct</methodname>
+   <void/>
+  </constructorsynopsis>
+  <para>
+   Constructs a new <classname>Override</classname> instance.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/predefined/versions.xml
+++ b/language/predefined/versions.xml
@@ -173,6 +173,8 @@
  <function name="SensitiveParameterValue::__construct" from="PHP 8 &gt;= 8.2.0"/>
  <function name="SensitiveParameterValue::__debugInfo" from="PHP 8 &gt;= 8.2.0"/>
  <function name="SensitiveParameterValue::getValue" from="PHP 8 &gt;= 8.2.0"/>
+ <function name="Override" from="PHP 8 &gt;= 8.3.0"/>
+ <function name="Override::__construct" from="PHP 8 &gt;= 8.3.0"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
So... I don't remember what the reason was to move the ``AllowDynamicProperties`` Class methods definition out of the subfolder like I did it this time.

But I can't see any issues with it.