### PR TITLE
Add method_exists errors and changelog

### DIFF
--- a/reference/classobj/functions/method-exists.xml
+++ b/reference/classobj/functions/method-exists.xml
@@ -49,6 +49,40 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   If <parameter>object_or_class</parameter> is not of type <type>string</type>
+   or <type>object</type>, a <classname>TypeError</classname> will be thrown.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       If <parameter>object_or_class</parameter> is not of type
+       <type>string</type> or <type>object</type>, a
+       <classname>TypeError</classname> will be thrown;
+       previously, an error of level <constant>E_WARNING</constant> has been
+       raised instead, and the function returned &false;.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>


### PR DESCRIPTION
Add information about a change to method_exists made in 8.0.0 which causes the function to now raise an error when the first argument is not a string or object.

1. [bug 79462](https://bugs.php.net/bug.php?id=79462)
2. [8.0.0 changelog (core section)](https://www.php.net/ChangeLog-8.php)