### PR TITLE
Update mb-str-pad.xml

### DIFF
--- a/reference/mbstring/functions/mb-str-pad.xml
+++ b/reference/mbstring/functions/mb-str-pad.xml
@@ -102,7 +102,7 @@ var_dump(mb_str_pad('▶▶', 6, '❤❓❇', STR_PAD_RIGHT)); // string(18) "�
 var_dump(mb_str_pad('▶▶', 6, '❤❓❇', STR_PAD_LEFT));  // string(18) "❤❓❇❤▶▶"
 var_dump(mb_str_pad('▶▶', 6, '❤❓❇', STR_PAD_BOTH));  // string(18) "❤❓▶▶❤❓"
 
-var_dump(mb_str_pad("🎉", 3, "祝", STR_PAD_LEFT)));   // string(10) "祝祝🎉"
+var_dump(mb_str_pad("🎉", 3, "祝", STR_PAD_LEFT));   // string(10) "祝祝🎉"
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
Remove extraneous parenthesis in last example. There are 3 closing parenthesis but there are only 2 opening parenthesis. As a result the example code won't run, this PR fixes that.