### PR TITLE
include 'Error:' message in the screen output

### DIFF
--- a/reference/mysqli/mysqli_stmt/error-list.xml
+++ b/reference/mysqli/mysqli_stmt/error-list.xml
@@ -123,6 +123,7 @@ mysqli_close($link);
    &examples.outputs;
    <screen>
 <![CDATA[
+Error:
 Array
 (
     [0] => Array


### PR DESCRIPTION
Included 'Error:' message in the screen output

The screen output is missing the 'Error:' message
introduced by the echo command in the example.

Closes #3017