### PR TITLE
MYSQLI_OPT_INT_AND_FLOAT_NATIVE has no effect on prepared statements

### DIFF
--- a/reference/mysqli/mysqli/options.xml
+++ b/reference/mysqli/mysqli/options.xml
@@ -113,8 +113,8 @@
           <row>
            <entry><constant>MYSQLI_OPT_INT_AND_FLOAT_NATIVE</constant></entry>
            <entry>
-             Convert integer and float columns back to PHP numbers. Only valid
-             for mysqlnd. Applies only for non-prepared statements.
+             Convert integer and float columns back to PHP numbers when using non-prepared statements. 
+             Only valid for mysqlnd.
            </entry>
           </row>
           <row>

--- a/reference/mysqli/mysqli/options.xml
+++ b/reference/mysqli/mysqli/options.xml
@@ -114,7 +114,7 @@
            <entry><constant>MYSQLI_OPT_INT_AND_FLOAT_NATIVE</constant></entry>
            <entry>
              Convert integer and float columns back to PHP numbers. Only valid
-             for mysqlnd.
+             for mysqlnd. Applies only for non-prepared statements.
            </entry>
           </row>
           <row>

--- a/reference/mysqli/mysqli/options.xml
+++ b/reference/mysqli/mysqli/options.xml
@@ -113,7 +113,7 @@
           <row>
            <entry><constant>MYSQLI_OPT_INT_AND_FLOAT_NATIVE</constant></entry>
            <entry>
-             Convert integer and float columns back to PHP numbers when using non-prepared statements. 
+             Convert integer and float columns back to PHP numbers when using non-prepared statements.
              Only valid for mysqlnd.
            </entry>
           </row>


### PR DESCRIPTION
As documented [here](https://www.php.net/manual/en/mysqli.quickstart.prepared-statements.php#example-4303), this option does nothing when prepared statements are used. I believe it is handy to have this mentioned right next to the option.