### PR TITLE
Fixed the signature compatibility rule of concrete method of trait.

### DIFF
--- a/language/oop5/traits.xml
+++ b/language/oop5/traits.xml
@@ -330,8 +330,9 @@ Hello World!
    </para>
    <caution>
     <simpara>
-     A concrete class fulfills this requirement by defining a concrete method
-     with the same name; its signature may be different.
+     As of PHP 8.0.0, the signature of a concrete method must follow the
+     <link linkend="language.oop.lsp">signature compatibility rules</link>.
+     Previously, its signature might be different.
     </simpara>
    </caution>
    <example xml:id="language.oop5.traits.abstract.ex1">


### PR DESCRIPTION
As of PHP 8.0.0, the signature of abstract methods defined in traits is checked against the implementing class method.

This changeLog in the migration guide is not updated in the traits documentation.

https://3v4l.org/3l0fF