### PR TITLE
Update constants.xml

### DIFF
--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -262,7 +262,7 @@
          included - with this option it is excluded.  This will reduce the
          size of the signed message but the verifier must have a copy of the
          signers certificate available locally (passed using the
-         <parameter>extracerts</parameter> to
+         <parameter>untrusted_certificates_filename</parameter> to
          <function>openssl_pkcs7_verify</function> for example).
          </entry>
         </row>

--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -230,7 +230,7 @@
          <entry>When verifying a message, certificates (if
            any) included in the message are normally searched for the
            signing certificate. With this option only the
-           certificates specified in the <parameter>extracerts</parameter>
+           certificates specified in the <parameter>untrusted_certificates_filename</parameter>
            parameter of <function>openssl_pkcs7_verify</function> are
            used.  The supplied certificates can still be used as
            untrusted CAs however.


### PR DESCRIPTION
The function openssl_pkcs7_verify() (https://www.php.net/manual/en/function.openssl-pkcs7-verify.php) has no parameter "extracerts", "untrusted_certificates_filename" intead. It has been changed in the http://doc.php.net/revcheck.php?p=plain&lang=es&hbp=96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26&f=reference/openssl/functions/openssl-pkcs7-verify.xml&c=on commit.