### PR TITLE
Fix MongoDB links in the library tutorial page

### DIFF
--- a/reference/mongodb/tutorial/library.xml
+++ b/reference/mongodb/tutorial/library.xml
@@ -83,12 +83,12 @@ require 'vendor/autoload.php';
    <para>
     If you have used MongoDB drivers in other languages, the library's API
     should look familiar. It contains a
-    <link xlink:href="&url.mongodb.library.apidocs;/class/MongoDBClient/">Client</link>
+    <link xlink:href="&url.mongodb.library.apidocs;class/MongoDBClient/">Client</link>
     class for connecting to MongoDB, a
-    <link xlink:href="&url.mongodb.library.apidocs;/class/MongoDBDatabase/">Database</link>
+    <link xlink:href="&url.mongodb.library.apidocs;class/MongoDBDatabase/">Database</link>
     class for database-level operations (e.g. commands, collection management),
     and a
-    <link xlink:href="&url.mongodb.library.apidocs;/class/MongoDBCollection">Collection</link>
+    <link xlink:href="&url.mongodb.library.apidocs;class/MongoDBCollection">Collection</link>
     class for collection-level operations (e.g.
     <link xlink:href="&url.mongodb.wiki.crud;">CRUD</link> methods, index management).
    </para>


### PR DESCRIPTION
Additional slashes result in a 404 pages. E. g.:

https://www.mongodb.com/docs/php-library/master/reference//class/MongoDBClient/

link contains a double-slash before "class" path's part.

https://www.php.net/manual/en/mongodb.tutorial.library.php