### PR TITLE
Add missing COM constants

### DIFF
--- a/reference/com/constants.xml
+++ b/reference/com/constants.xml
@@ -616,6 +616,18 @@
      </entry>
      <entry>As of PHP 7.0.0, the value is <literal>2147614731</literal> on x64.</entry>
     </row>
+    <row xml:id="constant.disp-e-paramnotfound">
+     <entry>
+      <constant>DISP_E_PARAMNOTFOUND</constant>
+      (<type>int</type>)
+     </entry>
+     <entry>-2147352572</entry>
+     <entry>
+      A return value that indicates that one of the parameter IDs
+      does not correspond to a parameter on the method.
+     </entry>
+     <entry>As of PHP 7.0.0, the value is <literal>2147614724</literal> on x64.</entry>
+    </row>
     <row xml:id="constant.mk-e-unavailable">
      <entry>
       <constant>MK_E_UNAVAILABLE</constant>
@@ -627,6 +639,29 @@
       failed due to unavailability.
      </entry>
      <entry>As of PHP 7.0.0, the value is <literal>2147746275</literal> on x64.</entry>
+    </row>
+    <row xml:id="constant.locale-neutral">
+     <entry>
+      <constant>LOCALE_NEUTRAL</constant>
+      (<type>int</type>)
+     </entry>
+     <entry>0</entry>
+     <entry>
+      The neutral locale. This constant is generally not used when calling NLS APIs.
+      Instead, use LOCALE_SYSTEM_DEFAULT.
+     </entry>
+     <entry></entry>
+    </row>
+    <row xml:id="constant.locale-system-default">
+     <entry>
+      <constant>LOCALE_SYSTEM_DEFAULT</constant>
+      (<type>int</type>)
+     </entry>
+     <entry>2048</entry>
+     <entry>
+      The default locale for the operating system.
+     </entry>
+     <entry></entry>
     </row>
    </tbody>
   </tgroup>


### PR DESCRIPTION
Add three missing COM constants that were listed in #2747.

References for these changes:
 - [LOCALE_NEUTRAL](https://learn.microsoft.com/en-us/windows/win32/intl/locale-neutral)
 - [LOCALE_SYSTEM_DEFAULT](https://learn.microsoft.com/en-us/windows/win32/intl/locale-system-default)
 - DISP_E_PARAMNOTFOUND [1](https://learn.microsoft.com/en-us/windows/win32/com/com-error-codes-2) and [2](https://learn.microsoft.com/en-us/windows/win32/api/oaidl/nf-oaidl-idispatch-invoke)

The values of the constants were verified on PHP 8.2 running on Windows 10.