### PR TITLE
Remove unnecessary and, thus, confusing comma

### DIFF
--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -154,7 +154,7 @@ readonly class Foo {
     </example>
 
     <para>
-     As neither untyped, nor static properties can be marked with the
+     As neither untyped nor static properties can be marked with the
      <literal>readonly</literal> modifier, readonly classes cannot declare
      them either:
     </para>


### PR DESCRIPTION
A comma is neither necessary nor conventional in a "neither/nor" construction and is confusing because it is in, though doesn't complete, the dependent clause.