### PR TITLE
Remove COM constant values

### DIFF
--- a/reference/com/constants.xml
+++ b/reference/com/constants.xml
@@ -22,8 +22,8 @@
      </entry>
      <entry>1</entry>
      <entry>
-      The code that creates and manages objects of this class is 
-      a DLL that runs in the same process as the caller of the 
+      The code that creates and manages objects of this class is
+      a DLL that runs in the same process as the caller of the
       function specifying the class context.
      </entry>
      <entry></entry>
@@ -35,9 +35,9 @@
      </entry>
      <entry>2</entry>
      <entry>
-      The code that manages objects of this class is an in-process 
-      handler. This is a DLL that runs in the client process and 
-      implements client-side structures of this class when instances 
+      The code that manages objects of this class is an in-process
+      handler. This is a DLL that runs in the client process and
+      implements client-side structures of this class when instances
       of the class are accessed remotely.
      </entry>
      <entry></entry>
@@ -49,7 +49,7 @@
      </entry>
      <entry>4</entry>
      <entry>
-      The EXE code that creates and manages objects of this class runs on 
+      The EXE code that creates and manages objects of this class runs on
       same machine but is loaded in a separate process space.
      </entry>
      <entry></entry>
@@ -61,7 +61,7 @@
      </entry>
      <entry>16</entry>
      <entry>
-      A remote context. The code that creates and manages objects of this 
+      A remote context. The code that creates and manages objects of this
       class is run on a different computer.
      </entry>
      <entry></entry>
@@ -73,9 +73,9 @@
      </entry>
      <entry>21</entry>
      <entry>
-      Indicates server code, whether in-process, local, or remote. This 
-      definition ORs <constant>CLSCTX_INPROC_SERVER</constant>, 
-      <constant>CLSCTX_LOCAL_SERVER</constant>, and 
+      Indicates server code, whether in-process, local, or remote. This
+      definition ORs <constant>CLSCTX_INPROC_SERVER</constant>,
+      <constant>CLSCTX_LOCAL_SERVER</constant>, and
       <constant>CLSCTX_REMOTE_SERVER</constant>.
      </entry>
      <entry></entry>
@@ -87,8 +87,8 @@
      </entry>
      <entry>23</entry>
      <entry>
-      Indicates all class contexts. This definition ORs 
-      <constant>CLSCTX_INPROC_HANDLER</constant> and 
+      Indicates all class contexts. This definition ORs
+      <constant>CLSCTX_INPROC_HANDLER</constant> and
       <constant>CLSCTX_SERVER</constant>.
      </entry>
      <entry></entry>
@@ -111,7 +111,7 @@
      </entry>
      <entry>0</entry>
      <entry>
-      A property with a type indicator of <constant>VT_EMPTY</constant> has 
+      A property with a type indicator of <constant>VT_EMPTY</constant> has
       no data associated with it; that is, the size of the value is zero.
      </entry>
      <entry></entry>
@@ -123,7 +123,7 @@
      </entry>
      <entry>22</entry>
      <entry>
-      4-byte signed integer value (equivalent to 
+      4-byte signed integer value (equivalent to
       <constant>VT_I4</constant>).
      </entry>
      <entry></entry>
@@ -179,7 +179,7 @@
      </entry>
      <entry>23</entry>
      <entry>
-      4-byte unsigned integer (equivalent to 
+      4-byte unsigned integer (equivalent to
       <constant>VT_UI4</constant>).
      </entry>
      <entry></entry>
@@ -268,7 +268,7 @@
      </entry>
      <entry>10</entry>
      <entry>
-      Error code; containing the status code associated with the 
+      Error code; containing the status code associated with the
       error.
      </entry>
      <entry></entry>
@@ -291,10 +291,10 @@
      </entry>
      <entry>7</entry>
      <entry>
-      A 64-bit floating point number representing the number of days 
-     (not seconds) since December 31, 1899. For example, 
-     <literal>January 1, 1900</literal>, is 2.0, <literal>January 2, 1900</literal>, 
-     is 3.0, and so on). This is stored in the same representation as 
+      A 64-bit floating point number representing the number of days
+     (not seconds) since December 31, 1899. For example,
+     <literal>January 1, 1900</literal>, is 2.0, <literal>January 2, 1900</literal>,
+     is 3.0, and so on). This is stored in the same representation as
      <constant>VT_R8</constant>.
      </entry>
      <entry></entry>
@@ -350,8 +350,8 @@
      </entry>
      <entry>12</entry>
      <entry>
-      A type indicator followed by the corresponding value. 
-      <constant>VT_VARIANT</constant> can be used only with 
+      A type indicator followed by the corresponding value.
+      <constant>VT_VARIANT</constant> can be used only with
       <constant>VT_BYREF</constant>.
      </entry>
      <entry></entry>
@@ -363,16 +363,16 @@
      </entry>
      <entry>8192</entry>
      <entry>
-      If the type indicator is combined with 
-      <constant>VT_ARRAY</constant> by an OR operator, the value is a pointer to a 
-      <literal>SAFEARRAY</literal>. <constant>VT_ARRAY</constant> 
-      can use the OR with the following data types: <constant>VT_I1</constant>, 
-      <constant>VT_UI1</constant>, <constant>VT_I2</constant>, <constant>VT_UI2</constant>, 
-      <constant>VT_I4</constant>, <constant>VT_UI4</constant>, <constant>VT_INT</constant>, 
-      <constant>VT_UINT</constant>, <constant>VT_R4</constant>, <constant>VT_R8</constant>, 
-      <constant>VT_BOOL</constant>, <constant>VT_DECIMAL</constant>, <constant>VT_ERROR</constant>, 
-      <constant>VT_CY</constant>, <constant>VT_DATE</constant>, <constant>VT_BSTR</constant>, 
-      <constant>VT_DISPATCH</constant>, <constant>VT_UNKNOWN</constant> and 
+      If the type indicator is combined with
+      <constant>VT_ARRAY</constant> by an OR operator, the value is a pointer to a
+      <literal>SAFEARRAY</literal>. <constant>VT_ARRAY</constant>
+      can use the OR with the following data types: <constant>VT_I1</constant>,
+      <constant>VT_UI1</constant>, <constant>VT_I2</constant>, <constant>VT_UI2</constant>,
+      <constant>VT_I4</constant>, <constant>VT_UI4</constant>, <constant>VT_INT</constant>,
+      <constant>VT_UINT</constant>, <constant>VT_R4</constant>, <constant>VT_R8</constant>,
+      <constant>VT_BOOL</constant>, <constant>VT_DECIMAL</constant>, <constant>VT_ERROR</constant>,
+      <constant>VT_CY</constant>, <constant>VT_DATE</constant>, <constant>VT_BSTR</constant>,
+      <constant>VT_DISPATCH</constant>, <constant>VT_UNKNOWN</constant> and
       <constant>VT_VARIANT</constant>.
      </entry>
      <entry></entry>
@@ -384,9 +384,9 @@
      </entry>
      <entry>16384</entry>
      <entry>
-      If the type indicator is combined with <constant>VT_BYREF</constant> 
-      by an OR operator, the value is a reference. Reference types are 
-      interpreted as a reference to data, similar to the reference type in 
+      If the type indicator is combined with <constant>VT_BYREF</constant>
+      by an OR operator, the value is a reference. Reference types are
+      interpreted as a reference to data, similar to the reference type in
       C++.
      </entry>
      <entry></entry>
@@ -475,7 +475,7 @@
      </entry>
      <entry>0</entry>
      <entry>
-      The left <literal>bstr</literal> is less than right 
+      The left <literal>bstr</literal> is less than right
       <literal>bstr</literal>.
      </entry>
      <entry></entry>
@@ -498,7 +498,7 @@
      </entry>
      <entry>2</entry>
      <entry>
-      The left <literal>bstr</literal> is greater than right 
+      The left <literal>bstr</literal> is greater than right
       <literal>bstr</literal>.
      </entry>
      <entry></entry>
@@ -600,7 +600,7 @@
      </entry>
      <entry>-2147352566</entry>
      <entry>
-      An error that indicates that a value could not be coerced to 
+      An error that indicates that a value could not be coerced to
       its expected representation.
      </entry>
      <entry>As of PHP 7.0.0, the value is <literal>2147614730</literal> on x64.</entry>
@@ -635,7 +635,7 @@
      </entry>
      <entry>-2147221021</entry>
      <entry>
-      iMoniker COM status code, return on errors where the function call 
+      iMoniker COM status code, return on errors where the function call
       failed due to unavailability.
      </entry>
      <entry>As of PHP 7.0.0, the value is <literal>2147746275</literal> on x64.</entry>

--- a/reference/com/constants.xml
+++ b/reference/com/constants.xml
@@ -267,10 +267,10 @@
      </entry>
      <entry>
       A 64-bit floating point number representing the number of days
-     (not seconds) since December 31, 1899. For example,
-     <literal>January 1, 1900</literal>, is 2.0, <literal>January 2, 1900</literal>,
-     is 3.0, and so on). This is stored in the same representation as
-     <constant>VT_R8</constant>.
+      (not seconds) since <literal>December 31, 1899</literal>.
+      For example, <literal>January 1, 1900</literal> is <literal>2.0</literal>,
+      <literal>January 2, 1900</literal> is <literal>3.0</literal>, etc.
+      This is stored in the same representation as <constant>VT_R8</constant>.
      </entry>
      <entry></entry>
     </row>

--- a/reference/com/constants.xml
+++ b/reference/com/constants.xml
@@ -9,7 +9,6 @@
    <thead>
     <row>
      <entry>Constant</entry>
-     <entry>Value</entry>
      <entry>Description</entry>
      <entry>Notes</entry>
     </row>
@@ -20,7 +19,6 @@
       <constant>CLSCTX_INPROC_SERVER</constant>
       (<type>int</type>)
      </entry>
-     <entry>1</entry>
      <entry>
       The code that creates and manages objects of this class is
       a DLL that runs in the same process as the caller of the
@@ -33,7 +31,6 @@
       <constant>CLSCTX_INPROC_HANDLER</constant>
       (<type>int</type>)
      </entry>
-     <entry>2</entry>
      <entry>
       The code that manages objects of this class is an in-process
       handler. This is a DLL that runs in the client process and
@@ -47,7 +44,6 @@
       <constant>CLSCTX_LOCAL_SERVER</constant>
       (<type>int</type>)
      </entry>
-     <entry>4</entry>
      <entry>
       The EXE code that creates and manages objects of this class runs on
       same machine but is loaded in a separate process space.
@@ -59,7 +55,6 @@
       <constant>CLSCTX_REMOTE_SERVER</constant>
       (<type>int</type>)
      </entry>
-     <entry>16</entry>
      <entry>
       A remote context. The code that creates and manages objects of this
       class is run on a different computer.
@@ -71,7 +66,6 @@
       <constant>CLSCTX_SERVER</constant>
       (<type>int</type>)
      </entry>
-     <entry>21</entry>
      <entry>
       Indicates server code, whether in-process, local, or remote. This
       definition ORs <constant>CLSCTX_INPROC_SERVER</constant>,
@@ -85,7 +79,6 @@
       <constant>CLSCTX_ALL</constant>
       (<type>int</type>)
      </entry>
-     <entry>23</entry>
      <entry>
       Indicates all class contexts. This definition ORs
       <constant>CLSCTX_INPROC_HANDLER</constant> and
@@ -98,7 +91,6 @@
       <constant>VT_NULL</constant>
       (<type>int</type>)
      </entry>
-     <entry>1</entry>
      <entry>
       NULL pointer reference.
      </entry>
@@ -109,7 +101,6 @@
       <constant>VT_EMPTY</constant>
       (<type>int</type>)
      </entry>
-     <entry>0</entry>
      <entry>
       A property with a type indicator of <constant>VT_EMPTY</constant> has
       no data associated with it; that is, the size of the value is zero.
@@ -121,7 +112,6 @@
       <constant>VT_INT</constant>
       (<type>int</type>)
      </entry>
-     <entry>22</entry>
      <entry>
       4-byte signed integer value (equivalent to
       <constant>VT_I4</constant>).
@@ -133,7 +123,6 @@
       <constant>VT_I1</constant>
       (<type>int</type>)
      </entry>
-     <entry>16</entry>
      <entry>
       1-byte signed integer.
      </entry>
@@ -144,7 +133,6 @@
       <constant>VT_I2</constant>
       (<type>int</type>)
      </entry>
-     <entry>2</entry>
      <entry>
       Two bytes representing a 2-byte signed integer value.
      </entry>
@@ -155,7 +143,6 @@
       <constant>VT_I4</constant>
       (<type>int</type>)
      </entry>
-     <entry>3</entry>
      <entry>
       4-byte signed integer value.
      </entry>
@@ -166,18 +153,16 @@
       <constant>VT_I8</constant>
       (<type>int</type>)
      </entry>
-     <entry>20</entry>
      <entry>
       8-byte signed integer value.
      </entry>
-     <entry>Available as of PHP 7.0.0 (x64 only).</entry>
+     <entry>x64 only</entry>
     </row>
     <row xml:id="constant.vt-uint">
      <entry>
       <constant>VT_UINT</constant>
       (<type>int</type>)
      </entry>
-     <entry>23</entry>
      <entry>
       4-byte unsigned integer (equivalent to
       <constant>VT_UI4</constant>).
@@ -189,7 +174,6 @@
       <constant>VT_UI1</constant>
       (<type>int</type>)
      </entry>
-     <entry>17</entry>
      <entry>
       1-byte unsigned integer.
      </entry>
@@ -200,7 +184,6 @@
       <constant>VT_UI2</constant>
       (<type>int</type>)
      </entry>
-     <entry>18</entry>
      <entry>
       2-byte unsigned integer.
      </entry>
@@ -211,7 +194,6 @@
       <constant>VT_UI4</constant>
       (<type>int</type>)
      </entry>
-     <entry>19</entry>
      <entry>
       4-byte unsigned integer.
      </entry>
@@ -222,18 +204,16 @@
       <constant>VT_UI8</constant>
       (<type>int</type>)
      </entry>
-     <entry>21</entry>
      <entry>
       8-byte unsigned integer.
      </entry>
-     <entry>Available as of PHP 7.0.0 (x64 only).</entry>
+     <entry>x64 only</entry>
     </row>
     <row xml:id="constant.vt-r4">
      <entry>
       <constant>VT_R4</constant>
       (<type>int</type>)
      </entry>
-     <entry>4</entry>
      <entry>
       32-bit IEEE floating point value.
      </entry>
@@ -244,7 +224,6 @@
       <constant>VT_R8</constant>
       (<type>int</type>)
      </entry>
-     <entry>5</entry>
      <entry>
       64-bit IEEE floating point value.
      </entry>
@@ -255,7 +234,6 @@
       <constant>VT_BOOL</constant>
       (<type>int</type>)
      </entry>
-     <entry>11</entry>
      <entry>
       Boolean value.
      </entry>
@@ -266,7 +244,6 @@
       <constant>VT_ERROR</constant>
       (<type>int</type>)
      </entry>
-     <entry>10</entry>
      <entry>
       Error code; containing the status code associated with the
       error.
@@ -278,7 +255,6 @@
       <constant>VT_CY</constant>
       (<type>int</type>)
      </entry>
-     <entry>6</entry>
      <entry>
       8-byte two's complement integer (scaled by 10,000).
      </entry>
@@ -289,7 +265,6 @@
       <constant>VT_DATE</constant>
       (<type>int</type>)
      </entry>
-     <entry>7</entry>
      <entry>
       A 64-bit floating point number representing the number of days
      (not seconds) since December 31, 1899. For example,
@@ -304,7 +279,6 @@
       <constant>VT_BSTR</constant>
       (<type>int</type>)
      </entry>
-     <entry>8</entry>
      <entry>
       Pointer to a null-terminated Unicode string.
      </entry>
@@ -315,7 +289,6 @@
       <constant>VT_DECIMAL</constant>
       (<type>int</type>)
      </entry>
-     <entry>14</entry>
      <entry>
       A decimal structure.
      </entry>
@@ -326,7 +299,6 @@
       <constant>VT_UNKNOWN</constant>
       (<type>int</type>)
      </entry>
-     <entry>13</entry>
      <entry>
       A pointer to an object that implements the IUnknown interface.
      </entry>
@@ -337,7 +309,6 @@
       <constant>VT_DISPATCH</constant>
       (<type>int</type>)
      </entry>
-     <entry>9</entry>
      <entry>
       A pointer to a pointer to an object was specified.
      </entry>
@@ -348,7 +319,6 @@
       <constant>VT_VARIANT</constant>
       (<type>int</type>)
      </entry>
-     <entry>12</entry>
      <entry>
       A type indicator followed by the corresponding value.
       <constant>VT_VARIANT</constant> can be used only with
@@ -361,7 +331,6 @@
       <constant>VT_ARRAY</constant>
       (<type>int</type>)
      </entry>
-     <entry>8192</entry>
      <entry>
       If the type indicator is combined with
       <constant>VT_ARRAY</constant> by an OR operator, the value is a pointer to a
@@ -382,7 +351,6 @@
       <constant>VT_BYREF</constant>
       (<type>int</type>)
      </entry>
-     <entry>16384</entry>
      <entry>
       If the type indicator is combined with <constant>VT_BYREF</constant>
       by an OR operator, the value is a reference. Reference types are
@@ -396,7 +364,6 @@
       <constant>CP_ACP</constant>
       (<type>int</type>)
      </entry>
-     <entry>0</entry>
      <entry>
       Default to ANSI code page.
      </entry>
@@ -407,7 +374,6 @@
       <constant>CP_MACCP</constant>
       (<type>int</type>)
      </entry>
-     <entry>2</entry>
      <entry>
       Macintosh code page.
      </entry>
@@ -418,7 +384,6 @@
       <constant>CP_OEMCP</constant>
       (<type>int</type>)
      </entry>
-     <entry>1</entry>
      <entry>
       Default to OEM code page.
      </entry>
@@ -429,7 +394,6 @@
       <constant>CP_UTF7</constant>
       (<type>int</type>)
      </entry>
-     <entry>65000</entry>
      <entry>
       Unicode (UTF-7).
      </entry>
@@ -440,7 +404,6 @@
       <constant>CP_UTF8</constant>
       (<type>int</type>)
      </entry>
-     <entry>65001</entry>
      <entry>
       Unicode (UTF-8).
      </entry>
@@ -451,7 +414,6 @@
       <constant>CP_SYMBOL</constant>
       (<type>int</type>)
      </entry>
-     <entry>42</entry>
      <entry>
       <literal>SYMBOL</literal> translations.
      </entry>
@@ -462,7 +424,6 @@
       <constant>CP_THREAD_ACP</constant>
       (<type>int</type>)
      </entry>
-     <entry>3</entry>
      <entry>
       Current thread's ANSI code page
      </entry>
@@ -473,7 +434,6 @@
       <constant>VARCMP_LT</constant>
       (<type>int</type>)
      </entry>
-     <entry>0</entry>
      <entry>
       The left <literal>bstr</literal> is less than right
       <literal>bstr</literal>.
@@ -485,7 +445,6 @@
       <constant>VARCMP_EQ</constant>
       (<type>int</type>)
      </entry>
-     <entry>1</entry>
      <entry>
       The two parameters are equal.
      </entry>
@@ -496,7 +455,6 @@
       <constant>VARCMP_GT</constant>
       (<type>int</type>)
      </entry>
-     <entry>2</entry>
      <entry>
       The left <literal>bstr</literal> is greater than right
       <literal>bstr</literal>.
@@ -508,7 +466,6 @@
       <constant>VARCMP_NULL</constant>
       (<type>int</type>)
      </entry>
-     <entry>3</entry>
      <entry>
       Either expression is NULL.
      </entry>
@@ -519,7 +476,6 @@
       <constant>NORM_IGNORECASE</constant>
       (<type>int</type>)
      </entry>
-     <entry>1</entry>
      <entry>
       Ignore case sensitivity.
      </entry>
@@ -530,7 +486,6 @@
       <constant>NORM_IGNORENONSPACE</constant>
       (<type>int</type>)
      </entry>
-     <entry>2</entry>
      <entry>
       Ignore nonspacing characters.
      </entry>
@@ -541,7 +496,6 @@
       <constant>NORM_IGNORESYMBOLS</constant>
       (<type>int</type>)
      </entry>
-     <entry>4</entry>
      <entry>
       Ignore symbols.
      </entry>
@@ -552,7 +506,6 @@
       <constant>NORM_IGNOREWIDTH</constant>
       (<type>int</type>)
      </entry>
-     <entry>131072</entry>
      <entry>
       Ignore string width.
      </entry>
@@ -563,7 +516,6 @@
       <constant>NORM_IGNOREKANATYPE</constant>
       (<type>int</type>)
      </entry>
-     <entry>65536</entry>
      <entry>
       Ignore Kana type.
      </entry>
@@ -574,7 +526,6 @@
       <constant>NORM_IGNOREKASHIDA</constant>
       (<type>int</type>)
      </entry>
-     <entry>262144</entry>
      <entry>
       Ignore Arabic kashida characters.
      </entry>
@@ -587,65 +538,59 @@
       <constant>DISP_E_DIVBYZERO</constant>
       (<type>int</type>)
      </entry>
-     <entry>-2147352558</entry>
      <entry>
       A return error that indicates a divide by zero error.
      </entry>
-     <entry>As of PHP 7.0.0, the value is <literal>2147614738</literal> on x64.</entry>
+     <entry></entry>
     </row>
     <row xml:id="constant.disp-e-overflow">
      <entry>
       <constant>DISP_E_OVERFLOW</constant>
       (<type>int</type>)
      </entry>
-     <entry>-2147352566</entry>
      <entry>
       An error that indicates that a value could not be coerced to
       its expected representation.
      </entry>
-     <entry>As of PHP 7.0.0, the value is <literal>2147614730</literal> on x64.</entry>
+     <entry></entry>
     </row>
     <row xml:id="constant.disp-e-badindex">
      <entry>
       <constant>DISP_E_BADINDEX</constant>
       (<type>int</type>)
      </entry>
-     <entry>-2147352565</entry>
      <entry>
       An error that indicates that an array index does not exist.
      </entry>
-     <entry>As of PHP 7.0.0, the value is <literal>2147614731</literal> on x64.</entry>
+     <entry></entry>
     </row>
     <row xml:id="constant.disp-e-paramnotfound">
      <entry>
       <constant>DISP_E_PARAMNOTFOUND</constant>
       (<type>int</type>)
      </entry>
-     <entry>-2147352572</entry>
      <entry>
       A return value that indicates that one of the parameter IDs
       does not correspond to a parameter on the method.
      </entry>
-     <entry>As of PHP 7.0.0, the value is <literal>2147614724</literal> on x64.</entry>
+     <entry></entry>
     </row>
     <row xml:id="constant.mk-e-unavailable">
      <entry>
       <constant>MK_E_UNAVAILABLE</constant>
       (<type>int</type>)
      </entry>
-     <entry>-2147221021</entry>
      <entry>
       iMoniker COM status code, return on errors where the function call
       failed due to unavailability.
      </entry>
-     <entry>As of PHP 7.0.0, the value is <literal>2147746275</literal> on x64.</entry>
+     <entry></entry>
     </row>
     <row xml:id="constant.locale-neutral">
      <entry>
       <constant>LOCALE_NEUTRAL</constant>
       (<type>int</type>)
      </entry>
-     <entry>0</entry>
      <entry>
       The neutral locale. This constant is generally not used when calling NLS APIs.
       Instead, use LOCALE_SYSTEM_DEFAULT.
@@ -657,7 +602,6 @@
       <constant>LOCALE_SYSTEM_DEFAULT</constant>
       (<type>int</type>)
      </entry>
-     <entry>2048</entry>
      <entry>
       The default locale for the operating system.
      </entry>


### PR DESCRIPTION
Removed all the values and references to PHP 7.0 from the table as advised [here](https://github.com/php/doc-en/pull/3043#discussion_r1438376597) and [here](https://github.com/php/doc-en/pull/3043#discussion_r1438376784).