### PR TITLE
Add more function/constant links to ob_get_status

### DIFF
--- a/reference/outcontrol/constants.xml
+++ b/reference/outcontrol/constants.xml
@@ -3,7 +3,7 @@
 <appendix xml:id="outcontrol.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants.core;
- <variablelist xml:id="constants.flags-passed-to-handler">
+ <variablelist xml:id="outcontrol.constants.flags-passed-to-handler">
   <title>Status flags passed to output handler</title>
   <para>
    The following flags are passed to the second (<parameter>phase</parameter>) parameter of the output handler set by <function>ob_start</function> as part of a bitmask:
@@ -95,7 +95,7 @@
    </listitem>
   </varlistentry>
  </variablelist>
- <variablelist xml:id="constants.buffer-control-flags">
+ <variablelist xml:id="outcontrol.constants.buffer-control-flags">
   <title>Output buffer control flags</title>
   <para>
    The following flags can be passed to the third (<parameter>flags</parameter>) parameter of the output handler set by <function>ob_start</function> as a bitmask:
@@ -159,7 +159,7 @@
    </listitem>
   </varlistentry>
  </variablelist>
- <variablelist xml:id="constants.flags-returned-by-handler">
+ <variablelist xml:id="outcontrol.constants.flags-returned-by-handler">
   <title>Output handler status flags</title>
   <para>
    The following flags are part of the <literal>flags</literal> bitmask

--- a/reference/outcontrol/constants.xml
+++ b/reference/outcontrol/constants.xml
@@ -3,7 +3,7 @@
 <appendix xml:id="outcontrol.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants.core;
- <variablelist>
+ <variablelist xml:id="constants.flags-passed-to-handler">
   <title>Status flags passed to output handler</title>
   <para>
    The following flags are passed to the second (<parameter>phase</parameter>) parameter of the output handler set by <function>ob_start</function> as part of a bitmask:
@@ -95,7 +95,7 @@
    </listitem>
   </varlistentry>
  </variablelist>
- <variablelist>
+ <variablelist xml:id="constants.buffer-control-flags">
   <title>Output buffer control flags</title>
   <para>
    The following flags can be passed to the third (<parameter>flags</parameter>) parameter of the output handler set by <function>ob_start</function> as a bitmask:
@@ -159,7 +159,7 @@
    </listitem>
   </varlistentry>
  </variablelist>
- <variablelist>
+ <variablelist xml:id="constants.flags-returned-by-handler">
   <title>Output handler status flags</title>
   <para>
    The following flags are part of the <literal>flags</literal> bitmask

--- a/reference/outcontrol/functions/ob-get-level.xml
+++ b/reference/outcontrol/functions/ob-get-level.xml
@@ -28,12 +28,17 @@
    Returns the level of nested output buffering handlers or zero if output
    buffering is not active.
   </para>
-  <para>
-   Note that the value returned for the same level
-   by <function>ob_get_status</function> is off by one.
-   The first level is <literal>1</literal> for <function>ob_get_level</function>,
-   and <literal>0</literal> for <function>ob_get_status</function>.
-  </para>
+  <caution>
+   <simpara>
+    The value for identical levels between <function>ob_get_level</function>
+    and <function>ob_get_status</function> is off by one.
+
+    For <function>ob_get_level</function>
+    the first level is <literal>1</literal>.
+    Whereas for <function>ob_get_status</function>
+    the first level is <literal>0</literal>.
+   </simpara>
+  </caution>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/outcontrol/functions/ob-get-level.xml
+++ b/reference/outcontrol/functions/ob-get-level.xml
@@ -5,7 +5,7 @@
   <refname>ob_get_level</refname>
   <refpurpose>Return the nesting level of the output buffering mechanism</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -28,6 +28,12 @@
    Returns the level of nested output buffering handlers or zero if output
    buffering is not active.
   </para>
+  <para>
+   Note that the value returned for the same level
+   by <function>ob_get_status</function> is off by one.
+   The first level is <literal>1</literal> for <function>ob_get_level</function>,
+   and <literal>0</literal> for <function>ob_get_status</function>.
+  </para>
  </refsect1>
 
  <refsect1 role="seealso">
@@ -35,6 +41,7 @@
   <para>
    <simplelist>
     <member><function>ob_start</function></member>
+    <member><function>ob_get_status</function></member>
     <member><function>ob_get_contents</function></member>
    </simplelist>
   </para>

--- a/reference/outcontrol/functions/ob-get-status.xml
+++ b/reference/outcontrol/functions/ob-get-status.xml
@@ -59,8 +59,7 @@
     <seglistitem>
      <seg>name</seg>
      <seg>
-      Name of active output handler (see the
-      <link linkend="function.ob-list-handlers.names">return values</link> of
+      Name of active output handler (see the return values of
       <function>ob_list_handlers</function> for details)
      </seg>
     </seglistitem>
@@ -77,7 +76,7 @@
       Bitmask of flags set by <function>ob_start</function>,
       the type of output handler (see above)
       and the status of the buffering process
-      (<link linkend="constants.flags-returned-by-handler">
+      (<link linkend="outcontrol.constants.flags-returned-by-handler">
        <constant>PHP_OUTPUT_HANDLER_<replaceable>*</replaceable></constant>
       </link> constants).
       If the handler successfully processed the buffer and did not return &false;,

--- a/reference/outcontrol/functions/ob-get-status.xml
+++ b/reference/outcontrol/functions/ob-get-status.xml
@@ -59,11 +59,9 @@
     <seglistitem>
      <seg>name</seg>
      <seg>
-      Name of active output handler as set by the <parameter>callback</parameter>
-      parameter of <function>ob_start</function>,
-      <link linkend="ini.output-handler">output_handler</link> if
-      <link linkend="ini.output-buffering">output_buffering</link> is enabled
-      or <literal>'default output handler'</literal> if none is set
+      Name of active output handler (see the
+      <link linkend="function.ob-list-handlers.names">return values</link> of
+      <function>ob_list_handlers</function> for details)
      </seg>
     </seglistitem>
     <seglistitem>
@@ -79,7 +77,7 @@
       Bitmask of flags set by <function>ob_start</function>,
       the type of output handler (see above)
       and the status of the buffering process
-      (<link linkend="outcontrol.constants">
+      (<link linkend="constants.flags-returned-by-handler">
        <constant>PHP_OUTPUT_HANDLER_<replaceable>*</replaceable></constant>
       </link> constants).
       If the handler successfully processed the buffer and did not return &false;,
@@ -117,6 +115,7 @@
      <seg>buffer_used</seg>
      <seg>
       Size of data in output buffer in bytes
+      (the same as the integer return value of <function>ob_get_length</function>)
      </seg>
     </seglistitem>
    </segmentedlist>
@@ -186,6 +185,7 @@ Array
    <simplelist>
     <member><function>ob_get_level</function></member>
     <member><function>ob_list_handlers</function></member>
+    <member><function>ob_get_length</function></member>
     <member><function>ob_start</function></member>
    </simplelist>
   </para>

--- a/reference/outcontrol/functions/ob-list-handlers.xml
+++ b/reference/outcontrol/functions/ob-list-handlers.xml
@@ -27,31 +27,29 @@
   <para>
    This will return an array with the output handlers in use (if any).
   </para>
-  <note>
-   <para xml:id="function.ob-list-handlers.names">
-    If <link linkend="ini.output-buffering">output_buffering</link> is enabled
-    and no <link linkend="ini.output-handler">output_handler</link> is set,
-    or no callback or &null; was passed to <function>ob_start</function>,
-    <literal>"default output handler"</literal> is returned.
-    Enabling <link linkend="ini.output-buffering">output_buffering</link>
-    and setting an <link linkend="ini.output-handler">output_handler</link>
-    is equivalent to passing
-    an <link linkend="functions.internal">internal (built-in) function</link>
-    to <function>ob_start</function>.
-   </para>
-   <para>
-    If a <type>callable</type> was passed to <function>ob_start</function>,
-    the <link linkend="language.namespaces.basics">fully qualified name</link>
-    of the <type>callable</type> is returned.
-    If the <type>callable</type> is an object implementing
-    <link linkend="language.oop5.magic.invoke">__invoke()</link>,
-    the <link linkend="language.namespaces.basics">fully qualified name</link>
-    of the object's <link linkend="language.oop5.magic.invoke">__invoke()</link>
-    method is returned.
-    If the <type>callable</type> is a <classname>Closure</classname>,
-    <literal>"Closure::__invoke"</literal> is returned.
-   </para>
-  </note>
+  <para>
+   If <link linkend="ini.output-buffering">output_buffering</link> is enabled
+   and no <link linkend="ini.output-handler">output_handler</link> is set,
+   or no callback or &null; was passed to <function>ob_start</function>,
+   <literal>"default output handler"</literal> is returned.
+   Enabling <link linkend="ini.output-buffering">output_buffering</link>
+   and setting an <link linkend="ini.output-handler">output_handler</link>
+   is equivalent to passing
+   an <link linkend="functions.internal">internal (built-in) function</link>
+   to <function>ob_start</function>.
+  </para>
+  <para>
+   If a <type>callable</type> was passed to <function>ob_start</function>,
+   the <link linkend="language.namespaces.basics">fully qualified name</link>
+   of the <type>callable</type> is returned.
+   If the <type>callable</type> is an object implementing
+   <link linkend="language.oop5.magic.invoke">__invoke()</link>,
+   the <link linkend="language.namespaces.basics">fully qualified name</link>
+   of the object's <link linkend="language.oop5.magic.invoke">__invoke()</link>
+   method is returned.
+   If the <type>callable</type> is a <classname>Closure</classname>,
+   <literal>"Closure::__invoke"</literal> is returned.
+  </para>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/outcontrol/functions/ob-list-handlers.xml
+++ b/reference/outcontrol/functions/ob-list-handlers.xml
@@ -27,29 +27,31 @@
   <para>
    This will return an array with the output handlers in use (if any).
   </para>
-  <para>
-   If <link linkend="ini.output-buffering">output_buffering</link> is enabled
-   and no <link linkend="ini.output-handler">output_handler</link> is set,
-   or no callback or &null; was passed to <function>ob_start</function>,
-   <literal>"default output handler"</literal> is returned.
-   Enabling <link linkend="ini.output-buffering">output_buffering</link>
-   and setting an <link linkend="ini.output-handler">output_handler</link>
-   is equivalent to passing
-   an <link linkend="functions.internal">internal (built-in) function</link>
-   to <function>ob_start</function>.
-  </para>
-  <para>
-   If a <type>callable</type> was passed to <function>ob_start</function>,
-   the <link linkend="language.namespaces.basics">fully qualified name</link>
-   of the <type>callable</type> is returned.
-   If the <type>callable</type> is an object implementing
-   <link linkend="language.oop5.magic.invoke">__invoke()</link>,
-   the <link linkend="language.namespaces.basics">fully qualified name</link>
-   of the object's <link linkend="language.oop5.magic.invoke">__invoke()</link>
-   method is returned.
-   If the <type>callable</type> is a <classname>Closure</classname>,
-   <literal>"Closure::__invoke"</literal> is returned.
-  </para>
+  <note>
+   <para xml:id="function.ob-list-handlers.names">
+    If <link linkend="ini.output-buffering">output_buffering</link> is enabled
+    and no <link linkend="ini.output-handler">output_handler</link> is set,
+    or no callback or &null; was passed to <function>ob_start</function>,
+    <literal>"default output handler"</literal> is returned.
+    Enabling <link linkend="ini.output-buffering">output_buffering</link>
+    and setting an <link linkend="ini.output-handler">output_handler</link>
+    is equivalent to passing
+    an <link linkend="functions.internal">internal (built-in) function</link>
+    to <function>ob_start</function>.
+   </para>
+   <para>
+    If a <type>callable</type> was passed to <function>ob_start</function>,
+    the <link linkend="language.namespaces.basics">fully qualified name</link>
+    of the <type>callable</type> is returned.
+    If the <type>callable</type> is an object implementing
+    <link linkend="language.oop5.magic.invoke">__invoke()</link>,
+    the <link linkend="language.namespaces.basics">fully qualified name</link>
+    of the object's <link linkend="language.oop5.magic.invoke">__invoke()</link>
+    method is returned.
+    If the <type>callable</type> is a <classname>Closure</classname>,
+    <literal>"Closure::__invoke"</literal> is returned.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Added `<link>`s to `ob_get_status()` to reference other functions/constants as appropriate and added appropriate `xml:id`s to these functions/constants so these can be linked to.

Also added the same note on the difference in `ob_get_level()` and `ob_get_status()` nesting levels as the one in `ob_get_status()`.