### PR TITLE
Add missing ZEND constants and descriptions of their PHP aliases

### DIFF
--- a/appendices/reserved.constants.core.xml
+++ b/appendices/reserved.constants.core.xml
@@ -80,6 +80,28 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.zend-thread-safe">
+   <term>
+    <constant>ZEND_THREAD_SAFE</constant>
+    (<type>bool</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Indicates whether the current build of PHP is thread safe.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.zend-debug-build">
+   <term>
+    <constant>ZEND_DEBUG_BUILD</constant>
+    (<type>bool</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Indicates whether the current build of PHP is a debug build.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.php-zts">
    <term>
     <constant>PHP_ZTS</constant>
@@ -87,7 +109,7 @@
    </term>
    <listitem>
     <simpara>
-
+     Indicates whether the current build of PHP is thread safe.
     </simpara>
    </listitem>
   </varlistentry>
@@ -98,7 +120,7 @@
    </term>
    <listitem>
     <simpara>
-
+     Indicates whether the current build of PHP is a debug build.
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
Added the missing constants (https://github.com/php/doc-en/issues/2747) ZEND_THREAD_SAFE and ZEND_DEBUG_BUILD, and descriptions of their PHP integer aliases (PHP_ZTS and PHP_DEBUG). 