### PR TITLE
Update namespace FAQ on overriding special constants

### DIFF
--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -1135,7 +1135,7 @@ A\B::foo();   // calls method "foo" of class "B" from namespace "A\A"
     <listitem>
      <simpara>
       <link linkend="language.namespaces.faq.builtinconst">Cannot override special
-      constants NULL, TRUE or FALSE</link>
+      constants &null;, &true; or &false;</link>
      </simpara>
     </listitem>
    </orderedlist>
@@ -1508,7 +1508,7 @@ $a = \Bar\FOO; // fatal error, undefined namespace constant Bar\FOO
    </para>
   </sect2>
   <sect2 xml:id="language.namespaces.faq.builtinconst">
-   <title>Cannot override special constants NULL, TRUE or FALSE</title>
+   <title>Cannot override special constants &null;, &true; or &false;</title>
    <para>
     Any attempt to define a namespaced constant that is a special, built-in constant
     results in a fatal error

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -1135,7 +1135,7 @@ A\B::foo();   // calls method "foo" of class "B" from namespace "A\A"
     <listitem>
      <simpara>
       <link linkend="language.namespaces.faq.builtinconst">Cannot override special
-      constants NULL, TRUE, FALSE, ZEND_THREAD_SAFE or ZEND_DEBUG_BUILD</link>
+      constants NULL, TRUE or FALSE</link>
      </simpara>
     </listitem>
    </orderedlist>
@@ -1508,7 +1508,7 @@ $a = \Bar\FOO; // fatal error, undefined namespace constant Bar\FOO
    </para>
   </sect2>
   <sect2 xml:id="language.namespaces.faq.builtinconst">
-   <title>Cannot override special constants NULL, TRUE, FALSE, ZEND_THREAD_SAFE or ZEND_DEBUG_BUILD</title>
+   <title>Cannot override special constants NULL, TRUE or FALSE</title>
    <para>
     Any attempt to define a namespaced constant that is a special, built-in constant
     results in a fatal error

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -42,7 +42,7 @@
    </orderedlist>
   </para>
   <simpara>
-   PHP Namespaces provide a way in which to group related classes, interfaces, 
+   PHP Namespaces provide a way in which to group related classes, interfaces,
    functions and constants.  Here is an example of namespace syntax in PHP:
   </simpara>
   <example>
@@ -74,12 +74,12 @@ echo constant($d); // see "Namespaces and dynamic language features" section
     <simpara>
      Namespace names are case-insensitive.
     </simpara>
-   </note>   
+   </note>
   <note>
    <para>
     The Namespace name <literal>PHP</literal>, and compound names starting
-    with this name (like <literal>PHP\Classes</literal>) are reserved for internal language use 
-    and should not be used in the userspace code. 
+    with this name (like <literal>PHP\Classes</literal>) are reserved for internal language use
+    and should not be used in the userspace code.
    </para>
   </note>
  </sect1>
@@ -390,7 +390,7 @@ subnamespace\foo(); // resolves to function Foo\Bar\subnamespace\foo
 subnamespace\foo::staticmethod(); // resolves to class Foo\Bar\subnamespace\foo,
                                   // method staticmethod
 echo subnamespace\FOO; // resolves to constant Foo\Bar\subnamespace\FOO
-                                  
+
 /* Fully qualified name */
 \Foo\Bar\foo(); // resolves to function Foo\Bar\foo
 \Foo\Bar\foo::staticmethod(); // resolves to class Foo\Bar\foo, method staticmethod
@@ -710,11 +710,11 @@ $obj = new \Another\thing; // instantiates object of class Another\thing
   <sect2 xml:id="language.namespaces.importing.scope">
    <title>Scoping rules for importing</title>
    <para>
-    The <literal>use</literal> keyword must be declared in the 
-    outermost scope of a file (the global scope) or inside namespace 
-    declarations. This is because the importing is done at compile 
-    time and not runtime, so it cannot be block scoped. The following 
-    example will show an illegal use of the <literal>use</literal> 
+    The <literal>use</literal> keyword must be declared in the
+    outermost scope of a file (the global scope) or inside namespace
+    declarations. This is because the importing is done at compile
+    time and not runtime, so it cannot be block scoped. The following
+    example will show an illegal use of the <literal>use</literal>
     keyword:
    </para>
    <para>
@@ -738,7 +738,7 @@ function toGreenlandic()
    </para>
    <note>
     <para>
-     Importing rules are per file basis, meaning included files will 
+     Importing rules are per file basis, meaning included files will
      <emphasis>NOT</emphasis> inherit the parent file's importing rules.
     </para>
    </note>
@@ -782,8 +782,8 @@ use const some\namespace\{ConstA, ConstB, ConstC};
   <para>
    Without any namespace definition, all class and function definitions are
    placed into the global space - as it was in PHP before namespaces were
-   supported. Prefixing a name with <literal>\</literal> will specify that 
-   the name is required from the global space even in the context of the 
+   supported. Prefixing a name with <literal>\</literal> will specify that
+   the name is required from the global space even in the context of the
    namespace.
    <example>
     <title>Using global space specification</title>
@@ -793,11 +793,11 @@ use const some\namespace\{ConstA, ConstB, ConstC};
 namespace A\B\C;
 
 /* This function is A\B\C\fopen */
-function fopen() { 
+function fopen() {
      /* ... */
      $f = \fopen(...); // call global fopen
      return $f;
-} 
+}
 ?>
     ]]>
     </programlisting>


### PR DESCRIPTION
Removed ZEND_THREAD_SAFE and ZEND_DEBUG_BUILD from the section about defining namespaced special, built-in constants resulting in a fatal error as this is no longer the case for these two.

This code (https://3v4l.org/iMP1P)
```php
<?php
namespace bar;
const ZEND_DEBUG_BUILD = true;
const ZEND_THREAD_SAFE = true;

var_dump(\ZEND_DEBUG_BUILD);
var_dump(\ZEND_THREAD_SAFE);

var_dump(ZEND_DEBUG_BUILD);
var_dump(ZEND_THREAD_SAFE);
```
no longer results in a fatal error but in this output

```
bool(false)
bool(false)
bool(true)
bool(true)
```