### PR TITLE
Add avif to gd installation instructions

### DIFF
--- a/reference/image/configure.xml
+++ b/reference/image/configure.xml
@@ -41,7 +41,7 @@
       <entry>
        To enable support for avif add
        <option role="configure">--with-avif</option>.
-       This requires PHP 8.1.0 or higher.
+       Available as of PHP 8.1.0.
       </entry>
      </row>
      <row>

--- a/reference/image/configure.xml
+++ b/reference/image/configure.xml
@@ -37,6 +37,14 @@
     </thead>
     <tbody>
      <row>
+      <entry><literal>avif</literal></entry>
+      <entry>
+       To enable support for avif add
+       <option role="configure">--with-avif</option>.
+       This requires PHP 8.1.0 or higher.
+      </entry>
+     </row>
+     <row>
       <entry><literal>jpeg</literal></entry>
       <entry>
        To enable support for jpeg add

--- a/reference/image/setup.xml
+++ b/reference/image/setup.xml
@@ -47,6 +47,11 @@
        <entry></entry>
       </row>
       <row>
+       <entry><literal>avif</literal></entry>
+       <entry></entry>
+       <entry></entry>
+      </row>
+      <row>
        <entry><literal>jpeg</literal></entry>
        <entry><link xlink:href="&url.jpeg;">&url.jpeg;</link></entry>
        <entry>
@@ -70,6 +75,11 @@
         It's likely you have this library already available, if your system
         has an installed X-Environment.
        </entry>
+      </row>
+      <row>
+       <entry><literal>webp</literal></entry>
+       <entry></entry>
+       <entry></entry>
       </row>
      </tbody>
     </tgroup>


### PR DESCRIPTION
This makes it slightly easier to find and recognise as an option.

Also add avif and webp to the list with supported types for reference. Note that this might require additional details (e.g. link to library) if that is preferred.