### PR TITLE
Add PDORow class to docs

### DIFF
--- a/reference/pdo/book.xml
+++ b/reference/pdo/book.xml
@@ -43,6 +43,7 @@
 
  &reference.pdo.pdo;
  &reference.pdo.pdostatement;
+ &reference.pdo.pdorow;
  &reference.pdo.pdoexception;
 
  &reference.pdo.drivers;

--- a/reference/pdo/book.xml
+++ b/reference/pdo/book.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
- 
+
 <book xml:id="book.pdo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="bundled" ?>
  <title>PHP Data Objects</title>
  <titleabbrev>PDO</titleabbrev>
- 
+
  <!-- {{{ preface -->
  <preface xml:id="intro.pdo">
   &reftitle.intro;
@@ -31,7 +31,7 @@
   </para>
  </preface>
  <!-- }}} -->
- 
+
  &reference.pdo.setup;
  &reference.pdo.constants;
 

--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -131,8 +131,10 @@
    <listitem>
     <simpara>
      Specifies that the fetch method shall return each row as an object with
-     variable names that correspond to the column names returned in the result
-     set. <constant>PDO::FETCH_LAZY</constant> creates the object variable names as they are accessed.
+     variable names that correspond to the column names returned in the result set.
+     <constant>PDO::FETCH_LAZY</constant> returns
+     a <classname>PDORow</classname> object
+     which creates the object variable names as they are accessed.
      Not valid inside <methodname>PDOStatement::fetchAll</methodname>.
     </simpara>
    </listitem>

--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -131,10 +131,10 @@
    <listitem>
     <simpara>
      Specifies that the fetch method shall return each row as an object with
-     variable names that correspond to the column names returned in the result set.
+     property names that correspond to the column names returned in the result set.
      <constant>PDO::FETCH_LAZY</constant> returns
      a <classname>PDORow</classname> object
-     which creates the object variable names as they are accessed.
+     which creates the object property names as they are accessed.
      Not valid inside <methodname>PDOStatement::fetchAll</methodname>.
     </simpara>
    </listitem>

--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -58,7 +58,7 @@
     <simpara>
      Flag to denote a string uses the national character set.
     </simpara>
-    <simpara> 
+    <simpara>
      Available since PHP 7.2.0
     </simpara>
    </listitem>
@@ -72,7 +72,7 @@
     <simpara>
      Flag to denote a string uses the regular character set.
     </simpara>
-    <simpara> 
+    <simpara>
      Available since PHP 7.2.0
     </simpara>
    </listitem>
@@ -270,7 +270,7 @@
    </term>
    <listitem>
     <simpara>
-     Allows completely customize the way data is treated on the fly (only 
+     Allows completely customize the way data is treated on the fly (only
      valid inside <methodname>PDOStatement::fetchAll</methodname>).
     </simpara>
    </listitem>
@@ -283,7 +283,7 @@
    <listitem>
     <simpara>
      Group return by values. Usually combined with
-     <constant>PDO::FETCH_COLUMN</constant> or 
+     <constant>PDO::FETCH_COLUMN</constant> or
      <constant>PDO::FETCH_KEY_PAIR</constant>.
     </simpara>
    </listitem>
@@ -476,7 +476,7 @@
    <listitem>
     <simpara>
      Selects the cursor type.  PDO currently supports either
-     <constant>PDO::CURSOR_FWDONLY</constant> and 
+     <constant>PDO::CURSOR_FWDONLY</constant> and
      <constant>PDO::CURSOR_SCROLL</constant>. Stick with
      <constant>PDO::CURSOR_FWDONLY</constant> unless you know that you need a
      scrollable cursor.
@@ -525,7 +525,7 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     (<type>int</type>)
    </term>
    <listitem>
-    <simpara> 
+    <simpara>
      Request a persistent connection, rather than creating a new connection.
      See <link linkend="pdo.connections">Connections and Connection
      management</link> for more information on this attribute.
@@ -538,7 +538,7 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     (<type>int</type>)
    </term>
    <listitem>
-    <simpara> 
+    <simpara>
      Sets the class name of which statements are returned as.
     </simpara>
    </listitem>
@@ -549,7 +549,7 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     (<type>int</type>)
    </term>
    <listitem>
-    <simpara> 
+    <simpara>
      Prepend the containing catalog name to each column name returned in the
      result set. The catalog name and column name are separated by a decimal
      (.) character.  Support of this attribute is at the driver level; it may
@@ -563,7 +563,7 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     (<type>int</type>)
    </term>
    <listitem>
-    <simpara> 
+    <simpara>
      Prepend the containing table name to each column name returned in the
      result set. The table name and column name are separated by a decimal (.)
      character. Support of this attribute is at the driver level; it may not
@@ -577,7 +577,7 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     (<type>int</type>)
    </term>
    <listitem>
-    <simpara> 
+    <simpara>
      Forces all values fetched to be treated as strings.
     </simpara>
    </listitem>
@@ -588,7 +588,7 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     (<type>int</type>)
    </term>
    <listitem>
-    <simpara> 
+    <simpara>
      Sets the maximum column name length.
     </simpara>
    </listitem>
@@ -599,7 +599,7 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     (<type>int</type>)
    </term>
    <listitem>
-    <simpara> 
+    <simpara>
 
     </simpara>
    </listitem>
@@ -622,7 +622,7 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
    </term>
    <listitem>
     <simpara>
-     Sets the default string parameter type, this can be one of <constant>PDO::PARAM_STR_NATL</constant> 
+     Sets the default string parameter type, this can be one of <constant>PDO::PARAM_STR_NATL</constant>
      and <constant>PDO::PARAM_STR_CHAR</constant>.
     </simpara>
     <simpara>
@@ -687,7 +687,7 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     (<type>int</type>)
    </term>
    <listitem>
-    <simpara> 
+    <simpara>
      Force column names to lower case.
     </simpara>
    </listitem>
@@ -836,7 +836,7 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     (<type>string</type>)
    </term>
    <listitem>
-    <simpara> 
+    <simpara>
      Corresponds to SQLSTATE '00000', meaning that the SQL statement was
      successfully issued with no errors or warnings.  This constant is for
      your convenience when checking <methodname>PDO::errorCode</methodname> or

--- a/reference/pdo/pdorow.xml
+++ b/reference/pdo/pdorow.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpdoc:classref xml:id="class.pdorow" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The PDORow class</title>
+ <titleabbrev>PDORow</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ PDORow intro -->
+  <section xml:id="pdorow.intro">
+   &reftitle.intro;
+   <para>
+    Represents a row from a result set returned
+    by <methodname>PDOStatement::fetch</methodname>
+    called with <constant>PDO_FETCH_LAZY</constant> fetch mode.
+   </para>
+   <para>
+    In addition to its default <property>queryString</property> property,
+    the <classname>PDORow</classname> object creates properties
+    that correspond to the column names returned in the result set
+    as they are accessed.
+   </para>
+   <para>
+    Objects of this class cannot be instantiated.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="pdorow.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier>final</modifier>
+     <classname>PDORow</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="pdorow.props.querystring">queryString</varname>
+    </fieldsynopsis>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+
+<!-- {{{ PDORow properties -->
+  <section xml:id="pdorow.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="pdorow.props.querystring">
+     <term><varname>queryString</varname></term>
+     <listitem>
+      <para>
+       Query string used by the <classname>PDOStatement</classname>
+       that returned the <classname>PDORow</classname> object.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+ </partintro>
+
+</phpdoc:classref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -70,7 +70,7 @@
          <literal>PDO::FETCH_LAZY</literal>: combines
          <literal>PDO::FETCH_BOTH</literal> and <literal>PDO::FETCH_OBJ</literal>,
          and is returning a <classname>PDORow</classname> object
-         which is creating the object variable names as they are accessed.
+         which is creating the object property names as they are accessed.
         </para></listitem>
         <listitem><para>
          <literal>PDO::FETCH_NAMED</literal>: returns an array with the same

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -69,7 +69,8 @@
         <listitem><para>
          <literal>PDO::FETCH_LAZY</literal>: combines
          <literal>PDO::FETCH_BOTH</literal> and <literal>PDO::FETCH_OBJ</literal>,
-         creating the object variable names as they are accessed
+         and is returning a <classname>PDORow</classname> object
+         which is creating the object variable names as they are accessed.
         </para></listitem>
         <listitem><para>
          <literal>PDO::FETCH_NAMED</literal>: returns an array with the same
@@ -115,7 +116,7 @@
     <varlistentry>
      <term><parameter>cursorOffset</parameter></term>
      <listitem>
-      <para> 
+      <para>
        For a PDOStatement object representing a scrollable cursor for which
        the <parameter>cursorOrientation</parameter> parameter is set to
        <literal>PDO::FETCH_ORI_ABS</literal>, this value specifies the
@@ -171,7 +172,7 @@ print_r($result);
 print "\n";
 
 print "PDO::FETCH_LAZY: ";
-print "Return next row as an anonymous object with column names as properties\n";
+print "Return next row as a PDORow object with column names as properties\n";
 $result = $sth->fetch(PDO::FETCH_LAZY);
 print_r($result);
 print "\n";
@@ -203,7 +204,7 @@ Array
     [1] => yellow
 )
 
-PDO::FETCH_LAZY: Return next row as an anonymous object with column names as properties
+PDO::FETCH_LAZY: Return next row as a PDORow object with column names as properties
 PDORow Object
 (
     [name] => orange

--- a/reference/pdo/versions.xml
+++ b/reference/pdo/versions.xml
@@ -46,6 +46,8 @@
  <function name="pdo_user::tokenizesql" from="PECL pdo_user &gt;= 0.2.0"/>
  <function name="pdo_user::tokenname" from="PECL pdo_user &gt;= 0.2.0"/>
 
+ <function name="pdorow" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 1.0.0"/>
+
  <function name="pdostatement" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 1.0.0"/>
  <function name="pdostatement::__sleep" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 1.0.0"/>
  <function name="pdostatement::__wakeup" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 1.0.0"/>


### PR DESCRIPTION
Add the PDORow class to the docs (#2162) and reference it from the appropriate parts of the PDO docs.

As this class has no methods and all but one the properties of this class are dynamic, I added the description of the class and it's dynamic properties to the introduction section (I've got the idea from stdClass's docs). Let me know whether this format is acceptable.