### PR TITLE
Add DOMNameSpaceNode class to docs

### DIFF
--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -33,6 +33,7 @@
  &reference.dom.domexception;
  &reference.dom.domimplementation;
  &reference.dom.domnamednodemap;
+ &reference.dom.domnamespacenode;
  &reference.dom.domnode;
  &reference.dom.domnodelist;
  &reference.dom.domnotation;

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -14,7 +14,7 @@
   </para>
   &dom.note.utf8;
  </preface>
- 
+
  &reference.dom.setup;
  &reference.dom.constants;
  &reference.dom.examples;
@@ -40,12 +40,12 @@
  &reference.dom.domprocessinginstruction;
  &reference.dom.domtext;
  &reference.dom.domxpath;
- 
+
  <!-- FIXME:
  <section xml:id="dom.class.domnamelist">
      <title><classname>DOMNameList</classname></title>
      <para>
-      
+
      </para>
      <section xml:id="dom.class.domnamelist.methods">
       &reftitle.methods;
@@ -78,13 +78,13 @@
           <entry>yes</entry>
           <entry>
            The number of pairs (name and namespaceURI) in the list. The range
-           of valid child node indices is 0 to <literal>length - 1</literal> 
+           of valid child node indices is 0 to <literal>length - 1</literal>
            inclusive.
           </entry>
          </row>
         </tbody>
        </tgroup>
-      </table>     
+      </table>
      </section>
     </section>-->
 
@@ -92,7 +92,7 @@
   <title>DOM &Functions;</title>
   &reference.dom.entities.functions;
  </reference>
- 
+
 </book>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/dom/domnamespacenode.xml
+++ b/reference/dom/domnamespacenode.xml
@@ -97,7 +97,7 @@
      <term><varname>nodeName</varname></term>
      <listitem>
       <para>
-       Returns the most accurate name for the current node type
+       The qualified name of this node.
       </para>
      </listitem>
     </varlistentry>
@@ -105,11 +105,7 @@
      <term><varname>nodeValue</varname></term>
      <listitem>
       <para>
-       The value of this node, depending on its type.
-       Contrary to the W3C specification, the node value of
-       <classname>DOMElement</classname> nodes is equal to
-       <link linkend="domnode.props.textcontent">DOMNode::textContent</link>
-       instead of &null;.
+       The namespace URI declared by this node, or &null; if the empty namespace.
       </para>
      </listitem>
     </varlistentry>
@@ -117,8 +113,10 @@
      <term><varname>nodeType</varname></term>
      <listitem>
       <para>
-       Gets the type of the node. One of the predefined
-       <link linkend="dom.constants">XML_xxx_NODE constants</link>
+       The type of the node. In this case it returns
+       <link linkend="dom.constants">
+        <constant>XML_NAMESPACE_DECL_NODE</constant>
+       </link>.
       </para>
      </listitem>
     </varlistentry>
@@ -126,7 +124,7 @@
      <term><varname>prefix</varname></term>
      <listitem>
       <para>
-       The namespace prefix of this node.
+       The namespace prefix declared by this node.
       </para>
      </listitem>
     </varlistentry>
@@ -134,7 +132,7 @@
      <term><varname>localName</varname></term>
      <listitem>
       <para>
-       Returns the local part of the qualified name of this node.
+       The local part of the qualified name of this node.
       </para>
      </listitem>
     </varlistentry>
@@ -142,7 +140,7 @@
      <term><varname>namespaceURI</varname></term>
      <listitem>
       <para>
-       The namespace URI of this node, or &null; if it is unspecified.
+       The namespace URI declared by this node, or &null; if it is unspecified.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dom/domnamespacenode.xml
+++ b/reference/dom/domnamespacenode.xml
@@ -174,7 +174,7 @@
      <term><varname>parentElement</varname></term>
      <listitem>
       <para>
-       The parent element of this element.
+       The parent element of this node.
        If there is no such element, this returns &null;.
       </para>
      </listitem>

--- a/reference/dom/domnamespacenode.xml
+++ b/reference/dom/domnamespacenode.xml
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpdoc:classref xml:id="class.domnamespacenode" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The DOMNameSpaceNode class</title>
+ <titleabbrev>DOMNameSpaceNode</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ DOMNameSpaceNode intro
+  <section xml:id="domnamespacenode.intro">
+   &reftitle.intro;
+   <para>
+
+   </para>
+  </section>
+}}} -->
+
+  <section xml:id="domnamespacenode.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>DOMNameSpaceNode</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="domnamespacenode.props.nodename">nodeName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="domnamespacenode.props.nodevalue">nodeValue</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="domnamespacenode.props.nodetype">nodeType</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="domnamespacenode.props.prefix">prefix</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="domnamespacenode.props.localname">localName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="domnamespacenode.props.namespaceuri">namespaceURI</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>bool</type>
+     <varname linkend="domnamespacenode.props.isconnected">isConnected</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>DOMDocument</type><type>null</type></type>
+     <varname linkend="domnamespacenode.props.ownerdocument">ownerDocument</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>DOMNode</type><type>null</type></type>
+     <varname linkend="domnamespacenode.props.parentnode">parentNode</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>DOMElement</type><type>null</type></type>
+     <varname linkend="domnamespacenode.props.parentelement">parentElement</varname>
+    </fieldsynopsis>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+<!-- {{{ DOMNameSpaceNode properties -->
+  <section xml:id="domnamespacenode.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="domnamespacenode.props.nodename">
+     <term><varname>nodeName</varname></term>
+     <listitem>
+      <para>
+       Returns the most accurate name for the current node type
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="domnamespacenode.props.nodevalue">
+     <term><varname>nodeValue</varname></term>
+     <listitem>
+      <para>
+       The value of this node, depending on its type.
+       Contrary to the W3C specification, the node value of
+       <classname>DOMElement</classname> nodes is equal to
+       <link linkend="domnode.props.textcontent">DOMNode::textContent</link>
+       instead of &null;.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="domnamespacenode.props.nodetype">
+     <term><varname>nodeType</varname></term>
+     <listitem>
+      <para>
+       Gets the type of the node. One of the predefined
+       <link linkend="dom.constants">XML_xxx_NODE constants</link>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="domnamespacenode.props.prefix">
+     <term><varname>prefix</varname></term>
+     <listitem>
+      <para>
+       The namespace prefix of this node.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="domnamespacenode.props.localname">
+     <term><varname>localName</varname></term>
+     <listitem>
+      <para>
+       Returns the local part of the qualified name of this node.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="domnamespacenode.props.namespaceuri">
+     <term><varname>namespaceURI</varname></term>
+     <listitem>
+      <para>
+       The namespace URI of this node, or &null; if it is unspecified.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="domnamespacenode.props.isconnected">
+     <term><varname>isConnected</varname></term>
+     <listitem>
+      <para>
+       Whether the node is connected to a document.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="domnamespacenode.props.ownerdocument">
+     <term><varname>ownerDocument</varname></term>
+     <listitem>
+      <para>
+       The <classname>DOMDocument</classname> object associated with this node,
+       or &null; if this node is a <classname>DOMDocument</classname>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="domnamespacenode.props.parentnode">
+     <term><varname>parentNode</varname></term>
+     <listitem>
+      <para>
+       The parent of this node.
+       If there is no such node, this returns &null;.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="domnamespacenode.props.parentelement">
+     <term><varname>parentElement</varname></term>
+     <listitem>
+      <para>
+       The parent element of this element.
+       If there is no such element, this returns &null;.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.3.0</entry>
+       <entry>
+        Properties <property>DOMNameSpaceNode::$parentElement</property>, and
+        <property>DOMNameSpaceNode::$isConnected</property> have been added.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
+ </partintro>
+
+</phpdoc:classref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -138,6 +138,8 @@
  <function name="domnamednodemap::setnameditem" from="PHP 5, PHP 7"/>
  <function name="domnamednodemap::setnameditemns" from="PHP 5, PHP 7"/>
 
+ <function name="domnamespacenode" from="PHP 5, PHP 7, PHP 8"/>
+
  <function name="domnode" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domnode::appendchild" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domnode::c14n" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -3,7 +3,7 @@
 <!--
   Do NOT translate this file
 -->
-<versions> 
+<versions>
  <function name="domattr" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domattr::__construct" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domattr::isid" from="PHP 5, PHP 7, PHP 8"/>
@@ -109,12 +109,12 @@
  <function name="domelement::setidattributenode" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domelement::setidattributens" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domelement::toggleattribute" from="PHP 8 &gt;= 8.3.0"/>
- 
+
   <function name="domentity" from="PHP 5, PHP 7, PHP 8"/>
 
  <function name="domentityreference" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domentityreference::__construct" from="PHP 5, PHP 7, PHP 8"/>
- 
+
   <function name="domexception" from="PHP 5, PHP 7, PHP 8"/>
 
  <function name="domimplementation" from="PHP 5, PHP 7, PHP 8"/>
@@ -168,9 +168,9 @@
  <function name="domnodelist::count" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
  <function name="domnodelist::getiterator" from="PHP 8"/>
  <function name="domnodelist::item" from="PHP 5, PHP 7, PHP 8"/>
- 
+
  <function name="domnotation" from="PHP 5, PHP 7, PHP 8"/>
- 
+
  <function name="domparentnode" from="PHP 8"/>
  <function name="domparentnode::append" from="PHP 8"/>
  <function name="domparentnode::prepend" from="PHP 8"/>


### PR DESCRIPTION
Add the missing DOMNameSpaceNode class to the docs (ref #2162) and reference it from the DOM book.