### PR TITLE
Update INI documentation for ibm_db2

### DIFF
--- a/reference/ibm_db2/ini.xml
+++ b/reference/ibm_db2/ini.xml
@@ -279,7 +279,7 @@
       This options affects the internal buffer allocation strategy on IBM i.
       By default, this option is <literal>0</literal>.
       When this option is set, buffers are allocated with a much larger size,
-      in case the database is misleading about character size when converting
+      in case the database underestimates a string's size when converting
       between encodings.
       This option uses six times as much memory for buffers (to account for
       the largest possible UTF-8 sequences), but may be needed if truncated
@@ -332,20 +332,23 @@
     </term>
     <listitem>
      <para>
-      This option sets if diagnostic messages like warnings and errors are
-      always sent to the error log on IBM i.
-      Normally, only a brief message on failure is sent, as this option is set
-      to <literal>0</literal> by default. Note that you can still and should
-      call i.e. <function>db2_stmt_errormsg</function> manually.
+      This option sets if SQL diagnostic messages like warnings and errors are
+      always sent to the PHP error log on IBM i.
+      Normally, only a brief message on failure is sent (such as "statement
+      execute failed") to the PHP error log, as this option is set to
+      <literal>0</literal> by default.
+      Note that you can still and should call i.e.
+      <function>db2_stmt_errormsg</function> manually as part of checking if
+      functions fail.
       <itemizedlist>
        <listitem>
         <para>
-         0 - Only logs concise messages.
+         0 - Only logs brief messages.
         </para>
        </listitem>
        <listitem>
         <para>
-         1 - Logs the SQL diagnostic message in addition to the concise message.
+         1 - Logs the SQL diagnostic message in addition to the brief message.
         </para>
        </listitem>
       </itemizedlist>
@@ -436,14 +439,18 @@
     </term>
     <listitem>
      <para>
-      The ASCII CCSID to use for character conversions from EBCDIC on IBM i.
-      Setting this to <literal>1208</literal> will use UTF-8.
+      The PASE CCSID to use for character conversions from EBCDIC on IBM i.
       By default, this is <literal>0</literal>, which will select the default
-      ASCII job CCSID.
+      PASE job CCSID, which comes from the PASE locale settings.
+      For example, setting this to <literal>1208</literal> will use UTF-8.
+      You should only need to set this if the PASE job CCSID isn't the expected
+      CCSID, and you can't change the locale.`
      </para>
      <para>
       To learn more about CCSIDs on IBM i, consult the
       <link xlink:href="https://www.ibm.com/docs/en/i/7.5?topic=information-ccsid-reference">IBM documentation</link>.
+      To learn how locales on IBM i PASE are mapped to CCSIDs, consult the
+      <link xlink:href="https://www.ibm.com/docs/en/i/7.5?topic=ssw_ibm_i_75/apis/pase_locales.html">IBM documentation</link>.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ibm_db2/ini.xml
+++ b/reference/ibm_db2/ini.xml
@@ -182,7 +182,7 @@
     <listitem>
      <para>
       This option controls the transaction isolation mode used.
-      By default, this is set to 0, so commitment control isn't used.
+      By default, this option is <literal>0</literal>, so commitment control isn't used.
       This option can be overriden when connecting if the array key
       <parameter>i5_commit</parameter> is set in the connection options array
       passed to <function>db2_connect</function> or

--- a/reference/ibm_db2/ini.xml
+++ b/reference/ibm_db2/ini.xml
@@ -224,10 +224,12 @@
     </term>
     <listitem>
      <para>
-      This controls if a blank user ID should be allowed on IBM i. By default,
-      this option is off. Unlike <parameter>ibm_db2.i5_ignore_userid</parameter>,
-      this option doesn't force all user IDs to be empty, but simply allows an
-      empty user ID to be passed, for connecting to Db2 as the current user.
+      This controls if a blank user ID should be allowed on IBM i.
+      By default, this option is <literal>0</literal>.
+      Unlike <parameter>ibm_db2.i5_ignore_userid</parameter>, this option
+      doesn't force all user IDs to be empty or change job behaviour, but
+      simply allows an empty user ID to be passed, for connecting to Db2 as the
+      current user.
       <itemizedlist>
        <listitem>
         <para>
@@ -363,21 +365,22 @@
     <listitem>
      <para>
       This option ignores the user ID when connecting to the database when
-      running on IBM i.
+      running on IBM i, and runs SQL/CLI functionality inside of the PHP job,
+      instead of a separate job.
       By default, this option is <literal>0</literal>.
-      When enabled, a blank user ID and password is always used when
-      connecting, so it uses the current profile when connecting.
-      Historically, this provided as a convenience for simple applications.
-      It should not be used in new applications.
+      When enabled, it no longer uses a separate database server job, and
+      always uses the current user profile for the database, ignoring the
+      username and password passed to <function>db2_connect</function> and
+      <function>db2_pconnect</function>.
       <itemizedlist>
        <listitem>
         <para>
-         0 - Uses the specified credentials.
+         0 - Uses the specified credentials, and use an SQL/CLI server job.
         </para>
        </listitem>
        <listitem>
         <para>
-         1 - Always uses a blank user ID and password.
+         1 - Always use blank credentials, and run SQL/CLI in the PHP job.
         </para>
        </listitem>
       </itemizedlist>

--- a/reference/ibm_db2/ini.xml
+++ b/reference/ibm_db2/ini.xml
@@ -12,7 +12,7 @@
       <entry>&Name;</entry>
       <entry>&Default;</entry>
       <entry>&Changeable;</entry>
-      <entry>Changelog</entry>
+      <entry>&Changelog;</entry>
      </row>
     </thead>
     <tbody xml:id="ibm-db2.configuration.list">
@@ -26,85 +26,85 @@
       <entry><link linkend="ini.ibm-db2.i5-all-pconnect">ibm_db2.i5_all_pconnect</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since ibm_db2 1.6.5.</entry>
+      <entry>Available as of ibm_db2 1.6.5.</entry>
      </row>     
      <row>
       <entry><link linkend="ini.ibm-db2.i5-allow-commit">ibm_db2.i5_allow_commit</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since ibm_db2 1.4.9.</entry>
+      <entry>Available as of ibm_db2 1.4.9.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-blank-userid">ibm_db2.i5_blank_userid</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since ibm_db2 1.9.7.</entry>
+      <entry>Available as of ibm_db2 1.9.7.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-char-trim">ibm_db2.i5_char_trim</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since ibm_db2 2.1.0.</entry>
+      <entry>Available as of ibm_db2 2.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-dbcs-alloc">ibm_db2.i5_dbcs_alloc</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since ibm_db2 1.5.0.</entry>
+      <entry>Available as of ibm_db2 1.5.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-guard-profile">ibm_db2.i5_guard_profile</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since ibm_db2 1.9.7.</entry>
+      <entry>Available as of ibm_db2 1.9.7.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-ignore-userid">ibm_db2.i5_ignore_userid</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since ibm_db2 1.8.0.</entry>
+      <entry>Available as of ibm_db2 1.8.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-job-sort">ibm_db2.i5_job_sort</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since ibm_db2 1.8.4.</entry>
+      <entry>Available as of ibm_db2 1.8.4.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-log-verbose">ibm_db2.i5_log_verbose</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since ibm_db2 1.9.7.</entry>
+      <entry>Available as of ibm_db2 1.9.7.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-max-pconnect">ibm_db2.i5_max_pconnect</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since ibm_db2 1.9.7.</entry>
+      <entry>Available as of ibm_db2 1.9.7.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-override-ccsid">ibm_db2.i5_override_ccsid</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since ibm_db2 1.9.7.</entry>
+      <entry>Available as of ibm_db2 1.9.7.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-servermode-subsystem">ibm_db2.i5_servermode_subsystem</link></entry>
       <entry>NULL</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since ibm_db2 1.9.7.</entry>
+      <entry>Available as of ibm_db2 1.9.7.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-sys-naming">ibm_db2.i5_sys_naming</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since ibm_db2 1.9.7.</entry>
+      <entry>Available as of ibm_db2 1.9.7.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.instance-name">ibm_db2.instance_name</link></entry>
       <entry>NULL</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since ibm_db2 1.0.2.</entry>
+      <entry>Available as of ibm_db2 1.0.2.</entry>
      </row>
     </tbody>
    </tgroup>
@@ -152,11 +152,13 @@
     </term>
     <listitem>
      <para>
-      This option forces all connections to be persistent on IBM i. Basically,
-      all <function>db2_connect</function> calls transparently become
-      <function>db2_pconnect</function> calls. By default, this option is 0.
+      This option forces all connections to be persistent on IBM i.
+      Basically, all <function>db2_connect</function> calls transparently become
+      <function>db2_pconnect</function> calls.
+      By default, this option is <literal>0</literal>.
       This option is provided as a convenience for cases where persistent
-      connections are faster. It should not be used in new applications.
+      connections are faster.
+      It should not be used in new applications.
       <itemizedlist>
        <listitem>
         <para>
@@ -179,10 +181,12 @@
     </term>
     <listitem>
      <para>
-      This option controls the transaction isolation mode used. By default,
-      this is set to 0, so commitment control isn't used. You can override the
-      option when connecting when <parameter>i5_commit</parameter> is in the
-      connection options array.
+      This option controls the transaction isolation mode used.
+      By default, this is set to 0, so commitment control isn't used.
+      This option can be overriden when connecting if the array key
+      <parameter>i5_commit</parameter> is set in the connection options array
+      passed to <function>db2_connect</function> or
+      <function>db2_pconnect</function>.
       <itemizedlist>
        <listitem>
         <para>
@@ -246,9 +250,10 @@
     </term>
     <listitem>
      <para>
-      This option controls if the end of strings are trimmed on IBM i. Since
-      many tables use fixed column sizes padded with spaces, this is provided
-      as a convenience.
+      This option controls if the end of strings are trimmed on IBM i.
+      Since many tables use fixed column sizes padded with spaces, this is
+      provided as a convenience.
+      By default, this option is <literal>0</literal>.
       <itemizedlist>
        <listitem>
         <para>
@@ -272,11 +277,13 @@
     <listitem>
      <para>
       This options affects the internal buffer allocation strategy on IBM i.
-      By default, this option is 0. When this option is set, buffers are
-      allocated with a much larger size, in case the database is misleading
-      about character size when converting between encodings. This option uses
-      six times as much memory for buffers (to account for the largest possible
-      UTF-8 sequences), but may be needed if truncated data is returned.
+      By default, this option is <literal>0</literal>.
+      When this option is set, buffers are allocated with a much larger size,
+      in case the database is misleading about character size when converting
+      between encodings.
+      This option uses six times as much memory for buffers (to account for
+      the largest possible UTF-8 sequences), but may be needed if truncated
+      data is returned.
       <itemizedlist>
        <listitem>
         <para>
@@ -301,7 +308,8 @@
      <para>
       This option checks if the database user profile was switched when
       connecting to a persistent database connection on IBM i, and if so,
-      disconnects from the database. By default, this option is set to 0.
+      disconnects from the database.
+      By default, this option is set to <literal>0</literal>.
       <itemizedlist>
        <listitem>
         <para>
@@ -325,9 +333,10 @@
     <listitem>
      <para>
       This option sets if diagnostic messages like warnings and errors are
-      always sent to the error log on IBM i. Normally, only a brief message on
-      failure is sent, as this option is set to 0 by default. Note that you can
-      still call i.e. <function>db2_stmt_errormsg</function> yourself.
+      always sent to the error log on IBM i.
+      Normally, only a brief message on failure is sent, as this option is set
+      to <literal>0</literal> by default. Note that you can still and should
+      call i.e. <function>db2_stmt_errormsg</function> manually.
       <itemizedlist>
        <listitem>
         <para>
@@ -351,11 +360,12 @@
     <listitem>
      <para>
       This option ignores the user ID when connecting to the database when
-      running on IBM i. By default, this option is off. When enabled, a blank
-      user ID and password is always used when connecting, so it uses the
-      current profile when connecting. Historically, this provided as a
-      convenience for simple applications. It should not be used in new
-      applications.
+      running on IBM i.
+      By default, this option is <literal>0</literal>.
+      When enabled, a blank user ID and password is always used when
+      connecting, so it uses the current profile when connecting.
+      Historically, this provided as a convenience for simple applications.
+      It should not be used in new applications.
       <itemizedlist>
        <listitem>
         <para>
@@ -378,12 +388,14 @@
     </term>
     <listitem>
      <para>
-      Controls the job sort option on IBM i. By default, this option is 0.
-      This corresponds to the SQL/CLI SQL_ATTR_CONN_SORT_SEQUENCE attribute.
+      Controls the job sort option on IBM i.
+      By default, this option is <literal>0</literal>.
+      This corresponds to the IBM i SQL/CLI
+      <constant>SQL_ATTR_CONN_SORT_SEQUENCE</constant> attribute.
       <itemizedlist>
        <listitem>
         <para>
-         0 - Uses the *HEX sort option, sorting by bytes.
+         0 - Uses the <constant>*HEX</constant> sort option, sorting by bytes.
         </para>
        </listitem>
        <listitem>
@@ -408,10 +420,12 @@
     <listitem>
      <para>
       This will affect how many times a persistent connection can be reused
-      when running on IBM i. By default, this is set to 0, which means a
-      persistent connection can always be reused. This option can help work
-      around issues in a long-running database job (i.e. if a procedure is
-      leaking memory), but is obviously not a long-term fix.
+      when running on IBM i.
+      By default, this is set to <literal>0</literal>, which means a persistent
+      connection can always be reused.
+      This option can help work around issues in a long-running database job
+      (i.e. if a procedure is leaking memory), but is obviously not a long-term
+      fix.
      </para>
     </listitem>
    </varlistentry>
@@ -422,9 +436,10 @@
     </term>
     <listitem>
      <para>
-      The ASCII CCSID to use for conversion from EBCDIC on IBM i. Setting this
-      to 1208 will use UTF-8. By default, this is 0, which will select the
-      default ASCII job CCSID.
+      The ASCII CCSID to use for character conversions from EBCDIC on IBM i.
+      Setting this to <literal>1208</literal> will use UTF-8.
+      By default, this is <literal>0</literal>, which will select the default
+      ASCII job CCSID.
      </para>
      <para>
       To learn more about CCSIDs on IBM i, consult the
@@ -440,11 +455,13 @@
     <listitem>
      <para>
       This option controls the naming mode when connecting to an IBM i system.
-      By default, this option is 0. The naming mode affects how names are
-      resolved and the allowed syntax for names. When set to 0, this uses
-      periods to qualify names and uses the default library or user ID to
-      resolve names. When set to 1, uses slashes to qualify names and uses
-      the job library list to resolve names.
+      By default, this option is <literal>0</literal>.
+      The naming mode affects how names are resolved and the allowed syntax for
+      names.
+      When set to <literal>0</literal>, this uses periods to qualify names and
+      uses the default library or user ID to resolve names.
+      When set to <literal>1</literal>, this uses slashes to qualify names and
+      uses the job library list to resolve names.
       <itemizedlist>
        <listitem>
         <para>
@@ -472,8 +489,9 @@
     <listitem>
      <para>
       This option changes which subsystem database server jobs run under on
-      IBM i. By default, this option is null, so jobs will run under the
-      default subsystem for QSQSERVER jobs.
+      IBM i.
+      By default, this option is &null;, so jobs will run under the default
+      subsystem for QSQSERVER jobs.
      </para>
     </listitem>
    </varlistentry>
@@ -485,8 +503,10 @@
     <listitem>
      <para>
       On Linux and UNIX operating systems, this option defines the name of the
-      instance to use for cataloged database connections. If this option is set,
-      its value overrides the DB2INSTANCE environment variable setting.
+      instance to use for cataloged database connections.
+      By default, this option is &null;.
+      If this option is set, its value overrides the
+      <varname>DB2INSTANCE</varname> environment variable setting.
      </para>
      <para>
       This option is ignored on Windows operating systems.

--- a/reference/ibm_db2/ini.xml
+++ b/reference/ibm_db2/ini.xml
@@ -498,7 +498,7 @@
       This option changes which subsystem database server jobs run under on
       IBM i.
       By default, this option is &null;, so jobs will run under the default
-      subsystem for QSQSERVER jobs.
+      subsystem for QSQSRVR jobs.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ibm_db2/ini.xml
+++ b/reference/ibm_db2/ini.xml
@@ -152,21 +152,20 @@
     </term>
     <listitem>
      <para>
-      This option overrides i5 <function>db2_connect</function> full open and close in the PHP 
-      application. When <parameter>ibm_db2.i5_all_pconnect</parameter> = 1, all db2 connections 
-      become persistent (<function>db2_pconnect</function>). On i5/OS, <function>db2_pconnect</function> performs 
-      dramatically better with lower machine stress over <function>db2_connect</function>. This 
-      is a convenience override of <function>db2_connect</function> to evoke <function>db2_pconnect</function> without 
-      PHP source code changes. 
+      This option forces all connections to be persistent on IBM i. Basically,
+      all <function>db2_connect</function> calls transparently become
+      <function>db2_pconnect</function> calls. By default, this option is 0.
+      This option is provided as a convenience for cases where persistent
+      connections are faster. It should not be used in new applications.
       <itemizedlist>
        <listitem>
         <para>
-         0 <function>db2_connect</function> default full open and close
+         0  - Persistent and non-persistent connections can be made.
         </para>
        </listitem>
        <listitem>
         <para>
-         1 <function>db2_connect</function> override to <function>db2_pconnect</function> for persistent connection only
+         1 - All connections are persistent.
         </para>
        </listitem>
       </itemizedlist>
@@ -180,8 +179,10 @@
     </term>
     <listitem>
      <para>
-      This option controls the isolation mode used for i5 schema collections 
-      in the PHP application (see <parameter>i5_commit</parameter> for override).
+      This option controls the transaction isolation mode used. By default,
+      this is set to 0, so commitment control isn't used. You can override the
+      option when connecting when <parameter>i5_commit</parameter> is in the
+      connection options array.
       <itemizedlist>
        <listitem>
         <para>
@@ -270,17 +271,21 @@
     </term>
     <listitem>
      <para>
-      This option controls the internal ibm_db2 allocation scheme 
-      for large DBCS column buffers.
+      This options affects the internal buffer allocation strategy on IBM i.
+      By default, this option is 0. When this option is set, buffers are
+      allocated with a much larger size, in case the database is misleading
+      about character size when converting between encodings. This option uses
+      six times as much memory for buffers (to account for the largest possible
+      UTF-8 sequences), but may be needed if truncated data is returned.
       <itemizedlist>
        <listitem>
         <para>
-         0 no expanded allocations (see <parameter>i5_dbcs_alloc</parameter> for override)
+         0 - Minimum size buffers are allocated.
         </para>
        </listitem>
        <listitem>
         <para>
-         1 use expanded allocations (see <parameter>i5_dbcs_alloc</parameter> for override)
+         1 - Larger size buffers are allocated.
         </para>
        </listitem>
       </itemizedlist>
@@ -295,8 +300,8 @@
     <listitem>
      <para>
       This option checks if the database user profile was switched when
-      connecting to a persistent database connection on IBM i. By
-      default, this option is set to 0.
+      connecting to a persistent database connection on IBM i, and if so,
+      disconnects from the database. By default, this option is set to 0.
       <itemizedlist>
        <listitem>
         <para>
@@ -345,24 +350,21 @@
     </term>
     <listitem>
      <para>
-      This option overrides i5 db2_(p)connect userid and password in the PHP 
-      application. When  <parameter>ibm_db2.i5_ignore_userid</parameter> = 1, 
-      all db2 (p)connections become null userid and null password. Therefore 
-      Apache jobs connect with the current profile (NOBODY). Use of this override 
-      is only for simple DB2 based websites that never require profile switching 
-      and therefore can avoid all overhead of server mode additional QSQSRVR jobs. 
-      This is a convenience override of db2_(p)connect to set the userid and password 
-      values to null without PHP source code changes. This override can be used in 
-      combination with <parameter>ibm_db2.i5_all_pconnect</parameter> = 1.
+      This option ignores the user ID when connecting to the database when
+      running on IBM i. By default, this option is off. When enabled, a blank
+      user ID and password is always used when connecting, so it uses the
+      current profile when connecting. Historically, this provided as a
+      convenience for simple applications. It should not be used in new
+      applications.
       <itemizedlist>
        <listitem>
         <para>
-         0 db2_(p)connect with specified userid and password
+         0 - Uses the specified credentials.
         </para>
        </listitem>
        <listitem>
         <para>
-         1 db2_(p)connect override connect with null userid and null password
+         1 - Always uses a blank user ID and password.
         </para>
        </listitem>
       </itemizedlist>
@@ -424,6 +426,10 @@
       to 1208 will use UTF-8. By default, this is 0, which will select the
       default ASCII job CCSID.
      </para>
+     <para>
+      To learn more about CCSIDs on IBM i, consult the
+      <link xlink:href="https://www.ibm.com/docs/en/i/7.5?topic=information-ccsid-reference">IBM documentation</link>.
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="ini.ibm-db2.i5-sys-naming">
@@ -451,6 +457,10 @@
         </para>
        </listitem>
       </itemizedlist>
+     </para>
+     <para>
+      To learn more about naming modes on IBM i, consult the
+      <link xlink:href="https://www.ibm.com/docs/en/i/7.5?topic=application-naming-distributed-relational-database-objects">IBM documentation</link>.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ibm_db2/ini.xml
+++ b/reference/ibm_db2/ini.xml
@@ -35,22 +35,76 @@
       <entry>Available since ibm_db2 1.4.9.</entry>
      </row>
      <row>
+      <entry><link linkend="ini.ibm-db2.i5-blank-userid">ibm_db2.i5_blank_userid</link></entry>
+      <entry>"0"</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry>Available since ibm_db2 1.9.7.</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.ibm-db2.i5-char-trim">ibm_db2.i5_char_trim</link></entry>
+      <entry>"0"</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry>Available since ibm_db2 2.1.0.</entry>
+     </row>
+     <row>
       <entry><link linkend="ini.ibm-db2.i5-dbcs-alloc">ibm_db2.i5_dbcs_alloc</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
       <entry>Available since ibm_db2 1.5.0.</entry>
      </row>
      <row>
-      <entry><link linkend="ini.ibm-db2.instance-name">ibm_db2.instance_name</link></entry>
-      <entry>NULL</entry>
+      <entry><link linkend="ini.ibm-db2.i5-guard-profile">ibm_db2.i5_guard_profile</link></entry>
+      <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
-      <entry>Available since ibm_db2 1.0.2.</entry>
+      <entry>Available since ibm_db2 1.9.7.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-ignore-userid">ibm_db2.i5_ignore_userid</link></entry>
       <entry>"0"</entry>
       <entry>PHP_INI_SYSTEM</entry>
       <entry>Available since ibm_db2 1.8.0.</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.ibm-db2.i5-job-sort">ibm_db2.i5_job_sort</link></entry>
+      <entry>"0"</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry>Available since ibm_db2 1.8.4.</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.ibm-db2.i5-log-verbose">ibm_db2.i5_log_verbose</link></entry>
+      <entry>"0"</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry>Available since ibm_db2 1.9.7.</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.ibm-db2.i5-max-pconnect">ibm_db2.i5_max_pconnect</link></entry>
+      <entry>"0"</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry>Available since ibm_db2 1.9.7.</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.ibm-db2.i5-override-ccsid">ibm_db2.i5_override_ccsid</link></entry>
+      <entry>"0"</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry>Available since ibm_db2 1.9.7.</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.ibm-db2.i5-servermode-subsystem">ibm_db2.i5_servermode_subsystem</link></entry>
+      <entry>NULL</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry>Available since ibm_db2 1.9.7.</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.ibm-db2.i5-sys-naming">ibm_db2.i5_sys_naming</link></entry>
+      <entry>"0"</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry>Available since ibm_db2 1.9.7.</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.ibm-db2.instance-name">ibm_db2.instance_name</link></entry>
+      <entry>NULL</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry>Available since ibm_db2 1.0.2.</entry>
      </row>
     </tbody>
    </tgroup>
@@ -158,6 +212,57 @@
      </para>
     </listitem>
    </varlistentry>
+   <varlistentry xml:id="ini.ibm-db2.i5-blank-userid">
+    <term>
+     <parameter>ibm_db2.i5_blank_userid</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <para>
+      This controls if a blank user ID should be allowed on IBM i. By default,
+      this option is off. Unlike <parameter>ibm_db2.i5_ignore_userid</parameter>,
+      this option doesn't force all user IDs to be empty, but simply allows an
+      empty user ID to be passed, for connecting to Db2 as the current user.
+      <itemizedlist>
+       <listitem>
+        <para>
+         0 - Don't allow a blank user ID to be passed.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         1 - Allow a blank user ID to be passed.
+        </para>
+       </listitem>
+      </itemizedlist>
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.ibm-db2.i5-char-trim">
+    <term>
+     <parameter>ibm_db2.i5_char_trim</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <para>
+      This option controls if the end of strings are trimmed on IBM i. Since
+      many tables use fixed column sizes padded with spaces, this is provided
+      as a convenience.
+      <itemizedlist>
+       <listitem>
+        <para>
+         0 - Columns are not trimmed.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         1 - Spaces at the end of returned character columns are removed.
+        </para>
+       </listitem>
+      </itemizedlist>
+     </para>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="ini.ibm-db2.i5-dbcs-alloc">
     <term>
      <parameter>ibm_db2.i5_dbcs_alloc</parameter>
@@ -182,19 +287,54 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="ini.ibm-db2.instance-name">
+   <varlistentry xml:id="ini.ibm-db2.i5-guard-profile">
     <term>
-     <parameter>ibm_db2.instance_name</parameter>
-     <type>string</type>
+     <parameter>ibm_db2.i5_guard_profile</parameter>
+     <type>int</type>
     </term>
     <listitem>
      <para>
-      On Linux and UNIX operating systems, this option defines the name of the
-      instance to use for cataloged database connections. If this option is set,
-      its value overrides the DB2INSTANCE environment variable setting.
+      This option checks if the database user profile was switched when
+      connecting to a persistent database connection on IBM i. By
+      default, this option is set to 0.
+      <itemizedlist>
+       <listitem>
+        <para>
+         0 - Don't check for profile swaps.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         1 - Check for profile swaps and disconnect if so.
+        </para>
+       </listitem>
+      </itemizedlist>
      </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.ibm-db2.i5-log-verbose">
+    <term>
+     <parameter>ibm_db2.i5_log_verbose</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
      <para>
-      This option is ignored on Windows operating systems.
+      This option sets if diagnostic messages like warnings and errors are
+      always sent to the error log on IBM i. Normally, only a brief message on
+      failure is sent, as this option is set to 0 by default. Note that you can
+      still call i.e. <function>db2_stmt_errormsg</function> yourself.
+      <itemizedlist>
+       <listitem>
+        <para>
+         0 - Only logs concise messages.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         1 - Logs the SQL diagnostic message in addition to the concise message.
+        </para>
+       </listitem>
+      </itemizedlist>
      </para>
     </listitem>
    </varlistentry>
@@ -226,6 +366,120 @@
         </para>
        </listitem>
       </itemizedlist>
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.ibm-db2.i5-job-sort">
+    <term>
+     <parameter>ibm_db2.i5_job_sort</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <para>
+      Controls the job sort option on IBM i. By default, this option is 0.
+      This corresponds to the SQL/CLI SQL_ATTR_CONN_SORT_SEQUENCE attribute.
+      <itemizedlist>
+       <listitem>
+        <para>
+         0 - Uses the *HEX sort option, sorting by bytes.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         1 - Uses the job sort sequence set for the PHP job.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         2 - Uses the job sort sequence set for the database job.
+        </para>
+       </listitem>
+      </itemizedlist>
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.ibm-db2.i5-max-pconnect">
+    <term>
+     <parameter>ibm_db2.i5_max_pconnect</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <para>
+      This will affect how many times a persistent connection can be reused
+      when running on IBM i. By default, this is set to 0, which means a
+      persistent connection can always be reused. This option can help work
+      around issues in a long-running database job (i.e. if a procedure is
+      leaking memory), but is obviously not a long-term fix.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.ibm-db2.i5-override-ccsid">
+    <term>
+     <parameter>ibm_db2.i5_override_ccsid</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <para>
+      The ASCII CCSID to use for conversion from EBCDIC on IBM i. Setting this
+      to 1208 will use UTF-8. By default, this is 0, which will select the
+      default ASCII job CCSID.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.ibm-db2.i5-sys-naming">
+    <term>
+     <parameter>ibm_db2.i5_sys_naming</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <para>
+      This option controls the naming mode when connecting to an IBM i system.
+      By default, this option is 0. The naming mode affects how names are
+      resolved and the allowed syntax for names. When set to 0, this uses
+      periods to qualify names and uses the default library or user ID to
+      resolve names. When set to 1, uses slashes to qualify names and uses
+      the job library list to resolve names.
+      <itemizedlist>
+       <listitem>
+        <para>
+         0 - Uses the SQL naming mode ("SCHEMA.TABLE").
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         1 - Uses the system naming mode ("LIBRARY/FILE").
+        </para>
+       </listitem>
+      </itemizedlist>
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.ibm-db2.i5-servermode-subsystem">
+    <term>
+     <parameter>ibm_db2.i5_servermode-subsystem</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <para>
+      This option changes which subsystem database server jobs run under on
+      IBM i. By default, this option is null, so jobs will run under the
+      default subsystem for QSQSERVER jobs.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.ibm-db2.instance-name">
+    <term>
+     <parameter>ibm_db2.instance_name</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <para>
+      On Linux and UNIX operating systems, this option defines the name of the
+      instance to use for cataloged database connections. If this option is set,
+      its value overrides the DB2INSTANCE environment variable setting.
+     </para>
+     <para>
+      This option is ignored on Windows operating systems.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ibm_db2/ini.xml
+++ b/reference/ibm_db2/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<section xml:id="ibm-db2.configuration" xmlns="http://docbook.org/ns/docbook">
+<section xml:id="ibm-db2.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.runtime;
  &extension.runtime;
  <para>

--- a/reference/ibm_db2/ini.xml
+++ b/reference/ibm_db2/ini.xml
@@ -446,8 +446,8 @@
       By default, this is <literal>0</literal>, which will select the default
       PASE job CCSID, which comes from the PASE locale settings.
       For example, setting this to <literal>1208</literal> will use UTF-8.
-      You should only need to set this if the PASE job CCSID isn't the expected
-      CCSID, and you can't change the locale.`
+      This should only be modified if the PASE job CCSID isn't the expected
+      CCSID, and the locale cannot be modified.
      </para>
      <para>
       To learn more about CCSIDs on IBM i, consult the


### PR DESCRIPTION
A bunch of previously undocumented stuff, including things that are ugly and probably should be deprecated.

Note some of these are platform-specific; I have tried to word based on this ("on IBM i" vs. "when connecting to IBM i"), but I've considered adding a column, if that would make sense.