### PR TITLE
Add ClosedGeneratorException to docs

### DIFF
--- a/language/predefined/closedgeneratorexception.xml
+++ b/language/predefined/closedgeneratorexception.xml
@@ -9,8 +9,8 @@
   <section xml:id="closedgeneratorexception.intro">
    &reftitle.intro;
    <para>
-    <classname>ClosedGeneratorException</classname> is thrown
-    when trying to access values of a closed <classname>Generator</classname>.
+    A <classname>ClosedGeneratorException</classname> is thrown when trying
+    to retrieve a value from a closed <classname>Generator</classname>.
    </para>
   </section>
 <!-- }}} -->

--- a/language/predefined/closedgeneratorexception.xml
+++ b/language/predefined/closedgeneratorexception.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpdoc:classref xml:id="class.closedgeneratorexception" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The ClosedGeneratorException class</title>
+ <titleabbrev>ClosedGeneratorException</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ ClosedGeneratorException intro -->
+  <section xml:id="closedgeneratorexception.intro">
+   &reftitle.intro;
+   <para>
+    <classname>ClosedGeneratorException</classname> is thrown
+    when trying to access values of a closed <classname>Generator</classname>.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="closedgeneratorexception.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>ClosedGeneratorException</exceptionname>
+    </ooexception>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Exception</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+</phpdoc:classref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/predefined/exceptions.xml
+++ b/language/predefined/exceptions.xml
@@ -12,6 +12,7 @@
 
  &language.predefined.exception;
  &language.predefined.errorexception;
+ &language.predefined.closedgeneratorexception;
 
  <!-- If this is updated, you should also update the hierarchy in
       language/errors/php7.xml. -->

--- a/language/predefined/versions.xml
+++ b/language/predefined/versions.xml
@@ -99,6 +99,8 @@
  <function name="generator::valid" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="generator::__wakeup" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
 
+ <function name="closedgeneratorexception" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+
  <function name="fiber" from="PHP 8 &gt;= 8.1.0"/>
  <function name="fiber::__construct" from="PHP 8 &gt;= 8.1.0"/>
  <function name="fiber::start" from="PHP 8 &gt;= 8.1.0"/>


### PR DESCRIPTION
Add the missing ClosedGeneratorException class to the docs (#2162). Also listed it under the predefined exceptions in the language reference as this seemed for it the appropriate place to be.