### PR TITLE
Add com_safearray_proxy to docs

### DIFF
--- a/reference/com/book.xml
+++ b/reference/com/book.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
- 
+
 <book xml:id="book.com" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="bundled" ?>
  <title>COM and .Net (Windows)</title>
  <titleabbrev>COM</titleabbrev>
- 
+
  <!-- {{{ preface -->
  <preface xml:id="intro.com">
   &reftitle.intro;
@@ -47,7 +47,7 @@
   </para>
  </preface>
  <!-- }}} -->
- 
+
  &reference.com.setup;
  &reference.com.constants;
  &reference.com.error-handling;
@@ -57,6 +57,7 @@
  &reference.com.variant;
  &reference.com.compersisthelper;
  &reference.com.com-exception;
+ &reference.com.com-safearray-proxy;
  &reference.com.reference;
 
 </book>

--- a/reference/com/com-safearray-proxy.xml
+++ b/reference/com/com-safearray-proxy.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpdoc:classref xml:id="class.com-safearray-proxy" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The com_safearray_proxy class</title>
+ <titleabbrev>com_safearray_proxy</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ com_safearray_proxy intro -->
+  <section xml:id="com-safearray-proxy.intro">
+   &reftitle.intro;
+   <para>
+    <classname>com_safearray_proxy</classname> is an internal class
+    used for resolving multi-dimensional array accesses on SafeArray types.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="com-safearray-proxy.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier>final</modifier>
+     <classname>com_safearray_proxy</classname>
+    </ooclass>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+</phpdoc:classref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/com/versions.xml
+++ b/reference/com/versions.xml
@@ -3,7 +3,7 @@
 <!--
   Do NOT translate this file
 -->
-<versions> 
+<versions>
  <function name="com" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
  <function name="com::__construct" from="PHP 4 &gt; 4.1.0, PHP 5, PHP 7, PHP 8"/>
  <function name="com_create_guid" from="PHP 5, PHP 7, PHP 8"/>
@@ -14,6 +14,8 @@
  <function name="com_print_typeinfo" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
 
  <function name="com_exception" from="PHP 5, PHP 7, PHP 8"/>
+
+ <function name="com-safearray-proxy" from="PHP 5, PHP 7, PHP 8"/>
 
  <function name="compersisthelper" from="PHP 5, PHP 7, PHP 8"/>
  <function name="compersisthelper::__construct" from="PHP 5, PHP 7, PHP 8"/>


### PR DESCRIPTION
Add com_safearray_proxy to docs (#2162). 

This internal class doesn't have any methods or properties and doesn't extend or implement any other class or interface hence the almost empty documentation.

The description of the class is based on the [comments](https://github.com/php/php-src/blob/0b7cd1423add534fc27030f57934cc8bb6d4c6a1/ext/com_dotnet/com_saproxy.c#L17-L22)  in the implementation.