### PR TITLE
Incorrect param name in mb_ereg_replace_callback() docs

### DIFF
--- a/reference/mbstring/functions/mb-ereg-replace-callback.xml
+++ b/reference/mbstring/functions/mb-ereg-replace-callback.xml
@@ -49,7 +49,7 @@
      <listitem>
       <para>
         A callback that will be called and passed an array of matched elements
-        in the  <parameter>subject</parameter> string. The callback should
+        in the  <parameter>string</parameter> string. The callback should
        return the replacement string.
       </para>
       <para>


### PR DESCRIPTION
Either the $string parameter needs to be changed to $subject, or the parameter name in the function description needs to be corrected