### PR TITLE
Update all ob_  clean/flush functions

### DIFF
--- a/reference/outcontrol/functions/ob-clean.xml
+++ b/reference/outcontrol/functions/ob-clean.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.ob-clean" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ob_clean</refname>
-  <refpurpose>Clean (erase) the output buffer</refpurpose>
+  <refpurpose>Clean (erase) active output buffer contents</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,17 +13,24 @@
    <void/>
   </methodsynopsis>
   <para>
-   This function discards the contents of the output buffer.
+   This function calls the output handler (with the
+   <link linkend="constant.php-output-handler-clean">
+    <constant>PHP_OUTPUT_HANDLER_CLEAN</constant>
+   </link>
+   flag), discards it's return value
+   and cleans (erases) the contents of the active output buffer.
   </para>
   <para>
-   This function does not destroy the output buffer like
-   <function>ob_end_clean</function> does.
+   This function does not turn off the active output buffer like
+   <function>ob_end_clean</function> or <function>ob_get_clean</function> does.
   </para>
   <para>
-   The output buffer must be started by
-   <function>ob_start</function> with <link
-   linkend="constant.php-output-handler-cleanable">PHP_OUTPUT_HANDLER_CLEANABLE</link>
-   flag. Otherwise <function>ob_clean</function> will not work.
+   <function>ob_clean</function> will fail
+   without an active output buffer started with the
+   <link linkend="constant.php-output-handler-cleanable">
+    <constant>PHP_OUTPUT_HANDLER_CLEANABLE</constant>
+   </link>
+   flag.
   </para>
  </refsect1>
 
@@ -39,13 +46,21 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   If the function fails it generates an <constant>E_NOTICE</constant>.
+  </para>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>ob_flush</function></member>
-    <member><function>ob_end_flush</function></member>
+    <member><function>ob_start</function></member>
     <member><function>ob_end_clean</function></member>
+    <member><function>ob_get_clean</function></member>
+    <member><function>ob_flush</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/outcontrol/functions/ob-clean.xml
+++ b/reference/outcontrol/functions/ob-clean.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.ob-clean" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ob_clean</refname>
-  <refpurpose>Clean (erase) active output buffer contents</refpurpose>
+  <refpurpose>Clean (erase) the contents of the active output buffer</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,11 +13,9 @@
    <void/>
   </methodsynopsis>
   <para>
-   This function calls the output handler (with the
-   <link linkend="constant.php-output-handler-clean">
-    <constant>PHP_OUTPUT_HANDLER_CLEAN</constant>
-   </link>
-   flag), discards it's return value
+   This function calls the output handler
+   (with the <constant>PHP_OUTPUT_HANDLER_CLEAN</constant> flag),
+   discards it's return value
    and cleans (erases) the contents of the active output buffer.
   </para>
   <para>
@@ -27,10 +25,7 @@
   <para>
    <function>ob_clean</function> will fail
    without an active output buffer started with the
-   <link linkend="constant.php-output-handler-cleanable">
-    <constant>PHP_OUTPUT_HANDLER_CLEANABLE</constant>
-   </link>
-   flag.
+   <constant>PHP_OUTPUT_HANDLER_CLEANABLE</constant> flag.
   </para>
  </refsect1>
 
@@ -58,6 +53,7 @@
   <para>
    <simplelist>
     <member><function>ob_start</function></member>
+    <member><function>ob_get_contents</function></member>
     <member><function>ob_end_clean</function></member>
     <member><function>ob_get_clean</function></member>
     <member><function>ob_flush</function></member>

--- a/reference/outcontrol/functions/ob-clean.xml
+++ b/reference/outcontrol/functions/ob-clean.xml
@@ -5,7 +5,7 @@
   <refname>ob_clean</refname>
   <refpurpose>Clean (erase) the output buffer</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -48,7 +48,7 @@
     <member><function>ob_end_clean</function></member>
    </simplelist>
   </para>
- </refsect1> 
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/outcontrol/functions/ob-end-clean.xml
+++ b/reference/outcontrol/functions/ob-end-clean.xml
@@ -3,7 +3,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ob-end-clean">
  <refnamediv>
   <refname>ob_end_clean</refname>
-  <refpurpose>Clean (erase) active output buffer contents and turn off active output buffer</refpurpose>
+  <refpurpose>Clean (erase) the contents of the active output buffer and turn it off</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,34 +13,23 @@
    <void/>
   </methodsynopsis>
   <para>
-   This function calls the output handler (with the
-   <link linkend="constant.php-output-handler-clean">
-    <constant>PHP_OUTPUT_HANDLER_CLEAN</constant>
-   </link>
-   and
-   <link linkend="constant.php-output-handler-final">
-    <constant>PHP_OUTPUT_HANDLER_FINAL</constant>
-   </link>
-   flags), discards it's return value,
+   This function calls the output handler
+   (with the <constant>PHP_OUTPUT_HANDLER_CLEAN</constant> and
+   <constant>PHP_OUTPUT_HANDLER_FINAL</constant> flags),
+   discards it's return value,
    discards the contents of the active output buffer
    and turns off the active output buffer.
   </para>
   <para>
    <function>ob_end_clean</function> will fail
    without an active output buffer started with the
-   <link linkend="constant.php-output-handler-removable">
-    <constant>PHP_OUTPUT_HANDLER_REMOVABLE</constant>
-   </link>
-   flag.
+   <constant>PHP_OUTPUT_HANDLER_REMOVABLE</constant> flag.
   </para>
   <para>
    <function>ob_end_clean</function>
    will discard the contents of the active output buffer
    even if it was started without the
-   <link linkend="constant.php-output-handler-cleanable">
-    <constant>PHP_OUTPUT_HANDLER_CLEANABLE</constant>
-   </link>
-   flag.
+   <constant>PHP_OUTPUT_HANDLER_CLEANABLE</constant> flag.
   </para>
  </refsect1>
 
@@ -90,6 +79,7 @@ ob_end_clean();
   <para>
    <simplelist>
     <member><function>ob_start</function></member>
+    <member><function>ob_get_contents</function></member>
     <member><function>ob_clean</function></member>
     <member><function>ob_get_clean</function></member>
     <member><function>ob_end_flush</function></member>
@@ -98,7 +88,6 @@ ob_end_clean();
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/outcontrol/functions/ob-end-clean.xml
+++ b/reference/outcontrol/functions/ob-end-clean.xml
@@ -3,7 +3,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ob-end-clean">
  <refnamediv>
   <refname>ob_end_clean</refname>
-  <refpurpose>Clean (erase) the output buffer and turn off output buffering</refpurpose>
+  <refpurpose>Clean (erase) active output buffer contents and turn off active output buffer</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,19 +13,34 @@
    <void/>
   </methodsynopsis>
   <para>
-   This function discards the contents of the topmost output buffer and turns
-   off this output buffering. If you want to further process the buffer's
-   contents you have to call <function>ob_get_contents</function> before
-   <function>ob_end_clean</function> as the buffer contents are discarded
-   when <function>ob_end_clean</function> is called.
+   This function calls the output handler (with the
+   <link linkend="constant.php-output-handler-clean">
+    <constant>PHP_OUTPUT_HANDLER_CLEAN</constant>
+   </link>
+   and
+   <link linkend="constant.php-output-handler-final">
+    <constant>PHP_OUTPUT_HANDLER_FINAL</constant>
+   </link>
+   flags), discards it's return value,
+   discards the contents of the active output buffer
+   and turns off the active output buffer.
   </para>
   <para>
-   The output buffer must be started by
-   <function>ob_start</function> with <link
-   linkend="constant.php-output-handler-cleanable">PHP_OUTPUT_HANDLER_CLEANABLE</link>
-   and <link
-   linkend="constant.php-output-handler-removable">PHP_OUTPUT_HANDLER_REMOVABLE</link>
-   flags. Otherwise <function>ob_end_clean</function> will not work.
+   <function>ob_end_clean</function> will fail
+   without an active output buffer started with the
+   <link linkend="constant.php-output-handler-removable">
+    <constant>PHP_OUTPUT_HANDLER_REMOVABLE</constant>
+   </link>
+   flag.
+  </para>
+  <para>
+   <function>ob_end_clean</function>
+   will discard the contents of the active output buffer
+   even if it was started without the
+   <link linkend="constant.php-output-handler-cleanable">
+    <constant>PHP_OUTPUT_HANDLER_CLEANABLE</constant>
+   </link>
+   flag.
   </para>
  </refsect1>
 
@@ -37,9 +52,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success; Reasons for failure are first that you called the
-   function without an active buffer or that for some reason a buffer could
-   not be deleted (possible for special buffer).
+   &return.success;
   </para>
  </refsect1>
 
@@ -53,7 +66,8 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-   The following example shows an easy way to get rid of all output buffers:
+   The following example shows an easy way to get rid of
+   the contents of the active output buffer:
   </para>
   <para>
    <example>
@@ -76,8 +90,9 @@ ob_end_clean();
   <para>
    <simplelist>
     <member><function>ob_start</function></member>
-    <member><function>ob_get_contents</function></member>
-    <member><function>ob_flush</function></member>
+    <member><function>ob_clean</function></member>
+    <member><function>ob_get_clean</function></member>
+    <member><function>ob_end_flush</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/outcontrol/functions/ob-end-clean.xml
+++ b/reference/outcontrol/functions/ob-end-clean.xml
@@ -5,7 +5,7 @@
   <refname>ob_end_clean</refname>
   <refpurpose>Clean (erase) the output buffer and turn off output buffering</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -80,7 +80,7 @@ ob_end_clean();
     <member><function>ob_flush</function></member>
    </simplelist>
   </para>
- </refsect1> 
+ </refsect1>
 
 </refentry>
 

--- a/reference/outcontrol/functions/ob-end-flush.xml
+++ b/reference/outcontrol/functions/ob-end-flush.xml
@@ -3,7 +3,10 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ob-end-flush">
  <refnamediv>
   <refname>ob_end_flush</refname>
-  <refpurpose>Flush (send) output handler return value and turn off active output buffer</refpurpose>
+  <refpurpose>
+   Flush (send) the return value of the active output handler
+   and turn the active output buffer off
+ </refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,30 +16,22 @@
    <void/>
   </methodsynopsis>
   <para>
-   This function calls the output handler (with the
-   <link linkend="constant.php-output-handler-final">
-    <constant>PHP_OUTPUT_HANDLER_FINAL</constant>
-   </link>
-   flag), flushes (sends) it's return value,
+   This function calls the output handler
+   (with the <constant>PHP_OUTPUT_HANDLER_FINAL</constant> flag),
+   flushes (sends) it's return value,
    discards the contents of the active output buffer
    and turns off the active output buffer.
   </para>
   <para>
    <function>ob_end_flush</function> will fail
    without an active output buffer started with the
-   <link linkend="constant.php-output-handler-removable">
-    <constant>PHP_OUTPUT_HANDLER_REMOVABLE</constant>
-   </link>
-   flag.
+   <constant>PHP_OUTPUT_HANDLER_REMOVABLE</constant> flag.
   </para>
   <para>
    <function>ob_end_flush</function> will flush (send)
    the return value of the output handler
    even if the active output buffer was started without the
-   <link linkend="constant.php-output-handler-flushable">
-    <constant>PHP_OUTPUT_HANDLER_FLUSHABLE</constant>
-   </link>
-   flag.
+   <constant>PHP_OUTPUT_HANDLER_FLUSHABLE</constant> flag.
   </para>
  </refsect1>
 
@@ -84,6 +79,7 @@
   <para>
    <simplelist>
     <member><function>ob_start</function></member>
+    <member><function>ob_get_contents</function></member>
     <member><function>ob_flush</function></member>
     <member><function>ob_get_flush</function></member>
     <member><function>ob_end_clean</function></member>
@@ -92,7 +88,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/outcontrol/functions/ob-end-flush.xml
+++ b/reference/outcontrol/functions/ob-end-flush.xml
@@ -3,7 +3,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ob-end-flush">
  <refnamediv>
   <refname>ob_end_flush</refname>
-  <refpurpose>Flush (send) the output buffer and turn off output buffering</refpurpose>
+  <refpurpose>Flush (send) output handler return value and turn off active output buffer</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,27 +13,31 @@
    <void/>
   </methodsynopsis>
   <para>
-   This function will send the contents of the topmost output buffer (if
-   any) and turn this output buffer off.  If you want to further
-   process the buffer's contents you have to call
-   <function>ob_get_contents</function> before
-   <function>ob_end_flush</function> as the buffer contents are
-   discarded after <function>ob_end_flush</function> is called.
+   This function calls the output handler (with the
+   <link linkend="constant.php-output-handler-final">
+    <constant>PHP_OUTPUT_HANDLER_FINAL</constant>
+   </link>
+   flag), flushes (sends) it's return value,
+   discards the contents of the active output buffer
+   and turns off the active output buffer.
   </para>
   <para>
-   The output buffer must be started by
-   <function>ob_start</function> with <link
-   linkend="constant.php-output-handler-flushable">PHP_OUTPUT_HANDLER_FLUSHABLE</link>
-   and <link
-   linkend="constant.php-output-handler-removable">PHP_OUTPUT_HANDLER_REMOVABLE</link>
-   flags. Otherwise <function>ob_end_flush</function> will not work.
+   <function>ob_end_flush</function> will fail
+   without an active output buffer started with the
+   <link linkend="constant.php-output-handler-removable">
+    <constant>PHP_OUTPUT_HANDLER_REMOVABLE</constant>
+   </link>
+   flag.
   </para>
-  <note>
-   <simpara>
-    This function is similar to <function>ob_get_flush</function>, except
-    that <function>ob_get_flush</function> returns the buffer as a string.
-   </simpara>
-  </note>
+  <para>
+   <function>ob_end_flush</function> will flush (send)
+   the return value of the output handler
+   even if the active output buffer was started without the
+   <link linkend="constant.php-output-handler-flushable">
+    <constant>PHP_OUTPUT_HANDLER_FLUSHABLE</constant>
+   </link>
+   flag.
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -44,9 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success; Reasons for failure are first that you called the
-   function without an active buffer or that for some reason a buffer could
-   not be deleted (possible for special buffer).
+   &return.success;
   </para>
  </refsect1>
 
@@ -82,9 +84,8 @@
   <para>
    <simplelist>
     <member><function>ob_start</function></member>
-    <member><function>ob_get_contents</function></member>
-    <member><function>ob_get_flush</function></member>
     <member><function>ob_flush</function></member>
+    <member><function>ob_get_flush</function></member>
     <member><function>ob_end_clean</function></member>
    </simplelist>
   </para>

--- a/reference/outcontrol/functions/ob-end-flush.xml
+++ b/reference/outcontrol/functions/ob-end-flush.xml
@@ -5,7 +5,7 @@
   <refname>ob_end_flush</refname>
   <refpurpose>Flush (send) the output buffer and turn off output buffering</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -88,7 +88,7 @@
     <member><function>ob_end_clean</function></member>
    </simplelist>
   </para>
- </refsect1> 
+ </refsect1>
 
 </refentry>
 

--- a/reference/outcontrol/functions/ob-flush.xml
+++ b/reference/outcontrol/functions/ob-flush.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.ob-flush" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ob_flush</refname>
-  <refpurpose>Flush (send) output handler return value</refpurpose>
+  <refpurpose>Flush (send) the return value of the active output handler</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,11 +13,9 @@
    <void/>
   </methodsynopsis>
   <para>
-   This function calls the output handler (with the
-   <link linkend="constant.php-output-handler-flush">
-    <constant>PHP_OUTPUT_HANDLER_FLUSH</constant>
-   </link>
-   flag), flushes (sends) it's return value
+   This function calls the output handler
+   (with the <constant>PHP_OUTPUT_HANDLER_FLUSH</constant> flag),
+   flushes (sends) it's return value
    and discards the contents of the active output buffer.
   </para>
   <para>
@@ -27,10 +25,7 @@
   <para>
    <function>ob_flush</function> will fail
    without an active output buffer started with the
-   <link linkend="constant.php-output-handler-flushable">
-    <constant>PHP_OUTPUT_HANDLER_FLUSHABLE</constant>
-   </link>
-   flag.
+   <constant>PHP_OUTPUT_HANDLER_FLUSHABLE</constant> flag.
   </para>
  </refsect1>
 
@@ -58,6 +53,7 @@
   <para>
    <simplelist>
     <member><function>ob_start</function></member>
+    <member><function>ob_get_contents</function></member>
     <member><function>ob_end_flush</function></member>
     <member><function>ob_get_flush</function></member>
     <member><function>ob_clean</function></member>

--- a/reference/outcontrol/functions/ob-flush.xml
+++ b/reference/outcontrol/functions/ob-flush.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.ob-flush" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ob_flush</refname>
-  <refpurpose>Flush (send) the output buffer</refpurpose>
+  <refpurpose>Flush (send) output handler return value</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,15 +13,24 @@
    <void/>
   </methodsynopsis>
   <para>
-   This function will send the contents of the output buffer (if any). If you
-   want to further process the buffer's contents you have to call
-   <function>ob_get_contents</function> before <function>ob_flush</function>
-   as the buffer contents are discarded after <function>ob_flush</function>
-   is called.
+   This function calls the output handler (with the
+   <link linkend="constant.php-output-handler-flush">
+    <constant>PHP_OUTPUT_HANDLER_FLUSH</constant>
+   </link>
+   flag), flushes (sends) it's return value
+   and discards the contents of the active output buffer.
   </para>
   <para>
-   This function does not destroy the output buffer like
-   <function>ob_end_flush</function> does.
+   This function does not turn off the active output buffer like
+   <function>ob_end_flush</function> or <function>ob_get_flush</function> does.
+  </para>
+  <para>
+   <function>ob_flush</function> will fail
+   without an active output buffer started with the
+   <link linkend="constant.php-output-handler-flushable">
+    <constant>PHP_OUTPUT_HANDLER_FLUSHABLE</constant>
+   </link>
+   flag.
   </para>
  </refsect1>
 
@@ -37,14 +46,21 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   If the function fails it generates an <constant>E_NOTICE</constant>.
+  </para>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>ob_get_contents</function></member>
-    <member><function>ob_clean</function></member>
+    <member><function>ob_start</function></member>
     <member><function>ob_end_flush</function></member>
-    <member><function>ob_end_clean</function></member>
+    <member><function>ob_get_flush</function></member>
+    <member><function>ob_clean</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/outcontrol/functions/ob-flush.xml
+++ b/reference/outcontrol/functions/ob-flush.xml
@@ -5,7 +5,7 @@
   <refname>ob_flush</refname>
   <refpurpose>Flush (send) the output buffer</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -47,7 +47,7 @@
     <member><function>ob_end_clean</function></member>
    </simplelist>
   </para>
- </refsect1> 
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/outcontrol/functions/ob-get-clean.xml
+++ b/reference/outcontrol/functions/ob-get-clean.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.ob-get-clean" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ob_get_clean</refname>
-  <refpurpose>Get active buffer contents and turn off active output buffer</refpurpose>
+  <refpurpose>Get the contents of the active output buffer and turn it off</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,41 +13,23 @@
    <void/>
   </methodsynopsis>
   <para>
-   This function calls the output handler (with the
-   <link linkend="constant.php-output-handler-clean">
-    <constant>PHP_OUTPUT_HANDLER_CLEAN</constant>
-   </link>
-   and
-   <link linkend="constant.php-output-handler-final">
-    <constant>PHP_OUTPUT_HANDLER_FINAL</constant>
-   </link>
-   flags), discards it's return value,
+   This function calls the output handler
+   (with the <constant>PHP_OUTPUT_HANDLER_CLEAN</constant> and
+   <constant>PHP_OUTPUT_HANDLER_FINAL</constant> flags),
+   discards it's return value,
    returns the contents of the active output buffer
    and turns off the active output buffer.
   </para>
   <para>
    <function>ob_get_clean</function> will fail
    without an active output buffer started with the
-   <link linkend="constant.php-output-handler-removable">
-    <constant>PHP_OUTPUT_HANDLER_REMOVABLE</constant>
-   </link>
-   flag.
+   <constant>PHP_OUTPUT_HANDLER_REMOVABLE</constant> flag.
   </para>
-  <caution>
-   <simpara>
-    <function>ob_get_clean</function> will return false
-    but will not generate an <constant>E_NOTICE</constant>
-    if there is no active output buffer.
-   </simpara>
-  </caution>
   <para>
    <function>ob_get_clean</function>
    will discard the contents of the active output buffer
    even if it was started without the
-   <link linkend="constant.php-output-handler-cleanable">
-    <constant>PHP_OUTPUT_HANDLER_CLEANABLE</constant>
-   </link>
-   flag.
+   <constant>PHP_OUTPUT_HANDLER_CLEANABLE</constant> flag.
   </para>
  </refsect1>
 
@@ -62,6 +44,13 @@
    Returns the contents of the active output buffer on success
    or &false; on failure.
   </para>
+  <caution>
+   <simpara>
+    <function>ob_get_clean</function> will return false
+    but will not generate an <constant>E_NOTICE</constant>
+    if there is no active output buffer.
+   </simpara>
+  </caution>
  </refsect1>
 
  <refsect1 role="errors">
@@ -108,6 +97,7 @@ string(11) "hello world"
   <para>
    <simplelist>
     <member><function>ob_start</function></member>
+    <member><function>ob_get_contents</function></member>
     <member><function>ob_clean</function></member>
     <member><function>ob_end_clean</function></member>
     <member><function>ob_get_flush</function></member>

--- a/reference/outcontrol/functions/ob-get-clean.xml
+++ b/reference/outcontrol/functions/ob-get-clean.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.ob-get-clean" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ob_get_clean</refname>
-  <refpurpose>Get current buffer contents and delete current output buffer</refpurpose>
+  <refpurpose>Get active buffer contents and turn off active output buffer</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,20 +13,41 @@
    <void/>
   </methodsynopsis>
   <para>
-   Gets the current buffer contents and delete current output buffer.
+   This function calls the output handler (with the
+   <link linkend="constant.php-output-handler-clean">
+    <constant>PHP_OUTPUT_HANDLER_CLEAN</constant>
+   </link>
+   and
+   <link linkend="constant.php-output-handler-final">
+    <constant>PHP_OUTPUT_HANDLER_FINAL</constant>
+   </link>
+   flags), discards it's return value,
+   returns the contents of the active output buffer
+   and turns off the active output buffer.
   </para>
   <para>
-   <function>ob_get_clean</function> essentially executes both
-   <function>ob_get_contents</function> and
-   <function>ob_end_clean</function>.
+   <function>ob_get_clean</function> will fail
+   without an active output buffer started with the
+   <link linkend="constant.php-output-handler-removable">
+    <constant>PHP_OUTPUT_HANDLER_REMOVABLE</constant>
+   </link>
+   flag.
   </para>
+  <caution>
+   <simpara>
+    <function>ob_get_clean</function> will return false
+    but will not generate an <constant>E_NOTICE</constant>
+    if there is no active output buffer.
+   </simpara>
+  </caution>
   <para>
-   The output buffer must be started by
-   <function>ob_start</function> with <link
-   linkend="constant.php-output-handler-cleanable">PHP_OUTPUT_HANDLER_CLEANABLE</link>
-   and <link
-   linkend="constant.php-output-handler-removable">PHP_OUTPUT_HANDLER_REMOVABLE</link>
-   flags. Otherwise <function>ob_get_clean</function> will not work.
+   <function>ob_get_clean</function>
+   will discard the contents of the active output buffer
+   even if it was started without the
+   <link linkend="constant.php-output-handler-cleanable">
+    <constant>PHP_OUTPUT_HANDLER_CLEANABLE</constant>
+   </link>
+   flag.
   </para>
  </refsect1>
 
@@ -38,8 +59,15 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the contents of the output buffer and end output buffering.
-   If output buffering isn't active then &false; is returned.
+   Returns the contents of the active output buffer on success
+   or &false; on failure.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   If the function fails it generates an <constant>E_NOTICE</constant>.
   </para>
  </refsect1>
 
@@ -79,8 +107,10 @@ string(11) "hello world"
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>ob_get_contents</function></member>
     <member><function>ob_start</function></member>
+    <member><function>ob_clean</function></member>
+    <member><function>ob_end_clean</function></member>
+    <member><function>ob_get_flush</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/outcontrol/functions/ob-get-clean.xml
+++ b/reference/outcontrol/functions/ob-get-clean.xml
@@ -5,7 +5,7 @@
   <refname>ob_get_clean</refname>
   <refpurpose>Get current buffer contents and delete current output buffer</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -83,7 +83,7 @@ string(11) "hello world"
     <member><function>ob_start</function></member>
    </simplelist>
   </para>
- </refsect1> 
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/outcontrol/functions/ob-get-flush.xml
+++ b/reference/outcontrol/functions/ob-get-flush.xml
@@ -5,7 +5,7 @@
   <refname>ob_get_flush</refname>
   <refpurpose>Flush the output buffer, return it as a string and turn off output buffering</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -86,7 +86,7 @@ Array
     <member><function>ob_list_handlers</function></member>
    </simplelist>
   </para>
- </refsect1> 
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/outcontrol/functions/ob-get-flush.xml
+++ b/reference/outcontrol/functions/ob-get-flush.xml
@@ -4,8 +4,8 @@
  <refnamediv>
   <refname>ob_get_flush</refname>
   <refpurpose>
-   Flush (send) output handler return value, return active output buffer contents
-   and turn off active output buffer
+   Flush (send) the return value of the active output handler,
+   return the contents of the active output buffer and turn it off
   </refpurpose>
  </refnamediv>
 
@@ -16,30 +16,22 @@
    <void/>
   </methodsynopsis>
   <para>
-   This function calls the output handler (with the
-   <link linkend="constant.php-output-handler-final">
-    <constant>PHP_OUTPUT_HANDLER_FINAL</constant>
-   </link>
-   flag), flushes (sends) it's return value,
+   This function calls the output handler
+   (with the <constant>PHP_OUTPUT_HANDLER_FINAL</constant> flag),
+   flushes (sends) it's return value,
    returns the contents of the active output buffer
    and turns off the active output buffer.
   </para>
   <para>
    <function>ob_get_flush</function> will fail
    without an active output buffer started with the
-   <link linkend="constant.php-output-handler-removable">
-    <constant>PHP_OUTPUT_HANDLER_REMOVABLE</constant>
-   </link>
-   flag.
+   <constant>PHP_OUTPUT_HANDLER_REMOVABLE</constant> flag.
   </para>
   <para>
    <function>ob_get_flush</function> will flush (send)
    the return value of the output handler
    even if the active output buffer was started without the
-   <link linkend="constant.php-output-handler-flushable">
-    <constant>PHP_OUTPUT_HANDLER_FLUSHABLE</constant>
-   </link>
-   flag.
+   <constant>PHP_OUTPUT_HANDLER_FLUSHABLE</constant> flag.
   </para>
  </refsect1>
 
@@ -53,6 +45,13 @@
   <para>
    Returns the contents of the active output buffer on success
    or &false; on failure.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   If the function fails it generates an <constant>E_NOTICE</constant>.
   </para>
  </refsect1>
 
@@ -96,6 +95,7 @@ Array
   <para>
    <simplelist>
     <member><function>ob_start</function></member>
+    <member><function>ob_get_contents</function></member>
     <member><function>ob_flush</function></member>
     <member><function>ob_end_flush</function></member>
     <member><function>ob_get_clean</function></member>

--- a/reference/outcontrol/functions/ob-get-flush.xml
+++ b/reference/outcontrol/functions/ob-get-flush.xml
@@ -3,7 +3,10 @@
 <refentry xml:id="function.ob-get-flush" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ob_get_flush</refname>
-  <refpurpose>Flush the output buffer, return it as a string and turn off output buffering</refpurpose>
+  <refpurpose>
+   Flush (send) output handler return value, return active output buffer contents
+   and turn off active output buffer
+  </refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,21 +16,31 @@
    <void/>
   </methodsynopsis>
   <para>
-   <function>ob_get_flush</function> flushes the output buffer, return
-   it as a string and turns off output buffering.
+   This function calls the output handler (with the
+   <link linkend="constant.php-output-handler-final">
+    <constant>PHP_OUTPUT_HANDLER_FINAL</constant>
+   </link>
+   flag), flushes (sends) it's return value,
+   returns the contents of the active output buffer
+   and turns off the active output buffer.
   </para>
   <para>
-   The output buffer must be started by
-   <function>ob_start</function> with <link
-   linkend="constant.php-output-handler-flushable">PHP_OUTPUT_HANDLER_FLUSHABLE</link>
-   flag. Otherwise <function>ob_get_flush</function> will not work.
+   <function>ob_get_flush</function> will fail
+   without an active output buffer started with the
+   <link linkend="constant.php-output-handler-removable">
+    <constant>PHP_OUTPUT_HANDLER_REMOVABLE</constant>
+   </link>
+   flag.
   </para>
-  <note>
-   <simpara>
-    This function is similar to <function>ob_end_flush</function>, except
-    that this function also returns the buffer as a string.
-   </simpara>
-  </note>
+  <para>
+   <function>ob_get_flush</function> will flush (send)
+   the return value of the output handler
+   even if the active output buffer was started without the
+   <link linkend="constant.php-output-handler-flushable">
+    <constant>PHP_OUTPUT_HANDLER_FLUSHABLE</constant>
+   </link>
+   flag.
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -38,7 +51,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the output buffer or &false; if no buffering is active.
+   Returns the contents of the active output buffer on success
+   or &false; on failure.
   </para>
  </refsect1>
 
@@ -81,9 +95,10 @@ Array
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>ob_end_clean</function></member>
+    <member><function>ob_start</function></member>
+    <member><function>ob_flush</function></member>
     <member><function>ob_end_flush</function></member>
-    <member><function>ob_list_handlers</function></member>
+    <member><function>ob_get_clean</function></member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
Update all six `ob_ clean/flush` functions' documentation with the following:

 - describe what each function does in detail
 - differentiate between contents of the output buffer and values returned by the output handler
 - list flags passed to output handlers
 - list flags affecting or, if unexpected, not affecting each function
 - use consistent terminology for output buffer, it's contents and it's handler, and 'turn off' instead of 'destroy' an output buffer
 - add a section on notices issued

Closes the following:
https://bugs.php.net/bug.php?id=64977
https://bugs.php.net/bug.php?id=69404
https://bugs.php.net/bug.php?id=71486
https://bugs.php.net/bug.php?id=74399
https://bugs.php.net/bug.php?id=76563