### PR TITLE
Ambiguous phrasing on the Scope Resolution Operator page

### DIFF
--- a/language/oop5/paamayim-nekudotayim.xml
+++ b/language/oop5/paamayim-nekudotayim.xml
@@ -5,11 +5,13 @@
 
  <para>
   The Scope Resolution Operator (also called Paamayim Nekudotayim) or in
-  simpler terms, the double colon, is a token that allows access to a
-  class <link linkend="language.oop5.constants">constant</link>, a
-  <link linkend="language.oop5.static">static</link> (or
-  <link linkend="language.oop5.late-static-bindings">overridden static</link>)
-  property or a method, or that of a parent class.
+  simpler terms, the double colon, is a token that allows access to
+  a <link linkend="language.oop5.constants">constant</link>,
+  <link linkend="language.oop5.static">static</link> property,
+  or <link linkend="language.oop5.static">static</link> method
+  of a class or one of its parents.
+  Moreover, static properties or methods can be overriden via
+  <link linkend="language.oop5.late-static-bindings">late static binding</link>.
  </para>
 
  <para>

--- a/language/oop5/paamayim-nekudotayim.xml
+++ b/language/oop5/paamayim-nekudotayim.xml
@@ -5,10 +5,11 @@
 
  <para>
   The Scope Resolution Operator (also called Paamayim Nekudotayim) or in
-  simpler terms, the double colon, is a token that allows access to
-  <link linkend="language.oop5.static">static</link>,
-  <link linkend="language.oop5.constants">constant</link>, and overridden
-  properties or methods of a class.
+  simpler terms, the double colon, is a token that allows access to a
+  class <link linkend="language.oop5.constants">constant</link>, a
+  <link linkend="language.oop5.static">static</link> (or
+  <link linkend="language.oop5.late-static-bindings">overridden static</link>)
+  property or a method, or that of a parent class.
  </para>
 
  <para>


### PR DESCRIPTION
My phrasing is ugly, and needs to be corrected by someone else, but I tried my best to make this definition more complete and less ambiguous. To me, the current phrasing suggests that any overridden property could be accessed, while, as I suppose, it's the late static binding is meant.