### PR TITLE
Example of tertiary level difference

### DIFF
--- a/reference/intl/collator/set-strength.xml
+++ b/reference/intl/collator/set-strength.xml
@@ -68,7 +68,7 @@
       Upper and lower case differences in characters are distinguished at
       the tertiary level (for example, "ao" &lt; "Ao" &lt; "aò"). In addition,
       a variant of a letter differs from the base form on the tertiary level
-      (such as "A" and " "). Another example is the difference between large
+      (such as "a" and "𝒶"). Another example is the difference between large
       and small Kana. A tertiary difference is ignored when there is a primary
       or secondary difference anywhere in the strings. This is also called the
       <literal>level 3</literal> strength.


### PR DESCRIPTION
The example of tertiary level difference is incorrect.

A good example was found in [Unicode's ICU Demo webpage](https://icu4c-demos.unicode.org/icu-bin/collation.html):
Character "a" (U+0061 : LATIN SMALL LETTER A) is compared as equal to
character "𝒶" (U+1D4B6 : MATHEMATICAL SCRIPT SMALL A), up to Collator::SECONDARY level.
From Collator::TERTIARY on, the sort functions distinguish the difference between them.

Closes #3082 