### PR TITLE
Improve example code to read ini shorthand

### DIFF
--- a/reference/info/functions/ini-get.xml
+++ b/reference/info/functions/ini-get.xml
@@ -62,23 +62,7 @@ echo 'display_errors = ' . ini_get('display_errors') . "\n";
 echo 'register_globals = ' . ini_get('register_globals') . "\n";
 echo 'post_max_size = ' . ini_get('post_max_size') . "\n";
 echo 'post_max_size+1 = ' . (ini_get('post_max_size')+1) . "\n";
-echo 'post_max_size in bytes = ' . return_bytes(ini_get('post_max_size'));
-
-function return_bytes($val) {
-    $val = trim($val);
-    $last = strtolower($val[strlen($val)-1]);
-    switch($last) {
-        // The 'G' modifier is available
-        case 'g':
-            $val *= 1024;
-        case 'm':
-            $val *= 1024;
-        case 'k':
-            $val *= 1024;
-    }
-
-    return $val;
-}
+echo 'post_max_size in bytes = ' . ini_parse_quantity(ini_get('post_max_size'));
 
 ?>
 ]]>


### PR DESCRIPTION
The existing example code cannot handle any later added shorthand formats and is simply outdated when a dedicated standard function exists.