### PR TITLE
Update Enumerations

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -279,6 +279,7 @@ print $suit->value;
   <programlisting role="php">
 <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -307,7 +308,10 @@ enum Suit implements Colorful
     }
 }
 
-function paint(Colorful $c) { ... }
+/**
+ * The Suit::Clubs is instanceof Colorful
+ */
+function paint(Colorful $c) {}
 
 paint(Suit::Clubs);  // Works
 

--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -37,6 +37,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit
 {
     case Hearts;
@@ -59,6 +60,7 @@ enum Suit
    <programlisting role="php">
 <![CDATA[
 <?php
+
 function pick_a_card(Suit $suit) { ... }
 
 $val = Suit::Diamonds;
@@ -91,6 +93,7 @@ pick_a_card('Spades');
    <programlisting role="php">
 <![CDATA[
 <?php
+
 $a = Suit::Spades;
 $b = Suit::Spades;
 
@@ -124,6 +127,7 @@ $a instanceof Suit;  // true
    <programlisting role="php">
 <![CDATA[
 <?php
+
 print Suit::Spades->name;
 // prints "Spades"
 ?>
@@ -154,6 +158,7 @@ print Suit::Spades->name;
   <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit: string
 {
     case Hearts = 'H';
@@ -195,6 +200,7 @@ enum Suit: string
   <programlisting role="php">
 <![CDATA[
 <?php
+
 print Suit::Clubs->value;
 // Prints "C"
 ?>
@@ -209,6 +215,7 @@ print Suit::Clubs->value;
   <programlisting role="php">
 <![CDATA[
 <?php
+
 $suit = Suit::Clubs;
 $ref = &$suit->value;
 // Error: Cannot acquire reference to property Suit::$value
@@ -249,6 +256,7 @@ $ref = &$suit->value;
   <programlisting role="php">
 <![CDATA[
 <?php
+
 $record = get_stuff_from_database($id);
 print $record['suit'];
 
@@ -309,7 +317,7 @@ enum Suit implements Colorful
 }
 
 /**
- * The Suit::Clubs is instanceof Colorful
+ * Suit::Clubs is an instanceof Colorful
  */
 function paint(Colorful $c) {}
 
@@ -333,6 +341,7 @@ print Suit::Diamonds->shape(); // prints "Rectangle"
   <programlisting role="php">
    <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -382,6 +391,7 @@ enum Suit: string implements Colorful
   <programlisting role="php">
 <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -437,6 +447,7 @@ final class Suit implements UnitEnum, Colorful
   <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Size
 {
     case Small;
@@ -476,6 +487,7 @@ enum Size
   <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Size
 {
     case Small;
@@ -501,6 +513,7 @@ enum Size
   <programlisting role="php">
 <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -555,6 +568,7 @@ enum Suit implements Colorful
   <programlisting role="php">
 <![CDATA[
 <?php
+
 // This is an entirely legal Enum definition.
 enum Direction implements ArrayAccess
 {
@@ -636,6 +650,7 @@ $x = Direction::Up['short'];
   <programlisting role="php">
 <![CDATA[
 <?php
+
 $clovers = new Suit();
 // Error: Cannot instantiate enum Suit
 $horseshoes = (new ReflectionClass(Suit::class))->newInstanceWithoutConstructor()
@@ -658,6 +673,7 @@ $horseshoes = (new ReflectionClass(Suit::class))->newInstanceWithoutConstructor(
   <programlisting role="php">
 <![CDATA[
 <?php
+
 Suit::cases();
 // Produces: [Suit::Hearts, Suit::Diamonds, Suit::Clubs, Suit::Spades]
 ?>
@@ -679,6 +695,7 @@ Suit::cases();
   <programlisting role="php">
 <![CDATA[
 <?php
+
 Suit::Hearts === unserialize(serialize(Suit::Hearts));
 
 print serialize(Suit::Hearts);
@@ -705,6 +722,7 @@ print serialize(Suit::Hearts);
   <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Foo {
     case Bar;
 }
@@ -768,6 +786,7 @@ function bar(B $b) {
   <programlisting role="php">
 <![CDATA[
 <?php
+
 enum ErrorCode {
     case SOMETHING_BROKE;
 }
@@ -797,6 +816,7 @@ function quux(ErrorCode $errorCode)
   <programlisting role="php">
 <![CDATA[
 <?php
+
 // Thought experiment code where enums are not final.
 // Note, this won't actually work in PHP.
 enum MoreErrorCode extends ErrorCode {
@@ -837,6 +857,7 @@ fot(MoreErrorCode::PEBKAC);
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum SortOrder
 {
     case Asc;
@@ -864,6 +885,7 @@ function query($fields, $filter, SortOrder $order = SortOrder::Asc) { ... }
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum UserStatus: string
 {
     case Pending = 'P';
@@ -901,6 +923,7 @@ enum UserStatus: string
     <programlisting role="php">
 <![CDATA[
 <?php
+
 foreach (UserStatus::cases() as $case) {
     printf('<option value="%s">%s</option>\n', $case->value, $case->label());
 }

--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -316,9 +316,6 @@ enum Suit implements Colorful
     }
 }
 
-/**
- * Suit::Clubs is an instanceof Colorful
- */
 function paint(Colorful $c) {}
 
 paint(Suit::Clubs);  // Works


### PR DESCRIPTION
On the one hand, we are writing a closing tag ?> in examples, probably, such an agreement is in effect so that the user can copy the example code and paste it into a document that may contain, say, HTML markup, and immediately look at the result of this code. At the same time, there are functions in the documentation whose signatures contain three dots, which, when trying to execute the example, will result in a syntax error: Parse error: syntax error, unexpected token "..." Wouldn't it be a good practice to abandon the three dots in the definition of functions in the examples?