### PR TITLE
Make code examples on enumeration documentation executable

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -61,14 +61,16 @@ enum Suit
 <![CDATA[
 <?php
 
-function pick_a_card(Suit $suit) { ... }
+function pick_a_card(Suit $suit) {}
 
 $val = Suit::Diamonds;
 
 // OK
 pick_a_card($val);
+
 // OK
 pick_a_card(Suit::Clubs);
+
 // TypeError: pick_a_card(): Argument #1 ($suit) must be of type Suit, string given
 pick_a_card('Spades');
 ?>
@@ -572,8 +574,8 @@ enum Direction implements ArrayAccess
     case Up;
     case Down;
 
-    public function offsetGet($val) { ... }
-    public function offsetExists($val) { ... }
+    public function offsetGet($val) {}
+    public function offsetExists($val) {}
     public function offsetSet($val) { throw new Exception(); }
     public function offsetUnset($val) { throw new Exception(); }
 }
@@ -650,6 +652,7 @@ $x = Direction::Up['short'];
 
 $clovers = new Suit();
 // Error: Cannot instantiate enum Suit
+
 $horseshoes = (new ReflectionClass(Suit::class))->newInstanceWithoutConstructor()
 // Error: Cannot instantiate enum Suit
 ?>
@@ -861,7 +864,7 @@ enum SortOrder
     case Desc;
 }
 
-function query($fields, $filter, SortOrder $order = SortOrder::Asc) { ... }
+function query($fields, $filter, SortOrder $order = SortOrder::Asc) {}
 ?>
 ]]>
     </programlisting>

--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -61,7 +61,10 @@ enum Suit
 <![CDATA[
 <?php
 
-function pick_a_card(Suit $suit) {}
+function pick_a_card(Suit $suit)
+{
+    /* ... */
+}
 
 $val = Suit::Diamonds;
 
@@ -318,7 +321,10 @@ enum Suit implements Colorful
     }
 }
 
-function paint(Colorful $c) {}
+function paint(Colorful $c)
+{
+   /* ... */
+}
 
 paint(Suit::Clubs);  // Works
 
@@ -882,7 +888,10 @@ enum SortOrder
     case Desc;
 }
 
-function query($fields, $filter, SortOrder $order = SortOrder::Asc) {}
+function query($fields, $filter, SortOrder $order = SortOrder::Asc)
+{
+     /* ... */
+}
 ?>
 ]]>
     </programlisting>

--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -574,24 +574,42 @@ enum Direction implements ArrayAccess
     case Up;
     case Down;
 
-    public function offsetGet($val) {}
-    public function offsetExists($val) {}
-    public function offsetSet($val) { throw new Exception(); }
-    public function offsetUnset($val) { throw new Exception(); }
+    public function offsetExists($offset): bool
+    {
+        return false;
+    }
+
+    public function offsetGet($offset): mixed
+    {
+        return null;
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        throw new Exception();
+    }
+
+    public function offsetUnset($offset): void
+    {
+        throw new Exception();
+    }
 }
 
 class Foo
 {
     // This is allowed.
-    const Bar = Direction::Down;
+    const DOWN = Direction::Down;
 
     // This is disallowed, as it may not be deterministic.
-    const Bar = Direction::Up['short'];
+    const UP = Direction::Up['short'];
     // Fatal error: Cannot use [] on enums in constant expression
 }
 
 // This is entirely legal, because it's not a constant expression.
 $x = Direction::Up['short'];
+var_dump("\$x is " . var_export($x, true));
+
+$foo = new Foo();
 ?>
 ]]>
   </programlisting>

--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -37,6 +37,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit
 {
     case Hearts;
@@ -59,6 +60,7 @@ enum Suit
    <programlisting role="php">
 <![CDATA[
 <?php
+
 function pick_a_card(Suit $suit) { ... }
 
 $val = Suit::Diamonds;
@@ -91,6 +93,7 @@ pick_a_card('Spades');
    <programlisting role="php">
 <![CDATA[
 <?php
+
 $a = Suit::Spades;
 $b = Suit::Spades;
 
@@ -124,6 +127,7 @@ $a instanceof Suit;  // true
    <programlisting role="php">
 <![CDATA[
 <?php
+
 print Suit::Spades->name;
 // prints "Spades"
 ?>
@@ -154,6 +158,7 @@ print Suit::Spades->name;
   <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit: string
 {
     case Hearts = 'H';
@@ -195,6 +200,7 @@ enum Suit: string
   <programlisting role="php">
 <![CDATA[
 <?php
+
 print Suit::Clubs->value;
 // Prints "C"
 ?>
@@ -209,6 +215,7 @@ print Suit::Clubs->value;
   <programlisting role="php">
 <![CDATA[
 <?php
+
 $suit = Suit::Clubs;
 $ref = &$suit->value;
 // Error: Cannot acquire reference to property Suit::$value
@@ -249,6 +256,7 @@ $ref = &$suit->value;
   <programlisting role="php">
 <![CDATA[
 <?php
+
 $record = get_stuff_from_database($id);
 print $record['suit'];
 
@@ -279,6 +287,7 @@ print $suit->value;
   <programlisting role="php">
 <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -307,7 +316,7 @@ enum Suit implements Colorful
     }
 }
 
-function paint(Colorful $c) { ... }
+function paint(Colorful $c) {}
 
 paint(Suit::Clubs);  // Works
 
@@ -329,6 +338,7 @@ print Suit::Diamonds->shape(); // prints "Rectangle"
   <programlisting role="php">
    <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -378,6 +388,7 @@ enum Suit: string implements Colorful
   <programlisting role="php">
 <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -433,6 +444,7 @@ final class Suit implements UnitEnum, Colorful
   <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Size
 {
     case Small;
@@ -472,6 +484,7 @@ enum Size
   <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Size
 {
     case Small;
@@ -497,6 +510,7 @@ enum Size
   <programlisting role="php">
 <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -551,6 +565,7 @@ enum Suit implements Colorful
   <programlisting role="php">
 <![CDATA[
 <?php
+
 // This is an entirely legal Enum definition.
 enum Direction implements ArrayAccess
 {
@@ -632,6 +647,7 @@ $x = Direction::Up['short'];
   <programlisting role="php">
 <![CDATA[
 <?php
+
 $clovers = new Suit();
 // Error: Cannot instantiate enum Suit
 $horseshoes = (new ReflectionClass(Suit::class))->newInstanceWithoutConstructor()
@@ -654,6 +670,7 @@ $horseshoes = (new ReflectionClass(Suit::class))->newInstanceWithoutConstructor(
   <programlisting role="php">
 <![CDATA[
 <?php
+
 Suit::cases();
 // Produces: [Suit::Hearts, Suit::Diamonds, Suit::Clubs, Suit::Spades]
 ?>
@@ -675,6 +692,7 @@ Suit::cases();
   <programlisting role="php">
 <![CDATA[
 <?php
+
 Suit::Hearts === unserialize(serialize(Suit::Hearts));
 
 print serialize(Suit::Hearts);
@@ -701,6 +719,7 @@ print serialize(Suit::Hearts);
   <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Foo {
     case Bar;
 }
@@ -764,6 +783,7 @@ function bar(B $b) {
   <programlisting role="php">
 <![CDATA[
 <?php
+
 enum ErrorCode {
     case SOMETHING_BROKE;
 }
@@ -793,6 +813,7 @@ function quux(ErrorCode $errorCode)
   <programlisting role="php">
 <![CDATA[
 <?php
+
 // Thought experiment code where enums are not final.
 // Note, this won't actually work in PHP.
 enum MoreErrorCode extends ErrorCode {
@@ -833,6 +854,7 @@ fot(MoreErrorCode::PEBKAC);
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum SortOrder
 {
     case Asc;
@@ -860,6 +882,7 @@ function query($fields, $filter, SortOrder $order = SortOrder::Asc) { ... }
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum UserStatus: string
 {
     case Pending = 'P';
@@ -897,6 +920,7 @@ enum UserStatus: string
     <programlisting role="php">
 <![CDATA[
 <?php
+
 foreach (UserStatus::cases() as $case) {
     printf('<option value="%s">%s</option>\n', $case->value, $case->label());
 }


### PR DESCRIPTION
On the one hand, we are writing a closing tag ?> in examples, probably, such an agreement is in effect so that the user can copy the example code and paste it into a document that may contain, say, HTML markup, and immediately look at the result of this code. At the same time, there are functions in the documentation whose signatures contain three dots, which, when trying to execute the example, will result in a syntax error: Parse error: syntax error, unexpected token "..." Wouldn't it be a good practice to abandon the three dots in the definition of functions in the examples?