### PR TITLE
Update jsonserialize.xml

### DIFF
--- a/reference/json/jsonserializable/jsonserialize.xml
+++ b/reference/json/jsonserializable/jsonserialize.xml
@@ -48,7 +48,7 @@ class ArrayValue implements JsonSerializable {
         $this->array = $array;
     }
 
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         return $this->array;
     }
 }


### PR DESCRIPTION
Deprecated: Return type of ArrayValue::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice