### PR TITLE
Update output_reset_rewrite_vars()

### DIFF
--- a/reference/outcontrol/functions/output-reset-rewrite-vars.xml
+++ b/reference/outcontrol/functions/output-reset-rewrite-vars.xml
@@ -5,7 +5,7 @@
   <refname>output_reset_rewrite_vars</refname>
   <refpurpose>Reset URL rewriter values</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -101,7 +101,7 @@ echo '<a href="file.php">link</a>';
     <member><link linkend="ini.session.trans-sid-hosts">session.trans_sid_hosts</link></member>
    </simplelist>
   </para>
- </refsect1>  
+ </refsect1>
 
 </refentry>
 

--- a/reference/outcontrol/functions/output-reset-rewrite-vars.xml
+++ b/reference/outcontrol/functions/output-reset-rewrite-vars.xml
@@ -13,9 +13,8 @@
    <void/>
   </methodsynopsis>
   <para>
-   This function resets the URL rewriter and removes all rewrite
-   variables previously set by the <function>output_add_rewrite_var</function>
-   function.
+   This function removes all rewrite variables previously set by
+   the <function>output_add_rewrite_var</function> function.
   </para>
  </refsect1>
 
@@ -66,7 +65,8 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-session_start();
+ini_set('url_rewriter.tags', 'a=href');
+
 output_add_rewrite_var('var', 'value');
 
 echo '<a href="file.php">link</a>';
@@ -80,7 +80,7 @@ echo '<a href="file.php">link</a>';
     &example.outputs;
     <screen>
 <![CDATA[
-<a href="file.php?PHPSESSID=xxx&var=value">link</a>
+<a href="file.php?var=value">link</a>
 <a href="file.php">link</a>
 ]]>
     </screen>


### PR DESCRIPTION
Remove the session ID rewrite from the example as that is using a different functionality which is also not available with the default ini settings. Update example and its output to work with default settings.

Remove confusing first clause of the description as from the users perspective the only thing that happens is that the variables set are removed.