### PR TITLE
IntlChar::istitle and IntlChar::totitle examples corrections

### DIFF
--- a/reference/intl/intlchar/istitle.xml
+++ b/reference/intl/intlchar/istitle.xml
@@ -47,11 +47,19 @@
    <programlisting role="php">
     <![CDATA[
 <?php
-var_dump(IntlChar::istitle("A"));
-var_dump(IntlChar::istitle("a"));
-var_dump(IntlChar::istitle("Φ"));
-var_dump(IntlChar::istitle("φ"));
-var_dump(IntlChar::istitle("1"));
+//Latin Capital Letter Dz with Caron U+01C4
+var_dump(IntlChar::istitle("Ǆ")); 
+//Latin Capital Letter D with Small Letter Z with Caron U+01C5
+var_dump(IntlChar::istitle("ǅ"));
+//Latin Small Letter Dz with Caron U+01C6    
+var_dump(IntlChar::istitle("ǆ"));
+
+//Greek Capital Letter Alpha with Prosgegrammeni U+1FBC    
+var_dump(IntlChar::istitle("ᾼ"));
+//Greek Small Letter Alpha with Ypogegrammeni U+1FB3    
+var_dump(IntlChar::istitle("ᾳ"));
+//Greek Capital Letter Alpha U+0391
+var_dump(IntlChar::istitle("Α"));
 ?>
 ]]>
    </programlisting>
@@ -62,6 +70,7 @@ bool(false)
 bool(true)
 bool(false)
 bool(true)
+bool(false)
 bool(false)
 ]]>
    </screen>

--- a/reference/intl/intlchar/istitle.xml
+++ b/reference/intl/intlchar/istitle.xml
@@ -48,15 +48,15 @@
     <![CDATA[
 <?php
 //Latin Capital Letter Dz with Caron U+01C4
-var_dump(IntlChar::istitle("Ǆ")); 
+var_dump(IntlChar::istitle("Ǆ"));
 //Latin Capital Letter D with Small Letter Z with Caron U+01C5
 var_dump(IntlChar::istitle("ǅ"));
-//Latin Small Letter Dz with Caron U+01C6    
+//Latin Small Letter Dz with Caron U+01C6
 var_dump(IntlChar::istitle("ǆ"));
 
-//Greek Capital Letter Alpha with Prosgegrammeni U+1FBC    
+//Greek Capital Letter Alpha with Prosgegrammeni U+1FBC
 var_dump(IntlChar::istitle("ᾼ"));
-//Greek Small Letter Alpha with Ypogegrammeni U+1FB3    
+//Greek Small Letter Alpha with Ypogegrammeni U+1FB3
 var_dump(IntlChar::istitle("ᾳ"));
 //Greek Capital Letter Alpha U+0391
 var_dump(IntlChar::istitle("Α"));

--- a/reference/intl/intlchar/istitle.xml
+++ b/reference/intl/intlchar/istitle.xml
@@ -47,18 +47,18 @@
    <programlisting role="php">
     <![CDATA[
 <?php
-//Latin Capital Letter Dz with Caron U+01C4
+// Latin Capital Letter Dz with Caron U+01C4
 var_dump(IntlChar::istitle("Ǆ"));
-//Latin Capital Letter D with Small Letter Z with Caron U+01C5
+// Latin Capital Letter D with Small Letter Z with Caron U+01C5
 var_dump(IntlChar::istitle("ǅ"));
-//Latin Small Letter Dz with Caron U+01C6
+// Latin Small Letter Dz with Caron U+01C6
 var_dump(IntlChar::istitle("ǆ"));
 
-//Greek Capital Letter Alpha with Prosgegrammeni U+1FBC
+// Greek Capital Letter Alpha with Prosgegrammeni U+1FBC
 var_dump(IntlChar::istitle("ᾼ"));
-//Greek Small Letter Alpha with Ypogegrammeni U+1FB3
+// Greek Small Letter Alpha with Ypogegrammeni U+1FB3
 var_dump(IntlChar::istitle("ᾳ"));
-//Greek Capital Letter Alpha U+0391
+// Greek Capital Letter Alpha U+0391
 var_dump(IntlChar::istitle("Α"));
 ?>
 ]]>

--- a/reference/intl/intlchar/totitle.xml
+++ b/reference/intl/intlchar/totitle.xml
@@ -46,25 +46,25 @@
    <programlisting role="php">
     <![CDATA[
 <?php
-var_dump(IntlChar::totitle("A"));
-var_dump(IntlChar::totitle("a"));
+var_dump(IntlChar::totitle("Ǆ"));
+var_dump(IntlChar::totitle("ǆ"));
 var_dump(IntlChar::totitle("Φ"));
 var_dump(IntlChar::totitle("φ"));
 var_dump(IntlChar::totitle("1"));
+var_dump(IntlChar::totitle("ᾳ");
 var_dump(IntlChar::totitle(ord("A")));
-var_dump(IntlChar::totitle(ord("a")));
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
     <![CDATA[
-string(1) "A"
-string(1) "A"
+string(1) "ǅ"
+string(1) "ǅ"
 string(2) "Φ"
-string(2) "Φ"
+string(2) "φ"
 string(1) "1"
-int(65)
+string(1) "ᾼ"
 int(65)
 ]]>
    </screen>
@@ -77,6 +77,7 @@ int(65)
    <simplelist>
     <member><function>IntlChar::tolower</function></member>
     <member><function>IntlChar::toupper</function></member>
+    <member><function>IntlChar::istitle</function></member>
     <member><function>mb_convert_case</function></member>
    </simplelist>
   </para>


### PR DESCRIPTION
The current examples are incorrect and are identical to the examples of islower.xml and toupper.xml respectively.

The istitle() function determines wether the character is a titlecase code point ("Lt" general category of Unicode). Titlecase characters are digraphs (in one character) formed by a combination of two glyphs, one uppercase and the other lowercase.
Similarly, totitle() converts a character to titlecase, if available.

The examples included in these commits were retrieved from the Unicode specification, also presented in https://www.compart.com/en/unicode/category/Lt