### PR TITLE
Document approach to set cookie params not known to setcookie()

### DIFF
--- a/reference/network/functions/header.xml
+++ b/reference/network/functions/header.xml
@@ -223,9 +223,9 @@ header("Expires: Sat, 26 Jul 1997 05:00:00 GMT"); // Date in the past
    <example>
     <title>Setting a cookie</title>
     <para>
-      <function>setcookie</function> provides a convenient way to set cookies. 
-      To set a cookie that includes attributes which <function>setcookie</function>
-      doesn't support, <function>header</function> can be used.
+     <function>setcookie</function> provides a convenient way to set cookies. 
+     To set a cookie that includes attributes which <function>setcookie</function>
+     doesn't support, <function>header</function> can be used.
     </para>
     <para>
      For example, the following sets a cookie that includes a 

--- a/reference/network/functions/header.xml
+++ b/reference/network/functions/header.xml
@@ -219,6 +219,24 @@ header("Expires: Sat, 26 Jul 1997 05:00:00 GMT"); // Date in the past
     </para>
    </example>
   </para>
+  <para>
+   <example>
+    <title>Setting a cookie</title>
+    <para>
+      <function>setcookie</function> provides a convenient way to set cookies. However, <function>header</function> lets you include parameters that <function>setcookie</function> may not support.
+    </para>
+    <para>
+     For example, the following sets a cookie that includes a <literal>Partitioned</literal> attribute.
+    </para>
+    <programlisting role="php">
+<![CDATA[
+<?php
+header('Set-Cookie: name=value; Secure; Path=/; SameSite=None; Partitioned;');
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/network/functions/header.xml
+++ b/reference/network/functions/header.xml
@@ -224,8 +224,8 @@ header("Expires: Sat, 26 Jul 1997 05:00:00 GMT"); // Date in the past
     <title>Setting a cookie</title>
     <para>
       <function>setcookie</function> provides a convenient way to set cookies. 
-      But <function>header</function> can be used to include attributes that 
-      <function>setcookie</function> doesn't support.
+      To set a cookie that includes attributes which <function>setcookie</function>
+      doesn't support, <function>header</function> can be used.
     </para>
     <para>
      For example, the following sets a cookie that includes a 

--- a/reference/network/functions/header.xml
+++ b/reference/network/functions/header.xml
@@ -224,8 +224,8 @@ header("Expires: Sat, 26 Jul 1997 05:00:00 GMT"); // Date in the past
     <title>Setting a cookie</title>
     <para>
       <function>setcookie</function> provides a convenient way to set cookies. 
-      However, <function>header</function> lets you include parameters that 
-      <function>setcookie</function> may not support.
+      But <function>header</function> can be used to include attributes that 
+      <function>setcookie</function> doesn't support.
     </para>
     <para>
      For example, the following sets a cookie that includes a 

--- a/reference/network/functions/header.xml
+++ b/reference/network/functions/header.xml
@@ -223,10 +223,13 @@ header("Expires: Sat, 26 Jul 1997 05:00:00 GMT"); // Date in the past
    <example>
     <title>Setting a cookie</title>
     <para>
-      <function>setcookie</function> provides a convenient way to set cookies. However, <function>header</function> lets you include parameters that <function>setcookie</function> may not support.
+      <function>setcookie</function> provides a convenient way to set cookies. 
+      However, <function>header</function> lets you include parameters that 
+      <function>setcookie</function> may not support.
     </para>
     <para>
-     For example, the following sets a cookie that includes a <literal>Partitioned</literal> attribute.
+     For example, the following sets a cookie that includes a 
+     <literal>Partitioned</literal> attribute.
     </para>
     <programlisting role="php">
 <![CDATA[

--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -170,6 +170,13 @@
        <literal>samesite</literal> element is omitted, no SameSite cookie
        attribute is set.
       </para>
+      <para>
+       <note>
+        <para>
+         To set a cookie that includes parameters that aren't among the keys listed, you can use <function>header</function>.
+        </para>
+       </note>
+      </para>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -222,7 +229,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-   Some examples follow how to send cookies:
+   The following examples demonstrate some ways to send cookies.
    <example>
     <title><function>setcookie</function> send example</title>
     <programlisting role="php">

--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -173,7 +173,8 @@
       <para>
        <note>
         <para>
-         To set a cookie that includes parameters that aren't among the keys listed, you can use <function>header</function>.
+         To set a cookie that includes parameters that aren't among the keys listed, 
+         use <function>header</function>.
         </para>
        </note>
       </para>

--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -173,7 +173,7 @@
       <para>
        <note>
         <para>
-         To set a cookie that includes parameters that aren't among the keys listed, 
+         To set a cookie that includes attributes that aren't among the keys listed, 
          use <function>header</function>.
         </para>
        </note>


### PR DESCRIPTION
As per [discussion in the StackOverflow chat](https://chat.stackoverflow.com/transcript/message/56990396#56990396), I added a note to the `setcookie()` doc to say that one can use `header()` to create cookies with arbitrary params. I then added an example to the `header()` doc.

I also propose a minor language fix-up.