### PR TITLE
ValueError on flags diferent to JSON_INVALID_UTF8_IGNORE

### DIFF
--- a/reference/json/functions/json-validate.xml
+++ b/reference/json/functions/json-validate.xml
@@ -100,6 +100,10 @@
    If <parameter>depth</parameter> is outside the allowed range,
    a <classname>ValueError</classname> is thrown.
   </para>
+  <para>
+   If <parameter>flags</parameter> is different than the constant <constant>JSON_INVALID_UTF8_IGNORE</constant>,
+   a <classname>ValueError</classname> is thrown.
+  </para>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/json/functions/json-validate.xml
+++ b/reference/json/functions/json-validate.xml
@@ -101,7 +101,7 @@
    a <classname>ValueError</classname> is thrown.
   </para>
   <para>
-   If <parameter>flags</parameter> is different than the constant <constant>JSON_INVALID_UTF8_IGNORE</constant>,
+   If <parameter>flags</parameter> is not a valid flag,
    a <classname>ValueError</classname> is thrown.
   </para>
  </refsect1>


### PR DESCRIPTION
If flags parameter is different than the constant JSON_INVALID_UTF8_IGNORE, a ValueError exception is thrown.