### PR TITLE
Update ob_implicit_flush()

### DIFF
--- a/reference/outcontrol/functions/ob-implicit-flush.xml
+++ b/reference/outcontrol/functions/ob-implicit-flush.xml
@@ -5,7 +5,7 @@
   <refname>ob_implicit_flush</refname>
   <refpurpose>Turn implicit flush on/off</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -18,6 +18,13 @@
    call, so that explicit calls to <function>flush</function> will no longer
    be needed.
   </para>
+  <note>
+   <simpara>
+    This function does not have any effect on user level output handlers
+    such as those started by <function>ob_start</function>
+    or <function>output_add_rewrite_var</function>.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Add a note that this function doesn't work with user level output handlers as this seems to be the most common misunderstanding regarding this function.