### PR TITLE
Add PHP 8.2 changelog entry to mb_convert_encoding() and mb_detect_encoding()

### DIFF
--- a/reference/mbstring/functions/mb-convert-encoding.xml
+++ b/reference/mbstring/functions/mb-convert-encoding.xml
@@ -5,7 +5,7 @@
   <refname>mb_convert_encoding</refname>
   <refpurpose>Convert a string from one character encoding to another</refpurpose>
  </refnamediv>
-   
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -66,7 +66,7 @@
    </variablelist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
@@ -78,7 +78,7 @@
   &reftitle.errors;
   <para>
    As of PHP 8.0.0, a <classname>ValueError</classname> is thrown if the
-   value of <parameter>to_encoding</parameter> or 
+   value of <parameter>to_encoding</parameter> or
    <parameter>from_encoding</parameter> is an invalid encoding.
    Prior to PHP 8.0.0, a <constant>E_WARNING</constant> was emitted instead.
   </para>
@@ -99,7 +99,7 @@
       <entry>8.0.0</entry>
       <entry>
        <function>mb_convert_encoding</function> will now throw a
-       <classname>ValueError</classname> when 
+       <classname>ValueError</classname> when
        <parameter>to_encoding</parameter> is passed an invalid encoding.
       </entry>
      </row>
@@ -107,7 +107,7 @@
       <entry>8.0.0</entry>
       <entry>
        <function>mb_convert_encoding</function> will now throw a
-       <classname>ValueError</classname> when 
+       <classname>ValueError</classname> when
        <parameter>from_encoding</parameter> is passed an invalid encoding.
       </entry>
      </row>
@@ -154,7 +154,7 @@ $str = mb_convert_encoding($str, "EUC-JP", "auto");
    </example>
   </para>
  </refsect1>
-  
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -165,7 +165,7 @@ $str = mb_convert_encoding($str, "EUC-JP", "auto");
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mbstring/functions/mb-convert-encoding.xml
+++ b/reference/mbstring/functions/mb-convert-encoding.xml
@@ -96,6 +96,16 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.2.0</entry>
+      <entry>
+       <function>mb_convert_encoding</function> will no longer return
+       the following non text encodings:
+       <literal>"Base64"</literal>, <literal>"QPrint"</literal>,
+       <literal>"UUencode"</literal>,<literal>"HTML entities"</literal>,
+       <literal>"7 bit"</literal> and <literal>"8 bit"</literal>.
+      </entry>
+     </row>
+     <row>
       <entry>8.0.0</entry>
       <entry>
        <function>mb_convert_encoding</function> will now throw a

--- a/reference/mbstring/functions/mb-detect-encoding.xml
+++ b/reference/mbstring/functions/mb-detect-encoding.xml
@@ -87,6 +87,32 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.2.0</entry>
+      <entry>
+       <function>mb_detect_encoding</function> will no longer return
+       the following non text encodings:
+       <literal>"Base64"</literal>, <literal>"QPrint"</literal>,
+       <literal>"UUencode"</literal>,<literal>"HTML entities"</literal>,
+       <literal>"7 bit"</literal> and <literal>"8 bit"</literal>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>


### PR DESCRIPTION
Add changelog entry to both functions about these functions no longer returning `Base64`, `QPrint`, `UUencode`, `HTML entities`, `7 bit` or`8 bit`. 

This should complete the appropriate part of the [PHP 8.2 documentation tracker](https://github.com/php/doc-en/issues/1803).

References can be found [here](https://github.com/php/php-src/commit/f07c1935839bf87e9d5a26a82a0ed8747c4f178f) and [here](https://github.com/php/php-src/commit/a2bc57e0e531367f40fc50aa935bffac60cd61e8).