### PR TITLE
Update flush() documentation

### DIFF
--- a/reference/outcontrol/functions/flush.xml
+++ b/reference/outcontrol/functions/flush.xml
@@ -5,7 +5,7 @@
   <refname>flush</refname>
   <refpurpose>Flush system output buffer</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -70,7 +70,7 @@
     <member><function>ob_end_clean</function></member>
    </simplelist>
   </para>
- </refsect1> 
+ </refsect1>
 
 </refentry>
 

--- a/reference/outcontrol/functions/flush.xml
+++ b/reference/outcontrol/functions/flush.xml
@@ -13,39 +13,33 @@
    <void/>
   </methodsynopsis>
   <para>
-   Flushes the system write buffers of PHP and whatever backend PHP is using (CGI,
-   a web server, etc).  This attempts to push current output all the way to
-   the browser with a few caveats.
+   Flushes the system write buffers of PHP and the backend used by PHP
+   (e.g.: CGI, a web server).
+   In a command line environment <function>flush</function>
+   will attempt to flush the contents of the buffers only
+   whereas in a web context headers and the contents of the buffers are flushed.
   </para>
-  <para>
-   <function>flush</function> may not be able to override the buffering scheme
-   of your web server and it has no effect on any client-side buffering in the
-   browser.  It also doesn't affect PHP's userspace output buffering mechanism.
-   This means <function>ob_flush</function> should be called before <function>flush</function>
-   to flush the output buffers if they are in use.
-  </para>
-  <para>
-   Several servers, especially on Win32, will still buffer the output from
-   your script until it terminates before transmitting the results to the
-   browser.
-  </para>
-  <para>
-   Server modules for Apache like mod_gzip may do buffering of their own that
-   will cause <function>flush</function> to not result in data being sent
-   immediately to the client.
-  </para>
-  <para>
-   Even the browser may buffer its input before displaying it. Netscape, for
-   example, buffers text until it receives an end-of-line or the beginning of
-   a tag, and it won't render tables until the &lt;/table&gt; tag of the
-   outermost table is seen.
-  </para>
-  <para>
-   Some versions of Microsoft Internet Explorer will only start to display
-   the page after they have received 256 bytes of output, so you may need to
-   send extra whitespace before flushing to get those browsers to display the
-   page.
-  </para>
+  <note>
+   <simpara>
+    <function>flush</function> may not be able to override
+    the buffering scheme of the web server
+    and it has no effect on any client-side buffering in the browser.
+   </simpara>
+  </note>
+  <note>
+   <simpara>
+    This function does not have any effect on user level output handlers
+    such as those started by <function>ob_start</function>
+    or <function>output_add_rewrite_var</function>.
+   </simpara>
+  </note>
+  <warning>
+   <simpara>
+    <function>flush</function> can interfere with output handlers
+    that set and send headers in a web context (e.g. <function>ob_gzhandler</function>)
+    by sending headers before these handlers can do so.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Removed sections of web server specific description (there is plenty of these in the comments of that page), add a sentence on how functionality differs on the CLI and in a web server, added a section on flush possibly interfering with output handlers and moved the notes user level handlers and web server/browser buffering into separate `<note>` tags.

Closes https://bugs.php.net/bug.php?id=65115.