### PR TITLE
Make the Operators list pure

### DIFF
--- a/language/operators/arithmetic.xml
+++ b/language/operators/arithmetic.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sect1 xml:id="language.operators.arithmetic">
  <title>Arithmetic Operators</title>
+ <titleabbrev>Arithmetic</titleabbrev>
  <simpara>
   Remember basic arithmetic from school? These work just
   like those.

--- a/language/operators/array.xml
+++ b/language/operators/array.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sect1 xml:id="language.operators.array">
  <title>Array Operators</title>
+ <titleabbrev>Array</titleabbrev>
  <table>
   <title>Array Operators</title>
   <tgroup cols="3">

--- a/language/operators/assignment.xml
+++ b/language/operators/assignment.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sect1 xml:id="language.operators.assignment">
  <title>Assignment Operators</title>
+ <titleabbrev>Assignment</titleabbrev>
  <simpara>
   The basic assignment operator is "=". Your first inclination might
   be to think of this as "equal to". Don't. It really means that the

--- a/language/operators/bitwise.xml
+++ b/language/operators/bitwise.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sect1 xml:id="language.operators.bitwise">
  <title>Bitwise Operators</title>
+ <titleabbrev>Bitwise</titleabbrev>
  <simpara>
   Bitwise operators allow evaluation and manipulation of specific
   bits within an integer.

--- a/language/operators/comparison.xml
+++ b/language/operators/comparison.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sect1 xml:id="language.operators.comparison">
  <title>Comparison Operators</title>
+ <titleabbrev>Comparison</titleabbrev>
  <simpara>
   Comparison operators, as their name implies, allow you to compare
   two values.  You may also be interested in viewing

--- a/language/operators/errorcontrol.xml
+++ b/language/operators/errorcontrol.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sect1 xml:id="language.operators.errorcontrol">
  <title>Error Control Operators</title>
+ <titleabbrev>Error Control</titleabbrev>
  <simpara>
   PHP supports one error control operator: the at sign (<literal>@</literal>).
   When prepended to an expression in PHP, any diagnostic error that might

--- a/language/operators/execution.xml
+++ b/language/operators/execution.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sect1 xml:id="language.operators.execution">
  <title>Execution Operators</title>
+ <titleabbrev>Execution</titleabbrev>
  <para>
   PHP supports one execution operator: backticks (``). Note that
   these are not single-quotes! PHP will attempt to execute the

--- a/language/operators/increment.xml
+++ b/language/operators/increment.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sect1 xml:id="language.operators.increment">
  <title>Incrementing/Decrementing Operators</title>
+ <titleabbrev>Incrementing/Decrementing</titleabbrev>
  <para>
   PHP supports pre- and post-increment and decrement operators.
   Those unary operators allow to increment or decrement the value by one.

--- a/language/operators/increment.xml
+++ b/language/operators/increment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sect1 xml:id="language.operators.increment">
  <title>Incrementing/Decrementing Operators</title>
- <titleabbrev>Incrementing/Decrementing</titleabbrev>
+ <titleabbrev>Increment and Decrement</titleabbrev>
  <para>
   PHP supports pre- and post-increment and decrement operators.
   Those unary operators allow to increment or decrement the value by one.

--- a/language/operators/logical.xml
+++ b/language/operators/logical.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sect1 xml:id="language.operators.logical">
  <title>Logical Operators</title>
+ <titleabbrev>Logic</titleabbrev>
 
  <table>
   <title>Logical Operators</title>

--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sect1 xml:id="language.operators.precedence">
  <title>Operator Precedence</title>
+ <titleabbrev>Precedence</titleabbrev>
  <para>
   The precedence of an operator specifies how "tightly" it binds two
   expressions together. For example, in the expression <literal>1 +

--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sect1 xml:id="language.operators.precedence">
  <title>Operator Precedence</title>
- <titleabbrev>Precedence</titleabbrev>
+ <titleabbrev>Operator Precedence</titleabbrev>
  <para>
   The precedence of an operator specifies how "tightly" it binds two
   expressions together. For example, in the expression <literal>1 +

--- a/language/operators/string.xml
+++ b/language/operators/string.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sect1 xml:id="language.operators.string">
  <title>String Operators</title>
+ <titleabbrev>String</titleabbrev>
  <simpara>
   There are two <type>string</type> operators. The first is the
   concatenation operator ('.'), which returns the concatenation of its

--- a/language/operators/type.xml
+++ b/language/operators/type.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sect1 xml:id="language.operators.type">
  <title>Type Operators</title>
+ <titleabbrev>Type</titleabbrev>
  <para>
   <literal>instanceof</literal> is used to determine whether a PHP variable
   is an instantiated object of a certain


### PR DESCRIPTION
### Problem
Now the list of operators looks very noisy. Take a look:

![operators-eng-dirty](https://github.com/php/doc-en/assets/39414600/64e64825-f604-4ac6-a62b-727d396cf7fc)

It's hard for the eye to catch on to the desired section. The list only shows Operators, Operators, Operators…

### Proposal
Make the list of operators (on the [Operators](https://www.php.net/manual/en/language.operators.php) page and in the [menu](https://www.php.net/manual/en/language.operators.precedence.php), which is located at the top right) pure, but keep the full titles on the pages.

![operators-eng-pure](https://github.com/php/doc-en/assets/39414600/7bcf6561-06ee-4661-bbc4-ca91fb6591ee)

Now it takes 5 times faster to select the desired section; the eye instantly catches on to the desired operator name.

P. S. I'm not 100 % sure that I chose the right way to add a short title for the sections via the `titleabbrev` tag, maybe someone will tell me how to do it better. I'm ready.