### PR TITLE
Correction to IntlDateFormatter examples

### DIFF
--- a/reference/intl/dateformatter/get-error-code.xml
+++ b/reference/intl/dateformatter/get-error-code.xml
@@ -25,7 +25,7 @@
   <para>
    Returns the error code from the last formatting operation.
   </para>
-  </refsect1>
+ </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -111,11 +111,11 @@ ERROR: U_ZERO_ERROR (0)
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
-    <simplelist>
+   <simplelist>
     <member><function>datefmt_get_error_message</function></member>
     <member><function>intl_get_error_code</function></member>
     <member><function>intl_is_failure</function></member>
-    </simplelist>
+   </simplelist>
   </para>
  </refsect1>
 </refentry>

--- a/reference/intl/dateformatter/get-error-code.xml
+++ b/reference/intl/dateformatter/get-error-code.xml
@@ -54,11 +54,12 @@
  
  <refsect1 role="examples">
   &reftitle.examples;
-   <example>
-    <title><function>datefmt_get_error_code</function> example</title>
-    <programlisting role="php">
+  <example>
+   <title><function>datefmt_get_error_code</function> example</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
+
 $fmt = datefmt_create(
     'en_US',
     IntlDateFormatter::FULL,
@@ -66,23 +67,23 @@ $fmt = datefmt_create(
     'America/Los_Angeles',
     IntlDateFormatter::GREGORIAN
 );
-$str = datefmt_format($fmt);
-if (!$str) {
-    printf(
-        "ERROR: %s (%d)\n",
-        datefmt_get_error_message($fmt),
-        datefmt_get_error_code($fmt)
-    );
-}
+$str = datefmt_format($fmt, 0);
+
+printf(
+    "ERROR: %s (%d)\n",
+    datefmt_get_error_message($fmt),
+    datefmt_get_error_code($fmt)
+);
 ?>
 ]]>
-    </programlisting>
-   </example>
-   <example>
-    <title>OO example</title>
-    <programlisting role="php">
+   </programlisting>
+  </example>
+  <example>
+   <title>OO example</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
+
 $fmt = new IntlDateFormatter(
     'en_US',
     IntlDateFormatter::FULL,
@@ -90,24 +91,23 @@ $fmt = new IntlDateFormatter(
     'America/Los_Angeles',
     IntlDateFormatter::GREGORIAN
 );
-$str = $fmt->format();
-if (!$str) {
-    printf(
-        "ERROR: %s (%d)\n",
-        $fmt->getErrorMessage(),
-        $fmt->getErrorCode()
-    );
-}
+$str = $fmt->format(0);
+
+printf(
+    "ERROR: %s (%d)\n",
+    $fmt->getErrorMessage(),
+    $fmt->getErrorCode()
+);
 ?>
 ]]>
-    </programlisting>
-   </example>
-     &example.outputs;
-     <screen>
-         <![CDATA[
+   </programlisting>
+  </example>
+  &example.outputs;
+  <screen>
+<![CDATA[
 ERROR: U_ZERO_ERROR (0)
 ]]>
-     </screen>
+  </screen>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/intl/dateformatter/get-error-code.xml
+++ b/reference/intl/dateformatter/get-error-code.xml
@@ -23,9 +23,8 @@
    <methodparam><type>IntlDateFormatter</type><parameter>formatter</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Get the error code from last operation.
-   Returns error code from the last number formatting operation. 
-  </para> 
+   Returns the error code from the last formatting operation.
+  </para>
   </refsect1>
 
  <refsect1 role="parameters">
@@ -36,22 +35,21 @@
      <term><parameter>formatter</parameter></term>
      <listitem>
       <para>
-       The formatter resource.      
+       The formatter resource.
       </para>
      </listitem>
     </varlistentry>
    </variablelist>
   </para>
  </refsect1>
-   
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The error code, one of UErrorCode values. Initial value is U_ZERO_ERROR. 
-   </para>
+   The error code, one of UErrorCode values. Initial value is U_ZERO_ERROR.
+  </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>

--- a/reference/intl/dateformatter/get-error-message.xml
+++ b/reference/intl/dateformatter/get-error-message.xml
@@ -23,10 +23,10 @@
    <methodparam><type>IntlDateFormatter</type><parameter>formatter</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Get the error text from the last operation.  
-  </para> 
+   Get the error text from the last operation.
+  </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -35,22 +35,21 @@
      <term><parameter>formatter</parameter></term>
      <listitem>
       <para>
-       The formatter resource.      
+       The formatter resource.
       </para>
      </listitem>
     </varlistentry>
    </variablelist>
   </para>
  </refsect1>
- 
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Description of the last error.  
+   Description of the last error.
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
@@ -58,6 +57,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+
 $fmt = datefmt_create(
     'en_US',
     IntlDateFormatter::FULL,
@@ -65,22 +65,22 @@ $fmt = datefmt_create(
     'America/Los_Angeles',
     IntlDateFormatter::GREGORIAN
 );
-$str = datefmt_format($fmt);
-if (!$str) {
-    printf(
-        "ERROR: %s (%d)\n",
-        datefmt_get_error_message($fmt),
-        datefmt_get_error_code($fmt)
-    );
-}
+$str = datefmt_format($fmt, 0);
+
+printf(
+    "ERROR: %s (%d)\n",
+    datefmt_get_error_message($fmt),
+    datefmt_get_error_code($fmt)
+);
 ?>
 ]]>
-    </programlisting>
+   </programlisting>
   </example>
   <example>
    <title>OO example</title>
    <programlisting role="php">
 <![CDATA[
+
 <?php
 $fmt = new IntlDateFormatter(
     'en_US',
@@ -89,18 +89,16 @@ $fmt = new IntlDateFormatter(
     'America/Los_Angeles',
     IntlDateFormatter::GREGORIAN
 );
-$str = $fmt->format();
-if(!$str) {
-    printf(
-        "ERROR: %s (%d)\n",
-        $fmt->getErrorMessage(),
-        $fmt->getErrorCode()
-    );
-}
+$str = $fmt->format(0);
 
+printf(
+    "ERROR: %s (%d)\n",
+    $fmt->getErrorMessage(),
+    $fmt->getErrorCode()
+);
 ?>
 ]]>
-    </programlisting>
+   </programlisting>
   </example>
   &example.outputs;
   <screen>
@@ -109,14 +107,14 @@ ERROR: U_ZERO_ERROR (0)
 ]]>
   </screen>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
    <simplelist>
     <member><function>datefmt_get_error_code</function></member>
-     <member><function>intl_get_error_code</function></member>
-     <member><function>intl_is_failure</function></member>
+    <member><function>intl_get_error_code</function></member>
+    <member><function>intl_is_failure</function></member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
reference/intl/dateformatter/get-error-code.xml
reference/intl/dateformatter/get-error-message.xml

* Examples in get-error-code.xml and get-error-message.xml use the function IntlDateFormatter::format() with less parameters than expected, both in OO and procedural. Corrections made by this commit intend to generate the expected error code and message given in the example. Tested with PHP 8.3.1.
* Rephrased purpose of function in get-error-code.xml, there was redundant information.
* Correction to identation.
* Removed trailing ws.
