### PR TITLE
Clarify output in ob_implicit_flush()

### DIFF
--- a/reference/outcontrol/functions/ob-implicit-flush.xml
+++ b/reference/outcontrol/functions/ob-implicit-flush.xml
@@ -14,10 +14,16 @@
   </methodsynopsis>
   <para>
    <function>ob_implicit_flush</function> will turn implicit flushing on or
-   off. Implicit flushing will result in a flush operation after every output
-   call, so that explicit calls to <function>flush</function> will no longer
-   be needed.
+   off. Implicit flushing will result in a flush operation after every block of
+   code resulting in output, so that explicit calls to <function>flush</function>
+   will no longer be needed.
   </para>
+  <note>
+   <simpara>
+    Printing empty strings or sending headers is not considered output
+    and will not result in a flush operation.
+   </simpara>
+  </note>
   <note>
    <simpara>
     This function does not have any effect on user level output handlers


### PR DESCRIPTION
Closes #3115 

Clarifies that empty strings or sending headers do not trigger implicit flushing.