### PR TITLE
grapheme_stristr function name is incorrect in parameter section

### DIFF
--- a/reference/intl/grapheme/grapheme-stristr.xml
+++ b/reference/intl/grapheme/grapheme-stristr.xml
@@ -43,7 +43,7 @@
      <term><parameter>beforeNeedle</parameter></term>
      <listitem>
       <para>
-       If &true;, <function>grapheme_strstr</function> returns the part of the
+       If &true;, <function>grapheme_stristr</function> returns the part of the
        <parameter>haystack</parameter> before the first occurrence of the needle (excluding <parameter>needle</parameter>).
       </para>
      </listitem>


### PR DESCRIPTION
grapheme_stristr function name is incorrect in parameter section

was: grapheme_strstr
to be: grapheme_stristr