### PR TITLE
Document details of output buffering / output control

### DIFF
--- a/reference/outcontrol/book.xml
+++ b/reference/outcontrol/book.xml
@@ -22,6 +22,9 @@
 
  &reference.outcontrol.setup;
  &reference.outcontrol.constants;
+ &reference.outcontrol.output-buffering;
+ &reference.outcontrol.flushing-system-buffers;
+ &reference.outcontrol.user-level-output-buffers;
  &reference.outcontrol.examples;
  &reference.outcontrol.reference;
 

--- a/reference/outcontrol/flushing-system-buffers.xml
+++ b/reference/outcontrol/flushing-system-buffers.xml
@@ -19,7 +19,7 @@
    With implicit flushing enabled, PHP will attempt to flush
    after every block of code resulting in output.
    Output in this context is non-zero length data that is:
-   <itemizedlist>
+   <itemizedlist xml:id="outputcontrol.what-is-output">
     <listitem>
      <simpara>
       outside of the <literal>&#60;?php ?&#62;</literal> tags
@@ -64,6 +64,14 @@
     and will not result in a flush operation.
    </simpara>
   </note>
+  <warning>
+   <simpara>
+    If implicit flushing is enabled, control characters
+    (e.g. <literal>"\n"</literal>, <literal>"\r"</literal>,
+    <literal>"\0"</literal>)
+    will trigger flushing as well.
+   </simpara>
+  </warning>
  </section>
 
  <section>
@@ -90,7 +98,7 @@
    and working with these can alleviate possible issues.
    Working in a web context, either the web server's buffering settings
    or the script's buffering could be adjusted to work in tandem
-   whereas working around various browsers' buffering strategies
+   whereas working around the buffering strategies of various browsers
    can be achieved by adjusting buffering in the PHP script.
    On consoles that implement line buffering,
    newline characters could be inserted in the appropriate places

--- a/reference/outcontrol/flushing-system-buffers.xml
+++ b/reference/outcontrol/flushing-system-buffers.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-
 <chapter xml:id="outcontrol.flushing-system-buffers" xmlns="http://docbook.org/ns/docbook">
  <section>
   <title>Flushing System Buffers</title>
@@ -8,63 +6,63 @@
    PHP provides two related ways
    to flush (send and discard the contents of) system buffers:
    through calling <function>flush</function>
-   and through turning implicit flushing on
+   and through enabling implicit flushing
    with <function>ob_implicit_flush</function>
    or the <link linkend="ini.implicit-flush">implicit_flush</link>
    <literal>ini</literal> setting.
   </para>
   <para>
-   With implicit flushing turned off, PHP will flush output only
+   With implicit flushing disabled, PHP will flush output only
    when <function>flush</function> is called or when the script ends.
   </para>
   <para>
-   With implicit flushing turned on, PHP will attempt to flush
+   With implicit flushing enabled, PHP will attempt to flush
    after every block of code resulting in output.
    Output in this context is non-zero length data that is:
    <itemizedlist>
     <listitem>
-     <para>
+     <simpara>
       outside of the <literal>&#60;?php ?&#62;</literal> tags
-     </para>
+     </simpara>
     </listitem>
     <listitem>
-     <para>
+     <simpara>
       printed by language constructs and functions
       whose explicit purpose is to output user provided variables or strings such as
       <function>echo</function>, <function>print</function>,
       <function>printf</function>, <function>var_dump</function>,
       <function>var_export</function>, <function>vprintf</function>
-     </para>
+     </simpara>
     </listitem>
     <listitem>
-     <para>
+     <simpara>
       printed by functions whose purpose is to collect and output
       data/information on the running script or PHP such as
       <function>debug_print_backtrace</function>, <function>phpcredits</function>,
       <function>phpinfo</function>,
       <methodname>ReflectionExtension::info</methodname>
-     </para>
+     </simpara>
     </listitem>
     <listitem>
-     <para>
+     <simpara>
       printed by PHP on an uncaught exception or an unhandled error
       (subject to the settings of
       <link linkend="ini.display-errors">display_errors</link>
       and <link linkend="ini.error-reporting">error_reporting</link>)
-     </para>
+     </simpara>
     </listitem>
     <listitem>
-     <para>
+     <simpara>
       anything written to <literal>php://output</literal>
-     </para>
+     </simpara>
     </listitem>
    </itemizedlist>
   </para>
   <note>
-   <para>
+   <simpara>
     Printing empty strings or sending headers is not considered output
     and will not result in a flush operation.
-   </para>
+   </simpara>
   </note>
  </section>
 
@@ -77,7 +75,7 @@
   </para>
   <warning>
    <simpara>
-    Calling <function>flush</function> or implicit flushing being turned on
+    Calling <function>flush</function> or implicit flushing being enabled
     can interfere with output handlers of user-level output buffers
     that set and send headers in a web context
     (e.g. <function>ob_gzhandler</function>)
@@ -128,7 +126,6 @@
  </section>
 
 </chapter>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/outcontrol/flushing-system-buffers.xml
+++ b/reference/outcontrol/flushing-system-buffers.xml
@@ -9,7 +9,7 @@
    and through enabling implicit flushing
    with <function>ob_implicit_flush</function>
    or the <link linkend="ini.implicit-flush">implicit_flush</link>
-   <literal>ini</literal> setting.
+   &php.ini; setting.
   </para>
   <para>
    With implicit flushing disabled, PHP will flush output only
@@ -114,20 +114,20 @@
    these implementations fall in one of two categories:
    <itemizedlist>
     <listitem>
-     <para>
+     <simpara>
       <acronym>SAPI</acronym>s used in a web context will flush headers first
       followed by the output.
       <literal>Apache2Handler</literal>, <literal>CGI</literal>,
       <literal>FastCGI</literal> and <literal>FPM</literal>
       are such <acronym>SAPI</acronym>s
-     </para>
+     </simpara>
     </listitem>
     <listitem>
-     <para>
+     <simpara>
       other <acronym>SAPI</acronym>s
       such as <literal>CLI</literal> and <literal>embed</literal>
       will flush output only
-     </para>
+     </simpara>
     </listitem>
    </itemizedlist>
   </para>

--- a/reference/outcontrol/flushing-system-buffers.xml
+++ b/reference/outcontrol/flushing-system-buffers.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<chapter xml:id="outcontrol.flushing-system-buffers" xmlns="http://docbook.org/ns/docbook">
+ <section>
+  <title>Flushing System Buffers</title>
+  <para>
+   PHP provides two related ways
+   to flush (send and discard the contents of) system buffers:
+   through calling <function>flush</function>
+   and through turning implicit flushing on
+   with <function>ob_implicit_flush</function>
+   or the <link linkend="ini.implicit-flush">implicit_flush</link>
+   <literal>ini</literal> setting.
+  </para>
+  <para>
+   With implicit flushing turned off, PHP will flush output only
+   when <function>flush</function> is called or when the script ends.
+  </para>
+  <para>
+   With implicit flushing turned on, PHP will attempt to flush
+   after every block of code resulting in output.
+   Output in this context is non-zero length data that is:
+   <itemizedlist>
+    <listitem>
+     <para>
+      outside of the <literal>&#60;?php ?&#62;</literal> tags
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      printed by language constructs and functions
+      whose explicit purpose is to output user provided variables or strings such as
+      <function>echo</function>, <function>print</function>,
+      <function>printf</function>, <function>var_dump</function>,
+      <function>var_export</function>, <function>vprintf</function>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      printed by functions whose purpose is to collect and output
+      data/information on the running script or PHP such as
+      <function>debug_print_backtrace</function>, <function>phpcredits</function>,
+      <function>phpinfo</function>,
+      <methodname>ReflectionExtension::info</methodname>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      printed by PHP on an uncaught exception or an unhandled error
+      (subject to the settings of
+      <link linkend="ini.display-errors">display_errors</link>
+      and <link linkend="ini.error-reporting">error_reporting</link>)
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      anything written to <literal>php://output</literal>
+     </para>
+    </listitem>
+   </itemizedlist>
+  </para>
+  <note>
+   <para>
+    Printing empty strings or sending headers is not considered output
+    and will not result in a flush operation.
+   </para>
+  </note>
+ </section>
+
+ <section>
+  <title>Limitations</title>
+  <para>
+   This functionality cannot flush user-level output buffers.
+   To use these together, user-level output buffers must be flushed
+   before flushing system buffers in order for PHP to produce any output.
+  </para>
+  <warning>
+   <simpara>
+    Calling <function>flush</function> or implicit flushing being turned on
+    can interfere with output handlers of user-level output buffers
+    that set and send headers in a web context
+    (e.g. <function>ob_gzhandler</function>)
+    by sending headers before these handlers can do so.
+   </simpara>
+  </warning>
+  <para>
+   Buffering implemented by the underlying software/hardware
+   cannot be overridden by PHP and should be taken into account
+   when working with PHP's buffer control functions.
+   Checking the web servers/browsers/consoles buffering settings
+   and working with these can alleviate possible issues.
+   Working in a web context, either the web server's buffering settings
+   or the script's buffering could be adjusted to work in tandem
+   whereas working around various browsers' buffering strategies
+   can be achieved by adjusting buffering in the PHP script.
+   On consoles that implement line buffering,
+   newline characters could be inserted in the appropriate places
+   before flushing output.
+  </para>
+ </section>
+
+ <section>
+  <title><acronym>SAPI</acronym> Differences In Flushing</title>
+  <para>
+   Although flushing is implemented by each <acronym>SAPI</acronym>
+   in a slightly different way,
+   these implementations fall in one of two categories:
+   <itemizedlist>
+    <listitem>
+     <para>
+      <acronym>SAPI</acronym>s used in a web context will flush headers first
+      followed by the output.
+      <literal>Apache2Handler</literal>, <literal>CGI</literal>,
+      <literal>FastCGI</literal> and <literal>FPM</literal>
+      are such <acronym>SAPI</acronym>s
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      other <acronym>SAPI</acronym>s
+      such as <literal>CLI</literal> and <literal>embed</literal>
+      will flush output only
+     </para>
+    </listitem>
+   </itemizedlist>
+  </para>
+ </section>
+
+</chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/outcontrol/output-buffering.xml
+++ b/reference/outcontrol/output-buffering.xml
@@ -46,19 +46,19 @@
    Specific use cases include:
    <itemizedlist>
     <listitem>
-     <para>
+     <simpara>
       caching the result of compute/time intensive scripts
       for example by generating static <literal>HTML</literal> pages
-     </para>
+     </simpara>
     </listitem>
     <listitem>
-     <para>
+     <simpara>
       re-using the generated output by displaying it, saving it to a file
       and/or sending it by email
-     </para>
+     </simpara>
     </listitem>
     <listitem>
-     <para>
+     <simpara>
       flushing the <literal>head</literal> of an <literal>HTML</literal> page
       separate from the <literal>body</literal> allows browsers
       to load external resources while the script executes
@@ -66,27 +66,27 @@
       (e.g. database/file access, external network connection).
       This is only useful if the <literal>HTTP</literal> status code
       cannot change after the headers are sent
-     </para>
+     </simpara>
     </listitem>
     <listitem>
-     <para>
+     <simpara>
       extracting information from functions that would otherwise produce output
       (e.g. <function>phpinfo</function>)
-     </para>
+     </simpara>
     </listitem>
     <listitem>
-     <para>
+     <simpara>
       controlling the output of third-party code by modifying/using parts
       (e.g. extracting data, replacing words/phrases,
       adding missing <literal>HTML</literal> tags),
       or discarding it entirely under certain conditions (e.g. errors)
-     </para>
+     </simpara>
     </listitem>
     <listitem>
-     <para>
+     <simpara>
       polyfilling certain unavailable web server functionality
       (e.g. compressing or encoding output)
-     </para>
+     </simpara>
     </listitem>
    </itemizedlist>
   </para>

--- a/reference/outcontrol/output-buffering.xml
+++ b/reference/outcontrol/output-buffering.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<chapter xml:id="outcontrol.output-buffering" xmlns="http://docbook.org/ns/docbook">
+ <section>
+  <title>Output Buffering</title>
+  <para>
+   Output buffering is the buffering (temporary storage) of output
+   before it is flushed (sent and discarded) to the browser (in a web context)
+   or to the shell (on the command line).
+   While output buffering is active no output is sent from the script,
+   instead the output is stored in an internal buffer.
+  </para>
+ </section>
+
+ <section>
+  <title>Buffering Affecting PHP</title>
+  <para>
+   PHP relies on the underlying software/hardware infrastructure
+   when flushing output.
+   Buffering implemented by consoles on the command line (e.g. line buffered)
+   or web servers and browser in a web context (e.g. fully buffered)
+   do affect when output is displayed to the end-user.
+   Some of these effects can be eliminated by fine-tuning server settings
+   and/or aligning buffer sizes of the various layers.
+  </para>
+ </section>
+
+ <section>
+  <title>Output Buffering Control In PHP</title>
+  <para>
+   PHP provides a fully buffered user-level output buffer
+   with functions to start, manipulate and turn off the buffer
+   (most <link linkend="ref.outcontrol">ob_<replaceable>*</replaceable></link> functions),
+   and two functions to flush the underlying system buffers
+   (<function>flush</function> and <function>ob_implicit_flush</function>).
+   Some of this functionality can be set and/or configured
+   using the appropriate <literal>ini</literal> settings as well.
+  </para>
+ </section>
+
+  <section>
+  <title>Use Cases</title>
+  <para>
+   Output buffering is generally useful in situations when the buffered output
+   is modified or inspected, or it is used more than once in a request;
+   or when the controlled flushing of output is desired.
+   Specific use cases include:
+   <itemizedlist>
+    <listitem>
+     <para>
+      caching the result of compute/time intensive scripts
+      for example by generating static <literal>HTML</literal> pages
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      re-using the generated output by displaying it, saving it to a file
+      and/or sending it by email
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      flushing the <literal>head</literal> of an <literal>HTML</literal> page
+      separate from the <literal>body</literal> allows browsers
+      to load external resources while the script executes
+      potentially more time consuming processes
+      (e.g. database/file access, external network connection).
+      This is only useful if the <literal>HTTP</literal> status code
+      cannot change after the headers are sent
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      extracting information from functions that would otherwise produce output
+      (e.g. <function>phpinfo</function>)
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      controlling the output of third-party code by modifying/using parts
+      (e.g. extracting data, replacing words/phrases,
+      adding missing <literal>HTML</literal> tags),
+      or discarding it entirely under certain conditions (e.g. errors)
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      polyfilling certain unavailable web server functionality
+      (e.g. compressing or encoding output)
+     </para>
+    </listitem>
+   </itemizedlist>
+  </para>
+ </section>
+
+</chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/outcontrol/output-buffering.xml
+++ b/reference/outcontrol/output-buffering.xml
@@ -33,11 +33,11 @@
    and two functions to flush the underlying system buffers
    (<function>flush</function> and <function>ob_implicit_flush</function>).
    Some of this functionality can be set and/or configured
-   using the appropriate <literal>ini</literal> settings as well.
+   using the appropriate &php.ini; settings as well.
   </para>
  </section>
 
-  <section>
+ <section>
   <title>Use Cases</title>
   <para>
    Output buffering is generally useful in situations when the buffered output

--- a/reference/outcontrol/output-buffering.xml
+++ b/reference/outcontrol/output-buffering.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-
 <chapter xml:id="outcontrol.output-buffering" xmlns="http://docbook.org/ns/docbook">
  <section>
   <title>Output Buffering</title>
@@ -95,7 +93,6 @@
  </section>
 
 </chapter>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/outcontrol/user-level-output-buffers.xml
+++ b/reference/outcontrol/user-level-output-buffers.xml
@@ -23,7 +23,7 @@
    </itemizedlist>
   </para>
   <note>
-   <para>
+   <simpara>
     Data that is written directly to <literal>stdout</literal>
     or passed to an SAPI function with a similar functionality
     will not be captured by user-level output buffers.
@@ -31,7 +31,7 @@
     writing data to <literal>stdout</literal> with <function>fwrite</function>
     or sending headers using <function>header</function>
     or <function>setcookie</function>.
-   </para>
+   </simpara>
   </note>
  </section>
 
@@ -42,7 +42,7 @@
    the <function>ob_start</function> function or by setting
    the <link linkend="ini.output-buffering">output_buffering</link>
    and <link linkend="ini.output-handler">output_handler</link>
-   <literal>ini</literal> settings.
+   &php.ini; settings.
    While both can create output buffers,
    <function>ob_start</function> is more flexible
    as it accepts user-defined functions as output handlers
@@ -64,23 +64,23 @@
    the <function>output_add_rewrite_var</function> function
    and/or by enabling the
    <link linkend="ini.session.use-trans-sid">session.use_trans_sid</link>
-   <literal>ini</literal> setting.
+   &php.ini; setting.
   </para>
   <para>
    The bundled <literal>zlib</literal> extension has its own
    output buffer which can be enabled by using the
    <link linkend="ini.zlib.output-compression">zlib.output_compression</link>
-   <literal>ini</literal> setting.
+   &php.ini; setting.
   </para>
   <note>
-   <para>
+   <simpara>
     While <literal>"URL-Rewriter"</literal> is special
     in that it only allows up to two instances of it running at any one time,
     all user-level output buffers use the same underlying buffers
     used by <function>ob_start</function>
     with their functionality implemented by a custom output handler function.
     As such, all of their functionality can be emulated by userland code.
-   </para>
+   </simpara>
   </note>
  </section>
 
@@ -162,9 +162,9 @@
   <para>
    The size of <literal>zlib</literal>'s output buffer is controlled by the
    <link linkend="ini.zlib.output-compression">zlib.output_compression</link>
-   <literal>ini</literal> setting.
+   &php.ini; setting.
    If set to <literal>"On"</literal> the buffer size will be
-   <literal>16,384</literal>.
+   <literal>"16K"</literal>/<literal>16384</literal>.
    If set to an integer then buffer size will correspond to that number in bytes.
   </para>
  </section>
@@ -390,7 +390,7 @@
    </simpara>
   </warning>
   <note>
-   <para>
+   <simpara>
     If the <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> of a handler is set,
     the handler will not be invoked by calling
     <function>ob_end_clean</function>, <function>ob_end_flush</function>,
@@ -398,7 +398,7 @@
     or during PHP's shutdown process.
     This flag has no effect on when calling <function>ob_clean</function>
     or <function>ob_flush</function>.
-   </para>
+   </simpara>
   </note>
   <note>
    <simpara>
@@ -426,7 +426,8 @@
     The value of <constant>PHP_OUTPUT_HANDLER_WRITE</constant> and its alias
     <constant>PHP_OUTPUT_HANDLER_CONT</constant> is <literal>0</literal>
     therefore whether it is set can only be determined
-    by using an equality operator
+    by using an
+    <link linkend="language.operators.comparison">equality operator</link>
     (<literal>==</literal> or <literal>===</literal>).
    </simpara>
   </warning>
@@ -576,7 +577,7 @@
     its <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> status flag is set.
    </simpara>
   </note>
-</section>
+ </section>
 
  <section>
   <title>Output Handler Status Flags</title>
@@ -596,7 +597,7 @@
    <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> is set.
   </para>
   <note>
-   <para>
+   <simpara>
     If the <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> of a handler is set,
     the handler will not be invoked by calling
     <function>ob_end_clean</function>, <function>ob_end_flush</function>,
@@ -604,7 +605,7 @@
     or during PHP's shutdown process.
     This flag has no effect on when calling <function>ob_clean</function>
     or <function>ob_flush</function>.
-   </para>
+   </simpara>
   </note>
  </section>
 

--- a/reference/outcontrol/user-level-output-buffers.xml
+++ b/reference/outcontrol/user-level-output-buffers.xml
@@ -1,16 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-
 <chapter xml:id="outcontrol.user-level-output-buffers" xmlns="http://docbook.org/ns/docbook">
  <section>
   <title>User-Level Output Buffers</title>
   <para>
    User-level output buffers can be started, manipulated
-   and turned off from PHP code.
+   and terminated from PHP code.
    Each of these buffers includes an output buffer
    and an associated output handler function.
-   The handler function of, and the size and the operations performed
-   on the buffers can be set when starting the buffers.
   </para>
  </section>
 
@@ -24,40 +20,40 @@
    In practical terms, output is non-zero length data that is:
    <itemizedlist>
     <listitem>
-     <para>
+     <simpara>
       outside of the <literal>&#60;?php ?&#62;</literal> tags
-     </para>
+     </simpara>
     </listitem>
     <listitem>
-     <para>
+     <simpara>
       printed by language constructs and functions
       whose explicit purpose is to output user provided variables or strings such as
       <function>echo</function>, <function>print</function>,
       <function>printf</function>, <function>var_dump</function>,
       <function>var_export</function>, <function>vprintf</function>
-     </para>
+     </simpara>
     </listitem>
     <listitem>
-     <para>
+     <simpara>
       printed by functions whose purpose is to collect and output
       data/information on the running script or PHP such as
       <function>debug_print_backtrace</function>, <function>phpcredits</function>,
       <function>phpinfo</function>,
       <methodname>ReflectionExtension::info</methodname>
-     </para>
+     </simpara>
     </listitem>
     <listitem>
-     <para>
+     <simpara>
       printed by PHP on an uncaught exception or an unhandled error
       (subject to the settings of
       <link linkend="ini.display-errors">display_errors</link>
       and <link linkend="ini.error-reporting">error_reporting</link>)
-     </para>
+     </simpara>
     </listitem>
     <listitem>
-     <para>
+     <simpara>
       anything written to <literal>php://output</literal>
-     </para>
+     </simpara>
     </listitem>
    </itemizedlist>
   </para>
@@ -87,19 +83,22 @@
    as it accepts user-defined functions as output handlers
    and the operations allowed on the buffer (flush, clean, remove)
    can be set as well.
-   Buffers started with <function>ob_start</function> function will be active
-   start buffering from the line they were called while those started with
+   Buffers started with <function>ob_start</function> will be active
+   from the line the function was called,
+   while those started with
    <link linkend="ini.output-buffering">output_buffering</link>
    will be buffering output from the first line of the script.
   </para>
   <para>
    PHP is also shipped with a built-in <literal>"URL-Rewriter"</literal>
    output handler which starts its own output buffer and only allows
-   a single instance of it running at any time.
-   This buffer can be started by calling
+   up to two instances of it running at any time
+   (one for user-level URL-rewriting
+   and one for transparent session id support).
+   These buffers can be started by calling
    the <function>output_add_rewrite_var</function> function
-   or by enabling the
-   <link linkend="ini.session.trans-sid-tags">session.use_trans_sid</link>
+   and/or by enabling the
+   <link linkend="ini.session.use-trans-sid">session.use_trans_sid</link>
    <literal>ini</literal> setting.
   </para>
   <para>
@@ -111,7 +110,7 @@
   <note>
    <para>
     While <literal>"URL-Rewriter"</literal> is special
-    in that it only allows a single instance of it running at any one time,
+    in that it only allows up to two instances of it running at any one time,
     all user-level output buffers use the same underlying buffers
     used by <function>ob_start</function>
     with their functionality implemented by a custom output handler function.
@@ -322,7 +321,8 @@
   </warning>
   <para>
    Every output buffer that has not been closed by the end of the script
-   or when exit is called will be flushed and turned off by PHP's shutdown process.
+   or when <function>exit</function> is called will be flushed
+   and turned off by PHP's shutdown process.
    The buffers will be flushed and turned off in reverse order
    of their starting up.
    The last buffered started will be first,
@@ -351,7 +351,7 @@
    </simpara>
   </note>
   <para>
-   If omitted or passed a null to when starting the output buffer
+   If omitted or &null; when starting the output buffer
    the internal <literal>"default output handler"</literal> will be used
    which returns the unmodified contents of the buffer when invoked.
    Output handlers can be used to return a modified version
@@ -361,7 +361,7 @@
    PHP comes with two internal output handlers:
    <literal>"default output handler"</literal>
    and <literal>"URL-Rewriter"</literal> (which is integrated into
-   its own output buffer and only one instance of it can be started).
+   its own output buffer and only up to two instances of it can be started).
   </para>
   <para>
    The bundled extensions include four additional output handlers:
@@ -436,10 +436,10 @@
    </para>
   </note>
   <note>
-   <para>
+   <simpara>
     The working directory of the script can change inside the shutdown function
     under some web servers, e.g. Apache or the built-in web server.
-   </para>
+   </simpara>
   </note>
  </section>
 
@@ -450,11 +450,11 @@
    of the output handler provides information on the invocation of the handler.
   </para>
   <note>
-   <para>
+   <simpara>
     The bitmask can include more than one flag
     and the bitwise <literal>&amp;</literal> operator should be used
     to check whether a flag is set.
-   </para>
+   </simpara>
   </note>
   <warning>
    <simpara>
@@ -490,69 +490,33 @@
    is called, <constant>PHP_OUTPUT_HANDLER_FINAL</constant> is set as well.
   </para>
   <note>
-   <para>
+   <simpara>
     When <function>ob_end_flush</function> or <function>ob_get_flush</function>
     is called, <constant>PHP_OUTPUT_HANDLER_FINAL</constant> is set
     but <constant>PHP_OUTPUT_HANDLER_FLUSH</constant> is not.
-   </para>
+   </simpara>
   </note>
  </section>
 
  <section>
   <title>Output Handler Return Values</title>
   <para>
-   While the return value of the output handler will be ultimately cast to string
-   the implementation of the handler can return a non-string value.
-   This casting to string of this value mostly follows PHP's type casting rules
-   with a few exceptions.
+   The return value of the output handler is internally coerced into a string
+   following standard PHP type semantics, with two exceptions:
+   <type>array</type>s and <type>boolean</type>s.
   </para>
   <para>
-   The following types and values follow the regular type casting rules:
-   <itemizedlist>
-    <listitem>
-     <para>
-      &null; - returns an empty string
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <type>int</type> and <type>float</type> - return a string
-      (e.g. <literal>"1"</literal>, <literal>"1.1"</literal>)
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <type>object</type> - returns a string or throws an exception
-      if <methodname>__toString</methodname> is not implemented
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <type>array</type> - returns <literal>"Array"</literal> but
-      does not trigger the <literal>Array to string conversion</literal> warning
-     </para>
-    </listitem>
-   </itemizedlist>
+   Arrays are converted into the string <literal>"Array"</literal>
+   but the <literal>Array to string conversion</literal> warning
+   is not triggered.
   </para>
   <para>
-   The following values will not be converted to string
-   and have special behavior associated with them.
-   <itemizedlist>
-    <listitem>
-     <para>
-      &false; - returns the contents of the buffer
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      &true; - returns an empty string
-     </para>
-    </listitem>
-   </itemizedlist>
+   If the handler returns &false; the contents of the buffer are returned.
+   If the handler returns &true; an empty string is returned.
   </para>
   <note>
    <simpara>
-    If a handler returns false or throws an exception
+    If a handler returns &false; or throws an exception
     its <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> status flag is set.
    </simpara>
   </note>
@@ -602,7 +566,7 @@
   </para>
   <note>
    <simpara>
-    If a handler returns false
+    If a handler returns &false;
     its <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> status flag is set.
    </simpara>
   </note>
@@ -638,12 +602,12 @@
    if the return value of a handler is &false;
    the contents of the buffer are flushed followed by the output.
    If the handler is not invoked during shutdown
-   the handler throwing an exception or exit being called
+   the handler throwing an exception or <function>exit</function> being called
    results in the same behavior.
   </para>
   <note>
    <simpara>
-    If a handler returns false
+    If a handler returns &false;
     its <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> status flag is set.
    </simpara>
   </note>
@@ -680,7 +644,6 @@
  </section>
 
 </chapter>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/outcontrol/user-level-output-buffers.xml
+++ b/reference/outcontrol/user-level-output-buffers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<chapter xml:id="outcontrol.user-level-output-buffers" xmlns="http://docbook.org/ns/docbook">
+<chapter xml:id="outcontrol.user-level-output-buffers" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <section>
   <title>User-Level Output Buffers</title>
   <para>
@@ -19,42 +19,7 @@
    is everything that PHP would display or send back to the browser.
    In practical terms, output is non-zero length data that is:
    <itemizedlist>
-    <listitem>
-     <simpara>
-      outside of the <literal>&#60;?php ?&#62;</literal> tags
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      printed by language constructs and functions
-      whose explicit purpose is to output user provided variables or strings such as
-      <function>echo</function>, <function>print</function>,
-      <function>printf</function>, <function>var_dump</function>,
-      <function>var_export</function>, <function>vprintf</function>
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      printed by functions whose purpose is to collect and output
-      data/information on the running script or PHP such as
-      <function>debug_print_backtrace</function>, <function>phpcredits</function>,
-      <function>phpinfo</function>,
-      <methodname>ReflectionExtension::info</methodname>
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      printed by PHP on an uncaught exception or an unhandled error
-      (subject to the settings of
-      <link linkend="ini.display-errors">display_errors</link>
-      and <link linkend="ini.error-reporting">error_reporting</link>)
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      anything written to <literal>php://output</literal>
-     </simpara>
-    </listitem>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('outputcontrol.what-is-output')/*)"><xi:fallback/></xi:include>
    </itemizedlist>
   </para>
   <note>
@@ -200,7 +165,7 @@
    <literal>ini</literal> setting.
    If set to <literal>"On"</literal> the buffer size will be
    <literal>16,384</literal>.
-   If set to an integer then buffer size will correspond to that number.
+   If set to an integer then buffer size will correspond to that number in bytes.
   </para>
  </section>
 
@@ -428,7 +393,7 @@
    <para>
     If the <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> of a handler is set,
     the handler will not be invoked by calling
-     <function>ob_end_clean</function>, <function>ob_end_flush</function>,
+    <function>ob_end_clean</function>, <function>ob_end_flush</function>,
     <function>ob_get_clean</function>, <function>ob_get_flush</function>
     or during PHP's shutdown process.
     This flag has no effect on when calling <function>ob_clean</function>
@@ -503,7 +468,7 @@
   <para>
    The return value of the output handler is internally coerced into a string
    following standard PHP type semantics, with two exceptions:
-   <type>array</type>s and <type>boolean</type>s.
+   <type>array</type>s and <type>bool</type>eans.
   </para>
   <para>
    Arrays are converted into the string <literal>"Array"</literal>
@@ -634,7 +599,7 @@
    <para>
     If the <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> of a handler is set,
     the handler will not be invoked by calling
-     <function>ob_end_clean</function>, <function>ob_end_flush</function>,
+    <function>ob_end_clean</function>, <function>ob_end_flush</function>,
     <function>ob_get_clean</function>, <function>ob_get_flush</function>
     or during PHP's shutdown process.
     This flag has no effect on when calling <function>ob_clean</function>

--- a/reference/outcontrol/user-level-output-buffers.xml
+++ b/reference/outcontrol/user-level-output-buffers.xml
@@ -1,0 +1,703 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<chapter xml:id="outcontrol.user-level-output-buffers" xmlns="http://docbook.org/ns/docbook">
+ <section>
+  <title>User-Level Output Buffers</title>
+  <para>
+   User-level output buffers can be started, manipulated
+   and turned off from PHP code.
+   Each of these buffers includes an output buffer
+   and an associated output handler function.
+   The handler function of, and the size and the operations performed
+   on the buffers can be set when starting the buffers.
+  </para>
+ </section>
+
+ <section>
+  <title>What Output Is Buffered?</title>
+  <para>
+   PHP's user-level output buffers buffer all output after they are started
+   until they are turned off or the script ends.
+   Output in the context of PHP's user-level output buffer
+   is everything that PHP would display or send back to the browser.
+   In practical terms, output is non-zero length data that is:
+   <itemizedlist>
+    <listitem>
+     <para>
+      outside of the <literal>&#60;?php ?&#62;</literal> tags
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      printed by language constructs and functions
+      whose explicit purpose is to output user provided variables or strings such as
+      <function>echo</function>, <function>print</function>,
+      <function>printf</function>, <function>var_dump</function>,
+      <function>var_export</function>, <function>vprintf</function>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      printed by functions whose purpose is to collect and output
+      data/information on the running script or PHP such as
+      <function>debug_print_backtrace</function>, <function>phpcredits</function>,
+      <function>phpinfo</function>,
+      <methodname>ReflectionExtension::info</methodname>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      printed by PHP on an uncaught exception or an unhandled error
+      (subject to the settings of
+      <link linkend="ini.display-errors">display_errors</link>
+      and <link linkend="ini.error-reporting">error_reporting</link>)
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      anything written to <literal>php://output</literal>
+     </para>
+    </listitem>
+   </itemizedlist>
+  </para>
+  <note>
+   <para>
+    Data that is written directly to <literal>stdout</literal>
+    or passed to an SAPI function with a similar functionality
+    will not be captured by user-level output buffers.
+    This includes
+    writing data to <literal>stdout</literal> with <function>fwrite</function>
+    or sending headers using <function>header</function>
+    or <function>setcookie</function>.
+   </para>
+  </note>
+ </section>
+
+ <section>
+  <title>Turning Output Buffering On</title>
+  <para>
+   Output buffering can be turned on by using
+   the <function>ob_start</function> function or by setting
+   the <link linkend="ini.output-buffering">output_buffering</link>
+   and <link linkend="ini.output-handler">output_handler</link>
+   <literal>ini</literal> settings.
+   While both can create output buffers,
+   <function>ob_start</function> is more flexible
+   as it accepts user-defined functions as output handlers
+   and the operations allowed on the buffer (flush, clean, remove)
+   can be set as well.
+   Buffers started with <function>ob_start</function> function will be active
+   start buffering from the line they were called while those started with
+   <link linkend="ini.output-buffering">output_buffering</link>
+   will be buffering output from the first line of the script.
+  </para>
+  <para>
+   PHP is also shipped with a built-in <literal>"URL-Rewriter"</literal>
+   output handler which starts its own output buffer and only allows
+   a single instance of it running at any time.
+   This buffer can be started by calling
+   the <function>output_add_rewrite_var</function> function
+   or by enabling the
+   <link linkend="ini.session.trans-sid-tags">session.use_trans_sid</link>
+   <literal>ini</literal> setting.
+  </para>
+  <para>
+   The bundled <literal>zlib</literal> extension has its own
+   output buffer which can be enabled by using the
+   <link linkend="ini.zlib.output-compression">zlib.output_compression</link>
+   <literal>ini</literal> setting.
+  </para>
+  <note>
+   <para>
+    While <literal>"URL-Rewriter"</literal> is special
+    in that it only allows a single instance of it running at any one time,
+    all user-level output buffers use the same underlying buffers
+    used by <function>ob_start</function>
+    with their functionality implemented by a custom output handler function.
+    As such, all of their functionality can be emulated by userland code.
+   </para>
+  </note>
+ </section>
+
+ <section>
+  <title>Nesting Output Buffers</title>
+  <para>
+   If there is an output buffer active when a new buffer is started,
+   the new buffer will be nested inside the previously active buffer.
+   The inner buffer will behave the same way regardless whether it is nested
+   but output buffered by it will not be buffered by the outer buffer.
+   Only output flushed by the inner buffer will be buffered by the outer buffer.
+  </para>
+  <para>
+   Most <literal>ob_<replaceable>*</replaceable></literal> functions only work
+   with the active output buffer (the last one started)
+   therefore only the active buffer can be flushed, cleaned and turned off.
+   The functions that work with other buffers are
+   <function>ob_list_handlers</function>
+   which returns the list of all buffers in use
+   and <function>ob_get_status</function>
+   which can return information on the active buffer only
+   or on all buffers in use.
+  </para>
+  <para>
+   Calling <function>ob_get_level</function>
+   or <function>ob_get_status</function> will return
+   the nesting level of the active output buffer.
+  </para>
+  <caution>
+   <simpara>
+    The value for identical levels between <function>ob_get_level</function>
+    and <function>ob_get_status</function> is off by one.
+    For <function>ob_get_level</function>
+    the first level is <literal>1</literal>,
+    whereas for <function>ob_get_status</function>
+    the first level is <literal>0</literal>.
+   </simpara>
+  </caution>
+ </section>
+
+ <section>
+  <title>Buffer Size</title>
+  <para>
+   Buffer sizes are expressed by integers
+   and represent the number of bytes the buffer can store without flushing.
+   When the size of output in the buffer exceeds the size of the buffer,
+   the contents of the buffer are sent to the output handler,
+   its return value is flushed and the buffer is cleared.
+  </para>
+  <para>
+   With the exception of <literal>"URL-Rewriter"</literal>,
+   the size of output buffers can be set when the buffer is started.
+   If set to <literal>0</literal>,
+   the output buffer is only limited by the memory available to PHP.
+   If set to <literal>1</literal>,
+   the buffer is flushed after every block of code producing
+   any non-zero length output.
+  </para>
+  <para>
+   The size of output buffers can be retrieved by calling
+   <function>ob_get_status</function>.
+  </para>
+  <para>
+   Output buffers started with <function>ob_start</function>
+   will have their buffer sizes set to the integer value passed to
+   the function's second <parameter>chunk_size</parameter> parameter.
+   If omitted, it is set to <literal>0</literal>.
+  </para>
+  <para>
+   The output buffer started with
+   <link linkend="ini.output-buffering">output_buffering</link>
+   set to <literal>"On"</literal> will have its buffer size set to 0.
+   If set to an integer than buffer size will correspond to that number.
+  </para>
+  <para>
+   <literal>"URL-Rewriter"</literal>'s buffer size is set to <literal>0</literal>,
+   therefore it is only limited by the memory available to PHP.
+  </para>
+  <para>
+   The size of <literal>zlib</literal>'s output buffer is controlled by the
+   <link linkend="ini.zlib.output-compression">zlib.output_compression</link>
+   <literal>ini</literal> setting.
+   If set to <literal>"On"</literal> the buffer size will be
+   <literal>16,384</literal>.
+   If set to an integer then buffer size will correspond to that number.
+  </para>
+ </section>
+
+ <section>
+  <title>Operations Allowed On Buffers</title>
+  <para>
+   The operations allowed on buffers can be controlled
+   by passing one of the
+   <link linkend="outcontrol.constants.buffer-control-flags">buffer control flags</link>
+   to <function>ob_start</function>'s third
+   <parameter>flags</parameter> parameter.
+   If omitted, all operations are allowed by default.
+   If <literal>0</literal> is used instead,
+   the buffer cannot be flushed, cleaned or removed
+   but it's contents can still be retrieved.
+  </para>
+  <para>
+   <constant>PHP_OUTPUT_HANDLER_CLEANABLE</constant> allows
+   <function>ob_clean</function> to clean the contents of the buffer.
+  </para>
+  <warning>
+   <simpara>
+    The absence of the <constant>PHP_OUTPUT_HANDLER_CLEANABLE</constant> flag
+    will not prevent <function>ob_end_clean</function>
+    or <function>ob_get_clean</function> from clearing the contents of the buffer.
+   </simpara>
+  </warning>
+  <para>
+   <constant>PHP_OUTPUT_HANDLER_FLUSHABLE</constant> allows
+   <function>ob_flush</function> to flush the contents of the buffer.
+  </para>
+  <warning>
+   <simpara>
+    The absence of the <constant>PHP_OUTPUT_HANDLER_FLUSHABLE</constant> flag
+    will not prevent <function>ob_end_flush</function>
+    or <function>ob_get_flush</function> from flushing the contents of the buffer.
+   </simpara>
+  </warning>
+  <para>
+   <constant>PHP_OUTPUT_HANDLER_REMOVABLE</constant> allows
+   <function>ob_end_clean</function>, <function>ob_end_flush</function>,
+   <function>ob_get_clean</function> or <function>ob_get_flush</function>
+   to turn off the buffer.
+  </para>
+  <para>
+   <constant>PHP_OUTPUT_HANDLER_STDFLAGS</constant>,
+   the combination of the three flags will allow each of the three operations
+   to be performed on the buffer.
+  </para>
+ </section>
+
+ <section>
+  <title>Flushing, Accessing And Cleaning Buffer Contents</title>
+  <para>
+   Flushing sends and discards the contents of the active buffer.
+   Output buffers get flushed when the size of the output
+   exceeds the size of the buffer; the script ends or
+   <function>ob_flush</function>, <function>ob_end_flush</function>
+   or <function>ob_get_flush</function> is called.
+  </para>
+  <caution>
+   <simpara>
+    Calling <function>ob_end_flush</function>
+    or <function>ob_get_flush</function> will turn off the active buffer.
+   </simpara>
+  </caution>
+  <caution>
+   <simpara>
+    Flushing buffers will flush the return value of the output handler
+    which can differ from the contents of the buffer.
+    For example, using <function>ob_gzhandler</function> will compress
+    the output and flush the compressed output.
+   </simpara>
+  </caution>
+  <para>
+   The contents of the active buffer can be retrieved by calling
+   <function>ob_get_contents</function>, <function>ob_get_clean</function>
+   or <function>ob_get_flush</function>.
+  </para>
+  <para>
+   If only the length of the buffer's contents are needed,
+   <function>ob_get_length</function> or <function>ob_get_status</function>
+   will return the length of the contents in bytes.
+  </para>
+  <caution>
+   <simpara>
+    Calling <function>ob_get_clean</function>
+    or <function>ob_get_flush</function> will turn off the active buffer
+    after returning the its contents.
+   </simpara>
+  </caution>
+  <para>
+   The contents of the active buffer can be cleaned by calling
+   <function>ob_clean</function>, <function>ob_end_clean</function>
+   or <function>ob_get_clean</function>.
+  </para>
+  <caution>
+   <simpara>
+    Calling <function>ob_end_clean</function>
+    or <function>ob_get_clean</function> will turn off the active buffer.
+   </simpara>
+  </caution>
+ </section>
+
+ <section>
+  <title>Turning Buffers Off</title>
+  <para>
+   Output buffers can be turned off by calling
+   <function>ob_end_clean</function>, <function>ob_end_flush</function>,
+   <function>ob_get_flush</function> or <function>ob_get_clean</function>.
+  </para>
+  <warning>
+   <simpara>
+    Output buffers started without the
+    <constant>PHP_OUTPUT_HANDLER_REMOVABLE</constant> flag
+    cannot be turned off and may generate an <constant>E_NOTICE</constant>.
+   </simpara>
+  </warning>
+  <para>
+   Every output buffer that has not been closed by the end of the script
+   or when exit is called will be flushed and turned off by PHP's shutdown process.
+   The buffers will be flushed and turned off in reverse order
+   of their starting up.
+   The last buffered started will be first,
+   the first buffer started will be last to be flushed and turned off.
+  </para>
+  <caution>
+   <simpara>
+    If flushing of the buffer's contents is not desired,
+    a custom output handler should be used to prevent flushing during shutdown.
+   </simpara>
+  </caution>
+ </section>
+
+ <section>
+  <title>Output Handlers</title>
+  <para>
+   Output handlers are <type>callable</type>s associated with output buffers
+   that are invoked by calling <function>ob_clean</function>,
+   <function>ob_flush</function>, <function>ob_end_flush</function>,
+   <function>ob_get_flush</function>, <function>ob_end_clean</function>,
+   <function>ob_get_clean</function> or during PHP's shutdown process.
+  </para>
+  <note>
+   <simpara>
+    The shutdown process will flush the return value of the handler.
+   </simpara>
+  </note>
+  <para>
+   If omitted or passed a null to when starting the output buffer
+   the internal <literal>"default output handler"</literal> will be used
+   which returns the unmodified contents of the buffer when invoked.
+   Output handlers can be used to return a modified version
+   of the buffer's contents and/or have side-effects (e.g. send headers).
+  </para>
+  <para>
+   PHP comes with two internal output handlers:
+   <literal>"default output handler"</literal>
+   and <literal>"URL-Rewriter"</literal> (which is integrated into
+   its own output buffer and only one instance of it can be started).
+  </para>
+  <para>
+   The bundled extensions include four additional output handlers:
+   <function>mb_output_handler</function>, <function>ob_gzhandler</function>,
+   <function>ob_iconv_handler</function>, <function>ob_tidyhandler</function>.
+  </para>
+ </section>
+
+ <section>
+  <title>Working With Output Handlers</title>
+  <para>
+   When invoked, output handlers are passed the contents of the buffer
+   and a bitmask indicating the status of output buffering.
+  </para>
+  <para>
+   <methodsynopsis>
+    <type>string</type>
+    <methodname>
+     <replaceable>handler</replaceable>
+    </methodname>
+    <methodparam>
+     <type>string</type>
+     <parameter>buffer</parameter>
+    </methodparam>
+    <methodparam choice="opt">
+     <type>int</type>
+     <parameter>phase</parameter>
+    </methodparam>
+   </methodsynopsis>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>buffer</parameter></term>
+     <listitem>
+      <simpara>
+       Contents of the output buffer.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>phase</parameter></term>
+     <listitem>
+      <simpara>
+       Bitmask of
+       <link linkend="constant.php-output-handler-start">
+        <constant>PHP_OUTPUT_HANDLER_<replaceable>*</replaceable></constant>
+        constants
+       </link>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+  <warning>
+   <simpara>
+    Calling any of the following functions from within an output handler
+    will result in a fatal error:
+    <function>ob_clean</function>, <function>ob_end_clean</function>,
+    <function>ob_end_flush</function>, <function>ob_flush</function>,
+    <function>ob_get_clean</function>, <function>ob_get_flush</function>,
+    <function>ob_start</function>.
+   </simpara>
+  </warning>
+  <note>
+   <para>
+    If the <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> of a handler is set,
+    the handler will not be invoked by calling
+     <function>ob_end_clean</function>, <function>ob_end_flush</function>,
+    <function>ob_get_clean</function>, <function>ob_get_flush</function>
+    or during PHP's shutdown process.
+    This flag has no effect on when calling <function>ob_clean</function>
+    or <function>ob_flush</function>.
+   </para>
+  </note>
+  <note>
+   <para>
+    The working directory of the script can change inside the shutdown function
+    under some web servers, e.g. Apache or the built-in web server.
+   </para>
+  </note>
+ </section>
+
+ <section>
+  <title>Flags Passed To Output Handlers</title>
+  <para>
+   The bitmask passed to the second <parameter>phase</parameter> parameter
+   of the output handler provides information on the invocation of the handler.
+  </para>
+  <note>
+   <para>
+    The bitmask can include more than one flag
+    and the bitwise <literal>&amp;</literal> operator should be used
+    to check whether a flag is set.
+   </para>
+  </note>
+  <warning>
+   <simpara>
+    The value of <constant>PHP_OUTPUT_HANDLER_WRITE</constant> and its alias
+    <constant>PHP_OUTPUT_HANDLER_CONT</constant> is <literal>0</literal>
+    therefore whether it is set can only be determined
+    by using an equality operator
+    (<literal>==</literal> or <literal>===</literal>).
+   </simpara>
+  </warning>
+  <para>
+   The following flags are set in a specific phase of the handler's lifecycle:
+   <constant>PHP_OUTPUT_HANDLER_START</constant> is set
+   when a handler is invoked for the first time.
+   <constant>PHP_OUTPUT_HANDLER_FINAL</constant>
+   or its alias <constant>PHP_OUTPUT_HANDLER_END</constant>
+   is set when a handler is invoked for the last time,
+   i.e. it is being turned off. This flag is also set
+   when buffers are being turned off by PHP's shutdown process.
+  </para>
+  <para>
+   The following flags are set by a specific invocation of the handler:
+   <constant>PHP_OUTPUT_HANDLER_FLUSH</constant> is set
+   when the handler is invoked by calling <function>ob_flush</function>.
+   <constant>PHP_OUTPUT_HANDLER_WRITE</constant>
+   or its alias <constant>PHP_OUTPUT_HANDLER_CONT</constant>
+   is set when the size of its contents equals or exceeds the size of the buffer
+   and the handler is invoked while the buffer is being automatically flushed.
+   <constant>PHP_OUTPUT_HANDLER_FLUSH</constant> is set
+   when the handler is invoked by calling <function>ob_clean</function>,
+   <function>ob_end_clean</function> or <function>ob_get_clean</function>.
+   When <function>ob_end_clean</function> or <function>ob_get_clean</function>
+   is called, <constant>PHP_OUTPUT_HANDLER_FINAL</constant> is set as well.
+  </para>
+  <note>
+   <para>
+    When <function>ob_end_flush</function> or <function>ob_get_flush</function>
+    is called, <constant>PHP_OUTPUT_HANDLER_FINAL</constant> is set
+    but <constant>PHP_OUTPUT_HANDLER_FLUSH</constant> is not.
+   </para>
+  </note>
+ </section>
+
+ <section>
+  <title>Output Handler Return Values</title>
+  <para>
+   While the return value of the output handler will be ultimately cast to string
+   the implementation of the handler can return a non-string value.
+   This casting to string of this value mostly follows PHP's type casting rules
+   with a few exceptions.
+  </para>
+  <para>
+   The following types and values follow the regular type casting rules:
+   <itemizedlist>
+    <listitem>
+     <para>
+      &null; - returns an empty string
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <type>int</type> and <type>float</type> - return a string
+      (e.g. <literal>"1"</literal>, <literal>"1.1"</literal>)
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <type>object</type> - returns a string or throws an exception
+      if <methodname>__toString</methodname> is not implemented
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <type>array</type> - returns <literal>"Array"</literal> but
+      does not trigger the <literal>Array to string conversion</literal> warning
+     </para>
+    </listitem>
+   </itemizedlist>
+  </para>
+  <para>
+   The following values will not be converted to string
+   and have special behavior associated with them.
+   <itemizedlist>
+    <listitem>
+     <para>
+      &false; - returns the contents of the buffer
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      &true; - returns an empty string
+     </para>
+    </listitem>
+   </itemizedlist>
+  </para>
+  <note>
+   <simpara>
+    If a handler returns false or throws an exception
+    its <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> status flag is set.
+   </simpara>
+  </note>
+ </section>
+
+ <section>
+  <title>Exceptions Thrown In Output Handlers</title>
+  <para>
+   If an uncaught exception is thrown in an output handler
+   the program terminates and the handler is invoked
+   by the shutdown process after which
+   the <literal>"Uncaught Exception"</literal> error message is flushed.
+  </para>
+  <para>
+   If the uncaught exception is thrown in a handler
+   invoked by <function>ob_flush</function>,
+   <function>ob_end_flush</function> or <function>ob_get_flush</function>,
+   the contents of the buffer are flushed before the error message.
+  </para>
+  <para>
+   If an uncaught exception is thrown in an output handler during shutdown,
+   the handler is terminated and neither the contents of the buffer
+   nor the error message is flushed.
+  </para>
+  <note>
+   <simpara>
+    If a handler throws an exception
+    its <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> status flag is set.
+   </simpara>
+  </note>
+ </section>
+
+ <section>
+  <title>Errors Raised In Output Handlers</title>
+  <para>
+   If a non-fatal error is raised in an output handler
+   the program continues execution.
+  </para>
+  <para>
+   If the non-fatal error is raised in a handler invoked by
+   <function>ob_flush</function>, <function>ob_end_flush</function>
+   or <function>ob_get_flush</function>,
+   the buffer flushes certain data depending on the return value of the handler.
+   If the handler returns &false; the buffer and the error message are flushed.
+   If the returns anything else the handler return value is flushed
+   but not the error message.
+  </para>
+  <note>
+   <simpara>
+    If a handler returns false
+    its <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> status flag is set.
+   </simpara>
+  </note>
+  <para>
+   If a fatal error is raised in an output handler
+   the program terminates and the handler is invoked
+   by the shutdown process after which the error message is flushed.
+  </para>
+  <para>
+   If the fatal error is raised in a handler
+   invoked by <function>ob_flush</function>,
+   <function>ob_end_flush</function> or <function>ob_get_flush</function>,
+   the contents of the buffers are flushed before the error message.
+  </para>
+  <para>
+   If a fatal error is raised in an output handler during shutdown
+   the program terminates without flushing the buffer or the error message.
+  </para>
+ </section>
+
+ <section>
+  <title>Output In Output Handlers</title>
+  <para>
+   In specific circumstances, output produced in the handler is flushed
+   along with the contents of the buffer.
+   This output is not appended to the buffer and is not part of the string
+   returned by <function>ob_get_flush</function>.
+  </para>
+  <para>
+   During flush operations (calling <function>ob_flush</function>,
+   <function>ob_end_flush</function>, <function>ob_get_flush</function>
+   and during shutdown)
+   if the return value of a handler is &false;
+   the contents of the buffer are flushed followed by the output.
+   If the handler is not invoked during shutdown
+   the handler throwing an exception or exit being called
+   results in the same behavior.
+  </para>
+  <note>
+   <simpara>
+    If a handler returns false
+    its <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> status flag is set.
+   </simpara>
+  </note>
+</section>
+
+ <section>
+  <title>Output Handler Status Flags</title>
+  <para>
+   The
+   <link linkend="outcontrol.constants.flags-returned-by-handler">
+    handler status flags
+   </link> of the buffer's <literal>flags</literal> bitmask
+   are set every time to the output handler is invoked
+   and are part of the <literal>flags</literal> returned by
+   <function>ob_get_status</function>.
+   If the handler successfully executes and does not return &false;,
+   <constant>PHP_OUTPUT_HANDLER_STARTED</constant> and
+   <constant>PHP_OUTPUT_HANDLER_PROCESSED</constant> is set.
+   If the handler returns &false; or throws and exception while executing,
+   <constant>PHP_OUTPUT_HANDLER_STARTED</constant> and
+   <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> is set.
+  </para>
+  <note>
+   <para>
+    If the <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> of a handler is set,
+    the handler will not be invoked by calling
+     <function>ob_end_clean</function>, <function>ob_end_flush</function>,
+    <function>ob_get_clean</function>, <function>ob_get_flush</function>
+    or during PHP's shutdown process.
+    This flag has no effect on when calling <function>ob_clean</function>
+    or <function>ob_flush</function>.
+   </para>
+  </note>
+ </section>
+
+</chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
The aim of this PR is to document most details of output control / output buffering. 

It adds three new pages to the `outcontrol` book: 
 - output buffering in general
 - flushing system buffers (`flush()` and implicit flushing)
 - user-level output buffering

I've checked all related user comments in the manual, and bugs, PR's and issues on `bugs.php.net`, `php-src` and `doc-en`. Additionally, I've tested everything before I've added it to these pages (on the CLI and a web server) so everything on them at least `"works on my machine"`.

If accepted, these pages or sections of it could be linked to from other output control pages.

Closes https://bugs.php.net/bug.php?id=60984
Closes https://bugs.php.net/bug.php?id=65115

Related bug report that is already resolved and can be closed https://bugs.php.net/bug.php?id=78495