### PR TITLE
Convert curl-getinfo() constant list to table

### DIFF
--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -5,7 +5,7 @@
   <refname>curl_getinfo</refname>
   <refpurpose>Get information regarding a specific transfer</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -14,7 +14,7 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>option</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Gets information about the last transfer. 
+   Gets information about the last transfer.
   </para>
  </refsect1>
 
@@ -93,7 +93,7 @@
         </listitem>
         <listitem>
          <simpara>
-          <constant>CURLINFO_REDIRECT_URL</constant> - With the <constant>CURLOPT_FOLLOWLOCATION</constant> option disabled: redirect URL found in the last transaction, that should be requested manually next. With the <constant>CURLOPT_FOLLOWLOCATION</constant> option enabled: this is empty. The redirect URL in this case is available in <constant>CURLINFO_EFFECTIVE_URL</constant> 
+          <constant>CURLINFO_REDIRECT_URL</constant> - With the <constant>CURLOPT_FOLLOWLOCATION</constant> option disabled: redirect URL found in the last transaction, that should be requested manually next. With the <constant>CURLOPT_FOLLOWLOCATION</constant> option enabled: this is empty. The redirect URL in this case is available in <constant>CURLINFO_EFFECTIVE_URL</constant>
          </simpara>
         </listitem>
         <listitem>
@@ -143,8 +143,8 @@
         </listitem>
         <listitem>
          <simpara>
-          <constant>CURLINFO_HEADER_OUT</constant> - The request string sent. For this to 
-          work, add the <constant>CURLINFO_HEADER_OUT</constant> option to the handle by calling 
+          <constant>CURLINFO_HEADER_OUT</constant> - The request string sent. For this to
+          work, add the <constant>CURLINFO_HEADER_OUT</constant> option to the handle by calling
           <function>curl_setopt</function>
          </simpara>
         </listitem>
@@ -324,7 +324,7 @@
         </listitem>
         <listitem>
          <simpara>
-          <constant>CURLINFO_SPEED_UPLOAD_T</constant> - The average upload speed in bytes/second that curl measured for the complete upload 
+          <constant>CURLINFO_SPEED_UPLOAD_T</constant> - The average upload speed in bytes/second that curl measured for the complete upload
          </simpara>
         </listitem>
         <listitem>
@@ -379,7 +379,7 @@
   &reftitle.returnvalues;
   <para>
    If <parameter>option</parameter> is given, returns its value.
-   Otherwise, returns an associative array with the following elements 
+   Otherwise, returns an associative array with the following elements
    (which correspond to <parameter>option</parameter>), or &false; on failure:
    <itemizedlist>
     <listitem>
@@ -514,7 +514,7 @@
     </listitem>
     <listitem>
      <simpara>
-      "request_header" (This is only set if the <constant>CURLINFO_HEADER_OUT</constant> 
+      "request_header" (This is only set if the <constant>CURLINFO_HEADER_OUT</constant>
       is set by a previous call to <function>curl_setopt</function>)
      </simpara>
     </listitem>
@@ -562,7 +562,7 @@
        <entry>7.3.0</entry>
        <entry>
         Introduced <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant>,
-        <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant>, 
+        <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant>,
         <constant>CURLINFO_HTTP_VERSION</constant>,
         <constant>CURLINFO_PROTOCOL</constant>,
         <constant>CURLINFO_PROXY_SSL_VERIFYRESULT</constant>,
@@ -586,7 +586,7 @@
    </informaltable>
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -644,13 +644,13 @@ curl_close($ch);
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
    <para>
-    Information gathered by this function is kept if the handle is re-used. This means 
-    that unless a statistic is overridden internally by this function, the previous info 
+    Information gathered by this function is kept if the handle is re-used. This means
+    that unless a statistic is overridden internally by this function, the previous info
     is returned.
    </para>
   </note>

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -28,346 +28,546 @@
      <listitem>
       <para>
        This may be one of the following constants:
-       <itemizedlist>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CAINFO</constant> - Default built-in CA certificate path
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CAPATH</constant> - Default built-in CA path string
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_EFFECTIVE_URL</constant> - Last effective URL
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTP_CODE</constant> -  The last response code.
-          As of cURL 7.10.8, this is a legacy alias of
-          <constant>CURLINFO_RESPONSE_CODE</constant>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_FILETIME</constant> - Remote time of the retrieved document, with the <constant>CURLOPT_FILETIME</constant> enabled; if -1 is returned the time of the document is unknown
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_TOTAL_TIME</constant> - Total transaction time in seconds for last transfer
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_NAMELOOKUP_TIME</constant> - Time in seconds until name resolving was complete
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONNECT_TIME</constant> - Time in seconds it took to establish the connection
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRETRANSFER_TIME</constant> - Time in seconds from start until just before file transfer begins
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_STARTTRANSFER_TIME</constant> - Time in seconds until the first byte is about to be transferred
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_COUNT</constant> - Number of redirects, with the <constant>CURLOPT_FOLLOWLOCATION</constant> option enabled
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_TIME</constant> - Time in seconds of all redirection steps before final transaction was started, with the <constant>CURLOPT_FOLLOWLOCATION</constant> option enabled
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_URL</constant> - With the <constant>CURLOPT_FOLLOWLOCATION</constant> option disabled: redirect URL found in the last transaction, that should be requested manually next. With the <constant>CURLOPT_FOLLOWLOCATION</constant> option enabled: this is empty. The redirect URL in this case is available in <constant>CURLINFO_EFFECTIVE_URL</constant>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRIMARY_IP</constant> - IP address of the most recent connection
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRIMARY_PORT</constant> - Destination port of the most recent connection
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_LOCAL_IP</constant> - Local (source) IP address of the most recent connection
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_LOCAL_PORT</constant> - Local (source) port of the most recent connection
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_UPLOAD</constant> - Total number of bytes uploaded
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_DOWNLOAD</constant> - Total number of bytes downloaded
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_DOWNLOAD</constant> - Average download speed
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_UPLOAD</constant> - Average upload speed
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HEADER_SIZE</constant> - Total size of all headers received
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HEADER_OUT</constant> - The request string sent. For this to
-          work, add the <constant>CURLINFO_HEADER_OUT</constant> option to the handle by calling
-          <function>curl_setopt</function>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REFERER</constant> - The referrer header
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-        <constant>CURLINFO_REQUEST_SIZE</constant> - Total size of issued requests, currently only for HTTP requests
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RETRY_AFTER</constant> - The information from the <literal>Retry-After:</literal> header, or zero if there was no valid header.
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SSL_VERIFYRESULT</constant> - Result of SSL certification verification requested by setting <constant>CURLOPT_SSL_VERIFYPEER</constant>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD</constant> - Content length of download, read from <literal>Content-Length:</literal> field
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_UPLOAD</constant> - Specified size of upload
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_TYPE</constant> - <literal>Content-Type:</literal> of the requested document. NULL indicates server did not send valid <literal>Content-Type:</literal> header
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRIVATE</constant> - Private data associated with this cURL handle, previously set with the <constant>CURLOPT_PRIVATE</constant> option of <function>curl_setopt</function>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROXY_ERROR</constant> - The detailed (SOCKS) proxy error code when the most recent
-          transfer returned a <constant>CURLE_PROXY</constant> error. The returned value will be exactly one
-          of the <constant>CURLPX_<replaceable>*</replaceable></constant> values.
-          The error code will be <constant>CURLPX_OK</constant> if no
-          response code was available.
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RESPONSE_CODE</constant> - The last response code
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTP_CONNECTCODE</constant> - The CONNECT response code
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTPAUTH_AVAIL</constant> - Bitmask indicating the authentication method(s) available according to the previous response
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROXYAUTH_AVAIL</constant> - Bitmask indicating the proxy authentication method(s) available according to the previous response
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_OS_ERRNO</constant> - Errno from a connect failure. The number is OS and system specific.
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_NUM_CONNECTS</constant> - Number of connections curl had to create to achieve the previous transfer
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SSL_ENGINES</constant> - OpenSSL crypto-engines supported
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_COOKIELIST</constant> - All known cookies
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_FTP_ENTRY_PATH</constant> - Entry path in FTP server
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_APPCONNECT_TIME</constant> - Time in seconds it took from the start until the SSL/SSH connect/handshake to the remote host was completed
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CERTINFO</constant> - TLS certificate chain
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONDITION_UNMET</constant> - Info on unmet time conditional
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_CLIENT_CSEQ</constant> - Next RTSP client CSeq
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_CSEQ_RECV</constant> - Recently received CSeq
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_SERVER_CSEQ</constant> - Next RTSP server CSeq
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_SESSION_ID</constant> - RTSP session ID
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant> - The content-length of the download. This is the value read from the <literal>Content-Length:</literal> field. -1 if the size isn't known
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant> - The specified size of the upload. -1 if the size isn't known
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTP_VERSION</constant> - The version used in the last HTTP connection. The return value will be one of the defined <constant>CURL_HTTP_VERSION_*</constant> constants or 0 if the version can't be determined
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROTOCOL</constant> - The protocol used in the last HTTP connection. The returned value will be exactly one of the <constant>CURLPROTO_*</constant> values
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROXY_SSL_VERIFYRESULT</constant> - The result of the certificate verification that was requested (using the <constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant> option). Only used for HTTPS proxies
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SCHEME</constant> - The URL scheme used for the most recent connection
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_DOWNLOAD_T</constant> - Total number of bytes that were downloaded. The number is only for the latest transfer and will be reset again for each new transfer
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_UPLOAD_T</constant> - Total number of bytes that were uploaded
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_DOWNLOAD_T</constant> - The average download speed in bytes/second that curl measured for the complete download
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_UPLOAD_T</constant> - The average upload speed in bytes/second that curl measured for the complete upload
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_APPCONNECT_TIME_T</constant> - Time, in microseconds, it took from the start until the SSL/SSH connect/handshake to the remote host was completed
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONNECT_TIME_T</constant> - Total time taken, in microseconds, from the start until the connection to the remote host (or proxy) was completed
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_FILETIME_T</constant> - Remote time of the retrieved document (as Unix timestamp), an alternative to <constant>CURLINFO_FILETIME</constant> to allow systems with 32 bit long variables to extract dates outside of the 32bit timestamp range
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_NAMELOOKUP_TIME_T</constant> - Time in microseconds from the start until the name resolving was completed
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRETRANSFER_TIME_T</constant> - Time taken from the start until the file transfer is just about to begin, in microseconds
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_TIME_T</constant> - Total time, in microseconds, it took for all redirection steps include name lookup, connect, pretransfer and transfer before final transaction was started
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_STARTTRANSFER_TIME_T</constant> - Time, in microseconds, it took from the start until the first byte is received
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_TOTAL_TIME_T</constant> - Total time in microseconds for the previous transfer, including name resolving, TCP connect etc.
-         </simpara>
-        </listitem>
-       </itemizedlist>
+       <informaltable>
+        <tgroup cols="3">
+         <thead>
+          <row>
+           <entry valign="top">Option</entry>
+           <entry valign="top">Description</entry>
+          </row>
+         </thead>
+         <tbody>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_CAINFO</constant>
+           </entry>
+           <entry valign="top">
+            Default built-in CA certificate path
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_CAPATH</constant>
+           </entry>
+           <entry valign="top">
+            Default built-in CA path string
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_EFFECTIVE_URL</constant>
+           </entry>
+           <entry valign="top">
+            Last effective URL
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_HTTP_CODE</constant>
+           </entry>
+           <entry valign="top">
+            The last response code. As of cURL 7.10.8, this is a legacy alias of CURLINFO_RESPONSE_CODE
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_FILETIME</constant>
+           </entry>
+           <entry valign="top">
+            Remote time of the retrieved document, with the CURLOPT_FILETIME enabled; if -1 is returned the time of the document is unknown
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_TOTAL_TIME</constant>
+           </entry>
+           <entry valign="top">
+            Total transaction time in seconds for last transfer
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_NAMELOOKUP_TIME</constant>
+           </entry>
+           <entry valign="top">
+            Time in seconds until name resolving was complete
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_CONNECT_TIME</constant>
+           </entry>
+           <entry valign="top">
+            Time in seconds it took to establish the connection
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_PRETRANSFER_TIME</constant>
+           </entry>
+           <entry valign="top">
+            Time in seconds from start until just before file transfer begins
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_STARTTRANSFER_TIME</constant>
+           </entry>
+           <entry valign="top">
+            Time in seconds until the first byte is about to be transferred
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_REDIRECT_COUNT</constant>
+           </entry>
+           <entry valign="top">
+            Number of redirects, with the CURLOPT_FOLLOWLOCATION option enabled
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_REDIRECT_TIME</constant>
+           </entry>
+           <entry valign="top">
+            Time in seconds of all redirection steps before final transaction was started, with the CURLOPT_FOLLOWLOCATION option enabled
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_REDIRECT_URL</constant>
+           </entry>
+           <entry valign="top">
+            With the CURLOPT_FOLLOWLOCATION option disabled: redirect URL found in the last transaction, that should be requested manually next. With the CURLOPT_FOLLOWLOCATION option enabled: this is empty. The redirect URL in this case is available in CURLINFO_EFFECTIVE_URL
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_PRIMARY_IP</constant>
+           </entry>
+           <entry valign="top">
+            IP address of the most recent connection
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_PRIMARY_PORT</constant>
+           </entry>
+           <entry valign="top">
+            Destination port of the most recent connection
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_LOCAL_IP</constant>
+           </entry>
+           <entry valign="top">
+            Local (source) IP address of the most recent connection
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_LOCAL_PORT</constant>
+           </entry>
+           <entry valign="top">
+            Local (source) port of the most recent connection
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_SIZE_UPLOAD</constant>
+           </entry>
+           <entry valign="top">
+            Total number of bytes uploaded
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_SIZE_DOWNLOAD</constant>
+           </entry>
+           <entry valign="top">
+            Total number of bytes downloaded
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_SPEED_DOWNLOAD</constant>
+           </entry>
+           <entry valign="top">
+            Average download speed
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_SPEED_UPLOAD</constant>
+           </entry>
+           <entry valign="top">
+            Average upload speed
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_HEADER_SIZE</constant>
+           </entry>
+           <entry valign="top">
+            Total size of all headers received
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_HEADER_OUT</constant>
+           </entry>
+           <entry valign="top">
+            The request string sent. For this to work, add the CURLINFO_HEADER_OUT option to the handle by calling curl_setopt()
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_REFERER</constant>
+           </entry>
+           <entry valign="top">
+            The referrer header
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_REQUEST_SIZE</constant>
+           </entry>
+           <entry valign="top">
+            Total size of issued requests, currently only for HTTP requests
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_RETRY_AFTER</constant>
+           </entry>
+           <entry valign="top">
+            The information from the Retry-After: header, or zero if there was no valid header.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_SSL_VERIFYRESULT</constant>
+           </entry>
+           <entry valign="top">
+            Result of SSL certification verification requested by setting CURLOPT_SSL_VERIFYPEER
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD</constant>
+           </entry>
+           <entry valign="top">
+            Content length of download, read from Content-Length: field
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_CONTENT_LENGTH_UPLOAD</constant>
+           </entry>
+           <entry valign="top">
+            Specified size of upload
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_CONTENT_TYPE</constant>
+           </entry>
+           <entry valign="top">
+            Content-Type: of the requested document. NULL indicates server did not send valid Content-Type: header
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_PRIVATE</constant>
+           </entry>
+           <entry valign="top">
+            Private data associated with this cURL handle, previously set with the CURLOPT_PRIVATE option of curl_setopt()
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_PROXY_ERROR</constant>
+           </entry>
+           <entry valign="top">
+            The detailed (SOCKS) proxy error code when the most recent transfer returned a CURLE_PROXY error. The returned value will be exactly one of the CURLPX_* values. The error code will be CURLPX_OK if no response code was available.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_RESPONSE_CODE</constant>
+           </entry>
+           <entry valign="top">
+            The last response code
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_HTTP_CONNECTCODE</constant>
+           </entry>
+           <entry valign="top">
+            The CONNECT response code
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_HTTPAUTH_AVAIL</constant>
+           </entry>
+           <entry valign="top">
+            Bitmask indicating the authentication method(s) available according to the previous response
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_PROXYAUTH_AVAIL</constant>
+           </entry>
+           <entry valign="top">
+            Bitmask indicating the proxy authentication method(s) available according to the previous response
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_OS_ERRNO</constant>
+           </entry>
+           <entry valign="top">
+            Errno from a connect failure. The number is OS and system specific.
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_NUM_CONNECTS</constant>
+           </entry>
+           <entry valign="top">
+            Number of connections curl had to create to achieve the previous transfer
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_SSL_ENGINES</constant>
+           </entry>
+           <entry valign="top">
+            OpenSSL crypto-engines supported
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_COOKIELIST</constant>
+           </entry>
+           <entry valign="top">
+            All known cookies
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_FTP_ENTRY_PATH</constant>
+           </entry>
+           <entry valign="top">
+            Entry path in FTP server
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_APPCONNECT_TIME</constant>
+           </entry>
+           <entry valign="top">
+            Time in seconds it took from the start until the SSL/SSH connect/handshake to the remote host was completed
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_CERTINFO</constant>
+           </entry>
+           <entry valign="top">
+            TLS certificate chain
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_CONDITION_UNMET</constant>
+           </entry>
+           <entry valign="top">
+            Info on unmet time conditional
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_RTSP_CLIENT_CSEQ</constant>
+           </entry>
+           <entry valign="top">
+            Next RTSP client CSeq
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_RTSP_CSEQ_RECV</constant>
+           </entry>
+           <entry valign="top">
+            Recently received CSeq
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_RTSP_SERVER_CSEQ</constant>
+           </entry>
+           <entry valign="top">
+            Next RTSP server CSeq
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_RTSP_SESSION_ID</constant>
+           </entry>
+           <entry valign="top">
+            RTSP session ID
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant>
+           </entry>
+           <entry valign="top">
+            The content-length of the download. This is the value read from the Content-Length: field. -1 if the size isn't known
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant>
+           </entry>
+           <entry valign="top">
+            The specified size of the upload. -1 if the size isn't known
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_HTTP_VERSION</constant>
+           </entry>
+           <entry valign="top">
+            The version used in the last HTTP connection. The return value will be one of the defined CURL_HTTP_VERSION_* constants or 0 if the version can't be determined
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_PROTOCOL</constant>
+           </entry>
+           <entry valign="top">
+            The protocol used in the last HTTP connection. The returned value will be exactly one of the CURLPROTO_* values
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_PROXY_SSL_VERIFYRESULT</constant>
+           </entry>
+           <entry valign="top">
+            The result of the certificate verification that was requested (using the CURLOPT_PROXY_SSL_VERIFYPEER option). Only used for HTTPS proxies
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_SCHEME</constant>
+           </entry>
+           <entry valign="top">
+            The URL scheme used for the most recent connection
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_SIZE_DOWNLOAD_T</constant>
+           </entry>
+           <entry valign="top">
+            Total number of bytes that were downloaded. The number is only for the latest transfer and will be reset again for each new transfer
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_SIZE_UPLOAD_T</constant>
+           </entry>
+           <entry valign="top">
+            Total number of bytes that were uploaded
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_SPEED_DOWNLOAD_T</constant>
+           </entry>
+           <entry valign="top">
+            The average download speed in bytes/second that curl measured for the complete download
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_SPEED_UPLOAD_T</constant>
+           </entry>
+           <entry valign="top">
+            The average upload speed in bytes/second that curl measured for the complete upload
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_APPCONNECT_TIME_T</constant>
+           </entry>
+           <entry valign="top">
+            Time, in microseconds, it took from the start until the SSL/SSH connect/handshake to the remote host was completed
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_CONNECT_TIME_T</constant>
+           </entry>
+           <entry valign="top">
+            Total time taken, in microseconds, from the start until the connection to the remote host (or proxy) was completed
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_FILETIME_T</constant>
+           </entry>
+           <entry valign="top">
+            Remote time of the retrieved document (as Unix timestamp), an alternative to CURLINFO_FILETIME to allow systems with 32 bit long variables to extract dates outside of the 32bit timestamp range
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_NAMELOOKUP_TIME_T</constant>
+           </entry>
+           <entry valign="top">
+            Time in microseconds from the start until the name resolving was completed
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_PRETRANSFER_TIME_T</constant>
+           </entry>
+           <entry valign="top">
+            Time taken from the start until the file transfer is just about to begin, in microseconds
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_REDIRECT_TIME_T</constant>
+           </entry>
+           <entry valign="top">
+            Total time, in microseconds, it took for all redirection steps include name lookup, connect, pretransfer and transfer before final transaction was started
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_STARTTRANSFER_TIME_T</constant>
+           </entry>
+           <entry valign="top">
+            Time, in microseconds, it took from the start until the first byte is received
+           </entry>
+          </row>
+          <row>
+           <entry valign="top">
+            <constant>CURLINFO_TOTAL_TIME_T</constant>
+           </entry>
+           <entry valign="top">
+            Total time in microseconds for the previous transfer, including name resolving, TCP connect etc.
+           </entry>
+          </row>
+         </tbody>
+        </tgroup>
+       </informaltable>
       </para>
      </listitem>
     </varlistentry>

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -33,7 +33,7 @@
          <thead>
           <row>
            <entry valign="top">Option</entry>
-           <entry valign="top">Description</entry>
+           <entry valign="top">&Description;</entry>
           </row>
          </thead>
          <tbody>


### PR DESCRIPTION
Converts the `curl-getinfo()` constant list to a table that matches the formatting of tables on the following functions' pages: `curl_multi_setopt()`, `curl_setopt()` and `curl_share_setopt()`.