### PR TITLE
Update array key exists key parameter for PHP 8.0.0

### DIFF
--- a/reference/array/functions/array-key-exists.xml
+++ b/reference/array/functions/array-key-exists.xml
@@ -72,7 +72,7 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       The <parameter>key</parameter> parameter now takes
+       The <parameter>key</parameter> parameter now accepts
        <parameter>bool</parameter>, <parameter>float</parameter>, <parameter>int</parameter>,
        <parameter>null</parameter>, <parameter>resource</parameter>, and
        <parameter>string</parameter> as arguments.

--- a/reference/array/functions/array-key-exists.xml
+++ b/reference/array/functions/array-key-exists.xml
@@ -58,30 +58,6 @@
   </note>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <informaltable>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>&Version;</entry>
-      <entry>&Description;</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>8.0.0</entry>
-      <entry>
-       The <parameter>key</parameter> parameter now takes
-       <parameter>string</parameter>, <parameter>int</parameter>, <parameter>bool</parameter>,
-       <parameter>null</parameter>, and <parameter>resource</parameter> as arguments.
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </informaltable>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/array/functions/array-key-exists.xml
+++ b/reference/array/functions/array-key-exists.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>array_key_exists</methodname>
-   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>int</type><type>float</type><type>bool</type><type>resource</type><type>null</type></type><parameter>key</parameter></methodparam>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -56,6 +56,31 @@
     Nested keys in multidimensional arrays will not be found.
    </para>
   </note>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       The <parameter>key</parameter> parameter now takes
+       <parameter>bool</parameter>, <parameter>float</parameter>, <parameter>int</parameter>,
+       <parameter>null</parameter>, <parameter>resource</parameter>, and
+       <parameter>string</parameter> as arguments.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/array/functions/array-key-exists.xml
+++ b/reference/array/functions/array-key-exists.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>array_key_exists</methodname>
-   <methodparam><type class="union"><type>string</type><type>int</type></type><parameter>key</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -56,6 +56,30 @@
     Nested keys in multidimensional arrays will not be found.
    </para>
   </note>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       The <parameter>key</parameter> parameter now takes
+       <parameter>string</parameter>, <parameter>int</parameter>, <parameter>bool</parameter>,
+       <parameter>null</parameter>, and <parameter>resource</parameter> as arguments.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
As of 8.0.0 [array_key_exists](https://github.com/php/php-src/blob/master/ext/standard/array.c#L6652) the `$key` parameter takes mixed arguments now (string, int, bool, null, and resource). So updated the docs to reflect that.

![Screenshot (5)](https://github.com/php/doc-en/assets/9804252/7a440c05-4537-4a2e-83de-deffa4062eb5)
Added screenshot for proof