### PR TITLE
Add description to INI mode constants

### DIFF
--- a/reference/info/constants.xml
+++ b/reference/info/constants.xml
@@ -279,7 +279,6 @@
   The following constants are only available if the host operating
   system is Windows, and can tell different versioning information
   so its possible to detect various features and make use of them.
-  They are all available as of PHP 5.3.0.
  </simpara>
  <table>
   <title>Windows specific constants</title>

--- a/reference/info/constants.xml
+++ b/reference/info/constants.xml
@@ -157,35 +157,56 @@
  </table>
 
  <table>
-  <title>INI constants</title>
-  <tgroup cols="3">
+  <title>INI mode constants</title>
+  <tgroup cols="2">
    <thead>
     <row>
      <entry>&Constants;</entry>
-     <entry>Value</entry>
      <entry>&Description;</entry>
     </row>
    </thead>
    <tbody>
     <row xml:id="constant.ini-user">
-     <entry><literal>INI_USER</literal></entry>
-     <entry>1</entry>
-     <entry>Unused</entry>
+     <entry>
+      <constant>INI_USER</constant>
+      (<type>int</type>)
+      &Alias; <constant>PHP_INI_USER</constant>
+     </entry>
+     <entry>
+      Entry can be set in user scripts (like with <function>ini_set</function>)
+      or in the <link linkend="configuration.changes.windows">Windows registry</link>.
+      Entry can be set in &user-ini;
+     </entry>
     </row>
     <row xml:id="constant.ini-perdir">
-     <entry><literal>INI_PERDIR</literal></entry>
-     <entry>2</entry>
-     <entry>Unused</entry>
+     <entry>
+      <constant>INI_PERDIR</constant>
+      (<type>int</type>)
+      &Alias; <constant>PHP_INI_PERDIR</constant>
+     </entry>
+     <entry>
+      Entry can be set in &php.ini;, &htaccess;, &httpd.conf; or &user-ini;
+     </entry>
     </row>
     <row xml:id="constant.ini-system">
-     <entry><literal>INI_SYSTEM</literal></entry>
-     <entry>4</entry>
-     <entry>Unused</entry>
+     <entry>
+      <constant>INI_SYSTEM</constant>
+      (<type>int</type>)
+      &Alias; <constant>PHP_INI_SYSTEM</constant>
+     </entry>
+     <entry>
+      Entry can be set in &php.ini; or &httpd.conf;
+     </entry>
     </row>
     <row xml:id="constant.ini-all">
-     <entry><literal>INI_ALL</literal></entry>
-     <entry>7</entry>
-     <entry>Unused</entry>
+     <entry>
+      <constant>INI_ALL</constant>
+      (<type>int</type>)
+      &Alias; <constant>PHP_INI_ALL</constant>
+     </entry>
+     <entry>
+      Entry can be set anywhere
+     </entry>
     </row>
    </tbody>
   </tgroup>

--- a/reference/info/constants.xml
+++ b/reference/info/constants.xml
@@ -170,7 +170,6 @@
      <entry>
       <constant>INI_USER</constant>
       (<type>int</type>)
-      &Alias; <constant>PHP_INI_USER</constant>
      </entry>
      <entry>
       Entry can be set in user scripts (like with <function>ini_set</function>)
@@ -182,7 +181,6 @@
      <entry>
       <constant>INI_PERDIR</constant>
       (<type>int</type>)
-      &Alias; <constant>PHP_INI_PERDIR</constant>
      </entry>
      <entry>
       Entry can be set in &php.ini;, &htaccess;, &httpd.conf; or &user-ini;
@@ -192,7 +190,6 @@
      <entry>
       <constant>INI_SYSTEM</constant>
       (<type>int</type>)
-      &Alias; <constant>PHP_INI_SYSTEM</constant>
      </entry>
      <entry>
       Entry can be set in &php.ini; or &httpd.conf;
@@ -202,7 +199,6 @@
      <entry>
       <constant>INI_ALL</constant>
       (<type>int</type>)
-      &Alias; <constant>PHP_INI_ALL</constant>
      </entry>
      <entry>
       Entry can be set anywhere

--- a/reference/info/constants.xml
+++ b/reference/info/constants.xml
@@ -259,9 +259,9 @@
  </table>
 
  <simpara>
-  The following constants are only available if the host operating 
-  system is Windows, and can tell different versioning information 
-  so its possible to detect various features and make use of them. 
+  The following constants are only available if the host operating
+  system is Windows, and can tell different versioning information
+  so its possible to detect various features and make use of them.
   They are all available as of PHP 5.3.0.
  </simpara>
  <table>
@@ -277,15 +277,15 @@
     <row xml:id="constant.php-windows-version-major">
      <entry><constant>PHP_WINDOWS_VERSION_MAJOR</constant></entry>
      <entry>
-      The major version of Windows, this can be either <literal>4</literal> (NT4/Me/98/95), 
+      The major version of Windows, this can be either <literal>4</literal> (NT4/Me/98/95),
       <literal>5</literal> (XP/2003 R2/2003/2000) or <literal>6</literal> (Vista/2008/7/8/8.1).
     </entry>
     </row>
     <row xml:id="constant.php-windows-version-minor">
      <entry><constant>PHP_WINDOWS_VERSION_MINOR</constant></entry>
      <entry>
-      The minor version of Windows, this can be either <literal>0</literal> (Vista/2008/2000/NT4/95), 
-      <literal>1</literal> (XP), <literal>2</literal> (2003 R2/2003/XP x64), <literal>10</literal> (98) 
+      The minor version of Windows, this can be either <literal>0</literal> (Vista/2008/2000/NT4/95),
+      <literal>1</literal> (XP), <literal>2</literal> (2003 R2/2003/XP x64), <literal>10</literal> (98)
       or <literal>90</literal> (ME).</entry>
     </row>
     <row xml:id="constant.php-windows-version-build">
@@ -295,29 +295,29 @@
     <row xml:id="constant.php-windows-version-platform">
      <entry><constant>PHP_WINDOWS_VERSION_PLATFORM</constant></entry>
      <entry>
-      The platform that PHP currently is running on, this value is <literal>2</literal> on Windows 
+      The platform that PHP currently is running on, this value is <literal>2</literal> on Windows
       Vista/XP/2000/NT4, Server 2008/2003 and on Windows ME/98/95 this value is <literal>1</literal>.
      </entry>
     </row>
     <row xml:id="constant.php-windows-version-sp-major">
      <entry><constant>PHP_WINDOWS_VERSION_SP_MAJOR</constant></entry>
      <entry>
-      The major version of the service pack installed, this value is <literal>0</literal> 
-      if no service pack is installed. For example, Windows XP with service pack 3 installed 
+      The major version of the service pack installed, this value is <literal>0</literal>
+      if no service pack is installed. For example, Windows XP with service pack 3 installed
       will make this value <literal>3</literal>.
      </entry>
     </row>
     <row xml:id="constant.php-windows-version-sp-minor">
      <entry><constant>PHP_WINDOWS_VERSION_SP_MINOR</constant></entry>
      <entry>
-      The minor version of the service pack installed, this value is <literal>0</literal> 
+      The minor version of the service pack installed, this value is <literal>0</literal>
       if no service pack is installed.
      </entry>
     </row>
     <row xml:id="constant.php-windows-version-suitemask">
      <entry><constant>PHP_WINDOWS_VERSION_SUITEMASK</constant></entry>
      <entry>
-      The suitemask is a bitmask that can tell if various features of Windows is installed, 
+      The suitemask is a bitmask that can tell if various features of Windows is installed,
       see the table below for possible bitfield values.
      </entry>
     </row>
@@ -325,7 +325,7 @@
      <entry><constant>PHP_WINDOWS_VERSION_PRODUCTTYPE</constant></entry>
      <entry>
       This contains the value used to determine the <literal>PHP_WINDOWS_NT_*</literal>
-      constants. This value may be one of the <literal>PHP_WINDOWS_NT_*</literal> constants 
+      constants. This value may be one of the <literal>PHP_WINDOWS_NT_*</literal> constants
       indicating the platform type.
      </entry>
     </row>
@@ -336,7 +336,7 @@
     <row xml:id="constant.php-windows-nt-server">
      <entry><constant>PHP_WINDOWS_NT_SERVER</constant></entry>
      <entry>
-      This is a server system (eg. Server 2008/2003/2000), note that if this is a 
+      This is a server system (eg. Server 2008/2003/2000), note that if this is a
       domain controller its reported as <constant>PHP_WINDOWS_NT_DOMAIN_CONTROLLER</constant>.
      </entry>
     </row>
@@ -348,7 +348,7 @@
   </tgroup>
  </table>
  <simpara>
-  This table shows a list of features that can be checked for using the 
+  This table shows a list of features that can be checked for using the
   <constant>PHP_WINDOWS_VERSION_SUITEMASK</constant> bitmask.
  </simpara>
  <table>
@@ -376,15 +376,15 @@
     <row>
      <entry><literal>0x00000080</literal></entry>
      <entry>
-      Windows Server 2008 Datacenter, Windows Server 2003, Datacenter Edition or 
+      Windows Server 2008 Datacenter, Windows Server 2003, Datacenter Edition or
       Windows 2000 Datacenter Server is installed.
      </entry>
     </row>
     <row>
      <entry><literal>0x00000002</literal></entry>
      <entry>
-      Windows Server 2008 Enterprise, Windows Server 2003, Enterprise Edition, 
-      Windows 2000 Advanced Server, or Windows NT Server 4.0 Enterprise Edition 
+      Windows Server 2008 Enterprise, Windows Server 2003, Enterprise Edition,
+      Windows 2000 Advanced Server, or Windows NT Server 4.0 Enterprise Edition
       is installed.
      </entry>
     </row>
@@ -395,28 +395,28 @@
     <row>
      <entry><literal>0x00000200</literal></entry>
      <entry>
-      Windows Vista Home Premium, Windows Vista Home Basic, or Windows XP Home 
+      Windows Vista Home Premium, Windows Vista Home Basic, or Windows XP Home
       Edition is installed.
      </entry>
     </row>
     <row>
      <entry><literal>0x00000100</literal></entry>
      <entry>
-      Remote Desktop is supported, but only one interactive session is supported. 
+      Remote Desktop is supported, but only one interactive session is supported.
       This value is set unless the system is running in application server mode.
      </entry>
     </row>
     <row>
      <entry><literal>0x00000001</literal></entry>
      <entry>
-      Microsoft Small Business Server was once installed on the system, but may have 
+      Microsoft Small Business Server was once installed on the system, but may have
       been upgraded to another version of Windows.
      </entry>
     </row>
     <row>
      <entry><literal>0x00000020</literal></entry>
      <entry>
-      Microsoft Small Business Server is installed with the restrictive client 
+      Microsoft Small Business Server is installed with the restrictive client
       license in force.
      </entry>
     </row>
@@ -427,8 +427,8 @@
     <row>
      <entry><literal>0x00000010</literal></entry>
      <entry>
-      Terminal Services is installed. This value is always set. If this value is set but 
-      <literal>0x00000100</literal> is not set, then the system is running in application 
+      Terminal Services is installed. This value is always set. If this value is set but
+      <literal>0x00000100</literal> is not set, then the system is running in application
       server mode.
      </entry>
     </row>


### PR DESCRIPTION
Adds descriptions to each `INI` mode constant, copied from their `PHP_INI` aliases.

These are also on the [missing constants list](https://github.com/php/doc-en/issues/2747) which I'm guessing is because these are in a `table` instead of a `variablelist`.