### PR TITLE
Add DOM\DocumentType documentation

### DIFF
--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -19,6 +19,8 @@
  &reference.dom.constants;
  &reference.dom.examples;
 
+ &reference.dom.dom.documenttype;
+
  &reference.dom.domattr;
  &reference.dom.domcdatasection;
  &reference.dom.domcharacterdata;

--- a/reference/dom/dom.documenttype.xml
+++ b/reference/dom/dom.documenttype.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpdoc:classref xml:id="class.dom.documenttype" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The DOM\DocumentType class</title>
+ <titleabbrev>DOM\DocumentType</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ DOM\DocumentType intro -->
+  <section xml:id="dom.documenttype.intro">
+   &reftitle.intro;
+   <para>
+    &Alias; <classname>DOMDocumentType</classname>
+   </para>
+   <para>
+    Each <classname>DOM\Document</classname> has a <literal>doctype</literal>
+    attribute whose value is either &null; or a <classname>DOM\DocumentType</classname> object.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="dom.documenttype.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom.documenttype')/db:titleabbrev/text())"><xi:fallback/></xi:include>
+     </classname>
+    </ooclass>
+
+    <ooclass>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.synopsis')/db:classsynopsis/db:ooclass[2]/*)"><xi:fallback/></xi:include>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="dom.documenttype.props.name">name</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>DOMNamedNodeMap</type>
+     <varname linkend="dom.documenttype.props.entities">entities</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>DOMNamedNodeMap</type>
+     <varname linkend="dom.documenttype.props.notations">notations</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="dom.documenttype.props.publicid">publicId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="dom.documenttype.props.systemid">systemId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="dom.documenttype.props.internalsubset">internalSubset</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+<!-- {{{ DOM\DocumentType properties -->
+  <section xml:id="dom.documenttype.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom.documenttype.props.publicid">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.publicid')/*)"><xi:fallback/></xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom.documenttype.props.systemid">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.systemid')/*)"><xi:fallback/></xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom.documenttype.props.name">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.name')/*)"><xi:fallback/></xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom.documenttype.props.entities">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.entities')/*)"><xi:fallback/></xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom.documenttype.props.notations">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.notations')/*)"><xi:fallback/></xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom.documenttype.props.internalsubset">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.internalsubset')/*)"><xi:fallback/></xi:include>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+ </partintro>
+
+</phpdoc:classref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -4,6 +4,8 @@
   Do NOT translate this file
 -->
 <versions>
+ <function name='dom\documenttype' from='PHP 8 &gt;= 8.4.0'/>
+
  <function name="domattr" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domattr::__construct" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domattr::isid" from="PHP 5, PHP 7, PHP 8"/>


### PR DESCRIPTION
Adds documentation for the DOM\DocumentType class. Part of #2162.

These classes under the `DOM` namespace seem to be the first ones that are aliases of other classes. As such, I didn't know what tag to use to indicate that this is an alias (`<refpurpose>` used for functions doesn't work here) so I added it as the first sentence of the intro. I've tried using `<subtitle>` but Phd gave me a `"No mapper found for 'subtitle'"` error.

I've `XInclude`d as much as could from `DOMDocumentType`. I've tried to `XInclude` the properties' `<modifier>`s and `<type>`s but ended up with no space between the words (e.g `"publicreadonlystring"`). I've tried `string-join()` but that didn't work so I'm guessing Phd doesn't support XPath 2.

The below is what I used which ended up being `"publicreadonlystring"` instead of `"public readonly string"`. Any help to achieve that would be appreciated.
```xml
<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.synopsis')/db:classsynopsis/db:fieldsynopsis[descendant::db:varname[text()='name']]/*[not(name()='varname')])">
 <xi:fallback/>
</xi:include>
```