### PR TITLE
Replace PHP_INI_* with INI_* constants

### DIFF
--- a/PHP_INI_to_INI.sh
+++ b/PHP_INI_to_INI.sh
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+\grep -lrE --include='*.xml' --include='*.ent' 'PHP_INI_\*' | xargs -d '\n' sed -i 's/PHP_INI_\*/INI_\*/g'
+
+\grep -lrE --include='*.xml' '<entry>\s*PHP_INI_USER\s*<\/entry>' | xargs -d '\n' sed -i 's/<entry>\s*PHP_INI_USER\s*<\/entry>/<entry><constant>INI_USER<\/constant><\/entry>/g'
+\grep -lrE --include='*.xml' '<entry>\s*PHP_INI_PERDIR\s*<\/entry>' | xargs -d '\n' sed -i 's/<entry>\s*PHP_INI_PERDIR\s*<\/entry>/<entry><constant>INI_PERDIR<\/constant><\/entry>/g'
+\grep -lrE --include='*.xml' '<entry>\s*PHP_INI_SYSTEM\s*<\/entry>' | xargs -d '\n' sed -i 's/<entry>\s*PHP_INI_SYSTEM\s*<\/entry>/<entry><constant>INI_SYSTEM<\/constant><\/entry>/g'
+\grep -lrE --include='*.xml' '<entry>\s*PHP_INI_ALL\s*<\/entry>|<entry>>\s*PHP_INI_ALL\s*<\/entry>' | xargs -d '\n' sed -i -E 's/<entry>\s*PHP_INI_ALL\s*<\/entry>|<entry>>\s*PHP_INI_ALL\s*<\/entry>/<entry><constant>INI_ALL<\/constant><\/entry>/g'
+
+\grep -lrE --include='*.xml' '<constant>\s*PHP_INI_USER\s*<\/constant>|<literal>\s*PHP_INI_USER\s*<\/literal>' | xargs -d '\n' sed -i -E 's/<constant>\s*PHP_INI_USER\s*<\/constant>|<literal>\s*PHP_INI_USER\s*<\/literal>/<constant>INI_USER<\/constant>/g'
+
+\grep -lrE --include='*.xml' '<constant>\s*PHP_INI_PERDIR\s*<\/constant>|<literal>\s*PHP_INI_PERDIR\s*<\/literal>' | xargs -d '\n' sed -i -E 's/<constant>\s*PHP_INI_PERDIR\s*<\/constant>|<literal>\s*PHP_INI_PERDIR\s*<\/literal>/<constant>INI_PERDIR<\/constant>/g'
+
+\grep -lrE --include='*.xml' '<constant>\s*PHP_INI_SYSTEM\s*<\/constant>|<literal>\s*PHP_INI_SYSTEM\s*<\/literal>' | xargs -d '\n' sed -i -E 's/<constant>\s*PHP_INI_SYSTEM\s*<\/constant>|<literal>\s*PHP_INI_SYSTEM\s*<\/literal>/<constant>INI_SYSTEM<\/constant>/g'
+
+\grep -lrE --include='*.xml' '<constant>\s*PHP_INI_ALL\s*<\/constant>|<literal>\s*PHP_INI_ALL\s*<\/literal>' | xargs -d '\n' sed -i -E 's/<constant>\s*PHP_INI_ALL\s*<\/constant>|<literal>\s*PHP_INI_ALL\s*<\/literal>/<constant>INI_ALL<\/constant>/g'
+
+\grep -lrE --include='*.xml' 'PHP_INI_SYSTEM\s*\|\s*PHP_INI_PERDIR' | xargs -d '\n' sed -i 's/PHP_INI_SYSTEM\s*[|]\s*PHP_INI_PERDIR/<constant>INI_SYSTEM<\/constant>\|<constant>INI_PERDIR<\/constant>/g'
+
+\grep -lrE --include='*.xml' '<literal>\\INI_ALL<\/literal>' | xargs -d '\n' sed -i 's/<literal>\\INI_ALL<\/literal>/\\<constant>INI_ALL<\/constant>/g'
+
+\grep -lrE --include='*.xml' ' PHP_INI_ALL ' | xargs -d '\n' sed -i 's/ PHP_INI_ALL / <constant>INI_ALL<\/constant> /g'
+
+\grep -lrE --include='*.xml' '<entry>PHP_INI_ALL ' | xargs -d '\n' sed -i 's/<entry>PHP_INI_ALL /<entry><constant>INI_ALL<\/constant> /g'
+
+\grep -lrE --include='*.xml' '<entry>PHP_INI_SYSTEM ' | xargs -d '\n' sed -i 's/<entry>PHP_INI_SYSTEM /<entry><constant>INI_SYSTEM<\/constant> /g'

--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -33,19 +33,19 @@
        <row>
         <entry><link linkend="ini.short-open-tag">short_open_tag</link></entry>
         <entry>"1"</entry>
-        <entry>PHP_INI_PERDIR</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.precision">precision</link></entry>
         <entry>"14"</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.serialize-precision">serialize_precision</link></entry>
         <entry>"-1"</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry>
          Prior to PHP 7.1.0, the default value was 17.
         </entry>
@@ -53,7 +53,7 @@
        <row>
         <entry><link linkend="ini.disable-functions">disable_functions</link></entry>
         <entry>""</entry>
-        <entry>PHP_INI_SYSTEM only</entry>
+        <entry><constant>INI_SYSTEM</constant> only</entry>
         <entry></entry>
        </row>
        <row>
@@ -65,7 +65,7 @@
        <row>
         <entry><link linkend="ini.exit-on-timeout">exit_on_timeout</link></entry>
         <entry>""</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
        <row>
@@ -77,58 +77,58 @@
        <row>
         <entry><link linkend="ini.hard-timeout">hard_timeout</link></entry>
         <entry>"2"</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry>Available as of PHP 7.1.0.</entry>
        </row>
        <row>
         <entry><link linkend="ini.zend.exception-ignore-args">zend.exception_ignore_args</link></entry>
         <entry>"0"</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry>Available as of PHP 7.4.0</entry>
        </row>
        <row>
         <entry><link linkend="ini.zend.multibyte">zend.multibyte</link></entry>
         <entry>"0"</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.zend.script-encoding">zend.script_encoding</link></entry>
         <entry>NULL</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.zend.detect-unicode">zend.detect_unicode</link></entry>
         <entry>NULL</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.zend.signal-check">zend.signal_check</link></entry>
         <entry>"0"</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.zend.assertions">zend.assertions</link></entry>
         <entry>"1"</entry>
-        <entry>PHP_INI_ALL with restrictions</entry>
+        <entry><constant>INI_ALL</constant> with restrictions</entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.zend.exception-string-param-max-len">zend.exception_string_param_max_len</link></entry>
         <entry>"15"</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry>Available as of PHP 8.0.0.</entry>
        </row>
       </tbody>
      </tgroup>
     </table>
    </para>
-   
+
    &ini.descriptions.title;
-   
+
    <para>
     <variablelist>
      <varlistentry xml:id="ini.short-open-tag">
@@ -148,13 +148,13 @@
        </para>
        <note>
         <para>
-         This directive does not affect the shorthand 
+         This directive does not affect the shorthand
          <userinput>&lt;?=</userinput>, which is always available.
         </para>
        </note>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.precision">
       <term>
        <parameter>precision</parameter>
@@ -163,7 +163,7 @@
       <listitem>
        <simpara>
         The number of significant digits displayed in floating point numbers.
-        <literal>-1</literal> means that an enhanced algorithm for rounding 
+        <literal>-1</literal> means that an enhanced algorithm for rounding
         such numbers will be used.
        </simpara>
       </listitem>
@@ -177,12 +177,12 @@
       <listitem>
        <simpara>
         The number of significant digits stored while serializing floating point numbers.
-        <literal>-1</literal> means that an enhanced algorithm for rounding 
+        <literal>-1</literal> means that an enhanced algorithm for rounding
         such numbers will be used.
       </simpara>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.expose-php">
       <term>
        <parameter>expose_php</parameter>
@@ -195,7 +195,7 @@
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.disable-functions">
       <term>
        <parameter>disable_functions</parameter>
@@ -203,7 +203,7 @@
       </term>
       <listitem>
        <para>
-        This directive allows you to disable certain functions. It takes 
+        This directive allows you to disable certain functions. It takes
         on a comma-delimited list of function names.
        </para>
        <para>
@@ -212,12 +212,12 @@
         are unaffected.
        </para>
        <para>
-        This directive must be set in &php.ini; For example, you 
+        This directive must be set in &php.ini; For example, you
         cannot set this in &httpd.conf;.
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.disable-classes">
       <term>
        <parameter>disable_classes</parameter>
@@ -246,7 +246,7 @@
         executed (development mode). When set to <literal>0</literal>,
         assertion code will be generated but it will be skipped (not executed)
         at runtime. When set to <literal>-1</literal>, assertion code will not
-        be generated, making the assertions zero-cost (production mode). 
+        be generated, making the assertions zero-cost (production mode).
        </simpara>
        <note>
         <para>
@@ -297,7 +297,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.zend.exception-ignore-args">
       <term>
        <parameter>zend.exception_ignore_args</parameter>
@@ -317,9 +317,9 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
       </term>
       <listitem>
        <para>
-        Enables parsing of source files in multibyte encodings. Enabling zend.multibyte 
+        Enables parsing of source files in multibyte encodings. Enabling zend.multibyte
         is required to use character encodings like SJIS, BIG5, etc that contain special
-        characters in multibyte string data. ISO-8859-1 compatible encodings like UTF-8, 
+        characters in multibyte string data. ISO-8859-1 compatible encodings like UTF-8,
         EUC, etc do not require this option.
        </para>
        <para>
@@ -327,7 +327,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.zend.script-encoding">
       <term>
        <parameter>zend.script_encoding</parameter>
@@ -363,7 +363,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.zend.signal-check">
       <term>
        <parameter>zend.signal_check</parameter>
@@ -375,7 +375,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.exit-on-timeout">
       <term>
        <parameter>exit_on_timeout</parameter>
@@ -389,11 +389,11 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        </para>
       </listitem>
      </varlistentry>
-     
+
     </variablelist>
    </para>
   </section>
-  
+
   <section xml:id="ini.sect.resource-limits">
    <title>Resource Limits</title>
    <para>
@@ -412,16 +412,16 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        <row>
         <entry><link linkend="ini.memory-limit">memory_limit</link></entry>
         <entry>"128M"</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
       </tbody>
      </tgroup>
     </table>
    </para>
-   
+
    &ini.descriptions.title;
-   
+
    <para>
     <variablelist>
      <varlistentry xml:id="ini.memory-limit">
@@ -436,9 +436,9 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         scripts for eating up all available memory on a server. Note that
         to have no memory limit, set this directive to <literal>-1</literal>.
        </para>
-       
+
        &ini.shorthandbytes;
-       
+
       </listitem>
      </varlistentry>
     </variablelist>
@@ -447,7 +447,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
     See also: <link linkend="ini.max-execution-time">max_execution_time</link>.
    </para>
   </section>
-  
+
   <section xml:id="ini.sect.performance">
    <title>Performance Tuning</title>
    <para>
@@ -466,13 +466,13 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        <row>
         <entry><link linkend="ini.realpath-cache-size">realpath_cache_size</link></entry>
         <entry>"4M"</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry>Prior to PHP 7.0.16 and 7.1.2, the default was <literal>"16K"</literal></entry>
        </row>
        <row>
         <entry><link linkend="ini.realpath-cache-ttl">realpath_cache_ttl</link></entry>
         <entry>"120"</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry></entry>
        </row>
       </tbody>
@@ -527,7 +527,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
     </variablelist>
    </para>
   </section>
-  
+
   <section xml:id="ini.sect.data-handling">
    <title>Data Handling</title>
    <para>
@@ -546,100 +546,100 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        <row>
         <entry><link linkend="ini.arg-separator.output">arg_separator.output</link></entry>
         <entry>"&amp;"</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.arg-separator.input">arg_separator.input</link></entry>
         <entry>"&amp;"</entry>
-        <entry>PHP_INI_PERDIR</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.variables-order">variables_order</link></entry>
         <entry>"EGPCS"</entry>
-        <entry>PHP_INI_PERDIR</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.request-order">request_order</link></entry>
         <entry>""</entry>
-        <entry>PHP_INI_PERDIR</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.auto-globals-jit">auto_globals_jit</link></entry>
         <entry>"1"</entry>
-        <entry>PHP_INI_PERDIR</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.register-argc-argv">register_argc_argv</link></entry>
         <entry>"1"</entry>
-        <entry>PHP_INI_PERDIR</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.enable-post-data-reading">enable_post_data_reading</link></entry>
         <entry>"1"</entry>
-        <entry>PHP_INI_PERDIR</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.post-max-size">post_max_size</link></entry>
         <entry>"8M"</entry>
-        <entry>PHP_INI_PERDIR</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.auto-prepend-file">auto_prepend_file</link></entry>
         <entry>NULL</entry>
-        <entry>PHP_INI_PERDIR</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.auto-append-file">auto_append_file</link></entry>
         <entry>NULL</entry>
-        <entry>PHP_INI_PERDIR</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.default-mimetype">default_mimetype</link></entry>
         <entry>"text/html"</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.default-charset">default_charset</link></entry>
         <entry>"UTF-8"</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.input-encoding">input_encoding</link></entry>
         <entry>""</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.output-encoding">output_encoding</link></entry>
         <entry>""</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.internal-encoding">internal_encoding</link></entry>
         <entry>""</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
       </tbody>
      </tgroup>
     </table>
    </para>
-   
+
    &ini.descriptions.title;
-   
+
    <para>
     <variablelist>
      <varlistentry xml:id="ini.arg-separator.output">
@@ -653,7 +653,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.arg-separator.input">
       <term>
        <parameter>arg_separator.input</parameter>
@@ -670,7 +670,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        </note>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.variables-order">
       <term>
        <parameter>variables_order</parameter>
@@ -707,7 +707,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        </note>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.request-order">
       <term>
        <parameter>request_order</parameter>
@@ -725,12 +725,12 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         <varname>$_REQUEST</varname> contents.
        </para>
        <para>
-        Note that the default distribution <filename>php.ini</filename> files does not contain 
+        Note that the default distribution <filename>php.ini</filename> files does not contain
         the <literal>'C'</literal> for cookies, due to security concerns.
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.auto-globals-jit">
       <term>
        <parameter>auto_globals_jit</parameter>
@@ -753,7 +753,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        </warning>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.register-argc-argv">
       <term>
        <parameter>register_argc_argv</parameter>
@@ -769,7 +769,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        </simpara>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.enable-post-data-reading">
       <term>
        <parameter>enable_post_data_reading</parameter>
@@ -803,9 +803,9 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         <link linkend="ini.memory-limit">memory_limit</link> should be
         larger than <parameter>post_max_size</parameter>.
        </simpara>
-       
+
        &ini.shorthandbytes;
-       
+
        <simpara>
         If the size of post data is greater than post_max_size, the
         <varname>$_POST</varname> and <varname>$_FILES</varname>
@@ -818,10 +818,10 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        <para>
         <note>
          <para>
-          PHP allows shortcuts for byte values, including K (kilo), M (mega) 
-          and G (giga). PHP will do the conversions automatically if you 
-          use any of these. Be careful not to exceed the 32 bit signed integer 
-          limit (if you're using 32bit versions) as it will cause your script 
+          PHP allows shortcuts for byte values, including K (kilo), M (mega)
+          and G (giga). PHP will do the conversions automatically if you
+          use any of these. Be careful not to exceed the 32 bit signed integer
+          limit (if you're using 32bit versions) as it will cause your script
           to fail.
          </para>
         </note>
@@ -874,7 +874,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.auto-append-file">
       <term>
        <parameter>auto_append_file</parameter>
@@ -897,7 +897,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.default-mimetype">
       <term>
        <parameter>default_mimetype</parameter>
@@ -913,7 +913,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.default-charset">
       <term>
        <parameter>default_charset</parameter>
@@ -951,7 +951,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.input-encoding">
       <term>
        <parameter>input_encoding</parameter>
@@ -964,7 +964,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.output-encoding">
       <term>
        <parameter>output_encoding</parameter>
@@ -977,7 +977,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        </para>
       </listitem>
      </varlistentry>
-      
+
      <varlistentry xml:id="ini.internal-encoding">
       <term>
        <parameter>internal_encoding</parameter>
@@ -991,11 +991,11 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        </para>
       </listitem>
      </varlistentry>
-      
+
     </variablelist>
    </para>
   </section>
-  
+
   <section xml:id="ini.sect.path-directory">
    <title>Paths and Directories</title>
    <para>
@@ -1014,43 +1014,43 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        <row>
         <entry><link linkend="ini.include-path">include_path</link></entry>
         <entry>".;/path/to/php/pear"</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.open-basedir">open_basedir</link></entry>
         <entry>NULL</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.doc-root">doc_root</link></entry>
         <entry>NULL</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.user-dir">user_dir</link></entry>
         <entry>NULL</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.user-ini.cache-ttl">user_ini.cache_ttl</link></entry>
         <entry>"300"</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.user-ini.filename">user_ini.filename</link></entry>
         <entry>".user.ini"</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.extension-dir">extension_dir</link></entry>
         <entry>"/path/to/php"</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry></entry>
        </row>
        <row>
@@ -1068,64 +1068,64 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        <row>
         <entry><link linkend="ini.cgi.check-shebang-line">cgi.check_shebang_line</link></entry>
         <entry>"1"</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.cgi.discard-path">cgi.discard_path</link></entry>
         <entry>"0"</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.cgi.fix-pathinfo">cgi.fix_pathinfo</link></entry>
         <entry>"1"</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.cgi.force-redirect">cgi.force_redirect</link></entry>
         <entry>"1"</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.cgi.nph">cgi.nph</link></entry>
         <entry>"0"</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.cgi.redirect-status-env">cgi.redirect_status_env</link></entry>
         <entry>NULL</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.cgi.rfc2616-headers">cgi.rfc2616_headers</link></entry>
         <entry>"0"</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.fastcgi.impersonate">fastcgi.impersonate</link></entry>
         <entry>"0"</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.fastcgi.logging">fastcgi.logging</link></entry>
         <entry>"1"</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry></entry>
        </row>
       </tbody>
      </tgroup>
     </table>
    </para>
-   
+
    &ini.descriptions.title;
-   
+
    <para>
     <variablelist>
      <varlistentry xml:id="ini.include-path">
@@ -1149,7 +1149,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         it, check the next path, until it either locates the included file or
         returns with an
         <constant>E_WARNING</constant>
-        or an <constant>E_ERROR</constant>. 
+        or an <constant>E_ERROR</constant>.
         You may modify or set your include path at runtime using
         <function>set_include_path</function>.
        </para>
@@ -1189,7 +1189,7 @@ include_path=".;c:\php\includes"
         <para>
          Environment variables may vary between Server APIs as those environments
          may be different.
-        </para>       
+        </para>
        </note>
        <para>
         <example>
@@ -1203,7 +1203,7 @@ include_path = ".:${USER}/pear/php"
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.open-basedir">
       <term>
        <parameter>open_basedir</parameter>
@@ -1215,16 +1215,16 @@ include_path = ".:${USER}/pear/php"
         directory-tree, including the file itself.
        </para>
        <para>
-        When a script tries to access the filesystem, for example using 
-        <function>include</function>, or <function>fopen</function>, the location of the file 
+        When a script tries to access the filesystem, for example using
+        <function>include</function>, or <function>fopen</function>, the location of the file
         is checked.
-        When the file is outside the specified directory-tree, PHP will refuse to access it. 
+        When the file is outside the specified directory-tree, PHP will refuse to access it.
         All symbolic links are resolved, so it's not possible to avoid this restriction
         with a symlink. If the file doesn't exist then the symlink couldn't be
         resolved and the filename is compared to (a resolved) <option>open_basedir</option>.
        </para>
        <para>
-        <option>open_basedir</option> can affect more than just filesystem functions; for example 
+        <option>open_basedir</option> can affect more than just filesystem functions; for example
         if <literal>MySQL</literal> is configured to use <literal>mysqlnd</literal> drivers,
         <literal>LOAD DATA INFILE</literal> will be affected by <option>open_basedir</option>.
         Much of the extended functionality of PHP uses <literal>open_basedir</literal> in this way.
@@ -1280,7 +1280,7 @@ include_path = ".:${USER}/pear/php"
        </caution>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.doc-root">
       <term>
        <parameter>doc_root</parameter>
@@ -1298,7 +1298,7 @@ include_path = ".:${USER}/pear/php"
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.user-ini.cache-ttl">
       <term>
        <parameter>user_ini.cache_ttl</parameter>
@@ -1309,7 +1309,7 @@ include_path = ".:${USER}/pear/php"
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.user-ini.filename">
       <term>
        <parameter>user_ini.filename</parameter>
@@ -1320,7 +1320,7 @@ include_path = ".:${USER}/pear/php"
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.user-dir">
       <term>
        <parameter>user_dir</parameter>
@@ -1334,7 +1334,7 @@ include_path = ".:${USER}/pear/php"
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.extension-dir">
       <term>
        <parameter>extension_dir</parameter>
@@ -1348,7 +1348,7 @@ include_path = ".:${USER}/pear/php"
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.extension">
       <term>
        <parameter>extension</parameter>
@@ -1360,7 +1360,7 @@ include_path = ".:${USER}/pear/php"
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.zend-extension">
       <term>
        <parameter>zend_extension</parameter>
@@ -1373,7 +1373,7 @@ include_path = ".:${USER}/pear/php"
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.cgi.check-shebang-line">
       <term>
        <parameter>cgi.check_shebang_line</parameter>
@@ -1390,7 +1390,7 @@ include_path = ".:${USER}/pear/php"
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.cgi.discard-path">
       <term>
        <parameter>cgi.discard_path</parameter>
@@ -1403,7 +1403,7 @@ include_path = ".:${USER}/pear/php"
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.cgi.fix-pathinfo">
       <term>
        <parameter>cgi.fix_pathinfo</parameter>
@@ -1426,7 +1426,7 @@ include_path = ".:${USER}/pear/php"
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.cgi.force-redirect">
       <term>
        <parameter>cgi.force_redirect</parameter>
@@ -1447,7 +1447,7 @@ include_path = ".:${USER}/pear/php"
        </note>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.cgi.nph">
       <term>
        <parameter>cgi.nph</parameter>
@@ -1460,7 +1460,7 @@ include_path = ".:${USER}/pear/php"
         </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.cgi.redirect-status-env">
       <term>
        <parameter>cgi.redirect_status_env</parameter>
@@ -1481,7 +1481,7 @@ include_path = ".:${USER}/pear/php"
        </note>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.cgi.rfc2616-headers">
       <term>
        <parameter>cgi.rfc2616_headers</parameter>
@@ -1490,15 +1490,15 @@ include_path = ".:${USER}/pear/php"
       <listitem>
       <para>
         Tells PHP what type of headers to use when sending HTTP response
-        code. If it's set to 0, PHP sends a <link xlink:href="&url.rfc;3875">RFC 3875</link> 
-        "Status:" header that is supported by Apache and other web servers. When this option 
+        code. If it's set to 0, PHP sends a <link xlink:href="&url.rfc;3875">RFC 3875</link>
+        "Status:" header that is supported by Apache and other web servers. When this option
         is set to 1, PHP will send <link xlink:href="&url.rfc;2616">RFC 2616</link> compliant
-        headers.  
+        headers.
        </para>
        <para>
         If this option is enabled, and you are running PHP in a CGI environment (e.g. PHP-FPM)
-        you should not use standard RFC 2616 style HTTP status response headers, you should 
-        instead use their RFC 3875 equivalent e.g. instead of header("HTTP/1.0 404 Not found"); 
+        you should not use standard RFC 2616 style HTTP status response headers, you should
+        instead use their RFC 3875 equivalent e.g. instead of header("HTTP/1.0 404 Not found");
         you should use header("Status: 404 Not Found");
        </para>
        <para>
@@ -1506,7 +1506,7 @@ include_path = ".:${USER}/pear/php"
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.fastcgi.impersonate">
       <term>
        <parameter>fastcgi.impersonate</parameter>
@@ -1522,7 +1522,7 @@ include_path = ".:${USER}/pear/php"
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.fastcgi.logging">
       <term>
        <parameter>fastcgi.logging</parameter>
@@ -1530,16 +1530,16 @@ include_path = ".:${USER}/pear/php"
       </term>
       <listitem>
        <para>
-        Turns on SAPI logging when using FastCGI. Default is 
+        Turns on SAPI logging when using FastCGI. Default is
         to enable logging.
        </para>
       </listitem>
      </varlistentry>
-     
+
     </variablelist>
    </para>
   </section>
-  
+
   <section xml:id="ini.sect.file-uploads">
    <title>File Uploads</title>
    <para>
@@ -1558,46 +1558,46 @@ include_path = ".:${USER}/pear/php"
        <row>
         <entry><link linkend="ini.file-uploads">file_uploads</link></entry>
         <entry>"1"</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.upload-tmp-dir">upload_tmp_dir</link></entry>
         <entry>NULL</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.max-input-nesting-level">max_input_nesting_level</link></entry>
         <entry>64</entry>
-        <entry>PHP_INI_PERDIR</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.max-input-vars">max_input_vars</link></entry>
         <entry>1000</entry>
-        <entry>PHP_INI_PERDIR</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.upload-max-filesize">upload_max_filesize</link></entry>
         <entry>"2M"</entry>
-        <entry>PHP_INI_PERDIR</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
         <entry></entry>
        </row>
        <row>
         <entry><link linkend="ini.max-file-uploads">max_file_uploads</link></entry>
         <entry>20</entry>
-        <entry>PHP_INI_PERDIR</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
         <entry></entry>
        </row>
       </tbody>
      </tgroup>
     </table>
    </para>
-   
+
    &ini.descriptions.title;
-   
+
    <para>
     <variablelist>
      <varlistentry xml:id="ini.file-uploads">
@@ -1615,7 +1615,7 @@ include_path = ".:${USER}/pear/php"
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.upload-tmp-dir">
       <term>
        <parameter>upload_tmp_dir</parameter>
@@ -1628,15 +1628,15 @@ include_path = ".:${USER}/pear/php"
         is running as. If not specified PHP will use the system's default.
        </para>
        <para>
-        If the directory specified here is not writable, PHP falls back to 
-        the system default temporary directory. If 
-        <link linkend="ini.open-basedir">open_basedir</link> is on, then 
-        the system default directory must be allowed for an upload to 
+        If the directory specified here is not writable, PHP falls back to
+        the system default temporary directory. If
+        <link linkend="ini.open-basedir">open_basedir</link> is on, then
+        the system default directory must be allowed for an upload to
         succeed.
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.upload-max-filesize">
       <term>
        <parameter>upload_max_filesize</parameter>
@@ -1649,12 +1649,12 @@ include_path = ".:${USER}/pear/php"
        <para>
         <link linkend="ini.post-max-size">post_max_size</link> must be larger than this value.
        </para>
-       
+
        &ini.shorthandbytes;
-       
+
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.max-file-uploads">
       <term>
        <parameter>max_file_uploads</parameter>
@@ -1671,7 +1671,7 @@ include_path = ".:${USER}/pear/php"
     </variablelist>
    </para>
   </section>
-  
+
   <section xml:id="ini.sect.sql-general">
    <title>General SQL</title>
    <para>
@@ -1690,16 +1690,16 @@ include_path = ".:${USER}/pear/php"
        <row>
         <entry><link linkend="ini.sql.safe-mode">sql.safe_mode</link></entry>
         <entry>"0"</entry>
-        <entry>PHP_INI_SYSTEM</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
         <entry>Removed as of PHP 7.2.0</entry>
        </row>
       </tbody>
      </tgroup>
     </table>
    </para>
-   
+
    &ini.descriptions.title;
-   
+
    <para>
     <variablelist>
      <varlistentry xml:id="ini.sql.safe-mode">
@@ -1724,7 +1724,7 @@ include_path = ".:${USER}/pear/php"
     </variablelist>
    </para>
   </section>
-  
+
   <section xml:id="ini.sect.windows">
    <title>Windows Specific</title>
    <para>
@@ -1743,16 +1743,16 @@ include_path = ".:${USER}/pear/php"
        <row>
         <entry><link linkend="ini.windows-show-crt-warning">windows.show_crt_warning</link></entry>
         <entry>"0"</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
       </tbody>
      </tgroup>
     </table>
    </para>
-   
+
    &ini.descriptions.title;
-   
+
    <para>
     <variablelist>
      <varlistentry xml:id="ini.windows-show-crt-warning">
@@ -1769,7 +1769,7 @@ include_path = ".:${USER}/pear/php"
     </variablelist>
    </para>
   </section>
-  
+
  </section>
 
 <!-- Keep this comment at the end of the file

--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -25,140 +25,140 @@
       <row>
        <entry><link linkend="ini.allow-url-fopen">allow_url_fopen</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.allow-url-include">allow_url_include</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry>Deprecated as of PHP 7.4.0.</entry>
       </row>
       <row>
        <entry><link linkend="ini.arg-separator.input">arg_separator.input</link></entry>
        <entry><literal>"&amp;"</literal></entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.arg-separator.output">arg_separator.output</link></entry>
        <entry><literal>"&amp;"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.assert.active">assert.active</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.assert.bail">assert.bail</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.assert.callback">assert.callback</link></entry>
        <entry>&null;</entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.assert.exception">assert.exception</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.assert.quiet-eval">assert.quiet_eval</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry>Removed as of PHP 8.0.0</entry>
       </row>
       <row>
        <entry><link linkend="ini.assert.warning">assert.warning</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.auto-append-file">auto_append_file</link></entry>
        <entry>&null;</entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.auto-detect-line-endings">auto_detect_line_endings</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.auto-globals-jit">auto_globals_jit</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.auto-prepend-file">auto_prepend_file</link></entry>
        <entry>&null;</entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bc.configuration.list')/*)"><xi:fallback/></xi:include>
       <row>
        <entry><link linkend="ini.browscap">browscap</link></entry>
        <entry>&null;</entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.cgi.check-shebang-line">cgi.check_shebang_line</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.cgi.discard-path">cgi.discard_path</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.cgi.fix-pathinfo">cgi.fix_pathinfo</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.cgi.force-redirect">cgi.force_redirect</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.cgi.nph">cgi.nph</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.cgi.redirect-status-env">cgi.redirect_status_env</link></entry>
        <entry>&null;</entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.cgi.rfc2616-headers">cgi.rfc2616_headers</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.child-terminate">child_terminate</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('readline.configuration.list')/*)"><xi:fallback/></xi:include>
@@ -170,37 +170,37 @@
       <row>
        <entry><link linkend="ini.default-charset">default_charset</link></entry>
        <entry><literal>"UTF-8"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
-       <entry></entry>
+       <entry><constant>INI_ALL</constant></entry>
+       <entry>Default to <literal>"UTF-8"</literal>.</entry>
       </row>
       <row>
        <entry><link linkend="ini.input-encoding">input_encoding</link></entry>
        <entry><literal>""</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.output-encoding">output_encoding</link></entry>
        <entry><literal>""</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.internal-encoding">internal_encoding</link></entry>
        <entry><literal>""</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.default-mimetype">default_mimetype</link></entry>
        <entry><literal>"text/html"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.default-socket-timeout">default_socket_timeout</link></entry>
        <entry><literal>"60"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
@@ -218,13 +218,13 @@
       <row>
        <entry><link linkend="ini.display-errors">display_errors</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.display-startup-errors">display_startup_errors</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry>
         Prior to PHP 8.0.0, the default value was <literal>"0"</literal>.
        </entry>
@@ -232,74 +232,74 @@
       <row>
        <entry><link linkend="ini.docref-ext">docref_ext</link></entry>
        <entry><literal>""</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.docref-root">docref_root</link></entry>
        <entry><literal>""</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.doc-root">doc_root</link></entry>
        <entry>&null;</entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.enable-dl">enable_dl</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry>&removed.php.future;</entry>
       </row>
       <row>
        <entry><link linkend="ini.enable-post-data-reading">enable_post_data_reading</link></entry>
        <entry><literal>"On"</literal></entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.engine">engine</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.error-append-string">error_append_string</link></entry>
        <entry>&null;</entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.error-log">error_log</link></entry>
        <entry>&null;</entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.error-log-mode">error_log_mode</link></entry>
        <entry><literal>0o644</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry>Available as of PHP 8.2.0</entry>
       </row>
       <row>
        <entry><link linkend="ini.error-prepend-string">error_prepend_string</link></entry>
        <entry>&null;</entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.error-reporting">error_reporting</link></entry>
        <entry>&null;</entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exif.configuration.list')/*)"><xi:fallback/></xi:include>
       <row>
        <entry><link linkend="ini.exit-on-timeout">exit_on_timeout</link></entry>
        <entry><literal>""</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('expect.configuration.list')/*)"><xi:fallback/></xi:include>
@@ -318,32 +318,32 @@
       <row>
        <entry><link linkend="ini.extension-dir">extension_dir</link></entry>
        <entry><literal>"/path/to/php"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.fastcgi.impersonate">fastcgi.impersonate</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.fastcgi.logging">fastcgi.logging</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.file-uploads">file_uploads</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('filter.configuration.list')/*)"><xi:fallback/></xi:include>
       <row>
        <entry><link linkend="ini.from">from</link></entry>
        <entry><literal>""</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('image.configuration.list')/*)"><xi:fallback/></xi:include>
@@ -351,43 +351,43 @@
       <row>
        <entry>hard_timeout</entry>
        <entry><literal>"2"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry>Available as of PHP 7.1.0.</entry>
       </row>
       <row>
        <entry><link linkend="ini.syntax-highlighting">highlight.comment</link></entry>
        <entry><literal>"#FF8000"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.syntax-highlighting">highlight.default</link></entry>
        <entry><literal>"#0000BB"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.syntax-highlighting">highlight.html</link></entry>
        <entry><literal>"#000000"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.syntax-highlighting">highlight.keyword</link></entry>
        <entry><literal>"#007700"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.syntax-highlighting">highlight.string</link></entry>
        <entry><literal>"#DD0000"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.html-errors">html_errors</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('ibase.configuration.list')/*)"><xi:fallback/></xi:include>
@@ -396,57 +396,57 @@
       <row>
        <entry><link linkend="ini.ignore-repeated-errors">ignore_repeated_errors</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.ignore-repeated-source">ignore_repeated_source</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.ignore-user-abort">ignore_user_abort</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.implicit-flush">implicit_flush</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.include-path">include_path</link></entry>
        <entry><literal>".:/path/to/php/pear"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('intl.configuration.list')/*)"><xi:fallback/></xi:include>
       <row>
        <entry><link linkend="ini.last-modified">last_modified</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('ldap.configuration.list')/*)"><xi:fallback/></xi:include>
       <row>
        <entry><link linkend="ini.log-errors">log_errors</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.log-errors-max-len">log_errors_max_len</link></entry>
        <entry><literal>"1024"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.mail.add-x-header">mail.add_x_header</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <row>
@@ -458,31 +458,31 @@
       <row>
        <entry><link linkend="ini.mail.log">mail.log</link></entry>
        <entry><literal>""</literal></entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.max-execution-time">max_execution_time</link></entry>
        <entry><literal>"30"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.max-input-nesting-level">max_input_nesting_level</link></entry>
        <entry><literal>"64"</literal></entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.max-input-vars">max_input_vars</link></entry>
        <entry><literal>1000</literal></entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.max-input-time">max_input_time</link></entry>
        <entry><literal>"-1"</literal></entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mbstring.configuration.list')/*)"><xi:fallback/></xi:include>
@@ -491,7 +491,7 @@
       <row>
        <entry><link linkend="ini.memory-limit">memory_limit</link></entry>
        <entry><literal>"128M"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysql.configuration.list')/*)"><xi:fallback/></xi:include>
@@ -503,19 +503,19 @@
       <row>
        <entry><link linkend="ini.open-basedir">open_basedir</link></entry>
        <entry>&null;</entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.output-buffering">output_buffering</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.output-handler">output_handler</link></entry>
        <entry>&null;</entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pcre.configuration.list')/*)"><xi:fallback/></xi:include>
@@ -526,68 +526,68 @@
       <row>
        <entry><link linkend="ini.post-max-size">post_max_size</link></entry>
        <entry><literal>"8M"</literal></entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.precision">precision</link></entry>
        <entry><literal>"14"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.realpath-cache-size">realpath_cache_size</link></entry>
        <entry><literal>"16K"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.realpath-cache-ttl">realpath_cache_ttl</link></entry>
        <entry><literal>"120"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.register-argc-argv">register_argc_argv</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.report-memleaks">report_memleaks</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry>report_zend_debug</entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.request-order">request_order</link></entry>
        <entry><literal>""</literal></entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('runkit7.configuration.list')/*)"><xi:fallback/></xi:include>
       <row>
        <entry><link linkend="ini.sendmail-from">sendmail_from</link></entry>
        <entry>&null;</entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.sendmail-path">sendmail_path</link></entry>
        <entry><literal>"/usr/sbin/sendmail -t -i"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.serialize-precision">serialize_precision</link></entry>
        <entry><literal>"-1"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry>
         Prior to PHP 7.1.0, the default value was <literal>17</literal>.
        </entry>
@@ -596,51 +596,51 @@
       <row>
        <entry><link linkend="ini.short-open-tag">short_open_tag</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.smtp">SMTP</link></entry>
        <entry><literal>"localhost"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.smtp-port">smtp_port</link></entry>
        <entry><literal>"25"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('soap.configuration.list')/*)"><xi:fallback/></xi:include>
       <row>
        <entry><link linkend="ini.sql.safe-mode">sql.safe_mode</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry>Removed as of PHP 7.2.0</entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('sqlite3.configuration.list')/*)"><xi:fallback/></xi:include>
       <row>
        <entry><link linkend="ini.syslog.facility">syslog.facility</link></entry>
        <entry><literal>"LOG_USER"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry>Available as of PHP 7.3.0.</entry>
       </row>
       <row>
        <entry><link linkend="ini.syslog.filter">syslog.filter</link></entry>
        <entry><literal>"no-ctrl"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry>Available as of PHP 7.3.0.</entry>
       </row>
       <row>
        <entry><link linkend="ini.syslog.ident">syslog.ident</link></entry>
        <entry><literal>"php"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry>Available as of PHP 7.3.0.</entry>
       </row>
       <row>
        <entry>sys_temp_dir</entry>
        <entry><literal>""</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('sem.configuration.list')/*)"><xi:fallback/></xi:include>
@@ -648,44 +648,44 @@
       <row>
        <entry><link linkend="ini.track-errors">track_errors</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry>Deprecated as of PHP 7.2.0, removed as of PHP 8.0.0</entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('unserialize.configuration.list')/*)"><xi:fallback/></xi:include>
       <row>
        <entry>uploadprogress.file.filename_template</entry>
        <entry><literal>"/tmp/upt_%s.txt"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.upload-max-filesize">upload_max_filesize</link></entry>
        <entry><literal>"2M"</literal></entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.max-file-uploads">max_file_uploads</link></entry>
        <entry><literal>20</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.upload-tmp-dir">upload_tmp_dir</link></entry>
        <entry>&null;</entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.url-rewriter.hosts">url_rewriter.hosts</link></entry>
        <entry><literal>""</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry>Available as of PHP 7.1.0.</entry>
       </row>
       <row>
        <entry><link linkend="ini.url-rewriter.tags">url_rewriter.tags</link></entry>
        <entry><literal>"form="</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry>
         Prior to PHP 7.1.0, the default value was
         <literal>"a=href,area=href,frame=src,form=,fieldset="</literal>.
@@ -694,104 +694,104 @@
       <row>
        <entry><link linkend="ini.user-agent">user_agent</link></entry>
        <entry>&null;</entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.user-dir">user_dir</link></entry>
        <entry>&null;</entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.user-ini.cache-ttl">user_ini.cache_ttl</link></entry>
        <entry><literal>"300"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.user-ini.filename">user_ini.filename</link></entry>
        <entry><literal>".user.ini"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('uopz.configuration.list')/*)"><xi:fallback/></xi:include>
       <row>
        <entry><link linkend="ini.variables-order">variables_order</link></entry>
        <entry><literal>"EGPCS"</literal></entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.windows-show-crt-warning">windows.show_crt_warning</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.xbithack">xbithack</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.xmlrpc-errors">xmlrpc_errors</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.xmlrpc-error-number">xmlrpc_error_number</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry>yaz.keepalive</entry>
        <entry><literal>"120"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry>yaz.log_mask</entry>
        <entry>&null;</entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry>Available as of yaz 1.0.3.</entry>
       </row>
       <row>
        <entry><link linkend="ini.zend.assertions">zend.assertions</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.zend.detect-unicode">zend.detect_unicode</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.zend.enable-gc">zend.enable_gc</link></entry>
        <entry><literal>"1"</literal></entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.zend.multibyte">zend.multibyte</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_PERDIR</entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.zend.script-encoding">zend.script_encoding</link></entry>
        <entry>&null;</entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.zend.signal-check">zend.signal_check</link></entry>
        <entry><literal>"0"</literal></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>

--- a/appendices/ini.sections.xml
+++ b/appendices/ini.sections.xml
@@ -31,21 +31,21 @@
      <tbody>
       <row>
        <entry><link linkend="ini.per-host">[HOST=]</link></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.per-path">[PATH=]</link></entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
      </tbody>
     </tgroup>
    </table>
   </para>
-  
+
   &ini.descriptions.title;
-  
+
   <para>
    <variablelist>
     <varlistentry xml:id="ini.per-host">
@@ -71,7 +71,7 @@ display_errors = On
       </para>
      </listitem>
     </varlistentry>
-    
+
     <varlistentry xml:id="ini.per-path">
      <term>
       <parameter>[PATH=&lt;path&gt;]</parameter>
@@ -94,11 +94,11 @@ auto_prepend_file=security.php
       </para>
      </listitem>
     </varlistentry>
-    
+
    </variablelist>
   </para>
  </section>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -198,7 +198,7 @@
 
    <para>
     <link linkend="ini.sqlite3.defensive">sqlite3.defensive</link>
-    is now <constant>PHP_INI_USER</constant>.
+    is now <constant>INI_USER</constant>.
    </para>
   </sect3>
 

--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -3,11 +3,11 @@
 <chapter xml:id="features.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Using PHP from the command line</title>
  <titleabbrev>Command line usage</titleabbrev>
- 
+
  <!--Introduction: {{{-->
  <section xml:id="features.commandline.introduction">
   <title>Introduction</title>
-  
+
   <para>
    The main focus of &cli.sapi;
    is for developing shell applications with PHP. There
@@ -23,7 +23,7 @@
    the <option role="configure">--disable-cli</option> option when running
    <command>./configure</command>.
   </para>
-  
+
   <para>
    The name, location and existence of the &cli;/<acronym>CGI</acronym>
    binaries will differ depending on how PHP is installed on your system. By
@@ -44,7 +44,7 @@
    can specify <option role="configure">--disable-cgi</option> in your configure
    line.
   </para>
-  
+
   <note>
    <para>
     Because both <option role="configure">--enable-cli</option> and
@@ -54,7 +54,7 @@
     <filename>{PREFIX}/bin/php</filename> during <command>make install</command>.
    </para>
   </note>
-  
+
   <para>
    The &cli; binary is distributed in the main folder as <filename>
    php.exe</filename> on Windows. The <acronym>CGI</acronym> version is
@@ -64,7 +64,7 @@
    the &cli; version, except that it doesn't output anything and thus provides
    no console.
   </para>
-  
+
   <note>
    <title>What SAPI do I have?</title>
    <para>
@@ -74,7 +74,7 @@
     <constant>PHP_SAPI</constant>.
    </para>
   </note>
-  
+
   <note>
    <para>
     A Unix <literal>man</literal>ual page is available by typing <command>man
@@ -83,11 +83,11 @@
   </note>
  </section>
  <!--}}}-->
- 
+
  <!--Differences: {{{-->
  <section xml:id="features.commandline.differences">
   <title>Differences to other <acronym>SAPI</acronym>s</title>
-  
+
   <para>
    Remarkable differences of the &cli; <acronym>SAPI</acronym> compared to other
    <acronym>SAPI</acronym>s:
@@ -116,7 +116,7 @@
       Plain text error messages (no <acronym>HTML</acronym> formatting).
      </para>
     </listitem>
-    
+
     <listitem>
      <para>
       There are certain &php.ini; directives which are overridden by the
@@ -227,7 +227,7 @@
       </para>
      </note>
     </listitem>
-    
+
     <listitem>
      <para>
       To ease working in the shell environment, a number of constants are
@@ -235,7 +235,7 @@
       </link>.
      </para>
     </listitem>
-    
+
     <listitem>
      <para>
       The &cli.sapi; does <emphasis role="strong">not</emphasis> change the
@@ -298,12 +298,12 @@ $ php -f another_directory/test.php
   </para>
  </section>
  <!--}}}-->
- 
+
  <!--Options: {{{-->
  <section xml:id="features.commandline.options">
   <title>Command line options</title>
   <titleabbrev>Options</titleabbrev>
-  
+
   <para>
    The list of command line options provided by the PHP binary can be queried
    at any time by running PHP with the <option>-h</option> switch:
@@ -352,7 +352,7 @@ Usage: php [options] [-f] <file> [--] [args...]
 ]]>
    </screen>
   </para>
-  
+
   <para>
    <table>
     <title>Command line options</title>
@@ -622,7 +622,7 @@ $ php -r " = get_defined_constants();"
 ]]>
           </screen>
          </informalexample>
-         
+
          <para>
           The correct way would be to use single quotes <literal>'</literal>.
           Variables in single-quoted strings are not expanded
@@ -1001,7 +1001,7 @@ date.sunrise_zenith => 90.583333 => 90.583333
     </tgroup>
    </table>
   </para>
-  
+
   <note>
    <para>
     Options <literal>-rBRFEH</literal>, <literal>--ini</literal> and
@@ -1010,12 +1010,12 @@ date.sunrise_zenith => 90.583333 => 90.583333
   </note>
  </section>
  <!--}}}-->
- 
+
  <!--Usage: {{{-->
  <section xml:id="features.commandline.usage">
   <title>Executing PHP files</title>
   <titleabbrev>Usage</titleabbrev>
-  
+
   <para>
    There are three different ways of supplying the &cli.sapi; with PHP code
    to be executed:
@@ -1083,7 +1083,7 @@ $ some_application | some_filter | php | sort -u > final_output.txt
    </orderedlist>
    You cannot combine any of the three ways to execute code.
   </para>
-  
+
   <para>
    As with every shell application, the PHP binary accepts a number of
    arguments; however, the PHP script can also receive further arguments. The
@@ -1104,7 +1104,7 @@ $ some_application | some_filter | php | sort -u > final_output.txt
    (<emphasis role="strong">not</emphasis> the number of arguments passed to the
    script).
   </para>
-  
+
   <para>
    As long as the arguments to be passed to the script do not start with
    the <literal>-</literal> character, there's nothing special to watch out for.
@@ -1114,7 +1114,7 @@ $ some_application | some_filter | php | sort -u > final_output.txt
    list separator <literal>--</literal>. After this separator has been parsed by
    PHP, every following argument is passed untouched to the script.
   </para>
-  
+
   <informalexample>
    <screen>
 <![CDATA[
@@ -1134,7 +1134,7 @@ array(2) {
 ]]>
    </screen>
   </informalexample>
-  
+
   <para>
    However, on Unix systems there's another way of using PHP for shell
    scripting: make the first line of the script start with
@@ -1144,7 +1144,7 @@ array(2) {
    the file are set appropriately (e.g. <command>chmod +x test</command>),
    the script can be executed like any other shell or perl script:
   </para>
-  
+
   <example>
    <title>Execute PHP script as shell script</title>
    <programlisting role="php">
@@ -1176,12 +1176,12 @@ array(4) {
 ]]>
    </screen>
   </example>
-  
+
   <para>
    As can be seen, in this case no special care needs to be taken when passing parameters
    starting with <literal>-</literal>.
   </para>
-  
+
   <para>
    The PHP executable can be used to run PHP scripts absolutely independent of
    the web server. On Unix systems, the special <literal>#!</literal> (or
@@ -1194,7 +1194,7 @@ array(4) {
    platform programs can be written by including it. A simple example of
    writing a command line PHP program is shown below.
   </para>
-  
+
   <para>
    <example>
     <title>Script intended to be run from command line (script.php)</title>
@@ -1224,13 +1224,13 @@ This is a command line PHP script with one option.
     </programlisting>
    </example>
   </para>
-  
+
   <para>
    The script above includes the Unix shebang first line to indicate that this
    file should be run by PHP. We are working with a &cli; version here, so
    no <acronym>HTTP</acronym> headers will be output.
   </para>
-  
+
   <para>
    The program first checks that there is the required one argument (in
    addition to the script name, which is also counted). If not, or if the
@@ -1240,14 +1240,14 @@ This is a command line PHP script with one option.
    typed on the command line. Otherwise, the argument is echoed out exactly as
    received.
   </para>
-  
+
   <para>
    To run the above script on Unix, it must be made
    executable, and called simply as <command>script.php echothis</command> or
    <command>script.php -h</command>. On Windows, a batch file similar to the
    following can be created for this task:
   </para>
-  
+
   <para>
    <example>
     <title>Batch file to run a command line PHP script (script.bat)</title>
@@ -1259,20 +1259,20 @@ This is a command line PHP script with one option.
     </programlisting>
    </example>
   </para>
-  
+
   <para>
    Assuming the above program is named <filename>script.php</filename>, and the
    &cli; <filename>php.exe</filename> is in <filename>C:\php\php.exe</filename>,
    this batch file will run it, passing on all appended options:
    <command>script.bat echothis</command> or <command>script.bat -h</command>.
   </para>
-  
+
   <para>
    See also the <link linkend="ref.readline">Readline</link> extension
    documentation for more functions which can be used to enhance command line
    applications in PHP.
   </para>
-  
+
   <para>
    On Windows, PHP can be configured to run without the need to
    supply the <filename>C:\php\php.exe</filename> or the <literal>.php</literal>
@@ -1289,17 +1289,17 @@ This is a command line PHP script with one option.
   </note>
  </section>
  <!--}}}-->
- 
+
  <!--I/O Streams: {{{-->
  <section xml:id="features.commandline.io-streams">
   <title>Input/output streams</title>
   <titleabbrev>I/O streams</titleabbrev>
-  
+
   <para>
    The &cli.sapi; defines a few constants for I/O streams to make programming
    for the command line a bit easier.
   </para>
-  
+
   <para>
    <table>
     <title>CLI specific Constants</title>
@@ -1369,7 +1369,7 @@ $stderr = fopen('php://stderr', 'w');
     </tgroup>
    </table>
   </para>
-  
+
   <para>
    Given the above, you don't need to open e.g. a stream for
    <literal>stderr</literal> yourself but simply use the constant instead of
@@ -1382,7 +1382,7 @@ php -r 'fwrite(STDERR, "stderr\n");'
    You do not need to explicitly close these streams, as they are closed
    automatically by PHP when your script ends.
   </para>
-  
+
   <note>
    <para>
     These constants are not available if reading the PHP script from
@@ -1444,7 +1444,7 @@ php >
    <programlisting role="shell">
 <![CDATA[
 php > strp[TAB][TAB]
-strpbrk   strpos    strptime  
+strpbrk   strpos    strptime
 php > strp
 ]]>
    </programlisting>
@@ -1497,8 +1497,8 @@ php > $foo[TAB]ThisIsAReallyLongVariableName
    </simpara>
    <programlisting role="shell">
 <![CDATA[
-php > #cli.prompt=hello world :> 
-hello world :> 
+php > #cli.prompt=hello world :>
+hello world :>
 ]]>
    </programlisting>
    <simpara>
@@ -1506,11 +1506,11 @@ hello world :>
    </simpara>
    <programlisting role="shell">
 <![CDATA[
-php > #cli.prompt=`echo date('H:i:s');` php > 
+php > #cli.prompt=`echo date('H:i:s');` php >
 15:49:35 php > echo 'hi';
 hi
 15:49:43 php > sleep(2);
-15:49:45 php > 
+15:49:45 php >
 ]]>
    </programlisting>
    <simpara>
@@ -1521,7 +1521,7 @@ hi
 php > #cli.pager=less
 php > phpinfo();
 (output displayed in less)
-php > 
+php >
 ]]>
    </programlisting>
   </example>
@@ -1735,7 +1735,7 @@ php >
 
 
   <example>
-   <title>Starting the web server</title> 
+   <title>Starting the web server</title>
    <programlisting role="shell">
 <![CDATA[
 $ cd ~/public_html
@@ -1778,7 +1778,7 @@ Press Ctrl-C to quit.
   </example>
 
   <example>
-   <title>Starting with a specific document root directory</title> 
+   <title>Starting with a specific document root directory</title>
    <programlisting role="shell">
 <![CDATA[
 $ cd ~/public_html
@@ -1799,7 +1799,7 @@ Press Ctrl-C to quit
   </example>
 
   <example>
-   <title>Using a Router Script</title> 
+   <title>Using a Router Script</title>
 <para>
   In this example, requests for images will display them, but requests for HTML files will display "Welcome to PHP":
 </para>
@@ -1809,7 +1809,7 @@ Press Ctrl-C to quit
 // router.php
 if (preg_match('/\.(?:png|jpg|jpeg|gif)$/', $_SERVER["REQUEST_URI"])) {
     return false;    // serve the requested resource as-is.
-} else { 
+} else {
     echo "<p>Welcome to PHP</p>";
 }
 ?>]]>
@@ -1822,7 +1822,7 @@ $ php -S localhost:8000 router.php
   </example>
 
   <example>
-   <title>Checking for CLI Web Server Use</title> 
+   <title>Checking for CLI Web Server Use</title>
 <para>
   To reuse a framework router script during development with the CLI web server and later also with a production web server:
 </para>
@@ -1844,7 +1844,7 @@ $ php -S localhost:8000 router.php
   </example>
 
   <example>
-   <title>Handling Unsupported File Types</title> 
+   <title>Handling Unsupported File Types</title>
 <para>
   If you need to serve a static resource whose MIME type is not handled by the CLI web server, use:
 </para>
@@ -1870,7 +1870,7 @@ $ php -S localhost:8000 router.php
   </example>
 
   <example>
-   <title>Accessing the CLI Web Server From Remote Machines</title> 
+   <title>Accessing the CLI Web Server From Remote Machines</title>
    <para>
     You can make the web server accessible on port 8000 to any interface with:
    </para>
@@ -1907,16 +1907,16 @@ $ php -S 0.0.0.0:8000
        <row>
         <entry><link linkend="ini.cli-server.color">cli_server.color</link></entry>
         <entry>"0"</entry>
-        <entry>PHP_INI_ALL</entry>
+        <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
       </tbody>
      </tgroup>
     </table>
    </para>
-   
+
    &ini.descriptions.title;
-   
+
    <para>
     <variablelist>
      <varlistentry xml:id="ini.cli-server.color">
@@ -1926,7 +1926,7 @@ $ php -S 0.0.0.0:8000
       </term>
       <listitem>
        <para>
-        Enable the built-in development web server to use ANSI color coding 
+        Enable the built-in development web server to use ANSI color coding
         in terminal output.
        </para>
       </listitem>
@@ -1934,7 +1934,7 @@ $ php -S 0.0.0.0:8000
     </variablelist>
    </para>
   </section>
-  
+
 </chapter>
 
 <!-- Keep this comment at the end of the file

--- a/install/ini.xml
+++ b/install/ini.xml
@@ -2,10 +2,10 @@
 <!-- $Revision$ -->
 <chapter xml:id="configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Runtime Configuration</title>
- 
+
  <sect1 xml:id="configuration.file">
   <title>The configuration file</title>
-  
+
   <simpara>
    The configuration file (&php.ini;)
    is read when PHP starts up. For the server module versions of PHP,
@@ -146,7 +146,7 @@ include_path = ".;c:\php\lib"
    <para>
     It is possible to configure PHP to scan for .ini files in a directory
     after reading &php.ini;. This can be done at compile time by setting the
-    <option role="configure">--with-config-file-scan-dir</option> option. 
+    <option role="configure">--with-config-file-scan-dir</option> option.
     The scan directory can then be overridden at run time
     by setting the <varname>PHP_INI_SCAN_DIR</varname> environment variable.
    </para>
@@ -194,10 +194,10 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
    </informalexample>
   </sect2>
  </sect1>
- 
+
  <sect1 xml:id="configuration.file.per-user">
   <title>.user.ini files</title>
-  
+
   <simpara>
    PHP includes support for configuration INI files on a
    per-directory basis. These files are processed <emphasis>only</emphasis> by
@@ -205,7 +205,7 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
    extension. If you are running PHP as Apache module, use &htaccess; files for the same
    effect.
   </simpara>
-  
+
   <simpara>
    In addition to the main &php.ini; file, PHP scans for INI files in each
    directory, starting with the directory of the requested PHP file, and
@@ -215,33 +215,33 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
   </simpara>
   <simpara>
    Only INI settings with the
-   modes <constant>PHP_INI_PERDIR</constant> and
-   <constant>PHP_INI_USER</constant> will be recognized in .user.ini-style INI
+   modes <constant>INI_PERDIR</constant> and
+   <constant>INI_USER</constant> will be recognized in .user.ini-style INI
    files.
   </simpara>
-  
+
   <simpara>
    Two new INI directives,
    <link linkend="ini.user-ini.filename">user_ini.filename</link> and
    <link linkend="ini.user-ini.cache-ttl">user_ini.cache_ttl</link>
    control the use of user INI files.
   </simpara>
-  
+
   <simpara>
    <link linkend="ini.user-ini.filename">user_ini.filename</link> sets the name of the file PHP looks for
    in each directory; if set to an empty string, PHP doesn't scan at all. The
    default is <literal>.user.ini</literal>.
   </simpara>
-  
+
   <simpara>
    <link linkend="ini.user-ini.cache-ttl">user_ini.cache_ttl</link> controls how often user INI files are
    re-read. The default is 300 seconds (5 minutes).
   </simpara>
  </sect1>
- 
+
  <sect1 xml:id="configuration.changes.modes">
   <title>Where a configuration setting may be set</title>
-  
+
   <para>
    These modes determine when and where a PHP directive may or may not
    be set, and each directive within the manual refers to one of these
@@ -249,20 +249,20 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
    using <function>ini_set</function>, whereas others may require
    &php.ini; or &httpd.conf;.
   </para>
-  
+
   <para>
    For example, the
    <link linkend="ini.output-buffering">output_buffering</link> setting
-   is <literal>PHP_INI_PERDIR</literal> therefore it may not be set using
+   is <constant>INI_PERDIR</constant> therefore it may not be set using
    <function>ini_set</function>. However, the
    <link linkend="ini.display-errors">display_errors</link> directive is
-   <literal>PHP_INI_ALL</literal> therefore it may be set anywhere,
+   <constant>INI_ALL</constant> therefore it may be set anywhere,
    including with <function>ini_set</function>.
   </para>
-  
+
   <para>
    <table>
-    <title>Definition of PHP_INI_* modes</title>
+    <title>Definition of INI_* modes</title>
     <tgroup cols="2">
      <thead>
       <row>
@@ -272,7 +272,7 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
      </thead>
      <tbody>
       <row>
-       <entry><literal>PHP_INI_USER</literal></entry>
+       <entry><constant>INI_USER</constant></entry>
        <entry>
         Entry can be set in user scripts (like with <function>ini_set</function>)
         or in the <link linkend="configuration.changes.windows">Windows registry</link>.
@@ -280,17 +280,17 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
        </entry>
       </row>
       <row>
-       <entry><literal>PHP_INI_PERDIR</literal></entry>
+       <entry><constant>INI_PERDIR</constant></entry>
        <entry>
         Entry can be set in &php.ini;, &htaccess;, &httpd.conf; or &user-ini;
        </entry>
       </row>
       <row>
-       <entry><literal>PHP_INI_SYSTEM</literal></entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry>Entry can be set in &php.ini; or &httpd.conf;</entry>
       </row>
       <row>
-       <entry><literal>PHP_INI_ALL</literal></entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry>Entry can be set anywhere</entry>
       </row>
      </tbody>
@@ -298,10 +298,10 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
    </table>
   </para>
  </sect1>
- 
+
  <sect1 xml:id="configuration.changes">
   <title>How to change configuration settings</title>
-  
+
   <sect2 xml:id="configuration.changes.apache">
    <title>Running PHP as an Apache module</title>
    <simpara>
@@ -310,16 +310,16 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
     files (e.g. &httpd.conf;) and &htaccess; files. You will need
     "AllowOverride Options" or "AllowOverride All" privileges to do so.
    </simpara>
-   
+
    <para>
     There are several Apache directives that allow you
     to change the PHP configuration from within the Apache configuration
     files.  For a listing of which directives are
-    <constant>PHP_INI_ALL</constant>, <constant>PHP_INI_PERDIR</constant>,
-    or <constant>PHP_INI_SYSTEM</constant>, have a look at the
+    <constant>INI_ALL</constant>, <constant>INI_PERDIR</constant>,
+    or <constant>INI_SYSTEM</constant>, have a look at the
     <link linkend="ini.list">List of php.ini directives</link> appendix.
    </para>
-   
+
    <para>
     <variablelist>
      <varlistentry>
@@ -331,7 +331,7 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
       <listitem>
        <para>
         Sets the value of the specified directive.
-        Can be used only with <constant>PHP_INI_ALL</constant> and <constant>PHP_INI_PERDIR</constant> type directives.
+        Can be used only with <constant>INI_ALL</constant> and <constant>INI_PERDIR</constant> type directives.
         To clear a previously set value use <literal>none</literal> as the value.
        </para>
        <note>
@@ -351,8 +351,8 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
       <listitem>
        <para>
         Used to set a boolean configuration directive.
-        Can be used only with <constant>PHP_INI_ALL</constant> and
-        <constant>PHP_INI_PERDIR</constant> type directives.
+        Can be used only with <constant>INI_ALL</constant> and
+        <constant>INI_PERDIR</constant> type directives.
        </para>
       </listitem>
      </varlistentry>
@@ -418,7 +418,7 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
     </para>
    </caution>
   </sect2>
-  
+
   <sect2 xml:id="configuration.changes.windows">
    <title>Changing PHP configuration via the Windows registry</title>
    <simpara>
@@ -435,12 +435,12 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
     should have the name of the PHP configuration directive and the
     string value. PHP constants in the values are not parsed.
     However, only configuration values changeable in
-    <constant>PHP_INI_USER</constant> can be set
-    this way, <constant>PHP_INI_PERDIR</constant> values can not,
+    <constant>INI_USER</constant> can be set
+    this way, <constant>INI_PERDIR</constant> values can not,
     because these configuration values are re-read for each request.
    </simpara>
   </sect2>
-  
+
   <sect2 xml:id="configuration.changes.other">
    <title>Other interfaces to PHP</title>
    <para>
@@ -458,7 +458,7 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
    </para>
   </sect2>
  </sect1>
- 
+
 </chapter>
 
 <!-- Keep this comment at the end of the file

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1886,7 +1886,7 @@ The behaviour of these functions is affected by settings in &php.ini;.
 </simpara>'>
 
 <!ENTITY ini.php.constants 'For further details and definitions of the
-PHP_INI_* modes, see the <xref xmlns="http://docbook.org/ns/docbook" linkend="configuration.changes.modes"/>.'>
+INI_* modes, see the <xref xmlns="http://docbook.org/ns/docbook" linkend="configuration.changes.modes"/>.'>
 
 <!-- Used in reference/$extname/constants.xml -->
 <!ENTITY extension.constants '<simpara xmlns="http://docbook.org/ns/docbook">

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -408,8 +408,8 @@ echo \Foo\Bar\FOO; // resolves to constant Foo\Bar\FOO
   <para>
    Note that to access any global
    class, function or constant, a fully qualified name can be used, such as
-   <function>\strlen</function> or <classname>\Exception</classname> or
-   <literal>\INI_ALL</literal>.
+   \<function>strlen</function> or \<classname>Exception</classname> or
+   \<constant>INI_ALL</constant>.
    <example>
     <title>Accessing global classes, functions and constants from within a namespace</title>
     <programlisting role="php">

--- a/reference/apache/ini.xml
+++ b/reference/apache/ini.xml
@@ -28,25 +28,25 @@
      <row>
       <entry><link linkend="ini.engine">engine</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.child-terminate">child_terminate</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.last-modified">last_modified</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.xbithack">xbithack</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
     </tbody>
@@ -54,9 +54,9 @@
   </table>
   &ini.php.constants;
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
    <varlistentry xml:id="ini.engine">
@@ -83,7 +83,7 @@
     </term>
     <listitem>
      <para>
-      Specify whether PHP scripts may request child process termination on end of request, 
+      Specify whether PHP scripts may request child process termination on end of request,
       see also <function>apache_child_terminate</function>.
      </para>
     </listitem>

--- a/reference/apcu/ini.xml
+++ b/reference/apcu/ini.xml
@@ -8,7 +8,7 @@
   users should consider tuning the following parameters.
  </para>
  <para>
-  There is one decision to be made configuring APCu.  
+  There is one decision to be made configuring APCu.
   How much memory is going to be allocated to APCu.
   The ini directive that controls this is <literal>apc.shm_size</literal>
   Read the sections on this carefully below.
@@ -16,7 +16,7 @@
  <para>
   Once the server is running, the <literal>apc.php</literal> script that
   is bundled with the extension should be copied somewhere into the docroot and
-  viewed with a browser as it provides a detailed analysis of the internal 
+  viewed with a browser as it provides a detailed analysis of the internal
   workings of APCu. If GD is enabled in PHP, it will even display some
   interesting graphs.</para>
   <para>
@@ -37,11 +37,11 @@
   to minimize this number is to allocate more memory for APCu.
  </para>
  <para>
-  When APCu is compiled with mmap support (Memory Mapping), it will use only one 
-  memory segment, unlike when APCu is built with SHM (SysV Shared Memory) support 
-  that uses multiple memory segments. MMAP does not have a maximum limit like SHM 
-  does in <literal>/proc/sys/kernel/shmmax</literal>. In general MMAP support is 
-  recommended because it will reclaim the memory faster when the webserver is 
+  When APCu is compiled with mmap support (Memory Mapping), it will use only one
+  memory segment, unlike when APCu is built with SHM (SysV Shared Memory) support
+  that uses multiple memory segments. MMAP does not have a maximum limit like SHM
+  does in <literal>/proc/sys/kernel/shmmax</literal>. In general MMAP support is
+  recommended because it will reclaim the memory faster when the webserver is
   restarted and all in all reduces memory allocation impact at startup.
  </para>
  <para>
@@ -60,79 +60,79 @@
      <row>
       <entry><link linkend="ini.apcu.enabled">apc.enabled</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.shm-segments">apc.shm_segments</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.shm-size">apc.shm_size</link></entry>
       <entry>"32M"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.entries-hint">apc.entries_hint</link></entry>
       <entry>"4096"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.ttl">apc.ttl</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.gc-ttl">apc.gc_ttl</link></entry>
       <entry>"3600"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.mmap-file-mask">apc.mmap_file_mask</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.slam-defense">apc.slam_defense</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.enable-cli">apc.enable_cli</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.use-request-time">apc.use_request_time</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Prior to APCu 5.1.19, the default was "1".</entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.serializer">apc.serializer</link></entry>
       <entry>"php"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Prior to APCu 5.1.15, the default was "default".</entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.coredump-unmap">apc.coredump_unmap</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.preload-path">apc.preload_path</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
     </tbody>
@@ -140,9 +140,9 @@
   </table>
   &ini.php.constants;
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
    <varlistentry xml:id="ini.apcu.enabled">
@@ -169,7 +169,7 @@
      <para>
       The number of shared memory segments to allocate
       for the compiler cache. If APC is running out of
-      shared memory but <literal>apc.shm_size</literal> 
+      shared memory but <literal>apc.shm_size</literal>
       is set as high as the system allows, raising
       this value might prevent APC from exhausting its memory.
      </para>
@@ -297,7 +297,7 @@
       able to enable APC for the CLI version of PHP easily.
      </para>
     </listitem>
-   </varlistentry> 
+   </varlistentry>
    <varlistentry xml:id="ini.apcu.serializer">
     <term>
      <parameter>apc.serializer</parameter>
@@ -320,7 +320,7 @@
       core files when signaled. When these signals are received,
       APC will attempt to unmap the shared memory segment in order
       to exclude it from the core file. This setting may improve
-      system stability when fatal signals are received and a large 
+      system stability when fatal signals are received and a large
       APC shared memory segment is configured.
      </para>
      <warning>
@@ -333,7 +333,7 @@
      <note>
       <para>
        Although some kernels may provide a facility to ignore various
-       types of shared memory when generating a core dump file, these 
+       types of shared memory when generating a core dump file, these
        implementations may also ignore important shared memory segments
        such as the Apache scoreboard.
       </para>
@@ -347,7 +347,7 @@
     </term>
     <listitem>
      <para>
-      Optionally, set a path to the directory that APC will load 
+      Optionally, set a path to the directory that APC will load
       cache data at startup.
      </para>
     </listitem>

--- a/reference/bc/ini.xml
+++ b/reference/bc/ini.xml
@@ -19,7 +19,7 @@
     <row>
      <entry><link linkend="ini.bcmath.scale">bcmath.scale</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     </tbody>
@@ -27,9 +27,9 @@
   </table>
   &ini.php.constants;
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
    <varlistentry xml:id="ini.bcmath.scale">
@@ -44,7 +44,7 @@
      </para>
     </listitem>
    </varlistentry>
-   
+
   </variablelist>
  </para>
 </section>

--- a/reference/com/ini.xml
+++ b/reference/com/ini.xml
@@ -19,43 +19,43 @@
     <row>
      <entry><link linkend="ini.com.allow-dcom">com.allow_dcom</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_SYSTEM</entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.com.autoregister-typelib">com.autoregister_typelib</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.com.autoregister-verbose">com.autoregister_verbose</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.com.autoregister-casesensitive">com.autoregister_casesensitive</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.com.code-page">com.code_page</link></entry>
      <entry>""</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.com.dotnet-version">com.dotnet_version</link></entry>
      <entry>""</entry>
-     <entry>PHP_INI_SYSTEM</entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry>As of PHP 8.0.0</entry>
     </row>
     <row>
      <entry><link linkend="ini.com.typelib-file">com.typelib_file</link></entry>
      <entry>""</entry>
-     <entry>PHP_INI_SYSTEM</entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry></entry>
     </row>
    </tbody>
@@ -80,7 +80,7 @@
     </para>
     </listitem>
    </varlistentry>
-   
+
    <varlistentry xml:id="ini.com.autoregister-typelib">
     <term>
      <parameter>com.autoregister_typelib</parameter>
@@ -178,10 +178,10 @@
     </para>
     </listitem>
    </varlistentry>
-  
+
   </variablelist>
  </para>
- 
+
 </section>
 
 <!-- Keep this comment at the end of the file

--- a/reference/curl/ini.xml
+++ b/reference/curl/ini.xml
@@ -19,7 +19,7 @@
      <row>
       <entry><link linkend="ini.curl.cainfo">curl.cainfo</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
     </tbody>

--- a/reference/datetime/ini.xml
+++ b/reference/datetime/ini.xml
@@ -19,31 +19,31 @@
      <row>
       <entry><link linkend="ini.date.default-latitude">date.default_latitude</link></entry>
       <entry>"31.7667"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.date.default-longitude">date.default_longitude</link></entry>
       <entry>"35.2333"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.date.sunrise-zenith">date.sunrise_zenith</link></entry>
       <entry>"90.833333"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Prior to PHP 8.0.0, the default was "90.583333"</entry>
      </row>
      <row>
       <entry><link linkend="ini.date.sunset-zenith">date.sunset_zenith</link></entry>
       <entry>"90.833333"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Prior to PHP 8.0.0, the default was "90.583333"</entry>
      </row>
      <row>
       <entry><link linkend="ini.date.timezone">date.timezone</link></entry>
       <entry>"UTC"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>From PHP 8.2, a warning is emitted when setting this to an invalid
       value or an empty string.</entry>
      </row>

--- a/reference/dba/setup.xml
+++ b/reference/dba/setup.xml
@@ -3,7 +3,7 @@
 
 <chapter xml:id="dba.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
- 
+
  <!-- {{{ Requirements -->
  <section xml:id="dba.requirements">
   &reftitle.required;
@@ -33,7 +33,7 @@
         handle the original dbm format.
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>ndbm</literal></entry>
        <entry>
@@ -42,7 +42,7 @@
         deprecated).
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>gdbm</literal></entry>
        <entry>
@@ -50,7 +50,7 @@
         manager</link>.
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>db2</literal></entry>
        <entry>
@@ -60,7 +60,7 @@
         standalone and client/server applications."
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>db3</literal></entry>
        <entry>
@@ -68,7 +68,7 @@
         3</link>.
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>db4</literal></entry>
        <entry>
@@ -77,7 +77,7 @@
         be used with BDB 5 as of PHP 5.3.3.
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>cdb</literal></entry>
        <entry>
@@ -88,39 +88,39 @@
         We support writing (not updating) through the internal cdb library.
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>cdb_make</literal></entry>
        <entry>
-        We support creation (not updating) of cdb files 
+        We support creation (not updating) of cdb files
         when the bundled cdb library is used.
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>flatfile</literal></entry>
        <entry>
         This is available for compatibility with the deprecated
-        <literal>dbm</literal> extension only and should be avoided. 
+        <literal>dbm</literal> extension only and should be avoided.
         However you may use this where files were created in this format. That
         happens when configure could not find any external library.
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>inifile</literal></entry>
        <entry>
-        This is available to be able to modify php.ini files 
-        from within PHP scripts. When working with ini files you can pass arrays 
-        of the form array(0=>group,1=>value_name) or strings of the form 
-        "[group]value_name" where group is optional. As the functions 
+        This is available to be able to modify php.ini files
+        from within PHP scripts. When working with ini files you can pass arrays
+        of the form array(0=>group,1=>value_name) or strings of the form
+        "[group]value_name" where group is optional. As the functions
         <function>dba_firstkey</function> and <function>dba_nextkey</function>
         return string representations of the key there is the function
         <function>dba_key_split</function> which allows
         to convert the string keys into array keys without loosing &false;.
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>qdbm</literal></entry>
        <entry>
@@ -132,7 +132,7 @@
       <row>
        <entry><literal>tcadb</literal></entry>
        <entry>
-        The Tokyo Cabinet library can be 
+        The Tokyo Cabinet library can be
         downloaded from <link xlink:href="&url.tcadb;"/>.
        </entry>
       </row>
@@ -140,11 +140,11 @@
       <row>
        <entry><literal>lmdb</literal></entry>
        <entry>
-        This is available since PHP 7.2.0. The Lightning Memory-Mapped Database library 
+        This is available since PHP 7.2.0. The Lightning Memory-Mapped Database library
         can be downloaded from <link xlink:href="&url.lmdb;"/>.
        </entry>
       </row>
-      
+
      </tbody>
     </tgroup>
    </table>
@@ -158,11 +158,11 @@
   </para>
  </section>
  <!-- }}} -->
- 
+
  <!-- {{{ Installation -->
  &reference.dba.configure;
  <!-- }}} -->
- 
+
  <!-- {{{ Configuration -->
  <section xml:id="dba.configuration">
   &reftitle.runtime;
@@ -185,16 +185,16 @@
         <link linkend="ini.dba.default_handler">dba.default_handler</link>
        </entry>
        <entry>DBA_DEFAULT</entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry><!-- leave empty, this will be filled by an automatic script --></entry>
       </row>
      </tbody>
     </tgroup>
    </table>
   </para>
-  
+
   &ini.descriptions.title;
-  
+
   <para>
    <variablelist>
     <varlistentry xml:id="ini.dba.default_handler">
@@ -208,12 +208,12 @@
       </para>
      </listitem>
     </varlistentry>
-    
+
    </variablelist>
   </para>
  </section>
  <!-- }}} -->
- 
+
  <!-- {{{ Resources -->
  <section xml:id="dba.resources">
   &reftitle.resources;
@@ -224,7 +224,7 @@
   </para>
  </section>
  <!-- }}} -->
- 
+
 </chapter>
 
 <!-- Keep this comment at the end of the file

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -19,19 +19,19 @@
     <row>
      <entry><link linkend="ini.error-reporting">error_reporting</link></entry>
      <entry>NULL</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.display-errors">display_errors</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.display-startup-errors">display_startup_errors</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>
        Prior to PHP 8.0.0, the default value was <literal>"0"</literal>.
      </entry>
@@ -39,109 +39,109 @@
     <row>
      <entry><link linkend="ini.log-errors">log_errors</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.log-errors-max-len">log_errors_max_len</link></entry>
      <entry>"1024"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>Had no effect as of PHP 8.0.0, removed as of PHP 8.1.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.ignore-repeated-errors">ignore_repeated_errors</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.ignore-repeated-source">ignore_repeated_source</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.report-memleaks">report_memleaks</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.track-errors">track_errors</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>Deprecated as of PHP 7.2.0, removed as of PHP 8.0.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.html-errors">html_errors</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.xmlrpc-errors">xmlrpc_errors</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_SYSTEM</entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.xmlrpc-error-number">xmlrpc_error_number</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.docref-root">docref_root</link></entry>
      <entry>""</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.docref-ext">docref_ext</link></entry>
      <entry>""</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.error-prepend-string">error_prepend_string</link></entry>
      <entry>NULL</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.error-append-string">error_append_string</link></entry>
      <entry>NULL</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.error-log">error_log</link></entry>
      <entry>NULL</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.error-log-mode">error_log_mode</link></entry>
      <entry>0o644</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>Available as of PHP 8.2.0</entry>
     </row>
     <row>
      <entry><link linkend="ini.syslog.facility">syslog.facility</link></entry>
      <entry>"LOG_USER"</entry>
-     <entry>PHP_INI_SYSTEM</entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry>Available as of PHP 7.3.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.syslog.filter">syslog.filter</link></entry>
      <entry>"no-ctrl"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>Available as of PHP 7.3.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.syslog.ident">syslog.ident</link></entry>
      <entry>"php"</entry>
-     <entry>PHP_INI_SYSTEM</entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry>Available as of PHP 7.3.0.</entry>
     </row>
     </tbody>
@@ -186,7 +186,7 @@
       <title>PHP Constants outside of PHP</title>
       <para>
        Using PHP Constants outside of PHP, like in <filename>httpd.conf</filename>,
-       will have no useful meaning so in such cases the <type>int</type> values 
+       will have no useful meaning so in such cases the <type>int</type> values
        are required. And since error levels will be added over time, the maximum
        value (for <constant>E_ALL</constant>) will likely change. So in place of
        <constant>E_ALL</constant> consider using a larger value to cover all bit
@@ -214,7 +214,7 @@
      </para>
      <note>
       <para>
-      This is a feature to support your development and should never be used 
+      This is a feature to support your development and should never be used
       on production systems (e.g. systems connected to the internet).
       </para>
      </note>
@@ -396,14 +396,14 @@
     </term>
     <listitem>
      <para>
-      The new error format contains a reference to a page describing the error or 
-      function causing the error. In case of manual pages you can download the 
+      The new error format contains a reference to a page describing the error or
+      function causing the error. In case of manual pages you can download the
       manual in your language and set this ini directive to the URL of your local
       copy. If your local copy of the manual can be reached by <literal>"/manual/"</literal>
-      you can simply use <userinput>docref_root=/manual/</userinput>. Additional you have 
-      to set docref_ext to match the fileextensions of your copy 
-      <userinput>docref_ext=.html</userinput>. It is possible to use external 
-      references. For example you can use 
+      you can simply use <userinput>docref_root=/manual/</userinput>. Additional you have
+      to set docref_ext to match the fileextensions of your copy
+      <userinput>docref_ext=.html</userinput>. It is possible to use external
+      references. For example you can use
       <userinput>docref_root=http://manual/en/</userinput> or
       <userinput>docref_root="http://landonize.it/?how=url&amp;theme=classic&amp;filter=Landon
       &amp;url=http%3A%2F%2Fwww.php.net%2F"</userinput>
@@ -414,8 +414,8 @@
      </para>
      <note>
       <para>
-       This is a feature to support your development since it makes it easy to 
-       lookup a function description. However it should never be used on 
+       This is a feature to support your development since it makes it easy to
+       lookup a function description. However it should never be used on
        production systems (e.g. systems connected to the internet).
       </para>
      </note>
@@ -480,7 +480,7 @@
       are sent to the system logger instead. On Unix, this means
       syslog(3) and on Windows it means the event log. See also:
       <function>syslog</function>.
-      If this directive is not set, errors are sent to the SAPI error logger. 
+      If this directive is not set, errors are sent to the SAPI error logger.
       For example, it is an error log in Apache or <literal>stderr</literal>
       in CLI.
       See also <function>error_log</function>.
@@ -523,25 +523,25 @@
      <para>
       Specifies the filter type to filter the logged messages. Allowed
       characters are passed unmodified; all others are written in their
-      hexadecimal representation prefixed with <literal>\x</literal>. 
+      hexadecimal representation prefixed with <literal>\x</literal>.
       <itemizedlist>
        <listitem>
-        <simpara><literal>all</literal> – the logged string will be split 
+        <simpara><literal>all</literal> – the logged string will be split
          at newline characters, and all characters are passed unaltered
         </simpara>
        </listitem>
        <listitem>
-        <simpara><literal>ascii</literal> – the logged string will be split 
+        <simpara><literal>ascii</literal> – the logged string will be split
          at newline characters, and any non-printable 7-bit ASCII characters will be escaped
         </simpara>
        </listitem>
        <listitem>
-        <simpara><literal>no-ctrl</literal> – the logged string will be split 
+        <simpara><literal>no-ctrl</literal> – the logged string will be split
          at newline characters, and any non-printable characters will be escaped
         </simpara>
        </listitem>
        <listitem>
-        <simpara><literal>raw</literal> – all characters are passed to the system 
+        <simpara><literal>raw</literal> – all characters are passed to the system
          logger unaltered, without splitting at newlines (identical to PHP before 7.3)
         </simpara>
        </listitem>

--- a/reference/exif/ini.xml
+++ b/reference/exif/ini.xml
@@ -4,7 +4,7 @@
  &reftitle.runtime;
  &extension.runtime;
  <para>
-  Exif supports automatically conversion for Unicode and JIS 
+  Exif supports automatically conversion for Unicode and JIS
   character encodings of user comments when module
   <link linkend="ref.mbstring">mbstring</link>
   is available. This is done by first decoding the comment
@@ -26,37 +26,37 @@
     <row>
      <entry><link linkend="ini.exif.encode-unicode">exif.encode_unicode</link></entry>
      <entry>"ISO-8859-15"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.exif.decode-unicode-motorola">exif.decode_unicode_motorola</link></entry>
      <entry>"UCS-2BE"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.exif.decode-unicode-intel">exif.decode_unicode_intel</link></entry>
      <entry>"UCS-2LE"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.exif.encode-jis">exif.encode_jis</link></entry>
      <entry>""</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.exif.decode-jis-motorola">exif.decode_jis_motorola</link></entry>
      <entry>"JIS"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.exif.decode-jis-intel">exif.decode_jis_intel</link></entry>
      <entry>"JIS"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     </tbody>
@@ -64,9 +64,9 @@
   </table>
   &ini.php.constants;
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
    <varlistentry xml:id="ini.exif.encode-unicode">
@@ -76,7 +76,7 @@
     </term>
     <listitem>
     <para>
-     <literal>exif.encode_unicode</literal> defines the 
+     <literal>exif.encode_unicode</literal> defines the
      characterset UNICODE user comments are handled.
      This defaults to ISO-8859-15 which should work for
      most non Asian countries. The setting can be empty
@@ -93,8 +93,8 @@
     </term>
     <listitem>
      <para>
-      <literal>exif.decode_unicode_motorola</literal> defines 
-      the image internal characterset for Unicode encoded user 
+      <literal>exif.decode_unicode_motorola</literal> defines
+      the image internal characterset for Unicode encoded user
       comments if image is in motorola byte order (big-endian).
       This setting cannot be empty but you can specify a list
       of encodings supported by mbstring. The default is UCS-2BE.
@@ -108,8 +108,8 @@
     </term>
     <listitem>
      <para>
-      <literal>exif.decode_unicode_intel</literal> defines 
-      the image internal characterset for Unicode encoded user 
+      <literal>exif.decode_unicode_intel</literal> defines
+      the image internal characterset for Unicode encoded user
       comments if image is in intel byte order (little-endian).
       This setting cannot be empty but you can specify a list
       of encodings supported by mbstring. The default is UCS-2LE.
@@ -123,9 +123,9 @@
     </term>
     <listitem>
      <para>
-      <literal>exif.encode_jis</literal> defines the 
+      <literal>exif.encode_jis</literal> defines the
       characterset JIS user comments are handled.
-      This defaults to an empty value which forces 
+      This defaults to an empty value which forces
       the functions to use the current internal encoding
       of mbstring.
      </para>
@@ -138,8 +138,8 @@
     </term>
     <listitem>
      <para>
-      <literal>exif.decode_jis_motorola</literal> defines 
-      the image internal characterset for JIS encoded user 
+      <literal>exif.decode_jis_motorola</literal> defines
+      the image internal characterset for JIS encoded user
       comments if image is in motorola byte order (big-endian).
       This setting cannot be empty but you can specify a list
       of encodings supported by mbstring. The default is JIS.
@@ -153,8 +153,8 @@
     </term>
     <listitem>
      <para>
-      <literal>exif.decode_jis_intel</literal> defines 
-      the image internal characterset for JIS encoded user 
+      <literal>exif.decode_jis_intel</literal> defines
+      the image internal characterset for JIS encoded user
       comments if image is in intel byte order (little-endian).
       This setting cannot be empty but you can specify a list
       of encodings supported by mbstring. The default is JIS.

--- a/reference/expect/ini.xml
+++ b/reference/expect/ini.xml
@@ -21,25 +21,25 @@
      <row>
       <entry><link linkend="ini.expect.timeout">expect.timeout</link></entry>
       <entry>"10"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.expect.loguser">expect.loguser</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.expect.logfile">expect.logfile</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.expect.match-max">expect.match_max</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
     </tbody>
@@ -47,9 +47,9 @@
   </table>
   &ini.php.constants;
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
    <varlistentry xml:id="ini.expect.timeout">

--- a/reference/ffi/setup.xml
+++ b/reference/ffi/setup.xml
@@ -35,13 +35,13 @@
       <row>
        <entry><link linkend="ini.ffi.enable">ffi.enable</link></entry>
        <entry>"preload"</entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
       <row>
        <entry><link linkend="ini.ffi.preload">ffi.preload</link></entry>
        <entry>""</entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
      </tbody>

--- a/reference/filesystem/ini.xml
+++ b/reference/filesystem/ini.xml
@@ -19,52 +19,52 @@
      <row>
       <entry><link linkend="ini.allow-url-fopen">allow_url_fopen</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.allow-url-include">allow_url_include</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Deprecated as of PHP 7.4.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.user-agent">user_agent</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.default-socket-timeout">default_socket_timeout</link></entry>
       <entry>"60"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
     </row>
      <row>
       <entry><link linkend="ini.from">from</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.auto-detect-line-endings">auto_detect_line_endings</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Deprecated as of PHP 8.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.sys-temp-dir">sys_temp_dir</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
     </tbody>
    </tgroup>
   </table>
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
    <varlistentry xml:id="ini.allow-url-fopen">
@@ -74,12 +74,12 @@
     </term>
     <listitem>
      <para>
-      This option enables the URL-aware fopen wrappers that enable 
-      accessing URL object like files. Default wrappers are provided for 
+      This option enables the URL-aware fopen wrappers that enable
+      accessing URL object like files. Default wrappers are provided for
       the access of <link linkend="features.remote-files">remote files</link>
       using the ftp or http protocol, some extensions like
       <link linkend="ref.zlib">zlib</link> may register additional
-      wrappers. 
+      wrappers.
      </para>
     </listitem>
    </varlistentry>
@@ -91,13 +91,13 @@
     </term>
     <listitem>
      <para>
-      This option allows the use of URL-aware fopen wrappers with the following 
-      functions: <function>include</function>, <function>include_once</function>, 
+      This option allows the use of URL-aware fopen wrappers with the following
+      functions: <function>include</function>, <function>include_once</function>,
       <function>require</function>, <function>require_once</function>.
      </para>
      <note>
       <para>
-       This setting requires allow_url_fopen to be on. 
+       This setting requires allow_url_fopen to be on.
       </para>
      </note>
     </listitem>
@@ -161,7 +161,7 @@
      </para>
     </listitem>
    </varlistentry>
-   
+
    <varlistentry xml:id="ini.sys-temp-dir">
     <term>
      <parameter>sys_temp_dir</parameter>

--- a/reference/filter/ini.xml
+++ b/reference/filter/ini.xml
@@ -19,13 +19,13 @@
      <row>
       <entry><link linkend="ini.filter.default">filter.default</link></entry>
       <entry>"unsafe_raw"</entry>
-      <entry>PHP_INI_PERDIR</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
       <entry>Deprecated as of PHP 8.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.filter.default-flags">filter.default_flags</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_PERDIR</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
       <entry></entry>
      </row>
     </tbody>
@@ -57,7 +57,7 @@
     </para>
     <note>
       <para>
-        Be careful about the default flags for the default filters. You should explicitly 
+        Be careful about the default flags for the default filters. You should explicitly
         set them to the value you want. For example, to configure the default filter to
         behave exactly like <function>htmlspecialchars</function> you need to set them
         default flags to 0 as shown below.
@@ -76,7 +76,7 @@ filter.default_flags = 0
    </note>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.filter.default-flags">
    <term>
     <parameter>filter.default_flags</parameter>
@@ -84,14 +84,14 @@ filter.default_flags = 0
    </term>
    <listitem>
     <para>
-     Default flags to apply when the default filter is set. This is set to 
+     Default flags to apply when the default filter is set. This is set to
      <constant>FILTER_FLAG_NO_ENCODE_QUOTES</constant> by default for backwards
      compatibility reasons.  See the <link linkend="filter.filters.flags">flag list</link>
      for the list of all the flag names.
     </para>
    </listitem>
   </varlistentry>
-  
+
  </variablelist>
  </para>
 </section>

--- a/reference/geoip/ini.xml
+++ b/reference/geoip/ini.xml
@@ -20,7 +20,7 @@
           <row>
             <entry><link linkend="ini.geoip.custom-directory">geoip.custom_directory</link></entry>
             <entry>""</entry>
-            <entry>PHP_INI_ALL</entry>
+            <entry><constant>INI_ALL</constant></entry>
             <entry><!-- leave empty, this will be filled by an automatic script --></entry>
           </row>
         </tbody>

--- a/reference/ibase/ini.xml
+++ b/reference/ibase/ini.xml
@@ -19,61 +19,61 @@
     <row>
      <entry><link linkend="ini.ibase.allow-persistent">ibase.allow_persistent</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_SYSTEM</entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.ibase.max-persistent">ibase.max_persistent</link></entry>
      <entry>"-1"</entry>
-     <entry>PHP_INI_SYSTEM</entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.ibase.max-links">ibase.max_links</link></entry>
      <entry>"-1"</entry>
-     <entry>PHP_INI_SYSTEM</entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.ibase.default-db">ibase.default_db</link></entry>
      <entry>NULL</entry>
-     <entry>PHP_INI_SYSTEM</entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.ibase.default-user">ibase.default_user</link></entry>
      <entry>NULL</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.ibase.default-password">ibase.default_password</link></entry>
      <entry>NULL</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.ibase.default-charset">ibase.default_charset</link></entry>
      <entry>NULL</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.ibase.timestampformat">ibase.timestampformat</link></entry>
      <entry>"%Y-%m-%d %H:%M:%S"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.ibase.dateformat">ibase.dateformat</link></entry>
      <entry>"%Y-%m-%d"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.ibase.timeformat">ibase.timeformat</link></entry>
      <entry>"%H:%M:%S"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
    </tbody>
@@ -99,7 +99,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.ibase.max-persistent">
    <term>
     <parameter>ibase.max_persistent</parameter>
@@ -113,7 +113,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.ibase.max-links">
    <term>
     <parameter>ibase.max_links</parameter>
@@ -151,7 +151,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.ibase.default-password">
    <term>
     <parameter>ibase.default_password</parameter>
@@ -176,9 +176,9 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <!-- Date and time directives -->
-  
+
   <varlistentry xml:id="ini.ibase.timestampformat">
    <term>
     <parameter>ibase.timestampformat</parameter>
@@ -208,11 +208,11 @@
     <para>
     These directives are used to set the date and time formats
     that are used when returning dates and times from a result set,
-    or when binding arguments to date and time parameters. 
+    or when binding arguments to date and time parameters.
     </para>
    </listitem>
   </varlistentry>
- 
+
  </variablelist>
  </para>
 </section>

--- a/reference/ibm_db2/ini.xml
+++ b/reference/ibm_db2/ini.xml
@@ -19,91 +19,91 @@
      <row>
       <entry><link linkend="ini.ibm-db2.binmode">ibm_db2.binmode</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-all-pconnect">ibm_db2.i5_all_pconnect</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of ibm_db2 1.6.5.</entry>
-     </row>     
+     </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-allow-commit">ibm_db2.i5_allow_commit</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of ibm_db2 1.4.9.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-blank-userid">ibm_db2.i5_blank_userid</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of ibm_db2 1.9.7.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-char-trim">ibm_db2.i5_char_trim</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of ibm_db2 2.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-dbcs-alloc">ibm_db2.i5_dbcs_alloc</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of ibm_db2 1.5.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-guard-profile">ibm_db2.i5_guard_profile</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of ibm_db2 1.9.7.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-ignore-userid">ibm_db2.i5_ignore_userid</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of ibm_db2 1.8.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-job-sort">ibm_db2.i5_job_sort</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of ibm_db2 1.8.4.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-log-verbose">ibm_db2.i5_log_verbose</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of ibm_db2 1.9.7.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-max-pconnect">ibm_db2.i5_max_pconnect</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of ibm_db2 1.9.7.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-override-ccsid">ibm_db2.i5_override_ccsid</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of ibm_db2 1.9.7.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-servermode-subsystem">ibm_db2.i5_servermode_subsystem</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of ibm_db2 1.9.7.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.i5-sys-naming">ibm_db2.i5_sys_naming</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of ibm_db2 1.9.7.</entry>
      </row>
      <row>
       <entry><link linkend="ini.ibm-db2.instance-name">ibm_db2.instance_name</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of ibm_db2 1.0.2.</entry>
      </row>
     </tbody>
@@ -111,9 +111,9 @@
   </table>
 
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
    <varlistentry xml:id="ini.ibm-db2.binmode">
@@ -173,7 +173,7 @@
       </itemizedlist>
      </para>
     </listitem>
-   </varlistentry>   
+   </varlistentry>
    <varlistentry xml:id="ini.ibm-db2.i5-allow-commit">
     <term>
      <parameter>ibm_db2.i5_allow_commit</parameter>
@@ -190,7 +190,7 @@
       <itemizedlist>
        <listitem>
         <para>
-         0 - commitment control is not used 
+         0 - commitment control is not used
         </para>
        </listitem>
        <listitem>

--- a/reference/iconv/ini.xml
+++ b/reference/iconv/ini.xml
@@ -20,19 +20,19 @@
      <row>
       <entry><link linkend="ini.iconv.input-encoding">iconv.input_encoding</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Deprecated in PHP 5.6.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.iconv.output-encoding">iconv.output_encoding</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Deprecated in PHP 5.6.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.iconv.internal-encoding">iconv.internal_encoding</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Deprecated in PHP 5.6.0.</entry>
      </row>
    </tbody>

--- a/reference/igbinary/ini.xml
+++ b/reference/igbinary/ini.xml
@@ -18,7 +18,7 @@
      <row>
       <entry><link linkend="ini.igbinary.compact-strings">igbinary.compact_strings</link></entry>
       <entry>1</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
     </tbody>
@@ -39,7 +39,7 @@
      <row>
       <entry><link linkend="ini.igbinary.save-handler">session.save_handler</link></entry>
       <entry>"files"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
     </tbody>

--- a/reference/image/ini.xml
+++ b/reference/image/ini.xml
@@ -19,7 +19,7 @@
      <row>
       <entry><link linkend="ini.gd.jpeg-ignore-warning">gd.jpeg_ignore_warning</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
     </tbody>
@@ -70,7 +70,7 @@
   See also the <link linkend="exif.configuration">exif</link> configuration
   directives.
  </para>
- 
+
  <warning>
   <para>
    Image functions are very memory intensive. Be sure to set <link

--- a/reference/imagick/ini.xml
+++ b/reference/imagick/ini.xml
@@ -19,29 +19,29 @@
      <row>
       <entry><link linkend="ini.imagick.locale-fix">imagick.locale_fix</link></entry>
       <entry>&false;</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available since Imagick 2.1.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.imagick.progress-monitor">imagick.progress_monitor</link></entry>
       <entry>&false;</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available since Imagick 2.2.2</entry>
      </row>
      <row>
       <entry><link linkend="ini.imagick.skip-version-check">imagick.skip_version_check</link></entry>
       <entry>&false;</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available since Imagick 3.3.0</entry>
-     </row>     
+     </row>
     </tbody>
    </tgroup>
   </table>
   &ini.php.constants;
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
    <varlistentry xml:id="ini.imagick.locale-fix">
@@ -79,7 +79,7 @@
      <para>
       When Imagick is loaded, it checks the version number of ImageMagick that it was compiled against, with the version number that is currently being used and will give a warning if they don't match. This warning can be suppressed by enabling this ini setting.
      </para>
-     <para>Using a version of Imagick that was compiled against a different version of ImageMagick than the one being used is not recommended. Although it may appear to work, it can lead to random crashes or other undefined behaviour. 
+     <para>Using a version of Imagick that was compiled against a different version of ImageMagick than the one being used is not recommended. Although it may appear to work, it can lead to random crashes or other undefined behaviour.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/imap/ini.xml
+++ b/reference/imap/ini.xml
@@ -21,7 +21,7 @@
      <row>
       <entry><link linkend="ini.imap.enable-insecure-rsh">imap.enable_insecure_rsh</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 7.1.25, 7.2.13 and 7.3.0. Formerly, it was implicitly enabled.</entry>
      </row>
     </tbody>
@@ -31,9 +31,9 @@
   &ini.php.constants;
 
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
 

--- a/reference/info/ini.xml
+++ b/reference/info/ini.xml
@@ -19,7 +19,7 @@
     <row>
      <entry><link linkend="ini.assert.active">assert.active</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>
       Deprecated as of PHP 8.3.0
      </entry>
@@ -27,7 +27,7 @@
     <row>
      <entry><link linkend="ini.assert.bail">assert.bail</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>
       Deprecated as of PHP 8.3.0
      </entry>
@@ -35,7 +35,7 @@
     <row>
      <entry><link linkend="ini.assert.warning">assert.warning</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>
       Deprecated as of PHP 8.3.0
      </entry>
@@ -43,7 +43,7 @@
     <row>
      <entry><link linkend="ini.assert.callback">assert.callback</link></entry>
      <entry>NULL</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>
       Deprecated as of PHP 8.3.0
      </entry>
@@ -51,13 +51,13 @@
     <row>
      <entry><link linkend="ini.assert.quiet-eval">assert.quiet_eval</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>Removed as of PHP 8.0.0</entry>
     </row>
     <row>
      <entry><link linkend="ini.assert.exception">assert.exception</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>
       Prior to PHP 8.0.0, defaults to <literal>"0"</literal>.
       Deprecated as of PHP 8.3.0
@@ -66,37 +66,37 @@
     <row>
      <entry><link linkend="ini.enable-dl">enable_dl</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_SYSTEM</entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry>&removed.php.future;</entry>
     </row>
     <row>
      <entry><link linkend="ini.max-execution-time">max_execution_time</link></entry>
      <entry>"30"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.max-input-time">max_input_time</link></entry>
      <entry>"-1"</entry>
-     <entry>PHP_INI_PERDIR</entry>
+     <entry><constant>INI_PERDIR</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.max-input-nesting-level">max_input_nesting_level</link></entry>
      <entry>"64"</entry>
-     <entry>PHP_INI_PERDIR</entry>
+     <entry><constant>INI_PERDIR</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.max-input-vars">max_input_vars</link></entry>
      <entry>1000</entry>
-     <entry>PHP_INI_PERDIR</entry>
+     <entry><constant>INI_PERDIR</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.zend.enable-gc">zend.enable_gc</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     </tbody>
@@ -104,9 +104,9 @@
   </table>
   &ini.php.constants;
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
    <varlistentry xml:id="ini.assert.active">
@@ -234,10 +234,10 @@
       details.
      </para>
      <para>
-      Your web server can have other timeout configurations that may 
-      also interrupt PHP execution. Apache has a 
-      <literal>Timeout</literal> directive and IIS has a CGI timeout 
-      function. Both default to 300 seconds. See your web server 
+      Your web server can have other timeout configurations that may
+      also interrupt PHP execution. Apache has a
+      <literal>Timeout</literal> directive and IIS has a CGI timeout
+      function. Both default to 300 seconds. See your web server
       documentation for specific details.
      </para>
     </listitem>
@@ -253,7 +253,7 @@
       This sets the maximum time in seconds a script is allowed to
       parse input data, like POST and GET. Timing begins at the moment PHP
       is invoked at the server and ends when execution begins.
-      The default setting is <literal>-1</literal>, which means that 
+      The default setting is <literal>-1</literal>, which means that
       <link linkend="ini.max-execution-time">max_execution_time</link>
       is used instead. Set to <literal>0</literal> to allow unlimited time.
      </para>
@@ -282,8 +282,8 @@
     <listitem>
      <para>
       How many <link linkend="language.variables.external">input
-      variables</link> may be accepted (limit is applied to 
-      $_GET, $_POST and $_COOKIE superglobal separately). Use of this directive 
+      variables</link> may be accepted (limit is applied to
+      $_GET, $_POST and $_COOKIE superglobal separately). Use of this directive
       mitigates the possibility of denial of service attacks which use hash collisions.
       If there are more input variables than specified by this directive,
       an <constant>E_WARNING</constant> is issued, and further input

--- a/reference/intl/ini.xml
+++ b/reference/intl/ini.xml
@@ -21,19 +21,19 @@
      <row>
       <entry><link linkend="ini.intl.default-locale">intl.default_locale</link></entry>
       <entry></entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.intl.error-level">intl.error_level</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.intl.use-exceptions">intl.use_exceptions</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available since PECL 3.0.0a1</entry>
      </row>
     </tbody>

--- a/reference/ldap/ini.xml
+++ b/reference/ldap/ini.xml
@@ -19,7 +19,7 @@
     <row>
      <entry><link linkend="ini.ldap.max_links">ldap.max_links</link></entry>
      <entry>"-1"</entry>
-     <entry>PHP_INI_SYSTEM</entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry></entry>
     </row>
    </tbody>
@@ -27,9 +27,9 @@
  </table>
  &ini.php.constants;
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
    <varlistentry xml:id="ini.ldap.max_links">

--- a/reference/mail/ini.xml
+++ b/reference/mail/ini.xml
@@ -19,43 +19,43 @@
     <row>
      <entry><link linkend="ini.mail.add-x-header">mail.add_x_header</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_PERDIR</entry>
+     <entry><constant>INI_PERDIR</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.mail.log">mail.log</link></entry>
      <entry>NULL</entry>
-     <entry>PHP_INI_SYSTEM|PHP_INI_PERDIR</entry>
+     <entry><constant>INI_SYSTEM</constant>|<constant>INI_PERDIR</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.mail.force_extra_parameters">mail.force_extra_parameters</link></entry>
      <entry>NULL</entry>
-     <entry>PHP_INI_SYSTEM|PHP_INI_PERDIR</entry>
+     <entry><constant>INI_SYSTEM</constant>|<constant>INI_PERDIR</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.smtp">SMTP</link></entry>
      <entry>"localhost"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.smtp-port">smtp_port</link></entry>
      <entry>"25"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.sendmail-from">sendmail_from</link></entry>
      <entry>NULL</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.sendmail-path">sendmail_path</link></entry>
      <entry>"/usr/sbin/sendmail -t -i"</entry>
-     <entry>PHP_INI_SYSTEM</entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry></entry>
     </row>
    </tbody>
@@ -63,9 +63,9 @@
  </table>
  &ini.php.constants;
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
  <variablelist>
   <varlistentry xml:id="ini.mail.add-x-header">

--- a/reference/mailparse/setup.xml
+++ b/reference/mailparse/setup.xml
@@ -35,7 +35,7 @@
       <row>
        <entry><link linkend="ini.mailparse.def_charset">mailparse.def_charset</link></entry>
        <entry>"us-ascii"</entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
      </tbody>

--- a/reference/mbstring/ini.xml
+++ b/reference/mbstring/ini.xml
@@ -19,43 +19,43 @@
      <row>
       <entry><link linkend="ini.mbstring.language">mbstring.language</link></entry>
       <entry>"neutral"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mbstring.detect-order">mbstring.detect_order</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mbstring.http-input">mbstring.http_input</link></entry>
       <entry>"pass"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Deprecated</entry>
      </row>
      <row>
       <entry><link linkend="ini.mbstring.http-output">mbstring.http_output</link></entry>
       <entry>"pass"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Deprecated</entry>
      </row>
      <row>
       <entry><link linkend="ini.mbstring.internal-encoding">mbstring.internal_encoding</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Deprecated</entry>
      </row>
      <row>
       <entry><link linkend="ini.mbstring.substitute-character">mbstring.substitute_character</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mbstring.func-overload">mbstring.func_overload</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>
        Deprecated as of PHP 7.2.0; removed as of PHP 8.0.0.
       </entry>
@@ -63,31 +63,31 @@
      <row>
       <entry><link linkend="ini.mbstring.encoding-translation">mbstring.encoding_translation</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_PERDIR</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mbstring.http-output-conv-mimetypes">mbstring.http_output_conv_mimetypes</link></entry>
       <entry>"^(text/|application/xhtml\+xml)"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mbstring.strict-detection">mbstring.strict_detection</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mbstring.regex-retry-limit">mbstring.regex_retry_limit</link></entry>
       <entry>"1000000"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 7.4.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.mbstring.regex-stack-limit">mbstring.regex_stack_limit</link></entry>
       <entry>"100000"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 7.3.5.</entry>
      </row>
     </tbody>
@@ -95,9 +95,9 @@
   </table>
   &ini.php.constants;
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
    <varlistentry xml:id="ini.mbstring.language">
@@ -123,7 +123,7 @@
      <para>
       Enables the transparent character encoding filter for the incoming HTTP queries,
       which performs detection and conversion of the input encoding to the
-      internal character encoding. 
+      internal character encoding.
      </para>
     </listitem>
    </varlistentry>
@@ -192,7 +192,7 @@
     <listitem>
      <para>
       Defines default character code detection order. See also
-      <function>mb_detect_order</function>. 
+      <function>mb_detect_order</function>.
      </para>
     </listitem>
    </varlistentry>
@@ -298,7 +298,7 @@
 <![CDATA[
 ; Set default language
 mbstring.language        = Neutral; Set default language to Neutral(UTF-8) (default)
-mbstring.language        = English; Set default language to English 
+mbstring.language        = English; Set default language to English
 mbstring.language        = Japanese; Set default language to Japanese
 
 ;; Set default internal encoding
@@ -310,13 +310,13 @@ mbstring.encoding_translation = On
 
 ;; Set default HTTP input character encoding
 ;; Note: Script cannot change http_input setting.
-mbstring.http_input           = pass    ; No conversion. 
+mbstring.http_input           = pass    ; No conversion.
 mbstring.http_input           = auto    ; Set HTTP input to auto
                                 ; "auto" is expanded according to mbstring.language
 mbstring.http_input           = SJIS    ; Set HTTP input to SJIS
 mbstring.http_input           = UTF-8,SJIS,EUC-JP ; Specify order
 
-;; Set default HTTP output character encoding 
+;; Set default HTTP output character encoding
 mbstring.http_output          = pass    ; No conversion
 mbstring.http_output          = UTF-8   ; Set HTTP output encoding to UTF-8
 
@@ -341,7 +341,7 @@ mbstring.substitute_character = long    ; Long Example: U+3000,JIS+7E7E
 output_buffering      = Off
 
 ;; Set HTTP header charset
-default_charset       = EUC-JP    
+default_charset       = EUC-JP
 
 ;; Set default language to Japanese
 mbstring.language = Japanese
@@ -350,16 +350,16 @@ mbstring.language = Japanese
 mbstring.encoding_translation = On
 
 ;; Set HTTP input encoding conversion to auto
-mbstring.http_input   = auto 
+mbstring.http_input   = auto
 
 ;; Convert HTTP output to EUC-JP
-mbstring.http_output  = EUC-JP    
+mbstring.http_output  = EUC-JP
 
 ;; Set internal encoding to EUC-JP
-mbstring.internal_encoding = EUC-JP    
+mbstring.internal_encoding = EUC-JP
 
 ;; Do not print invalid characters
-mbstring.substitute_character = none   
+mbstring.substitute_character = none
 ]]>
    </programlisting>
   </example>
@@ -382,16 +382,16 @@ default_charset      = Shift_JIS
 mbstring.language = Japanese
 
 ;; Set http input encoding conversion to auto
-mbstring.http_input  = auto 
+mbstring.http_input  = auto
 
 ;; Convert to SJIS
-mbstring.http_output = SJIS    
+mbstring.http_output = SJIS
 
 ;; Set internal encoding to EUC-JP
-mbstring.internal_encoding = EUC-JP    
+mbstring.internal_encoding = EUC-JP
 
 ;; Do not print invalid characters
-mbstring.substitute_character = none   
+mbstring.substitute_character = none
 ]]>
    </programlisting>
   </example>

--- a/reference/mcrypt/ini.xml
+++ b/reference/mcrypt/ini.xml
@@ -19,13 +19,13 @@
     <row>
      <entry><link linkend="ini.mcrypt.algorithms-dir">mcrypt.algorithms_dir</link></entry>
      <entry>&null;</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.mcrypt.modes-dir">mcrypt.modes_dir</link></entry>
      <entry>&null;</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
    </tbody>

--- a/reference/memcache/ini.xml
+++ b/reference/memcache/ini.xml
@@ -19,67 +19,67 @@
      <row>
       <entry><link linkend="ini.memcache.allow-failover">memcache.allow_failover</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available since memcache 2.0.2.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcache.max-failover-attempts">memcache.max_failover_attempts</link></entry>
       <entry>"20"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available since memcache 2.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcache.chunk-size">memcache.chunk_size</link></entry>
       <entry>"8192"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available since memcache 2.0.2.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcache.default-port">memcache.default_port</link></entry>
       <entry>"11211"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available since memcache 2.0.2.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcache.hash-strategy">memcache.hash_strategy</link></entry>
       <entry>"standard"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available since memcache 2.2.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcache.hash-function">memcache.hash_function</link></entry>
       <entry>"crc32"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available since memcache 2.2.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcache.protocol">memcache.protocol</link></entry>
       <entry>ascii</entry>
-      <entry>>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Supported since memcache 3.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcache.redundancy">memcache.redundancy</link></entry>
       <entry>1</entry>
-      <entry>>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Supported since memcache 3.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcache.session-redundancy">memcache.session_redundancy</link></entry>
       <entry>2</entry>
-      <entry>>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Supported since memcache 3.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcache.compress-threshold">memcache.compress_threshold</link></entry>
       <entry>20000</entry>
-      <entry>>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Supported since memcache 3.0.3</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcache.lock-timeout">memcache.lock_timeout</link></entry>
       <entry>15</entry>
-      <entry>>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Supported since memcache 3.0.4</entry>
      </row>
     </tbody>
@@ -100,13 +100,13 @@
      <row>
       <entry><link linkend="ini.memcache.save-handler">session.save_handler</link></entry>
       <entry>"files"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Supported since memcache 2.1.2</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcache.save-path">session.save_path</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Supported since memcache 2.1.2</entry>
      </row>
     </tbody>
@@ -119,7 +119,7 @@
 
 <para>
  <variablelist>
-  
+
   <varlistentry xml:id="ini.memcache.allow-failover">
    <term>
     <parameter>memcache.allow_failover</parameter>
@@ -127,12 +127,12 @@
    </term>
    <listitem>
     <para>
-     Whether to transparently failover to other servers on 
+     Whether to transparently failover to other servers on
      errors.
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.memcache.max-failover-attempts">
    <term>
     <parameter>memcache.max_failover_attempts</parameter>
@@ -145,7 +145,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.memcache.chunk-size">
    <term>
     <parameter>memcache.chunk_size</parameter>
@@ -154,13 +154,13 @@
    <listitem>
     <para>
      Data will be transferred in chunks of this size, setting
-     the value lower requires more network writes. Try 
-     increasing this value to 32768 if noticing otherwise 
+     the value lower requires more network writes. Try
+     increasing this value to 32768 if noticing otherwise
      inexplicable slowdowns.
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.memcache.default-port">
    <term>
     <parameter>memcache.default_port</parameter>
@@ -181,15 +181,15 @@
    </term>
    <listitem>
     <para>
-     Controls which strategy to use when mapping keys to servers. Set this value to 
-     <literal>consistent</literal> to enable consistent hashing which allows servers 
+     Controls which strategy to use when mapping keys to servers. Set this value to
+     <literal>consistent</literal> to enable consistent hashing which allows servers
      to be added or removed from the pool without causing keys to be remapped.
      Setting this value to <literal>standard</literal> results in the old strategy
      being used.
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.memcache.hash-function">
    <term>
     <parameter>memcache.hash_function</parameter>
@@ -197,7 +197,7 @@
    </term>
    <listitem>
     <para>
-     Controls which hash function to apply when mapping keys to servers, <literal>crc32</literal> 
+     Controls which hash function to apply when mapping keys to servers, <literal>crc32</literal>
      uses the standard CRC32 hash while <literal>fnv</literal> uses FNV-1a.
     </para>
    </listitem>
@@ -210,7 +210,7 @@
    </term>
    <listitem>
     <para>
-     
+
     </para>
    </listitem>
   </varlistentry>
@@ -222,7 +222,7 @@
    </term>
    <listitem>
     <para>
-     
+
     </para>
    </listitem>
   </varlistentry>
@@ -234,7 +234,7 @@
    </term>
    <listitem>
     <para>
-     
+
     </para>
    </listitem>
   </varlistentry>
@@ -246,7 +246,7 @@
    </term>
    <listitem>
     <para>
-     
+
     </para>
    </listitem>
   </varlistentry>
@@ -258,7 +258,7 @@
    </term>
    <listitem>
     <para>
-     
+
     </para>
    </listitem>
   </varlistentry>
@@ -286,8 +286,8 @@
      <literal>"tcp://host1:11211, tcp://host2:11211"</literal>.
     </para>
     <para>
-     Each url may contain parameters which are applied to that server, they are the same 
-     as for the <function>Memcache::addServer</function> method. For example 
+     Each url may contain parameters which are applied to that server, they are the same
+     as for the <function>Memcache::addServer</function> method. For example
      <literal>"tcp://host1:11211?persistent=1&amp;weight=1&amp;timeout=1&amp;retry_interval=15"</literal>
     </para>
    </listitem>

--- a/reference/memcached/ini.xml
+++ b/reference/memcached/ini.xml
@@ -20,175 +20,175 @@
      <row>
       <entry><link linkend="ini.memcached.sess-locking">memcached.sess_locking</link></entry>
       <entry>On</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 0.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-consistent-hash">memcached.sess_consistent_hash</link></entry>
       <entry>On</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 2.1.0. Default value is <literal>On</literal> as of memcached 3.0.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-binary">memcached.sess_binary</link></entry>
       <entry>Off</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 2.0.0. Replaced by <literal>memcached.sess_binary_protocol</literal> as of memcached 3.0.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-lock-wait">memcached.sess_lock_wait</link></entry>
       <entry>150000</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 0.1.0. Removed as of memcached 3.0.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-prefix">memcached.sess_prefix</link></entry>
       <entry>memc.sess.key.</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 0.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-number-of-replicas">memcached.sess_number_of_replicas</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 2.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-randomize-replica-read">memcached.sess_randomize_replica_read</link></entry>
       <entry>Off</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 2.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-remove-failed">memcached.sess_remove_failed</link></entry>
       <entry>On</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 2.1.0. Replaced by <literal>memcached.sess_remove_failed_servers</literal> as of memcached 3.0.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.compression-type">memcached.compression_type</link></entry>
       <entry>fastlz</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 0.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.compression-factor">memcached.compression_factor</link></entry>
       <entry>1.3</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 0.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.compression-threshold">memcached.compression_threshold</link></entry>
       <entry>2000</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 0.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.serializer">memcached.serializer</link></entry>
       <entry>igbinary</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 0.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.use-sasl">memcached.use_sasl</link></entry>
       <entry>Off</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 2.2.0. Removed as of memcached 3.0.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.default-binary-protocol">memcached.default_binary_protocol</link></entry>
       <entry>Off</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 3.0.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.default-connect-timeout">memcached.default_connect_timeout</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 3.0.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.default-consistent-hash">memcached.default_consistent_hash</link></entry>
       <entry>Off</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 3.0.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-binary-protocol">memcached.sess_binary_protocol</link></entry>
       <entry>On</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 3.0.0. Replace <literal>memcached.sess_binary</literal>.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-connect-timeout">memcached.sess_connect_timeout</link></entry>
        <entry>1000</entry>
-       <entry>PHP_INI_ALL</entry>
+       <entry><constant>INI_ALL</constant></entry>
        <entry>Available as of memcached 2.2.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-consistent-hash-type">memcached.sess_consistent_hash_type</link></entry>
       <entry>ketama</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 3.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-lock-expire">memcached.sess_lock_expire</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 2.2.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-lock-retries">memcached.sess_lock_retries</link></entry>
       <entry>5</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 3.0.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-lock-wait-max">memcached.sess_lock_wait_max</link></entry>
       <entry>150</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 3.0.0. Default value <literal>150</literal> as of memcached 3.1.0 (previously <literal>2000</literal>).</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-lock-wait-min">memcached.sess_lock_wait_min</link></entry>
       <entry>150</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 3.0.0. Default value <literal>150</literal> as of memcached 3.1.0 (previously <literal>1000</literal>).</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-persistent">memcached.sess_persistent</link></entry>
       <entry>Off</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 3.0.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-remove-failed-servers">memcached.sess_remove_failed_servers</link></entry>
       <entry>Off</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 3.0.0. Replace <literal>memcached.sess_remove_failed</literal>.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-server-failure-limit">memcached.sess_server_failure_limit</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 3.0.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-sasl-password">memcached.sess_sasl_password</link></entry>
       <entry>null</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 2.2.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.sess-sasl-username">memcached.sess_sasl_username</link></entry>
       <entry>null</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of memcached 2.2.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.memcached.store-retry-count">memcached.store_retry_count</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>
        Available as of memcached 2.2.0.
        Default value <literal>0</literal> as of memcached 3.2.0

--- a/reference/misc/ini.xml
+++ b/reference/misc/ini.xml
@@ -19,43 +19,43 @@
      <row>
       <entry><link linkend="ini.ignore-user-abort">ignore_user_abort</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.syntax-highlighting">highlight.string</link></entry>
       <entry>"#DD0000"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.syntax-highlighting">highlight.comment</link></entry>
       <entry>"#FF8000"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.syntax-highlighting">highlight.keyword</link></entry>
       <entry>"#007700"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.syntax-highlighting">highlight.default</link></entry>
       <entry>"#0000BB"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.syntax-highlighting">highlight.html</link></entry>
       <entry>"#000000"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.browscap">browscap</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
     </tbody>
@@ -63,9 +63,9 @@
   </table>
   &ini.php.constants;
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
 

--- a/reference/mongodb/ini.xml
+++ b/reference/mongodb/ini.xml
@@ -20,7 +20,7 @@
      <row>
       <entry><link linkend="ini.mongodb.debug">mongodb.debug</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
     </tbody>

--- a/reference/mysql/ini.xml
+++ b/reference/mysql/ini.xml
@@ -19,67 +19,67 @@
      <row>
       <entry><link linkend="ini.mysql.allow-local-infile">mysql.allow_local_infile</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysql.allow-persistent">mysql.allow_persistent</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysql.max-persistent">mysql.max_persistent</link></entry>
       <entry>"-1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysql.max-links">mysql.max_links</link></entry>
       <entry>"-1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysql.trace-mode">mysql.trace_mode</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysql.default-port">mysql.default_port</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysql.default-socket">mysql.default_socket</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysql.default-host">mysql.default_host</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysql.default-user">mysql.default_user</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysql.default-password">mysql.default_password</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysql.connect-timeout">mysql.connect_timeout</link></entry>
       <entry>"60"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
     </tbody>
@@ -92,7 +92,7 @@
 
 <para>
  <variablelist>
-  
+
   <varlistentry xml:id="ini.mysql.allow-local-infile">
    <term>
     <parameter>mysql.allow_local_infile</parameter>
@@ -119,7 +119,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.mysql.max-persistent">
    <term>
     <parameter>mysql.max_persistent</parameter>
@@ -132,7 +132,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.mysql.max-links">
    <term>
     <parameter>mysql.max_links</parameter>
@@ -145,7 +145,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.mysql.trace-mode">
    <term>
     <parameter>mysql.trace_mode</parameter>
@@ -153,8 +153,8 @@
    </term>
    <listitem>
     <para>
-     Trace mode. When <literal>mysql.trace_mode</literal> is enabled, warnings 
-     for table/index scans, non free result sets, and SQL-Errors will be 
+     Trace mode. When <literal>mysql.trace_mode</literal> is enabled, warnings
+     for table/index scans, non free result sets, and SQL-Errors will be
      displayed. (Introduced in PHP 4.3.0)
     </para>
    </listitem>
@@ -178,7 +178,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.mysql.default-socket">
    <term>
     <parameter>mysql.default_socket</parameter>
@@ -204,7 +204,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.mysql.default-user">
    <term>
     <parameter>mysql.default_user</parameter>
@@ -218,7 +218,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.mysql.default-password">
    <term>
     <parameter>mysql.default_password</parameter>
@@ -244,7 +244,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
  </variablelist>
  </para>
 </section>

--- a/reference/mysql_xdevapi/ini.xml
+++ b/reference/mysql_xdevapi/ini.xml
@@ -20,37 +20,37 @@
      <row>
       <entry><link linkend="ini.xmysqlnd.collect-memory-statistics">xmysqlnd.collect_memory_statistics</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.xmysqlnd.collect-statistics">xmysqlnd.collect_statistics</link></entry>
       <entry>1</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.xmysqlnd.debug">xmysqlnd.debug</link></entry>
       <entry></entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.xmysqlnd.mempool-default-size">xmysqlnd.mempool_default_size</link></entry>
       <entry>16000</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.xmysqlnd.net-read-timeout">xmysqlnd.net_read_timeout</link></entry>
       <entry>31536000</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.xmysqlnd.trace-alloc">xmysqlnd.trace_alloc</link></entry>
       <entry></entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
     </tbody>
@@ -69,7 +69,7 @@
      </term>
      <listitem>
       <para>
-       
+
       </para>
      </listitem>
     </varlistentry>
@@ -80,7 +80,7 @@
      </term>
      <listitem>
       <para>
-       
+
       </para>
      </listitem>
     </varlistentry>
@@ -91,7 +91,7 @@
      </term>
      <listitem>
       <para>
-       
+
       </para>
      </listitem>
     </varlistentry>
@@ -102,7 +102,7 @@
      </term>
      <listitem>
       <para>
-       
+
       </para>
      </listitem>
     </varlistentry>
@@ -113,7 +113,7 @@
      </term>
      <listitem>
       <para>
-       
+
       </para>
      </listitem>
     </varlistentry>
@@ -124,7 +124,7 @@
      </term>
      <listitem>
       <para>
-       
+
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mysqli/ini.xml
+++ b/reference/mysqli/ini.xml
@@ -19,73 +19,73 @@
      <row>
       <entry><link linkend="ini.mysqli.allow-local-infile">mysqli.allow_local_infile</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Before PHP 7.2.16 and 7.3.3 the default was "1".</entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqli.local-infile-directory">mysqli.local_infile_directory</link></entry>
       <entry></entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqli.allow-persistent">mysqli.allow_persistent</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqli.max-persistent">mysqli.max_persistent</link></entry>
       <entry>"-1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqli.max-links">mysqli.max_links</link></entry>
       <entry>"-1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqli.default-port">mysqli.default_port</link></entry>
       <entry>"3306"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqli.default-socket">mysqli.default_socket</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqli.default-host">mysqli.default_host</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqli.default-user">mysqli.default_user</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqli.default-pw">mysqli.default_pw</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqli.reconnect">mysqli.reconnect</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Removed as of PHP 8.2.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqli.rollback-on-cached-plink">mysqli.rollback_on_cached_plink</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
     </tbody>
@@ -93,7 +93,7 @@
   </table>
  </para>
  <para>
-  For further details and definitions of the preceding PHP_INI_* constants, see
+  For further details and definitions of the preceding INI_* constants, see
   the chapter on <link linkend="configuration.changes">configuration
   changes</link>.
  </para>
@@ -102,7 +102,7 @@
 
  <para>
  <variablelist>
-  
+
   <varlistentry xml:id="ini.mysqli.allow-local-infile">
    <term>
     <parameter>mysqli.allow_local_infile</parameter>
@@ -123,7 +123,7 @@
    </term>
    <listitem>
     <para>
-     Allows restricting LOCAL DATA loading to files located in this designated 
+     Allows restricting LOCAL DATA loading to files located in this designated
      directory.
     </para>
    </listitem>
@@ -136,7 +136,7 @@
    </term>
    <listitem>
     <para>
-     Enable the ability to create persistent connections using 
+     Enable the ability to create persistent connections using
      <function>mysqli_connect</function>.
     </para>
    </listitem>
@@ -148,7 +148,7 @@
    </term>
    <listitem>
     <para>
-     Maximum of persistent connections that can be made. Set to 
+     Maximum of persistent connections that can be made. Set to
      0 for unlimited.
     </para>
    </listitem>
@@ -182,7 +182,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.mysqli.default-socket">
    <term>
     <parameter>mysqli.default_socket</parameter>
@@ -207,7 +207,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.mysqli.default-user">
    <term>
     <parameter>mysqli.default_user</parameter>
@@ -220,7 +220,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.mysqli.default-pw">
    <term>
     <parameter>mysqli.default_pw</parameter>
@@ -233,7 +233,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.mysqli.reconnect">
    <term>
     <parameter>mysqli.reconnect</parameter>
@@ -265,14 +265,14 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
  </variablelist>
  </para>
  <para>
-   Users cannot set <literal>MYSQL_OPT_READ_TIMEOUT</literal> through an API 
+   Users cannot set <literal>MYSQL_OPT_READ_TIMEOUT</literal> through an API
    call or runtime configuration setting. Note that if it were possible there
-   would be differences between how <literal>libmysqlclient</literal> and 
-   streams would interpret the value of <literal>MYSQL_OPT_READ_TIMEOUT</literal>. 
+   would be differences between how <literal>libmysqlclient</literal> and
+   streams would interpret the value of <literal>MYSQL_OPT_READ_TIMEOUT</literal>.
  </para>
 </section>
 

--- a/reference/mysqlnd/config.xml
+++ b/reference/mysqlnd/config.xml
@@ -21,70 +21,70 @@
      <row>
       <entry><link linkend="ini.mysqlnd.collect-statistics">mysqlnd.collect_statistics</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqlnd.collect-memory-statistics">mysqlnd.collect_memory_statistics</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqlnd.debug">mysqlnd.debug</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqlnd.log-mask">mysqlnd.log_mask</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqlnd.mempool-default-size">mysqlnd.mempool_default_size</link></entry>
       <entry>16000</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqlnd.net-read-timeout">mysqlnd.net_read_timeout</link></entry>
       <entry>"86400"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>
        Before PHP 7.2.0 the default value was "31536000"
-       and the changeability was <constant>PHP_INI_SYSTEM</constant>
+       and the changeability was <constant>INI_SYSTEM</constant>
       </entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqlnd.net-cmd-buffer-size">mysqlnd.net_cmd_buffer_size</link></entry>
       <entry>"4096"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqlnd.net-read-buffer-size">mysqlnd.net_read_buffer_size</link></entry>
       <entry>"32768"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mysqlnd.sha256-server-public-key">mysqlnd.sha256_server_public_key</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_PERDIR</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
       <entry></entry>
      </row>
       <row>
        <entry><link linkend="ini.mysqlnd.trace-alloc">mysqlnd.trace_alloc</link></entry>
        <entry>""</entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
      <row>
       <entry><link linkend="ini.mysqlnd.fetch_data_copy">mysqlnd.fetch_data_copy</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Removed as of PHP 8.1.0</entry>
      </row>
     </tbody>

--- a/reference/oci8/ini.xml
+++ b/reference/oci8/ini.xml
@@ -19,61 +19,61 @@
         <row>
          <entry><link linkend="ini.oci8.connection-class">oci8.connection_class</link></entry>
          <entry>""</entry>
-         <entry>PHP_INI_ALL</entry>
+         <entry><constant>INI_ALL</constant></entry>
          <entry></entry>
         </row>
         <row>
          <entry><link linkend="ini.oci8.default-prefetch">oci8.default_prefetch</link></entry>
          <entry>"100"</entry>
-         <entry>PHP_INI_SYSTEM</entry>
+         <entry><constant>INI_SYSTEM</constant></entry>
          <entry></entry>
         </row>
         <row>
          <entry><link linkend="ini.oci8.events">oci8.events</link></entry>
          <entry>Off</entry>
-         <entry>PHP_INI_SYSTEM</entry>
+         <entry><constant>INI_SYSTEM</constant></entry>
          <entry></entry>
         </row>
         <row>
          <entry><link linkend="ini.oci8.max-persistent">oci8.max_persistent</link></entry>
          <entry>"-1"</entry>
-         <entry>PHP_INI_SYSTEM</entry>
+         <entry><constant>INI_SYSTEM</constant></entry>
          <entry></entry>
         </row>
         <row>
          <entry><link linkend="ini.oci8.old-oci-close-semantics">oci8.old_oci_close_semantics</link></entry>
          <entry>Off</entry>
-         <entry>PHP_INI_SYSTEM</entry>
+         <entry><constant>INI_SYSTEM</constant></entry>
          <entry>Deprecated as of PHP 8.1.0.</entry>
         </row>
         <row>
          <entry><link linkend="ini.oci8.persistent-timeout">oci8.persistent_timeout</link></entry>
          <entry>"-1"</entry>
-         <entry>PHP_INI_SYSTEM</entry>
+         <entry><constant>INI_SYSTEM</constant></entry>
          <entry></entry>
         </row>
         <row>
          <entry><link linkend="ini.oci8.ping-interval">oci8.ping_interval</link></entry>
          <entry>"60"</entry>
-         <entry>PHP_INI_SYSTEM</entry>
+         <entry><constant>INI_SYSTEM</constant></entry>
          <entry></entry>
         </row>
         <row>
          <entry><link linkend="ini.oci8.prefetch-lob-size">oci8.prefetch_lob_size</link></entry>
          <entry>"0"</entry>
-         <entry>PHP_INI_SYSTEM</entry>
+         <entry><constant>INI_SYSTEM</constant></entry>
          <entry>Available since PECL OCI8 3.2.</entry>
         </row>
         <row>
          <entry><link linkend="ini.oci8.privileged-connect">oci8.privileged_connect</link></entry>
          <entry>Off</entry>
-         <entry>PHP_INI_SYSTEM</entry>
+         <entry><constant>INI_SYSTEM</constant></entry>
          <entry></entry>
         </row>
         <row>
          <entry><link linkend="ini.oci8.statement-cache-size">oci8.statement_cache_size</link></entry>
          <entry>"20"</entry>
-         <entry>PHP_INI_SYSTEM</entry>
+         <entry><constant>INI_SYSTEM</constant></entry>
          <entry></entry>
         </row>
        </tbody>

--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -19,350 +19,350 @@
      <row>
       <entry><link linkend="ini.opcache.enable">opcache.enable</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.enable-cli">opcache.enable_cli</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Between PHP 7.1.2 and 7.1.6 inclusive, the default was "1"</entry>
      </row>
      <row>
       <entry><link
       linkend="ini.opcache.memory-consumption">opcache.memory_consumption</link></entry>
       <entry>"128"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.interned-strings-buffer">opcache.interned_strings_buffer</link></entry>
       <entry>"8"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.max-accelerated-files">opcache.max_accelerated_files</link></entry>
       <entry>"10000"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.max-wasted-percentage">opcache.max_wasted_percentage</link></entry>
       <entry>"5"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.use-cwd">opcache.use_cwd</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.validate-timestamps">opcache.validate_timestamps</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.revalidate-freq">opcache.revalidate_freq</link></entry>
       <entry>"2"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.revalidate-path">opcache.revalidate_path</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.save-comments">opcache.save_comments</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.fast-shutdown">opcache.fast_shutdown</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Removed in PHP 7.2.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.enable-file-override">opcache.enable_file_override</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.optimization-level">opcache.optimization_level</link></entry>
       <entry>"0x7FFEBFFF"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Changed from 0x7FFFBFFF in PHP 7.3.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.inherited-hack">opcache.inherited_hack</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Removed in PHP 7.3.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.dups-fix">opcache.dups_fix</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.blacklist-filename">opcache.blacklist_filename</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.max-file-size">opcache.max_file_size</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.consistency-checks">opcache.consistency_checks</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Disabled as of 8.1.18 and 8.2.5. Removed as of PHP 8.3.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.force-restart-timeout">opcache.force_restart_timeout</link></entry>
       <entry>"180"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.error-log">opcache.error_log</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.log-verbosity-level">opcache.log_verbosity_level</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.record-warnings">opcache.record_warnings</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.preferred-memory-model">opcache.preferred_memory_model</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.protect-memory">opcache.protect_memory</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.mmap-base">opcache.mmap_base</link></entry>
       <entry>&null;</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.restrict-api">opcache.restrict_api</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.file_update_protection">opcache.file_update_protection</link></entry>
       <entry>"2"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.huge_code_pages">opcache.huge_code_pages</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.lockfile_path">opcache.lockfile_path</link></entry>
       <entry>"/tmp"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.opt_debug_level">opcache.opt_debug_level</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 7.1.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.file-cache">opcache.file_cache</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.file-cache-only">opcache.file_cache_only</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.file-cache-consistency-checks">opcache.file_cache_consistency_checks</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.file-cache-fallback">opcache.file_cache_fallback</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Windows only.</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.validate-permission">opcache.validate_permission</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 7.0.14</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.validate-root">opcache.validate_root</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 7.0.14</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.preload">opcache.preload</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 7.4.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.preload-user">opcache.preload_user</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 7.4.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.cache-id">opcache.cache_id</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Windows only. Available as of PHP 7.4.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit">opcache.jit</link></entry>
       <entry>"tracing"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-buffer-size">opcache.jit_buffer_size</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-debug">opcache.jit_debug</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-bisect-limit">opcache.jit_bisect_limit</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-prof-threshold">opcache.jit_prof_threshold</link></entry>
       <entry>"0.005"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-max-root-traces">opcache.jit_max_root_traces</link></entry>
       <entry>"1024"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-max-side-traces">opcache.jit_max_side_traces</link></entry>
       <entry>"128"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-max-exit-counters">opcache.jit_max_exit_counters</link></entry>
       <entry>"8192"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-hot-loop">opcache.jit_hot_loop</link></entry>
       <entry>"64"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-hot-func">opcache.jit_hot_func</link></entry>
       <entry>"127"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-hot-return">opcache.jit_hot_return</link></entry>
       <entry>"8"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-hot-side-exit">opcache.jit_hot_side_exit</link></entry>
       <entry>"8"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-blacklist-root-trace">opcache.jit_blacklist_root_trace</link></entry>
       <entry>"16"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-blacklist-side-trace">opcache.jit_blacklist_side_trace</link></entry>
       <entry>"8"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-max-loop-unrolls">opcache.jit_max_loop_unrolls</link></entry>
       <entry>"8"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-max-recursive-calls">opcache.jit_max_recursive_calls</link></entry>
       <entry>"2"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-max-recursive-return">opcache.jit_max_recursive_returns</link></entry>
       <entry>"2"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-max-polymorphic-calls">opcache.jit_max_polymorphic_calls</link></entry>
       <entry>"2"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
     </tbody>
@@ -370,9 +370,9 @@
   </table>
   &ini.php.constants;
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
    <varlistentry xml:id="ini.opcache.enable">
@@ -382,7 +382,7 @@
     </term>
     <listitem>
      <para>
-      Enables the opcode cache. When disabled, code is not optimised or 
+      Enables the opcode cache. When disabled, code is not optimised or
       cached. The setting <literal>opcache.enable</literal> can not be
       enabled at runtime through <function>ini_set</function>, it can only
       be disabled. Trying to enable it in a script will generate a warning.
@@ -570,7 +570,7 @@
       <function>is_file</function> and <function>is_readable</function> are
       called. This may increase performance in applications that check the
       existence and readability of PHP scripts, but risks returning stale data
-      if 
+      if
       <link linkend="ini.opcache.validate-timestamps">opcache.validate_timestamps</link>
       is disabled.
      </para>
@@ -834,7 +834,7 @@
     <listitem>
      <para>
       Produces opcode dumps for debugging different stages of optimizations.
-      0x10000 will output opcodes as the compiler produced them before any optimization occurs 
+      0x10000 will output opcodes as the compiler produced them before any optimization occurs
       while 0x20000 will output optimized codes.
      </para>
     </listitem>
@@ -932,7 +932,7 @@
       Specifies a PHP script that is going to be compiled and executed at server start-up,
       and which may preload other files, either by <function>include</function>ing them or by
       using the <function>opcache_compile_file</function> function. All the entities (e.g.
-      functions and classes) defined in these files will be available to requests out of 
+      functions and classes) defined in these files will be available to requests out of
       the box, until the server is shut down.
      </para>
      <note>

--- a/reference/openssl/ini.xml
+++ b/reference/openssl/ini.xml
@@ -19,13 +19,13 @@
      <row>
       <entry>openssl.cafile</entry>
       <entry>""</entry>
-      <entry>PHP_INI_PERDIR</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry>openssl.capath</entry>
       <entry>""</entry>
-      <entry>PHP_INI_PERDIR</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
       <entry></entry>
      </row>
     </tbody>

--- a/reference/outcontrol/ini.xml
+++ b/reference/outcontrol/ini.xml
@@ -19,25 +19,25 @@
     <row>
      <entry><link linkend="ini.output-buffering">output_buffering</link></entry>
      <entry><literal>"0"</literal></entry>
-     <entry>PHP_INI_PERDIR</entry>
+     <entry><constant>INI_PERDIR</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.output-handler">output_handler</link></entry>
      <entry>&null;</entry>
-     <entry>PHP_INI_PERDIR</entry>
+     <entry><constant>INI_PERDIR</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.implicit-flush">implicit_flush</link></entry>
      <entry><literal>"0"</literal></entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.url-rewriter.tags">url_rewriter.tags</link></entry>
      <entry><literal>"form="</literal></entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>
       As of PHP 7.1.0, this INI setting only affects
       <function>output_add_rewrite_var</function>.
@@ -48,7 +48,7 @@
     <row>
      <entry><link linkend="ini.url-rewriter.hosts">url_rewriter.hosts</link></entry>
      <entry><literal>$_SERVER['HTTP_HOST']</literal> is used as default.</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>Available as of PHP 7.1.0</entry>
     </row>
     </tbody>

--- a/reference/pcre/ini.xml
+++ b/reference/pcre/ini.xml
@@ -19,19 +19,19 @@
      <row>
       <entry><link linkend="ini.pcre.backtrack-limit">pcre.backtrack_limit</link></entry>
       <entry>"1000000"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.pcre.recursion-limit">pcre.recursion_limit</link></entry>
       <entry>"100000"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.pcre.jit">pcre.jit</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
     </tbody>

--- a/reference/pdo/ini.xml
+++ b/reference/pdo/ini.xml
@@ -25,7 +25,7 @@
     </tbody>
    </tgroup>
   </table>
-  <!-- Uncomment after adding a constant with PHP_INI_* mode: &ini.php.constants; -->
+  <!-- Uncomment after adding a constant with INI_* mode: &ini.php.constants; -->
 </para>
 
 &ini.descriptions.title;
@@ -44,7 +44,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
  </variablelist>
  </para>
 </section>

--- a/reference/pdo_ibm/ini.xml
+++ b/reference/pdo_ibm/ini.xml
@@ -19,13 +19,13 @@
      <row>
       <entry><link linkend="ini.pdo-ibm.i5-dbcs-alloc">pdo_ibm.i5_dbcs_alloc</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Added in PDO_IBM 1.5.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.pdo-ibm.i5-override-ccsid">pdo_ibm.i5_override_ccsid</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Added in PDO_IBM 1.5.0</entry>
      </row>
     </tbody>

--- a/reference/pdo_mysql/ini.xml
+++ b/reference/pdo_mysql/ini.xml
@@ -18,12 +18,12 @@
      <row>
       <entry><link linkend="ini.pdo-mysql.default-socket">pdo_mysql.default_socket</link></entry>
       <entry>"/tmp/mysql.sock"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
      </row>
      <row>
       <entry><link linkend="ini.pdo-mysql.debug">pdo_mysql.debug</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
      </row>
     </tbody>
    </tgroup>
@@ -42,7 +42,7 @@
     </term>
     <listitem>
      <para>
-      Sets a Unix domain socket. This value can either be set at compile time if 
+      Sets a Unix domain socket. This value can either be set at compile time if
       a domain socket is found at configure. This ini setting is Unix only.
      </para>
     </listitem>
@@ -54,7 +54,7 @@
     </term>
     <listitem>
      <para>
-      Enables debugging for PDO_MYSQL. This setting is only available when PDO_MYSQL is 
+      Enables debugging for PDO_MYSQL. This setting is only available when PDO_MYSQL is
       compiled against mysqlnd and in PDO debug mode.
      </para>
     </listitem>

--- a/reference/pdo_odbc/ini.xml
+++ b/reference/pdo_odbc/ini.xml
@@ -19,13 +19,13 @@
      <row>
       <entry><link linkend="ini.pdo-odbc.connection-pooling">pdo_odbc.connection_pooling</link></entry>
       <entry>"strict"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.pdo-odbc.db2-instance-name">pdo_odbc.db2_instance_name</link></entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>&removed.php.future;</entry>
      </row>
     </tbody>
@@ -100,7 +100,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
  </variablelist>
  </para>
 </section>

--- a/reference/pgsql/ini.xml
+++ b/reference/pgsql/ini.xml
@@ -19,37 +19,37 @@
     <row>
      <entry><link linkend="ini.pgsql.allow-persistent">pgsql.allow_persistent</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_SYSTEM</entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.pgsql.max-persistent">pgsql.max_persistent</link></entry>
      <entry>"-1"</entry>
-     <entry>PHP_INI_SYSTEM</entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.pgsql.max-links">pgsql.max_links</link></entry>
      <entry>"-1"</entry>
-     <entry>PHP_INI_SYSTEM</entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.pgsql.auto-reset-persistent">pgsql.auto_reset_persistent</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_SYSTEM</entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.pgsql.ignore-notice">pgsql.ignore_notice</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.pgsql.log-notice">pgsql.log_notice</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
    </tbody>
@@ -57,12 +57,12 @@
  </table>
   &ini.php.constants;
   </para>
-  
+
   &ini.descriptions.title;
-  
+
   <para>
   <variablelist>
-   
+
    <varlistentry xml:id="ini.pgsql.allow-persistent">
     <term>
      <parameter>pgsql.allow_persistent</parameter>
@@ -74,7 +74,7 @@
      </para>
     </listitem>
    </varlistentry>
-   
+
    <varlistentry xml:id="ini.pgsql.max-persistent">
     <term>
      <parameter>pgsql.max_persistent</parameter>
@@ -87,7 +87,7 @@
      </para>
     </listitem>
    </varlistentry>
-   
+
    <varlistentry xml:id="ini.pgsql.max-links">
     <term>
      <parameter>pgsql.max_links</parameter>
@@ -100,7 +100,7 @@
      </para>
     </listitem>
    </varlistentry>
-   
+
    <varlistentry xml:id="ini.pgsql.auto-reset-persistent">
     <term>
      <parameter>pgsql.auto_reset_persistent</parameter>
@@ -109,7 +109,7 @@
     <listitem>
      <para>
       Detect broken persistent links with <function>pg_pconnect</function>.
-      Needs a little overhead. 
+      Needs a little overhead.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/phar/ini.xml
+++ b/reference/phar/ini.xml
@@ -19,28 +19,28 @@
      <row>
       <entry><link linkend="ini.phar.readonly">phar.readonly</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.phar.require-hash">phar.require_hash</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.phar.cache-list">phar.cache_list</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
     </tbody>
    </tgroup>
   </table>
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
    <varlistentry xml:id="ini.phar.readonly">

--- a/reference/phpdbg/ini.xml
+++ b/reference/phpdbg/ini.xml
@@ -20,7 +20,7 @@
      <row>
       <entry><link linkend="ini.phpdbg.eol">phpdbg.eol</link></entry>
       <entry>2</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Removed as of PHP 8.1.0</entry>
      </row>
      <row>
@@ -45,7 +45,7 @@
      </term>
      <listitem>
       <para>
-       The kind of line ending to use for output. For setting the value, one of 
+       The kind of line ending to use for output. For setting the value, one of
        the string aliases must be used.
        <informaltable>
         <tgroup cols="2">
@@ -90,7 +90,7 @@
      </term>
      <listitem>
       <para>
-       
+
       </para>
      </listitem>
     </varlistentry>

--- a/reference/readline/ini.xml
+++ b/reference/readline/ini.xml
@@ -20,13 +20,13 @@
      <row>
       <entry><link linkend="ini.cli.pager">cli.pager</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.cli.prompt">cli.prompt</link></entry>
       <entry>"\\b \\> "</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
     </tbody>

--- a/reference/runkit7/ini.xml
+++ b/reference/runkit7/ini.xml
@@ -20,13 +20,13 @@
      <row>
       <entry><link linkend="ini.runkit7.superglobal">runkit.superglobal</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_PERDIR</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.runkit7.internal-override">runkit.internal_override</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
     </tbody>

--- a/reference/seaslog/ini.xml
+++ b/reference/seaslog/ini.xml
@@ -20,145 +20,145 @@
      <row>
       <entry><link linkend="ini.seaslog.appender">seaslog.appender</link></entry>
       <entry>1</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.appender-retry">seaslog.appender_retry</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.level">seaslog.level</link></entry>
       <entry>8</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.remote-host">seaslog.remote_host</link></entry>
       <entry>127.0.0.1</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.remote-port">seaslog.remote_port</link></entry>
       <entry>514</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.remote-timeout">seaslog.remote_timeout</link></entry>
       <entry>1</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
-     </row>        
+     </row>
      <row>
       <entry><link linkend="ini.seaslog.default-basepath">seaslog.default_basepath</link></entry>
       <entry>/var/log/www</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.default-logger">seaslog.default_logger</link></entry>
       <entry>default</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.default-template">seaslog.default_template</link></entry>
       <entry>%T | %L | %P | %Q | %t | %M</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.default-datetime-format">seaslog.default_datetime_format</link></entry>
       <entry>Y-m-d H:i:s</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.trace-error">seaslog.trace_error</link></entry>
       <entry>1</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.trace-exception">seaslog.trace_exception</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.trace-notice">seaslog.trace_notice</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.trace-warning">seaslog.trace_warning</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.use-buffer">seaslog.use_buffer</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.buffer-size">seaslog.buffer_size</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.buffer-disabled-in-cli">seaslog.buffer_disabled_in_cli</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.disting-type">seaslog.disting_type</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.disting-folder">seaslog.disting_folder</link></entry>
       <entry>1</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.disting-by-hour">seaslog.disting_by_hour</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.recall-depth">seaslog.recall_depth</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.trim-wrap">seaslog.trim_wrap</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.ignore-warning">seaslog.ignore_warning</link></entry>
       <entry>1</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.seaslog.throw-exception">seaslog.throw_exception</link></entry>
       <entry>1</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
     </tbody>
@@ -180,7 +180,7 @@
        Switch the Record Log Data Store. 1File 2TCP 3UDP (Switch default 1)
       </para>
       <para>
-        SeasLog will send log to  tcp://remote_host:remote_port or udp://remote_host:remote_port server, 
+        SeasLog will send log to  tcp://remote_host:remote_port or udp://remote_host:remote_port server,
        when <emphasis>seaslog.appender</emphasis> configured to <literal>2 (TCP)</literal> or <literal>3 (UDP)</literal>.
       </para>
       <para>
@@ -219,10 +219,10 @@ The log style finally formatted such as:
        Disable buffer in cli. 1-Y 0-N(Default)
       </para>
       <para>
-       Switch the configure buffer_disabled_in_cli on. 
-       The buffer_disabled_in_cli switch default off. 
-       If switch buffer_disabled_in_cli on, and running in cli, 
-       seaslog.use_buffer setting will be discarded, 
+       Switch the configure buffer_disabled_in_cli on.
+       The buffer_disabled_in_cli switch default off.
+       If switch buffer_disabled_in_cli on, and running in cli,
+       seaslog.use_buffer setting will be discarded,
        Seaslog write to the Data Store IMMEDIATELY.
       </para>
      </listitem>
@@ -234,9 +234,9 @@ The log style finally formatted such as:
      </term>
      <listitem>
       <para>
-       Configure the buffer_size with 100. 
-       The buffer_size default 0, it’s meaning don’t use buffer. 
-       If buffer_size > 0,SeasLog will rewritten down into the Data Store 
+       Configure the buffer_size with 100.
+       The buffer_size default 0, it’s meaning don’t use buffer.
+       If buffer_size > 0,SeasLog will rewritten down into the Data Store
        when the prerecorded log in memory count >= this buffer_size,and then refresh the memory poll.
       </para>
      </listitem>
@@ -285,7 +285,7 @@ The log style finally formatted such as:
       </para>
       <note>
         <para>
-        <emphasis>seaslog.disting_by_hour = 1</emphasis> Switch use Logger DisTing by hour. 
+        <emphasis>seaslog.disting_by_hour = 1</emphasis> Switch use Logger DisTing by hour.
         It’s  meaning SeasLog will create the file each one hour.
         </para>
       </note>
@@ -302,9 +302,9 @@ The log style finally formatted such as:
       </para>
       <note>
         <para>
-        <emphasis>seaslog.disting_folder = 1</emphasis> Switch use Logger DisTing by folder, 
-        it’s meaning SeasLog will create the file deistic by folder, 
-        and when this configure close SeasLog will create file 
+        <emphasis>seaslog.disting_folder = 1</emphasis> Switch use Logger DisTing by folder,
+        it’s meaning SeasLog will create the file deistic by folder,
+        and when this configure close SeasLog will create file
         use underline connect Logger and Time like default_20180211.log.
         </para>
       </note>
@@ -321,7 +321,7 @@ The log style finally formatted such as:
       </para>
       <note>
         <para>
-        <emphasis>seaslog.disting_type = 1</emphasis> Switch use Logger DisTing by type, 
+        <emphasis>seaslog.disting_type = 1</emphasis> Switch use Logger DisTing by type,
         it’s meaning SeasLog will create the file deistic info\warn\error and the other type.
         </para>
       </note>
@@ -338,8 +338,8 @@ The log style finally formatted such as:
       </para>
       <note>
         <para>
-        <emphasis>seaslog.ignore_warning = 1</emphasis> Open a warning to ignore SeasLog itself. 
-        When directory permissions or receive server ports are blocked, they are ignored; 
+        <emphasis>seaslog.ignore_warning = 1</emphasis> Open a warning to ignore SeasLog itself.
+        When directory permissions or receive server ports are blocked, they are ignored;
         when closed, a warning is thrown.
         </para>
       </note>
@@ -358,7 +358,7 @@ The log style finally formatted such as:
       <note>
         <para>
           Tips: The configuration item has changed since the 1.7.0 version.
-          Before the 1.7.0 version, the smaller the value, the more logs are taken according to the level: 
+          Before the 1.7.0 version, the smaller the value, the more logs are taken according to the level:
           0-all 1-debug 2-info 3-notice 4-warning 5-error 6-critical 7-alert 8-emergency
           Before the 1.7.0 version, Default 0 (All of them).
         </para>
@@ -421,8 +421,8 @@ The log style finally formatted such as:
       </para>
       <note>
         <para>
-        <emphasis>seaslog.throw_exception = 1</emphasis> Open an exception that throws the SeasLog to throw itself. 
-        When the directory authority or the receive server port is blocked, 
+        <emphasis>seaslog.throw_exception = 1</emphasis> Open an exception that throws the SeasLog to throw itself.
+        When the directory authority or the receive server port is blocked,
         throw an exception; do not throw an exception when closed.
         </para>
       </note>
@@ -494,10 +494,10 @@ The log style finally formatted such as:
       </para>
       <note>
         <para>
-        <emphasis>seaslog.use_buffer = 1</emphasis> Switch the configure use_buffer on. 
-        The use_buffer switch default off. 
-        If switch use_buffer on, SeasLog prerecord the log with memory, 
-        and them would be rewritten down into the Data Store by request shutdown 
+        <emphasis>seaslog.use_buffer = 1</emphasis> Switch the configure use_buffer on.
+        The use_buffer switch default off.
+        If switch use_buffer on, SeasLog prerecord the log with memory,
+        and them would be rewritten down into the Data Store by request shutdown
         or php process exit (PHP RSHUTDOWN or PHP MSHUTDOWN).
         </para>
       </note>
@@ -510,13 +510,13 @@ The log style finally formatted such as:
      </term>
      <listitem>
       <para>
-       Default Log template. 
+       Default Log template.
        Default "%T | %L | %P | %Q | %t | %M".
       </para>
       <note>
         <para>
-        The following default variables are provided, 
-        which can be used directly in the log template and replaced as a corresponding value 
+        The following default variables are provided,
+        which can be used directly in the log template and replaced as a corresponding value
         when the log is eventually generated.
         </para>
         <para>
@@ -555,9 +555,9 @@ The log style finally formatted such as:
               </row>
               <row>
                 <entry>%Q</entry>
-                <entry>RequestId. To distinguish a single request, 
+                <entry>RequestId. To distinguish a single request,
                  such as not invoking the <literal>SeasLog::setRequestId($string)</literal> function,
-                 the unique value generated by the built-in <literal>static char *get_uniqid ()</literal> 
+                 the unique value generated by the built-in <literal>static char *get_uniqid ()</literal>
                 function is used when the request is initialized.</entry>
               </row>
               <row>
@@ -574,7 +574,7 @@ The log style finally formatted such as:
               </row>
               <row>
                 <entry>%R</entry>
-               <entry>Request URI. Such as <literal>/app/user/signin</literal>; 
+               <entry>Request URI. Such as <literal>/app/user/signin</literal>;
                 When Cli it's the index script, Such as <literal>CliIndex.php</literal>.</entry>
               </row>
               <row>
@@ -583,7 +583,7 @@ The log style finally formatted such as:
               </row>
               <row>
                 <entry>%I</entry>
-               <entry>Client IP; When Cli it's <literal>local</literal>. 
+               <entry>Client IP; When Cli it's <literal>local</literal>.
                 Priority value: HTTP_X_REAL_IP > HTTP_X_FORWARDED_FOR > REMOTE_ADDR</entry>
               </row>
               <row>

--- a/reference/sem/ini.xml
+++ b/reference/sem/ini.xml
@@ -19,7 +19,7 @@
     <row>
      <entry><link linkend="ini.sysvshm.init-mem">sysvshm.init_mem</link></entry>
      <entry>10000</entry>
-     <entry>PHP_INI_SYSTEM</entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry></entry>
     </row>
    </tbody>
@@ -31,7 +31,7 @@
  </para>
 
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
 

--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -19,217 +19,217 @@
     <row>
      <entry><link linkend="ini.session.save-path">session.save_path</link></entry>
      <entry>""</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.name">session.name</link></entry>
      <entry>"PHPSESSID"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.save-handler">session.save_handler</link></entry>
      <entry>"files"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.auto-start">session.auto_start</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_PERDIR</entry>
+     <entry><constant>INI_PERDIR</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.gc-probability">session.gc_probability</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.gc-divisor">session.gc_divisor</link></entry>
      <entry>"100"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.gc-maxlifetime">session.gc_maxlifetime</link></entry>
      <entry>"1440"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.serialize-handler">session.serialize_handler</link></entry>
      <entry>"php"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.cookie-lifetime">session.cookie_lifetime</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.cookie-path">session.cookie_path</link></entry>
      <entry>"/"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.cookie-domain">session.cookie_domain</link></entry>
      <entry>""</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.cookie-secure">session.cookie_secure</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>Prior to PHP 7.2.0, the default was <literal>""</literal>.</entry>
     </row>
     <row>
      <entry><link linkend="ini.session.cookie-httponly">session.cookie_httponly</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>Prior to PHP 7.2.0, the default was <literal>""</literal>.</entry>
     </row>
     <row>
      <entry><link linkend="ini.session.cookie-samesite">session.cookie_samesite</link></entry>
      <entry>""</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>Available as of PHP 7.3.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.session.use-strict-mode">session.use_strict_mode</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.use-cookies">session.use_cookies</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.use-only-cookies">session.use_only_cookies</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.referer-check">session.referer_check</link></entry>
      <entry>""</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.cache-limiter">session.cache_limiter</link></entry>
      <entry>"nocache"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.cache-expire">session.cache_expire</link></entry>
      <entry>"180"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.use-trans-sid">session.use_trans_sid</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.trans-sid-tags">session.trans_sid_tags</link></entry>
      <entry>"a=href,area=href,frame=src,form="</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>Available as of PHP 7.1.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.session.trans-sid-hosts">session.trans_sid_hosts</link></entry>
      <entry><literal>$_SERVER['HTTP_HOST']</literal></entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>Available as of PHP 7.1.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.session.sid-length">session.sid_length</link></entry>
      <entry>"32"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>Available as of PHP 7.1.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.session.sid-bits-per-character">session.sid_bits_per_character</link></entry>
      <entry>"4"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>Available as of PHP 7.1.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.session.upload-progress.enabled">session.upload_progress.enabled</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_PERDIR</entry>
+     <entry><constant>INI_PERDIR</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.upload-progress.cleanup">session.upload_progress.cleanup</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_PERDIR</entry>
+     <entry><constant>INI_PERDIR</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.upload-progress.prefix">session.upload_progress.prefix</link></entry>
      <entry>"upload_progress_"</entry>
-     <entry>PHP_INI_PERDIR</entry>
+     <entry><constant>INI_PERDIR</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.upload-progress.name">session.upload_progress.name</link></entry>
      <entry>"PHP_SESSION_UPLOAD_PROGRESS"</entry>
-     <entry>PHP_INI_PERDIR</entry>
+     <entry><constant>INI_PERDIR</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.upload-progress.freq">session.upload_progress.freq</link></entry>
      <entry>"1%"</entry>
-     <entry>PHP_INI_PERDIR</entry>
+     <entry><constant>INI_PERDIR</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.upload-progress.min-freq">session.upload_progress.min_freq</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_PERDIR</entry>
+     <entry><constant>INI_PERDIR</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.lazy-write">session.lazy_write</link></entry>
      <entry>"1"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.session.hash-function">session.hash_function</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>Removed as of PHP 7.1.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.session.hash-bits-per-character">session.hash_bits_per_character</link></entry>
      <entry>"4"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>Removed as of PHP 7.1.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.session.entropy-file">session.entropy_file</link></entry>
      <entry>""</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>Removed as of PHP 7.1.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.session.entropy-length">session.entropy_length</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>Removed as of PHP 7.1.0</entry>
     </row>
    </tbody>
@@ -272,10 +272,10 @@
      <literal>session.save_path</literal> defines the argument which
      is passed to the save handler. If you choose the default files
      handler, this is the path where the files are created. See also
-     <function>session_save_path</function>. 
+     <function>session_save_path</function>.
     </simpara>
     <para>
-     There is an optional <literal>N</literal> argument to this directive that determines 
+     There is an optional <literal>N</literal> argument to this directive that determines
      the number of directory levels your session files will be spread
      around in.  For example, setting to <literal>'5;/tmp'</literal>
      may end up creating a session file and location like
@@ -288,15 +288,15 @@
      used and greater than 0 then automatic garbage collection will
      not be performed, see a copy of &php.ini; for further
      information.  Also, if you use <literal>N</literal>, be sure to surround
-     <literal>session.save_path</literal> in  
+     <literal>session.save_path</literal> in
      "quotes" because the separator (<literal>;</literal>) is
      also used for comments in &php.ini;.
     </para>
     <para>
      The file storage module creates files using mode 600 by default.
      This default can be changed with the optional <literal>MODE</literal> argument:
-     <literal>N;MODE;/path</literal> where <literal>MODE</literal> is the octal 
-     representation of the mode. 
+     <literal>N;MODE;/path</literal> where <literal>MODE</literal> is the octal
+     representation of the mode.
      Setting <literal>MODE</literal> does not affect the process umask.
     </para>
     <warning>
@@ -338,7 +338,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.session.auto-start">
    <term>
     <parameter>session.auto_start</parameter>
@@ -403,9 +403,9 @@
    </term>
    <listitem>
     <simpara>
-     <literal>session.gc_divisor</literal> coupled with 
-     <literal>session.gc_probability</literal> defines the probability 
-     that the gc (garbage collection) process is started on every session 
+     <literal>session.gc_divisor</literal> coupled with
+     <literal>session.gc_probability</literal> defines the probability
+     that the gc (garbage collection) process is started on every session
      initialization.
      The probability is calculated by using gc_probability/gc_divisor,
      e.g. 1/100 means there is a 1% chance that the GC process starts
@@ -414,7 +414,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.session.gc-maxlifetime">
    <term>
     <parameter>session.gc_maxlifetime</parameter>
@@ -472,7 +472,7 @@
      which are available on many Unix systems.
     </simpara>
     <simpara>
-     This feature is supported on Windows. Setting 
+     This feature is supported on Windows. Setting
      <literal>session.entropy_length</literal> to a non zero value
      will make PHP use the Windows Random API as entropy source.
     </simpara>
@@ -524,7 +524,7 @@
     <note>
      <simpara>
      Enabling <literal>session.use_strict_mode</literal> is mandatory for
-     general session security. All sites are advised to enable this. See 
+     general session security. All sites are advised to enable this. See
      <function>session_create_id</function> example code for more details.
      </simpara>
     </note>
@@ -592,7 +592,7 @@
       The expiration timestamp is set relative to the server time, which is
       not necessarily the same as the time in the client's browser.
      </simpara>
-    </note> 
+    </note>
    </listitem>
   </varlistentry>
 
@@ -692,7 +692,7 @@
      <literal>session.cache_limiter</literal> specifies the cache
      control method used for session pages.
      It may be one of the following values:
-     <literal>nocache</literal>, <literal>private</literal>, 
+     <literal>nocache</literal>, <literal>private</literal>,
      <literal>private_no_expire</literal>, or <literal>public</literal>.
      Defaults to <literal>nocache</literal>. See also the
      <function>session_cache_limiter</function> documentation for
@@ -738,7 +738,7 @@
       always, for example.
      </simpara>
      <simpara>
-      Since PHP 7.1.0, full URL path, e.g. https://php.net/, is 
+      Since PHP 7.1.0, full URL path, e.g. https://php.net/, is
       handled by trans sid feature. Previous PHP handled relative
       URL path only. Rewrite target hosts are defined by <link
       linkend="ini.session.trans-sid-hosts">session.trans_sid_hosts</link>.
@@ -766,7 +766,7 @@
     <note>
      <simpara>
       Before PHP 7.1.0, <link linkend="ini.url-rewriter.tags">url_rewriter.tags</link>
-      was used for this purpose. Since PHP 7.1.0, <literal>fieldset</literal> 
+      was used for this purpose. Since PHP 7.1.0, <literal>fieldset</literal>
       is no longer considered as special tag.
      </simpara>
     </note>
@@ -821,7 +821,7 @@
       <literal>session.sid_bits_per_character</literal>, otherwise you
       will have weaker session ID.
      </para>
-    </tip> 
+    </tip>
     <note>
      <simpara>
       This setting is introduced in PHP 7.1.0.
@@ -838,7 +838,7 @@
    <listitem>
     <simpara>
      <literal>session.sid_bits_per_character</literal> allows you to specify the
-     number of bits in encoded session ID character. The possible values are 
+     number of bits in encoded session ID character. The possible values are
      '4' (0-9, a-f), '5' (0-9, a-v), and '6' (0-9, a-z, A-Z, "-", ",").
     </simpara>
     <simpara>

--- a/reference/soap/ini.xml
+++ b/reference/soap/ini.xml
@@ -20,31 +20,31 @@
      <row>
       <entry><link linkend="ini.soap.wsdl-cache-enabled">soap.wsdl_cache_enabled</link></entry>
       <entry>1</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.soap.wsdl-cache-dir">soap.wsdl_cache_dir</link></entry>
       <entry>/tmp</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.soap.wsdl-cache-ttl">soap.wsdl_cache_ttl</link></entry>
       <entry>86400</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.soap.wsdl-cache">soap.wsdl_cache</link></entry>
       <entry>1</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.soap.wsdl-cache-limit">soap.wsdl_cache_limit</link></entry>
       <entry>5</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
 </tbody>

--- a/reference/sqlite3/ini.xml
+++ b/reference/sqlite3/ini.xml
@@ -20,17 +20,17 @@
      <row>
       <entry><link linkend="ini.sqlite3.extension-dir">sqlite3.extension_dir</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.sqlite3.defensive">sqlite3.defensive</link></entry>
       <entry>1</entry>
-      <entry>PHP_INI_USER</entry>
+      <entry><constant>INI_USER</constant></entry>
       <entry>
        Available as of PHP 7.2.17 and 7.3.4 for libsqlite ≥ 3.26.0.
        Prior to PHP 8.2.0 this setting was changeable only as
-       <constant>PHP_INI_SYSTEM</constant>.
+       <constant>INI_SYSTEM</constant>.
       </entry>
      </row>
     </tbody>

--- a/reference/sqlsrv/ini.xml
+++ b/reference/sqlsrv/ini.xml
@@ -3,8 +3,8 @@
 <section xml:id="sqlsrv.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.runtime;
  &extension.runtime;
- <para>The following table lists the configuration options available in the SQLSRV 
- extension. For more information about these options, see 
+ <para>The following table lists the configuration options available in the SQLSRV
+ extension. For more information about these options, see
  <link xlink:href="&url.sqlsrv.error.handling;">Handling SQLSRV Warnings and Errors</link>.</para>
  <para>
   <table>
@@ -22,19 +22,19 @@
      <row>
       <entry>sqlsrv.WarningsReturnAsErrors</entry>
       <entry>1 (&true;)</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available since SQLSRV 1.0</entry>
      </row>
      <row>
       <entry>sqlsrv.LogSubsystems</entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available since SQLSRV 1.0</entry>
      </row>
      <row>
       <entry>sqlsrv.LogSeverity</entry>
       <entry>1</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available since SQLSRV 1.0</entry>
      </row>
     </tbody>
@@ -43,9 +43,9 @@
 
 <!--  &php_ini_constants; -->
  </para>
- 
+
  <!--&ini.descriptions.title;
- 
+
   <para>
   <variablelist>
    <varlistentry xml:id="ini.extname.theini-option">
@@ -55,7 +55,7 @@
     </term>
     <listitem>
      <para>
-     
+
      </para>
     </listitem>
    </varlistentry>

--- a/reference/stomp/ini.xml
+++ b/reference/stomp/ini.xml
@@ -20,32 +20,32 @@
      <row>
       <entry><link linkend="ini.stomp.default-broker">stomp.default_broker</link></entry>
       <entry>tcp://localhost:61613</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.stomp.default-connection-timeout-sec">stomp.default_connection_timeout_sec</link></entry>
       <entry>2</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.stomp.default-connection-timeout-usec">stomp.default_connection_timeout_usec</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
 
      <row>
       <entry><link linkend="ini.stomp.default-read-timeout-sec">stomp.default_read_timeout_sec</link></entry>
       <entry>2</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.stomp.default-read-timeout-usec">stomp.default_read_timeout_usec</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
 </tbody>

--- a/reference/swoole/ini.xml
+++ b/reference/swoole/ini.xml
@@ -20,55 +20,55 @@
      <row>
       <entry><link linkend="ini.swoole.aio-thread-num">swoole.aio_thread_num</link></entry>
       <entry>2</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.swoole.display-errors">swoole.display_errors</link></entry>
       <entry>On</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.swoole.fast-serialize">swoole.fast_serialize</link></entry>
       <entry>Off</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.swoole.unixsock-buffer-size">swoole.unixsock_buffer_size</link></entry>
       <entry>8388608</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.swoole.use-namespace">swoole.use_namespace</link></entry>
       <entry>On</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.swoole.enable-coroutine">swoole.enable_coroutine</link></entry>
       <entry>On</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of swoole 4.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.swoole.use-shortname">swoole.use_shortname</link></entry>
       <entry>On</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of swoole 4.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.swoole.enable-preemptive-scheduler">swoole.enable_preemptive_scheduler</link></entry>
       <entry>Off</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of swoole 4.4.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.swoole.enable-library">swoole.enable_library</link></entry>
       <entry>On</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of swoole 4.0.0</entry>
      </row>
     </tbody>

--- a/reference/taint/ini.xml
+++ b/reference/taint/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
- 
+
 <section xml:id="taint.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;
@@ -20,13 +20,13 @@
      <row>
       <entry><link linkend="ini.taint.enable">taint.enable</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.taint.error-level">taint.error_level</link></entry>
       <entry>E_WARNING</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
     </tbody>

--- a/reference/tidy/ini.xml
+++ b/reference/tidy/ini.xml
@@ -19,13 +19,13 @@
      <row>
       <entry><link linkend="ini.tidy.default-config">tidy.default_config</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.tidy.clean-output">tidy.clean_output</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_USER</entry>
+      <entry><constant>INI_USER</constant></entry>
       <entry></entry>
      </row>
     </tbody>

--- a/reference/trader/ini.xml
+++ b/reference/trader/ini.xml
@@ -20,13 +20,13 @@
      <row>
       <entry><link linkend="ini.trader.real-precision">trader.real_precision</link></entry>
       <entry>3</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Since trader 0.2.1</entry>
      </row>
      <row>
       <entry><link linkend="ini.trader.real-round-mode">trader.real_round_mode</link></entry>
       <entry>HALF_DOWN</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Since trader 0.3.0</entry>
      </row>
     </tbody>

--- a/reference/uodbc/ini.xml
+++ b/reference/uodbc/ini.xml
@@ -19,61 +19,61 @@
      <row>
       <entry><link linkend="ini.uodbc.default-db">odbc.default_db</link> *</entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.uodbc.default-user">odbc.default_user</link> *</entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.uodbc.default-pw">odbc.default_pw</link> *</entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.uodbc.allow-persistent">odbc.allow_persistent</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.uodbc.check-persistent">odbc.check_persistent</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.uodbc.max-persistent">odbc.max_persistent</link></entry>
       <entry>"-1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.uodbc.max-links">odbc.max_links</link></entry>
       <entry>"-1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.uodbc.defaultlrl">odbc.defaultlrl</link></entry>
       <entry>"4096"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.uodbc.defaultbinmode">odbc.defaultbinmode</link></entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.uodbc.defaultcursortype">odbc.default_cursortype</link></entry>
       <entry>"3"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
     </tbody>
@@ -86,9 +86,9 @@
   </note>
   &ini.php.constants;
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
  <variablelist>
    <varlistentry xml:id="ini.uodbc.default-db">
@@ -104,7 +104,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.uodbc.default-user">
    <term>
     <parameter>odbc.default_user</parameter>
@@ -118,7 +118,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.uodbc.default-pw">
    <term>
     <parameter>odbc.default_pw</parameter>
@@ -132,7 +132,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.uodbc.allow-persistent">
    <term>
     <parameter>odbc.allow_persistent</parameter>
@@ -144,7 +144,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.uodbc.check-persistent">
    <term>
     <parameter>odbc.check_persistent</parameter>
@@ -156,7 +156,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.uodbc.max-persistent">
    <term>
     <parameter>odbc.max_persistent</parameter>
@@ -168,7 +168,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.uodbc.max-links">
    <term>
     <parameter>odbc.max_links</parameter>
@@ -197,7 +197,7 @@
 
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="ini.uodbc.defaultbinmode">
    <term>
     <parameter>odbc.defaultbinmode</parameter>
@@ -226,7 +226,7 @@
     </para>
    </listitem>
   </varlistentry>
-  
+
  </variablelist>
  </para>
 </section>

--- a/reference/uopz/setup.xml
+++ b/reference/uopz/setup.xml
@@ -14,8 +14,8 @@
  <section xml:id="uopz.installation">
   &reftitle.install;
   <para>
-   uopz releases are hosted by PECL and the source code by 
-    <link xlink:href="&url.git.hub;krakjoe/uopz">github</link>, 
+   uopz releases are hosted by PECL and the source code by
+    <link xlink:href="&url.git.hub;krakjoe/uopz">github</link>,
    the easiest route to installation is the normal PECL route:
    <link xlink:href="&url.pecl.package;uopz">&url.pecl.package;uopz</link>.
   </para>
@@ -23,7 +23,7 @@
  Windows users can download prebuilt release binaries from the <link xlink:href="&url.pecl.windows.releases;uopz">PECL</link> website.
   </para>
   <para>
-   As of uopz 5.0.0 the extension must be loaded as 
+   As of uopz 5.0.0 the extension must be loaded as
    <link linkend="ini.extension">extension</link>. Before this version it must be
    loaded as <link linkend="ini.zend-extension">zend_extension</link>.
   </para>
@@ -48,19 +48,19 @@
       <row>
        <entry><link linkend="ini.uopz.disable">uopz.disable</link></entry>
        <entry>"0"</entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry>Available as of uopz 5.0.2</entry>
       </row>
       <row>
        <entry><link linkend="ini.uopz.exit">uopz.exit</link></entry>
        <entry>"0"</entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry>Available as of uopz 6.0.1</entry>
       </row>
       <row>
        <entry><link linkend="ini.uopz.overloads">uopz.overloads</link></entry>
        <entry>"1"</entry>
-       <entry>PHP_INI_SYSTEM</entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
        <entry>Available as of uopz 2.0.2. Removed as of uopz 5.0.0.</entry>
       </row>
      </tbody>

--- a/reference/v8js/ini.xml
+++ b/reference/v8js/ini.xml
@@ -20,13 +20,13 @@
      <row>
       <entry><link linkend="ini.v8js.max-disposed-contexts">v8js.max_disposed_contexts</link></entry>
       <entry>25</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.v8js.flags">v8js.flags</link></entry>
       <entry></entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
     </tbody>

--- a/reference/var/ini.xml
+++ b/reference/var/ini.xml
@@ -19,13 +19,13 @@
     <row>
      <entry><link linkend="ini.unserialize-callback-func">unserialize_callback_func</link></entry>
      <entry>&null;</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
     </row>
     <row>
      <entry><link linkend="ini.unserialize-max-depth">unserialize_max_depth</link></entry>
      <entry>"4096"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry><constant>INI_ALL</constant></entry>
      <entry>Available as of PHP 7.4.0.</entry>
     </row>
     </tbody>
@@ -33,9 +33,9 @@
   </table>
   &ini.php.constants;
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
    <varlistentry xml:id="ini.unserialize-callback-func">

--- a/reference/wincache/ini.xml
+++ b/reference/wincache/ini.xml
@@ -4,7 +4,7 @@
  &reftitle.runtime;
  &extension.runtime;
  <para>
-  The following table lists and explains the configuration settings 
+  The following table lists and explains the configuration settings
   provided by the WinCache extension:
  </para>
  <para>
@@ -26,24 +26,24 @@
       <entry><link linkend="ini.wincache.fcenabled">wincache.fcenabled</link></entry>
       <entry>"1"</entry>
       <entry>"0"</entry>
-      <entry>"1"</entry>      
-      <entry>PHP_INI_ALL</entry>
+      <entry>"1"</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of WinCache 1.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.wincache.fcenabledfilter">wincache.fcenabledfilter</link></entry>
       <entry>"NULL"</entry>
       <entry>"NULL"</entry>
-      <entry>"NULL"</entry>      
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry>"NULL"</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of WinCache 1.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.wincache.fcachesize">wincache.fcachesize</link></entry>
       <entry>"24"</entry>
       <entry>"5"</entry>
-      <entry>"255"</entry>      
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry>"255"</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of WinCache 1.0.0</entry>
      </row>
      <row>
@@ -51,111 +51,111 @@
       <entry>"1"</entry>
       <entry>"0"</entry>
       <entry>"1"</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of WinCache 1.1.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.wincache.maxfilesize">wincache.maxfilesize</link></entry>
       <entry>"256"</entry>
       <entry>"10"</entry>
-      <entry>"2048"</entry>      
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry>"2048"</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of WinCache 1.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.wincache.ocenabled">wincache.ocenabled</link></entry>
       <entry>"1"</entry>
       <entry>"0"</entry>
-      <entry>"1"</entry>      
-      <entry>PHP_INI_ALL</entry>
+      <entry>"1"</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of WinCache 1.0.0. Removed as of 2.0.0.0</entry>
-     </row> 
+     </row>
      <row>
       <entry><link linkend="ini.wincache.ocenabledfilter">wincache.ocenabledfilter</link></entry>
       <entry>"NULL"</entry>
       <entry>"NULL"</entry>
-      <entry>"NULL"</entry>      
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry>"NULL"</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of WinCache 1.0.0. Removed as of 2.0.0.0</entry>
-     </row>     
+     </row>
      <row>
       <entry><link linkend="ini.wincache.ocachesize">wincache.ocachesize</link></entry>
       <entry>"96"</entry>
       <entry>"15"</entry>
-      <entry>"255"</entry>      
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry>"255"</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of WinCache 1.0.0. Removed as of 2.0.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.wincache.filecount">wincache.filecount</link></entry>
       <entry>"4096"</entry>
       <entry>"1024"</entry>
-      <entry>"16384"</entry>      
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry>"16384"</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of WinCache 1.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.wincache.chkinterval">wincache.chkinterval</link></entry>
       <entry>"30"</entry>
       <entry>"0"</entry>
-      <entry>"300"</entry>      
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry>"300"</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of WinCache 1.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.wincache.ttlmax">wincache.ttlmax</link></entry>
       <entry>"1200"</entry>
       <entry>"0"</entry>
-      <entry>"7200"</entry>      
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry>"7200"</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of WinCache 1.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.wincache.enablecli">wincache.enablecli</link></entry>
       <entry>0</entry>
       <entry>0</entry>
-      <entry>1</entry>      
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry>1</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of WinCache 1.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.wincache.ignorelist">wincache.ignorelist</link></entry>
       <entry>NULL</entry>
       <entry>NULL</entry>
-      <entry>NULL</entry>      
-      <entry>PHP_INI_ALL</entry>
+      <entry>NULL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of WinCache 1.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.wincache.namesalt">wincache.namesalt</link></entry>
       <entry>NULL</entry>
       <entry>NULL</entry>
-      <entry>NULL</entry>      
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry>NULL</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of WinCache 1.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.wincache.ucenabled">wincache.ucenabled</link></entry>
       <entry>1</entry>
       <entry>0</entry>
-      <entry>1</entry>      
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry>1</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of WinCache 1.1.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.wincache.ucachesize">wincache.ucachesize</link></entry>
       <entry>8</entry>
       <entry>5</entry>
-      <entry>85</entry>      
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry>85</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of WinCache 1.1.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.wincache.scachesize">wincache.scachesize</link></entry>
       <entry>8</entry>
       <entry>5</entry>
-      <entry>85</entry>      
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry>85</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of WinCache 1.1.0</entry>
      </row>
      <row>
@@ -163,31 +163,31 @@
       <entry>NULL</entry>
       <entry>NULL</entry>
       <entry>NULL</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of WinCache 1.2.0. Removed as of 1.3.7</entry>
      </row>
      <row>
       <entry><link linkend="ini.wincache.reroute_enabled">wincache.reroute_enabled</link></entry>
       <entry>1</entry>
       <entry>0</entry>
-      <entry>1</entry>      
-      <entry>PHP_INI_SYSTEM | PHP_INI_PERDIR</entry>
+      <entry>1</entry>
+      <entry><constant>INI_SYSTEM</constant> | <constant>INI_PERDIR</constant></entry>
       <entry>Available as of WinCache 1.3.7</entry>
      </row>
      <row>
       <entry><link linkend="ini.wincache.srwlocks">wincache.srwlocks</link></entry>
       <entry>1</entry>
       <entry>0</entry>
-      <entry>1</entry>      
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry>1</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of WinCache 1.3.6.3. Removed as of 2.0.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.wincache.filemapdir">wincache.filemapdir</link></entry>
       <entry>NULL</entry>
       <entry>NULL</entry>
-      <entry>NULL</entry>      
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry>NULL</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of WinCache 1.3.7.4</entry>
      </row>
     </tbody>
@@ -195,9 +195,9 @@
   </table>
   &ini.php.constants;
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
    <varlistentry xml:id="ini.wincache.fcenabled">
@@ -216,12 +216,12 @@
     </term>
     <listitem>
      <simpara>
-      Defines a comma-separated list of IIS web site identifiers where file 
-      cache should be enabled or disabled. This setting works in conjunction 
-      with <literal>wincache.fcenabled</literal>: if <literal>wincache.fcenabled</literal> 
+      Defines a comma-separated list of IIS web site identifiers where file
+      cache should be enabled or disabled. This setting works in conjunction
+      with <literal>wincache.fcenabled</literal>: if <literal>wincache.fcenabled</literal>
       is set to 1, then the sites listed in the <literal>wincache.fcenabledfilter</literal>
-      will have the file cache turned off; if <literal>wincache.fcenabled</literal> 
-      is set to 0, then the sites listed in the <literal>wincache.fcenabledfilter</literal> 
+      will have the file cache turned off; if <literal>wincache.fcenabled</literal>
+      is set to 0, then the sites listed in the <literal>wincache.fcenabledfilter</literal>
       will have the file cache turned on.
      </simpara>
     </listitem>
@@ -233,8 +233,8 @@
     </term>
     <listitem>
      <simpara>
-      Defines the maximum memory size (in megabytes) that is allocated for the file cache. 
-      If the total size of all the cached files exceeds the value specified in this setting, 
+      Defines the maximum memory size (in megabytes) that is allocated for the file cache.
+      If the total size of all the cached files exceeds the value specified in this setting,
       then most stale files will be removed from the file cache.
      </simpara>
     </listitem>
@@ -246,10 +246,10 @@
     </term>
     <listitem>
      <simpara>
-      Enables or disables the file change notification detection functionality. If file change 
+      Enables or disables the file change notification detection functionality. If file change
       notification is supported then it will be used to refresh the opcode and file cache entries
-      as soon as the corresponding files are modified on a file system. If file change notification 
-      is not supported, for example when using network file shares, then wincache will poll for 
+      as soon as the corresponding files are modified on a file system. If file change notification
+      is not supported, for example when using network file shares, then wincache will poll for
       file changes at regular time intervals specified by <literal>wincache.chkinterval</literal>.
      </simpara>
     </listitem>
@@ -261,8 +261,8 @@
     </term>
     <listitem>
      <simpara>
-      Defines the maximum allowed size (in kilobytes) for a single file to be cached. 
-      If a file size exceeds the specified value, the file will not be cached. 
+      Defines the maximum allowed size (in kilobytes) for a single file to be cached.
+      If a file size exceeds the specified value, the file will not be cached.
       This setting applies to the file cache only.
      </simpara>
     </listitem>
@@ -285,12 +285,12 @@
     <listitem>
      <warning xmlns="http://docbook.org/ns/docbook"><simpara>This option has been <emphasis>REMOVED</emphasis> as of 2.0.0.0</simpara></warning>
      <simpara>
-      Defines a comma-separated list of IIS web site identifiers where opcode 
-      cache should be enabled or disabled. This setting works in conjunction 
-      with <literal>wincache.ocenabled</literal>: if <literal>wincache.ocenabled</literal> 
+      Defines a comma-separated list of IIS web site identifiers where opcode
+      cache should be enabled or disabled. This setting works in conjunction
+      with <literal>wincache.ocenabled</literal>: if <literal>wincache.ocenabled</literal>
       is set to 1, then the sites listed in the <literal>wincache.ocenabledfilter</literal>
-      will have the opcode cache turned off; if <literal>wincache.ocenabled</literal> 
-      is set to 0, then the sites listed in the <literal>wincache.ocenabledfilter</literal> 
+      will have the opcode cache turned off; if <literal>wincache.ocenabled</literal>
+      is set to 0, then the sites listed in the <literal>wincache.ocenabledfilter</literal>
       will have the opcode cache turned on.
      </simpara>
     </listitem>
@@ -303,10 +303,10 @@
     <listitem>
      <warning xmlns="http://docbook.org/ns/docbook"><simpara>This option has been <emphasis>REMOVED</emphasis> as of 2.0.0.0</simpara></warning>
      <simpara>
-      Defines the maximum memory size (in megabytes) that is allocated for the 
-      opcode cache. If the cached opcode size exceeds the specified value, 
-      then most stale opcode will be removed from the cache. Note that the opcode 
-      cache size must be at least 3 times bigger than file cache size. 
+      Defines the maximum memory size (in megabytes) that is allocated for the
+      opcode cache. If the cached opcode size exceeds the specified value,
+      then most stale opcode will be removed from the cache. Note that the opcode
+      cache size must be at least 3 times bigger than file cache size.
       If that is not the case the opcode cache size will be automatically increased.
      </simpara>
     </listitem>
@@ -318,8 +318,8 @@
     </term>
     <listitem>
      <simpara>
-      Defines how many files are expected to be cached by the extension, so that appropriate 
-      memory size is allocated at the startup time. If the number of files exceeds the specified 
+      Defines how many files are expected to be cached by the extension, so that appropriate
+      memory size is allocated at the startup time. If the number of files exceeds the specified
       value, the WinCache will re-allocate more memory as needed.
      </simpara>
     </listitem>
@@ -331,10 +331,10 @@
     </term>
     <listitem>
      <simpara>
-      Defines how often (in seconds) the extension checks for file changes in order 
-      to refresh the cache. Setting it to 0 will disable the refreshing of the cache. 
-      The file changes will not be reflected in the cache unless the cache entry for 
-      that file is removed by scavenger or IIS application pool is recycled or 
+      Defines how often (in seconds) the extension checks for file changes in order
+      to refresh the cache. Setting it to 0 will disable the refreshing of the cache.
+      The file changes will not be reflected in the cache unless the cache entry for
+      that file is removed by scavenger or IIS application pool is recycled or
       wincache_refresh_if_changed function is called.
      </simpara>
     </listitem>
@@ -346,7 +346,7 @@
     </term>
     <listitem>
      <simpara>
-      Defines the maximum time to live (in seconds) for a cached entry without being used. 
+      Defines the maximum time to live (in seconds) for a cached entry without being used.
       Setting it to 0 will disable the cache scavenger, so the cached entries will never
       be removed from the cache during the lifetime of the IIS worker process.
      </simpara>
@@ -370,8 +370,8 @@
     </term>
     <listitem>
      <para>
-      Defines a list of files that should not be cached by the extension. 
-      The files list is specified by using file names only, separated by 
+      Defines a list of files that should not be cached by the extension.
+      The files list is specified by using file names only, separated by
       the pipe symbol - "|".
       <example>
        <title><literal>wincache.ignorelist</literal> example</title>
@@ -391,10 +391,10 @@ wincache.ignorelist = "index.php|misc.php|admin.php"
     </term>
     <listitem>
      <simpara>
-      Defines a string that will be used when naming the extension 
-      specific objects that are stored in shared memory. This is used 
-      to avoid conflicts that may be caused if other applications within 
-      an IIS worker process tries to access shared memory. The length of 
+      Defines a string that will be used when naming the extension
+      specific objects that are stored in shared memory. This is used
+      to avoid conflicts that may be caused if other applications within
+      an IIS worker process tries to access shared memory. The length of
       the namesalt string cannot exceed 8 characters.
      </simpara>
     </listitem>
@@ -417,8 +417,8 @@ wincache.ignorelist = "index.php|misc.php|admin.php"
     </term>
     <listitem>
      <simpara>
-      Defines the maximum memory size in megabytes that is allocated for the user cache. If the total 
-      size of variables stored in the user cache exceeds the specified value, then the most stale variables 
+      Defines the maximum memory size in megabytes that is allocated for the user cache. If the total
+      size of variables stored in the user cache exceeds the specified value, then the most stale variables
       will be removed from the cache.
      </simpara>
     </listitem>
@@ -430,8 +430,8 @@ wincache.ignorelist = "index.php|misc.php|admin.php"
     </term>
     <listitem>
      <simpara>
-      Defines the maximum memory size in megabytes that is allocated for the session cache. If the total 
-      size of data stored in the session cache exceeds the specified value, then the most stale data 
+      Defines the maximum memory size in megabytes that is allocated for the session cache. If the total
+      size of data stored in the session cache exceeds the specified value, then the most stale data
       will be removed from the cache.
      </simpara>
     </listitem>
@@ -446,8 +446,8 @@ wincache.ignorelist = "index.php|misc.php|admin.php"
       This option has been <emphasis>REMOVED</emphasis> as of 1.3.7.  See <literal>wincache.reroute_enabled</literal> for similar functionality as of 1.3.7.
       </simpara></warning>
      <simpara>
-      Specifies an absolute or a relateve path to the reroute.ini file that contains the list of PHP functions 
-      whose implementation should be replaced with the WinCache function equivalents. If a relative path is specified 
+      Specifies an absolute or a relateve path to the reroute.ini file that contains the list of PHP functions
+      whose implementation should be replaced with the WinCache function equivalents. If a relative path is specified
       then it is assumed to be relative to the location of php-cgi.exe file.
      </simpara>
     </listitem>

--- a/reference/wkhtmltox/ini.xml
+++ b/reference/wkhtmltox/ini.xml
@@ -20,7 +20,7 @@
     <entry>wkhtmltox.graphics</entry>
     <entry>allow libwkhtmltox to use graphics</entry>
     <entry>Off</entry>
-    <entry>PHP_INI_SYSTEM | PHP_INI_PERDIR</entry>
+    <entry><constant>INI_SYSTEM</constant> | <constant>INI_PERDIR</constant></entry>
     <entry>&gt;= 0.3.2</entry>
    </row>
   </tbody>

--- a/reference/xhprof/ini.xml
+++ b/reference/xhprof/ini.xml
@@ -20,7 +20,7 @@
      <row>
       <entry><link linkend="ini.xhprof.output-dir">xhprof.output_dir</link></entry>
       <entry>""</entry>
-      <entry><constant>PHP_INI_ALL</constant></entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
     </tbody>
@@ -40,7 +40,7 @@
      <para>
       Directory used by the default implementation of the iXHProfRuns
       interface (namely, the XHProfRuns_Default class) for storing
-      XHProf runs. 
+      XHProf runs.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/yac/ini.xml
+++ b/reference/yac/ini.xml
@@ -20,43 +20,43 @@
      <row>
       <entry><link linkend="ini.yac.compress-threshold">yac.compress_threshold</link></entry>
       <entry>-1</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yac.debug">yac.debug</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yac.enable">yac.enable</link></entry>
       <entry>1</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yac.enable-cli">yac.enable_cli</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yac.keys-memory-size">yac.keys_memory_size</link></entry>
       <entry>4M</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yac.serializer">yac.serializer</link></entry>
       <entry>php</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yac.values-memory-size">yac.values_memory_size</link></entry>
       <entry>64M</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
     </tbody>
@@ -75,7 +75,7 @@
      </term>
      <listitem>
       <para>
-       
+
       </para>
      </listitem>
     </varlistentry>
@@ -86,7 +86,7 @@
      </term>
      <listitem>
       <para>
-       
+
       </para>
      </listitem>
     </varlistentry>
@@ -97,7 +97,7 @@
      </term>
      <listitem>
       <para>
-       
+
       </para>
      </listitem>
     </varlistentry>
@@ -108,7 +108,7 @@
      </term>
      <listitem>
       <para>
-       
+
       </para>
      </listitem>
     </varlistentry>
@@ -119,7 +119,7 @@
      </term>
      <listitem>
       <para>
-       
+
       </para>
      </listitem>
     </varlistentry>
@@ -130,7 +130,7 @@
      </term>
      <listitem>
       <para>
-       
+
       </para>
      </listitem>
     </varlistentry>
@@ -141,7 +141,7 @@
      </term>
      <listitem>
       <para>
-       
+
       </para>
      </listitem>
     </varlistentry>

--- a/reference/yaconf/ini.xml
+++ b/reference/yaconf/ini.xml
@@ -20,13 +20,13 @@
      <row>
       <entry><link linkend="ini.yaconf.check-delay">yaconf.check_delay</link></entry>
       <entry>300</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yaconf.directory">yaconf.directory</link></entry>
       <entry>/tmp/conf/</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
     </tbody>

--- a/reference/yaf/appconfig.xml
+++ b/reference/yaf/appconfig.xml
@@ -6,7 +6,7 @@
  <para>
   You should give an array of config or an ini config file(see
   <classname>Yaf_Config_Ini</classname>) path to
-  <methodname>Yaf_Application::__construct</methodname>. 
+  <methodname>Yaf_Application::__construct</methodname>.
  </para>
  <para>
   Yaf will merge the application configurations and user configurations
@@ -200,7 +200,7 @@ yaf.dispatcher.catchException = 0
      <listitem>
       <para>
        A comma-separated list of the registered modules, used in the route
-       process, especially while there are more than three segments in the PATH_INFO, 
+       process, especially while there are more than three segments in the PATH_INFO,
       </para>
       <para>
        Yaf need a way to find out whether the first segment is a module name or not.
@@ -220,7 +220,7 @@ yaf.dispatcher.catchException = 0
        <note>
         <para>
             After Yaf 2.1.6, this config entry can be an array. The library path
-            will try to use the items setted in <link 
+            will try to use the items setted in <link
             linkend="configuration.yaf.library.directory">application.library.directory</link>
         </para>
        </note>
@@ -271,14 +271,14 @@ yaf.dispatcher.catchException = 0
      </term>
      <listitem>
       <para>
-       Used to remove a fixed prefix of request uri in route process. 
+       Used to remove a fixed prefix of request uri in route process.
        Take a example, comes a request with request uri
        "/prefix/controller/action". if you set application.baseUri to
        "/prefix", then only "/controller/action" will take as the PATH_INFO in
        route process.
       </para>
       <para>
-       In generally, there is no need to set this value. 
+       In generally, there is no need to set this value.
       </para>
      </listitem>
     </varlistentry>
@@ -368,7 +368,7 @@ yaf.dispatcher.catchException = 0
        <link linkend="ini.yaf.lowcase-path">application.system.lowcase_path</link>
        <note>
         <para>
-        only those PHP_INI_ALL configures can be set in this way
+        only those <constant>INI_ALL</constant> configures can be set in this way
        </para>
        </note>
       </para>

--- a/reference/yaf/ini.xml
+++ b/reference/yaf/ini.xml
@@ -20,61 +20,61 @@
      <row>
       <entry><link linkend="ini.yaf.library">yaf.library</link></entry>
       <entry></entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yaf.action-prefer">yaf.action_prefer</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yaf.lowcase-path">yaf.lowcase_path</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yaf.use-spl-autoload">yaf.use_spl_autoload</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yaf.forward-limit">yaf.forward_limit</link></entry>
       <entry>5</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yaf.name-suffix">yaf.name_suffix</link></entry>
       <entry>1</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yaf.name-separator">yaf.name_separator</link></entry>
       <entry></entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yaf.cache-config">yaf.cache_config</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yaf.environ">yaf.environ</link></entry>
       <entry>product</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yaf.use-namespace">yaf.use_namespace</link></entry>
       <entry>0</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
     </tbody>
@@ -94,7 +94,7 @@
      <listitem>
       <para>
         The global library path, Yaf_loader will search global library in this
-        directory.      
+        directory.
       </para>
      </listitem>
     </varlistentry>
@@ -133,7 +133,7 @@
       <para>
         When this value is On, if <classname>Yaf_Loader</classname> can not
         find a class, it will return &false;, then give chance to other auto
-        load function to be called.      
+        load function to be called.
       </para>
       <para>
         When this value is Off, if <classname>Yaf_Loader</classname> can not
@@ -142,7 +142,7 @@
       </para>
       <note>
        <para>
-        Yaf will register its loader during a instantiation of  
+        Yaf will register its loader during a instantiation of
         <classname>Yaf_Application</classname>, so any other auto loaders
         which is register before the instantiation will be called before
         <methodname>Yaf_Loader::autoload</methodname>.

--- a/reference/yaml/ini.xml
+++ b/reference/yaml/ini.xml
@@ -20,37 +20,37 @@
           <row>
             <entry><link linkend="ini.yaml.decode-binary">yaml.decode_binary</link></entry>
             <entry>0</entry>
-            <entry>PHP_INI_ALL</entry>
+            <entry><constant>INI_ALL</constant></entry>
             <entry><!-- leave empty, this will be filled by an automatic script --></entry>
           </row>
           <row>
             <entry><link linkend="ini.yaml.decode-php">yaml.decode_php</link></entry>
             <entry>0</entry>
-            <entry>PHP_INI_ALL</entry>
+            <entry><constant>INI_ALL</constant></entry>
             <entry>Added in 1.2.0, before 2.0.0 the default was 1</entry>
           </row>
           <row>
             <entry><link linkend="ini.yaml.decode-timestamp">yaml.decode_timestamp</link></entry>
             <entry>0</entry>
-            <entry>PHP_INI_ALL</entry>
+            <entry><constant>INI_ALL</constant></entry>
             <entry><!-- leave empty, this will be filled by an automatic script --></entry>
           </row>
           <row>
             <entry><link linkend="ini.yaml.output-canonical">yaml.output_canonical</link></entry>
             <entry>0</entry>
-            <entry>PHP_INI_ALL</entry>
+            <entry><constant>INI_ALL</constant></entry>
             <entry><!-- leave empty, this will be filled by an automatic script --></entry>
           </row>
           <row>
             <entry><link linkend="ini.yaml.output-indent">yaml.output_indent</link></entry>
             <entry>2</entry>
-            <entry>PHP_INI_ALL</entry>
+            <entry><constant>INI_ALL</constant></entry>
             <entry><!-- leave empty, this will be filled by an automatic script --></entry>
           </row>
           <row>
             <entry><link linkend="ini.yaml.output-width">yaml.output_width</link></entry>
             <entry>80</entry>
-            <entry>PHP_INI_ALL</entry>
+            <entry><constant>INI_ALL</constant></entry>
             <entry><!-- leave empty, this will be filled by an automatic script --></entry>
           </row>
         </tbody>

--- a/reference/yar/ini.xml
+++ b/reference/yar/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <section xml:id="yar.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -20,31 +20,31 @@
      <row>
       <entry><link linkend="ini.yar.packager">yar.packager</link></entry>
       <entry>php</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yar.debug">yar.debug</link></entry>
       <entry>Off</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yar.connect-timeout">yar.connect_timeout</link></entry>
       <entry>1000</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yar.timeout">yar.timeout</link></entry>
       <entry>5000</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
       <entry><link linkend="ini.yar.expose-info">yar.expose_info</link></entry>
       <entry>On</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
     </tbody>
@@ -74,7 +74,7 @@
      </term>
      <listitem>
       <para>
-       
+
       </para>
      </listitem>
     </varlistentry>
@@ -85,7 +85,7 @@
      </term>
      <listitem>
       <para>
-       timeout in ms 
+       timeout in ms
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zlib/ini.xml
+++ b/reference/zlib/ini.xml
@@ -23,19 +23,19 @@
      <row>
       <entry><link linkend="ini.zlib.output-compression">zlib.output_compression</link></entry>
       <entry>"0"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.zlib.output-compression-level">zlib.output_compression_level</link></entry>
       <entry>"-1"</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.zlib.output-handler">zlib.output_handler</link></entry>
       <entry>""</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
     </tbody>
@@ -43,9 +43,9 @@
   </table>
    &ini.php.constants;
 </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
  <variablelist>
   <varlistentry xml:id="ini.zlib.output-compression">
@@ -70,7 +70,7 @@
     </para>
     <note>
      <para>
-      <link linkend="ini.output-handler">output_handler</link> must be 
+      <link linkend="ini.output-handler">output_handler</link> must be
       empty if this is set 'On' ! Instead you must use <literal>zlib.output_handler</literal>.
      </para>
     </note>

--- a/reference/zookeeper/ini.xml
+++ b/reference/zookeeper/ini.xml
@@ -23,19 +23,19 @@
      <row>
       <entry><link linkend="ini.zookeeper.recv_timeout">zookeeper.recv_timeout</link></entry>
       <entry>10000</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.zookeeper.session_lock">zookeeper.session_lock</link></entry>
       <entry>1</entry>
-      <entry>PHP_INI_SYSTEM</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.zookeeper.sess_lock_wait">zookeeper.sess_lock_wait</link></entry>
       <entry>150000</entry>
-      <entry>PHP_INI_ALL</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
     </tbody>
@@ -45,9 +45,9 @@
   &ini.php.constants;
 
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
 


### PR DESCRIPTION
The documentation made liberal use of the `PHP_INI_*` constants which are used in the C source code but were never exposed to userland. This PR replaces them with their `INI_*` aliases and adds `<constant>` tags where applicable.

I will wait for #3136 to land before rebasing this PR.