### PR TITLE
FPM Status page: Fix proxypass URL

### DIFF
--- a/reference/fpm/status.xml
+++ b/reference/fpm/status.xml
@@ -36,8 +36,7 @@
    <programlisting role="apache-conf">
     <![CDATA[
 <LocationMatch "/fpm-status">
- Order Allow,Deny
- Allow from 127.0.0.1
+ Require local
  ProxyPass "unix:/var/run/php-fpm.sock|fcgi://localhost/"
 </LocationMatch>
 ]]>

--- a/reference/fpm/status.xml
+++ b/reference/fpm/status.xml
@@ -38,7 +38,7 @@
 <LocationMatch "/fpm-status">
  Order Allow,Deny
  Allow from 127.0.0.1
- ProxyPass "unix:/var/run/php-fpm.sock|fcgi://localhost/fpm-status"
+ ProxyPass "unix:/var/run/php-fpm.sock|fcgi://localhost/"
 </LocationMatch>
 ]]>
    </programlisting>


### PR DESCRIPTION
Fixes issue raised in note: https://www.php.net/manual/en/fpm.status.php#128833

Additionally updates the "Allow from" Apache (2.2) directive to (Apache 2.4+) "Require" (and allows IPv6 connections)