### PR TITLE
Link duplicate INI constant table

### DIFF
--- a/install/ini.xml
+++ b/install/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<chapter xml:id="configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Runtime Configuration</title>
 
  <sect1 xml:id="configuration.file">
@@ -262,39 +262,7 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
 
   <para>
    <table>
-    <title>Definition of INI_* modes</title>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>Mode</entry>
-       <entry>Meaning</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry><constant>INI_USER</constant></entry>
-       <entry>
-        Entry can be set in user scripts (like with <function>ini_set</function>)
-        or in the <link linkend="configuration.changes.windows">Windows registry</link>.
-        Entry can be set in &user-ini;
-       </entry>
-      </row>
-      <row>
-       <entry><constant>INI_PERDIR</constant></entry>
-       <entry>
-        Entry can be set in &php.ini;, &htaccess;, &httpd.conf; or &user-ini;
-       </entry>
-      </row>
-      <row>
-       <entry><constant>INI_SYSTEM</constant></entry>
-       <entry>Entry can be set in &php.ini; or &httpd.conf;</entry>
-      </row>
-      <row>
-       <entry><constant>INI_ALL</constant></entry>
-       <entry>Entry can be set anywhere</entry>
-      </row>
-     </tbody>
-    </tgroup>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('constant.ini-mode')/*)"><xi:fallback/></xi:include>
    </table>
   </para>
  </sect1>

--- a/install/ini.xml
+++ b/install/ini.xml
@@ -2,10 +2,10 @@
 <!-- $Revision$ -->
 <chapter xml:id="configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Runtime Configuration</title>
- 
+
  <sect1 xml:id="configuration.file">
   <title>The configuration file</title>
-  
+
   <simpara>
    The configuration file (&php.ini;)
    is read when PHP starts up. For the server module versions of PHP,
@@ -146,7 +146,7 @@ include_path = ".;c:\php\lib"
    <para>
     It is possible to configure PHP to scan for .ini files in a directory
     after reading &php.ini;. This can be done at compile time by setting the
-    <option role="configure">--with-config-file-scan-dir</option> option. 
+    <option role="configure">--with-config-file-scan-dir</option> option.
     The scan directory can then be overridden at run time
     by setting the <varname>PHP_INI_SCAN_DIR</varname> environment variable.
    </para>
@@ -194,10 +194,10 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
    </informalexample>
   </sect2>
  </sect1>
- 
+
  <sect1 xml:id="configuration.file.per-user">
   <title>.user.ini files</title>
-  
+
   <simpara>
    PHP includes support for configuration INI files on a
    per-directory basis. These files are processed <emphasis>only</emphasis> by
@@ -205,7 +205,7 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
    extension. If you are running PHP as Apache module, use &htaccess; files for the same
    effect.
   </simpara>
-  
+
   <simpara>
    In addition to the main &php.ini; file, PHP scans for INI files in each
    directory, starting with the directory of the requested PHP file, and
@@ -219,29 +219,29 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
    <constant>INI_USER</constant> will be recognized in .user.ini-style INI
    files.
   </simpara>
-  
+
   <simpara>
    Two new INI directives,
    <link linkend="ini.user-ini.filename">user_ini.filename</link> and
    <link linkend="ini.user-ini.cache-ttl">user_ini.cache_ttl</link>
    control the use of user INI files.
   </simpara>
-  
+
   <simpara>
    <link linkend="ini.user-ini.filename">user_ini.filename</link> sets the name of the file PHP looks for
    in each directory; if set to an empty string, PHP doesn't scan at all. The
    default is <literal>.user.ini</literal>.
   </simpara>
-  
+
   <simpara>
    <link linkend="ini.user-ini.cache-ttl">user_ini.cache_ttl</link> controls how often user INI files are
    re-read. The default is 300 seconds (5 minutes).
   </simpara>
  </sect1>
- 
+
  <sect1 xml:id="configuration.changes.modes">
   <title>Where a configuration setting may be set</title>
-  
+
   <para>
    These modes determine when and where a PHP directive may or may not
    be set, and each directive within the manual refers to one of these
@@ -249,7 +249,7 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
    using <function>ini_set</function>, whereas others may require
    &php.ini; or &httpd.conf;.
   </para>
-  
+
   <para>
    For example, the
    <link linkend="ini.output-buffering">output_buffering</link> setting
@@ -259,7 +259,7 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
    <constant>INI_ALL</constant> therefore it may be set anywhere,
    including with <function>ini_set</function>.
   </para>
-  
+
   <para>
    <table>
     <title>Definition of INI_* modes</title>
@@ -298,10 +298,10 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
    </table>
   </para>
  </sect1>
- 
+
  <sect1 xml:id="configuration.changes">
   <title>How to change configuration settings</title>
-  
+
   <sect2 xml:id="configuration.changes.apache">
    <title>Running PHP as an Apache module</title>
    <simpara>
@@ -310,7 +310,7 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
     files (e.g. &httpd.conf;) and &htaccess; files. You will need
     "AllowOverride Options" or "AllowOverride All" privileges to do so.
    </simpara>
-   
+
    <para>
     There are several Apache directives that allow you
     to change the PHP configuration from within the Apache configuration
@@ -319,7 +319,7 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
     or <constant>INI_SYSTEM</constant>, have a look at the
     <link linkend="ini.list">List of php.ini directives</link> appendix.
    </para>
-   
+
    <para>
     <variablelist>
      <varlistentry>
@@ -418,7 +418,7 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
     </para>
    </caution>
   </sect2>
-  
+
   <sect2 xml:id="configuration.changes.windows">
    <title>Changing PHP configuration via the Windows registry</title>
    <simpara>
@@ -440,7 +440,7 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
     because these configuration values are re-read for each request.
    </simpara>
   </sect2>
-  
+
   <sect2 xml:id="configuration.changes.other">
    <title>Other interfaces to PHP</title>
    <para>
@@ -458,7 +458,7 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
    </para>
   </sect2>
  </sect1>
- 
+
 </chapter>
 
 <!-- Keep this comment at the end of the file

--- a/reference/info/constants.xml
+++ b/reference/info/constants.xml
@@ -156,7 +156,7 @@
   </tgroup>
  </table>
 
- <table>
+ <table xml:id="constant.ini-mode">
   <title>INI mode constants</title>
   <tgroup cols="2">
    <thead>
@@ -166,7 +166,7 @@
     </row>
    </thead>
    <tbody>
-    <row xml:id="constant.ini-user">
+    <row>
      <entry>
       <constant>INI_USER</constant>
       (<type>int</type>)
@@ -177,7 +177,7 @@
       Entry can be set in &user-ini;
      </entry>
     </row>
-    <row xml:id="constant.ini-perdir">
+    <row>
      <entry>
       <constant>INI_PERDIR</constant>
       (<type>int</type>)
@@ -186,7 +186,7 @@
       Entry can be set in &php.ini;, &htaccess;, &httpd.conf; or &user-ini;
      </entry>
     </row>
-    <row xml:id="constant.ini-system">
+    <row>
      <entry>
       <constant>INI_SYSTEM</constant>
       (<type>int</type>)
@@ -195,7 +195,7 @@
       Entry can be set in &php.ini; or &httpd.conf;
      </entry>
     </row>
-    <row xml:id="constant.ini-all">
+    <row>
      <entry>
       <constant>INI_ALL</constant>
       (<type>int</type>)


### PR DESCRIPTION
Replace the duplicate of the `INI` mode table with a link to its copy on a constant list page. This is a continuation of #3140 and the final piece in the `PHP_INI_` mode constant cleanup.

As a side note, `INI_USER`, `INI_PERDIR`, `INI_SYSTEM` and `INI_ALL` can be marked as complete on the [missing constants list](https://github.com/php/doc-en/issues/2747).