### PR TITLE
Cleanup of GLOB constants

### DIFF
--- a/reference/filesystem/constants.xml
+++ b/reference/filesystem/constants.xml
@@ -88,7 +88,25 @@
    </term>
    <listitem>
     <simpara>
-
+     Expands {a,b,c} to match 'a', 'b', or 'c'
+    </simpara>
+    <note>
+     <simpara>
+      <constant>GLOB_BRACE</constant> is not available on some non GNU systems,
+      like Solaris or Alpine Linux.
+     </simpara>
+    </note>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.glob-err">
+   <term>
+    <constant>GLOB_ERR</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Stop on read errors (like unreadable directories),
+     by default errors are ignored.
     </simpara>
    </listitem>
   </varlistentry>
@@ -99,7 +117,7 @@
    </term>
    <listitem>
     <simpara>
-
+     Return only directory entries which match the pattern
     </simpara>
    </listitem>
   </varlistentry>
@@ -110,7 +128,7 @@
    </term>
    <listitem>
     <simpara>
-
+     Adds a slash (a backslash on Windows) to each directory returned
     </simpara>
    </listitem>
   </varlistentry>
@@ -121,7 +139,8 @@
    </term>
    <listitem>
     <simpara>
-
+     Return files as they appear in the directory (no sorting).
+     When this flag is not used, the pathnames are sorted alphabetically
     </simpara>
    </listitem>
   </varlistentry>
@@ -132,7 +151,7 @@
    </term>
    <listitem>
     <simpara>
-
+     Return the search pattern if no files matching it were found
     </simpara>
    </listitem>
   </varlistentry>
@@ -143,7 +162,7 @@
    </term>
    <listitem>
     <simpara>
-
+     Backslashes do not quote metacharacters
     </simpara>
    </listitem>
   </varlistentry>
@@ -154,7 +173,11 @@
    </term>
    <listitem>
     <simpara>
-
+     All <constant>GLOB_<replaceable>*</replaceable></constant> flags combined.
+     Equivalent to <literal>0</literal> | <constant>GLOB_BRACE</constant> |
+     <constant>GLOB_MARK</constant> | <constant>GLOB_NOSORT</constant> |
+     <constant>GLOB_NOCHECK</constant> | <constant>GLOB_NOESCAPE</constant> |
+     <constant>GLOB_ERR</constant> | <constant>GLOB_ONLYDIR</constant>
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/filesystem/constants.xml
+++ b/reference/filesystem/constants.xml
@@ -11,7 +11,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -22,7 +22,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -33,7 +33,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -44,7 +44,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -55,7 +55,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -66,7 +66,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -77,7 +77,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -268,7 +268,7 @@
      Binary mode.
      <note>
       <para>
-       This constant has no effect, and is only available for 
+       This constant has no effect, and is only available for
        <literal>forward compatibility</literal>.
       </para>
      </note>
@@ -286,7 +286,7 @@
      Text mode.
      <note>
       <para>
-       This constant has no effect, and is only available for 
+       This constant has no effect, and is only available for
        <literal>forward compatibility</literal>.
       </para>
      </note>
@@ -317,7 +317,7 @@
     </simpara>
    </listitem>
   </varlistentry>
- 
+
   <varlistentry xml:id="constant.ini-scanner-typed">
    <term>
     <constant>INI_SCANNER_TYPED</constant>
@@ -329,7 +329,7 @@
     </simpara>
    </listitem>
   </varlistentry>
- 
+
   <varlistentry xml:id="constant.fnm-noescape">
    <term>
     <constant>FNM_NOESCAPE</constant>

--- a/reference/filesystem/constants.xml
+++ b/reference/filesystem/constants.xml
@@ -81,7 +81,9 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.glob-brace">
+ </variablelist>
+ <variablelist xml:id="constant.glob-constant-variablelist">
+  <varlistentry>
    <term>
     <constant>GLOB_BRACE</constant>
      (<type>int</type>)
@@ -98,7 +100,7 @@
     </note>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.glob-err">
+  <varlistentry>
    <term>
     <constant>GLOB_ERR</constant>
      (<type>int</type>)
@@ -110,7 +112,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.glob-onlydir">
+  <varlistentry>
    <term>
     <constant>GLOB_ONLYDIR</constant>
      (<type>int</type>)
@@ -121,7 +123,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.glob-mark">
+  <varlistentry>
    <term>
     <constant>GLOB_MARK</constant>
      (<type>int</type>)
@@ -132,7 +134,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.glob-nosort">
+  <varlistentry>
    <term>
     <constant>GLOB_NOSORT</constant>
      (<type>int</type>)
@@ -144,7 +146,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.glob-nocheck">
+  <varlistentry>
    <term>
     <constant>GLOB_NOCHECK</constant>
      (<type>int</type>)
@@ -155,7 +157,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.glob-noescape">
+  <varlistentry>
    <term>
     <constant>GLOB_NOESCAPE</constant>
      (<type>int</type>)
@@ -166,7 +168,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.glob-available-flags">
+  <varlistentry>
    <term>
     <constant>GLOB_AVAILABLE_FLAGS</constant>
      (<type>int</type>)
@@ -181,6 +183,8 @@
     </simpara>
    </listitem>
   </varlistentry>
+ </variablelist>
+ <variablelist>
   <varlistentry xml:id="constant.pathinfo-dirname">
    <term>
     <constant>PATHINFO_DIRNAME</constant>

--- a/reference/filesystem/functions/glob.xml
+++ b/reference/filesystem/functions/glob.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="function.glob" xmlns="http://docbook.org/ns/docbook">
+<refentry xml:id="function.glob" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>glob</refname>
   <refpurpose>Find pathnames matching a pattern</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -66,56 +66,9 @@
      <listitem>
       <para>
        Valid flags:
-       <itemizedlist>
-        <listitem>
-         <simpara>
-          <constant>GLOB_MARK</constant> - Adds a slash (a backslash on Windows) to each directory returned
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>GLOB_NOSORT</constant> - Return files as they appear in the
-          directory (no sorting). When this flag is not used, the pathnames are
-          sorted alphabetically
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>GLOB_NOCHECK</constant> - Return the search pattern if no
-          files matching it were found
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>GLOB_NOESCAPE</constant> - Backslashes do not quote
-          metacharacters
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>GLOB_BRACE</constant> - Expands {a,b,c} to match 'a', 'b',
-          or 'c'
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>GLOB_ONLYDIR</constant> - Return only directory entries
-          which match the pattern
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>GLOB_ERR</constant> - Stop on read errors (like unreadable
-          directories), by default errors are ignored.
-         </simpara>
-        </listitem>
-       </itemizedlist>
-       <note>
-        <simpara>
-         The <constant>GLOB_BRACE</constant> flag is not available on some non GNU
-         systems, like Solaris or Alpine Linux.
-        </simpara>
-       </note>
+       <variablelist>
+        <xi:include set-xml-id="" xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('constant.glob-constant-variablelist')/*)"><xi:fallback/></xi:include>
+       </variablelist>
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Adds the missing GLOB_ERR constant, adds descriptions to each GLOB constant and `XInclude`s them on the `glob()` function's page.