### PR TITLE
Add missing PASSWORD constants

### DIFF
--- a/reference/password/constants.xml
+++ b/reference/password/constants.xml
@@ -50,6 +50,18 @@
      </itemizedlist>
     </listitem>
    </varlistentry>
+   <varlistentry xml:id="constant.password-bcrypt-default-cost">
+    <term>
+     <constant>PASSWORD_BCRYPT_DEFAULT_COST</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <para>
+     </para>
+     <para>
+     </para>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="constant.password-argon2i">
     <term>
      <constant>PASSWORD_ARGON2I</constant>
@@ -146,6 +158,19 @@
      </para>
      <para>
       Available as of PHP 7.2.0.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.password-argon2-provider">
+    <term>
+     <constant>PASSWORD_ARGON2_PROVIDER</constant>
+     (<type>string</type>)
+    </term>
+    <listitem>
+     <para>
+     </para>
+     <para>
+      Available as of PHP 7.4.0.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Adds two missing PASSWORD_ constants. 

These are the last two constants that were missing due to them being registered in a `c` instead of a `stub` file. I think a few of those ~30 constants could be registered through a `stub` file.