### PR TITLE
Add DigitalOcean section in Cloud Hosting installation section

### DIFF
--- a/install/cloud/digitalocean.xml
+++ b/install/cloud/digitalocean.xml
@@ -3,7 +3,8 @@
 <sect1 xml:id="install.cloud.digitalocean" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>DigitalOcean</title>
  <para>
-  DigitalOcean offers the below platforms to get PHP installed and running web application on its cloud-hosting infrastructure.
+  DigitalOcean offers the following platforms to get PHP installed,
+  and running web application on its cloud-hosting infrastructure.
  </para>
  <itemizedlist spacing="compact">
   <listitem>

--- a/install/cloud/digitalocean.xml
+++ b/install/cloud/digitalocean.xml
@@ -8,22 +8,39 @@
  <itemizedlist spacing="compact">
   <listitem>
    <para>
-    <link xlink:href="https://www.cloudways.com/en/managed-hosting-for-digital-ocean.php">Cloudways</link>: One-click deployment of major PHP applications: WordPress, Magento, Drupal, Laravel, and more.
+    <link xlink:href="https://www.cloudways.com/en/managed-hosting-for-digital-ocean.php">Cloudways</link>:
+    One-click deployment of major PHP applications:
+    WordPress, Magento, Drupal, Laravel, and more.
    </para>
   </listitem>
   <listitem>
    <para>
-    <link xlink:href="https://www.digitalocean.com/products/droplets">Droplet</link>: Virtual machine boxes and installing <link xlink:href="https://www.digitalocean.com/community/tutorials/how-to-install-linux-apache-mysql-php-lamp-stack-on-ubuntu-16-04">Lamp stack on a Linux server</link>.
+    <link xlink:href="https://www.digitalocean.com/products/droplets">Droplet</link>:
+    Virtual machine boxes and installing
+    <link xlink:href="https://www.digitalocean.com/community/tutorials/how-to-install-linux-apache-mysql-php-lamp-stack-on-ubuntu-16-04">
+     Lamp stack on a Linux server
+    </link>.
    </para>
   </listitem>
   <listitem>
    <para>
-    <link xlink:href="https://www.digitalocean.com/products/app-platform">App Platform</link>: Managed infrastructure to build, deploy, and scale apps quickly. Learn <link xlink:href="https://docs.digitalocean.com/products/app-platform/getting-started/sample-apps/php/">how to run PHP application on the App Platform</link>.
+    <link xlink:href="https://www.digitalocean.com/products/app-platform">App Platform</link>:
+    Managed infrastructure to build, deploy, and scale apps quickly.
+    Learn
+    <link xlink:href="https://docs.digitalocean.com/products/app-platform/getting-started/sample-apps/php/">
+     how to run PHP application on the App Platform
+    </link>.
    </para>
   </listitem>
   <listitem>
    <para>
-    <link xlink:href="https://www.digitalocean.com/products/functions">Functions</link>: Serverless platform that allows developers to run code without provisioning or managing servers. PHP is supported natively. Learn <link xlink:href="https://docs.digitalocean.com/products/functions/reference/runtimes/php/">how to create serverless functions in PHP</link>.
+    <link xlink:href="https://www.digitalocean.com/products/functions">Functions</link>:
+    Serverless platform that allows developers to run code without provisioning or managing servers.
+    PHP is supported natively.
+    Learn
+    <link xlink:href="https://docs.digitalocean.com/products/functions/reference/runtimes/php/">
+     how to create serverless functions in PHP
+    </link>.
    </para>
   </listitem>
  </itemizedlist>

--- a/install/cloud/digitalocean.xml
+++ b/install/cloud/digitalocean.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<sect1 xml:id="install.cloud.digitalocean" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>DigitalOcean</title>
+ <para>
+  DigitalOcean offers the below platforms to get PHP installed and running web application on its cloud-hosting infrastructure.
+ </para>
+ <itemizedlist spacing="compact">
+  <listitem>
+   <para>
+    <link xlink:href="https://www.cloudways.com/en/managed-hosting-for-digital-ocean.php">Cloudways</link>: One-click deployment of major PHP applications: WordPress, Magento, Drupal, Laravel, and more.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    <link xlink:href="https://www.digitalocean.com/products/droplets">Droplet</link>: Virtual machine boxes and installing <link xlink:href="https://www.digitalocean.com/community/tutorials/how-to-install-linux-apache-mysql-php-lamp-stack-on-ubuntu-16-04">Lamp stack on a Linux server</link>.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    <link xlink:href="https://www.digitalocean.com/products/app-platform">App Platform</link>: Managed infrastructure to build, deploy, and scale apps quickly. Learn <link xlink:href="https://docs.digitalocean.com/products/app-platform/getting-started/sample-apps/php/">how to run PHP application on the App Platform</link>.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    <link xlink:href="https://www.digitalocean.com/products/functions">Functions</link>: Serverless platform that allows developers to run code without provisioning or managing servers. PHP is supported natively. Learn <link xlink:href="https://docs.digitalocean.com/products/functions/reference/runtimes/php/">how to create serverless functions in PHP</link>.
+   </para>
+  </listitem>
+ </itemizedlist>
+</sect1>
+
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/install/cloud/index.xml
+++ b/install/cloud/index.xml
@@ -7,6 +7,7 @@
  </para>
  &install.cloud.azure;
  &install.cloud.ec2;
+ &install.cloud.digitalocean;
 </chapter>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
As php.net and manual are hosted for years on DigitalOcean, it would be good to mention it in this section.