### PR TITLE
PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT is mysqlnd only

### DIFF
--- a/reference/pdo_mysql/constants.xml
+++ b/reference/pdo_mysql/constants.xml
@@ -239,7 +239,7 @@ foreach ($unbufferedResult as $row) {
    </term>
    <listitem>
     <para>
-     Provides a way to disable verification of the server SSL certificate.
+     Provides a way to disable verification of the server SSL certificate (requires mysqlnd).
     </para>
     <para>
      &version.exists.asof; 7.0.18 and PHP 7.1.4.

--- a/reference/pdo_mysql/constants.xml
+++ b/reference/pdo_mysql/constants.xml
@@ -240,7 +240,6 @@ foreach ($unbufferedResult as $row) {
    <listitem>
     <para>
      Provides a way to disable verification of the server SSL certificate.
-     
      This option is available only with mysqlnd.
     </para>
     <para>

--- a/reference/pdo_mysql/constants.xml
+++ b/reference/pdo_mysql/constants.xml
@@ -239,7 +239,7 @@ foreach ($unbufferedResult as $row) {
    </term>
    <listitem>
     <para>
-     Provides a way to disable verification of the server SSL certificate (requires mysqlnd).
+     Provides a way to disable verification of the server SSL certificate. This option is available only with mysqlnd.
     </para>
     <para>
      &version.exists.asof; 7.0.18 and PHP 7.1.4.

--- a/reference/pdo_mysql/constants.xml
+++ b/reference/pdo_mysql/constants.xml
@@ -239,7 +239,9 @@ foreach ($unbufferedResult as $row) {
    </term>
    <listitem>
     <para>
-     Provides a way to disable verification of the server SSL certificate. This option is available only with mysqlnd.
+     Provides a way to disable verification of the server SSL certificate.
+     
+     This option is available only with mysqlnd.
     </para>
     <para>
      &version.exists.asof; 7.0.18 and PHP 7.1.4.


### PR DESCRIPTION
note that `PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT` is [only available with mysqlnd](https://github.com/php/php-src/blob/87edeed3b9fcb9d066d8e18b10fb0ed8cb976873/ext/pdo_mysql/pdo_mysql.c#L143-L145).

Recently we ran into a problem that this constant requires a `defined` check, as its not always defined.