### PR TITLE
Replace deprecated `${var}` string interpolations with `{$var}`

### DIFF
--- a/faq/html.xml
+++ b/faq/html.xml
@@ -315,7 +315,7 @@ if (isset($_GET['width']) AND isset($_GET['height'])) {
   //   -- post variables will need to handled differently)
 
   echo "<script language='javascript'>\n";
-  echo "  location.href=\"${_SERVER['SCRIPT_NAME']}?${_SERVER['QUERY_STRING']}"
+  echo "  location.href=\"{$_SERVER['SCRIPT_NAME']}?{$_SERVER['QUERY_STRING']}"
             . "&width=\" + screen.width + \"&height=\" + screen.height;\n";
   echo "</script>\n";
   exit();

--- a/reference/mysql_xdevapi/examples.xml
+++ b/reference/mysql_xdevapi/examples.xml
@@ -108,7 +108,7 @@ array(4) {
 <?php
 $result = $collection->find()->execute();
 foreach ($result as $doc) {
-  echo "${doc["name"]} is a ${doc["job"]}.\n";
+  echo "{$doc["name"]} is a {$doc["job"]}.\n";
 }
 ?>
 ]]>

--- a/reference/pgsql/functions/pg-send-query-params.xml
+++ b/reference/pgsql/functions/pg-send-query-params.xml
@@ -101,10 +101,10 @@
   // Using parameters.  Note that it is not necessary to quote or escape
   // the parameter.
   pg_send_query_params($dbconn, 'select count(*) from authors where city = $1', array('Perth'));
-  
+
   // Compare against basic pg_send_query usage
   $str = pg_escape_string('Perth');
-  pg_send_query($dbconn, "select count(*) from authors where city = '${str}'");
+  pg_send_query($dbconn, "select count(*) from authors where city = '{$str}'");
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
There have remained some code samples with `${var}` style interpolation which was deprecated since PHP 8.2.
This PR fixed them.

`language/types/string.xml` is going to be edited by #2000, so this PR does not change the file.