### PR TITLE
Update array-search.xml: wrong the parameter name

### DIFF
--- a/reference/array/functions/array-search.xml
+++ b/reference/array/functions/array-search.xml
@@ -70,7 +70,7 @@
    If <parameter>needle</parameter> is found in <parameter>haystack</parameter>
    more than once, the first matching key is returned. To return the keys for
    all matching values, use <function>array_keys</function> with the optional
-   <parameter>search_value</parameter> parameter instead.
+   <parameter>filter_value</parameter> parameter instead.
   </para>
   &return.falseproblem;
  </refsect1>


### PR DESCRIPTION
The second parameter of the [array_keys()](https://www.php.net/manual/en/function.array-keys.php) function is `filter_value`, but not `search_value`