### PR TITLE
[PHP 8.3] Update PGSQL

### DIFF
--- a/reference/pgsql/functions/pg-convert.xml
+++ b/reference/pgsql/functions/pg-convert.xml
@@ -85,6 +85,14 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   A <classname>ValueError</classname> or <classname>TypeError</classname> is thrown
+   when the value or type of field does not match properly with a PostgreSQL's type.
+  </para>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -96,6 +104,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       Now throws a <classname>ValueError</classname> or <classname>TypeError</classname> error
+       when the value or type of field does not match properly with a PostgreSQL's type;
+       previously an <constant>E_WARNING</constant> was emitted.
+      </entry>
+     </row>
      &pgsql.changelog.connection-object;
     </tbody>
    </tgroup>

--- a/reference/pgsql/functions/pg-fetch-object.xml
+++ b/reference/pgsql/functions/pg-fetch-object.xml
@@ -85,6 +85,14 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   A <classname>ValueError</classname> is thrown when
+   the <parameter>constructor_args</parameter> is non-empty with the class not having constructor.
+  </para>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -96,6 +104,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       Now throws a <classname>ValueError</classname> exception when
+       the <parameter>constructor_args</parameter> is non-empty with the class not having constructor;
+       previously an <classname>Exception</classname> was thrown.
+      </entry>
+     </row>
      &pgsql.changelog.result-object;
     </tbody>
    </tgroup>

--- a/reference/pgsql/functions/pg-fetch-result.xml
+++ b/reference/pgsql/functions/pg-fetch-result.xml
@@ -93,7 +93,7 @@
      <row>
       <entry>8.3.0</entry>
       <entry>
-       The <parameter>row</parameter> parameter is now nullable.
+       <parameter>row</parameter> is now nullable.
       </entry>
      </row>
      &pgsql.changelog.result-object;

--- a/reference/pgsql/functions/pg-fetch-result.xml
+++ b/reference/pgsql/functions/pg-fetch-result.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type><type>null</type></type><methodname>pg_fetch_result</methodname>
    <methodparam><type>PgSql\Result</type><parameter>result</parameter></methodparam>
-   <methodparam><type>int</type><parameter>row</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>false</type><type>null</type></type><parameter>row</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>field</parameter></methodparam>
   </methodsynopsis>
   <methodsynopsis>
@@ -90,6 +90,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       The <parameter>row</parameter> parameter is now nullable.
+      </entry>
+     </row>
      &pgsql.changelog.result-object;
     </tbody>
    </tgroup>

--- a/reference/pgsql/functions/pg-field-is-null.xml
+++ b/reference/pgsql/functions/pg-field-is-null.xml
@@ -85,7 +85,7 @@
      <row>
       <entry>8.3.0</entry>
       <entry>
-       The <parameter>row</parameter> parameter is now nullable.
+       <parameter>row</parameter> is now nullable.
       </entry>
      </row>
      &pgsql.changelog.result-object;

--- a/reference/pgsql/functions/pg-field-is-null.xml
+++ b/reference/pgsql/functions/pg-field-is-null.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <type>int</type><methodname>pg_field_is_null</methodname>
    <methodparam><type>PgSql\Result</type><parameter>result</parameter></methodparam>
-   <methodparam><type>int</type><parameter>row</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>false</type><type>null</type></type><parameter>row</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>field</parameter></methodparam>
   </methodsynopsis>
   <methodsynopsis>
@@ -82,6 +82,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       The <parameter>row</parameter> parameter is now nullable.
+      </entry>
+     </row>
      &pgsql.changelog.result-object;
     </tbody>
    </tgroup>

--- a/reference/pgsql/functions/pg-field-prtlen.xml
+++ b/reference/pgsql/functions/pg-field-prtlen.xml
@@ -86,7 +86,7 @@
      <row>
       <entry>8.3.0</entry>
       <entry>
-       The <parameter>row</parameter> parameter is now nullable.
+       <parameter>row</parameter> is now nullable.
       </entry>
      </row>
      &pgsql.changelog.result-object;

--- a/reference/pgsql/functions/pg-field-prtlen.xml
+++ b/reference/pgsql/functions/pg-field-prtlen.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <type>int</type><methodname>pg_field_prtlen</methodname>
    <methodparam><type>PgSql\Result</type><parameter>result</parameter></methodparam>
-   <methodparam><type>int</type><parameter>row_number</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>false</type><type>null</type></type><parameter>row</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>field_name_or_number</parameter></methodparam>
   </methodsynopsis>
   <methodsynopsis>
@@ -83,6 +83,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       The <parameter>row</parameter> parameter is now nullable.
+      </entry>
+     </row>
      &pgsql.changelog.result-object;
     </tbody>
    </tgroup>

--- a/reference/pgsql/functions/pg-insert.xml
+++ b/reference/pgsql/functions/pg-insert.xml
@@ -97,6 +97,17 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   A <classname>ValueError</classname> is thrown when the specified table is invalid.
+  </para>
+  <para>
+   A <classname>ValueError</classname> or <classname>TypeError</classname> is thrown
+   when the value or type of field does not match properly with a PostgreSQL's type.
+  </para>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -108,6 +119,21 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       Now throws a <classname>ValueError</classname> error when the specified table is invalid;
+       previously an <constant>E_WARNING</constant> was emitted.
+      </entry>
+     </row>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       Now throws a <classname>ValueError</classname> or <classname>TypeError</classname> error
+       when the value or type of field does not match properly with a PostgreSQL's type;
+       previously an <constant>E_WARNING</constant> was emitted.
+      </entry>
+     </row>
      &pgsql.changelog.return-result-object;
      &pgsql.changelog.connection-object;
     </tbody>


### PR DESCRIPTION
For [`pg_fetch_result()`](https://github.com/php/php-src/blob/PHP-8.3/ext/pgsql/pgsql.stub.php#L605), [`pg_field_prtlen()`](https://github.com/php/php-src/blob/PHP-8.3/ext/pgsql/pgsql.stub.php#L652), and [`pg_field_is_null()`](https://github.com/php/php-src/blob/PHP-8.3/ext/pgsql/pgsql.stub.php#L661) updated signature, based on stubs.