### PR TITLE
Fix return type of time()

### DIFF
--- a/reference/datetime/functions/time.xml
+++ b/reference/datetime/functions/time.xml
@@ -10,7 +10,6 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>time</methodname>
-   <void/>
   </methodsynopsis>
   <para>
    Returns the current time measured in the number of seconds since


### PR DESCRIPTION
Documentation displayed: time(): intvoid
Removed the unnecessary </void> tag.