### PR TITLE
Fix error constant IDs

### DIFF
--- a/appendices/reserved.constants.core.xml
+++ b/appendices/reserved.constants.core.xml
@@ -456,7 +456,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.e-error">
+  <varlistentry>
    <term>
     <constant>E_ERROR</constant>
     (<type>int</type>)
@@ -467,7 +467,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.e-warning">
+  <varlistentry>
    <term>
     <constant>E_WARNING</constant>
     (<type>int</type>)
@@ -478,7 +478,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.e-parse">
+  <varlistentry>
    <term>
     <constant>E_PARSE</constant>
     (<type>int</type>)
@@ -489,7 +489,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.e-notice">
+  <varlistentry>
    <term>
     <constant>E_NOTICE</constant>
     (<type>int</type>)
@@ -500,7 +500,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.e-core-error">
+  <varlistentry>
    <term>
     <constant>E_CORE_ERROR</constant>
     (<type>int</type>)
@@ -511,7 +511,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.e-core-warning">
+  <varlistentry>
    <term>
     <constant>E_CORE_WARNING</constant>
     (<type>int</type>)
@@ -522,7 +522,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.e-compile-error">
+  <varlistentry>
    <term>
     <constant>E_COMPILE_ERROR</constant>
     (<type>int</type>)
@@ -533,7 +533,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.e-compile-warning">
+  <varlistentry>
    <term>
     <constant>E_COMPILE_WARNING</constant>
     (<type>int</type>)
@@ -544,7 +544,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.e-user-error">
+  <varlistentry>
    <term>
     <constant>E_USER_ERROR</constant>
     (<type>int</type>)
@@ -555,7 +555,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.e-user-warning">
+  <varlistentry>
    <term>
     <constant>E_USER_WARNING</constant>
     (<type>int</type>)
@@ -566,7 +566,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.e-user-notice">
+  <varlistentry>
    <term>
     <constant>E_USER_NOTICE</constant>
     (<type>int</type>)
@@ -577,7 +577,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.e-recoverble-error">
+  <varlistentry>
    <term>
     <constant>E_RECOVERABLE_ERROR</constant>
     (<type>int</type>)
@@ -588,7 +588,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.e-deprecated">
+  <varlistentry>
    <term>
     <constant>E_DEPRECATED</constant>
     (<type>int</type>)
@@ -599,7 +599,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.e-user-deprecated">
+  <varlistentry>
    <term>
     <constant>E_USER_DEPRECATED</constant>
     (<type>int</type>)
@@ -610,7 +610,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.e-all">
+  <varlistentry>
    <term>
     <constant>E_ALL</constant>
     (<type>int</type>)
@@ -621,7 +621,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.e-strict">
+  <varlistentry>
    <term>
     <constant>E_STRICT</constant>
     (<type>int</type>)

--- a/error_constant_ids.sh
+++ b/error_constant_ids.sh
@@ -1,0 +1,24 @@
+#! /bin/bash
+# remove xml IDs from core constants page
+\grep -lrE --include='*.xml' 'xml:id="constant.e-error"' | xargs -d '\n' sed -i 's/ xml:id="constant\.e-error"//g'
+\grep -lrE --include='*.xml' 'xml:id="constant.e-warning"' | xargs -d '\n' sed -i 's/ xml:id="constant\.e-warning"//g'
+\grep -lrE --include='*.xml' 'xml:id="constant.e-parse"' | xargs -d '\n' sed -i 's/ xml:id="constant\.e-parse"//g'
+\grep -lrE --include='*.xml' 'xml:id="constant.e-notice"' | xargs -d '\n' sed -i 's/ xml:id="constant\.e-notice"//g'
+\grep -lrE --include='*.xml' 'xml:id="constant.e-core-error"' | xargs -d '\n' sed -i 's/ xml:id="constant\.e-core-error"//g'
+\grep -lrE --include='*.xml' 'xml:id="constant.e-core-warning"' | xargs -d '\n' sed -i 's/ xml:id="constant\.e-core-warning"//g'
+\grep -lrE --include='*.xml' 'xml:id="constant.e-compile-error"' | xargs -d '\n' sed -i 's/ xml:id="constant\.e-compile-error"//g'
+\grep -lrE --include='*.xml' 'xml:id="constant.e-compile-warning"' | xargs -d '\n' sed -i 's/ xml:id="constant\.e-compile-warning"//g'
+\grep -lrE --include='*.xml' 'xml:id="constant.e-user-error"' | xargs -d '\n' sed -i 's/ xml:id="constant\.e-user-error"//g'
+\grep -lrE --include='*.xml' 'xml:id="constant.e-user-warning"' | xargs -d '\n' sed -i 's/ xml:id="constant\.e-user-warning"//g'
+\grep -lrE --include='*.xml' 'xml:id="constant.e-user-notice"' | xargs -d '\n' sed -i 's/ xml:id="constant\.e-user-notice"//g'
+\grep -lrE --include='*.xml' 'xml:id="constant.e-user-deprecated"' | xargs -d '\n' sed -i 's/ xml:id="constant\.e-user-deprecated"//g'
+\grep -lrE --include='*.xml' 'xml:id="constant.e-recoverble-error"' | xargs -d '\n' sed -i 's/ xml:id="constant\.e-recoverble-error"//g'
+\grep -lrE --include='*.xml' 'xml:id="constant.e-deprecated"' | xargs -d '\n' sed -i 's/ xml:id="constant\.e-deprecated"//g'
+\grep -lrE --include='*.xml' 'xml:id="constant.e-all"' | xargs -d '\n' sed -i 's/ xml:id="constant\.e-all"//g'
+\grep -lrE --include='*.xml' 'xml:id="constant.e-strict"' | xargs -d '\n' sed -i 's/ xml:id="constant\.e-strict"//g'
+
+# change error level IDs to standard format
+\grep -lrE --include='*.xml' '"errorfunc\.constants\.errorlevels\.' | xargs -d '\n' sed -i 's/errorfunc\.constants\.errorlevels\./constant\./g'
+
+# fix incorrectly named ID
+\grep -lrE --include='*.xml' '"constant\.e-deprecated-error"' | xargs -d '\n' sed -i 's/"constant\.e-deprecated-error"/"constant\.e-deprecated"/g'

--- a/reference/errorfunc/constants.xml
+++ b/reference/errorfunc/constants.xml
@@ -22,7 +22,7 @@
     </row>
    </thead>
    <tbody>
-    <row xml:id="errorfunc.constants.errorlevels.e-error">
+    <row xml:id="constant.e-error">
      <entry>1</entry>
      <entry>
       <constant>E_ERROR</constant> 
@@ -36,7 +36,7 @@
      <entry></entry>
     </row>
 
-    <row xml:id="errorfunc.constants.errorlevels.e-warning">
+    <row xml:id="constant.e-warning">
      <entry>2</entry>
      <entry>
       <constant>E_WARNING</constant> 
@@ -49,7 +49,7 @@
      <entry></entry>
     </row>
 
-    <row xml:id="errorfunc.constants.errorlevels.e-parse">
+    <row xml:id="constant.e-parse">
      <entry>4</entry>
      <entry>
       <constant>E_PARSE</constant> 
@@ -62,7 +62,7 @@
      <entry></entry>
     </row>
 
-    <row xml:id="errorfunc.constants.errorlevels.e-notice">
+    <row xml:id="constant.e-notice">
      <entry>8</entry>
      <entry>
       <constant>E_NOTICE</constant> 
@@ -76,7 +76,7 @@
      <entry></entry>
     </row>
 
-    <row xml:id="errorfunc.constants.errorlevels.e-core-error">
+    <row xml:id="constant.e-core-error">
      <entry>16</entry>
      <entry>
       <constant>E_CORE_ERROR</constant> 
@@ -89,7 +89,7 @@
      <entry></entry>
     </row>
 
-    <row xml:id="errorfunc.constants.errorlevels.e-core-warning">
+    <row xml:id="constant.e-core-warning">
      <entry>32</entry>
      <entry>
       <constant>E_CORE_WARNING</constant> 
@@ -103,7 +103,7 @@
      <entry></entry>
     </row>
 
-    <row xml:id="errorfunc.constants.errorlevels.e-compile-error">
+    <row xml:id="constant.e-compile-error">
      <entry>64</entry>
      <entry>
       <constant>E_COMPILE_ERROR</constant> 
@@ -116,7 +116,7 @@
      <entry></entry>
     </row>
 
-    <row xml:id="errorfunc.constants.errorlevels.e-compile-warning">
+    <row xml:id="constant.e-compile-warning">
      <entry>128</entry>
      <entry>
       <constant>E_COMPILE_WARNING</constant> 
@@ -130,7 +130,7 @@
      <entry></entry>
     </row>
 
-    <row xml:id="errorfunc.constants.errorlevels.e-user-error">
+    <row xml:id="constant.e-user-error">
      <entry>256</entry>
      <entry>
       <constant>E_USER_ERROR</constant> 
@@ -144,7 +144,7 @@
      <entry></entry>
     </row>
 
-    <row xml:id="errorfunc.constants.errorlevels.e-user-warning">
+    <row xml:id="constant.e-user-warning">
      <entry>512</entry>
      <entry>
       <constant>E_USER_WARNING</constant> 
@@ -158,7 +158,7 @@
      <entry></entry>
     </row>
 
-    <row xml:id="errorfunc.constants.errorlevels.e-user-notice">
+    <row xml:id="constant.e-user-notice">
      <entry>1024</entry>
      <entry>
       <constant>E_USER_NOTICE</constant> 
@@ -172,7 +172,7 @@
      <entry></entry>
     </row>
 
-    <row xml:id="errorfunc.constants.errorlevels.e-strict">
+    <row xml:id="constant.e-strict">
      <entry>2048</entry>
      <entry>
       <constant>E_STRICT</constant> 
@@ -186,7 +186,7 @@
      <entry></entry>
     </row>
 
-    <row xml:id="errorfunc.constants.errorlevels.e-recoverable-error">
+    <row xml:id="constant.e-recoverable-error">
      <entry>4096</entry>
      <entry>
       <constant>E_RECOVERABLE_ERROR</constant> 
@@ -202,7 +202,7 @@
      <entry></entry>
     </row>
 
-    <row xml:id="errorfunc.constants.errorlevels.e-deprecated-error">
+    <row xml:id="constant.e-deprecated">
      <entry>8192</entry>
      <entry>
       <constant>E_DEPRECATED</constant> 
@@ -215,7 +215,7 @@
      <entry></entry>
     </row>
 
-    <row xml:id="errorfunc.constants.errorlevels.e-user-deprecated">
+    <row xml:id="constant.e-user-deprecated">
      <entry>16384</entry>
      <entry>
       <constant>E_USER_DEPRECATED</constant> 
@@ -229,7 +229,7 @@
      <entry></entry>
     </row>
 
-    <row xml:id="errorfunc.constants.errorlevels.e-all">
+    <row xml:id="constant.e-all">
      <entry>32767</entry>
      <entry>
       <constant>E_ALL</constant> 


### PR DESCRIPTION
The script (which can be applied to all translations) will do the following:

 - remove IDs from error constants on the core constants page
 - standardize constant IDs on the error handling constant page