### PR TITLE
Fix return type of date_sun_info()

### DIFF
--- a/reference/datetime/functions/date-sun-info.xml
+++ b/reference/datetime/functions/date-sun-info.xml
@@ -50,8 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns array on success&return.falseforfailure;.
-   The structure of the array is detailed in the following list:
+   Returns an array whose structure is detailed in the following list:
   </para>
   <para>
    <variablelist>


### PR DESCRIPTION
This function no longer returns false since PHP 8.

Also, "success" for this function means calling the function with three arguments of the correct type.

- https://github.com/php/php-src/blob/php-7.0.0/ext/date/php_date.c#L4725-L4737
- https://github.com/php/php-src/blob/php-7.4.0/ext/date/php_date.c#L5077-L5094

Therefore, only `array` was consistently written in the return value of the prototype.