### PR TITLE
Update Parle constant IDs

### DIFF
--- a/parle_constant_ids.sh
+++ b/parle_constant_ids.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+\grep -lrE --include='*.xml' '"parle\.constant\.utf32"' | xargs -d '\n' sed -i 's/"parle\.constant\.utf32"/"constant\.parle-internal-utf32"/g'
+\grep -lrE --include='*.xml' '"parle(.)+\.constants\.flag-regex-' | xargs -d '\n' sed -i 's/\.constants\.flag-regex-/\.constants\./g'

--- a/reference/parle/constants.xml
+++ b/reference/parle/constants.xml
@@ -4,7 +4,7 @@
  &reftitle.constants;
  &extension.constants;
  <variablelist>
-  <varlistentry xml:id="parle.constant.utf32">
+  <varlistentry xml:id="constant.parle-internal-utf32">
    <term>
     <constant>Parle\INTERNAL_UTF32</constant>
      <type>bool</type>

--- a/reference/parle/parle.lexer.xml
+++ b/reference/parle/parle.lexer.xml
@@ -35,31 +35,31 @@
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="parle-lexer.constants.flag-regex-icase">Parle\Lexer::ICASE</varname>
+     <varname linkend="parle-lexer.constants.icase">Parle\Lexer::ICASE</varname>
      <initializer>1</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="parle-lexer.constants.flag-regex-dot-not-lf">Parle\Lexer::DOT_NOT_LF</varname>
+     <varname linkend="parle-lexer.constants.dot-not-lf">Parle\Lexer::DOT_NOT_LF</varname>
      <initializer>2</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="parle-lexer.constants.flag-regex-dot-not-cr-lf">Parle\Lexer::DOT_NOT_CRLF</varname>
+     <varname linkend="parle-lexer.constants.dot-not-cr-lf">Parle\Lexer::DOT_NOT_CRLF</varname>
      <initializer>4</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="parle-lexer.constants.flag-regex-skip-ws">Parle\Lexer::SKIP_WS</varname>
+     <varname linkend="parle-lexer.constants.skip-ws">Parle\Lexer::SKIP_WS</varname>
      <initializer>8</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="parle-lexer.constants.flag-regex-match-zero-len">Parle\Lexer::MATCH_ZERO_LEN</varname>
+     <varname linkend="parle-lexer.constants.match-zero-len">Parle\Lexer::MATCH_ZERO_LEN</varname>
      <initializer>16</initializer>
     </fieldsynopsis>
 
@@ -107,35 +107,35 @@
    &reftitle.constants;
    <variablelist>
 
-    <varlistentry xml:id="parle-lexer.constants.flag-regex-icase">
+    <varlistentry xml:id="parle-lexer.constants.icase">
      <term><constant>Parle\Lexer::ICASE</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="parle-lexer.constants.flag-regex-dot-not-lf">
+    <varlistentry xml:id="parle-lexer.constants.dot-not-lf">
      <term><constant>Parle\Lexer::DOT_NOT_LF</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="parle-lexer.constants.flag-regex-dot-not-cr-lf">
+    <varlistentry xml:id="parle-lexer.constants.dot-not-cr-lf">
      <term><constant>Parle\Lexer::DOT_NOT_CRLF</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="parle-lexer.constants.flag-regex-skip-ws">
+    <varlistentry xml:id="parle-lexer.constants.skip-ws">
      <term><constant>Parle\Lexer::SKIP_WS</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="parle-lexer.constants.flag-regex-match-zero-len">
+    <varlistentry xml:id="parle-lexer.constants.match-zero-len">
      <term><constant>Parle\Lexer::MATCH_ZERO_LEN</constant></term>
      <listitem>
       <para></para>

--- a/reference/parle/parle.rlexer.xml
+++ b/reference/parle/parle.rlexer.xml
@@ -35,31 +35,31 @@
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="parle-rlexer.constants.flag-regex-icase">Parle\RLexer::ICASE</varname>
+     <varname linkend="parle-rlexer.constants.icase">Parle\RLexer::ICASE</varname>
      <initializer>1</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="parle-rlexer.constants.flag-regex-dot-not-lf">Parle\RLexer::DOT_NOT_LF</varname>
+     <varname linkend="parle-rlexer.constants.dot-not-lf">Parle\RLexer::DOT_NOT_LF</varname>
      <initializer>2</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="parle-rlexer.constants.flag-regex-dot-not-cr-lf">Parle\RLexer::DOT_NOT_CRLF</varname>
+     <varname linkend="parle-rlexer.constants.dot-not-cr-lf">Parle\RLexer::DOT_NOT_CRLF</varname>
      <initializer>4</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="parle-rlexer.constants.flag-regex-skip-ws">Parle\RLexer::SKIP_WS</varname>
+     <varname linkend="parle-rlexer.constants.skip-ws">Parle\RLexer::SKIP_WS</varname>
      <initializer>8</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="parle-rlexer.constants.flag-regex-match-zero-len">Parle\RLexer::MATCH_ZERO_LEN</varname>
+     <varname linkend="parle-rlexer.constants.match-zero-len">Parle\RLexer::MATCH_ZERO_LEN</varname>
      <initializer>16</initializer>
     </fieldsynopsis>
 
@@ -107,35 +107,35 @@
    &reftitle.constants;
    <variablelist>
 
-    <varlistentry xml:id="parle-rlexer.constants.flag-regex-icase">
+    <varlistentry xml:id="parle-rlexer.constants.icase">
      <term><constant>Parle\RLexer::ICASE</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="parle-rlexer.constants.flag-regex-dot-not-lf">
+    <varlistentry xml:id="parle-rlexer.constants.dot-not-lf">
      <term><constant>Parle\RLexer::DOT_NOT_LF</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="parle-rlexer.constants.flag-regex-dot-not-cr-lf">
+    <varlistentry xml:id="parle-rlexer.constants.dot-not-cr-lf">
      <term><constant>Parle\RLexer::DOT_NOT_CRLF</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="parle-rlexer.constants.flag-regex-skip-ws">
+    <varlistentry xml:id="parle-rlexer.constants.skip-ws">
      <term><constant>Parle\RLexer::SKIP_WS</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="parle-rlexer.constants.flag-regex-match-zero-len">
+    <varlistentry xml:id="parle-rlexer.constants.match-zero-len">
      <term><constant>Parle\RLexer::MATCH_ZERO_LEN</constant></term>
      <listitem>
       <para></para>


### PR DESCRIPTION
Update Parle constant IDs to the "standard" global and class constant ID formats.

Add bash script this update was made with so that it can be applied to translations as well.