### PR TITLE
Update expect constant IDs

### DIFF
--- a/expect_constant_ids.sh
+++ b/expect_constant_ids.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+\grep -lrE --include='*.xml' '"constants\.expect\.(.)+"' | xargs -d '\n' sed -i 's/"constants\.expect\./"constant\./g'

--- a/reference/expect/constants.xml
+++ b/reference/expect/constants.xml
@@ -4,7 +4,7 @@
  &reftitle.constants;
  &extension.constants;
  <variablelist>
-  <varlistentry xml:id="constants.expect.exp-glob">
+  <varlistentry xml:id="constant.exp-glob">
    <term>
     <constant>EXP_GLOB</constant>
      (<type>int</type>)
@@ -15,7 +15,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constants.expect.exp-exact">
+  <varlistentry xml:id="constant.exp-exact">
    <term>
     <constant>EXP_EXACT</constant>
      (<type>int</type>)
@@ -26,7 +26,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constants.expect.exp-regexp">
+  <varlistentry xml:id="constant.exp-regexp">
    <term>
     <constant>EXP_REGEXP</constant>
      (<type>int</type>)
@@ -37,7 +37,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constants.expect.exp-eof">
+  <varlistentry xml:id="constant.exp-eof">
    <term>
     <constant>EXP_EOF</constant>
      (<type>int</type>)
@@ -49,7 +49,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constants.expect.exp-timeout">
+  <varlistentry xml:id="constant.exp-timeout">
    <term>
     <constant>EXP_TIMEOUT</constant>
      (<type>int</type>)
@@ -61,7 +61,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constants.expect.exp-fullbuffer">
+  <varlistentry xml:id="constant.exp-fullbuffer">
    <term>
     <constant>EXP_FULLBUFFER</constant>
      (<type>int</type>)

--- a/reference/expect/functions/expect-expectl.xml
+++ b/reference/expect/functions/expect-expectl.xml
@@ -78,13 +78,13 @@
            <entry>integer</entry>
            <entry>
             pattern type, one of:
-            <link linkend="constants.expect.exp-glob"><constant>EXP_GLOB</constant></link>,
-            <link linkend="constants.expect.exp-exact"><constant>EXP_EXACT</constant></link>
+            <link linkend="constant.exp-glob"><constant>EXP_GLOB</constant></link>,
+            <link linkend="constant.exp-exact"><constant>EXP_EXACT</constant></link>
             or
-            <link linkend="constants.expect.exp-regexp"><constant>EXP_REGEXP</constant></link>
+            <link linkend="constant.exp-regexp"><constant>EXP_REGEXP</constant></link>
            </entry>
            <entry>no</entry>
-           <entry><link linkend="constants.expect.exp-glob"><constant>EXP_GLOB</constant></link></entry>
+           <entry><link linkend="constant.exp-glob"><constant>EXP_GLOB</constant></link></entry>
           </row>
          </tbody>
         </tgroup>
@@ -102,10 +102,10 @@
   </para>
   <para>
    On failure this function returns:
-   <link linkend="constants.expect.exp-eof"><constant>EXP_EOF</constant></link>,
-   <link linkend="constants.expect.exp-timeout"><constant>EXP_TIMEOUT</constant></link>
+   <link linkend="constant.exp-eof"><constant>EXP_EOF</constant></link>,
+   <link linkend="constant.exp-timeout"><constant>EXP_TIMEOUT</constant></link>
    or
-   <link linkend="constants.expect.exp-fullbuffer"><constant>EXP_FULLBUFFER</constant></link>
+   <link linkend="constant.exp-fullbuffer"><constant>EXP_FULLBUFFER</constant></link>
   </para>
  </refsect1>
  <refsect1 role="changelog">


### PR DESCRIPTION
Update expect constant IDs to the "standard" global constant ID format.

Add bash script this update was made with so that it can be applied to translations as well.