### PR TITLE
Update gender constant IDs

### DIFF
--- a/gender_constant_ids.sh
+++ b/gender_constant_ids.sh
@@ -1,3 +1,0 @@
-#! /bin/bash
-
-\grep -lrE --include='*.xml' '"gender\.constants\.(.)+"' | xargs -d '\n' sed -i 's/"gender\.constants\./"gender-gender\.constants\./g'

--- a/gender_constant_ids.sh
+++ b/gender_constant_ids.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+\grep -lrE --include='*.xml' '"gender\.constants\.(.)+"' | xargs -d '\n' sed -i 's/"gender\.constants\./"gender-gender\.constants\./g'

--- a/reference/gender/gender.xml
+++ b/reference/gender/gender.xml
@@ -35,373 +35,373 @@
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.is-female">Gender\Gender::IS_FEMALE</varname>
+     <varname linkend="gender-gender.constants.is-female">Gender\Gender::IS_FEMALE</varname>
      <initializer>70</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.is-mostly-female">Gender\Gender::IS_MOSTLY_FEMALE</varname>
+     <varname linkend="gender-gender.constants.is-mostly-female">Gender\Gender::IS_MOSTLY_FEMALE</varname>
      <initializer>102</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.is-male">Gender\Gender::IS_MALE</varname>
+     <varname linkend="gender-gender.constants.is-male">Gender\Gender::IS_MALE</varname>
      <initializer>77</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.is-mostly-male">Gender\Gender::IS_MOSTLY_MALE</varname>
+     <varname linkend="gender-gender.constants.is-mostly-male">Gender\Gender::IS_MOSTLY_MALE</varname>
      <initializer>109</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.is-unisex-name">Gender\Gender::IS_UNISEX_NAME</varname>
+     <varname linkend="gender-gender.constants.is-unisex-name">Gender\Gender::IS_UNISEX_NAME</varname>
      <initializer>63</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.is-a-couple">Gender\Gender::IS_A_COUPLE</varname>
+     <varname linkend="gender-gender.constants.is-a-couple">Gender\Gender::IS_A_COUPLE</varname>
      <initializer>67</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.name-not-found">Gender\Gender::NAME_NOT_FOUND</varname>
+     <varname linkend="gender-gender.constants.name-not-found">Gender\Gender::NAME_NOT_FOUND</varname>
      <initializer>32</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.error-in-name">Gender\Gender::ERROR_IN_NAME</varname>
+     <varname linkend="gender-gender.constants.error-in-name">Gender\Gender::ERROR_IN_NAME</varname>
      <initializer>69</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.any-country">Gender\Gender::ANY_COUNTRY</varname>
+     <varname linkend="gender-gender.constants.any-country">Gender\Gender::ANY_COUNTRY</varname>
      <initializer>0</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.britain">Gender\Gender::BRITAIN</varname>
+     <varname linkend="gender-gender.constants.britain">Gender\Gender::BRITAIN</varname>
      <initializer>1</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.ireland">Gender\Gender::IRELAND</varname>
+     <varname linkend="gender-gender.constants.ireland">Gender\Gender::IRELAND</varname>
      <initializer>2</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.usa">Gender\Gender::USA</varname>
+     <varname linkend="gender-gender.constants.usa">Gender\Gender::USA</varname>
      <initializer>3</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.spain">Gender\Gender::SPAIN</varname>
+     <varname linkend="gender-gender.constants.spain">Gender\Gender::SPAIN</varname>
      <initializer>4</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.portugal">Gender\Gender::PORTUGAL</varname>
+     <varname linkend="gender-gender.constants.portugal">Gender\Gender::PORTUGAL</varname>
      <initializer>5</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.italy">Gender\Gender::ITALY</varname>
+     <varname linkend="gender-gender.constants.italy">Gender\Gender::ITALY</varname>
      <initializer>6</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.malta">Gender\Gender::MALTA</varname>
+     <varname linkend="gender-gender.constants.malta">Gender\Gender::MALTA</varname>
      <initializer>7</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.france">Gender\Gender::FRANCE</varname>
+     <varname linkend="gender-gender.constants.france">Gender\Gender::FRANCE</varname>
      <initializer>8</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.belgium">Gender\Gender::BELGIUM</varname>
+     <varname linkend="gender-gender.constants.belgium">Gender\Gender::BELGIUM</varname>
      <initializer>9</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.luxembourg">Gender\Gender::LUXEMBOURG</varname>
+     <varname linkend="gender-gender.constants.luxembourg">Gender\Gender::LUXEMBOURG</varname>
      <initializer>10</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.netherlands">Gender\Gender::NETHERLANDS</varname>
+     <varname linkend="gender-gender.constants.netherlands">Gender\Gender::NETHERLANDS</varname>
      <initializer>11</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.germany">Gender\Gender::GERMANY</varname>
+     <varname linkend="gender-gender.constants.germany">Gender\Gender::GERMANY</varname>
      <initializer>12</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.east-frisia">Gender\Gender::EAST_FRISIA</varname>
+     <varname linkend="gender-gender.constants.east-frisia">Gender\Gender::EAST_FRISIA</varname>
      <initializer>13</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.austria">Gender\Gender::AUSTRIA</varname>
+     <varname linkend="gender-gender.constants.austria">Gender\Gender::AUSTRIA</varname>
      <initializer>14</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.swiss">Gender\Gender::SWISS</varname>
+     <varname linkend="gender-gender.constants.swiss">Gender\Gender::SWISS</varname>
      <initializer>15</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.iceland">Gender\Gender::ICELAND</varname>
+     <varname linkend="gender-gender.constants.iceland">Gender\Gender::ICELAND</varname>
      <initializer>16</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.denmark">Gender\Gender::DENMARK</varname>
+     <varname linkend="gender-gender.constants.denmark">Gender\Gender::DENMARK</varname>
      <initializer>17</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.norway">Gender\Gender::NORWAY</varname>
+     <varname linkend="gender-gender.constants.norway">Gender\Gender::NORWAY</varname>
      <initializer>18</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.sweden">Gender\Gender::SWEDEN</varname>
+     <varname linkend="gender-gender.constants.sweden">Gender\Gender::SWEDEN</varname>
      <initializer>19</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.finland">Gender\Gender::FINLAND</varname>
+     <varname linkend="gender-gender.constants.finland">Gender\Gender::FINLAND</varname>
      <initializer>20</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.estonia">Gender\Gender::ESTONIA</varname>
+     <varname linkend="gender-gender.constants.estonia">Gender\Gender::ESTONIA</varname>
      <initializer>21</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.latvia">Gender\Gender::LATVIA</varname>
+     <varname linkend="gender-gender.constants.latvia">Gender\Gender::LATVIA</varname>
      <initializer>22</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.lithuania">Gender\Gender::LITHUANIA</varname>
+     <varname linkend="gender-gender.constants.lithuania">Gender\Gender::LITHUANIA</varname>
      <initializer>23</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.poland">Gender\Gender::POLAND</varname>
+     <varname linkend="gender-gender.constants.poland">Gender\Gender::POLAND</varname>
      <initializer>24</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.czech-rep">Gender\Gender::CZECH_REP</varname>
+     <varname linkend="gender-gender.constants.czech-rep">Gender\Gender::CZECH_REP</varname>
      <initializer>25</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.slovakia">Gender\Gender::SLOVAKIA</varname>
+     <varname linkend="gender-gender.constants.slovakia">Gender\Gender::SLOVAKIA</varname>
      <initializer>26</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.hungary">Gender\Gender::HUNGARY</varname>
+     <varname linkend="gender-gender.constants.hungary">Gender\Gender::HUNGARY</varname>
      <initializer>27</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.romania">Gender\Gender::ROMANIA</varname>
+     <varname linkend="gender-gender.constants.romania">Gender\Gender::ROMANIA</varname>
      <initializer>28</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.bulgaria">Gender\Gender::BULGARIA</varname>
+     <varname linkend="gender-gender.constants.bulgaria">Gender\Gender::BULGARIA</varname>
      <initializer>29</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.bosnia">Gender\Gender::BOSNIA</varname>
+     <varname linkend="gender-gender.constants.bosnia">Gender\Gender::BOSNIA</varname>
      <initializer>30</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.croatia">Gender\Gender::CROATIA</varname>
+     <varname linkend="gender-gender.constants.croatia">Gender\Gender::CROATIA</varname>
      <initializer>31</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.kosovo">Gender\Gender::KOSOVO</varname>
+     <varname linkend="gender-gender.constants.kosovo">Gender\Gender::KOSOVO</varname>
      <initializer>32</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.macedonia">Gender\Gender::MACEDONIA</varname>
+     <varname linkend="gender-gender.constants.macedonia">Gender\Gender::MACEDONIA</varname>
      <initializer>33</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.montenegro">Gender\Gender::MONTENEGRO</varname>
+     <varname linkend="gender-gender.constants.montenegro">Gender\Gender::MONTENEGRO</varname>
      <initializer>34</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.serbia">Gender\Gender::SERBIA</varname>
+     <varname linkend="gender-gender.constants.serbia">Gender\Gender::SERBIA</varname>
      <initializer>35</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.slovenia">Gender\Gender::SLOVENIA</varname>
+     <varname linkend="gender-gender.constants.slovenia">Gender\Gender::SLOVENIA</varname>
      <initializer>36</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.albania">Gender\Gender::ALBANIA</varname>
+     <varname linkend="gender-gender.constants.albania">Gender\Gender::ALBANIA</varname>
      <initializer>37</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.greece">Gender\Gender::GREECE</varname>
+     <varname linkend="gender-gender.constants.greece">Gender\Gender::GREECE</varname>
      <initializer>38</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.russia">Gender\Gender::RUSSIA</varname>
+     <varname linkend="gender-gender.constants.russia">Gender\Gender::RUSSIA</varname>
      <initializer>39</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.belarus">Gender\Gender::BELARUS</varname>
+     <varname linkend="gender-gender.constants.belarus">Gender\Gender::BELARUS</varname>
      <initializer>40</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.moldova">Gender\Gender::MOLDOVA</varname>
+     <varname linkend="gender-gender.constants.moldova">Gender\Gender::MOLDOVA</varname>
      <initializer>41</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.ukraine">Gender\Gender::UKRAINE</varname>
+     <varname linkend="gender-gender.constants.ukraine">Gender\Gender::UKRAINE</varname>
      <initializer>42</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.armenia">Gender\Gender::ARMENIA</varname>
+     <varname linkend="gender-gender.constants.armenia">Gender\Gender::ARMENIA</varname>
      <initializer>43</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.azerbaijan">Gender\Gender::AZERBAIJAN</varname>
+     <varname linkend="gender-gender.constants.azerbaijan">Gender\Gender::AZERBAIJAN</varname>
      <initializer>44</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.georgia">Gender\Gender::GEORGIA</varname>
+     <varname linkend="gender-gender.constants.georgia">Gender\Gender::GEORGIA</varname>
      <initializer>45</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.kazakh-uzbek">Gender\Gender::KAZAKH_UZBEK</varname>
+     <varname linkend="gender-gender.constants.kazakh-uzbek">Gender\Gender::KAZAKH_UZBEK</varname>
      <initializer>46</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.turkey">Gender\Gender::TURKEY</varname>
+     <varname linkend="gender-gender.constants.turkey">Gender\Gender::TURKEY</varname>
      <initializer>47</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.arabia">Gender\Gender::ARABIA</varname>
+     <varname linkend="gender-gender.constants.arabia">Gender\Gender::ARABIA</varname>
      <initializer>48</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.israel">Gender\Gender::ISRAEL</varname>
+     <varname linkend="gender-gender.constants.israel">Gender\Gender::ISRAEL</varname>
      <initializer>49</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.china">Gender\Gender::CHINA</varname>
+     <varname linkend="gender-gender.constants.china">Gender\Gender::CHINA</varname>
      <initializer>50</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.india">Gender\Gender::INDIA</varname>
+     <varname linkend="gender-gender.constants.india">Gender\Gender::INDIA</varname>
      <initializer>51</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.japan">Gender\Gender::JAPAN</varname>
+     <varname linkend="gender-gender.constants.japan">Gender\Gender::JAPAN</varname>
      <initializer>52</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="gender.constants.korea">Gender\Gender::KOREA</varname>
+     <varname linkend="gender-gender.constants.korea">Gender\Gender::KOREA</varname>
      <initializer>53</initializer>
     </fieldsynopsis>
 
@@ -422,434 +422,434 @@
    &reftitle.constants;
    <variablelist>
 
-    <varlistentry xml:id="gender.constants.is-female">
+    <varlistentry xml:id="gender-gender.constants.is-female">
      <term><constant>Gender\Gender::IS_FEMALE</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.is-mostly-female">
+    <varlistentry xml:id="gender-gender.constants.is-mostly-female">
      <term><constant>Gender\Gender::IS_MOSTLY_FEMALE</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.is-male">
+    <varlistentry xml:id="gender-gender.constants.is-male">
      <term><constant>Gender\Gender::IS_MALE</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.is-mostly-male">
+    <varlistentry xml:id="gender-gender.constants.is-mostly-male">
      <term><constant>Gender\Gender::IS_MOSTLY_MALE</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.is-unisex-name">
+    <varlistentry xml:id="gender-gender.constants.is-unisex-name">
      <term><constant>Gender\Gender::IS_UNISEX_NAME</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.is-a-couple">
+    <varlistentry xml:id="gender-gender.constants.is-a-couple">
      <term><constant>Gender\Gender::IS_A_COUPLE</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.name-not-found">
+    <varlistentry xml:id="gender-gender.constants.name-not-found">
      <term><constant>Gender\Gender::NAME_NOT_FOUND</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.error-in-name">
+    <varlistentry xml:id="gender-gender.constants.error-in-name">
      <term><constant>Gender\Gender::ERROR_IN_NAME</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.any-country">
+    <varlistentry xml:id="gender-gender.constants.any-country">
      <term><constant>Gender\Gender::ANY_COUNTRY</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.britain">
+    <varlistentry xml:id="gender-gender.constants.britain">
      <term><constant>Gender\Gender::BRITAIN</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.ireland">
+    <varlistentry xml:id="gender-gender.constants.ireland">
      <term><constant>Gender\Gender::IRELAND</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.usa">
+    <varlistentry xml:id="gender-gender.constants.usa">
      <term><constant>Gender\Gender::USA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.spain">
+    <varlistentry xml:id="gender-gender.constants.spain">
      <term><constant>Gender\Gender::SPAIN</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.portugal">
+    <varlistentry xml:id="gender-gender.constants.portugal">
      <term><constant>Gender\Gender::PORTUGAL</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.italy">
+    <varlistentry xml:id="gender-gender.constants.italy">
      <term><constant>Gender\Gender::ITALY</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.malta">
+    <varlistentry xml:id="gender-gender.constants.malta">
      <term><constant>Gender\Gender::MALTA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.france">
+    <varlistentry xml:id="gender-gender.constants.france">
      <term><constant>Gender\Gender::FRANCE</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.belgium">
+    <varlistentry xml:id="gender-gender.constants.belgium">
      <term><constant>Gender\Gender::BELGIUM</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.luxembourg">
+    <varlistentry xml:id="gender-gender.constants.luxembourg">
      <term><constant>Gender\Gender::LUXEMBOURG</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.netherlands">
+    <varlistentry xml:id="gender-gender.constants.netherlands">
      <term><constant>Gender\Gender::NETHERLANDS</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.germany">
+    <varlistentry xml:id="gender-gender.constants.germany">
      <term><constant>Gender\Gender::GERMANY</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.east-frisia">
+    <varlistentry xml:id="gender-gender.constants.east-frisia">
      <term><constant>Gender\Gender::EAST_FRISIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.austria">
+    <varlistentry xml:id="gender-gender.constants.austria">
      <term><constant>Gender\Gender::AUSTRIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.swiss">
+    <varlistentry xml:id="gender-gender.constants.swiss">
      <term><constant>Gender\Gender::SWISS</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.iceland">
+    <varlistentry xml:id="gender-gender.constants.iceland">
      <term><constant>Gender\Gender::ICELAND</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.denmark">
+    <varlistentry xml:id="gender-gender.constants.denmark">
      <term><constant>Gender\Gender::DENMARK</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.norway">
+    <varlistentry xml:id="gender-gender.constants.norway">
      <term><constant>Gender\Gender::NORWAY</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.sweden">
+    <varlistentry xml:id="gender-gender.constants.sweden">
      <term><constant>Gender\Gender::SWEDEN</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.finland">
+    <varlistentry xml:id="gender-gender.constants.finland">
      <term><constant>Gender\Gender::FINLAND</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.estonia">
+    <varlistentry xml:id="gender-gender.constants.estonia">
      <term><constant>Gender\Gender::ESTONIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.latvia">
+    <varlistentry xml:id="gender-gender.constants.latvia">
      <term><constant>Gender\Gender::LATVIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.lithuania">
+    <varlistentry xml:id="gender-gender.constants.lithuania">
      <term><constant>Gender\Gender::LITHUANIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.poland">
+    <varlistentry xml:id="gender-gender.constants.poland">
      <term><constant>Gender\Gender::POLAND</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.czech-rep">
+    <varlistentry xml:id="gender-gender.constants.czech-rep">
      <term><constant>Gender\Gender::CZECH_REP</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.slovakia">
+    <varlistentry xml:id="gender-gender.constants.slovakia">
      <term><constant>Gender\Gender::SLOVAKIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.hungary">
+    <varlistentry xml:id="gender-gender.constants.hungary">
      <term><constant>Gender\Gender::HUNGARY</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.romania">
+    <varlistentry xml:id="gender-gender.constants.romania">
      <term><constant>Gender\Gender::ROMANIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.bulgaria">
+    <varlistentry xml:id="gender-gender.constants.bulgaria">
      <term><constant>Gender\Gender::BULGARIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.bosnia">
+    <varlistentry xml:id="gender-gender.constants.bosnia">
      <term><constant>Gender\Gender::BOSNIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.croatia">
+    <varlistentry xml:id="gender-gender.constants.croatia">
      <term><constant>Gender\Gender::CROATIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.kosovo">
+    <varlistentry xml:id="gender-gender.constants.kosovo">
      <term><constant>Gender\Gender::KOSOVO</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.macedonia">
+    <varlistentry xml:id="gender-gender.constants.macedonia">
      <term><constant>Gender\Gender::MACEDONIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.montenegro">
+    <varlistentry xml:id="gender-gender.constants.montenegro">
      <term><constant>Gender\Gender::MONTENEGRO</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.serbia">
+    <varlistentry xml:id="gender-gender.constants.serbia">
      <term><constant>Gender\Gender::SERBIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.slovenia">
+    <varlistentry xml:id="gender-gender.constants.slovenia">
      <term><constant>Gender\Gender::SLOVENIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.albania">
+    <varlistentry xml:id="gender-gender.constants.albania">
      <term><constant>Gender\Gender::ALBANIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.greece">
+    <varlistentry xml:id="gender-gender.constants.greece">
      <term><constant>Gender\Gender::GREECE</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.russia">
+    <varlistentry xml:id="gender-gender.constants.russia">
      <term><constant>Gender\Gender::RUSSIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.belarus">
+    <varlistentry xml:id="gender-gender.constants.belarus">
      <term><constant>Gender\Gender::BELARUS</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.moldova">
+    <varlistentry xml:id="gender-gender.constants.moldova">
      <term><constant>Gender\Gender::MOLDOVA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.ukraine">
+    <varlistentry xml:id="gender-gender.constants.ukraine">
      <term><constant>Gender\Gender::UKRAINE</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.armenia">
+    <varlistentry xml:id="gender-gender.constants.armenia">
      <term><constant>Gender\Gender::ARMENIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.azerbaijan">
+    <varlistentry xml:id="gender-gender.constants.azerbaijan">
      <term><constant>Gender\Gender::AZERBAIJAN</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.georgia">
+    <varlistentry xml:id="gender-gender.constants.georgia">
      <term><constant>Gender\Gender::GEORGIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.kazakh-uzbek">
+    <varlistentry xml:id="gender-gender.constants.kazakh-uzbek">
      <term><constant>Gender\Gender::KAZAKH_UZBEK</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.turkey">
+    <varlistentry xml:id="gender-gender.constants.turkey">
      <term><constant>Gender\Gender::TURKEY</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.arabia">
+    <varlistentry xml:id="gender-gender.constants.arabia">
      <term><constant>Gender\Gender::ARABIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.israel">
+    <varlistentry xml:id="gender-gender.constants.israel">
      <term><constant>Gender\Gender::ISRAEL</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.china">
+    <varlistentry xml:id="gender-gender.constants.china">
      <term><constant>Gender\Gender::CHINA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.india">
+    <varlistentry xml:id="gender-gender.constants.india">
      <term><constant>Gender\Gender::INDIA</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.japan">
+    <varlistentry xml:id="gender-gender.constants.japan">
      <term><constant>Gender\Gender::JAPAN</constant></term>
      <listitem>
       <para></para>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="gender.constants.korea">
+    <varlistentry xml:id="gender-gender.constants.korea">
      <term><constant>Gender\Gender::KOREA</constant></term>
      <listitem>
       <para></para>


### PR DESCRIPTION
Update gender constant IDs to the "standard" class constant ID format.

Add bash script this update was made with so that it can be applied to translations as well.