### PR TITLE
Update SQLite, Zookeeper and SNMP constant IDs

### DIFF
--- a/reference/snmp/snmp.xml
+++ b/reference/snmp/snmp.xml
@@ -29,73 +29,73 @@
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="snmp.class.constants.version-1">SNMP::VERSION_1</varname>
+     <varname linkend="snmp.constants.version-1">SNMP::VERSION_1</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="snmp.class.constants.version-2c">SNMP::VERSION_2c</varname>
+     <varname linkend="snmp.constants.version-2c">SNMP::VERSION_2c</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="snmp.class.constants.version-2c">SNMP::VERSION_2C</varname>
+     <varname linkend="snmp.constants.version-2c">SNMP::VERSION_2C</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="snmp.class.constants.version-3">SNMP::VERSION_3</varname>
+     <varname linkend="snmp.constants.version-3">SNMP::VERSION_3</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="snmp.class.constants.errno-noerror">SNMP::ERRNO_NOERROR</varname>
+     <varname linkend="snmp.constants.errno-noerror">SNMP::ERRNO_NOERROR</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="snmp.class.constants.errno-any">SNMP::ERRNO_ANY</varname>
+     <varname linkend="snmp.constants.errno-any">SNMP::ERRNO_ANY</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="snmp.class.constants.errno-generic">SNMP::ERRNO_GENERIC</varname>
+     <varname linkend="snmp.constants.errno-generic">SNMP::ERRNO_GENERIC</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="snmp.class.constants.errno-timeout">SNMP::ERRNO_TIMEOUT</varname>
+     <varname linkend="snmp.constants.errno-timeout">SNMP::ERRNO_TIMEOUT</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="snmp.class.constants.errno-error-in-reply">SNMP::ERRNO_ERROR_IN_REPLY</varname>
+     <varname linkend="snmp.constants.errno-error-in-reply">SNMP::ERRNO_ERROR_IN_REPLY</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="snmp.class.constants.errno-oid-not-increasing">SNMP::ERRNO_OID_NOT_INCREASING</varname>
+     <varname linkend="snmp.constants.errno-oid-not-increasing">SNMP::ERRNO_OID_NOT_INCREASING</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="snmp.class.constants.errno-oid-parsing-error">SNMP::ERRNO_OID_PARSING_ERROR</varname>
+     <varname linkend="snmp.constants.errno-oid-parsing-error">SNMP::ERRNO_OID_PARSING_ERROR</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="snmp.class.constants.errno-multiple-set-queries">SNMP::ERRNO_MULTIPLE_SET_QUERIES</varname>
+     <varname linkend="snmp.constants.errno-multiple-set-queries">SNMP::ERRNO_MULTIPLE_SET_QUERIES</varname>
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
@@ -271,39 +271,39 @@
   <!-- {{{ SNMP constants -->
   <section xml:id="snmp.class.constants">
    &reftitle.constants;
-   <section xml:id="snmp.class.constants.error-types">
+   <section xml:id="snmp.constants.error-types">
     <title><acronym>SNMP</acronym> Error Types</title>
     <variablelist>
 
-     <varlistentry xml:id="snmp.class.constants.errno-noerror">
+     <varlistentry xml:id="snmp.constants.errno-noerror">
       <term><constant>SNMP::ERRNO_NOERROR</constant></term>
       <listitem>
        <para>No <acronym>SNMP</acronym>-specific error occurred.</para>
       </listitem>
      </varlistentry>
 
-     <varlistentry xml:id="snmp.class.constants.errno-generic">
+     <varlistentry xml:id="snmp.constants.errno-generic">
       <term><constant>SNMP::ERRNO_GENERIC</constant></term>
       <listitem>
        <para>A generic <acronym>SNMP</acronym> error occurred.</para>
       </listitem>
      </varlistentry>
 
-     <varlistentry xml:id="snmp.class.constants.errno-timeout">
+     <varlistentry xml:id="snmp.constants.errno-timeout">
       <term><constant>SNMP::ERRNO_TIMEOUT</constant></term>
       <listitem>
        <para>Request to <acronym>SNMP</acronym> agent timed out.</para>
       </listitem>
      </varlistentry>
 
-     <varlistentry xml:id="snmp.class.constants.errno-error-in-reply">
+     <varlistentry xml:id="snmp.constants.errno-error-in-reply">
       <term><constant>SNMP::ERRNO_ERROR_IN_REPLY</constant></term>
       <listitem>
        <para><acronym>SNMP</acronym> agent returned an error in reply.</para>
       </listitem>
      </varlistentry>
 
-     <varlistentry xml:id="snmp.class.constants.errno-oid-not-increasing">
+     <varlistentry xml:id="snmp.constants.errno-oid-not-increasing">
       <term><constant>SNMP::ERRNO_OID_NOT_INCREASING</constant></term>
       <listitem>
        <para>
@@ -314,7 +314,7 @@
       </listitem>
      </varlistentry>
 
-     <varlistentry xml:id="snmp.class.constants.errno-oid-parsing-error">
+     <varlistentry xml:id="snmp.constants.errno-oid-parsing-error">
       <term><constant>SNMP::ERRNO_OID_PARSING_ERROR</constant></term>
       <listitem>
        <para>
@@ -324,7 +324,7 @@
       </listitem>
      </varlistentry>
 
-     <varlistentry xml:id="snmp.class.constants.errno-multiple-set-queries">
+     <varlistentry xml:id="snmp.constants.errno-multiple-set-queries">
       <term><constant>SNMP::ERRNO_MULTIPLE_SET_QUERIES</constant></term>
       <listitem>
        <para>
@@ -336,7 +336,7 @@
       </listitem>
      </varlistentry>
 
-     <varlistentry xml:id="snmp.class.constants.errno-any">
+     <varlistentry xml:id="snmp.constants.errno-any">
       <term><constant>SNMP::ERRNO_ANY</constant></term>
       <listitem>
        <para>
@@ -347,25 +347,25 @@
 
     </variablelist>
    </section>
-   <section xml:id="snmp.class.constants.protocols">
+   <section xml:id="snmp.constants.protocols">
     <title><acronym>SNMP</acronym> Protocol Versions</title>
     <variablelist>
 
-     <varlistentry xml:id="snmp.class.constants.version-1">
+     <varlistentry xml:id="snmp.constants.version-1">
       <term><constant>SNMP::VERSION_1</constant></term>
       <listitem>
        <para/>
       </listitem>
      </varlistentry>
 
-     <varlistentry xml:id="snmp.class.constants.version-2c">
+     <varlistentry xml:id="snmp.constants.version-2c">
       <term><constant>SNMP::VERSION_2C</constant>, <constant>SNMP::VERSION_2c</constant></term>
       <listitem>
        <para/>
       </listitem>
      </varlistentry>
 
-     <varlistentry xml:id="snmp.class.constants.version-3">
+     <varlistentry xml:id="snmp.constants.version-3">
       <term><constant>SNMP::VERSION_3</constant></term>
       <listitem>
        <para/>

--- a/reference/sqlite3/sqlite3.xml
+++ b/reference/sqlite3/sqlite3.xml
@@ -29,223 +29,223 @@
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.ok">SQLite3::OK</varname>
+     <varname linkend="sqlite3.constants.ok">SQLite3::OK</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.deny">SQLite3::DENY</varname>
+     <varname linkend="sqlite3.constants.deny">SQLite3::DENY</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.ignore">SQLite3::IGNORE</varname>
+     <varname linkend="sqlite3.constants.ignore">SQLite3::IGNORE</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.create-index">SQLite3::CREATE_INDEX</varname>
+     <varname linkend="sqlite3.constants.create-index">SQLite3::CREATE_INDEX</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.create-table">SQLite3::CREATE_TABLE</varname>
+     <varname linkend="sqlite3.constants.create-table">SQLite3::CREATE_TABLE</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.create-temp-index">SQLite3::CREATE_TEMP_INDEX</varname>
+     <varname linkend="sqlite3.constants.create-temp-index">SQLite3::CREATE_TEMP_INDEX</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.create-temp-table">SQLite3::CREATE_TEMP_TABLE</varname>
+     <varname linkend="sqlite3.constants.create-temp-table">SQLite3::CREATE_TEMP_TABLE</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.create-temp-trigger">SQLite3::CREATE_TEMP_TRIGGER</varname>
+     <varname linkend="sqlite3.constants.create-temp-trigger">SQLite3::CREATE_TEMP_TRIGGER</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.create-temp-view">SQLite3::CREATE_TEMP_VIEW</varname>
+     <varname linkend="sqlite3.constants.create-temp-view">SQLite3::CREATE_TEMP_VIEW</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.create-trigger">SQLite3::CREATE_TRIGGER</varname>
+     <varname linkend="sqlite3.constants.create-trigger">SQLite3::CREATE_TRIGGER</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.create-view">SQLite3::CREATE_VIEW</varname>
+     <varname linkend="sqlite3.constants.create-view">SQLite3::CREATE_VIEW</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.delete">SQLite3::DELETE</varname>
+     <varname linkend="sqlite3.constants.delete">SQLite3::DELETE</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.drop-index">SQLite3::DROP_INDEX</varname>
+     <varname linkend="sqlite3.constants.drop-index">SQLite3::DROP_INDEX</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.drop-table">SQLite3::DROP_TABLE</varname>
+     <varname linkend="sqlite3.constants.drop-table">SQLite3::DROP_TABLE</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.drop-temp-index">SQLite3::DROP_TEMP_INDEX</varname>
+     <varname linkend="sqlite3.constants.drop-temp-index">SQLite3::DROP_TEMP_INDEX</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.drop-temp-table">SQLite3::DROP_TEMP_TABLE</varname>
+     <varname linkend="sqlite3.constants.drop-temp-table">SQLite3::DROP_TEMP_TABLE</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.drop-temp-trigger">SQLite3::DROP_TEMP_TRIGGER</varname>
+     <varname linkend="sqlite3.constants.drop-temp-trigger">SQLite3::DROP_TEMP_TRIGGER</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.drop-temp-view">SQLite3::DROP_TEMP_VIEW</varname>
+     <varname linkend="sqlite3.constants.drop-temp-view">SQLite3::DROP_TEMP_VIEW</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.drop-trigger">SQLite3::DROP_TRIGGER</varname>
+     <varname linkend="sqlite3.constants.drop-trigger">SQLite3::DROP_TRIGGER</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.drop-view">SQLite3::DROP_VIEW</varname>
+     <varname linkend="sqlite3.constants.drop-view">SQLite3::DROP_VIEW</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.insert">SQLite3::INSERT</varname>
+     <varname linkend="sqlite3.constants.insert">SQLite3::INSERT</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.pragma">SQLite3::PRAGMA</varname>
+     <varname linkend="sqlite3.constants.pragma">SQLite3::PRAGMA</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.read">SQLite3::READ</varname>
+     <varname linkend="sqlite3.constants.read">SQLite3::READ</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.select">SQLite3::SELECT</varname>
+     <varname linkend="sqlite3.constants.select">SQLite3::SELECT</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.transaction">SQLite3::TRANSACTION</varname>
+     <varname linkend="sqlite3.constants.transaction">SQLite3::TRANSACTION</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.update">SQLite3::UPDATE</varname>
+     <varname linkend="sqlite3.constants.update">SQLite3::UPDATE</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.attach">SQLite3::ATTACH</varname>
+     <varname linkend="sqlite3.constants.attach">SQLite3::ATTACH</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.detach">SQLite3::DETACH</varname>
+     <varname linkend="sqlite3.constants.detach">SQLite3::DETACH</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.alter-table">SQLite3::ALTER_TABLE</varname>
+     <varname linkend="sqlite3.constants.alter-table">SQLite3::ALTER_TABLE</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.reindex">SQLite3::REINDEX</varname>
+     <varname linkend="sqlite3.constants.reindex">SQLite3::REINDEX</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.analyze">SQLite3::ANALYZE</varname>
+     <varname linkend="sqlite3.constants.analyze">SQLite3::ANALYZE</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.create-vtable">SQLite3::CREATE_VTABLE</varname>
+     <varname linkend="sqlite3.constants.create-vtable">SQLite3::CREATE_VTABLE</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.drop-vtable">SQLite3::DROP_VTABLE</varname>
+     <varname linkend="sqlite3.constants.drop-vtable">SQLite3::DROP_VTABLE</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.function">SQLite3::FUNCTION</varname>
+     <varname linkend="sqlite3.constants.function">SQLite3::FUNCTION</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.savepoint">SQLite3::SAVEPOINT</varname>
+     <varname linkend="sqlite3.constants.savepoint">SQLite3::SAVEPOINT</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.copy">SQLite3::COPY</varname>
+     <varname linkend="sqlite3.constants.copy">SQLite3::COPY</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="sqlite3.class.constants.recursive">SQLite3::RECURSIVE</varname>
+     <varname linkend="sqlite3.constants.recursive">SQLite3::RECURSIVE</varname>
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
@@ -264,259 +264,259 @@
   <section xml:id="sqlite3.class.constants">
    &reftitle.constants;
    <variablelist>
-    <varlistentry xml:id="sqlite3.class.constants.ok">
+    <varlistentry xml:id="sqlite3.constants.ok">
      <term><constant>SQLite3::OK</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.deny">
+    <varlistentry xml:id="sqlite3.constants.deny">
      <term><constant>SQLite3::DENY</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.ignore">
+    <varlistentry xml:id="sqlite3.constants.ignore">
      <term><constant>SQLite3::IGNORE</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.create-index">
+    <varlistentry xml:id="sqlite3.constants.create-index">
      <term><constant>SQLite3::CREATE_INDEX</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.create-table">
+    <varlistentry xml:id="sqlite3.constants.create-table">
      <term><constant>SQLite3::CREATE_TABLE</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.create-temp-index">
+    <varlistentry xml:id="sqlite3.constants.create-temp-index">
      <term><constant>SQLite3::CREATE_TEMP_INDEX</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.create-temp-table">
+    <varlistentry xml:id="sqlite3.constants.create-temp-table">
      <term><constant>SQLite3::CREATE_TEMP_TABLE</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.create-temp-trigger">
+    <varlistentry xml:id="sqlite3.constants.create-temp-trigger">
      <term><constant>SQLite3::CREATE_TEMP_TRIGGER</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.create-temp-view">
+    <varlistentry xml:id="sqlite3.constants.create-temp-view">
      <term><constant>SQLite3::CREATE_TEMP_VIEW</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.create-trigger">
+    <varlistentry xml:id="sqlite3.constants.create-trigger">
      <term><constant>SQLite3::CREATE_TRIGGER</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.create-view">
+    <varlistentry xml:id="sqlite3.constants.create-view">
      <term><constant>SQLite3::CREATE_VIEW</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.delete">
+    <varlistentry xml:id="sqlite3.constants.delete">
      <term><constant>SQLite3::DELETE</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.drop-index">
+    <varlistentry xml:id="sqlite3.constants.drop-index">
      <term><constant>SQLite3::DROP_INDEX</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.drop-table">
+    <varlistentry xml:id="sqlite3.constants.drop-table">
      <term><constant>SQLite3::DROP_TABLE</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.drop-temp-index">
+    <varlistentry xml:id="sqlite3.constants.drop-temp-index">
      <term><constant>SQLite3::DROP_TEMP_INDEX</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.drop-temp-table">
+    <varlistentry xml:id="sqlite3.constants.drop-temp-table">
      <term><constant>SQLite3::DROP_TEMP_TABLE</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.drop-temp-trigger">
+    <varlistentry xml:id="sqlite3.constants.drop-temp-trigger">
      <term><constant>SQLite3::DROP_TEMP_TRIGGER</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.drop-temp-view">
+    <varlistentry xml:id="sqlite3.constants.drop-temp-view">
      <term><constant>SQLite3::DROP_TEMP_VIEW</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.drop-trigger">
+    <varlistentry xml:id="sqlite3.constants.drop-trigger">
      <term><constant>SQLite3::DROP_TRIGGER</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.drop-view">
+    <varlistentry xml:id="sqlite3.constants.drop-view">
      <term><constant>SQLite3::DROP_VIEW</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.insert">
+    <varlistentry xml:id="sqlite3.constants.insert">
      <term><constant>SQLite3::INSERT</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.pragma">
+    <varlistentry xml:id="sqlite3.constants.pragma">
      <term><constant>SQLite3::PRAGMA</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.read">
+    <varlistentry xml:id="sqlite3.constants.read">
      <term><constant>SQLite3::READ</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.select">
+    <varlistentry xml:id="sqlite3.constants.select">
      <term><constant>SQLite3::SELECT</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.transaction">
+    <varlistentry xml:id="sqlite3.constants.transaction">
      <term><constant>SQLite3::TRANSACTION</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.update">
+    <varlistentry xml:id="sqlite3.constants.update">
      <term><constant>SQLite3::UPDATE</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.attach">
+    <varlistentry xml:id="sqlite3.constants.attach">
      <term><constant>SQLite3::ATTACH</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.detach">
+    <varlistentry xml:id="sqlite3.constants.detach">
      <term><constant>SQLite3::DETACH</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.alter-table">
+    <varlistentry xml:id="sqlite3.constants.alter-table">
      <term><constant>SQLite3::ALTER_TABLE</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.reindex">
+    <varlistentry xml:id="sqlite3.constants.reindex">
      <term><constant>SQLite3::REINDEX</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.analyze">
+    <varlistentry xml:id="sqlite3.constants.analyze">
      <term><constant>SQLite3::ANALYZE</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.create-vtable">
+    <varlistentry xml:id="sqlite3.constants.create-vtable">
      <term><constant>SQLite3::CREATE_VTABLE</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.drop-vtable">
+    <varlistentry xml:id="sqlite3.constants.drop-vtable">
      <term><constant>SQLite3::DROP_VTABLE</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.function">
+    <varlistentry xml:id="sqlite3.constants.function">
      <term><constant>SQLite3::FUNCTION</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.savepoint">
+    <varlistentry xml:id="sqlite3.constants.savepoint">
      <term><constant>SQLite3::SAVEPOINT</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.copy">
+    <varlistentry xml:id="sqlite3.constants.copy">
      <term><constant>SQLite3::COPY</constant></term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="sqlite3.class.constants.recursive">
+    <varlistentry xml:id="sqlite3.constants.recursive">
      <term><constant>SQLite3::RECURSIVE</constant></term>
      <listitem>
       <para/>

--- a/reference/zookeeper/zookeeper.xml
+++ b/reference/zookeeper/zookeeper.xml
@@ -51,337 +51,337 @@
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.perm-read">PERM_READ</varname>
+     <varname linkend="zookeeper.constants.perm-read">PERM_READ</varname>
      <initializer>1</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.perm-write">PERM_WRITE</varname>
+     <varname linkend="zookeeper.constants.perm-write">PERM_WRITE</varname>
      <initializer>2</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.perm-create">PERM_CREATE</varname>
+     <varname linkend="zookeeper.constants.perm-create">PERM_CREATE</varname>
      <initializer>4</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.perm-delete">PERM_DELETE</varname>
+     <varname linkend="zookeeper.constants.perm-delete">PERM_DELETE</varname>
      <initializer>8</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.perm-admin">PERM_ADMIN</varname>
+     <varname linkend="zookeeper.constants.perm-admin">PERM_ADMIN</varname>
      <initializer>16</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.perm-all">PERM_ALL</varname>
+     <varname linkend="zookeeper.constants.perm-all">PERM_ALL</varname>
      <initializer>31</initializer>
     </fieldsynopsis>
 
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.ephemeral">EPHEMERAL</varname>
+     <varname linkend="zookeeper.constants.ephemeral">EPHEMERAL</varname>
      <initializer>1</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.sequence">SEQUENCE</varname>
+     <varname linkend="zookeeper.constants.sequence">SEQUENCE</varname>
      <initializer>2</initializer>
     </fieldsynopsis>
 
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.log-level-error">LOG_LEVEL_ERROR</varname>
+     <varname linkend="zookeeper.constants.log-level-error">LOG_LEVEL_ERROR</varname>
      <initializer>1</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.log-level-warn">LOG_LEVEL_WARN</varname>
+     <varname linkend="zookeeper.constants.log-level-warn">LOG_LEVEL_WARN</varname>
      <initializer>2</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.log-level-info">LOG_LEVEL_INFO</varname>
+     <varname linkend="zookeeper.constants.log-level-info">LOG_LEVEL_INFO</varname>
      <initializer>3</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.log-level-debug">LOG_LEVEL_DEBUG</varname>
+     <varname linkend="zookeeper.constants.log-level-debug">LOG_LEVEL_DEBUG</varname>
      <initializer>4</initializer>
     </fieldsynopsis>
 
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.expired-session-state">EXPIRED_SESSION_STATE</varname>
+     <varname linkend="zookeeper.constants.expired-session-state">EXPIRED_SESSION_STATE</varname>
      <initializer>-112</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.auth-failed-state">AUTH_FAILED_STATE</varname>
+     <varname linkend="zookeeper.constants.auth-failed-state">AUTH_FAILED_STATE</varname>
      <initializer>-113</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.connecting-state">CONNECTING_STATE</varname>
+     <varname linkend="zookeeper.constants.connecting-state">CONNECTING_STATE</varname>
      <initializer>1</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.associating-state">ASSOCIATING_STATE</varname>
+     <varname linkend="zookeeper.constants.associating-state">ASSOCIATING_STATE</varname>
      <initializer>2</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.connected-state">CONNECTED_STATE</varname>
+     <varname linkend="zookeeper.constants.connected-state">CONNECTED_STATE</varname>
      <initializer>3</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.readonly-state">READONLY_STATE</varname>
+     <varname linkend="zookeeper.constants.readonly-state">READONLY_STATE</varname>
      <initializer>5</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.notconnected-state">NOTCONNECTED_STATE</varname>
+     <varname linkend="zookeeper.constants.notconnected-state">NOTCONNECTED_STATE</varname>
      <initializer>999</initializer>
     </fieldsynopsis>
 
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.created-event">CREATED_EVENT</varname>
+     <varname linkend="zookeeper.constants.created-event">CREATED_EVENT</varname>
      <initializer>1</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.deleted-event">DELETED_EVENT</varname>
+     <varname linkend="zookeeper.constants.deleted-event">DELETED_EVENT</varname>
      <initializer>2</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.changed-event">CHANGED_EVENT</varname>
+     <varname linkend="zookeeper.constants.changed-event">CHANGED_EVENT</varname>
      <initializer>3</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.child-event">CHILD_EVENT</varname>
+     <varname linkend="zookeeper.constants.child-event">CHILD_EVENT</varname>
      <initializer>4</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.session-event">SESSION_EVENT</varname>
+     <varname linkend="zookeeper.constants.session-event">SESSION_EVENT</varname>
      <initializer>-1</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.notwatching-event">NOTWATCHING_EVENT</varname>
+     <varname linkend="zookeeper.constants.notwatching-event">NOTWATCHING_EVENT</varname>
      <initializer>-2</initializer>
     </fieldsynopsis>
 
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.systemerror">SYSTEMERROR</varname>
+     <varname linkend="zookeeper.constants.systemerror">SYSTEMERROR</varname>
      <initializer>-1</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.runtimeinconsistency">RUNTIMEINCONSISTENCY</varname>
+     <varname linkend="zookeeper.constants.runtimeinconsistency">RUNTIMEINCONSISTENCY</varname>
      <initializer>-2</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.datainconsistency">DATAINCONSISTENCY</varname>
+     <varname linkend="zookeeper.constants.datainconsistency">DATAINCONSISTENCY</varname>
      <initializer>-3</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.connectionloss">CONNECTIONLOSS</varname>
+     <varname linkend="zookeeper.constants.connectionloss">CONNECTIONLOSS</varname>
      <initializer>-4</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.marshallingerror">MARSHALLINGERROR</varname>
+     <varname linkend="zookeeper.constants.marshallingerror">MARSHALLINGERROR</varname>
      <initializer>-5</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.unimplemented">UNIMPLEMENTED</varname>
+     <varname linkend="zookeeper.constants.unimplemented">UNIMPLEMENTED</varname>
      <initializer>-6</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.operationtimeout">OPERATIONTIMEOUT</varname>
+     <varname linkend="zookeeper.constants.operationtimeout">OPERATIONTIMEOUT</varname>
      <initializer>-7</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.badarguments">BADARGUMENTS</varname>
+     <varname linkend="zookeeper.constants.badarguments">BADARGUMENTS</varname>
      <initializer>-8</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.invalidstate">INVALIDSTATE</varname>
+     <varname linkend="zookeeper.constants.invalidstate">INVALIDSTATE</varname>
      <initializer>-9</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.newconfignoquorum">NEWCONFIGNOQUORUM</varname>
+     <varname linkend="zookeeper.constants.newconfignoquorum">NEWCONFIGNOQUORUM</varname>
      <initializer>-13</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.reconfiginprogress">RECONFIGINPROGRESS</varname>
+     <varname linkend="zookeeper.constants.reconfiginprogress">RECONFIGINPROGRESS</varname>
      <initializer>-14</initializer>
     </fieldsynopsis>
 
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.ok">OK</varname>
+     <varname linkend="zookeeper.constants.ok">OK</varname>
      <initializer>0</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.apierror">APIERROR</varname>
+     <varname linkend="zookeeper.constants.apierror">APIERROR</varname>
      <initializer>-100</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.nonode">NONODE</varname>
+     <varname linkend="zookeeper.constants.nonode">NONODE</varname>
      <initializer>-101</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.noauth">NOAUTH</varname>
+     <varname linkend="zookeeper.constants.noauth">NOAUTH</varname>
      <initializer>-102</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.badversion">BADVERSION</varname>
+     <varname linkend="zookeeper.constants.badversion">BADVERSION</varname>
      <initializer>-103</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.nochildrenforephemerals">NOCHILDRENFOREPHEMERALS</varname>
+     <varname linkend="zookeeper.constants.nochildrenforephemerals">NOCHILDRENFOREPHEMERALS</varname>
      <initializer>-108</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.nodeexists">NODEEXISTS</varname>
+     <varname linkend="zookeeper.constants.nodeexists">NODEEXISTS</varname>
      <initializer>-110</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.notempty">NOTEMPTY</varname>
+     <varname linkend="zookeeper.constants.notempty">NOTEMPTY</varname>
      <initializer>-111</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.sessionexpired">SESSIONEXPIRED</varname>
+     <varname linkend="zookeeper.constants.sessionexpired">SESSIONEXPIRED</varname>
      <initializer>-112</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.invalidcallback">INVALIDCALLBACK</varname>
+     <varname linkend="zookeeper.constants.invalidcallback">INVALIDCALLBACK</varname>
      <initializer>-113</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.invalidacl">INVALIDACL</varname>
+     <varname linkend="zookeeper.constants.invalidacl">INVALIDACL</varname>
      <initializer>-114</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.authfailed">AUTHFAILED</varname>
+     <varname linkend="zookeeper.constants.authfailed">AUTHFAILED</varname>
      <initializer>-115</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.closing">CLOSING</varname>
+     <varname linkend="zookeeper.constants.closing">CLOSING</varname>
      <initializer>-116</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.nothing">NOTHING</varname>
+     <varname linkend="zookeeper.constants.nothing">NOTHING</varname>
      <initializer>-117</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.sessionmoved">SESSIONMOVED</varname>
+     <varname linkend="zookeeper.constants.sessionmoved">SESSIONMOVED</varname>
      <initializer>-118</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.notreadonly">NOTREADONLY</varname>
+     <varname linkend="zookeeper.constants.notreadonly">NOTREADONLY</varname>
      <initializer>-119</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.ephemeralonlocalsession">EPHEMERALONLOCALSESSION</varname>
+     <varname linkend="zookeeper.constants.ephemeralonlocalsession">EPHEMERALONLOCALSESSION</varname>
      <initializer>-120</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.nowatcher">NOWATCHER</varname>
+     <varname linkend="zookeeper.constants.nowatcher">NOWATCHER</varname>
      <initializer>-121</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="zookeeper.class.constants.reconfigdisabled">RECONFIGDISABLED</varname>
+     <varname linkend="zookeeper.constants.reconfigdisabled">RECONFIGDISABLED</varname>
      <initializer>-122</initializer>
     </fieldsynopsis>
 <!-- }}} -->
@@ -396,41 +396,41 @@
    &reftitle.constants;
 
 <!-- {{{ Constants Permissions -->
-   <section xml:id="zookeeper.class.constants.perms">
+   <section xml:id="zookeeper.constants.perms">
     <title><acronym>ZooKeeper</acronym> Permissions</title>
     <variablelist>
 
-     <varlistentry xml:id="zookeeper.class.constants.perm-read">
+     <varlistentry xml:id="zookeeper.constants.perm-read">
       <term><constant>Zookeeper::PERM_READ</constant></term>
       <listitem>
        <para>Can read nodes value and list its children</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.perm-write">
+     <varlistentry xml:id="zookeeper.constants.perm-write">
       <term><constant>Zookeeper::PERM_WRITE</constant></term>
       <listitem>
        <para>Can set the nodes value</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.perm-create">
+     <varlistentry xml:id="zookeeper.constants.perm-create">
       <term><constant>Zookeeper::PERM_CREATE</constant></term>
       <listitem>
        <para>Can create children</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.perm-delete">
+     <varlistentry xml:id="zookeeper.constants.perm-delete">
       <term><constant>Zookeeper::PERM_DELETE</constant></term>
       <listitem>
        <para>Can delete children</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.perm-admin">
+     <varlistentry xml:id="zookeeper.constants.perm-admin">
       <term><constant>Zookeeper::PERM_ADMIN</constant></term>
       <listitem>
        <para>Can execute set_acl()</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.perm-all">
+     <varlistentry xml:id="zookeeper.constants.perm-all">
       <term><constant>Zookeeper::PERM_ALL</constant></term>
       <listitem>
        <para>All of the above flags ORd together</para>
@@ -442,17 +442,17 @@
 <!-- }}} -->
 
 <!-- {{{ Constants Create Flags -->
-   <section xml:id="zookeeper.class.constants.create-flags">
+   <section xml:id="zookeeper.constants.create-flags">
     <title><acronym>ZooKeeper</acronym> Create Flags</title>
     <variablelist>
 
-     <varlistentry xml:id="zookeeper.class.constants.ephemeral">
+     <varlistentry xml:id="zookeeper.constants.ephemeral">
       <term><constant>Zookeeper::EPHEMERAL</constant></term>
       <listitem>
        <para>If Zookeeper::EPHEMERAL flag is set, the node will automatically get removed if the client session goes away.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.sequence">
+     <varlistentry xml:id="zookeeper.constants.sequence">
       <term><constant>Zookeeper::SEQUENCE</constant></term>
       <listitem>
        <para>If the Zookeeper::SEQUENCE flag is set, a unique monotonically increasing sequence number is appended to the path name. The sequence number is always fixed length of 10 digits, 0 padded.</para>
@@ -463,29 +463,29 @@
 <!-- }}} -->
 
 <!-- {{{ Constants Log Levels -->
-   <section xml:id="zookeeper.class.constants.log-levels">
+   <section xml:id="zookeeper.constants.log-levels">
     <title><acronym>ZooKeeper</acronym> Log Levels</title>
     <variablelist>
 
-     <varlistentry xml:id="zookeeper.class.constants.log-level-error">
+     <varlistentry xml:id="zookeeper.constants.log-level-error">
       <term><constant>Zookeeper::LOG_LEVEL_ERROR</constant></term>
       <listitem>
        <para>Outputs only error mesages</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.log-level-warn">
+     <varlistentry xml:id="zookeeper.constants.log-level-warn">
       <term><constant>Zookeeper::LOG_LEVEL_WARN</constant></term>
       <listitem>
        <para>Outputs errors/warnings</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.log-level-info">
+     <varlistentry xml:id="zookeeper.constants.log-level-info">
       <term><constant>Zookeeper::LOG_LEVEL_INFO</constant></term>
       <listitem>
        <para>Outputs big action messages besides errors/warnings</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.log-level-debug">
+     <varlistentry xml:id="zookeeper.constants.log-level-debug">
       <term><constant>Zookeeper::LOG_LEVEL_DEBUG</constant></term>
       <listitem>
        <para>Outputs all</para>
@@ -497,47 +497,47 @@
 <!-- }}} -->
 
 <!-- {{{ Constants States -->
-   <section xml:id="zookeeper.class.constants.states">
+   <section xml:id="zookeeper.constants.states">
     <title><acronym>ZooKeeper</acronym> States</title>
     <variablelist>
 
-     <varlistentry xml:id="zookeeper.class.constants.expired-session-state">
+     <varlistentry xml:id="zookeeper.constants.expired-session-state">
       <term><constant>Zookeeper::EXPIRED_SESSION_STATE</constant></term>
       <listitem>
        <para>Connected but session expired</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.auth-failed-state">
+     <varlistentry xml:id="zookeeper.constants.auth-failed-state">
       <term><constant>Zookeeper::AUTH_FAILED_STATE</constant></term>
       <listitem>
        <para>Connected but auth failed</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.connecting-state">
+     <varlistentry xml:id="zookeeper.constants.connecting-state">
       <term><constant>Zookeeper::CONNECTING_STATE</constant></term>
       <listitem>
        <para>Connecting</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.associating-state">
+     <varlistentry xml:id="zookeeper.constants.associating-state">
       <term><constant>Zookeeper::ASSOCIATING_STATE</constant></term>
       <listitem>
        <para>Associating</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.connected-state">
+     <varlistentry xml:id="zookeeper.constants.connected-state">
       <term><constant>Zookeeper::CONNECTED_STATE</constant></term>
       <listitem>
        <para>Connected</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.readonly-state">
+     <varlistentry xml:id="zookeeper.constants.readonly-state">
       <term><constant>Zookeeper::READONLY_STATE</constant></term>
       <listitem>
        <para>TODO: help us improve this extension.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.notconnected-state">
+     <varlistentry xml:id="zookeeper.constants.notconnected-state">
       <term><constant>Zookeeper::NOTCONNECTED_STATE</constant></term>
       <listitem>
        <para>Connection failed</para>
@@ -549,46 +549,46 @@
 <!-- }}} -->
 
 <!-- {{{ Constants Watch Types -->
-   <section xml:id="zookeeper.class.constants.watch-types">
+   <section xml:id="zookeeper.constants.watch-types">
     <title><acronym>ZooKeeper</acronym> Watch Types</title>
     <variablelist>
 
-     <varlistentry xml:id="zookeeper.class.constants.created-event">
+     <varlistentry xml:id="zookeeper.constants.created-event">
       <term><constant>Zookeeper::CREATED_EVENT</constant></term>
       <listitem>
        <para>A node has been created</para>
        <para>This is only generated by watches on non-existent nodes. These watches are set using Zookeeper::exists.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.deleted-event">
+     <varlistentry xml:id="zookeeper.constants.deleted-event">
       <term><constant>Zookeeper::DELETED_EVENT</constant></term>
       <listitem>
        <para>A node has been deleted</para>
        <para>This is only generated by watches on nodes. These watches are set using Zookeeper::exists and Zookeeper::get.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.changed-event">
+     <varlistentry xml:id="zookeeper.constants.changed-event">
       <term><constant>Zookeeper::CHANGED_EVENT</constant></term>
       <listitem>
        <para>A node has changed</para>
        <para>This is only generated by watches on nodes. These watches are set using Zookeeper::exists and Zookeeper::get.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.child-event">
+     <varlistentry xml:id="zookeeper.constants.child-event">
       <term><constant>Zookeeper::CHILD_EVENT</constant></term>
       <listitem>
        <para>A change as occurred in the list of children</para>
        <para>This is only generated by watches on the child list of a node. These watches are set using Zookeeper::getChildren.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.session-event">
+     <varlistentry xml:id="zookeeper.constants.session-event">
       <term><constant>Zookeeper::SESSION_EVENT</constant></term>
       <listitem>
        <para>A session has been lost</para>
        <para>This is generated when a client loses contact or reconnects with a server.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.notwatching-event">
+     <varlistentry xml:id="zookeeper.constants.notwatching-event">
       <term><constant>Zookeeper::NOTWATCHING_EVENT</constant></term>
       <listitem>
        <para>A watch has been removed</para>
@@ -601,71 +601,71 @@
 <!-- }}} -->
 
 <!-- {{{ Constants System and Server-side Errors -->
-   <section xml:id="zookeeper.class.constants.system-n-server-side-errors">
+   <section xml:id="zookeeper.constants.system-n-server-side-errors">
     <title><acronym>ZooKeeper</acronym> System and Server-side Errors</title>
     <variablelist>
-     <varlistentry xml:id="zookeeper.class.constants.systemerror">
+     <varlistentry xml:id="zookeeper.constants.systemerror">
       <term><constant>Zookeeper::SYSTEMERROR</constant></term>
       <listitem>
        <para>This is never thrown by the server, it shouldn't be used other than to indicate a range. Specifically error codes greater than this value, but lesser than Zookeeper::APIERROR, are system errors.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.runtimeinconsistency">
+     <varlistentry xml:id="zookeeper.constants.runtimeinconsistency">
       <term><constant>Zookeeper::RUNTIMEINCONSISTENCY</constant></term>
       <listitem>
        <para>A runtime inconsistency was found.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.datainconsistency">
+     <varlistentry xml:id="zookeeper.constants.datainconsistency">
       <term><constant>Zookeeper::DATAINCONSISTENCY</constant></term>
       <listitem>
        <para>A data inconsistency was found.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.connectionloss">
+     <varlistentry xml:id="zookeeper.constants.connectionloss">
       <term><constant>Zookeeper::CONNECTIONLOSS</constant></term>
       <listitem>
        <para>Connection to the server has been lost.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.marshallingerror">
+     <varlistentry xml:id="zookeeper.constants.marshallingerror">
       <term><constant>Zookeeper::MARSHALLINGERROR</constant></term>
       <listitem>
        <para>Error while marshalling or unmarshalling data.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.unimplemented">
+     <varlistentry xml:id="zookeeper.constants.unimplemented">
       <term><constant>Zookeeper::UNIMPLEMENTED</constant></term>
       <listitem>
        <para>Operation is unimplemented.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.operationtimeout">
+     <varlistentry xml:id="zookeeper.constants.operationtimeout">
       <term><constant>Zookeeper::OPERATIONTIMEOUT</constant></term>
       <listitem>
        <para>Operation timeout.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.badarguments">
+     <varlistentry xml:id="zookeeper.constants.badarguments">
       <term><constant>Zookeeper::BADARGUMENTS</constant></term>
       <listitem>
        <para>Invalid arguments.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.invalidstate">
+     <varlistentry xml:id="zookeeper.constants.invalidstate">
       <term><constant>Zookeeper::INVALIDSTATE</constant></term>
       <listitem>
        <para>Invliad zhandle state.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.newconfignoquorum">
+     <varlistentry xml:id="zookeeper.constants.newconfignoquorum">
       <term><constant>Zookeeper::NEWCONFIGNOQUORUM</constant></term>
       <listitem>
        <para>No quorum of new config is connected and up-to-date with the leader of last committed config - try invoking reconfiguration after new servers are connected and synced.</para>
        <para>Available as of ZooKeeper 3.5.0</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.reconfiginprogress">
+     <varlistentry xml:id="zookeeper.constants.reconfiginprogress">
       <term><constant>Zookeeper::RECONFIGINPROGRESS</constant></term>
       <listitem>
        <para>Reconfiguration requested while another reconfiguration is currently in progress. This is currently not supported. Please retry.</para>
@@ -677,118 +677,118 @@
 <!-- }}} -->
 
 <!-- {{{ Constants API Errors -->
-   <section xml:id="zookeeper.class.constants.api-errors">
+   <section xml:id="zookeeper.constants.api-errors">
     <title><acronym>ZooKeeper</acronym> API Errors</title>
     <variablelist>
-     <varlistentry xml:id="zookeeper.class.constants.ok">
+     <varlistentry xml:id="zookeeper.constants.ok">
       <term><constant>Zookeeper::OK</constant></term>
       <listitem>
        <para>Everything is OK.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.apierror">
+     <varlistentry xml:id="zookeeper.constants.apierror">
       <term><constant>Zookeeper::APIERROR</constant></term>
       <listitem>
        <para>This is never thrown by the server, it shouldn't be used other than to indicate a range. Specifically error codes greater than this value are API errors (while values less than this indicate a Zookeeper::SYSTEMERROR).</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.nonode">
+     <varlistentry xml:id="zookeeper.constants.nonode">
       <term><constant>Zookeeper::NONODE</constant></term>
       <listitem>
        <para>Node does not exist.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.noauth">
+     <varlistentry xml:id="zookeeper.constants.noauth">
       <term><constant>Zookeeper::NOAUTH</constant></term>
       <listitem>
        <para>Not authenticated.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.badversion">
+     <varlistentry xml:id="zookeeper.constants.badversion">
       <term><constant>Zookeeper::BADVERSION</constant></term>
       <listitem>
        <para>Version conflict.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.nochildrenforephemerals">
+     <varlistentry xml:id="zookeeper.constants.nochildrenforephemerals">
       <term><constant>Zookeeper::NOCHILDRENFOREPHEMERALS</constant></term>
       <listitem>
        <para>Ephemeral nodes may not have children.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.nodeexists">
+     <varlistentry xml:id="zookeeper.constants.nodeexists">
       <term><constant>Zookeeper::NODEEXISTS</constant></term>
       <listitem>
        <para>The node already exists.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.notempty">
+     <varlistentry xml:id="zookeeper.constants.notempty">
       <term><constant>Zookeeper::NOTEMPTY</constant></term>
       <listitem>
        <para>The node has children.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.sessionexpired">
+     <varlistentry xml:id="zookeeper.constants.sessionexpired">
       <term><constant>Zookeeper::SESSIONEXPIRED</constant></term>
       <listitem>
        <para>The session has been expired by the server.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.invalidcallback">
+     <varlistentry xml:id="zookeeper.constants.invalidcallback">
       <term><constant>Zookeeper::INVALIDCALLBACK</constant></term>
       <listitem>
        <para>Invalid callback specified.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.invalidacl">
+     <varlistentry xml:id="zookeeper.constants.invalidacl">
       <term><constant>Zookeeper::INVALIDACL</constant></term>
       <listitem>
        <para>Invalid ACL specified.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.authfailed">
+     <varlistentry xml:id="zookeeper.constants.authfailed">
       <term><constant>Zookeeper::AUTHFAILED</constant></term>
       <listitem>
        <para>Client authentication failed.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.closing">
+     <varlistentry xml:id="zookeeper.constants.closing">
       <term><constant>Zookeeper::CLOSING</constant></term>
       <listitem>
        <para>ZooKeeper is closing.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.nothing">
+     <varlistentry xml:id="zookeeper.constants.nothing">
       <term><constant>Zookeeper::NOTHING</constant></term>
       <listitem>
        <para>(not error) No server responses to process.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.sessionmoved">
+     <varlistentry xml:id="zookeeper.constants.sessionmoved">
       <term><constant>Zookeeper::SESSIONMOVED</constant></term>
       <listitem>
        <para>Session moved to another server, so operation is ignored.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.notreadonly">
+     <varlistentry xml:id="zookeeper.constants.notreadonly">
       <term><constant>Zookeeper::NOTREADONLY</constant></term>
       <listitem>
        <para>State-changing request is passed to read-only server.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.ephemeralonlocalsession">
+     <varlistentry xml:id="zookeeper.constants.ephemeralonlocalsession">
       <term><constant>Zookeeper::EPHEMERALONLOCALSESSION</constant></term>
       <listitem>
        <para>Attempt to create ephemeral node on a local session.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.nowatcher">
+     <varlistentry xml:id="zookeeper.constants.nowatcher">
       <term><constant>Zookeeper::NOWATCHER</constant></term>
       <listitem>
        <para>The watcher couldn't be found.</para>
       </listitem>
      </varlistentry>
-     <varlistentry xml:id="zookeeper.class.constants.reconfigdisabled">
+     <varlistentry xml:id="zookeeper.constants.reconfigdisabled">
       <term><constant>Zookeeper::RECONFIGDISABLED</constant></term>
       <listitem>
        <para>Attempts to perform a reconfiguration operation when reconfiguration feature is disabled.</para>

--- a/reference/zookeeper/zookeeper/addauth.xml
+++ b/reference/zookeeper/zookeeper/addauth.xml
@@ -113,7 +113,7 @@ nodevalue
    <member><methodname>Zookeeper::create</methodname></member>
    <member><methodname>Zookeeper::setAcl</methodname></member>
    <member><methodname>Zookeeper::getAcl</methodname></member>
-   <member><link linkend="zookeeper.class.constants.states">ZooKeeper States</link></member>
+   <member><link linkend="zookeeper.constants.states">ZooKeeper States</link></member>
    <member><classname>ZookeeperException</classname></member>
   </simplelist>
  </refsect1>

--- a/reference/zookeeper/zookeeper/create.xml
+++ b/reference/zookeeper/zookeeper/create.xml
@@ -120,7 +120,7 @@ else
   <simplelist>
    <member><methodname>Zookeeper::delete</methodname></member>
    <member><methodname>Zookeeper::getChildren</methodname></member>
-   <member><link linkend="zookeeper.class.constants.perms">ZooKeeper Permissions</link></member>
+   <member><link linkend="zookeeper.constants.perms">ZooKeeper Permissions</link></member>
    <member><classname>ZookeeperException</classname></member>
   </simplelist>
  </refsect1>

--- a/reference/zookeeper/zookeeper/getacl.xml
+++ b/reference/zookeeper/zookeeper/getacl.xml
@@ -102,7 +102,7 @@ array(1) {
   <simplelist>
    <member><methodname>Zookeeper::create</methodname></member>
    <member><methodname>Zookeeper::setAcl</methodname></member>
-   <member><link linkend="zookeeper.class.constants.perms">ZooKeeper Permissions</link></member>
+   <member><link linkend="zookeeper.constants.perms">ZooKeeper Permissions</link></member>
    <member><classname>ZookeeperException</classname></member>
   </simplelist>
  </refsect1>

--- a/reference/zookeeper/zookeeper/getclientid.xml
+++ b/reference/zookeeper/zookeeper/getclientid.xml
@@ -46,7 +46,7 @@
    <member><methodname>Zookeeper::__construct</methodname></member>
    <member><methodname>Zookeeper::connect</methodname></member>
    <member><methodname>Zookeeper::getState</methodname></member>
-   <member><link linkend="zookeeper.class.constants.states">ZooKeeper States</link></member>
+   <member><link linkend="zookeeper.constants.states">ZooKeeper States</link></member>
    <member><classname>ZookeeperException</classname></member>
   </simplelist>
  </refsect1>

--- a/reference/zookeeper/zookeeper/getstate.xml
+++ b/reference/zookeeper/zookeeper/getstate.xml
@@ -46,7 +46,7 @@
    <member><methodname>Zookeeper::__construct</methodname></member>
    <member><methodname>Zookeeper::connect</methodname></member>
    <member><methodname>Zookeeper::getClientId</methodname></member>
-   <member><link linkend="zookeeper.class.constants.states">ZooKeeper States</link></member>
+   <member><link linkend="zookeeper.constants.states">ZooKeeper States</link></member>
    <member><classname>ZookeeperException</classname></member>
   </simplelist>
  </refsect1>

--- a/reference/zookeeper/zookeeper/isrecoverable.xml
+++ b/reference/zookeeper/zookeeper/isrecoverable.xml
@@ -49,7 +49,7 @@
    <member><methodname>Zookeeper::__construct</methodname></member>
    <member><methodname>Zookeeper::connect</methodname></member>
    <member><methodname>Zookeeper::getClientId</methodname></member>
-   <member><link linkend="zookeeper.class.constants.states">ZooKeeper States</link></member>
+   <member><link linkend="zookeeper.constants.states">ZooKeeper States</link></member>
    <member><classname>ZookeeperException</classname></member>
   </simplelist>
  </refsect1>

--- a/reference/zookeeper/zookeeper/setacl.xml
+++ b/reference/zookeeper/zookeeper/setacl.xml
@@ -120,7 +120,7 @@ array(1) {
   <simplelist>
    <member><methodname>Zookeeper::create</methodname></member>
    <member><methodname>Zookeeper::getAcl</methodname></member>
-   <member><link linkend="zookeeper.class.constants.perms">ZooKeeper Permissions</link></member>
+   <member><link linkend="zookeeper.constants.perms">ZooKeeper Permissions</link></member>
    <member><classname>ZookeeperException</classname></member>
   </simplelist>
  </refsect1>

--- a/reference/zookeeper/zookeeper/setdebuglevel.xml
+++ b/reference/zookeeper/zookeeper/setdebuglevel.xml
@@ -81,7 +81,7 @@ SUCCESS
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><link linkend="zookeeper.class.constants.log-levels">ZooKeeper Log Levels</link></member>
+   <member><link linkend="zookeeper.constants.log-levels">ZooKeeper Log Levels</link></member>
    <member><classname>ZookeeperException</classname></member>
   </simplelist>
  </refsect1>

--- a/sqlite_zookeeper_snmp_constant_ids.sh
+++ b/sqlite_zookeeper_snmp_constant_ids.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+\grep -lrE --include='*.xml' '"(.)+\.class\.constants\.(.)+"' | xargs -d '\n' sed -i 's/\.class\.constants\./\.constants\./g'

--- a/sqlite_zookeeper_snmp_constant_ids.sh
+++ b/sqlite_zookeeper_snmp_constant_ids.sh
@@ -1,3 +1,0 @@
-#! /bin/bash
-
-\grep -lrE --include='*.xml' '"(.)+\.class\.constants\.(.)+"' | xargs -d '\n' sed -i 's/\.class\.constants\./\.constants\./g'


### PR DESCRIPTION
Update SQLite, Zookeeper and SNMP constant IDs to the "standard" class constant ID format.

Add bash script this update was made with so that it can be applied to translations as well.