### PR TITLE
Update APCu constant IDs

### DIFF
--- a/apcu_constant_ids.sh
+++ b/apcu_constant_ids.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+\grep -lrE --include='*.xml' '"constant\.apcu-' | xargs -d '\n' sed -i 's/"constant\.apcu-/"constant\.apc-/g'

--- a/reference/apcu/constants.xml
+++ b/reference/apcu/constants.xml
@@ -7,7 +7,7 @@
 
  <para>
   <variablelist>
-   <varlistentry xml:id="constant.apcu-iter-all">
+   <varlistentry xml:id="constant.apc-iter-all">
     <term>
      <constant>APC_ITER_ALL</constant>
      (<type>int</type>)
@@ -18,7 +18,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.apcu-iter-atime">
+   <varlistentry xml:id="constant.apc-iter-atime">
     <term>
      <constant>APC_ITER_ATIME</constant>
      (<type>int</type>)
@@ -29,7 +29,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.apcu-iter-ctime">
+   <varlistentry xml:id="constant.apc-iter-ctime">
     <term>
      <constant>APC_ITER_CTIME</constant>
      (<type>int</type>)
@@ -40,7 +40,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.apcu-iter-device">
+   <varlistentry xml:id="constant.apc-iter-device">
     <term>
      <constant>APC_ITER_DEVICE</constant>
      (<type>int</type>)
@@ -51,7 +51,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.apcu-iter-dtime">
+   <varlistentry xml:id="constant.apc-iter-dtime">
     <term>
      <constant>APC_ITER_DTIME</constant>
      (<type>int</type>)
@@ -62,7 +62,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.apcu-iter-filename">
+   <varlistentry xml:id="constant.apc-iter-filename">
     <term>
      <constant>APC_ITER_FILENAME</constant>
      (<type>int</type>)
@@ -73,7 +73,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.apcu-iter-inode">
+   <varlistentry xml:id="constant.apc-iter-inode">
     <term>
      <constant>APC_ITER_INODE</constant>
      (<type>int</type>)
@@ -84,7 +84,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.apcu-iter-key">
+   <varlistentry xml:id="constant.apc-iter-key">
     <term>
      <constant>APC_ITER_KEY</constant>
      (<type>int</type>)
@@ -95,7 +95,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.apcu-iter-md5">
+   <varlistentry xml:id="constant.apc-iter-md5">
     <term>
      <constant>APC_ITER_MD5</constant>
      (<type>int</type>)
@@ -106,7 +106,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.apcu-iter-mem-size">
+   <varlistentry xml:id="constant.apc-iter-mem-size">
     <term>
      <constant>APC_ITER_MEM_SIZE</constant>
      (<type>int</type>)
@@ -117,7 +117,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.apcu-iter-mtime">
+   <varlistentry xml:id="constant.apc-iter-mtime">
     <term>
      <constant>APC_ITER_MTIME</constant>
      (<type>int</type>)
@@ -128,7 +128,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.apcu-iter-none">
+   <varlistentry xml:id="constant.apc-iter-none">
     <term>
      <constant>APC_ITER_NONE</constant>
      (<type>int</type>)
@@ -139,7 +139,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.apcu-iter-num-hits">
+   <varlistentry xml:id="constant.apc-iter-num-hits">
     <term>
      <constant>APC_ITER_NUM_HITS</constant>
      (<type>int</type>)
@@ -150,7 +150,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.apcu-iter-refcount">
+   <varlistentry xml:id="constant.apc-iter-refcount">
     <term>
      <constant>APC_ITER_REFCOUNT</constant>
      (<type>int</type>)
@@ -161,7 +161,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.apcu-iter-ttl">
+   <varlistentry xml:id="constant.apc-iter-ttl">
     <term>
      <constant>APC_ITER_TTL</constant>
      (<type>int</type>)
@@ -172,7 +172,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.apcu-iter-type">
+   <varlistentry xml:id="constant.apc-iter-type">
     <term>
      <constant>APC_ITER_TYPE</constant>
      (<type>int</type>)
@@ -183,7 +183,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.apcu-iter-value">
+   <varlistentry xml:id="constant.apc-iter-value">
     <term>
      <constant>APC_ITER_VALUE</constant>
      (<type>int</type>)
@@ -194,7 +194,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.apcu-list-active">
+   <varlistentry xml:id="constant.apc-list-active">
     <term>
      <constant>APC_LIST_ACTIVE</constant>
      (<type>int</type>)
@@ -205,7 +205,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.apcu-list-deleted">
+   <varlistentry xml:id="constant.apc-list-deleted">
     <term>
      <constant>APC_LIST_DELETED</constant>
      (<type>int</type>)


### PR DESCRIPTION
Update Parle constant IDs to the "standard" global constant ID format.

Add bash script this update was made with so that it can be applied to translations as well.