### PR TITLE
Update FFI constant ID

### DIFF
--- a/ffi_constant_id.sh
+++ b/ffi_constant_id.sh
@@ -1,3 +1,0 @@
-#! /bin/bash
-
-\grep -lrE --include='*.xml' '"ffi-ffi\.constants\.biggest-alignment"' | xargs -d '\n' sed -i 's/"ffi-ffi\.constants\.biggest-alignment"/"ffi\.constants\.--biggest-alignment--"/g'

--- a/ffi_constant_id.sh
+++ b/ffi_constant_id.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+\grep -lrE --include='*.xml' '"ffi-ffi\.constants\.biggest-alignment"' | xargs -d '\n' sed -i 's/"ffi-ffi\.constants\.biggest-alignment"/"ffi\.constants\.--biggest-alignment--"/g'

--- a/reference/ffi/ffi.xml
+++ b/reference/ffi/ffi.xml
@@ -49,7 +49,7 @@
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="ffi-ffi.constants.biggest-alignment">FFI::__BIGGEST_ALIGNMENT__</varname>
+     <varname linkend="ffi.constants.--biggest-alignment--">FFI::__BIGGEST_ALIGNMENT__</varname>
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
@@ -64,7 +64,7 @@
   <section xml:id="ffi-ffi.constants">
    &reftitle.constants;
    <variablelist>
-    <varlistentry xml:id="ffi-ffi.constants.biggest-alignment">
+    <varlistentry xml:id="ffi.constants.--biggest-alignment--">
      <term><constant>FFI::__BIGGEST_ALIGNMENT__</constant></term>
      <listitem>
       <para/>

--- a/reference/ffi/ffi.xml
+++ b/reference/ffi/ffi.xml
@@ -49,7 +49,7 @@
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="ffi.constants.--biggest-alignment--">FFI::__BIGGEST_ALIGNMENT__</varname>
+     <varname linkend="ffi.constants.biggest-alignment">FFI::__BIGGEST_ALIGNMENT__</varname>
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
@@ -64,7 +64,7 @@
   <section xml:id="ffi-ffi.constants">
    &reftitle.constants;
    <variablelist>
-    <varlistentry xml:id="ffi.constants.--biggest-alignment--">
+    <varlistentry xml:id="ffi.constants.biggest-alignment">
      <term><constant>FFI::__BIGGEST_ALIGNMENT__</constant></term>
      <listitem>
       <para/>


### PR DESCRIPTION
Update FFI constant ID to the "standard" class constant ID format.

Add bash script this update was made with so that it can be applied to translations as well.