### PR TITLE
Update Radius constant ID

### DIFF
--- a/radius_constant_id.sh
+++ b/radius_constant_id.sh
@@ -1,3 +1,0 @@
-#! /bin/bash
-
-\grep -lrE --include='*.xml' '"radius\.constants\.radius-mppe-key-len"' | xargs -d '\n' sed -i 's/"radius\.constants\.radius-mppe-key-len"/"constant.radius-mppe-key-len"/g'

--- a/radius_constant_id.sh
+++ b/radius_constant_id.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+\grep -lrE --include='*.xml' '"radius\.constants\.radius-mppe-key-len"' | xargs -d '\n' sed -i 's/"radius\.constants\.radius-mppe-key-len"/"constant.radius-mppe-key-len"/g'

--- a/reference/radius/constants.xml
+++ b/reference/radius/constants.xml
@@ -5,7 +5,7 @@
  &extension.constants;
  
  <variablelist>
-  <varlistentry xml:id="radius.constants.radius-mppe-key-len">
+  <varlistentry xml:id="constant.radius-mppe-key-len">
    <term>
     <constant>RADIUS_MPPE_KEY_LEN</constant>
      (<type>int</type>)


### PR DESCRIPTION
Update Radius constant ID to the "standard" global constant ID format.

Add bash script this update was made with so that it can be applied to translations as well.