### PR TITLE
Update memcache constant IDs

### DIFF
--- a/reference/memcache/constants.xml
+++ b/reference/memcache/constants.xml
@@ -12,71 +12,71 @@
      </row>
     </thead>
     <tbody>
-     <row>
+     <row xml:id="constant.memcache-compressed">
       <entry>
-       <constant xml:id="constantmemcache-compressed">MEMCACHE_COMPRESSED</constant>
+       <constant>MEMCACHE_COMPRESSED</constant>
        (<type>int</type>)
       </entry>
       <entry>
        Used to turn on-the-fly data compression on with
-       <function>Memcache::set</function>, 
+       <function>Memcache::set</function>,
        <function>Memcache::add</function>&listendand;
        <function>Memcache::replace</function>.
       </entry>
      </row>
-     <row>
+     <row xml:id="constant.memcache-have-session">
       <entry>
-       <constant xml:id="constantmemcache-have-session">MEMCACHE_HAVE_SESSION</constant>
+       <constant>MEMCACHE_HAVE_SESSION</constant>
        (<type>int</type>)
       </entry>
       <entry>
        1 if this Memcache session handler is available, 0 otherwise.
       </entry>
      </row>
-     <row>
+     <row xml:id="constant.memcache-user1">
       <entry>
-       <constant xml:id="constantmemcache-user1">MEMCACHE_USER1</constant>
+       <constant>MEMCACHE_USER1</constant>
        (<type>int</type>)
       </entry>
       <entry>
        Used to turn user-defined application flag on with
-       <function>Memcache::set</function>, 
+       <function>Memcache::set</function>,
        <function>Memcache::add</function>&listendand;
        <function>Memcache::replace</function>.
       </entry>
      </row>
-     <row>
+     <row xml:id="constant.memcache-user2">
       <entry>
-       <constant xml:id="constantmemcache-user2">MEMCACHE_USER2</constant>
+       <constant>MEMCACHE_USER2</constant>
        (<type>int</type>)
       </entry>
       <entry>
        Used to turn user-defined application flag on with
-       <function>Memcache::set</function>, 
+       <function>Memcache::set</function>,
        <function>Memcache::add</function>&listendand;
        <function>Memcache::replace</function>.
       </entry>
      </row>
-     <row>
+     <row xml:id="constant.memcache-user3">
       <entry>
-       <constant xml:id="constantmemcache-user3">MEMCACHE_USER3</constant>
+       <constant>MEMCACHE_USER3</constant>
        (<type>int</type>)
       </entry>
       <entry>
        Used to turn user-defined application flag on with
-       <function>Memcache::set</function>, 
+       <function>Memcache::set</function>,
        <function>Memcache::add</function>&listendand;
        <function>Memcache::replace</function>.
       </entry>
      </row>
-     <row>
+     <row xml:id="constant.memcache-user4">
       <entry>
-       <constant xml:id="constantmemcache-user4">MEMCACHE_USER4</constant>
+       <constant>MEMCACHE_USER4</constant>
        (<type>int</type>)
       </entry>
       <entry>
        Used to turn user-defined application flag on with
-       <function>Memcache::set</function>, 
+       <function>Memcache::set</function>,
        <function>Memcache::add</function>&listendand;
        <function>Memcache::replace</function>.
       </entry>


### PR DESCRIPTION
Update memcache constant IDs to standard global constant ID format. 
Move IDs to <row> tags as those on <constant> tags are not rendered.