### PR TITLE
Update SSH2 constant ID

### DIFF
--- a/reference/ssh2/constants.xml
+++ b/reference/ssh2/constants.xml
@@ -185,7 +185,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.ssh2-pollhub">
+  <varlistentry xml:id="constant.ssh2-pollhup">
    <term>
     <constant>SSH2_POLLHUP</constant>
      (<type>int</type>)

--- a/ssh2_constant_id.sh
+++ b/ssh2_constant_id.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+\grep -lrE --include='*.xml' '"constant\.ssh2-pollhub"' | xargs -d '\n' sed -i 's/"constant\.ssh2-pollhub"/"constant\.ssh2-pollhup"/g'

--- a/ssh2_constant_id.sh
+++ b/ssh2_constant_id.sh
@@ -1,3 +1,0 @@
-#! /bin/bash
-
-\grep -lrE --include='*.xml' '"constant\.ssh2-pollhub"' | xargs -d '\n' sed -i 's/"constant\.ssh2-pollhub"/"constant\.ssh2-pollhup"/g'


### PR DESCRIPTION
There was a typo in the ID.

Bash script can be used to apply update to all translations.