### PR TITLE
Update yar constant IDs

### DIFF
--- a/reference/yar/constants.xml
+++ b/reference/yar/constants.xml
@@ -26,7 +26,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.yar-client-opt-packager">
+   <varlistentry xml:id="constant.yar-opt-packager">
     <term>
      <constant>YAR_OPT_PACKAGER</constant>
      (<type>int</type>)
@@ -36,7 +36,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.yar-client-opt-timeout">
+   <varlistentry xml:id="constant.yar-opt-timeout">
     <term>
      <constant>YAR_OPT_TIMEOUT</constant>
      (<type>int</type>)
@@ -46,7 +46,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.yar-client-opt-connect-timeout">
+   <varlistentry xml:id="constant.yar-opt-connect-timeout">
     <term>
      <constant>YAR_OPT_CONNECT_TIMEOUT</constant>
      (<type>int</type>)
@@ -56,7 +56,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.yar-client-opt-header">
+   <varlistentry xml:id="constant.yar-opt-header">
     <term>
      <constant>YAR_OPT_HEADER</constant>
      (<type>array</type>)

--- a/yar_constant_ids.sh
+++ b/yar_constant_ids.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+\grep -lrE --include='*.xml' '"constant\.yar-client-opt-packager"' | xargs -d '\n' sed -i 's/"constant\.yar-client-opt-packager"/"constant.yar-opt-packager"/g'
+\grep -lrE --include='*.xml' '"constant\.yar-client-opt-timeout"' | xargs -d '\n' sed -i 's/"constant\.yar-client-opt-timeout"/"constant.yar-opt-timeout"/g'
+\grep -lrE --include='*.xml' '"constant\.yar-client-opt-connect-timeout"' | xargs -d '\n' sed -i 's/"constant\.yar-client-opt-connect-timeout"/"constant.yar-opt-connect-timeout"/g'
+\grep -lrE --include='*.xml' '"constant\.yar-client-opt-header"' | xargs -d '\n' sed -i 's/"constant\.yar-client-opt-header"/"constant.yar-opt-header"/g'


### PR DESCRIPTION
Update yar constant IDs to the "standard" global constant ID format.

Add bash update script which can be used to apply the same update to all translations.