### PR TITLE
Remove link to __TRAIT__

### DIFF
--- a/appendices/tokens.xml
+++ b/appendices/tokens.xml
@@ -820,7 +820,7 @@ defined('T_FN') || define('T_FN', 10001);
     <row>
      <entry><constant>T_TRAIT_C</constant></entry>
      <entry>__TRAIT__</entry>
-     <entry><link linkend="constant.trait">__TRAIT__</link></entry>
+     <entry><constant>__TRAIT__</constant></entry>
     </row>
     <row>
      <entry><constant>T_TRY</constant></entry>


### PR DESCRIPTION
Remove link to __TRAIT__ as Phd now automatically links to constants.

This update was made with the following bash script:

```bash 
\grep -lrE --include='*.xml' '<link linkend="constant\.trait">__TRAIT__<\/link>' | xargs -d '\n' sed -i 's/<link linkend="constant\.trait">__TRAIT__<\/link>/<constant>__TRAIT__<\/constant>/g'
```