### PR TITLE
Update COMPILER_HALT_OFFSET ID

### DIFF
--- a/appendices/reserved.constants.core.xml
+++ b/appendices/reserved.constants.core.xml
@@ -632,7 +632,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.compiler-halt-offset">
+  <varlistentry>
    <term>
     <constant>__COMPILER_HALT_OFFSET__</constant>
     (<type>int</type>)

--- a/reference/misc/constants.xml
+++ b/reference/misc/constants.xml
@@ -37,7 +37,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.--compiler-halt-offset--">
+  <varlistentry xml:id="constant.compiler-halt-offset">
    <term>
     <constant>__COMPILER_HALT_OFFSET__</constant>
     (<type>int</type>)


### PR DESCRIPTION
Remove duplicate ID from core constants and update ID in `misc` constants.

This update was made with the following bash script:

```bash
\grep -lrE --include='*.xml' '<varlistentry xml:id="constant\.compiler-halt-offset">' | xargs -d '\n' sed -i 's/<varlistentry xml:id="constant\.compiler-halt-offset">/<varlistentry>/g'
\grep -lrE --include='*.xml' '"constant\.--compiler-halt-offset--"' | xargs -d '\n' sed -i 's/"constant\.--compiler-halt-offset--"/"constant\.compiler-halt-offset"/g'
```