### PR TITLE
OAuth::enableSSLChecks non-false value turns checks on, not off.

### DIFF
--- a/reference/oauth/oauth/enablesslchecks.xml
+++ b/reference/oauth/oauth/enablesslchecks.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Turns on the usual SSL peer certificate and host checks (enabled by default).
-   Alternatively, the <parameter>sslChecks</parameter> member can be set to a 
+   Alternatively, the <parameter>sslChecks</parameter> member can be set to a
    non-&false; value to turn SSL checks on.
   </para>
  </refsect1>

--- a/reference/oauth/oauth/enablesslchecks.xml
+++ b/reference/oauth/oauth/enablesslchecks.xml
@@ -14,7 +14,9 @@
    <void />
   </methodsynopsis>
   <para>
-   Turns on the usual SSL peer certificate and host checks (enabled by default). Alternatively, the <parameter>sslChecks</parameter> member can be set to a non-&false; value to turn SSL checks off.
+   Turns on the usual SSL peer certificate and host checks (enabled by default).
+   Alternatively, the <parameter>sslChecks</parameter> member can be set to a 
+   non-&false; value to turn SSL checks on.
   </para>
  </refsect1>
 

--- a/reference/oauth/oauth/enablesslchecks.xml
+++ b/reference/oauth/oauth/enablesslchecks.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Turns on the usual SSL peer certificate and host checks (enabled by default).
-   Alternatively, the <link linkend="oath.props.sslChecks">sslChecks</link> property can be set to a
+   Alternatively, the <link linkend="oauth.props.sslChecks">sslChecks</link> property can be set to a
    non-&false; value to turn SSL checks on.
   </para>
  </refsect1>

--- a/reference/oauth/oauth/enablesslchecks.xml
+++ b/reference/oauth/oauth/enablesslchecks.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Turns on the usual SSL peer certificate and host checks (enabled by default).
-   Alternatively, the <parameter>sslChecks</parameter> member can be set to a
+   Alternatively, the <link linkend="oath.props.sslChecks">sslChecks</link> property can be set to a
    non-&false; value to turn SSL checks on.
   </para>
  </refsect1>

--- a/reference/oauth/oauth/enablesslchecks.xml
+++ b/reference/oauth/oauth/enablesslchecks.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Turns on the usual SSL peer certificate and host checks (enabled by default).
-   Alternatively, the <link linkend="oauth.props.sslChecks">sslChecks</link> property can be set to a
+   Alternatively, the <link linkend="oauth.props.sslchecks">sslChecks</link> property can be set to a
    non-&false; value to turn SSL checks on.
   </para>
  </refsect1>


### PR DESCRIPTION
In reference/oauth/oauth/enablesslchecks.xml:
A non-false value in sslChecks member turns SSL checks on, not off.