### PR TITLE
Add CLI constants to core constant list

### DIFF
--- a/appendices/reserved.constants.core.xml
+++ b/appendices/reserved.constants.core.xml
@@ -700,6 +700,54 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.php-cli-process-title">
+   <term>
+    <constant>PHP_CLI_PROCESS_TITLE</constant>
+    (<type>bool</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Indicates whether the setting and getting of the process title is available.
+     Available only under the CLI SAPI.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.stderr">
+   <term>
+    <constant>STDERR</constant>
+    (<type>resource</type>)
+   </term>
+   <listitem>
+    <simpara>
+     An already opened stream to <literal>stderr</literal>.
+     Available only under the CLI SAPI.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.stdin">
+   <term>
+    <constant>STDIN</constant>
+    (<type>resource</type>)
+   </term>
+   <listitem>
+    <simpara>
+     An already opened stream to <literal>stdin</literal>.
+     Available only under the CLI SAPI.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.stdout">
+   <term>
+    <constant>STDOUT</constant>
+    (<type>resource</type>)
+   </term>
+   <listitem>
+    <simpara>
+     An already opened stream to <literal>stdout</literal>.
+     Available only under the CLI SAPI.
+    </simpara>
+   </listitem>
+  </varlistentry>
  </variablelist>
  <para>
   See also: <link linkend="language.constants.magic">Magic


### PR DESCRIPTION
Add the following CLI constants to the core constant list:

 - PHP_CLI_PROCESS_TITLE
 - STDERR
 - STDIN
 - STDOUT