### PR TITLE
Change some constant and literal tags to the appropriate tags

### DIFF
--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -1618,18 +1618,18 @@ echo file_get_contents('http://example.org', false, $ctx);
   <itemizedlist>
    <listitem>
     <para>
-     <literal>T_COMMENT</literal> tokens will no longer include a trailing newline. The newline will
-     instead be part of a following <literal>T_WHITESPACE</literal> token. It should be noted that
-     <literal>T_COMMENT</literal> is not always followed by whitespace, it may also be followed by
-     <literal>T_CLOSE_TAG</literal> or end-of-file.
+     <constant>T_COMMENT</constant> tokens will no longer include a trailing newline. The newline will
+     instead be part of a following <constant>T_WHITESPACE</constant> token. It should be noted that
+     <constant>T_COMMENT</constant> is not always followed by whitespace, it may also be followed by
+     <constant>T_CLOSE_TAG</constant> or end-of-file.
     </para>
    </listitem>
    <listitem>
     <para>
-     Namespaced names are now represented using the <literal>T_NAME_QUALIFIED</literal>
-     (<code>Foo\Bar</code>), <literal>T_NAME_FULLY_QUALIFIED</literal> (<code>\Foo\Bar</code>) and
-     <literal>T_NAME_RELATIVE</literal> (<code>namespace\Foo\Bar</code>) tokens.
-     <literal>T_NS_SEPARATOR</literal> is only used for standalone namespace separators, and only
+     Namespaced names are now represented using the <constant>T_NAME_QUALIFIED</constant>
+     (<code>Foo\Bar</code>), <constant>T_NAME_FULLY_QUALIFIED</constant> (<code>\Foo\Bar</code>) and
+     <constant>T_NAME_RELATIVE</constant> (<code>namespace\Foo\Bar</code>) tokens.
+     <constant>T_NS_SEPARATOR</constant> is only used for standalone namespace separators, and only
      syntactially valid in conjunction with group use declarations.
      <!-- RFC: https://wiki.php.net/rfc/namespaced_names_as_token -->
     </para>

--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1095,7 +1095,7 @@ $ some_application | some_filter | php | sort -u > final_output.txt
    command line. Note that, if the code is executed in-line using the command
    line switch <option>-r</option>, the value of <varname>$argv[0]</varname>
    will be <literal>"Standard input code"</literal>; prior to PHP 7.2.0, it was a dash (<literal>"-"</literal>) instead. The same is true if the code is
-   executed via a pipe from <literal>STDIN</literal>.
+   executed via a pipe from <constant>STDIN</constant>.
   </para>
 
   <para>

--- a/language/operators/bitwise.xml
+++ b/language/operators/bitwise.xml
@@ -646,7 +646,7 @@ Expression: 0 = -4 << 62
  <warning>
   <para>
    Use functions from the <link linkend="book.gmp">gmp</link> extension for
-   bitwise manipulation on numbers beyond <literal>PHP_INT_MAX</literal>.
+   bitwise manipulation on numbers beyond <constant>PHP_INT_MAX</constant>.
   </para>
  </warning>
 

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -76,7 +76,7 @@
           <row>
            <entry valign="top"><constant>CURLOPT_CERTINFO</constant></entry>
            <entry valign="top">
-            &true; to output SSL certification information to <literal>STDERR</literal>
+            &true; to output SSL certification information to <constant>STDERR</constant>
             on secure transfers.
            </entry>
            <entry valign="top">
@@ -564,7 +564,7 @@
            <entry valign="top">
             &true; to use ASCII mode for FTP transfers.
             For LDAP, it retrieves data in plain text instead of HTML. On
-            Windows systems, it will not set <literal>STDOUT</literal> to binary
+            Windows systems, it will not set <constant>STDOUT</constant> to binary
             mode.
            </entry>
            <entry valign="top">
@@ -593,7 +593,7 @@
            <entry valign="top"><constant>CURLOPT_VERBOSE</constant></entry>
            <entry valign="top">
             &true; to output verbose information. Writes
-            output to <literal>STDERR</literal>, or the file specified using
+            output to <constant>STDERR</constant>, or the file specified using
             <constant>CURLOPT_STDERR</constant>.
            </entry>
            <entry valign="top">
@@ -684,9 +684,9 @@
            <entry valign="top"><constant>CURLOPT_FTPSSLAUTH</constant></entry>
            <entry valign="top">
             The FTP authentication method (when is activated):
-            <literal>CURLFTPAUTH_SSL</literal> (try SSL first),
-            <literal>CURLFTPAUTH_TLS</literal> (try TLS first), or
-            <literal>CURLFTPAUTH_DEFAULT</literal> (let cURL decide).
+            <constant>CURLFTPAUTH_SSL</constant> (try SSL first),
+            <constant>CURLFTPAUTH_TLS</constant> (try TLS first), or
+            <constant>CURLFTPAUTH_DEFAULT</constant> (let cURL decide).
            </entry>
            <entry valign="top">
             Added in cURL 7.12.2.
@@ -760,7 +760,7 @@
              the one it finds most secure.
             </para>
             <para>
-             <constant>CURLAUTH_ANYSAFE</constant> sets all bits except <literal>CURLAUTH_BASIC</literal>.
+             <constant>CURLAUTH_ANYSAFE</constant> sets all bits except <constant>CURLAUTH_BASIC</constant>.
              cURL will automatically select the one it finds most secure.
             </para>
            </entry>
@@ -2330,7 +2330,7 @@
            <entry valign="top"><constant>CURLOPT_FILE</constant></entry>
            <entry valign="top">
             The file that the transfer should be written to. The default
-            is <literal>STDOUT</literal> (the browser window).
+            is <constant>STDOUT</constant> (the browser window).
            </entry>
           </row>
           <row>
@@ -2343,7 +2343,7 @@
            <entry valign="top"><constant>CURLOPT_STDERR</constant></entry>
            <entry valign="top">
             An alternative location to output errors to instead of
-            <literal>STDERR</literal>.
+            <constant>STDERR</constant>.
            </entry>
           </row>
           <row>

--- a/reference/filesystem/functions/fgetcsv.xml
+++ b/reference/filesystem/functions/fgetcsv.xml
@@ -25,7 +25,7 @@
   <note>
    <para>
     The locale settings are taken into account by this function. If
-    <literal>LC_CTYPE</literal> is e.g. <literal>en_US.UTF-8</literal>, files in
+    <constant>LC_CTYPE</constant> is e.g. <literal>en_US.UTF-8</literal>, files in
     one-byte encodings may be read wrongly by this function.
    </para>
   </note>

--- a/reference/ftp/functions/ftp-rename.xml
+++ b/reference/ftp/functions/ftp-rename.xml
@@ -51,7 +51,7 @@
   &reftitle.returnvalues;
   <para>
    &return.success; Upon failure (such as attempting to rename a non-existent
-   file), an <literal>E_WARNING</literal> error will be emitted.
+   file), an <constant>E_WARNING</constant> error will be emitted.
   </para>
  </refsect1>
 

--- a/reference/ibm_db2/functions/db2-autocommit.xml
+++ b/reference/ibm_db2/functions/db2-autocommit.xml
@@ -40,7 +40,7 @@
        One of the following constants: 
        <variablelist>
         <varlistentry>
-         <term><literal>DB2_AUTOCOMMIT_OFF</literal></term>
+         <term><constant>DB2_AUTOCOMMIT_OFF</constant></term>
          <listitem>
           <para>
            Turns AUTOCOMMIT off.
@@ -48,7 +48,7 @@
          </listitem>
         </varlistentry>
         <varlistentry>
-         <term><literal>DB2_AUTOCOMMIT_ON</literal></term>
+         <term><constant>DB2_AUTOCOMMIT_ON</constant></term>
          <listitem>
           <para>
            Turns AUTOCOMMIT on.

--- a/reference/ibm_db2/functions/db2-bind-param.xml
+++ b/reference/ibm_db2/functions/db2-bind-param.xml
@@ -64,11 +64,11 @@
      <listitem>
       <para>
        A constant specifying whether the PHP variable should be bound to the
-       SQL parameter as an input parameter (<literal>DB2_PARAM_IN</literal>),
-       an output parameter (<literal>DB2_PARAM_OUT</literal>), or as a
+       SQL parameter as an input parameter (<constant>DB2_PARAM_IN</constant>),
+       an output parameter (<constant>DB2_PARAM_OUT</constant>), or as a
        parameter that accepts input and returns output
-       (<literal>DB2_PARAM_INOUT</literal>). To avoid memory overhead, you can
-       also specify <literal>DB2_PARAM_FILE</literal> to bind the PHP variable
+       (<constant>DB2_PARAM_INOUT</constant>). To avoid memory overhead, you can
+       also specify <constant>DB2_PARAM_FILE</constant> to bind the PHP variable
        to the name of a file that contains large object (BLOB, CLOB, or DBCLOB)
        data.
       </para>
@@ -79,9 +79,9 @@
      <listitem>
       <para>
        A constant specifying the SQL data type that the PHP variable should be
-       bound as: one of <literal>DB2_BINARY</literal>,
-       <literal>DB2_CHAR</literal>, <literal>DB2_DOUBLE</literal>, or
-       <literal>DB2_LONG</literal> .
+       bound as: one of <constant>DB2_BINARY</constant>,
+       <constant>DB2_CHAR</constant>, <literal>DB2_DOUBLE</literal>, or
+       <constant>DB2_LONG</constant> .
       </para>
      </listitem>
     </varlistentry>

--- a/reference/ibm_db2/functions/db2-connect.xml
+++ b/reference/ibm_db2/functions/db2-connect.xml
@@ -123,11 +123,11 @@
          <term><parameter>autocommit</parameter></term>
          <listitem>
           <para>
-           Passing the <literal>DB2_AUTOCOMMIT_ON</literal> value turns
+           Passing the <constant>DB2_AUTOCOMMIT_ON</constant> value turns
            autocommit on for this connection handle.
           </para>
           <para>
-           Passing the <literal>DB2_AUTOCOMMIT_OFF</literal> value turns
+           Passing the <constant>DB2_AUTOCOMMIT_OFF</constant> value turns
            autocommit off for this connection handle.
           </para>
          </listitem>
@@ -136,15 +136,15 @@
          <term><parameter>DB2_ATTR_CASE</parameter></term>
          <listitem>
           <para>
-           Passing the <literal>DB2_CASE_NATURAL</literal> value specifies
+           Passing the <constant>DB2_CASE_NATURAL</constant> value specifies
            that column names are returned in natural case.
           </para>
           <para>
-           Passing the <literal>DB2_CASE_LOWER</literal> value specifies
+           Passing the <constant>DB2_CASE_LOWER</constant> value specifies
            that column names are returned in lower case.
           </para>
           <para>
-           Passing the <literal>DB2_CASE_UPPER</literal> value specifies
+           Passing the <constant>DB2_CASE_UPPER</constant> value specifies
            that column names are returned in upper case.
           </para>
          </listitem>
@@ -153,12 +153,12 @@
          <term><parameter>CURSOR</parameter></term>
          <listitem>
           <para>
-           Passing the <literal>DB2_FORWARD_ONLY</literal> value specifies a
+           Passing the <constant>DB2_FORWARD_ONLY</constant> value specifies a
            forward-only cursor for a statement resource. This is the default
            cursor type and is supported on all database servers.
           </para>
           <para>
-           Passing the <literal>DB2_SCROLLABLE</literal> value specifies a
+           Passing the <constant>DB2_SCROLLABLE</constant> value specifies a
            scrollable cursor for a statement resource. This mode enables
            random access to rows in a result set, but currently is supported
            only by IBM DB2 Universal Database.

--- a/reference/ibm_db2/functions/db2-cursor-type.xml
+++ b/reference/ibm_db2/functions/db2-cursor-type.xml
@@ -39,8 +39,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns either <literal>DB2_FORWARD_ONLY</literal> if the statement
-   resource uses a forward-only cursor or <literal>DB2_SCROLLABLE</literal> if
+   Returns either <constant>DB2_FORWARD_ONLY</constant> if the statement
+   resource uses a forward-only cursor or <constant>DB2_SCROLLABLE</constant> if
    the statement resource uses a scrollable cursor.
   </para>
  </refsect1>

--- a/reference/ibm_db2/functions/db2-pconnect.xml
+++ b/reference/ibm_db2/functions/db2-pconnect.xml
@@ -84,11 +84,11 @@
          <term><parameter>autocommit</parameter></term>
          <listitem>
           <para>
-           Passing the <literal>DB2_AUTOCOMMIT_ON</literal> value turns
+           Passing the <constant>DB2_AUTOCOMMIT_ON</constant> value turns
            autocommit on for this connection handle.
           </para>
           <para>
-           Passing the <literal>DB2_AUTOCOMMIT_OFF</literal> value turns
+           Passing the <constant>DB2_AUTOCOMMIT_OFF</constant> value turns
            autocommit off for this connection handle.
           </para>
          </listitem>
@@ -97,15 +97,15 @@
          <term><parameter>DB2_ATTR_CASE</parameter></term>
          <listitem>
           <para>
-           Passing the <literal>DB2_CASE_NATURAL</literal> value specifies
+           Passing the <constant>DB2_CASE_NATURAL</constant> value specifies
            that column names are returned in natural case.
           </para>
           <para>
-           Passing the <literal>DB2_CASE_LOWER</literal> value specifies
+           Passing the <constant>DB2_CASE_LOWER</constant> value specifies
            that column names are returned in lower case.
           </para>
           <para>
-           Passing the <literal>DB2_CASE_UPPER</literal> value specifies
+           Passing the <constant>DB2_CASE_UPPER</constant> value specifies
            that column names are returned in upper case.
           </para>
          </listitem>
@@ -114,12 +114,12 @@
          <term><parameter>CURSOR</parameter></term>
          <listitem>
           <para>
-           Passing the <literal>DB2_FORWARD_ONLY</literal> value specifies a
+           Passing the <constant>DB2_FORWARD_ONLY</constant> value specifies a
            forward-only cursor for a statement resource. This is the default
            cursor type and is supported on all database servers.
           </para>
           <para>
-           Passing the <literal>DB2_SCROLLABLE</literal> value specifies a
+           Passing the <constant>DB2_SCROLLABLE</constant> value specifies a
            scrollable cursor for a statement resource. This mode enables
            random access to rows in a result set, but currently is supported
            only by IBM DB2 Universal Database.

--- a/reference/ibm_db2/functions/db2-set-option.xml
+++ b/reference/ibm_db2/functions/db2-set-option.xml
@@ -9,13 +9,13 @@
     &reftitle.description;
     <methodsynopsis>
       <type>bool</type><methodname>db2_set_option</methodname>
-      <methodparam><type>resource</type><parameter>resource</parameter></methodparam>      
+      <methodparam><type>resource</type><parameter>resource</parameter></methodparam>
       <methodparam><type>array</type><parameter>options</parameter></methodparam>
       <methodparam><type>int</type><parameter>type</parameter></methodparam>
     </methodsynopsis>
     <para>
      Sets options for a statement resource or a connection resource. You
-     cannot set options for result set resources. 
+     cannot set options for result set resources.
     </para>
   </refsect1>
   <refsect1 role="parameters">
@@ -119,32 +119,32 @@
                  <term><parameter>deferred_prepare</parameter></term>
                  <listitem>
                   <para>
-                   Passing <constant>DB2_DEFERRED_PREPARE_ON</constant> turns deferred 
+                   Passing <constant>DB2_DEFERRED_PREPARE_ON</constant> turns deferred
                    prepare on for the specified statement resource.
                   </para>
                   <para>
-                   Passing <constant>DB2_DEFERRED_PREPARE_OFF</constant> turns deferred 
+                   Passing <constant>DB2_DEFERRED_PREPARE_OFF</constant> turns deferred
                    prepare off for the specified statement resource.
                   </para>
                  </listitem>
-                </varlistentry>                
+                </varlistentry>
               </variablelist>
             </para>
             <para>
-             The following new i5/OS options are available in ibm_db2 version 1.5.1 
+             The following new i5/OS options are available in ibm_db2 version 1.5.1
              and later. These options apply only when running PHP and ibm_db2 natively on i5 systems.
               <variablelist>
                 <varlistentry>
                   <term><parameter>i5_fetch_only</parameter></term>
                   <listitem>
                     <para>
-                     <literal>DB2_I5_FETCH_ON</literal> - Cursors are read-only 
-                     and cannot be used for positioned updates or deletes. This 
-                     is the default unless <literal>SQL_ATTR_FOR_FETCH_ONLY</literal> 
+                     <literal>DB2_I5_FETCH_ON</literal> - Cursors are read-only
+                     and cannot be used for positioned updates or deletes. This
+                     is the default unless <literal>SQL_ATTR_FOR_FETCH_ONLY</literal>
                      environment has been set to <literal>SQL_FALSE</literal>.
                     </para>
                     <para>
-                     <literal>DB2_I5_FETCH_OFF</literal> - Cursors can be used 
+                     <literal>DB2_I5_FETCH_OFF</literal> - Cursors can be used
                      for positioned updates and deletes.
                     </para>
                   </listitem>
@@ -158,9 +158,9 @@
                   <term><parameter>rowcount</parameter></term>
                   <listitem>
                     <para>
-                     <literal>DB2_ROWCOUNT_PREFETCH_ON</literal> - Client can request 
-                     the full row count prior to fetching, which means that 
-                     <function>db2_num_rows</function> returns the number of rows selected 
+                     <literal>DB2_ROWCOUNT_PREFETCH_ON</literal> - Client can request
+                     the full row count prior to fetching, which means that
+                     <function>db2_num_rows</function> returns the number of rows selected
                      even when a <literal>ROLLFORWARD_ONLY</literal> cursor is used.
                     </para>
                     <para>
@@ -170,7 +170,7 @@
                   </listitem>
                 </varlistentry>
               </variablelist>
-            </para>            
+            </para>
             <para>
              The following new options are available in ibm_db2 version 1.7.0 and later.
               <variablelist>
@@ -178,8 +178,8 @@
                   <term><parameter>trusted_user</parameter></term>
                   <listitem>
                     <para>
-                     To switch the user to a trusted user, pass the User ID (String) 
-                     of the trusted user as the value of this key. This option can 
+                     To switch the user to a trusted user, pass the User ID (String)
+                     of the trusted user as the value of this key. This option can
                      be set on a connection resource only. To use this option, trusted
                      context must be enabled on the connection resource.
                     </para>
@@ -193,21 +193,21 @@
                      by the trusted_user key.
                     </para>
                   </listitem>
-                </varlistentry>                
+                </varlistentry>
                </variablelist>
-            </para>            
+            </para>
             <para>
-             The following new options are available in ibm_db2 version 1.6.0 and later. 
-             These options provide useful tracking information that can be accessed during 
+             The following new options are available in ibm_db2 version 1.6.0 and later.
+             These options provide useful tracking information that can be accessed during
              execution with <function>db2_get_option</function>.
              <note>
               <para>
-               When the value in each option is being set, some servers might not handle 
+               When the value in each option is being set, some servers might not handle
                the entire length provided and might truncate the value.
               </para>
               <para>
-               To ensure that the data specified in each option is converted correctly 
-               when transmitted to a host system, use only the characters A through Z, 
+               To ensure that the data specified in each option is converted correctly
+               when transmitted to a host system, use only the characters A through Z,
                0 through 9, and the underscore (_) or period (.).
               </para>
              </note>
@@ -216,13 +216,13 @@
                <term><parameter>userid</parameter></term>
                <listitem>
                 <para>
-                 <literal>SQL_ATTR_INFO_USERID</literal> - A pointer to a null-terminated 
-                 character string used to identify the client user ID sent to the host 
+                 <literal>SQL_ATTR_INFO_USERID</literal> - A pointer to a null-terminated
+                 character string used to identify the client user ID sent to the host
                  database server when using DB2 Connect.
                  <note>
                   <para>
-                   DB2 for z/OS and OS/390 servers support up to a length of 16 characters. 
-                   This user-id is not to be confused with the authentication user-id, it is for 
+                   DB2 for z/OS and OS/390 servers support up to a length of 16 characters.
+                   This user-id is not to be confused with the authentication user-id, it is for
                    identification purposes only and is not used for any authorization.
                   </para>
                  </note>
@@ -233,8 +233,8 @@
                <term><parameter>acctstr</parameter></term>
                <listitem>
                 <para>
-                 <literal>SQL_ATTR_INFO_ACCTSTR</literal> - A pointer to a null-terminated 
-                 character string used to identify the client accounting string sent to the 
+                 <literal>SQL_ATTR_INFO_ACCTSTR</literal> - A pointer to a null-terminated
+                 character string used to identify the client accounting string sent to the
                  host database server when using DB2 Connect.
                  <note>
                   <para>
@@ -248,8 +248,8 @@
                <term><parameter>applname</parameter></term>
                <listitem>
                 <para>
-                 <literal>SQL_ATTR_INFO_APPLNAME</literal> - A pointer to a null-terminated 
-                 character string used to identify the client application name sent to the 
+                 <literal>SQL_ATTR_INFO_APPLNAME</literal> - A pointer to a null-terminated
+                 character string used to identify the client application name sent to the
                  host database server when using DB2 Connect.
                  <note>
                   <para>
@@ -263,8 +263,8 @@
                <term><parameter>wrkstnname</parameter></term>
                <listitem>
                 <para>
-                 <literal>SQL_ATTR_INFO_WRKSTNNAME</literal> - A pointer to a null-terminated 
-                 character string used to identify the client workstation name sent to the 
+                 <literal>SQL_ATTR_INFO_WRKSTNNAME</literal> - A pointer to a null-terminated
+                 character string used to identify the client workstation name sent to the
                  host database server when using DB2 Connect.
                  <note>
                   <para>
@@ -312,7 +312,7 @@
           <colspec colnum="3" colname="col3" align="center" />
           <colspec colnum="4" colname="col4" align="center" />
           <colspec colnum="5" colname="col5" align="center" />
-          
+
           <thead>
             <row>
               <entry morerows="1">Key</entry>
@@ -486,7 +486,7 @@
       </table>
     </para>
   </refsect1>
-  
+
   <refsect1 role="returnvalues">
     &reftitle.returnvalues;
     <para>
@@ -494,7 +494,7 @@
     </para>
   </refsect1>
   <!-- Place Changelog next if any -->
-  
+
   <!-- Place Examples next if any -->
   <refsect1 role="examples">
     &reftitle.examples;
@@ -565,7 +565,7 @@ $conn_string .= "UID=$username;PWD=$password;";
 $conn = db2_connect($conn_string, '', '');
 
 /* Create the associative options array with valid key-value pairs */
-$options = array('autocommit' => DB2_AUTOCOMMIT_OFF, 
+$options = array('autocommit' => DB2_AUTOCOMMIT_OFF,
                     'binmode' => DB2_PASSTHRU,
               'db2_attr_case' => DB2_CASE_UPPER,
                      'cursor' => DB2_SCROLLABLE);
@@ -612,7 +612,7 @@ $conn_string .= "UID=$username;PWD=$password;";
 $conn = db2_connect($conn_string, '', '');
 
 /* Create the associative options array with valid key-value pairs */
-$options = array('autocommit' => DB2_AUTOCOMMIT_OFF, 
+$options = array('autocommit' => DB2_AUTOCOMMIT_OFF,
              'MY_INVALID_KEY' => DB2_PASSTHRU,
               'db2_attr_case' => DB2_CASE_UPPER,
                      'cursor' => DB2_SCROLLABLE);
@@ -659,7 +659,7 @@ $conn_string .= "UID=$username;PWD=$password;";
 $conn = db2_connect($conn_string, '', '');
 
 /* Create the associative options array with valid key-value pairs */
-$options = array('autocommit' => DB2_AUTOCOMMIT_OFF, 
+$options = array('autocommit' => DB2_AUTOCOMMIT_OFF,
                     'binmode' => 'INVALID_VALUE',
               'db2_attr_case' => DB2_CASE_UPPER,
                      'cursor' => DB2_SCROLLABLE);
@@ -705,7 +705,7 @@ $conn_string .= "UID=$username;PWD=$password;";
 $conn = db2_connect($conn_string, '', '');
 
 /* Create the associative options array with valid key-value pairs */
-$options = array('autocommit' => DB2_AUTOCOMMIT_OFF, 
+$options = array('autocommit' => DB2_AUTOCOMMIT_OFF,
                     'binmode' => DB2_PASSTHRU,
               'db2_attr_case' => DB2_CASE_UPPER,
                      'cursor' => DB2_SCROLLABLE);
@@ -751,7 +751,7 @@ $conn_string .= "UID=$username;PWD=$password;";
 $conn = db2_connect($conn_string, '', '');
 
 /* Create the associative options array with valid key-value pairs */
-$options = array('autocommit' => DB2_AUTOCOMMIT_OFF, 
+$options = array('autocommit' => DB2_AUTOCOMMIT_OFF,
                     'binmode' => DB2_PASSTHRU,
               'db2_attr_case' => DB2_CASE_UPPER,
                      'cursor' => DB2_SCROLLABLE);

--- a/reference/ibm_db2/functions/db2-set-option.xml
+++ b/reference/ibm_db2/functions/db2-set-option.xml
@@ -47,11 +47,11 @@
                   <term><parameter>autocommit</parameter></term>
                   <listitem>
                     <para>
-                     Passing <literal>DB2_AUTOCOMMIT_ON</literal> turns
+                     Passing <constant>DB2_AUTOCOMMIT_ON</constant> turns
                      autocommit on for the specified connection resource.
                     </para>
                     <para>
-                     Passing <literal>DB2_AUTOCOMMIT_OFF</literal> turns
+                     Passing <constant>DB2_AUTOCOMMIT_OFF</constant> turns
                      autocommit off for the specified connection resource.
                     </para>
                   </listitem>
@@ -60,13 +60,13 @@
                   <term><parameter>cursor</parameter></term>
                   <listitem>
                     <para>
-                     Passing <literal>DB2_FORWARD_ONLY</literal> specifies a
+                     Passing <constant>DB2_FORWARD_ONLY</constant> specifies a
                      forward-only cursor for a statement resource. This is the
                      default cursor type, and is supported by all database
                      servers.
                     </para>
                     <para>
-                     Passing <literal>DB2_SCROLLABLE</literal> specifies a
+                     Passing <constant>DB2_SCROLLABLE</constant> specifies a
                      scrollable cursor for a statement resource. Scrollable
                      cursors enable result set rows to be accessed in
                      non-sequential order, but are only supported by
@@ -78,19 +78,19 @@
                   <term><parameter>binmode</parameter></term>
                   <listitem>
                     <para>
-                     Passing <literal>DB2_BINARY</literal> specifies that
+                     Passing <constant>DB2_BINARY</constant> specifies that
                      binary data will be returned as is. This is the default
                      mode. This is the equivalent of setting
                      <literal>ibm_db2.binmode=1</literal> in &php.ini;.
                     </para>
                     <para>
-                     Passing <literal>DB2_CONVERT</literal> specifies that
+                     Passing <constant>DB2_CONVERT</constant> specifies that
                      binary data will be converted to hexadecimal encoding,
                      and will be returned as such. This is the equivalent of
                      setting <literal>ibm_db2.binmode=2</literal> in &php.ini;.
                     </para>
                     <para>
-                     Passing <literal>DB2_PASSTHRU</literal> specifies that
+                     Passing <constant>DB2_PASSTHRU</constant> specifies that
                      binary data will be converted to &null;. This is the
                      equivalent of setting <literal>ibm_db2.binmode=3</literal>
                      in &php.ini;.
@@ -101,15 +101,15 @@
                   <term><parameter>db2_attr_case</parameter></term>
                   <listitem>
                     <para>
-                     Passing <literal>DB2_CASE_LOWER</literal> specifies that
+                     Passing <constant>DB2_CASE_LOWER</constant> specifies that
                      column names of the result set are returned in lower case.
                     </para>
                     <para>
-                     Passing <literal>DB2_CASE_UPPER</literal> specifies that
+                     Passing <constant>DB2_CASE_UPPER</constant> specifies that
                      column names of the result set are returned in upper case.
                     </para>
                     <para>
-                     Passing <literal>DB2_CASE_NATURAL</literal> specifies that
+                     Passing <constant>DB2_CASE_NATURAL</constant> specifies that
                      column names of the result set are returned in natural
                      case.
                     </para>
@@ -119,11 +119,11 @@
                  <term><parameter>deferred_prepare</parameter></term>
                  <listitem>
                   <para>
-                   Passing <literal>DB2_DEFERRED_PREPARE_ON</literal> turns deferred 
+                   Passing <constant>DB2_DEFERRED_PREPARE_ON</constant> turns deferred 
                    prepare on for the specified statement resource.
                   </para>
                   <para>
-                   Passing <literal>DB2_DEFERRED_PREPARE_OFF</literal> turns deferred 
+                   Passing <constant>DB2_DEFERRED_PREPARE_OFF</constant> turns deferred 
                    prepare off for the specified statement resource.
                   </para>
                  </listitem>
@@ -329,84 +329,84 @@
             </row>
             <row>
               <entry>autocommit</entry>
-              <entry><literal>DB2_AUTOCOMMIT_ON</literal></entry>
+              <entry><constant>DB2_AUTOCOMMIT_ON</constant></entry>
               <entry colname="col3">X</entry>
               <entry colname="col4">-</entry>
               <entry colname="col5">-</entry>
             </row>
             <row>
               <entry>autocommit</entry>
-              <entry><literal>DB2_AUTOCOMMIT_OFF</literal></entry>
+              <entry><constant>DB2_AUTOCOMMIT_OFF</constant></entry>
               <entry colname="col3">X</entry>
               <entry colname="col4">-</entry>
               <entry colname="col5">-</entry>
             </row>
             <row>
               <entry>cursor</entry>
-              <entry><literal>DB2_SCROLLABLE</literal></entry>
+              <entry><constant>DB2_SCROLLABLE</constant></entry>
               <entry colname="col3">-</entry>
               <entry colname="col4">X</entry>
               <entry colname="col5">-</entry>
             </row>
             <row>
               <entry>cursor</entry>
-              <entry><literal>DB2_FORWARD_ONLY</literal></entry>
+              <entry><constant>DB2_FORWARD_ONLY</constant></entry>
               <entry colname="col3">-</entry>
               <entry colname="col4">X</entry>
               <entry colname="col5">-</entry>
             </row>
             <row>
               <entry>binmode</entry>
-              <entry><literal>DB2_BINARY</literal></entry>
+              <entry><constant>DB2_BINARY</constant></entry>
               <entry colname="col3">X</entry>
               <entry colname="col4">X</entry>
               <entry colname="col5">-</entry>
             </row>
             <row>
               <entry>binmode</entry>
-              <entry><literal>DB2_CONVERT</literal></entry>
+              <entry><constant>DB2_CONVERT</constant></entry>
               <entry colname="col3">X</entry>
               <entry colname="col4">X</entry>
               <entry colname="col5">-</entry>
             </row>
             <row>
               <entry>binmode</entry>
-              <entry><literal>DB2_PASSTHRU</literal></entry>
+              <entry><constant>DB2_PASSTHRU</constant></entry>
               <entry colname="col3">X</entry>
               <entry colname="col4">X</entry>
               <entry colname="col5">-</entry>
             </row>
             <row>
               <entry>db2_attr_case</entry>
-              <entry><literal>DB2_CASE_LOWER</literal></entry>
+              <entry><constant>DB2_CASE_LOWER</constant></entry>
               <entry colname="col3">X</entry>
               <entry colname="col4">X</entry>
               <entry colname="col5">-</entry>
             </row>
             <row>
               <entry>db2_attr_case</entry>
-              <entry><literal>DB2_CASE_UPPER</literal></entry>
+              <entry><constant>DB2_CASE_UPPER</constant></entry>
               <entry colname="col3">X</entry>
               <entry colname="col4">X</entry>
               <entry colname="col5">-</entry>
             </row>
             <row>
               <entry>db2_attr_case</entry>
-              <entry><literal>DB2_CASE_NATURAL</literal></entry>
+              <entry><constant>DB2_CASE_NATURAL</constant></entry>
               <entry colname="col3">X</entry>
               <entry colname="col4">X</entry>
               <entry colname="col5">-</entry>
             </row>
             <row>
               <entry>deferred_prepare</entry>
-              <entry><literal>DB2_DEFERRED_PREPARE_ON</literal></entry>
+              <entry><constant>DB2_DEFERRED_PREPARE_ON</constant></entry>
               <entry colname="col3">-</entry>
               <entry colname="col4">X</entry>
               <entry colname="col5">-</entry>
             </row>
             <row>
               <entry>deferred_prepare</entry>
-              <entry><literal>DB2_DEFERRED_PREPARE_OFF</literal></entry>
+              <entry><constant>DB2_DEFERRED_PREPARE_OFF</constant></entry>
               <entry colname="col3">-</entry>
               <entry colname="col4">X</entry>
               <entry colname="col5">-</entry>

--- a/reference/math/functions/fdiv.xml
+++ b/reference/math/functions/fdiv.xml
@@ -15,11 +15,11 @@
   <para>
    Returns the floating point result of dividing the
    <parameter>num1</parameter> by the <parameter>num2</parameter>.
-   If the <parameter>num2</parameter> is zero, then one of <literal>INF</literal>,
-   <literal>-INF</literal>, or <literal>NAN</literal> will be returned.
+   If the <parameter>num2</parameter> is zero, then one of <constant>INF</constant>,
+   -<constant>INF</constant>, or <constant>NAN</constant> will be returned.
   </para>
   <para>
-   Note that in comparisons, <literal>NAN</literal> will never <code>==</code> or <code>===</code>,
+   Note that in comparisons, <constant>NAN</constant> will never <code>==</code> or <code>===</code>,
    any value, including itself.
   </para>
  </refsect1>

--- a/reference/math/functions/is-finite.xml
+++ b/reference/math/functions/is-finite.xml
@@ -41,7 +41,7 @@
   &reftitle.returnvalues;
   <para>
    &true; if <parameter>num</parameter> is none of <constant>NAN</constant>,
-   <constant>INF</constant>, <literal>-INF</literal>, else &false;.
+   <constant>INF</constant>, -<constant>INF</constant>, else &false;.
   </para>
  </refsect1>
 

--- a/reference/math/functions/is-finite.xml
+++ b/reference/math/functions/is-finite.xml
@@ -16,7 +16,7 @@
    Returns whether the given <parameter>num</parameter> is a finite float.
   </para>
   <para>
-   A finite float is neither <literal>NAN</literal> (<function>is_nan</function>),
+   A finite float is neither <constant>NAN</constant> (<function>is_nan</function>),
    nor infinite (<function>is_infinite</function>).
   </para>
  </refsect1>
@@ -40,8 +40,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &true; if <parameter>num</parameter> is none of <literal>NAN</literal>,
-   <literal>INF</literal>, <literal>-INF</literal>, else &false;.
+   &true; if <parameter>num</parameter> is none of <constant>NAN</constant>,
+   <constant>INF</constant>, <literal>-INF</literal>, else &false;.
   </para>
  </refsect1>
 

--- a/reference/math/functions/is-infinite.xml
+++ b/reference/math/functions/is-infinite.xml
@@ -13,7 +13,7 @@
    <methodparam><type>float</type><parameter>num</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Returns whether the given <parameter>num</parameter> is either <literal>INF</literal>
+   Returns whether the given <parameter>num</parameter> is either <constant>INF</constant>
    or <literal>-INF</literal>.
   </para>
  </refsect1>
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &true; if <parameter>num</parameter> is either <literal>INF</literal>
+   &true; if <parameter>num</parameter> is either <constant>INF</constant>
    or <literal>-INF</literal>, else &false;.
   </para>
  </refsect1>

--- a/reference/math/functions/is-infinite.xml
+++ b/reference/math/functions/is-infinite.xml
@@ -14,7 +14,7 @@
   </methodsynopsis>
   <para>
    Returns whether the given <parameter>num</parameter> is either <constant>INF</constant>
-   or <literal>-INF</literal>.
+   or -<constant>INF</constant>.
   </para>
  </refsect1>
 
@@ -38,7 +38,7 @@
   &reftitle.returnvalues;
   <para>
    &true; if <parameter>num</parameter> is either <constant>INF</constant>
-   or <literal>-INF</literal>, else &false;.
+   or -<constant>INF</constant>, else &false;.
   </para>
  </refsect1>
 

--- a/reference/math/functions/is-nan.xml
+++ b/reference/math/functions/is-nan.xml
@@ -13,25 +13,25 @@
    <methodparam><type>float</type><parameter>num</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Returns whether the given <parameter>num</parameter> is <literal>NAN</literal> (<quote>Not A Number</quote>).
+   Returns whether the given <parameter>num</parameter> is <constant>NAN</constant> (<quote>Not A Number</quote>).
   </para>
   <para>
-   <literal>NAN</literal> is returned from mathematical operations that are undefined,
+   <constant>NAN</constant> is returned from mathematical operations that are undefined,
    for example when passing parameters outside of function’s input domain. The square root
    (<function>sqrt</function>) is only defined for positive numbers, passing a negative number
-   will result in <literal>NAN</literal>. Other examples of operations returning <literal>NAN</literal>
-   are dividing <literal>INF</literal> by <literal>INF</literal> and any operation involving an
-   existing <literal>NAN</literal> value.
+   will result in <constant>NAN</constant>. Other examples of operations returning <constant>NAN</constant>
+   are dividing <constant>INF</constant> by <constant>INF</constant> and any operation involving an
+   existing <constant>NAN</constant> value.
   </para>
   <note>
    <para>
-    Despite its name of <quote>Not A Number</quote>, <literal>NAN</literal> is a valid value of type &float;.
+    Despite its name of <quote>Not A Number</quote>, <constant>NAN</constant> is a valid value of type &float;.
    </para>
   </note>
   <caution>
    <para>
-    <literal>NAN</literal> does not compare equal to <literal>NAN</literal>. To check whether
-    a float is <literal>NAN</literal>, <function>is_nan</function> must be used. Checking
+    <constant>NAN</constant> does not compare equal to <constant>NAN</constant>. To check whether
+    a float is <constant>NAN</constant>, <function>is_nan</function> must be used. Checking
     <code>$float === NAN</code> will not work.
    </para>
   </caution>
@@ -56,7 +56,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &true; if <parameter>num</parameter> is <literal>NAN</literal>, else &false;.
+   &true; if <parameter>num</parameter> is <constant>NAN</constant>, else &false;.
   </para>
  </refsect1>
 

--- a/reference/math/functions/sqrt.xml
+++ b/reference/math/functions/sqrt.xml
@@ -34,7 +34,7 @@
   &reftitle.returnvalues;
   <para>
    The square root of <parameter>num</parameter>
-   or the special value <literal>NAN</literal> for negative numbers.
+   or the special value <constant>NAN</constant> for negative numbers.
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/mysqli/mysqli_stmt/attr-set.xml
+++ b/reference/mysqli/mysqli_stmt/attr-set.xml
@@ -57,8 +57,8 @@
            <entry>MYSQLI_STMT_ATTR_CURSOR_TYPE</entry>
            <entry>
             Type of cursor to open for statement when <function>mysqli_stmt_execute</function>
-            is invoked. <parameter>value</parameter> can be <literal>MYSQLI_CURSOR_TYPE_NO_CURSOR</literal>
-            (the default) or <literal>MYSQLI_CURSOR_TYPE_READ_ONLY</literal>.
+            is invoked. <parameter>value</parameter> can be <constant>MYSQLI_CURSOR_TYPE_NO_CURSOR</constant>
+            (the default) or <constant>MYSQLI_CURSOR_TYPE_READ_ONLY</constant>.
            </entry>
           </row>
           <row>
@@ -74,8 +74,8 @@
        </table>
       </para>
       <para>
-       If you use the <literal>MYSQLI_STMT_ATTR_CURSOR_TYPE</literal> option with
-       <literal>MYSQLI_CURSOR_TYPE_READ_ONLY</literal>, a cursor is opened for the
+       If you use the <constant>MYSQLI_STMT_ATTR_CURSOR_TYPE</constant> option with
+       <constant>MYSQLI_CURSOR_TYPE_READ_ONLY</constant>, a cursor is opened for the
        statement when you invoke <function>mysqli_stmt_execute</function>. If there
        is already an open cursor from a previous <function>mysqli_stmt_execute</function> call,
        it closes the cursor before opening a new one. <function>mysqli_stmt_reset</function>

--- a/reference/network/functions/syslog.xml
+++ b/reference/network/functions/syslog.xml
@@ -144,7 +144,7 @@ closelog();
   </para>
   <note>
    <para>
-    Use of <literal>LOG_LOCAL0</literal> through
+    Use of <constant>LOG_LOCAL0</constant> through
     <literal>LOG_LOCAL7</literal> for the <parameter>facility</parameter>
     parameter of <function>openlog</function> is not available
     in Windows.

--- a/reference/oci8/functions/oci-define-by-name.xml
+++ b/reference/oci8/functions/oci-define-by-name.xml
@@ -61,8 +61,8 @@
       <para>
         The data type to be returned.  Generally not needed.  Note that
         Oracle-style data conversions are not performed.  For example,
-        <literal>SQLT_INT</literal> will be ignored and the returned
-        data type will still be <literal>SQLT_CHR</literal>.
+        <constant>SQLT_INT</constant> will be ignored and the returned
+        data type will still be <constant>SQLT_CHR</constant>.
       </para>
       <para>
        You can optionally use <function>oci_new_descriptor</function>

--- a/reference/pcntl/functions/pcntl-rfork.xml
+++ b/reference/pcntl/functions/pcntl-rfork.xml
@@ -45,7 +45,7 @@
         </member>
         <member>
          <constant>RFCFDG</constant>: If set, the new process starts with a clean file descriptor table.
-         Is mutually exclusive with <literal>RFFDG</literal>.
+         Is mutually exclusive with <constant>RFFDG</constant>.
         </member>
         <member>
          <constant>RFLINUXTHPN</constant>: If set, the kernel will return SIGUSR1 instead of SIGCHILD upon thread exit for the child.

--- a/reference/pcntl/functions/pcntl-wait.xml
+++ b/reference/pcntl/functions/pcntl-wait.xml
@@ -68,13 +68,13 @@
         <tgroup cols="2">
          <tbody>
           <row>
-           <entry><literal>WNOHANG</literal></entry>
+           <entry><constant>WNOHANG</constant></entry>
            <entry>
             Return immediately if no child has exited.
            </entry>
           </row>
           <row>
-           <entry><literal>WUNTRACED</literal></entry>
+           <entry><constant>WUNTRACED</constant></entry>
            <entry>
             Return for children which are stopped, and whose status has
             not been reported.

--- a/reference/pcntl/functions/pcntl-waitpid.xml
+++ b/reference/pcntl/functions/pcntl-waitpid.xml
@@ -112,13 +112,13 @@
         <tgroup cols="2">
          <tbody>
           <row>
-           <entry><literal>WNOHANG</literal></entry>
+           <entry><constant>WNOHANG</constant></entry>
            <entry>
             return immediately if no child has exited.
            </entry>
           </row>
           <row>
-           <entry><literal>WUNTRACED</literal></entry>
+           <entry><constant>WUNTRACED</constant></entry>
            <entry>
             return for children which are stopped, and whose status has
             not been reported.

--- a/reference/pcntl/functions/pcntl-wifstopped.xml
+++ b/reference/pcntl/functions/pcntl-wifstopped.xml
@@ -16,7 +16,7 @@
    Checks whether the child process which caused the return is currently
    stopped; this is only possible if the call to
    <function>pcntl_waitpid</function> was done using the option
-   <literal>WUNTRACED</literal>.
+   <constant>WUNTRACED</constant>.
   </para>
  </refsect1>
 

--- a/reference/posix/constants.xml
+++ b/reference/posix/constants.xml
@@ -173,11 +173,11 @@
     <listitem>
      <simpara>
       The maximum amount of CPU time that the process can use, in seconds.
-      When the soft limit is hit, a <literal>SIGXCPU</literal> signal will be
+      When the soft limit is hit, a <constant>SIGXCPU</constant> signal will be
       sent, which can be caught with <function>pcntl_signal</function>.
-      Depending on the operating system, additional <literal>SIGXCPU</literal>
+      Depending on the operating system, additional <constant>SIGXCPU</constant>
       signals may be sent each second until the hard limit is hit, at which
-      point an uncatchable <literal>SIGKILL</literal> signal is sent.
+      point an uncatchable <constant>SIGKILL</constant> signal is sent.
      </simpara>
      <simpara>
       See also <function>set_time_limit</function>.

--- a/reference/ps/functions/ps-hyphenate.xml
+++ b/reference/ps/functions/ps-hyphenate.xml
@@ -21,7 +21,7 @@
    hyphendict must be set before calling this function.
   </para>
   <para>
-   This function requires the locale category LC_CTYPE to be set properly.
+   This function requires the locale category <constant>LC_CTYPE</constant> to be set properly.
    This is done when the extension is initialized by using the environment
    variables. On Unix systems read the man page of locale for more information.
   </para>

--- a/reference/spl/splfileobject/fgetcsv.xml
+++ b/reference/spl/splfileobject/fgetcsv.xml
@@ -20,7 +20,7 @@
   <note>
    <para>
     The locale settings are taken into account by this function. If
-    <literal>LC_CTYPE</literal> is e.g. <literal>en_US.UTF-8</literal>, files in
+    <constant>LC_CTYPE</constant> is e.g. <literal>en_US.UTF-8</literal>, files in
     one-byte encodings may be read wrongly by this function.
    </para>
   </note>

--- a/reference/sqlite3/sqlite3/construct.xml
+++ b/reference/sqlite3/sqlite3/construct.xml
@@ -47,19 +47,19 @@
        <itemizedlist>
         <listitem>
          <para>
-          <literal>SQLITE3_OPEN_READONLY</literal>: Open the database for
+          <constant>SQLITE3_OPEN_READONLY</constant>: Open the database for
           reading only.
          </para>
         </listitem>
         <listitem>
          <para>
-          <literal>SQLITE3_OPEN_READWRITE</literal>: Open the database for
+          <constant>SQLITE3_OPEN_READWRITE</constant>: Open the database for
           reading and writing.
          </para>
         </listitem>
         <listitem>
          <para>
-          <literal>SQLITE3_OPEN_CREATE</literal>: Create the database if it
+          <constant>SQLITE3_OPEN_CREATE</constant>: Create the database if it
           does not exist.
          </para>
         </listitem>

--- a/reference/sqlite3/sqlite3/open.xml
+++ b/reference/sqlite3/sqlite3/open.xml
@@ -41,19 +41,19 @@
        <itemizedlist>
         <listitem>
          <para>
-          <literal>SQLITE3_OPEN_READONLY</literal>: Open the database for
+          <constant>SQLITE3_OPEN_READONLY</constant>: Open the database for
           reading only.
          </para>
         </listitem>
         <listitem>
          <para>
-          <literal>SQLITE3_OPEN_READWRITE</literal>: Open the database for
+          <constant>SQLITE3_OPEN_READWRITE</constant>: Open the database for
           reading and writing.
          </para>
         </listitem>
         <listitem>
          <para>
-          <literal>SQLITE3_OPEN_CREATE</literal>: Create the database if it
+          <constant>SQLITE3_OPEN_CREATE</constant>: Create the database if it
           does not exist.
          </para>
         </listitem>

--- a/reference/sqlite3/sqlite3result/fetcharray.xml
+++ b/reference/sqlite3/sqlite3result/fetcharray.xml
@@ -29,25 +29,25 @@
      <listitem>
       <para>
        Controls how the next row will be returned to the caller. This value
-       must be one of either <literal>SQLITE3_ASSOC</literal>,
-       <literal>SQLITE3_NUM</literal>, or <literal>SQLITE3_BOTH</literal>.
+       must be one of either <constant>SQLITE3_ASSOC</constant>,
+       <constant>SQLITE3_NUM</constant>, or <constant>SQLITE3_BOTH</constant>.
        <itemizedlist>
         <listitem>
          <para>
-          <literal>SQLITE3_ASSOC</literal>: returns an array indexed by column
+          <constant>SQLITE3_ASSOC</constant>: returns an array indexed by column
           name as returned in the corresponding result set
          </para>
         </listitem>
         <listitem>
          <para>
-          <literal>SQLITE3_NUM</literal>: returns an array indexed by column
+          <constant>SQLITE3_NUM</constant>: returns an array indexed by column
           number as returned in the corresponding result set, starting at
           column 0
          </para>
         </listitem>
         <listitem>
          <para>
-          <literal>SQLITE3_BOTH</literal>: returns an array indexed by both
+          <constant>SQLITE3_BOTH</constant>: returns an array indexed by both
           column name and number as returned in the corresponding result set,
           starting at column 0
          </para>

--- a/reference/strings/functions/nl-langinfo.xml
+++ b/reference/strings/functions/nl-langinfo.xml
@@ -46,7 +46,7 @@
          </thead>
          <tbody>
           <row>
-           <entry namest="c1" nameend="c2" align="center"><emphasis>LC_TIME Category Constants</emphasis></entry>
+           <entry namest="c1" nameend="c2" align="center"><emphasis><constant>LC_TIME</constant> Category Constants</emphasis></entry>
           </row>
           <row>
            <entry><constant>ABDAY_(1-7)</constant></entry>
@@ -109,7 +109,7 @@
            <entry>Time in alternate era format (string can be used in <function>strftime</function>).</entry>
           </row>
           <row>
-           <entry namest="c1" nameend="c2" align="center"><emphasis>LC_MONETARY Category Constants</emphasis></entry>
+           <entry namest="c1" nameend="c2" align="center"><emphasis><constant>LC_MONETARY</constant> Category Constants</emphasis></entry>
           </row>
           <row>
            <entry><constant>INT_CURR_SYMBOL</constant></entry>
@@ -203,7 +203,7 @@
            <entry><constant>N_SIGN_POSN</constant></entry>
           </row>
           <row>
-           <entry namest="c1" nameend="c2" align="center"><emphasis>LC_NUMERIC Category Constants</emphasis></entry>
+           <entry namest="c1" nameend="c2" align="center"><emphasis><constant>LC_NUMERIC</constant> Category Constants</emphasis></entry>
           </row>
           <row>
            <entry><constant>DECIMAL_POINT</constant></entry>
@@ -226,7 +226,7 @@
            <entry/>
           </row>
           <row>
-           <entry namest="c1" nameend="c2" align="center"><emphasis>LC_MESSAGES Category Constants</emphasis></entry>
+           <entry namest="c1" nameend="c2" align="center"><emphasis><constant>LC_MESSAGES</constant> Category Constants</emphasis></entry>
           </row>
           <row>
            <entry><constant>YESEXPR</constant></entry>
@@ -245,7 +245,7 @@
            <entry>Output string for <literal>"no"</literal>.</entry>
           </row>
           <row>
-           <entry namest="c1" nameend="c2" align="center"><emphasis>LC_CTYPE Category Constants</emphasis></entry>
+           <entry namest="c1" nameend="c2" align="center"><emphasis><constant>LC_CTYPE</constant> Category Constants</emphasis></entry>
           </row>
           <row>
            <entry><constant>CODESET</constant></entry>

--- a/reference/strings/functions/str-getcsv.xml
+++ b/reference/strings/functions/str-getcsv.xml
@@ -24,7 +24,7 @@
   <note>
    <para>
     The locale settings are taken into account by this function. If
-    <literal>LC_CTYPE</literal> is e.g. <literal>en_US.UTF-8</literal>, strings in
+    <constant>LC_CTYPE</constant> is e.g. <literal>en_US.UTF-8</literal>, strings in
     one-byte encodings may be read wrongly by this function.
    </para>
   </note>


### PR DESCRIPTION
Add the `<constant>` tags to PHP constant wrapped in a `<literal>` tag or no tag at all, and swap the `<constant>` tag with a `<literal>` tag where it used on non-PHP constants.