### PR TITLE
Fix mysqli constant IDs

### DIFF
--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -4,7 +4,7 @@
  &reftitle.constants;
  &extension.constants;
   <variablelist>
-   <varlistentry xml:id="constantmysqli-read-default-group">
+   <varlistentry xml:id="constant.mysqli-read-default-group">
     <term>
      <constant>MYSQLI_READ_DEFAULT_GROUP</constant>
      (<type>int</type>)
@@ -16,7 +16,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-read-default-file">
+   <varlistentry xml:id="constant.mysqli-read-default-file">
     <term>
      <constant>MYSQLI_READ_DEFAULT_FILE</constant>
      (<type>int</type>)
@@ -27,7 +27,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-opt-connect-timeout">
+   <varlistentry xml:id="constant.mysqli-opt-connect-timeout">
     <term>
      <constant>MYSQLI_OPT_CONNECT_TIMEOUT</constant>
      (<type>int</type>)
@@ -38,7 +38,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-opt-read-timeout">
+   <varlistentry xml:id="constant.mysqli-opt-read-timeout">
     <term>
      <constant>MYSQLI_OPT_READ_TIMEOUT</constant>
      (<type>int</type>)
@@ -49,7 +49,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-opt-local-infile">
+   <varlistentry xml:id="constant.mysqli-opt-local-infile">
     <term>
      <constant>MYSQLI_OPT_LOCAL_INFILE</constant>
      (<type>int</type>)
@@ -60,7 +60,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-opt-int-and-float-native">
+   <varlistentry xml:id="constant.mysqli-opt-int-and-float-native">
     <term>
      <constant>MYSQLI_OPT_INT_AND_FLOAT_NATIVE</constant>
      (<type>int</type>)
@@ -71,7 +71,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-opt-net-cmd-buffer-size">
+   <varlistentry xml:id="constant.mysqli-opt-net-cmd-buffer-size">
     <term>
      <constant>MYSQLI_OPT_NET_CMD_BUFFER_SIZE</constant>
      (<type>int</type>)
@@ -82,7 +82,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-opt-net-read-buffer-size">
+   <varlistentry xml:id="constant.mysqli-opt-net-read-buffer-size">
     <term>
      <constant>MYSQLI_OPT_NET_READ_BUFFER_SIZE</constant>
      (<type>int</type>)
@@ -94,7 +94,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-opt-ssl-verify-server-cert">
+   <varlistentry xml:id="constant.mysqli-opt-ssl-verify-server-cert">
     <term>
      <constant>MYSQLI_OPT_SSL_VERIFY_SERVER_CERT</constant>
      (<type>int</type>)
@@ -105,7 +105,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-init-command">
+   <varlistentry xml:id="constant.mysqli-init-command">
     <term>
      <constant>MYSQLI_INIT_COMMAND</constant>
      (<type>int</type>)
@@ -116,19 +116,19 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-client-ssl">
+   <varlistentry xml:id="constant.mysqli-client-ssl">
     <term>
      <constant>MYSQLI_CLIENT_SSL</constant>
      (<type>int</type>)
     </term>
     <listitem>
      <para>
-      Use SSL (encrypted protocol). This option should not be set by application programs; 
+      Use SSL (encrypted protocol). This option should not be set by application programs;
       it is set internally in the MySQL client library
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-client-compress">
+   <varlistentry xml:id="constant.mysqli-client-compress">
     <term>
      <constant>MYSQLI_CLIENT_COMPRESS</constant>
      (<type>int</type>)
@@ -139,7 +139,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-client-interactive">
+   <varlistentry xml:id="constant.mysqli-client-interactive">
     <term>
      <constant>MYSQLI_CLIENT_INTERACTIVE</constant>
      (<type>int</type>)
@@ -150,22 +150,22 @@
       (instead of <literal>wait_timeout</literal> seconds) of inactivity before
       closing the connection.  The client's session
       <literal>wait_timeout</literal> variable will be set to
-      the value of the session <literal>interactive_timeout</literal> variable. 
+      the value of the session <literal>interactive_timeout</literal> variable.
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-client-ignore-space">
+   <varlistentry xml:id="constant.mysqli-client-ignore-space">
     <term>
      <constant>MYSQLI_CLIENT_IGNORE_SPACE</constant>
      (<type>int</type>)
     </term>
     <listitem>
      <para>
-      Allow spaces after function names. Makes all functions names reserved words. 
+      Allow spaces after function names. Makes all functions names reserved words.
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-client-no-schema">
+   <varlistentry xml:id="constant.mysqli-client-no-schema">
     <term>
      <constant>MYSQLI_CLIENT_NO_SCHEMA</constant>
      (<type>int</type>)
@@ -176,7 +176,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-client-multi-queries">
+   <varlistentry xml:id="constant.mysqli-client-multi-queries">
     <term><constant>MYSQLI_CLIENT_MULTI_QUERIES</constant></term>
     <listitem>
      <para>
@@ -184,7 +184,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-store-result">
+   <varlistentry xml:id="constant.mysqli-store-result">
     <term>
      <constant>MYSQLI_STORE_RESULT</constant>
      (<type>int</type>)
@@ -195,7 +195,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-use-result">
+   <varlistentry xml:id="constant.mysqli-use-result">
     <term>
      <constant>MYSQLI_USE_RESULT</constant>
      (<type>int</type>)
@@ -206,7 +206,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-assoc">
+   <varlistentry xml:id="constant.mysqli-assoc">
     <term>
      <constant>MYSQLI_ASSOC</constant>
      (<type>int</type>)
@@ -217,7 +217,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-num">
+   <varlistentry xml:id="constant.mysqli-num">
     <term>
      <constant>MYSQLI_NUM</constant>
      (<type>int</type>)
@@ -228,18 +228,18 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-both">
+   <varlistentry xml:id="constant.mysqli-both">
     <term>
      <constant>MYSQLI_BOTH</constant>
      (<type>int</type>)
     </term>
     <listitem>
      <para>
-      Columns are returned into the array having both a numerical index and the fieldname as the associative index. 
+      Columns are returned into the array having both a numerical index and the fieldname as the associative index.
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-not-null-flag">
+   <varlistentry xml:id="constant.mysqli-not-null-flag">
     <term>
      <constant>MYSQLI_NOT_NULL_FLAG</constant>
      (<type>int</type>)
@@ -250,7 +250,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-pri-key-flag">
+   <varlistentry xml:id="constant.mysqli-pri-key-flag">
     <term>
      <constant>MYSQLI_PRI_KEY_FLAG</constant>
      (<type>int</type>)
@@ -261,7 +261,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-unique-key-flag">
+   <varlistentry xml:id="constant.mysqli-unique-key-flag">
     <term>
      <constant>MYSQLI_UNIQUE_KEY_FLAG</constant>
      (<type>int</type>)
@@ -273,7 +273,7 @@
     </listitem>
    </varlistentry>
 
-   <varlistentry xml:id="constantmysqli-multiple-key-flag">
+   <varlistentry xml:id="constant.mysqli-multiple-key-flag">
     <term>
      <constant>MYSQLI_MULTIPLE_KEY_FLAG</constant>
      (<type>int</type>)
@@ -284,7 +284,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-blob-flag">
+   <varlistentry xml:id="constant.mysqli-blob-flag">
     <term>
      <constant>MYSQLI_BLOB_FLAG</constant>
      (<type>int</type>)
@@ -295,7 +295,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-unsigned-flag">
+   <varlistentry xml:id="constant.mysqli-unsigned-flag">
     <term>
      <constant>MYSQLI_UNSIGNED_FLAG</constant>
      (<type>int</type>)
@@ -306,7 +306,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-zerofill-flag">
+   <varlistentry xml:id="constant.mysqli-zerofill-flag">
     <term>
      <constant>MYSQLI_ZEROFILL_FLAG</constant>
      (<type>int</type>)
@@ -317,7 +317,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-auto-increment-flag">
+   <varlistentry xml:id="constant.mysqli-auto-increment-flag">
     <term>
      <constant>MYSQLI_AUTO_INCREMENT_FLAG</constant>
      (<type>int</type>)
@@ -328,7 +328,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-timestamp-flag">
+   <varlistentry xml:id="constant.mysqli-timestamp-flag">
     <term>
      <constant>MYSQLI_TIMESTAMP_FLAG</constant>
      (<type>int</type>)
@@ -339,7 +339,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-set-flag">
+   <varlistentry xml:id="constant.mysqli-set-flag">
     <term>
      <constant>MYSQLI_SET_FLAG</constant>
      (<type>int</type>)
@@ -350,7 +350,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-num-flag">
+   <varlistentry xml:id="constant.mysqli-num-flag">
     <term>
      <constant>MYSQLI_NUM_FLAG</constant>
      (<type>int</type>)
@@ -361,7 +361,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-part-key-flag">
+   <varlistentry xml:id="constant.mysqli-part-key-flag">
     <term>
      <constant>MYSQLI_PART_KEY_FLAG</constant>
      (<type>int</type>)
@@ -372,7 +372,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-group-flag">
+   <varlistentry xml:id="constant.mysqli-group-flag">
     <term>
      <constant>MYSQLI_GROUP_FLAG</constant>
      (<type>int</type>)
@@ -383,7 +383,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-decimal">
+   <varlistentry xml:id="constant.mysqli-type-decimal">
     <term>
      <constant>MYSQLI_TYPE_DECIMAL</constant>
      (<type>int</type>)
@@ -394,7 +394,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-newdecimal">
+   <varlistentry xml:id="constant.mysqli-type-newdecimal">
     <term>
      <constant>MYSQLI_TYPE_NEWDECIMAL</constant>
      (<type>int</type>)
@@ -405,7 +405,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-bit">
+   <varlistentry xml:id="constant.mysqli-type-bit">
     <term>
      <constant>MYSQLI_TYPE_BIT</constant>
      (<type>int</type>)
@@ -416,7 +416,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-tiny">
+   <varlistentry xml:id="constant.mysqli-type-tiny">
     <term>
      <constant>MYSQLI_TYPE_TINY</constant>
      (<type>int</type>)
@@ -427,7 +427,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-short">
+   <varlistentry xml:id="constant.mysqli-type-short">
     <term>
      <constant>MYSQLI_TYPE_SHORT</constant>
      (<type>int</type>)
@@ -438,7 +438,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-long">
+   <varlistentry xml:id="constant.mysqli-type-long">
     <term>
      <constant>MYSQLI_TYPE_LONG</constant>
      (<type>int</type>)
@@ -449,7 +449,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-fload">
+   <varlistentry xml:id="constant.mysqli-type-float">
     <term>
      <constant>MYSQLI_TYPE_FLOAT</constant>
      (<type>int</type>)
@@ -460,7 +460,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-double">
+   <varlistentry xml:id="constant.mysqli-type-double">
     <term>
      <constant>MYSQLI_TYPE_DOUBLE</constant>
      (<type>int</type>)
@@ -471,7 +471,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-null">
+   <varlistentry xml:id="constant.mysqli-type-null">
     <term>
      <constant>MYSQLI_TYPE_NULL</constant>
      (<type>int</type>)
@@ -482,7 +482,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-timestamp">
+   <varlistentry xml:id="constant.mysqli-type-timestamp">
     <term>
      <constant>MYSQLI_TYPE_TIMESTAMP</constant>
      (<type>int</type>)
@@ -493,7 +493,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-longlong">
+   <varlistentry xml:id="constant.mysqli-type-longlong">
     <term>
      <constant>MYSQLI_TYPE_LONGLONG</constant>
      (<type>int</type>)
@@ -504,7 +504,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-int24">
+   <varlistentry xml:id="constant.mysqli-type-int24">
     <term>
      <constant>MYSQLI_TYPE_INT24</constant>
      (<type>int</type>)
@@ -515,7 +515,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-date">
+   <varlistentry xml:id="constant.mysqli-type-date">
     <term>
      <constant>MYSQLI_TYPE_DATE</constant>
      (<type>int</type>)
@@ -526,7 +526,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-time">
+   <varlistentry xml:id="constant.mysqli-type-time">
     <term>
      <constant>MYSQLI_TYPE_TIME</constant>
      (<type>int</type>)
@@ -537,7 +537,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-datetime">
+   <varlistentry xml:id="constant.mysqli-type-datetime">
     <term>
      <constant>MYSQLI_TYPE_DATETIME</constant>
      (<type>int</type>)
@@ -548,7 +548,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-year">
+   <varlistentry xml:id="constant.mysqli-type-year">
     <term>
      <constant>MYSQLI_TYPE_YEAR</constant>
      (<type>int</type>)
@@ -559,7 +559,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-newdate">
+   <varlistentry xml:id="constant.mysqli-type-newdate">
     <term>
      <constant>MYSQLI_TYPE_NEWDATE</constant>
      (<type>int</type>)
@@ -570,7 +570,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-interval">
+   <varlistentry xml:id="constant.mysqli-type-interval">
     <term>
      <constant>MYSQLI_TYPE_INTERVAL</constant>
      (<type>int</type>)
@@ -581,7 +581,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-enum">
+   <varlistentry xml:id="constant.mysqli-type-enum">
     <term>
      <constant>MYSQLI_TYPE_ENUM</constant>
      (<type>int</type>)
@@ -592,7 +592,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-set">
+   <varlistentry xml:id="constant.mysqli-type-set">
     <term>
      <constant>MYSQLI_TYPE_SET</constant>
      (<type>int</type>)
@@ -603,7 +603,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-tiny-blob">
+   <varlistentry xml:id="constant.mysqli-type-tiny-blob">
     <term>
      <constant>MYSQLI_TYPE_TINY_BLOB</constant>
      (<type>int</type>)
@@ -614,7 +614,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-medium-blob">
+   <varlistentry xml:id="constant.mysqli-type-medium-blob">
     <term>
      <constant>MYSQLI_TYPE_MEDIUM_BLOB</constant>
      (<type>int</type>)
@@ -625,7 +625,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-long-blob">
+   <varlistentry xml:id="constant.mysqli-type-long-blob">
     <term>
      <constant>MYSQLI_TYPE_LONG_BLOB</constant>
      (<type>int</type>)
@@ -636,7 +636,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-blob">
+   <varlistentry xml:id="constant.mysqli-type-blob">
     <term>
      <constant>MYSQLI_TYPE_BLOB</constant>
      (<type>int</type>)
@@ -647,7 +647,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-var-string">
+   <varlistentry xml:id="constant.mysqli-type-var-string">
     <term>
      <constant>MYSQLI_TYPE_VAR_STRING</constant>
      (<type>int</type>)
@@ -658,7 +658,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-string">
+   <varlistentry xml:id="constant.mysqli-type-string">
     <term>
      <constant>MYSQLI_TYPE_STRING</constant>
      (<type>int</type>)
@@ -669,7 +669,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-char">
+   <varlistentry xml:id="constant.mysqli-type-char">
     <term>
      <constant>MYSQLI_TYPE_CHAR</constant>
      (<type>int</type>)
@@ -681,7 +681,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-geometry">
+   <varlistentry xml:id="constant.mysqli-type-geometry">
     <term>
      <constant>MYSQLI_TYPE_GEOMETRY</constant>
      (<type>int</type>)
@@ -692,7 +692,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-type-json">
+   <varlistentry xml:id="constant.mysqli-type-json">
     <term>
      <constant>MYSQLI_TYPE_JSON</constant>
      (<type>int</type>)
@@ -704,7 +704,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-need-data">
+   <varlistentry xml:id="constant.mysqli-need-data">
     <term><constant>MYSQLI_NEED_DATA</constant></term>
     <listitem>
      <para>
@@ -712,7 +712,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-no-data">
+   <varlistentry xml:id="constant.mysqli-no-data">
     <term>
      <constant>MYSQLI_NO_DATA</constant>
      (<type>int</type>)
@@ -723,7 +723,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-data-truncated">
+   <varlistentry xml:id="constant.mysqli-data-truncated">
     <term>
      <constant>MYSQLI_DATA_TRUNCATED</constant>
      (<type>int</type>)
@@ -734,7 +734,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-enum-flag">
+   <varlistentry xml:id="constant.mysqli-enum-flag">
     <term>
      <constant>MYSQLI_ENUM_FLAG</constant>
      (<type>int</type>)
@@ -745,7 +745,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-binary-flag">
+   <varlistentry xml:id="constant.mysqli-binary-flag">
     <term>
      <constant>MYSQLI_BINARY_FLAG</constant>
      (<type>int</type>)
@@ -756,7 +756,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-cursor-type-for-update">
+   <varlistentry xml:id="constant.mysqli-cursor-type-for-update">
     <term>
      <constant>MYSQLI_CURSOR_TYPE_FOR_UPDATE</constant>
      (<type>int</type>)
@@ -766,7 +766,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-cursor-type-no-cursor">
+   <varlistentry xml:id="constant.mysqli-cursor-type-no-cursor">
     <term>
      <constant>MYSQLI_CURSOR_TYPE_NO_CURSOR</constant>
      (<type>int</type>)
@@ -776,7 +776,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-cursor-type-read-only">
+   <varlistentry xml:id="constant.mysqli-cursor-type-read-only">
     <term>
      <constant>MYSQLI_CURSOR_TYPE_READ_ONLY</constant>
      (<type>int</type>)
@@ -786,7 +786,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-cursor-type-scrollable">
+   <varlistentry xml:id="constant.mysqli-cursor-type-scrollable">
     <term>
      <constant>MYSQLI_CURSOR_TYPE_SCROLLABLE</constant>
      (<type>int</type>)
@@ -796,7 +796,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-stmt-attr-cursor-type">
+   <varlistentry xml:id="constant.mysqli-stmt-attr-cursor-type">
     <term>
      <constant>MYSQLI_STMT_ATTR_CURSOR_TYPE</constant>
      (<type>int</type>)
@@ -806,7 +806,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-stmt-attr-prefetch-rows">
+   <varlistentry xml:id="constant.mysqli-stmt-attr-prefetch-rows">
     <term>
      <constant>MYSQLI_STMT_ATTR_PREFETCH_ROWS</constant>
      (<type>int</type>)
@@ -816,7 +816,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-stmt-attr-update-max-length">
+   <varlistentry xml:id="constant.mysqli-stmt-attr-update-max-length">
     <term>
      <constant>MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH</constant>
      (<type>int</type>)
@@ -826,7 +826,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-set-charset-name">
+   <varlistentry xml:id="constant.mysqli-set-charset-name">
     <term>
      <constant>MYSQLI_SET_CHARSET_NAME</constant>
      (<type>int</type>)
@@ -836,7 +836,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-report-index">
+   <varlistentry xml:id="constant.mysqli-report-index">
     <term>
      <constant>MYSQLI_REPORT_INDEX</constant>
      (<type>int</type>)
@@ -847,7 +847,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-report-error">
+   <varlistentry xml:id="constant.mysqli-report-error">
     <term>
      <constant>MYSQLI_REPORT_ERROR</constant>
      (<type>int</type>)
@@ -858,7 +858,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-report-strict">
+   <varlistentry xml:id="constant.mysqli-report-strict">
     <term>
      <constant>MYSQLI_REPORT_STRICT</constant>
      (<type>int</type>)
@@ -869,7 +869,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-report-all">
+   <varlistentry xml:id="constant.mysqli-report-all">
     <term>
      <constant>MYSQLI_REPORT_ALL</constant>
      (<type>int</type>)
@@ -880,7 +880,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-report-off">
+   <varlistentry xml:id="constant.mysqli-report-off">
     <term>
      <constant>MYSQLI_REPORT_OFF</constant>
      (<type>int</type>)
@@ -891,7 +891,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-debug-trace-enabled">
+   <varlistentry xml:id="constant.mysqli-debug-trace-enabled">
     <term>
      <constant>MYSQLI_DEBUG_TRACE_ENABLED</constant>
      (<type>int</type>)
@@ -902,7 +902,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-server-query-no-good-index-used">
+   <varlistentry xml:id="constant.mysqli-server-query-no-good-index-used">
     <term>
      <constant>MYSQLI_SERVER_QUERY_NO_GOOD_INDEX_USED</constant>
      (<type>int</type>)
@@ -912,7 +912,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-server-query-no-index-used">
+   <varlistentry xml:id="constant.mysqli-server-query-no-index-used">
     <term>
      <constant>MYSQLI_SERVER_QUERY_NO_INDEX_USED</constant>
      (<type>int</type>)
@@ -922,7 +922,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-server-public-key">
+   <varlistentry xml:id="constant.mysqli-server-public-key">
     <term>
      <constant>MYSQLI_SERVER_PUBLIC_KEY</constant>
      (<type>int</type>)
@@ -932,7 +932,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-refresh-grant">
+   <varlistentry xml:id="constant.mysqli-refresh-grant">
     <term>
      <constant>MYSQLI_REFRESH_GRANT</constant>
      (<type>int</type>)
@@ -943,7 +943,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-refresh-log">
+   <varlistentry xml:id="constant.mysqli-refresh-log">
     <term>
      <constant>MYSQLI_REFRESH_LOG</constant>
      (<type>int</type>)
@@ -955,7 +955,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-refresh-tables">
+   <varlistentry xml:id="constant.mysqli-refresh-tables">
     <term>
      <constant>MYSQLI_REFRESH_TABLES</constant>
      (<type>int</type>)
@@ -967,7 +967,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-refresh-hosts">
+   <varlistentry xml:id="constant.mysqli-refresh-hosts">
     <term>
      <constant>MYSQLI_REFRESH_HOSTS</constant>
      (<type>int</type>)
@@ -979,7 +979,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-refresh-replica">
+   <varlistentry xml:id="constant.mysqli-refresh-replica">
     <term>
      <constant>MYSQLI_REFRESH_REPLICA</constant>
      (<type>int</type>)
@@ -991,7 +991,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-refresh-status">
+   <varlistentry xml:id="constant.mysqli-refresh-status">
     <term>
      <constant>MYSQLI_REFRESH_STATUS</constant>
      (<type>int</type>)
@@ -1003,7 +1003,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-refresh-threads">
+   <varlistentry xml:id="constant.mysqli-refresh-threads">
     <term>
      <constant>MYSQLI_REFRESH_THREADS</constant>
      (<type>int</type>)
@@ -1014,20 +1014,20 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-refresh-slave">
+   <varlistentry xml:id="constant.mysqli-refresh-slave">
     <term>
      <constant>MYSQLI_REFRESH_SLAVE</constant>
      (<type>int</type>)
     </term>
     <listitem>
      <para>
-      On a slave replication server: resets the master server information, and 
+      On a slave replication server: resets the master server information, and
       restarts the slave. Like executing the <literal>RESET SLAVE</literal>
       <acronym>SQL</acronym> statement.
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-refresh-master">
+   <varlistentry xml:id="constant.mysqli-refresh-master">
     <term>
      <constant>MYSQLI_REFRESH_MASTER</constant>
      (<type>int</type>)
@@ -1040,7 +1040,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-trans-cor-and-chain">
+   <varlistentry xml:id="constant.mysqli-trans-cor-and-chain">
     <term>
      <constant>MYSQLI_TRANS_COR_AND_CHAIN</constant>
      (<type>int</type>)
@@ -1052,7 +1052,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-trans-cor-and-no-chain">
+   <varlistentry xml:id="constant.mysqli-trans-cor-and-no-chain">
     <term>
      <constant>MYSQLI_TRANS_COR_AND_NO_CHAIN</constant>
      (<type>int</type>)
@@ -1064,7 +1064,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-trans-cor-release">
+   <varlistentry xml:id="constant.mysqli-trans-cor-release">
     <term>
      <constant>MYSQLI_TRANS_COR_RELEASE</constant>
      (<type>int</type>)
@@ -1076,7 +1076,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-trans-cor-no-release">
+   <varlistentry xml:id="constant.mysqli-trans-cor-no-release">
     <term>
      <constant>MYSQLI_TRANS_COR_NO_RELEASE</constant>
      (<type>int</type>)
@@ -1088,7 +1088,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-trans-start-read-only">
+   <varlistentry xml:id="constant.mysqli-trans-start-read-only">
     <term>
      <constant>MYSQLI_TRANS_START_READ_ONLY</constant>
      (<type>int</type>)
@@ -1100,7 +1100,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-trans-start-read-write">
+   <varlistentry xml:id="constant.mysqli-trans-start-read-write">
     <term>
      <constant>MYSQLI_TRANS_START_READ_WRITE</constant>
      (<type>int</type>)
@@ -1112,7 +1112,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-trans-start-consistent-snapshot">
+   <varlistentry xml:id="constant.mysqli-trans-start-consistent-snapshot">
     <term><constant>MYSQLI_TRANS_START_CONSISTENT_SNAPSHOT</constant></term>
     <listitem>
      <para>
@@ -1121,7 +1121,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-client-ssl-dont-verify-server-cert">
+   <varlistentry xml:id="constant.mysqli-client-ssl-dont-verify-server-cert">
     <term>
      <constant>MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT</constant>
      (<type>int</type>)
@@ -1132,7 +1132,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constantmysqli-is-mariadb">
+   <varlistentry xml:id="constant.mysqli-is-mariadb">
     <term>
      <constant>MYSQLI_IS_MARIADB</constant>
      (<type>bool</type>)


### PR DESCRIPTION
Fix mysqli constant IDs so these can be linked to.

This update was done with using following bash script:

```bash
#!/bin/bash
\grep -lrE --include="*.xml" '"constantmysqli-' | xargs -d '\n' sed -i 's/"constantmysqli-/"constant.mysqli-/g'
\grep -lrE --include="*.xml" '"constant.mysqli-type-fload"' | xargs -d '\n' sed -i 's/"constant.mysqli-type-fload"/"constant.mysqli-type-float"/g'

```