### PR TITLE
Remove constant tag from literal values

### DIFF
--- a/appendices/filters.xml
+++ b/appendices/filters.xml
@@ -302,7 +302,7 @@ fclose($fp);
     <parameter>window</parameter> is the base-2 log of the compression loopback window size.
     Higher values (up to 15 -- 32768 bytes) yield better compression at a cost of memory,
     while lower values (down to 9 -- 512 bytes) yield worse compression in a smaller memory footprint.
-    Default <parameter>window</parameter> size is currently <constant>15</constant>.
+    Default <parameter>window</parameter> size is currently <literal>15</literal>.
 
     <parameter>memory</parameter> is a scale indicating how much work memory should be allocated.
     Valid values range from 1 (minimal allocation) to 9 (maximum allocation).  This memory allocation

--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -805,109 +805,109 @@
           <tbody>
            <row>
             <entry>
-             <constant>%C</constant>
+             <literal>%C</literal>
             </entry>
             <entry>%CPU</entry>
            </row>
            <row>
             <entry>
-             <constant>%d</constant>
+             <literal>%d</literal>
             </entry>
             <entry>duration µs</entry>
            </row>
            <row>
             <entry>
-             <constant>%e</constant>
+             <literal>%e</literal>
             </entry>
             <entry>fastcgi env</entry>
            </row>
            <row>
             <entry>
-             <constant>%f</constant>
+             <literal>%f</literal>
             </entry>
             <entry>script</entry>
            </row>
            <row>
             <entry>
-             <constant>%l</constant>
+             <literal>%l</literal>
             </entry>
             <entry>content length</entry>
            </row>
            <row>
             <entry>
-             <constant>%m</constant>
+             <literal>%m</literal>
             </entry>
             <entry>method</entry>
            </row>
            <row>
             <entry>
-             <constant>%M</constant>
+             <literal>%M</literal>
             </entry>
             <entry>memory</entry>
            </row>
            <row>
             <entry>
-             <constant>%n</constant>
+             <literal>%n</literal>
             </entry>
             <entry>pool name</entry>
            </row>
            <row>
             <entry>
-             <constant>%o</constant>
+             <literal>%o</literal>
             </entry>
             <entry>header output</entry>
            </row>
            <row>
             <entry>
-             <constant>%p</constant>
+             <literal>%p</literal>
             </entry>
             <entry>PID</entry>
            </row>
            <row>
             <entry>
-             <constant>%q</constant>
+             <literal>%q</literal>
             </entry>
             <entry>query string</entry>
            </row>
            <row>
             <entry>
-             <constant>%Q</constant>
+             <literal>%Q</literal>
             </entry>
             <entry>the glue between %q and %r</entry>
            </row>
            <row>
             <entry>
-             <constant>%r</constant>
+             <literal>%r</literal>
             </entry>
             <entry>request URI</entry>
            </row>
            <row>
             <entry>
-             <constant>%R</constant>
+             <literal>%R</literal>
             </entry>
             <entry>remote IP address</entry>
            </row>
            <row>
             <entry>
-             <constant>%s</constant>
+             <literal>%s</literal>
             </entry>
             <entry>status</entry>
            </row>
            <row>
             <entry>
-             <constant>%T</constant>
+             <literal>%T</literal>
             </entry>
             <entry>time</entry>
            </row>
            <row>
             <entry>
-             <constant>%t</constant>
+             <literal>%t</literal>
             </entry>
             <entry>time</entry>
            </row>
            <row>
             <entry>
-             <constant>%u</constant>
+             <literal>%u</literal>
             </entry>
             <entry>remote user</entry>
            </row>

--- a/reference/cubrid/cubridmysql/cubrid-real-escape-string.xml
+++ b/reference/cubrid/cubridmysql/cubrid-real-escape-string.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
     This function returns the escaped string version of the given string. It
-    will escape the following characters: <constant>'</constant>. 
+    will escape the following characters: <literal>'</literal>. 
 
     In general, single quotations are used to enclose character string. Double
     quotations may be used as well depending on the value of ansi_quotes,

--- a/reference/cubrid/cubridmysql/cubrid-real-escape-string.xml
+++ b/reference/cubrid/cubridmysql/cubrid-real-escape-string.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
     This function returns the escaped string version of the given string. It
-    will escape the following characters: <literal>'</literal>. 
+    will escape the following characters: <literal>'</literal>.
 
     In general, single quotations are used to enclose character string. Double
     quotations may be used as well depending on the value of ansi_quotes,

--- a/reference/dom/domattr.xml
+++ b/reference/dom/domattr.xml
@@ -120,8 +120,8 @@
       <note>
        <para>
         Note, XML entities are expanded upon setting a value.
-        Thus the <constant>&amp;</constant> character has a special meaning.
-        Setting <varname>value</varname> to itself will fail when <varname>value</varname> contains an <constant>&amp;</constant>.
+        Thus the <literal>&amp;</literal> character has a special meaning.
+        Setting <varname>value</varname> to itself will fail when <varname>value</varname> contains an <literal>&amp;</literal>.
         To avoid entity expansion, use <methodname>DOMElement::setAttribute</methodname> instead.
        </para>
       </note>

--- a/reference/eio/functions/eio-chmod.xml
+++ b/reference/eio/functions/eio-chmod.xml
@@ -43,7 +43,7 @@
     <term><parameter>mode</parameter></term>
     <listitem>
      <para>
-     The new permissions. E.g. <constant>0644</constant>.
+     The new permissions. E.g. <literal>0644</literal>.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/eio/functions/eio-poll.xml
+++ b/reference/eio/functions/eio-poll.xml
@@ -32,7 +32,7 @@
   &reftitle.returnvalues;
   <para>
   If any request invocation returns a non-zero value, returns that value.
-  Otherwise, it returns <constant>0</constant>.
+  Otherwise, it returns <literal>0</literal>.
   </para>
  </refsect1>
 

--- a/reference/ev/ev/depth.xml
+++ b/reference/ev/ev/depth.xml
@@ -23,9 +23,9 @@
    was exited normally, in other words, the recursion depth. Outside
    <methodname>Ev::run</methodname>
    , this number is
-   <constant>0</constant>
+   <literal>0</literal>
    . In a callback, this number is
-   <constant>1</constant>
+   <literal>1</literal>
    , unless
    <methodname>Ev::run</methodname>
    was invoked recursively (or from another thread), in which case it is

--- a/reference/ev/ev/run.xml
+++ b/reference/ev/ev/run.xml
@@ -63,7 +63,7 @@
         <tbody>
          <row>
           <entry>
-           <constant>0</constant>
+           <literal>0</literal>
           </entry>
           <entry>The default behavior described above</entry>
          </row>

--- a/reference/ev/evchild.xml
+++ b/reference/ev/evchild.xml
@@ -83,7 +83,7 @@
       <para>
        <emphasis>Readonly</emphasis>
        . The process ID this watcher watches out for, or
-       <constant>0</constant>
+       <literal>0</literal>
        , meaning any process ID.
       </para>
      </listitem>

--- a/reference/ev/evchild/construct.xml
+++ b/reference/ev/evchild/construct.xml
@@ -48,7 +48,7 @@
    if
    <parameter>pid</parameter>
    is
-   <constant>0</constant>
+   <literal>0</literal>
    ) has been received(a status change happens when the process terminates or
    is killed, or, when
    <parameter>trace</parameter>
@@ -105,7 +105,7 @@
      <para>
       Wait for status changes of process PID(or any process if PID is
       specified as
-      <constant>0</constant>
+      <literal>0</literal>
       ).
      </para>
     </listitem>

--- a/reference/ev/evloop.xml
+++ b/reference/ev/evloop.xml
@@ -146,7 +146,7 @@
      <listitem>
       <para>
        The number of pending watchers.
-       <constant>0</constant>
+       <literal>0</literal>
        indicates that there are no watchers pending.
       </para>
      </listitem>
@@ -179,10 +179,10 @@
        programs can usually benefit by setting the
        <varname>io_interval</varname>
        to a value near
-       <constant>0.1</constant>
+       <literal>0.1</literal>
        , which is often enough for interactive servers(not for games). It
        usually doesn't make much sense to set it to a lower value than
-       <constant>0.01</constant>
+       <literal>0.01</literal>
        , as this approaches the timing granularity of most systems.
       </para>
       <para>

--- a/reference/ev/evloop/run.xml
+++ b/reference/ev/evloop/run.xml
@@ -60,7 +60,7 @@
         <tbody>
          <row>
           <entry>
-           <constant>0</constant>
+           <literal>0</literal>
           </entry>
           <entry>The default behavior described above</entry>
          </row>

--- a/reference/ev/evperiodic.xml
+++ b/reference/ev/evperiodic.xml
@@ -30,13 +30,13 @@
     (e.g.
     <methodname>EvLoop::now</methodname>
     +
-    <constant>10.0</constant>
+    <literal>10.0</literal>
     , i.e. an absolute time, not a delay), and the system clock is reset to
     <emphasis>January of the previous year</emphasis>
     , then it will take a year or more to trigger the event (unlike an
     <classname>EvTimer</classname>
     , which would still trigger roughly
-    <constant>10</constant>
+    <literal>10</literal>
     seconds after starting it as it uses a relative timeout).
    </para>
    <para>

--- a/reference/ev/evstat.xml
+++ b/reference/ev/evstat.xml
@@ -19,16 +19,16 @@
     The path does not need to exist: changing from "path exists" to "path does
     not exist" is a status change like any other. The condition "path does not
     exist" is signified by the
-    <constant>'nlink'</constant>
+    <literal>'nlink'</literal>
     item being 0(returned by
     <methodname>EvStat::attr</methodname>
     method).
    </para>
    <para>
     The path must not end in a slash or contain special components such as
-    <constant>'.'</constant>
+    <literal>'.'</literal>
     or
-    <constant>..</constant>
+    <literal>..</literal>
     . The path should be absolute: if it is relative and the working directory
     changes, then the behaviour is undefined.
    </para>
@@ -39,13 +39,13 @@
     regularly on the path to see if it changed somehow. For this case a
     recommended polling interval can be specified. If one specifies a polling
     interval of
-    <constant>0.0</constant>
+    <literal>0.0</literal>
     (highly recommended) then a suitable, unspecified default value will be
     used(which could be expected to be around 5 seconds, although this might
     change dynamically).
     <emphasis>libev</emphasis>
     will also impose a minimum interval which is currently around
-    <constant>0.1</constant>
+    <literal>0.1</literal>
     , but that’s usually overkill.
    </para>
    <para>
@@ -107,7 +107,7 @@
        <emphasis>Readonly</emphasis>
        . Hint on how quickly a change is expected to be detected and should
        normally be specified as
-       <constant>0.0</constant>
+       <literal>0.0</literal>
        to let
        <emphasis>libev</emphasis>
        choose a suitable value.

--- a/reference/ev/evstat/attr.xml
+++ b/reference/ev/evstat/attr.xml
@@ -41,79 +41,79 @@
      <tbody>
       <row>
        <entry>
-        <constant>'dev'</constant>
+        <literal>'dev'</literal>
        </entry>
        <entry>ID of device containing file</entry>
       </row>
       <row>
        <entry>
-        <constant>'ino'</constant>
+        <literal>'ino'</literal>
        </entry>
        <entry>inode number</entry>
       </row>
       <row>
        <entry>
-        <constant>'mode'</constant>
+        <literal>'mode'</literal>
        </entry>
        <entry>protection</entry>
       </row>
       <row>
        <entry>
-        <constant>'nlink'</constant>
+        <literal>'nlink'</literal>
        </entry>
        <entry>number of hard links</entry>
       </row>
       <row>
        <entry>
-        <constant>'uid'</constant>
+        <literal>'uid'</literal>
        </entry>
        <entry>user ID of owner</entry>
       </row>
       <row>
        <entry>
-        <constant>'size'</constant>
+        <literal>'size'</literal>
        </entry>
        <entry>total size, in bytes</entry>
       </row>
       <row>
        <entry>
-        <constant>'gid'</constant>
+        <literal>'gid'</literal>
        </entry>
        <entry>group ID of owner</entry>
       </row>
       <row>
        <entry>
-        <constant>'rdev'</constant>
+        <literal>'rdev'</literal>
        </entry>
        <entry>device ID (if special file)</entry>
       </row>
       <row>
        <entry>
-        <constant>'blksize'</constant>
+        <literal>'blksize'</literal>
        </entry>
        <entry>blocksize for file system I/O</entry>
       </row>
       <row>
        <entry>
-        <constant>'blocks'</constant>
+        <literal>'blocks'</literal>
        </entry>
        <entry>number of 512B blocks allocated</entry>
       </row>
       <row>
        <entry>
-        <constant>'atime'</constant>
+        <literal>'atime'</literal>
        </entry>
        <entry>time of last access</entry>
       </row>
       <row>
        <entry>
-        <constant>'ctime'</constant>
+        <literal>'ctime'</literal>
        </entry>
        <entry>time of last status change</entry>
       </row>
       <row>
        <entry>
-        <constant>'mtime'</constant>
+        <literal>'mtime'</literal>
        </entry>
        <entry>time of last modification</entry>
       </row>

--- a/reference/ev/evstat/construct.xml
+++ b/reference/ev/evstat/construct.xml
@@ -60,7 +60,7 @@
      <para>
       Hint on how quickly a change is expected to be detected and should
       normally be specified as
-      <constant>0.0</constant>
+      <literal>0.0</literal>
       to let
       <emphasis>libev</emphasis>
       choose a suitable value.

--- a/reference/ev/evstat/createstopped.xml
+++ b/reference/ev/evstat/createstopped.xml
@@ -66,7 +66,7 @@
      <para>
       Hint on how quickly a change is expected to be detected and should
       normally be specified as
-      <constant>0.0</constant>
+      <literal>0.0</literal>
       to let
       <emphasis>libev</emphasis>
       choose a suitable value.

--- a/reference/ev/evstat/set.xml
+++ b/reference/ev/evstat/set.xml
@@ -45,7 +45,7 @@
      <para>
       Hint on how quickly a change is expected to be detected and should
       normally be specified as
-      <constant>0.0</constant>
+      <literal>0.0</literal>
       to let
       <emphasis>libev</emphasis>
       choose a suitable value.

--- a/reference/ev/evtimer.xml
+++ b/reference/ev/evtimer.xml
@@ -32,12 +32,12 @@
    <para>
     The timer itself will do a best-effort at avoiding drift, that is, if a
     timer is configured to trigger every
-    <constant>10</constant>
+    <literal>10</literal>
     seconds, then it will normally trigger at exactly
-    <constant>10</constant>
+    <literal>10</literal>
     second intervals. If, however, the script cannot keep up with the timer
     because it takes longer than those
-    <constant>10</constant>
+    <literal>10</literal>
     seconds to do) the timer will not fire more than once per event loop
     iteration.
    </para>
@@ -92,7 +92,7 @@
      <listitem>
       <para>
        If repeat is
-       <constant>0.0</constant>
+       <literal>0.0</literal>
        , then it will automatically be stopped once the timeout is reached. If
        it is positive, then the timer will automatically be configured to
        trigger again every repeat seconds later, until stopped manually.
@@ -115,21 +115,21 @@
        with an
        <parameter>after</parameter>
        value of
-       <constant>5.0</constant>
+       <literal>5.0</literal>
        and
        <parameter>repeat</parameter>
        value of
-       <constant>7.0</constant>
+       <literal>7.0</literal>
        ,
        <varname>remaining</varname>
        returns
-       <constant>5.0</constant>
+       <literal>5.0</literal>
        . When the timer is started and one second passes,
        <varname>remaining</varname>
        will return
-       <constant>4.0</constant>
+       <literal>4.0</literal>
        . When the timer expires and is restarted, it will return roughly
-       <constant>7.0</constant>
+       <literal>7.0</literal>
        (likely slightly less as callback invocation takes some time too), and
        so on.
       </para>

--- a/reference/ev/evtimer/construct.xml
+++ b/reference/ev/evtimer/construct.xml
@@ -61,7 +61,7 @@
     <listitem>
      <para>
       If repeat is
-      <constant>0.0</constant>
+      <literal>0.0</literal>
       , then it will automatically be stopped once the timeout is reached. If
       it is positive, then the timer will automatically be configured to
       trigger again every repeat seconds later, until stopped manually.

--- a/reference/ev/evtimer/createstopped.xml
+++ b/reference/ev/evtimer/createstopped.xml
@@ -66,7 +66,7 @@
     <listitem>
      <para>
       If repeat is
-      <constant>0.0</constant>
+      <literal>0.0</literal>
       , then it will automatically be stopped once the timeout is reached. If
       it is positive, then the timer will automatically be configured to
       trigger again every repeat seconds later, until stopped manually.

--- a/reference/ev/evtimer/set.xml
+++ b/reference/ev/evtimer/set.xml
@@ -46,7 +46,7 @@
     <listitem>
      <para>
       If repeat is
-      <constant>0.0</constant>
+      <literal>0.0</literal>
       , then it will automatically be stopped once the timeout is reached. If
       it is positive, then the timer will automatically be configured to
       trigger again every repeat seconds later, until stopped manually.

--- a/reference/ev/evwatcher/clear.xml
+++ b/reference/ev/evwatcher/clear.xml
@@ -20,7 +20,7 @@
    <varname>revents</varname>
    bitset(as if its callback was invoked). If the watcher isn&apos;t pending
    it does nothing and returns
-   <constant>0</constant>
+   <literal>0</literal>
    .
   </para>
   <para>
@@ -41,7 +41,7 @@
    <link
   linkend="ev.watcher-callbacks">watcher callback</link>
    had been invoked. Otherwise returns
-   <constant>0</constant>
+   <literal>0</literal>
    .
   </para>
  </refsect1>

--- a/reference/ev/periodic-modes.xml
+++ b/reference/ev/periodic-modes.xml
@@ -19,7 +19,7 @@
     . In this mode
     <parameter>interval</parameter>
     =
-    <constant>0</constant>
+    <literal>0</literal>
     ,
     <parameter>reschedule_cb</parameter>
     = &null;. This time simply fires at the wallclock time
@@ -37,7 +37,7 @@
     . In this mode
     <parameter>interval</parameter>
     &gt;
-    <constant>0</constant>
+    <literal>0</literal>
     ,
     <parameter>reschedule_cb</parameter>
     = &null;; the watcher will always be scheduled to timeout at the next
@@ -63,7 +63,7 @@ $hourly = EvPeriodic(0, 3600, NULL, function () {
 ]]>
     </programlisting>
     That doesn't mean there will always be
-    <constant>3600</constant>
+    <literal>3600</literal>
     seconds in between triggers, but only that the callback will be called
     when the system time shows a full hour(
     <emphasis>UTC</emphasis>
@@ -106,7 +106,7 @@ $hourly = EvPeriodic(0, 3600, NULL, function () {
     stop or destroy this or any other periodic watchers, ever, and
     <emphasis>must not</emphasis>
     call any event loop functions or methods. To stop it return
-    <constant>1e30</constant>
+    <literal>1e30</literal>
     and stop it afterwards. An
     <classname>EvPrepare</classname>
     watcher may be used for this task.

--- a/reference/event/eventbuffer.xml
+++ b/reference/event/eventbuffer.xml
@@ -164,8 +164,8 @@
        linefeed. (This is also known as
        <literal>"\r\n"</literal>
        . The ASCII values are
-       <constant>0x0D</constant>
-       <constant>0x0A</constant>
+       <literal>0x0D</literal>
+       <literal>0x0A</literal>
        ).
       </para>
      </listitem>
@@ -180,7 +180,7 @@
        as
        <literal>"\n"</literal>
        . It is ASCII value is
-       <constant>0x0A</constant>
+       <literal>0x0A</literal>
        .)
       </para>
      </listitem>

--- a/reference/event/eventbufferevent/construct.xml
+++ b/reference/event/eventbufferevent/construct.xml
@@ -95,7 +95,7 @@
       <link linkend="eventbufferevent.constants">EventBufferEvent::OPT_*
      constants</link>
       , or
-      <constant>0</constant>
+      <literal>0</literal>
       .
      </para>
     </listitem>

--- a/reference/event/eventbufferevent/setwatermark.xml
+++ b/reference/event/eventbufferevent/setwatermark.xml
@@ -72,7 +72,7 @@
     <listitem>
      <para>
       Maximum watermark value.
-      <constant>0</constant>
+      <literal>0</literal>
       means "unlimited".
      </para>
     </listitem>

--- a/reference/event/eventconfig/setmaxdispatchinterval.xml
+++ b/reference/event/eventconfig/setmaxdispatchinterval.xml
@@ -47,7 +47,7 @@
      <para>
       An interval after which Libevent should stop running callbacks and check
       for more events, or
-      <constant>0</constant>
+      <literal>0</literal>
       , if there should be no such interval.
      </para>
     </listitem>
@@ -76,11 +76,11 @@
       and
       <parameter>max_callbacks</parameter>
       should not be enforced. If this is set to
-      <constant>0</constant>
+      <literal>0</literal>
       , they are enforced for events of every priority; if it&apos;s set to
-      <constant>1</constant>
+      <literal>1</literal>
       , they&apos;re enforced for events of priority
-      <constant>1</constant>
+      <literal>1</literal>
       and above, and so on.
      </para>
     </listitem>

--- a/reference/event/eventdnsbase/parseresolvconf.xml
+++ b/reference/event/eventdnsbase/parseresolvconf.xml
@@ -49,17 +49,17 @@
       If this function encounters an error, the possible return values are:
       <simplelist>
        <member>
-        <constant>1</constant> = failed to open file</member>
+        <literal>1</literal> = failed to open file</member>
        <member>
-        <constant>2</constant> = failed to stat file</member>
+        <literal>2</literal> = failed to stat file</member>
        <member>
-        <constant>3</constant> = file too large</member>
+        <literal>3</literal> = file too large</member>
        <member>
-        <constant>4</constant> = out of memory</member>
+        <literal>4</literal> = out of memory</member>
        <member>
-        <constant>5</constant> = short read from file</member>
+        <literal>5</literal> = short read from file</member>
        <member>
-        <constant>6</constant> = no nameservers listed in the file</member>
+        <literal>6</literal> = no nameservers listed in the file</member>
       </simplelist>
      </para>
     </listitem>

--- a/reference/event/eventdnsbase/setsearchndots.xml
+++ b/reference/event/eventdnsbase/setsearchndots.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <para>
    Set the
-   <constant>'ndots'</constant>
+   <parameter>'ndots'</parameter>
    parameter for searches. Sets the number of dots which, when found in a
    name, causes the first query to be without any search domain.
   </para>

--- a/reference/event/eventutil.xml
+++ b/reference/event/eventutil.xml
@@ -223,7 +223,7 @@
        the
        <literal>CAP_NET_ADMIN</literal>
        capability or an effective user ID of
-       <constant>0</constant>
+       <literal>0</literal>
        . (Added in event-1.6.0.)
       </para>
      </listitem>

--- a/reference/filesystem/functions/stat.xml
+++ b/reference/filesystem/functions/stat.xml
@@ -166,38 +166,38 @@
      </thead>
      <tbody>
       <row>
-       <entry><constant>0140000</constant></entry>
+       <entry><literal>0140000</literal></entry>
        <entry>socket</entry>
       </row>
       <row>
-       <entry><constant>0120000</constant></entry>
+       <entry><literal>0120000</literal></entry>
        <entry>link</entry>
       </row>
       <row>
-       <entry><constant>0100000</constant></entry>
+       <entry><literal>0100000</literal></entry>
        <entry>regular file</entry>
       </row>
       <row>
-       <entry><constant>0060000</constant></entry>
+       <entry><literal>0060000</literal></entry>
        <entry>block device</entry>
       </row>
       <row>
-       <entry><constant>0040000</constant></entry>
+       <entry><literal>0040000</literal></entry>
        <entry>directory</entry>
       </row>
       <row>
-       <entry><constant>0020000</constant></entry>
+       <entry><literal>0020000</literal></entry>
        <entry>character device</entry>
       </row>
       <row>
-       <entry><constant>0010000</constant></entry>
+       <entry><literal>0010000</literal></entry>
        <entry>fifo</entry>
       </row>
      </tbody>
     </tgroup>
    </table>
-   So for example a regular file could be <constant>0100644</constant> and a directory could be
-   <constant>0040755</constant>.
+   So for example a regular file could be <literal>0100644</literal> and a directory could be
+   <literal>0040755</literal>.
   </para>
   <para>
    In case of error, <function>stat</function> returns &false;.

--- a/reference/imagick/imagickpixel/getcolor.xml
+++ b/reference/imagick/imagickpixel/getcolor.xml
@@ -44,7 +44,7 @@
         <tbody>
          <row>
           <entry>
-           <constant>0</constant>
+           <literal>0</literal>
           </entry>
           <entry>
            The RGB values are returned as <type>int</type>s in the range <literal>0</literal>
@@ -55,7 +55,7 @@
          </row>
          <row>
           <entry>
-           <constant>1</constant>
+           <literal>1</literal>
           </entry>
           <entry>
            The RGBA values are returned as <type>float</type>s in the range <literal>0</literal>
@@ -64,7 +64,7 @@
          </row>
          <row>
           <entry>
-           <constant>2</constant>
+           <literal>2</literal>
           </entry>
           <entry>
            The RGBA values are returned as <type>int</type>s in the range <literal>0</literal>

--- a/reference/intl/intlcalendar.xml
+++ b/reference/intl/intlcalendar.xml
@@ -357,8 +357,8 @@
      <listitem>
       <para>
        Calendar field for the day of the year. For the Gregorian calendar,
-       starts with <constant>1</constant> and ends with
-       <constant>365</constant> or <constant>366</constant>.
+       starts with <literal>1</literal> and ends with
+       <literal>365</literal> or <literal>366</literal>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mcrypt/constants.xml
+++ b/reference/mcrypt/constants.xml
@@ -67,12 +67,12 @@
   <itemizedlist>
    <listitem>
     <simpara>
-     <constant>"ctr"</constant> (<literal>counter mode</literal>) is a stream cipher mode.
+     <literal>"ctr"</literal> (<literal>counter mode</literal>) is a stream cipher mode.
     </simpara>
    </listitem>
    <listitem>
     <simpara>
-     <constant>"ncfb"</constant> (<literal>cipher feedback,
+     <literal>"ncfb"</literal> (<literal>cipher feedback,
      in n-bit mode</literal>) is comparable to <literal>CFB</literal> mode, 
      but operates on the full block size of the algorithm.
     </simpara>

--- a/reference/mongodb/bson/packedarray/fromphp.xml
+++ b/reference/mongodb/bson/packedarray/fromphp.xml
@@ -23,7 +23,7 @@
     <listitem>
      <para>
       The PHP array to convert to a BSON array. The array must be a list (i.e.
-      have sequential numeric keys starting with <constant>0</constant>).
+      have sequential numeric keys starting with <literal>0</literal>).
      </para>
     </listitem>
    </varlistentry>
@@ -34,7 +34,7 @@
   &reftitle.errors;
   <simplelist>
    &mongodb.throws.argumentparsing;
-   <member>Throws <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> if the given array is not a list (i.e. has sequential numeric keys starting with <constant>0</constant>).</member>
+   <member>Throws <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> if the given array is not a list (i.e. has sequential numeric keys starting with <literal>0</literal>).</member>
   </simplelist>
  </refsect1>
 

--- a/reference/oci8/functions/oci-set-prefetch.xml
+++ b/reference/oci8/functions/oci-set-prefetch.xml
@@ -178,10 +178,10 @@ oci_close($conn);
   <para>
    If PHP OCI8 fetches from a REF CURSOR and then passes the REF
    CURSOR back to a second PL/SQL procedure for further processing,
-   then set the REF CURSOR prefetch count to <constant>0</constant> to
+   then set the REF CURSOR prefetch count to <literal>0</literal> to
    avoid rows being "lost" from the result set.  The prefetch value is
    the number of extra rows fetched in each OCI8 internal request to
-   the database, so setting it to <constant>0</constant> means only
+   the database, so setting it to <literal>0</literal> means only
    fetch one row at a time.
    <example>
     <title>Setting the prefetch value when passing a REF CURSOR back to Oracle</title>

--- a/reference/oci8/taf.xml
+++ b/reference/oci8/taf.xml
@@ -214,7 +214,7 @@
        <itemizedlist>
         <listitem>
          <para>
-          <constant>0</constant> indicates the failover
+          <literal>0</literal> indicates the failover
           steps should continue normally.
          </para>
         </listitem>

--- a/reference/sockets/functions/socket-read.xml
+++ b/reference/sockets/functions/socket-read.xml
@@ -41,8 +41,8 @@
       <para>
        The maximum number of bytes read is specified by the
        <parameter>length</parameter> parameter. Otherwise you can use
-       <constant>\r</constant>, <constant>\n</constant>,
-       or <constant>\0</constant> to end reading (depending on the <parameter>mode</parameter>
+       <literal>\r</literal>, <literal>\n</literal>,
+       or <literal>\0</literal> to end reading (depending on the <parameter>mode</parameter>
        parameter, see below).
       </para>
      </listitem>

--- a/reference/stream/streamwrapper/url-stat.xml
+++ b/reference/stream/streamwrapper/url-stat.xml
@@ -120,7 +120,7 @@
   <para>
    Should return an &array; with the same elements as <function>stat</function> does.
    Unknown or unavailable values should be set to a rational value
-   (usually <constant>0</constant>). Special attention should be payed to
+   (usually <literal>0</literal>). Special attention should be payed to
    <literal>mode</literal> as documented under <function>stat</function>.
    Should return &false; on failure.
   </para>


### PR DESCRIPTION
Replace `<constant>` tags with `<literal>` tags for literals which are mostly one of the following:

 - strings
 - format placeholders
 - array keys
 - numbers (integers, floats, hexadecimals and numers using scientific (e) notation)
