### PR TITLE
Replace constant with literal tags for IBM DB2 options

### DIFF
--- a/reference/ibm_db2/ini.xml
+++ b/reference/ibm_db2/ini.xml
@@ -397,11 +397,11 @@
       Controls the job sort option on IBM i.
       By default, this option is <literal>0</literal>.
       This corresponds to the IBM i SQL/CLI
-      <constant>SQL_ATTR_CONN_SORT_SEQUENCE</constant> attribute.
+      <literal>SQL_ATTR_CONN_SORT_SEQUENCE</literal> attribute.
       <itemizedlist>
        <listitem>
         <para>
-         0 - Uses the <constant>*HEX</constant> sort option, sorting by bytes.
+         0 - Uses the <literal>*HEX</literal> sort option, sorting by bytes.
         </para>
        </listitem>
        <listitem>


### PR DESCRIPTION
These are not constants but IBM DB2 options that are not exposed to PHP userland in any way. 

These changes were made with the following bash script:

```bash
#!/bin/bash
sed -i -E 's/<constant>(\*HEX)<\/constant>/<literal>\1<\/literal>/g' reference/ibm_db2/ini.xml
sed -i -E 's/<constant>(SQL_ATTR_CONN_SORT_SEQUENCE)<\/constant>/<literal>\1<\/literal>/g' reference/ibm_db2/ini.xml

```