### PR TITLE
Remove links from within constant tags

### DIFF
--- a/appendices/migration72/constants.xml
+++ b/appendices/migration72/constants.xml
@@ -147,7 +147,7 @@
   <itemizedlist>
    <listitem>
     <simpara>
-     <constant><link linkend="constant.preg-unmatched-as-null">PREG_UNMATCHED_AS_NULL</link></constant>
+     <constant>PREG_UNMATCHED_AS_NULL</constant>
     </simpara>
    </listitem>
   </itemizedlist>

--- a/reference/simplexml/simplexmlelement/construct.xml
+++ b/reference/simplexml/simplexmlelement/construct.xml
@@ -45,7 +45,7 @@
       </para>
       <note>
        <para>
-        It may be necessary to pass <constant><link linkend="constant.libxml-parsehuge">LIBXML_PARSEHUGE</link></constant>
+        It may be necessary to pass <constant>LIBXML_PARSEHUGE</constant>
         to be able to process deeply nested XML or very large text nodes.
        </para>
       </note>

--- a/reference/zip/ziparchive/close.xml
+++ b/reference/zip/ziparchive/close.xml
@@ -18,7 +18,7 @@
   <para>
    If the archive contains no files, the file is completely removed by default
    (no empty archive is written) according to the value of the
-   <constant><link linkend="ziparchive.constants.afl-create-or-keep-file-for-empty-archive">ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</link></constant>
+   <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
    global flag.
   </para>
  </refsect1>

--- a/reference/zip/ziparchive/getarchiveflag.xml
+++ b/reference/zip/ziparchive/getarchiveflag.xml
@@ -29,22 +29,22 @@
        <itemizedlist>
         <listitem>
          <para>
-          <constant><link linkend="ziparchive.constants.afl-rdonly">ZipArchive::AFL_RDONLY</link></constant>
+          <constant>ZipArchive::AFL_RDONLY</constant>
          </para>
         </listitem>
         <listitem>
          <para>
-          <constant><link linkend="ziparchive.constants.afl-is-torrentzip">ZipArchive::AFL_IS_TORRENTZIP</link></constant>
+          <constant>ZipArchive::AFL_IS_TORRENTZIP</constant>
          </para>
         </listitem>
         <listitem>
          <para>
-          <constant><link linkend="ziparchive.constants.afl-want-torrentzip">ZipArchive::AFL_WANT_TORRENTZIP</link></constant>
+          <constant>ZipArchive::AFL_WANT_TORRENTZIP</constant>
          </para>
         </listitem>
         <listitem>
          <para>
-          <constant><link linkend="ziparchive.constants.afl-create-or-keep-file-for-empty-archive">ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</link></constant>
+          <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
          </para>
         </listitem>
        </itemizedlist>

--- a/reference/zip/ziparchive/open.xml
+++ b/reference/zip/ziparchive/open.xml
@@ -39,27 +39,27 @@
        <itemizedlist>
         <listitem>
          <para>
-          <constant><link linkend="ziparchive.constants.overwrite">ZipArchive::OVERWRITE</link></constant>
+          <constant>ZipArchive::OVERWRITE</constant>
          </para>
         </listitem>
         <listitem>
          <para>
-          <constant><link linkend="ziparchive.constants.create">ZipArchive::CREATE</link></constant>
+          <constant>ZipArchive::CREATE</constant>
          </para>
         </listitem>
         <listitem>
          <para>
-          <constant><link linkend="ziparchive.constants.rdonly">ZipArchive::RDONLY</link></constant>
+          <constant>ZipArchive::RDONLY</constant>
          </para>
         </listitem>
         <listitem>
          <para>
-          <constant><link linkend="ziparchive.constants.excl">ZipArchive::EXCL</link></constant>
+          <constant>ZipArchive::EXCL</constant>
          </para>
         </listitem>
         <listitem>
          <para>
-          <constant><link linkend="ziparchive.constants.checkcons">ZipArchive::CHECKCONS</link></constant>
+          <constant>ZipArchive::CHECKCONS</constant>
          </para>
         </listitem>
        </itemizedlist>

--- a/reference/zip/ziparchive/setarchiveflag.xml
+++ b/reference/zip/ziparchive/setarchiveflag.xml
@@ -28,12 +28,12 @@
        <itemizedlist>
         <listitem>
          <para>
-          <constant><link linkend="ziparchive.constants.afl-want-torrentzip">ZipArchive::AFL_WANT_TORRENTZIP</link></constant>
+          <constant>ZipArchive::AFL_WANT_TORRENTZIP</constant>
          </para>
         </listitem>
         <listitem>
          <para>
-          <constant><link linkend="ziparchive.constants.afl-create-or-keep-file-for-empty-archive">ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</link></constant>
+          <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
          </para>
         </listitem>
        </itemizedlist>


### PR DESCRIPTION
This makes it easier to programmatically/manually cross-reference the contents of `<constant>` tags with constant IDs.

_Edit:_
Links are not needed for constants anymore as these are now rendered by Phd.