### PR TITLE
construct.xml: fiexed the example's syntax and amend the function arg

### DIFF
--- a/reference/reflection/reflectionproperty/construct.xml
+++ b/reference/reflection/reflectionproperty/construct.xml
@@ -55,6 +55,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+
 class Str
 {
     public $length  = 5;
@@ -73,7 +74,7 @@ printf(
         $prop->isStatic() ? ' static' : '',
         $prop->getName(),
         $prop->isDefault() ? 'declared at compile-time' : 'created at run-time',
-        var_export(Reflection::getModifierNames($prop->getModifiers()), 1)
+        var_export(Reflection::getModifierNames($prop->getModifiers()), true)
 );
 
 // Create an instance of Str
@@ -90,6 +91,7 @@ var_dump($prop->getValue($obj));
 
 // Dump object
 var_dump($obj);
+
 ?>
 ]]>
     </programlisting>
@@ -115,7 +117,8 @@ object(Str)#2 (1) {
 <![CDATA[
 <?php
 
-class Foo {
+class Foo
+{
     public $x = 1;
     protected $y = 2;
     private $z = 3;


### PR DESCRIPTION
In strict mode: 

> Fatal error: Uncaught TypeError: var_export(): Argument #2 ($return) must be of type bool, int given