### PR TITLE
Update getmxrr.xml: Change argument name: `weight` -> `preference`

### DIFF
--- a/reference/network/functions/getmxrr.xml
+++ b/reference/network/functions/getmxrr.xml
@@ -12,7 +12,7 @@
    <type>bool</type><methodname>getmxrr</methodname>
    <methodparam><type>string</type><parameter>hostname</parameter></methodparam>
    <methodparam><type>array</type><parameter role="reference">hosts</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter role="reference">weights</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">preferences</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Searches DNS for MX records corresponding to 


### PR DESCRIPTION
Page: https://www.php.net/manual/en/function.getmxrr.php

I'm suggesting to rename the argument to "preferences", since this is the term that the RFC uses: https://datatracker.ietf.org/doc/html/rfc5321#section-5.1

> MX records contain a preference indication that MUST be used in
   sorting if more than one such record appears (see below).  Lower
   numbers are more preferred than higher ones.

Waiting for feedback before finishing...