### PR TITLE
Fix GH-3160: sodium_crypto_pwhash misleading $salt length requirement

### DIFF
--- a/reference/sodium/functions/sodium-crypto-pwhash.xml
+++ b/reference/sodium/functions/sodium-crypto-pwhash.xml
@@ -49,7 +49,7 @@
     <term><parameter>salt</parameter></term>
     <listitem>
      <para>
-      A salt to add to the password before hashing. The salt should be unpredictable, ideally generated from a good random number source such as <function>random_bytes</function>, and have a length of at least <constant>SODIUM_CRYPTO_PWHASH_SALTBYTES</constant> bytes.
+      A salt to add to the password before hashing. The salt should be unpredictable, ideally generated from a good random number source such as <function>random_bytes</function>, and have a length of exactly <constant>SODIUM_CRYPTO_PWHASH_SALTBYTES</constant> bytes.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Code requires the length to be exactly, not at least, this amount of bytes.