### PR TITLE
pattern.modifiers.xml: include parenthesis within literals sequence

### DIFF
--- a/reference/pcre/pattern.modifiers.xml
+++ b/reference/pcre/pattern.modifiers.xml
@@ -122,7 +122,7 @@
         This modifier inverts the "greediness" of the quantifiers so
         that they are not greedy by default, but become greedy if
         followed by <literal>?</literal>. It is not compatible with Perl. It can also
-        be set by a (<literal>?U</literal>)
+        be set by a <literal>(?U)</literal>
         <link linkend="regexp.reference.internal-options">modifier setting within
         the pattern</link> or by a question mark behind a quantifier (e.g.
         <literal>.*?</literal>).


### PR DESCRIPTION
The parentheses must be included into the literals sequence, as described in https://www.php.net/manual/en/regexp.reference.internal-options.php

```
<?php

declare(strict_types = 1);


preg_match_all(
	pattern: '~
	?U".*" # It is wrong without parenthesis
	~x',
	subject: '"Bob" and "Alice"',
	matches: $matches,
);

print_r($matches);

```

And correct with:

```
<?php

declare(strict_types = 1);


preg_match_all(
	pattern: '~
	(?U)".*" # Find each word in quotes
	~x',
	subject: '"Bob" and "Alice"',
	matches: $matches,
);

print_r($matches);

```