### PR TITLE
basic.xml: It is not possible to create an object with a string containing the name of the class

### DIFF
--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -204,7 +204,7 @@ readonly class Foo
     requirement).
    </para>
    <para>
-    If a <type>string</type> containing the name of a class is used with
+    If a variable containing a <type>string</type> with the name of a class is used with
     <literal>new</literal>, a new instance of that class will be created. If
     the class is in a namespace, its fully qualified name must be used when
     doing this.


### PR DESCRIPTION
 **Wrong example**

```
<php

class Foo {}

new
	// This is a string containing the name of a class
	'Foo'
; // Parse error: syntax error, unexpected single-quoted string "Foo"

?>
```

**Correct example**

```
<?php

class Foo {}

$foo = 'Foo';

new
	// This is a variable (!) containing a string with the name of class
	$foo
; // OK

?>
```