### PR TITLE
fix: document BC on count function in PHP 8.0

### DIFF
--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -310,6 +310,10 @@ function test(int $arg = null) {}
         Passing the wrong number of arguments to a non-variadic built-in
         function will throw an <classname>ArgumentCountError</classname>.
        </member>
+       <member>
+        Passing invalid countable types to <function>count</function> will throw
+        a <classname>TypeError</classname>.
+       </member>
       </simplelist>
      </para>
      <para>


### PR DESCRIPTION
[count](https://www.php.net/manual/en/function.count) provides information about its BC, but [migration documentation](https://www.php.net/manual/en/migration80.incompatible.php) does not.
