### PR TITLE
Clarify usage of Iterator::valid methods

### DIFF
--- a/reference/spl/emptyiterator/valid.xml
+++ b/reference/spl/emptyiterator/valid.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="emptyiterator.valid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EmptyIterator::valid</refname>
-  <refpurpose>The valid() method</refpurpose>
+  <refpurpose>Checks whether the current element is valid</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,11 +13,14 @@
    <void/>
   </methodsynopsis>
   <para>
-   The EmptyIterator valid() method.
+   Checks whether the current element is valid.
   </para>
-
-  &warn.undocumented.func;
-
+  <note>
+   <para>
+    The <classname>EmptyIterator</classname> is always empty and will never have a valid value.
+    The return value is always &false;.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/spl/filteriterator/valid.xml
+++ b/reference/spl/filteriterator/valid.xml
@@ -13,11 +13,15 @@
    <void/>
   </methodsynopsis>
 
-   &warn.undocumented.func;
-
   <para>
    Checks whether the current element is valid.
   </para>
+  <note>
+   <para>
+    The standard implementation of this function will initially return &false;
+    until the inner iterator is advanced to the first accepted element.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/spl/iteratoriterator/valid.xml
+++ b/reference/spl/iteratoriterator/valid.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="iteratoriterator.valid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IteratorIterator::valid</refname>
-  <refpurpose>Checks if the iterator is valid</refpurpose>
+  <refpurpose>Checks if the current element is valid</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,7 +13,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Checks if the iterator is valid.
+   Checks whether the current element is valid.
   </para>
  </refsect1>
 
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns &true; if the iterator is valid, otherwise &false;
+   Returns &true; if the current element is valid, otherwise &false;
   </para>
  </refsect1>
 


### PR DESCRIPTION
This commit updates the documentation for the `valid` method of the following iterators:

- `EmptyIterator` - add a note that this will always return false
- `FilterIterator` - add a note that the value will be false until the pointer is advanced to the first valid element
- `IteratorIterator` - clarify that the method checks if the element is valid.

These now match the source.

I have checked other iterators and these seem to be correctly documented.

It's worth noting that the `ArrayIterator::valid` method behaves differently - it checks if the next element is valid (confirmed in source).

The `DirectoryIterator::valid` method may also be incorrectly documented but I am not 100% sure of this. The documentation states that the method checks if it is a valid _file_, but I believe that the method checks if the Iterator element is valid. However, given the DirectoryIterator should only Iterator over files in the first place, this is arguably correct.