### PR TITLE
Add implicit nullability deprecation note to functions.xml

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -439,8 +439,8 @@ Making a bowl of raspberry natural yogurt.
      dropping the default value, since it will never be used.
      One exception to this rule are arguments of the form
      <code>Type $param = null</code>, where the &null; default makes the type implicitly
-     nullable. This usage remains allowed, though it is recommended to use an
-     explicit <link linkend="language.types.declarations.nullable">nullable type</link> instead.
+     nullable. This usage is deprecatd as of PHP 8.4.0. It is recommended to use an explicit
+     <link linkend="language.types.declarations.nullable">nullable type</link> instead.
      <example>
       <title>Declaring optional arguments after mandatory arguments</title>
       <programlisting role="php">
@@ -449,7 +449,7 @@ Making a bowl of raspberry natural yogurt.
  function foo($a = [], $b) {} // Default not used; deprecated as of PHP 8.0.0
  function foo($a, $b) {}      // Functionally equivalent, no deprecation notice
 
- function bar(A $a = null, $b) {} // Still allowed; $a is required but nullable
+ function bar(A $a = null, $b) {} // Deprecated as of PHP 8.4.0; $a is required but nullable
  function bar(?A $a, $b) {}       // Recommended
  ?>
  ]]>


### PR DESCRIPTION
Found this piece of documentation about implicit nullability behavior learning about it a few years ago, then remembered it while reading about [https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated) today.

Given that 8.4 is not anywhere near being officially released, I understand this might not be suitable for merging just yet or even should be closed and put on on some tracklist elsewhere. However given I couldn't find anything of that sorts, I decided just to leae this suggestion here.