### PR TITLE
Add U_ error constants to intl constant list

### DIFF
--- a/reference/intl/constants.xml
+++ b/reference/intl/constants.xml
@@ -306,6 +306,1560 @@
      </simpara>
     </listitem>
    </varlistentry>
+   <varlistentry xml:id="constant.u-ambiguous-alias-warning">
+    <term>
+     <constant>U_AMBIGUOUS_ALIAS_WARNING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      This converter alias can go to different converter implementations.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-bad-variable-definition">
+    <term>
+     <constant>U_BAD_VARIABLE_DEFINITION</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Missing <literal>'$'</literal> or duplicate variable name.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-brk-assign-error">
+    <term>
+     <constant>U_BRK_ASSIGN_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Syntax error in RBBI rule assignment statement.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-brk-error-limit">
+    <term>
+     <constant>U_BRK_ERROR_LIMIT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      This must always be the last value to indicate the limit for Break Iterator failures.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-brk-error-start">
+    <term>
+     <constant>U_BRK_ERROR_START</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Start of codes indicating Break Iterator failures.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-brk-hex-digits-expected">
+    <term>
+     <constant>U_BRK_HEX_DIGITS_EXPECTED</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Hex digits expected as part of a escaped char in a rule.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-brk-init-error">
+    <term>
+     <constant>U_BRK_INIT_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Initialization failure. Probable missing ICU Data.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-brk-internal-error">
+    <term>
+     <constant>U_BRK_INTERNAL_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      An internal error (bug) was detected.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-brk-malformed-rule-tag">
+    <term>
+     <constant>U_BRK_MALFORMED_RULE_TAG</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      The <literal>{nnn}</literal> tag on a rule is mal formed.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-brk-mismatched-paren">
+    <term>
+     <constant>U_BRK_MISMATCHED_PAREN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Mis-matched parentheses in an RBBI rule.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-brk-new-line-in-quoted-string">
+    <term>
+     <constant>U_BRK_NEW_LINE_IN_QUOTED_STRING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Missing closing quote in an RBBI rule.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-brk-rule-empty-set">
+    <term>
+     <constant>U_BRK_RULE_EMPTY_SET</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Rule contains an empty Unicode Set.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-brk-rule-syntax">
+    <term>
+     <constant>U_BRK_RULE_SYNTAX</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Syntax error in RBBI rule.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-brk-semicolon-expected">
+    <term>
+     <constant>U_BRK_SEMICOLON_EXPECTED</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Missing <literal>';'</literal> at the end of a RBBI rule.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-brk-unclosed-set">
+    <term>
+     <constant>U_BRK_UNCLOSED_SET</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      UnicodeSet witing an RBBI rule missing a closing <literal>']'</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-brk-undefined-variable">
+    <term>
+     <constant>U_BRK_UNDEFINED_VARIABLE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Use of an undefined <code>$Variable</code> in an RBBI rule.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-brk-unrecognized-option">
+    <term>
+     <constant>U_BRK_UNRECOGNIZED_OPTION</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Option in RBBI rules not recognized.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-brk-variable-redfinition">
+    <term>
+     <constant>U_BRK_VARIABLE_REDFINITION</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      RBBI rule variable redefined.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-buffer-overflow-error">
+    <term>
+     <constant>U_BUFFER_OVERFLOW_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A result would not fit in the supplied buffer.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-ce-not-found-error">
+    <term>
+     <constant>U_CE_NOT_FOUND_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Currently used only while setting variable top, but can be used generally.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-collator-version-mismatch">
+    <term>
+     <constant>U_COLLATOR_VERSION_MISMATCH</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Collator version is not compatible with the base version.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-different-uca-version">
+    <term>
+     <constant>U_DIFFERENT_UCA_VERSION</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      ucol_open encountered a mismatch between UCA version and collator image version, so the collator was constructed from rules. No impact to further function.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-enum-out-of-sync-error">
+    <term>
+     <constant>U_ENUM_OUT_OF_SYNC_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      <code>UEnumeration</code> out of sync with underlying collection.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-error-limit">
+    <term>
+     <constant>U_ERROR_LIMIT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Alias of <constant>U_PLUGIN_ERROR_LIMIT</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-error-warning-limit">
+    <term>
+     <constant>U_ERROR_WARNING_LIMIT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      This must always be the last warning value to indicate the limit for UErrorCode warnings (last warning code +1).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-error-warning-start">
+    <term>
+     <constant>U_ERROR_WARNING_START</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Start of information results (semantically successful).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-file-access-error">
+    <term>
+     <constant>U_FILE_ACCESS_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      The requested file cannot be found.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-fmt-parse-error-limit">
+    <term>
+     <constant>U_FMT_PARSE_ERROR_LIMIT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      The limit for format library errors.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-fmt-parse-error-start">
+    <term>
+     <constant>U_FMT_PARSE_ERROR_START</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Start of format library errors.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-ace-prefix-error">
+    <term>
+     <constant>U_IDNA_ACE_PREFIX_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-check-bidi-error">
+    <term>
+     <constant>U_IDNA_CHECK_BIDI_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-domain-name-too-long-error">
+    <term>
+     <constant>U_IDNA_DOMAIN_NAME_TOO_LONG_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-error-limit">
+    <term>
+     <constant>U_IDNA_ERROR_LIMIT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-error-start">
+    <term>
+     <constant>U_IDNA_ERROR_START</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-label-too-long-error">
+    <term>
+     <constant>U_IDNA_LABEL_TOO_LONG_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-prohibited-error">
+    <term>
+     <constant>U_IDNA_PROHIBITED_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-std3-ascii-rules-error">
+    <term>
+     <constant>U_IDNA_STD3_ASCII_RULES_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-unassigned-error">
+    <term>
+     <constant>U_IDNA_UNASSIGNED_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-verification-error">
+    <term>
+     <constant>U_IDNA_VERIFICATION_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-zero-length-label-error">
+    <term>
+     <constant>U_IDNA_ZERO_LENGTH_LABEL_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-illegal-argument-error">
+    <term>
+     <constant>U_ILLEGAL_ARGUMENT_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Indicates an incorrect argument value.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-illegal-char-found">
+    <term>
+     <constant>U_ILLEGAL_CHAR_FOUND</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Character conversion: Illegal input sequence.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-illegal-char-in-segment">
+    <term>
+     <constant>U_ILLEGAL_CHAR_IN_SEGMENT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unused as of ICU 2.4.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-illegal-character">
+    <term>
+     <constant>U_ILLEGAL_CHARACTER</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A special character is outside its allowed context.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-illegal-escape-sequence">
+    <term>
+     <constant>U_ILLEGAL_ESCAPE_SEQUENCE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      ISO-2022 illlegal escape sequence.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-illegal-pad-position">
+    <term>
+     <constant>U_ILLEGAL_PAD_POSITION</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Pad symbol misplaced in number pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-index-outofbounds-error">
+    <term>
+     <constant>U_INDEX_OUTOFBOUNDS_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Trying to access the index that is out of bounds.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-internal-program-error">
+    <term>
+     <constant>U_INTERNAL_PROGRAM_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Indicates a bug in the library code.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-internal-transliterator-error">
+    <term>
+     <constant>U_INTERNAL_TRANSLITERATOR_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Internal transliterator system error.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invalid-char-found">
+    <term>
+     <constant>U_INVALID_CHAR_FOUND</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Character conversion: Unmappable input sequence. In other APIs: Invalid character.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invalid-format-error">
+    <term>
+     <constant>U_INVALID_FORMAT_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Data format is not what is expected.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invalid-function">
+    <term>
+     <constant>U_INVALID_FUNCTION</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A <literal>'&amp;fn()'</literal> rule specifies an unknown transliterator.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invalid-id">
+    <term>
+     <constant>U_INVALID_ID</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A <literal>'::id'</literal> rule specifies an unknown transliterator.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invalid-property-pattern">
+    <term>
+     <constant>U_INVALID_PROPERTY_PATTERN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unused as of ICU 2.4.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invalid-rbt-syntax">
+    <term>
+     <constant>U_INVALID_RBT_SYNTAX</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A <literal>'::id'</literal> rule was passed to the RuleBasedTransliterator parser.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invalid-state-error">
+    <term>
+     <constant>U_INVALID_STATE_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Requested operation can not be completed with ICU in its current state.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invalid-table-file">
+    <term>
+     <constant>U_INVALID_TABLE_FILE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Conversion table file not found.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invalid-table-format">
+    <term>
+     <constant>U_INVALID_TABLE_FORMAT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Conversion table file found, but corrupted.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invariant-conversion-error">
+    <term>
+     <constant>U_INVARIANT_CONVERSION_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unable to convert a <code>UChar*</code> string to <code>char*</code>
+      with the invariant converter.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-malformed-exponential-pattern">
+    <term>
+     <constant>U_MALFORMED_EXPONENTIAL_PATTERN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Grouping symbol in exponent pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-malformed-pragma">
+    <term>
+     <constant>U_MALFORMED_PRAGMA</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A <literal>'use'</literal> pragma is invalid.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-malformed-rule">
+    <term>
+     <constant>U_MALFORMED_RULE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Elements of a rule are misplaced.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-malformed-set">
+    <term>
+     <constant>U_MALFORMED_SET</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A <code>UnicodeSet</code> pattern is invalid.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-malformed-symbol-reference">
+    <term>
+     <constant>U_MALFORMED_SYMBOL_REFERENCE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unused as of ICU 2.4.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-malformed-unicode-escape">
+    <term>
+     <constant>U_MALFORMED_UNICODE_ESCAPE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A Unicode escape pattern is invalid.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-malformed-variable-definition">
+    <term>
+     <constant>U_MALFORMED_VARIABLE_DEFINITION</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A variable definition is invalid.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-malformed-variable-reference">
+    <term>
+     <constant>U_MALFORMED_VARIABLE_REFERENCE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A variable reference is invalid.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-memory-allocation-error">
+    <term>
+     <constant>U_MEMORY_ALLOCATION_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Memory allocation error.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-message-parse-error">
+    <term>
+     <constant>U_MESSAGE_PARSE_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unable to parse a message (message format).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-mismatched-segment-delimiters">
+    <term>
+     <constant>U_MISMATCHED_SEGMENT_DELIMITERS</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unused as of ICU 2.4.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-misplaced-anchor-start">
+    <term>
+     <constant>U_MISPLACED_ANCHOR_START</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A start anchor appears at an illegal position.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-misplaced-compound-filter">
+    <term>
+     <constant>U_MISPLACED_COMPOUND_FILTER</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A compound filter is in an invalid location.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-misplaced-cursor-offset">
+    <term>
+     <constant>U_MISPLACED_CURSOR_OFFSET</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A cursor offset occurs at an illegal position.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-misplaced-quantifier">
+    <term>
+     <constant>U_MISPLACED_QUANTIFIER</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A quantifier appears after a segment close delimiter.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-missing-operator">
+    <term>
+     <constant>U_MISSING_OPERATOR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A rule contains no operator.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-missing-resource-error">
+    <term>
+     <constant>U_MISSING_RESOURCE_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      The requested resource cannot be found.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-missing-segment-close">
+    <term>
+     <constant>U_MISSING_SEGMENT_CLOSE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unused as of ICU 2.4.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-multiple-ante-contexts">
+    <term>
+     <constant>U_MULTIPLE_ANTE_CONTEXTS</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      More than one ante context.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-multiple-compound-filters">
+    <term>
+     <constant>U_MULTIPLE_COMPOUND_FILTERS</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      More than one compound filter.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-multiple-cursors">
+    <term>
+     <constant>U_MULTIPLE_CURSORS</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      More than one cursor.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-multiple-decimal-separators">
+    <term>
+     <constant>U_MULTIPLE_DECIMAL_SEPARATORS</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      More than one decimal separator in number pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-multiple-decimal-seperators">
+    <term>
+     <constant>U_MULTIPLE_DECIMAL_SEPERATORS</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Alias of <constant>U_MULTIPLE_DECIMAL_SEPARATORS</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-multiple-exponential-symbols">
+    <term>
+     <constant>U_MULTIPLE_EXPONENTIAL_SYMBOLS</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      More than one exponent symbol in number pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-multiple-pad-specifiers">
+    <term>
+     <constant>U_MULTIPLE_PAD_SPECIFIERS</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      More than one pad symbol in number pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-multiple-percent-symbols">
+    <term>
+     <constant>U_MULTIPLE_PERCENT_SYMBOLS</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      More than one percent symbol in number pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-multiple-permill-symbols">
+    <term>
+     <constant>U_MULTIPLE_PERMILL_SYMBOLS</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      More than one permill symbol in number pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-multiple-post-contexts">
+    <term>
+     <constant>U_MULTIPLE_POST_CONTEXTS</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      More than one post context.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-no-space-available">
+    <term>
+     <constant>U_NO_SPACE_AVAILABLE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      No space available for in-buffer expansion for Arabic shaping.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-no-write-permission">
+    <term>
+     <constant>U_NO_WRITE_PERMISSION</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Attempt to modify read-only or constant data.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-parse-error">
+    <term>
+     <constant>U_PARSE_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Equivalent to Java <code>ParseException</code>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-parse-error-limit">
+    <term>
+     <constant>U_PARSE_ERROR_LIMIT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      The limit for Transliterator errors.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-parse-error-start">
+    <term>
+     <constant>U_PARSE_ERROR_START</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Start of Transliterator errors.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-pattern-syntax-error">
+    <term>
+     <constant>U_PATTERN_SYNTAX_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Syntax error in format pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-primary-too-long-error">
+    <term>
+     <constant>U_PRIMARY_TOO_LONG_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      User tried to set variable top to a primary that is longer than two bytes.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-bad-escape-sequence">
+    <term>
+     <constant>U_REGEX_BAD_ESCAPE_SEQUENCE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unrecognized backslash escape sequence in pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-bad-interval">
+    <term>
+     <constant>U_REGEX_BAD_INTERVAL</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Error in <literal>{min,max}</literal> interval.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-error-limit">
+    <term>
+     <constant>U_REGEX_ERROR_LIMIT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      This must always be the last value to indicate the limit for regexp errors.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-error-start">
+    <term>
+     <constant>U_REGEX_ERROR_START</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Start of codes indicating Regexp failures.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-internal-error">
+    <term>
+     <constant>U_REGEX_INTERNAL_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      An internal error (bug) was detected.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-invalid-back-ref">
+    <term>
+     <constant>U_REGEX_INVALID_BACK_REF</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Back-reference to a non-existent capture group.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-invalid-flag">
+    <term>
+     <constant>U_REGEX_INVALID_FLAG</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Invalid value for match mode flags.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-invalid-state">
+    <term>
+     <constant>U_REGEX_INVALID_STATE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      <code>RegexMatcher</code> in invalid state for requested operation.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-look-behind-limit">
+    <term>
+     <constant>U_REGEX_LOOK_BEHIND_LIMIT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Look-Behind pattern matches must have a bounded maximum length.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-max-lt-min">
+    <term>
+     <constant>U_REGEX_MAX_LT_MIN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      In <literal>{min,max}</literal>, max is less than min.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-mismatched-paren">
+    <term>
+     <constant>U_REGEX_MISMATCHED_PAREN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Incorrectly nested parentheses in regexp pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-number-too-big">
+    <term>
+     <constant>U_REGEX_NUMBER_TOO_BIG</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Decimal number is too large.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-property-syntax">
+    <term>
+     <constant>U_REGEX_PROPERTY_SYNTAX</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Incorrect Unicode property.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-rule-syntax">
+    <term>
+     <constant>U_REGEX_RULE_SYNTAX</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Syntax error in regexp pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-set-contains-string">
+    <term>
+     <constant>U_REGEX_SET_CONTAINS_STRING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Regexps cannot have <code>UnicodeSet</code>s containing strings.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-unimplemented">
+    <term>
+     <constant>U_REGEX_UNIMPLEMENTED</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Use of regexp feature that is not yet implemented.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-resource-type-mismatch">
+    <term>
+     <constant>U_RESOURCE_TYPE_MISMATCH</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      An operation is requested over a resource that does not support it.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-rule-mask-error">
+    <term>
+     <constant>U_RULE_MASK_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A rule is hidden by an earlier more general rule.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-safeclone-allocated-warning">
+    <term>
+     <constant>U_SAFECLONE_ALLOCATED_WARNING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A <code>SafeClone</code> operation required allocating memory (informational only).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-sort-key-too-short-warning">
+    <term>
+     <constant>U_SORT_KEY_TOO_SHORT_WARNING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Number of levels requested in <code>getBound</code> is higher
+      than the number of levels in the sort key.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-standard-error-limit">
+    <term>
+     <constant>U_STANDARD_ERROR_LIMIT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      This must always be the last value to indicate the limit for standard errors.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-state-old-warning">
+    <term>
+     <constant>U_STATE_OLD_WARNING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      ICU has to use compatibility layer to construct the service.
+      Expect performance/memory usage degradation.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-state-too-old-error">
+    <term>
+     <constant>U_STATE_TOO_OLD_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      ICU cannot construct a service from this state, as it is no longer supported.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-string-not-terminated-warning">
+    <term>
+     <constant>U_STRING_NOT_TERMINATED_WARNING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      An output string could not be NUL-terminated because output <code>length==destCapacity</code>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-stringprep-check-bidi-error">
+    <term>
+     <constant>U_STRINGPREP_CHECK_BIDI_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Alias of <constant>U_IDNA_CHECK_BIDI_ERROR</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-stringprep-prohibited-error">
+    <term>
+     <constant>U_STRINGPREP_PROHIBITED_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Alias of <constant>U_IDNA_PROHIBITED_ERROR</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-stringprep-unassigned-error">
+    <term>
+     <constant>U_STRINGPREP_UNASSIGNED_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Alias of <constant>U_IDNA_UNASSIGNED_ERROR</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-too-many-aliases-error">
+    <term>
+     <constant>U_TOO_MANY_ALIASES_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      There are too many aliases in the path to the requested resource. It is very possible that a circular alias definition has occured.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-trailing-backslash">
+    <term>
+     <constant>U_TRAILING_BACKSLASH</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A dangling backslash.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-truncated-char-found">
+    <term>
+     <constant>U_TRUNCATED_CHAR_FOUND</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Character conversion: Incomplete input sequence.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-unclosed-segment">
+    <term>
+     <constant>U_UNCLOSED_SEGMENT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A closing <literal>')'</literal> is missing.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-undefined-segment-reference">
+    <term>
+     <constant>U_UNDEFINED_SEGMENT_REFERENCE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A segment reference does not correspond to a defined segment.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-undefined-variable">
+    <term>
+     <constant>U_UNDEFINED_VARIABLE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A variable reference does not correspond to a defined variable.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-unexpected-token">
+    <term>
+     <constant>U_UNEXPECTED_TOKEN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Syntax error in format pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-unmatched-braces">
+    <term>
+     <constant>U_UNMATCHED_BRACES</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Braces do not match in message pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-unquoted-special">
+    <term>
+     <constant>U_UNQUOTED_SPECIAL</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A special character was not quoted or escaped.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-unsupported-attribute">
+    <term>
+     <constant>U_UNSUPPORTED_ATTRIBUTE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unused as of ICU 2.4.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-unsupported-error">
+    <term>
+     <constant>U_UNSUPPORTED_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Requested operation not supported in current context.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-unsupported-escape-sequence">
+    <term>
+     <constant>U_UNSUPPORTED_ESCAPE_SEQUENCE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      ISO-2022 unsupported escape sequence.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-unsupported-property">
+    <term>
+     <constant>U_UNSUPPORTED_PROPERTY</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unused as of ICU 2.4.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-unterminated-quote">
+    <term>
+     <constant>U_UNTERMINATED_QUOTE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A closing single quote is missing.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-useless-collator-error">
+    <term>
+     <constant>U_USELESS_COLLATOR_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Collator is options only and no base is specified.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-using-default-warning">
+    <term>
+     <constant>U_USING_DEFAULT_WARNING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A resource bundle lookup returned a result from the root locale (not an error).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-using-fallback-warning">
+    <term>
+     <constant>U_USING_FALLBACK_WARNING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A resource bundle lookup returned a fallback result (not an error).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-variable-range-exhausted">
+    <term>
+     <constant>U_VARIABLE_RANGE_EXHAUSTED</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Too many stand-ins generated for the given variable range.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-variable-range-overlap">
+    <term>
+     <constant>U_VARIABLE_RANGE_OVERLAP</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      The variable range overlaps characters used in rules.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-zero-error">
+    <term>
+     <constant>U_ZERO_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      No error, no warning.
+     </simpara>
+    </listitem>
+   </varlistentry>
   </variablelist>
  </para>
 </appendix>

--- a/reference/intl/constants.xml
+++ b/reference/intl/constants.xml
@@ -544,7 +544,8 @@
     </term>
     <listitem>
      <simpara>
-      ucol_open encountered a mismatch between UCA version and collator image version, so the collator was constructed from rules. No impact to further function.
+      ucol_open encountered a mismatch between UCA version and collator image version,
+      so the collator was constructed from rules. No impact to further function.
      </simpara>
     </listitem>
    </varlistentry>
@@ -577,7 +578,8 @@
     </term>
     <listitem>
      <simpara>
-      This must always be the last warning value to indicate the limit for UErrorCode warnings (last warning code +1).
+      This must always be the last warning value to indicate
+      the limit for UErrorCode warnings (last warning code +1).
      </simpara>
     </listitem>
    </varlistentry>
@@ -1647,7 +1649,8 @@
     </term>
     <listitem>
      <simpara>
-      There are too many aliases in the path to the requested resource. It is very possible that a circular alias definition has occured.
+      There are too many aliases in the path to the requested resource.
+      It is very possible that a circular alias definition has occured.
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Add missing `U_` error constants to `intl` constant list. All of these are listed on the missing constant list (#2747).

_Edit:_
I used the following script which can also be used to update all translations:
https://gist.github.com/haszi/66f36bc412323e0365b8614aeabaa816
Please note that the scripts unconditionally adds the constants to the constants page, ie. without checking whether these are already present so running it more than once is not advised.