### PR TITLE
Copy constants from nl_langinfo() to constants page

### DIFF
--- a/reference/strings/constants.xml
+++ b/reference/strings/constants.xml
@@ -335,6 +335,498 @@
    </listitem>
   </varlistentry>
  </variablelist>
+ <variablelist role="constant_list">
+  <title><function>nl_langinfo</function> <constant>LC_TIME</constant> Category Constants</title>
+  <varlistentry>
+   <term>
+    <constant>ABDAY_(1-7)</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Abbreviated name of n-th day of the week.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>
+    <constant>DAY_(1-7)</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Name of the n-th day of the week (DAY_1 = Sunday).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>
+    <constant>ABMON_(1-12)</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Abbreviated name of the n-th month of the year.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>
+    <constant>MON_(1-12)</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Name of the n-th month of the year.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.am-str">
+   <term>
+    <constant>AM_STR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     String for Ante meridian.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pm-str">
+   <term>
+    <constant>PM_STR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     String for Post meridian.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.d-t-fmt">
+   <term>
+    <constant>D_T_FMT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     String that can be used as the format string for <function>strftime</function> to represent time and date.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.d-fmt">
+   <term>
+    <constant>D_FMT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     String that can be used as the format string for <function>strftime</function> to represent date.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.t-fmt">
+   <term>
+    <constant>T_FMT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     String that can be used as the format string for <function>strftime</function> to represent time.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.t-fmt-ampm">
+   <term>
+    <constant>T_FMT_AMPM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     String that can be used as the format string for <function>strftime</function> to represent time in 12-hour format with ante/post meridian.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.era">
+   <term>
+    <constant>ERA</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Alternate era.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.era-year">
+   <term>
+    <constant>ERA_YEAR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Year in alternate era format.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.era-d-t-fmt">
+   <term>
+    <constant>ERA_D_T_FMT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Date and time in alternate era format (string can be used in <function>strftime</function>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.era-d-fmt">
+   <term>
+    <constant>ERA_D_FMT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Date in alternate era format (string can be used in <function>strftime</function>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.era-t-fmt">
+   <term>
+    <constant>ERA_T_FMT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Time in alternate era format (string can be used in <function>strftime</function>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+ <variablelist role="constant_list">
+  <title><function>nl_langinfo</function> <constant>LC_MONETARY</constant> Category Constants</title>
+  <varlistentry xml:id="constant.int-curr-symbol">
+   <term>
+    <constant>INT_CURR_SYMBOL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     International currency symbol.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.currency-symbol">
+   <term>
+    <constant>CURRENCY_SYMBOL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Local currency symbol.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.crncystr">
+   <term>
+    <constant>CRNCYSTR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Same value as <constant>CURRENCY_SYMBOL</constant>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.mon-decimal-point">
+   <term>
+    <constant>MON_DECIMAL_POINT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Decimal point character.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.mon-thousands-sep">
+   <term>
+    <constant>MON_THOUSANDS_SEP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Thousands separator (groups of three digits).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.mon-grouping">
+   <term>
+    <constant>MON_GROUPING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Like <literal>"grouping"</literal> element.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.positive-sign">
+   <term>
+    <constant>POSITIVE_SIGN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Sign for positive values.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.negative-sign">
+   <term>
+    <constant>NEGATIVE_SIGN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Sign for negative values.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.int-frac-digits">
+   <term>
+    <constant>INT_FRAC_DIGITS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     International fractional digits.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.frac-digits">
+   <term>
+    <constant>FRAC_DIGITS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Local fractional digits.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.p-cs-precedes">
+   <term>
+    <constant>P_CS_PRECEDES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Returns 1 if <constant>CURRENCY_SYMBOL</constant> precedes a positive value.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.p-sep-by-space">
+   <term>
+    <constant>P_SEP_BY_SPACE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Returns 1 if a space separates <constant>CURRENCY_SYMBOL</constant> from a positive value.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.n-cs-precedes">
+   <term>
+    <constant>N_CS_PRECEDES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Returns 1 if <constant>CURRENCY_SYMBOL</constant> precedes a negative value.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.n-sep-by-space">
+   <term>
+    <constant>N_SEP_BY_SPACE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Returns 1 if a space separates <constant>CURRENCY_SYMBOL</constant> from a negative value.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.p-sign-posn">
+   <term>
+    <constant>P_SIGN_POSN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     <itemizedlist>
+             <listitem>
+              <simpara>
+                Returns 0 if parentheses surround the quantity and <constant>CURRENCY_SYMBOL</constant>.
+              </simpara>
+             </listitem>
+             <listitem>
+              <simpara>
+               Returns 1 if the sign string precedes the quantity and <constant>CURRENCY_SYMBOL</constant>.
+              </simpara>
+             </listitem>
+             <listitem>
+              <simpara>
+               Returns 2 if the sign string follows the quantity and <constant>CURRENCY_SYMBOL</constant>.
+              </simpara>
+             </listitem>
+             <listitem>
+              <simpara>
+               Returns 3 if the sign string immediately precedes the <constant>CURRENCY_SYMBOL</constant>.
+              </simpara>
+             </listitem>
+             <listitem>
+              <simpara>
+               Returns 4 if the sign string immediately follows the <constant>CURRENCY_SYMBOL</constant>.
+              </simpara>
+             </listitem>
+            </itemizedlist>
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.n-sign-posn">
+   <term>
+    <constant>N_SIGN_POSN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+ <variablelist role="constant_list">
+  <title><function>nl_langinfo</function> <constant>LC_NUMERIC</constant> Category Constants</title>
+  <varlistentry xml:id="constant.decimal-point">
+   <term>
+    <constant>DECIMAL_POINT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Decimal point character.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.radixchar">
+   <term>
+    <constant>RADIXCHAR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Same value as <constant>DECIMAL_POINT</constant>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.thousands-sep">
+   <term>
+    <constant>THOUSANDS_SEP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Separator character for thousands (groups of three digits).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.thousep">
+   <term>
+    <constant>THOUSEP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Same value as <constant>THOUSANDS_SEP</constant>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.grouping">
+   <term>
+    <constant>GROUPING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+ <variablelist role="constant_list">
+  <title><function>nl_langinfo</function> <constant>LC_MESSAGES</constant> Category Constants</title>
+  <varlistentry xml:id="constant.yesexpr">
+   <term>
+    <constant>YESEXPR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Regex string for matching <literal>"yes"</literal> input.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.noexpr">
+   <term>
+    <constant>NOEXPR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Regex string for matching <literal>"no"</literal> input.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yesstr">
+   <term>
+    <constant>YESSTR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Output string for <literal>"yes"</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.nostr">
+   <term>
+    <constant>NOSTR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Output string for <literal>"no"</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+ <variablelist role="constant_list">
+  <title><function>nl_langinfo</function> <constant>LC_CTYPE</constant> Category Constants</title>
+  <varlistentry xml:id="constant.codeset">
+   <term>
+    <constant>CODESET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Return a string with the name of the character encoding.
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
 </appendix>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Copy constants from `nl_langinfo()` to constants page.

The `ABDAY`, `DAY`, `ABMON` and `MON` constants need to be listed individually (as opposed to the current `(1-7)` and `(1-12)`) format) so they can be automatically linked to which will be done in a follow up PR.

I used the following script for this update which can also be used to update all translations having the necessary files in one go:
https://gist.github.com/haszi/be927f351ab7efe23f46a11cc92c2000
If used, please note that the script should only be ran once as it will just blindly add the new constant tables to the constants page.
