### PR TITLE
Fix typo in xlswriter/xlsx-kernel/set-row.xml

### DIFF
--- a/reference/xlswriter/xlsx-kernel/set-row.xml
+++ b/reference/xlswriter/xlsx-kernel/set-row.xml
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>resource</type><parameter>format</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Set the format of the column.
+    Set the format of the row.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Apparently, the `Vtiful\Kernel\Excel::set Row` method sets the format of a row, not a column