### PR TITLE
Fix mysqli fetch field

### DIFF
--- a/reference/mysqli/mysqli_result/fetch-field-direct.xml
+++ b/reference/mysqli/mysqli_result/fetch-field-direct.xml
@@ -83,6 +83,14 @@
       <entry>The default value for this field, represented as a string</entry>
      </row>
      <row>
+      <entry>db</entry>
+      <entry>The name of the database</entry>
+     </row>
+     <row>
+      <entry>catalog</entry>
+      <entry>The catalog name, always "def"</entry>
+     </row>
+     <row>
       <entry>max_length</entry>
       <entry>The maximum width of the field for the result set. As of PHP 8.1, this value is always <literal>0</literal>.</entry>
      </row>

--- a/reference/mysqli/mysqli_result/fetch-field-direct.xml
+++ b/reference/mysqli/mysqli_result/fetch-field-direct.xml
@@ -53,11 +53,11 @@
   </para>
   <para>
   <table xml:id="mysqli-result.fetch-field-direct.returnvalues">
-   <title>Object attributes</title>
+   <title>Object properties</title>
    <tgroup cols="2">
     <thead>
      <row>
-      <entry>Attribute</entry>
+      <entry>Property</entry>
       <entry>Description</entry>
      </row>
     </thead>
@@ -80,7 +80,7 @@
      </row>
      <row>
       <entry>def</entry>
-      <entry>The default value for this field, represented as a string</entry>
+      <entry>Reserved for default value, currently always ""</entry>
      </row>
      <row>
       <entry>db</entry>
@@ -96,11 +96,16 @@
      </row>
      <row>
       <entry>length</entry>
-      <entry>The width of the field, as specified in the table definition.</entry>
+      <entry>
+       The width of the field, in bytes, as specified in the table definition. Note that
+       this number (bytes) might differ from your table definition value (characters), depending on
+       the character set you use. For example, the character set utf8 has 3 bytes per character,
+       so varchar(10) will return a length of 30 for utf8 (10*3), but return 10 for latin1 (10*1).
+      </entry>
      </row>
      <row>
       <entry>charsetnr</entry>
-      <entry>The character set number for the field.</entry>
+      <entry>The character set number (id) for the field.</entry>
      </row>
      <row>
       <entry>flags</entry>
@@ -112,7 +117,7 @@
      </row>
      <row>
       <entry>decimals</entry>
-      <entry>The number of decimals used (for numeric fields)</entry>
+      <entry>The number of decimals for numeric fields, and the fractional seconds precision for temporal fields.</entry>
      </row>
     </tbody>
    </tgroup>

--- a/reference/mysqli/mysqli_result/fetch-field.xml
+++ b/reference/mysqli/mysqli_result/fetch-field.xml
@@ -82,15 +82,20 @@
      </row>
      <row>
       <entry>max_length</entry>
-      <entry>The maximum width of the field for the result set.</entry>
+      <entry>The maximum width of the field for the result set. As of PHP 8.1, this value is always <literal>0</literal>.</entry>
      </row>
      <row>
       <entry>length</entry>
-      <entry>The width of the field, as specified in the table definition.</entry>
+      <entry>
+       The width of the field, in bytes, as specified in the table definition. Note that
+       this number (bytes) might differ from your table definition value (characters), depending on
+       the character set you use. For example, the character set utf8 has 3 bytes per character,
+       so varchar(10) will return a length of 30 for utf8 (10*3), but return 10 for latin1 (10*1).
+      </entry>
      </row>
      <row>
       <entry>charsetnr</entry>
-      <entry>The character set number for the field.</entry>
+      <entry>The character set number (id) for the field.</entry>
      </row>
      <row>
       <entry>flags</entry>
@@ -102,7 +107,7 @@
      </row>
      <row>
       <entry>decimals</entry>
-      <entry>The number of decimals used (for integer fields)</entry>
+      <entry>The number of decimals for numeric fields, and the fractional seconds precision for temporal fields.</entry>
      </row>
     </tbody>
    </tgroup>

--- a/reference/mysqli/mysqli_result/fetch-fields.xml
+++ b/reference/mysqli/mysqli_result/fetch-fields.xml
@@ -70,6 +70,18 @@
       <entry>Original table name if an alias was specified</entry>
      </row>
      <row>
+      <entry>def</entry>
+      <entry>Reserved for default value, currently always ""</entry>
+     </row>
+     <row>
+      <entry>db</entry>
+      <entry>The name of the database</entry>
+     </row>
+     <row>
+      <entry>catalog</entry>
+      <entry>The catalog name, always "def"</entry>
+     </row>
+     <row>
       <entry>max_length</entry>
       <entry>The maximum width of the field for the result set. As of PHP 8.1, this value is always <literal>0</literal>.</entry>
      </row>

--- a/reference/mysqli/mysqli_result/fetch-fields.xml
+++ b/reference/mysqli/mysqli_result/fetch-fields.xml
@@ -108,7 +108,7 @@
      </row>
      <row>
       <entry>decimals</entry>
-      <entry>The number of decimals used (for integer fields)</entry>
+      <entry>The number of decimals for numeric fields, and the fractional seconds precision for temporal fields.</entry>
      </row>
     </tbody>
    </tgroup>


### PR DESCRIPTION
This PR adds missing properties and unifies property descriptions for `mysqli_fetch_fields`, `mysqli_fetch_field` and `mysqli_fetch_field_direct`.