### PR TITLE
Modify the description of the max_children_reached

### DIFF
--- a/reference/fpm/status.xml
+++ b/reference/fpm/status.xml
@@ -164,7 +164,7 @@
      <row>
       <entry>max children reached</entry>
       <entry>
-       Has the maximum number of processes ever been reached? If so the displayed value is
+       Has the maximum number of processes ever been reached? If so the displayed value is greater than or equal to
        <literal>1</literal> otherwise the value is <literal>0</literal>.
       </entry>
      </row>


### PR DESCRIPTION
reference/fpm/status.xml: if reach the maximun number of processes, max_children_reached is greater than or equal to 1