### PR TITLE
Update functions.arguments to include output of code samples

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -318,6 +318,13 @@ echo makecoffee();
 echo makecoffee(array("cappuccino", "lavazza"), "teapot");?>
 ]]>
       </programlisting>
+      &example.outputs;
+      <screen>
+<![CDATA[
+Making a cup of cappuccino with hands.
+Making a cup of cappuccino, lavazza with teapot.
+]]>
+      </screen>
      </example>
     </para>
     <para>
@@ -328,12 +335,12 @@ echo makecoffee(array("cappuccino", "lavazza"), "teapot");?>
 <?php
 class DefaultCoffeeMaker {
     public function brew() {
-        return 'Making coffee.';
+        return "Making coffee.\n";
     }
 }
 class FancyCoffeeMaker {
     public function brew() {
-        return 'Crafting a beautiful coffee just for you.';
+        return "Crafting a beautiful coffee just for you.\n";
     }
 }
 function makecoffee($coffeeMaker = new DefaultCoffeeMaker)
@@ -345,6 +352,14 @@ echo makecoffee(new FancyCoffeeMaker);
 ?>
 ]]>
       </programlisting>
+
+      &example.outputs;
+      <screen>
+<![CDATA[
+Making coffee.
+Crafting a beautiful coffee just for you.
+]]>
+      </screen>
      </example>
     </para>
     <simpara>


### PR DESCRIPTION
# Description
On page https://www.php.net/manual/en/functions.arguments.php, examples 4 and 7 have both code and output, but examples 5 and 6 only have the code. This PR does a tiny bit of code change (to add line breaks in example 6)  but otherwise is about adding the output of examples 5 and 6.

# Screenshots
## Example 4
<img width="523" alt="Screenshot 2024-04-14 at 10 08 53" src="https://github.com/php/doc-en/assets/766573/d78f4c54-d378-44e0-9b94-66875fb0017e">

## Examples 5 and 6
<img width="1043" alt="Screenshot 2024-04-14 at 10 12 07" src="https://github.com/php/doc-en/assets/766573/4e1b9e12-ae4e-408c-aa79-b5e58eb1ae97">
