### PR TITLE
Document how to debug connection issues

### DIFF
--- a/reference/ldap/functions/ldap-set-option.xml
+++ b/reference/ldap/functions/ldap-set-option.xml
@@ -282,6 +282,23 @@ if (!ldap_set_option($ds, LDAP_OPT_SERVER_CONTROLS, array($ctrl1, $ctrl2))) {
 ]]>
     </programlisting>
    </example>
+   <example>
+    <title>Debugging connection issue</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// Debugging must be enabled before the connection is attempted
+// otherwise it is ignored.
+// TODO: Document allowed values - `man 3 ldap_set_option` describes allowed values as constants found in
+// https://git.openldap.org/openldap/openldap/-/blob/master/include/ldap_log.h?ref_type=heads#L107
+ldap_set_option(NULL, LDAP_OPT_DEBUG_LEVEL, 7);
+$ldapurl = "ldaps://" . $parameters['host'] . ":" . $parameters['port'];
+$ldapconn = ldap_connect($ldapurl) or die ("Couldn't connect");
+$ldapbind = ldap_bind($ldapconn);
+?>
+]]>
+    </programlisting>
+   </example>
   </para>
  </refsect1>
 


### PR DESCRIPTION
I've spent enormous amount of time trying to debug my connection issue. The main reason was lack of proper documentation on php.net which I'm trying to resolve here.

There is a TODO in the proposed change - the reason for it is that I'm not sure where that magical value `7` is coming from and what level it relates to. I've scanned the `php-src` code base, but found nothing useful. That TODO comment represents my findings.