### PR TITLE
Fix minor markup conformance issue in DateTime extension

### DIFF
--- a/reference/datetime/dateperiod.xml
+++ b/reference/datetime/dateperiod.xml
@@ -154,7 +154,7 @@
        <constant>DatePeriod::INCLUDE_END_DATE</constant>.
       </para>
       <para>
-       <example>
+       <informalexample>
         <programlisting role="php">
 <![CDATA[<?php
 $start = new DateTime('2018-12-31 00:00:00');
@@ -188,7 +188,7 @@ echo $period->recurrences, "\n";
 1
 0
          </screen>
-        </example>
+        </informalexample>
        </para>
       <para>
        See also <methodname>DatePeriod::getRecurrences</methodname>.

--- a/reference/datetime/formats.xml
+++ b/reference/datetime/formats.xml
@@ -78,7 +78,7 @@
   <listitem>
    <para>
     There is an additional check if an invalid date is provided:
-    <example>
+    <informalexample>
      <programlisting role="php">
 <![CDATA[
 <?php
@@ -96,7 +96,7 @@ array(1) {
 }
 ]]>
      </screen>
-    </example>
+    </informalexample>
    </para>
   </listitem>
   <listitem>
@@ -104,7 +104,7 @@ array(1) {
     It is already possible to handle the edge cases, but then
     <function>DateTimeImmutable::createFromFormat</function> must be used
     while supplying the correct format.
-    <example>
+    <informalexample>
      <programlisting role="php">
 <![CDATA[
 <?php
@@ -125,7 +125,7 @@ object(DateTimeImmutable)#1 (3) {
 }
 ]]>
      </screen>
-    </example>
+    </informalexample>
    </para>
   </listitem>
  </orderedlist>


### PR DESCRIPTION
Part of https://github.com/php/doc-en/issues/3326, an `<example>` tag requires a `<title>`.

I couldn't come up with titles for the 3 examples, so I converted them to `<informalexample>` which don't have that requirement. @derickr if you have suggestions for titles to use instead, let me know.