### PR TITLE
Rewrite installation docs for Zip extension

### DIFF
--- a/reference/zip/configure.xml
+++ b/reference/zip/configure.xml
@@ -6,7 +6,7 @@
  <section xml:id="zip.installation.linux">
   <title>Linux systems</title>
   <para>
-   In order to use these functions PHP must be compiled PHP with ZIP support
+   In order to use these functions PHP must be compiled with ZIP support
    by using the <option role="configure">--with-zip</option>
    configure option.
   </para>

--- a/reference/zip/configure.xml
+++ b/reference/zip/configure.xml
@@ -3,42 +3,41 @@
 <section xml:id="zip.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
 
- <section xml:id="zip.installation.new">
+ <section xml:id="zip.installation.linux">
+  <title>Linux systems</title>
+  <para>
+   In order to use these functions PHP must be compiled PHP with ZIP support
+   by using the <option role="configure">--with-zip</option>
+   configure option.
+  </para>
+  <para>
+   Prior to PHP 7.4.0, libzip was bundled with PHP,
+   and to compile the extension one needed to use the
+   <option role="configure">--enable-zip</option>
+   configure option.
+   Building against the bundled libzip was discouraged as of PHP 7.3.0,
+   but still possible by using the
+   <option role="configure">--without-libzip</option>
+   configure option.
+  </para>
+  <para>
+   A <option role="configure">--with-libzip=DIR</option>
+   configure option has been added to use a system libzip installation. libzip
+   version 0.11 is required, with 0.11.2 or later recommended.
+  </para>
+ </section>
   
-  <section xml:id="zip.installation.new.linux">
-   <title>Linux systems</title>
-   <para>
-    As of PHP 7.4.0, in order to use these functions you must compile PHP with zip support
-    by using the <option role="configure">--with-zip</option>
-    configure option.
-    Previously, zip support had to be enabled by using the <option role="configure">--enable-zip</option>
-    configure option.
-    As of PHP 7.4.0, the bundled libzip is removed.
-   </para>
-   <para>
-    As of PHP 7.3.0, building against the bundled libzip is discouraged, but
-    still possible by adding <option role="configure">--without-libzip</option>
-    to the configuration.
-   </para>
-   <para>
-    A <option role="configure">--with-libzip=DIR</option>
-    configure option has been added to use a system libzip installation. libzip
-    version 0.11 is required, with 0.11.2 or later recommended.
-   </para>
-  </section>
-  
-  <section xml:id="zip.installation.new.windows">
-   <title>Windows</title>
-   <para>
-    As of PHP 8.2.0, <filename>php_zip.dll</filename> DLL must be
-    <link linkend="install.pecl.windows.loading">enabled</link> in
-    &php.ini;.
-    Previously, this extension was built-in.
-   </para>
-  </section>
+ <section xml:id="zip.installation.new.windows">
+  <title>Windows</title>
+  <para>
+   As of PHP 8.2.0, <filename>php_zip.dll</filename> DLL must be
+   <link linkend="install.pecl.windows.loading">enabled</link> in
+   &php.ini;.
+   Previously, this extension was built-in.
+  </para>
  </section>
 
- <section xml:id="zip.pecl.installation">
+ <section xml:id="zip.installation.pecl">
   <title>Installation via PECL</title>
   <para>
    &pecl.info;


### PR DESCRIPTION
This is part of #3326, a `<section>` tag needs to be immediately be followed by a `<title>` tag to conform to the DocBook schema.

At the same time, we take the opportunity to rewrite the documentation in such a way that it is easier to remove PHP 7 related docs when the time comes to remove them.