### PR TITLE
Fix markup issues in OCI8 extension docs

### DIFF
--- a/reference/oci8/dtrace.xml
+++ b/reference/oci8/dtrace.xml
@@ -2,14 +2,12 @@
 <!-- $Revision$ -->
 <chapter xml:id="oci8.dtrace" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>OCI8 and DTrace Dynamic Tracing</title>
- <section>
-  <para>
-   OCI8 2.0 introduced static DTrace probes that can be used on
-   operating systems that support DTrace.
-   See <link linkend="features.dtrace">DTrace Dynamic Tracing</link>
-   for an overview of PHP and DTrace.
-  </para>
- </section>
+ <para>
+  OCI8 2.0 introduced static DTrace probes that can be used on
+  operating systems that support DTrace.
+  See <link linkend="features.dtrace">DTrace Dynamic Tracing</link>
+  for an overview of PHP and DTrace.
+ </para>
 
 <section>
  <title>Installing OCI8 with DTrace Support</title>

--- a/reference/oci8/fan.xml
+++ b/reference/oci8/fan.xml
@@ -2,7 +2,6 @@
 <!-- $Revision$ -->
 <chapter xml:id="oci8.fan" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>OCI8 Fast Application Notification (FAN) Support</title>
- <section>
   <para>
    FAN support gives fast connection failover, an Oracle Database high availability
    feature.  This allows PHP OCI8 scripts to be notified when a
@@ -95,9 +94,7 @@
     </listitem>
    </itemizedlist>
   </para>
- </section>
 </chapter>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
@@ -118,4 +115,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/oci8/taf.xml
+++ b/reference/oci8/taf.xml
@@ -2,44 +2,43 @@
 <!-- $Revision$ -->
 <chapter xml:id="oci8.taf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>OCI8 Transparent Application Failover (TAF) Support</title>
- <section>
-  <para>
-   TAF is an Oracle Database feature that provides high availability.
-   It enables PHP OCI8 applications to automatically reconnect to a
-   preconfigured database when database connectivity fails due to
-   instance or network failure.
-  </para>
-  <para>
-   In a configured Oracle Database system, TAF occurs when the PHP
-   application detects that the database instance is down or
-   unreachable. It establishes a connection to another node in an
-   Oracle <link xlink:href="&url.oracle.taf.rac;">RAC</link>
-   configuration, a hot standby database, or the same database
-   instance
-   itself. See <link xlink:href="&url.oracle.taf.ociguide;">Oracle
-   Call Interface Programmer's Guide</link> for more information about
-   OCI TAF.
-  </para>
-  <para>
-   An application callback can be registered
-   with <function>oci_register_taf_callback</function>. During
-   failover, normal application processing stops and the registered
-   callback is invoked.  The callback notifies the application of the
-   failover events. If the failover succeeds, normal processing will
-   be resumed. If the failover aborts, any following database
-   operations in the application will fail due to no connection being
-   available.
-  </para>
-  <para>
-   When a connection fails over to another database, the callback can
-   reset any necessary connection state, for example replaying any
-   necessary ALTER SESSION commands if the database service did not have
-   -failover_restore enabled.
-  </para>
-  <para>
-   An application callback can be removed by calling <function>oci_unregister_taf_callback</function>.
-  </para>
- </section>
+ <para>
+  TAF is an Oracle Database feature that provides high availability.
+  It enables PHP OCI8 applications to automatically reconnect to a
+  preconfigured database when database connectivity fails due to
+  instance or network failure.
+ </para>
+ <para>
+  In a configured Oracle Database system, TAF occurs when the PHP
+  application detects that the database instance is down or
+  unreachable. It establishes a connection to another node in an
+  Oracle <link xlink:href="&url.oracle.taf.rac;">RAC</link>
+  configuration, a hot standby database, or the same database
+  instance
+  itself. See <link xlink:href="&url.oracle.taf.ociguide;">Oracle
+  Call Interface Programmer's Guide</link> for more information about
+  OCI TAF.
+ </para>
+ <para>
+  An application callback can be registered
+  with <function>oci_register_taf_callback</function>. During
+  failover, normal application processing stops and the registered
+  callback is invoked.  The callback notifies the application of the
+  failover events. If the failover succeeds, normal processing will
+  be resumed. If the failover aborts, any following database
+  operations in the application will fail due to no connection being
+  available.
+ </para>
+ <para>
+  When a connection fails over to another database, the callback can
+  reset any necessary connection state, for example replaying any
+  necessary ALTER SESSION commands if the database service did not have
+  -failover_restore enabled.
+ </para>
+ <para>
+  An application callback can be removed by calling <function>oci_unregister_taf_callback</function>.
+ </para>
+
  <section>
   <title>Configuring Transparent Application Failover</title>
   <para>
@@ -235,9 +234,7 @@
    </variablelist>
   </para>
   <example>
-   <para>
-    The following example registers a TAF callback
-   </para>
+   <title>Registering a TAF callback</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/oci8/testing.xml
+++ b/reference/oci8/testing.xml
@@ -1,129 +1,125 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
- <section xml:id="oci8.test">
-  <title xmlns="http://docbook.org/ns/docbook">Testing</title>
-   <section xml:id="oci8.testing" xmlns="http://docbook.org/ns/docbook">
-    <para>
-     The OCI8 test suite is in <filename>ext/oci8/tests</filename>.
-     After OCI8 tests are run this directory will also contain logs of
-     any failures.
-    </para>
-   </section>
-   <section>
-    <para>
-     Before running PHP's tests, edit <filename>details.inc</filename>
-     and set $user, $password and the $dbase connection string.  The
-     OCI8 test suite has been developed using
-     the <literal>SYSTEM</literal> account.  Some tests will fail if
-     the test user does not have equivalent permissions.
-    </para>
-    <para>
-     If Oracle Database Resident Connection Pooling is being
-     tested, set $test_drcp to &true; and ensure the
-     connection string uses an appropriate DRCP pooled server.
-    </para>
-    <para>
-     An alternative to editing <filename>details.inc</filename> is the
-     set environment variables, for example:
-     <programlisting>
+<section xml:id="oci8.test" xmlns="http://docbook.org/ns/docbook">
+ <title>Testing</title>
+ <para>
+  The OCI8 test suite is in <filename>ext/oci8/tests</filename>.
+  After OCI8 tests are run this directory will also contain logs of
+  any failures.
+ </para>
+ <para>
+  Before running PHP's tests, edit <filename>details.inc</filename>
+  and set $user, $password and the $dbase connection string.  The
+  OCI8 test suite has been developed using
+  the <literal>SYSTEM</literal> account.  Some tests will fail if
+  the test user does not have equivalent permissions.
+ </para>
+ <para>
+  If Oracle Database Resident Connection Pooling is being
+  tested, set $test_drcp to &true; and ensure the
+  connection string uses an appropriate DRCP pooled server.
+ </para>
+ <para>
+  An alternative to editing <filename>details.inc</filename> is the
+  set environment variables, for example:
+  <programlisting>
 <![CDATA[
     $ export PHP_OCI8_TEST_USER=system
     $ export PHP_OCI8_TEST_PASS=oracle
     $ export PHP_OCI8_TEST_DB=localhost/XE
     $ export PHP_OCI8_TEST_DRCP=FALSE
 ]]>
-     </programlisting>
-     Note in some shells these variables are not propagated correctly
-     to the PHP process and tests will fail to connect if this method
-     is used.
-    </para>
-    <para>
-     Next, set any necessary environment for the Oracle database.  If you are
-     running PHP on the same machines as Oracle Database, you can run:
-   <programlisting>
+  </programlisting>
+  Note in some shells these variables are not propagated correctly
+  to the PHP process and tests will fail to connect if this method
+  is used.
+ </para>
+ <para>
+  Next, set any necessary environment for the Oracle database.  If you are
+  running PHP on the same machines as Oracle Database, you can run:
+  <programlisting>
 <![CDATA[
     $ . /usr/local/bin/oraenv
 ]]>
-   </programlisting>
-    </para>
-    <para>
-     With Oracle 11<emphasis>g</emphasis>R2 XE do:
-     <programlisting>
+  </programlisting>
+ </para>
+ <para>
+  With Oracle 11<emphasis>g</emphasis>R2 XE do:
+  <programlisting>
 <![CDATA[
     $ . /u01/app/oracle/product/11.2.0/xe/bin/oracle_env.sh
 ]]>
-     </programlisting>
-    </para>
-    <para>
-     Some shells require that &php.ini; has <literal>E</literal> in the
-     variables_order parameter, for example:
-     <programlisting>
+  </programlisting>
+ </para>
+ <para>
+  Some shells require that &php.ini; has <literal>E</literal> in the
+  variables_order parameter, for example:
+  <programlisting>
 <![CDATA[
     variables_order = "EGPCS"
 ]]>
-     </programlisting>
-    </para>
-    <para>
-     Run all the PHP tests with:
-   <programlisting>
+  </programlisting>
+ </para>
+ <para>
+  Run all the PHP tests with:
+  <programlisting>
 <![CDATA[
     $ cd your_php_src_directory
     $ make test
 ]]>
-   </programlisting>
-   or run only the OCI8 tests with
-   <programlisting>
+  </programlisting>
+  or run only the OCI8 tests with
+  <programlisting>
 <![CDATA[
     $ cd your_php_src_directory
     $ make test TESTS=ext/oci8
 ]]>
-   </programlisting>
-    </para>
-    <para>
-      When the tests have completed, review any test failures. On slow
-      systems, some tests may take longer than the default test
-      timeout in <filename>run-tests.php</filename>.  To correct this,
-      set the environment variable <literal>TEST_TIMEOUT</literal> to
-      a larger number of seconds.
-    </para>
-    <para>
-     On fast machines with a local database configured for light load
-     (e.g. Oracle 11<emphasis>g</emphasis>R2 XE) some tests might fail with ORA-12516 or
-     ORA-12520 errors.  To prevent this, increase the database
-     <literal>PROCESSES</literal> parameter using the following steps:
-    </para>
-    <para>
-     Connect as the oracle software owner:
-     <programlisting>
+  </programlisting>
+ </para>
+ <para>
+  When the tests have completed, review any test failures. On slow
+  systems, some tests may take longer than the default test
+  timeout in <filename>run-tests.php</filename>.  To correct this,
+  set the environment variable <literal>TEST_TIMEOUT</literal> to
+  a larger number of seconds.
+ </para>
+ <para>
+  On fast machines with a local database configured for light load
+  (e.g. Oracle 11<emphasis>g</emphasis>R2 XE) some tests might fail with ORA-12516 or
+  ORA-12520 errors.  To prevent this, increase the database
+  <literal>PROCESSES</literal> parameter using the following steps:
+ </para>
+ <para>
+  Connect as the oracle software owner:
+  <programlisting>
 <![CDATA[
     $ su - oracle
 ]]>
-     </programlisting>
-    </para>
-    <para>
-     Set the necessary Oracle environment with <filename>oracle_env.sh</filename> or
-     <filename>oraenv</filename>, as described above.
-    </para>
-    <para>
-     Start the SQL*Plus command line tool and
-     increase <literal>PROCESSES</literal>
-     <programlisting>
+  </programlisting>
+ </para>
+ <para>
+  Set the necessary Oracle environment with <filename>oracle_env.sh</filename> or
+  <filename>oraenv</filename>, as described above.
+ </para>
+ <para>
+  Start the SQL*Plus command line tool and
+  increase <literal>PROCESSES</literal>
+  <programlisting>
 <![CDATA[
     $ sqlplus / as sysdba
     SQL> alter system set processes=100 scope=spfile
 ]]>
-     </programlisting>
-    </para>
-    <para>
-     Restart the database:
-     <programlisting>
+  </programlisting>
+ </para>
+ <para>
+  Restart the database:
+  <programlisting>
 <![CDATA[
     SQL> startup force
 ]]>
-     </programlisting>
-    </para>
-   </section>
- </section>
+  </programlisting>
+ </para>
+</section>
 
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
This is part of https://github.com/php/doc-en/issues/3326, a `<section>` tag needs to be immediately be followed by a <title> tag to conform to the DocBook schema.

There are still more OCI8 fixes required, so splitting this into its own PR.