### PR TITLE
CLI docs: Remove PHP 5 era changelog and rework markup

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -5,7 +5,7 @@
  <titleabbrev>Command line usage</titleabbrev>
  
  <!--Introduction: {{{-->
- <section xml:id="features.commandline.introduction">
+ <section xml:id="features.commandline.introduction" annotations="chunk:false">
   <title>Introduction</title>
   
   <para>
@@ -1645,95 +1645,82 @@ php >
   </para>
 
   <para>
-    Standard MIME types are returned for files with extensions: .3gp,
-    .apk, .avi, .bmp, .css, .csv, .doc, .docx, .flac, .gif, .gz,
-    .gzip, .htm, .html, .ics, .jpe, .jpeg, .jpg, .js, .kml, .kmz,
-    .m4a, .mov, .mp3, .mp4, .mpeg, .mpg, .odp, .ods, .odt, .oga, .ogg,
-    .ogv, .pdf, .pdf, .png, .pps, .pptx, .qt, .svg, .swf, .tar, .text,
-    .tif, .txt, .wav, .webm, .wmv, .xls, .xlsx, .xml, .xsl, .xsd, and .zip.
+   Standard MIME types are returned for files with extensions:
+   <simplelist type="inline">
+    <member><literal>.3gp</literal></member>
+    <member><literal>.apk</literal></member>
+    <member><literal>.avi</literal></member>
+    <member><literal>.bmp</literal></member>
+    <member><literal>.css</literal></member>
+    <member><literal>.csv</literal></member>
+    <member><literal>.doc</literal></member>
+    <member><literal>.docx</literal></member>
+    <member><literal>.flac</literal></member>
+    <member><literal>.gif</literal></member>
+    <member><literal>.gz</literal></member>
+    <member><literal>.gzip</literal></member>
+    <member><literal>.htm</literal></member>
+    <member><literal>.html</literal></member>
+    <member><literal>.ics</literal></member>
+    <member><literal>.jpe</literal></member>
+    <member><literal>.jpeg</literal></member>
+    <member><literal>.jpg</literal></member>
+    <member><literal>.js</literal></member>
+    <member><literal>.kml</literal></member>
+    <member><literal>.kmz</literal></member>
+    <member><literal>.m4a</literal></member>
+    <member><literal>.mov</literal></member>
+    <member><literal>.mp3</literal></member>
+    <member><literal>.mp4</literal></member>
+    <member><literal>.mpeg</literal></member>
+    <member><literal>.mpg</literal></member>
+    <member><literal>.odp</literal></member>
+    <member><literal>.ods</literal></member>
+    <member><literal>.odt</literal></member>
+    <member><literal>.oga</literal></member>
+    <member><literal>.ogg</literal></member>
+    <member><literal>.ogv</literal></member>
+    <member><literal>.pdf</literal></member>
+    <member><literal>.png</literal></member>
+    <member><literal>.pps</literal></member>
+    <member><literal>.pptx</literal></member>
+    <member><literal>.qt</literal></member>
+    <member><literal>.svg</literal></member>
+    <member><literal>.swf</literal></member>
+    <member><literal>.tar</literal></member>
+    <member><literal>.text</literal></member>
+    <member><literal>.tif</literal></member>
+    <member><literal>.txt</literal></member>
+    <member><literal>.wav</literal></member>
+    <member><literal>.webm</literal></member>
+    <member><literal>.wmv</literal></member>
+    <member><literal>.xls</literal></member>
+    <member><literal>.xlsx</literal></member>
+    <member><literal>.xml</literal></member>
+    <member><literal>.xsl</literal></member>
+    <member><literal>.xsd</literal></member>
+    <member><literal>.zip</literal></member>
+   </simplelist>
+   .
   </para>
 
-
-  <table>
-   <title>Changelog: Supported MIME Types (file extensions)</title>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>&Version;</entry>
-      <entry>&Description;</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>5.5.12</entry>
-      <entry>
-       .xml, .xsl, and .xsd
-      </entry>
-     </row>
-     <row>
-      <entry>5.5.7</entry>
-      <entry>
-       .3gp, .apk, .avi, .bmp, .csv, .doc, .docx, .flac, .gz, .gzip,
-       .ics, .kml, .kmz, .m4a, .mp3, .mp4, .mpg, .mpeg, .mov, .odp, .ods,
-       .odt, .oga, .pdf, .pptx, .pps, .qt, .swf, .tar, .text, .tif, .wav,
-       .wmv, .xls, .xlsx, and .zip
-      </entry>
-     </row>
-     <row>
-      <entry>5.5.5</entry>
-      <entry>
-       .pdf
-      </entry>
-     </row>
-     <row>
-      <entry>5.4.11</entry>
-      <entry>
-       .ogg, .ogv, and .webm
-      </entry>
-     </row>
-     <row>
-      <entry>5.4.4</entry>
-      <entry>
-        .htm and .svg
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </table>
-
-
-  <table>
-   <title>Changelog</title>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>&Version;</entry>
-      <entry>&Description;</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>7.4.0</entry>
-      <entry>
-       You can configure the built-in webserver to fork multiple workers
-       in order to test code that requires multiple concurrent requests to
-       the built-in webserver. Set the <envar>PHP_CLI_SERVER_WORKERS</envar>
-       environment variable to the number of desired workers before starting
-       the server.
-       This is not supported on Windows.
-       <warning>
-        <para>
-         This <emphasis>experimental</emphasis> feature is <emphasis>not</emphasis>
-         intended for production usage. Generally, the built-in Web Server is
-         <emphasis>not</emphasis> intended for production usage.
-        </para>
-       </warning>
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </table>
-
+  <simpara>
+   As of PHP 7.4.0, the built-in webserver can be configured to fork multiple
+   workers in order to test code that requires multiple concurrent requests
+   to the built-in webserver.
+   Set the <envar>PHP_CLI_SERVER_WORKERS</envar> environment variable to the
+   number of desired workers before starting the server.
+  </simpara>
+  <note>
+   <simpara>This feature is not supported on Windows.</simpara>
+  </note>
+  <warning>
+   <para>
+    This <emphasis>experimental</emphasis> feature is <emphasis>not</emphasis>
+    intended for production usage. Generally, the built-in Web Server is
+    <emphasis>not</emphasis> intended for production usage.
+   </para>
+  </warning>
 
   <example>
    <title>Starting the web server</title> 


### PR DESCRIPTION
To make it compliant with the DocBook schema.

Mark the introduction as not chunked so that the rendering of the manual doesn't just have a ToC: https://www.php.net/manual/en/features.commandline.php