### PR TITLE
Document removal of --with-openssl[=DIR] argument

### DIFF
--- a/reference/openssl/configure.xml
+++ b/reference/openssl/configure.xml
@@ -4,7 +4,7 @@
  &reftitle.install;
  <para>
   To use PHP's OpenSSL support you must also compile PHP <option
-  role="configure">--with-openssl[=DIR]</option>.
+  role="configure">--with-openssl</option>.
  </para>
  <para>
   The OpenSSL library also has additional requirements for normal operation at
@@ -87,6 +87,16 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>7.4.0</entry>
+       <entry>
+        The <option role="configure">--with-openssl[=DIR]</option> doesn't
+        accept a directory argument anymore in favor of setting the pkg-config
+        variable <envar>PKG_CONFIG_PATH</envar> to OpenSSL location, or by
+        specifying the <envar>OPENSSL_LIBS</envar> and
+        <envar>OPENSSL_CFLAGS</envar> variables.
+       </entry>
+      </row>
       <row>
        <entry>7.4.0</entry>
        <entry>


### PR DESCRIPTION
The optional DIR argument in --with-openssl configure option was removed in PHP 7.4.0.