### PR TITLE
Convert info constant tables to variablelists

### DIFF
--- a/install/ini.xml
+++ b/install/ini.xml
@@ -261,9 +261,9 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
   </para>
 
   <para>
-   <table>
+   <variablelist>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('constant.ini-mode')/*)"><xi:fallback/></xi:include>
-   </table>
+   </variablelist>
   </para>
  </sect1>
 

--- a/reference/info/constants.xml
+++ b/reference/info/constants.xml
@@ -3,366 +3,472 @@
 <appendix xml:id="info.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants.core;
- <table>
-  <title>Pre-defined <function>phpcredits</function> constants</title>
-  <tgroup cols="3">
-   <thead>
-    <row>
-     <entry>&Constants;</entry>
-     <entry>Value</entry>
-     <entry>&Description;</entry>
-    </row>
-   </thead>
-   <tbody>
-    <row xml:id="constant.credits-group">
-     <entry><constant>CREDITS_GROUP</constant></entry>
-     <entry>1</entry>
-     <entry>A list of the core developers</entry>
-    </row>
-    <row xml:id="constant.credits-general">
-     <entry><constant>CREDITS_GENERAL</constant></entry>
-     <entry>2</entry>
-     <entry>
-      General credits: Language design and concept, PHP
-      authors and SAPI module.
-     </entry>
-    </row>
-    <row xml:id="constant.credits-sapi">
-     <entry><constant>CREDITS_SAPI</constant></entry>
-     <entry>4</entry>
-     <entry>
-      A list of the server API modules for PHP, and their authors.
-     </entry>
-    </row>
-    <row xml:id="constant.credits-modules">
-     <entry><constant>CREDITS_MODULES</constant></entry>
-     <entry>8</entry>
-     <entry>
-      A list of the extension modules for PHP, and their authors.
-     </entry>
-    </row>
-    <row xml:id="constant.credits-docs">
-     <entry><constant>CREDITS_DOCS</constant></entry>
-     <entry>16</entry>
-     <entry>
-      The credits for the documentation team.
-     </entry>
-    </row>
-    <row xml:id="constant.credits-fullpage">
-     <entry><constant>CREDITS_FULLPAGE</constant></entry>
-     <entry>32</entry>
-     <entry>
-      Usually used in combination with the other flags. Indicates
-      that a complete stand-alone HTML page needs to be
-      printed including the information indicated by the other
-      flags.
-     </entry>
-    </row>
-    <row xml:id="constant.credits-qa">
-     <entry><constant>CREDITS_QA</constant></entry>
-     <entry>64</entry>
-     <entry>
-      The credits for the quality assurance team.
-     </entry>
-    </row>
-    <row xml:id="constant.credits-all">
-     <entry><constant>CREDITS_ALL</constant></entry>
-     <entry>-1</entry>
-     <entry>
-      All the credits, equivalent to using: <literal>CREDITS_DOCS +
-      CREDITS_GENERAL + CREDITS_GROUP + CREDITS_MODULES + CREDITS_QA
-      CREDITS_FULLPAGE</literal>. It generates a complete stand-alone HTML
-      page with the appropriate tags. This is the default value.
-     </entry>
-    </row>
-   </tbody>
-  </tgroup>
- </table>
+ <variablelist xml:id="constant.credits.constants" role="constant_list">
+  <title>Pre-defined <function xmlns="http://docbook.org/ns/docbook">phpcredits</function> constants</title>
+  <varlistentry xml:id="constant.credits-group">
+   <term>
+    <constant>CREDITS_GROUP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     A list of the core developers
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.credits-general">
+   <term>
+    <constant>CREDITS_GENERAL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     General credits: Language design and concept, PHP
+     authors and SAPI module.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.credits-sapi">
+   <term>
+    <constant>CREDITS_SAPI</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     A list of the server API modules for PHP, and their authors.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.credits-modules">
+   <term>
+    <constant>CREDITS_MODULES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     A list of the extension modules for PHP, and their authors.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.credits-docs">
+   <term>
+    <constant>CREDITS_DOCS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The credits for the documentation team.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.credits-fullpage">
+   <term>
+    <constant>CREDITS_FULLPAGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Usually used in combination with the other flags. Indicates
+     that a complete stand-alone HTML page needs to be
+     printed including the information indicated by the other
+     flags.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.credits-qa">
+   <term>
+    <constant>CREDITS_QA</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The credits for the quality assurance team.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.credits-all">
+   <term>
+    <constant>CREDITS_ALL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     All the credits, equivalent to using: <literal xmlns="http://docbook.org/ns/docbook">CREDITS_DOCS +
+     CREDITS_GENERAL + CREDITS_GROUP + CREDITS_MODULES + CREDITS_QA
+     CREDITS_FULLPAGE</literal>. It generates a complete stand-alone HTML
+     page with the appropriate tags. This is the default value.
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
 
- <table>
-  <title><function>phpinfo</function> constants</title>
-  <tgroup cols="3">
-   <thead>
-    <row>
-     <entry>&Constants;</entry>
-     <entry>Value</entry>
-     <entry>&Description;</entry>
-    </row>
-   </thead>
-   <tbody>
-    <row xml:id="constant.info-general">
-     <entry><constant>INFO_GENERAL</constant></entry>
-     <entry>1</entry>
-     <entry>
-      The configuration line, &php.ini; location, build date, Web
-      Server, System and more.
-     </entry>
-    </row>
-    <row xml:id="constant.info-credits">
-     <entry><constant>INFO_CREDITS</constant></entry>
-     <entry>2</entry>
-     <entry>
-      PHP Credits.  See also <function>phpcredits</function>.
-     </entry>
-    </row>
-    <row xml:id="constant.info-configuration">
-     <entry><constant>INFO_CONFIGURATION</constant></entry>
-     <entry>4</entry>
-     <entry>
-      Current Local and Master values for PHP directives. See
-      also <function>ini_get</function>.
-     </entry>
-    </row>
-    <row xml:id="constant.info-modules">
-     <entry><constant>INFO_MODULES</constant></entry>
-     <entry>8</entry>
-     <entry>
-      Loaded modules and their respective settings.
-     </entry>
-    </row>
-    <row xml:id="constant.info-environment">
-     <entry><constant>INFO_ENVIRONMENT</constant></entry>
-     <entry>16</entry>
-     <entry>
-      Environment Variable information that's also available in
-      <varname>$_ENV</varname>.
-     </entry>
-    </row>
-    <row xml:id="constant.info-variables">
-     <entry><constant>INFO_VARIABLES</constant></entry>
-     <entry>32</entry>
-     <entry>
-      Shows all <link linkend="language.variables.predefined">
-      predefined variables</link> from <literal>EGPCS</literal> (Environment, GET,
-      POST, Cookie, Server).
-     </entry>
-    </row>
-    <row xml:id="constant.info-license">
-     <entry><constant>INFO_LICENSE</constant></entry>
-     <entry>64</entry>
-     <entry>
-      PHP License information.  See also the <link
-      xlink:href="&url.php.license;">license faq</link>.
-     </entry>
-    </row>
-    <row xml:id="constant.info-all">
-     <entry><constant>INFO_ALL</constant></entry>
-     <entry>-1</entry>
-     <entry>
-      Shows all of the above. This is the default value.
-     </entry>
-    </row>
-   </tbody>
-  </tgroup>
- </table>
+ <variablelist xml:id="constant.info.constants" role="constant_list">
+  <title><function xmlns="http://docbook.org/ns/docbook">phpinfo</function> constants</title>
+  <varlistentry xml:id="constant.info-general">
+   <term>
+    <constant>INFO_GENERAL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The configuration line, &php.ini; location, build date, Web
+     Server, System and more.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.info-credits">
+   <term>
+    <constant>INFO_CREDITS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     PHP Credits.  See also <function xmlns="http://docbook.org/ns/docbook">phpcredits</function>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.info-configuration">
+   <term>
+    <constant>INFO_CONFIGURATION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Current Local and Master values for PHP directives. See
+     also <function xmlns="http://docbook.org/ns/docbook">ini_get</function>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.info-modules">
+   <term>
+    <constant>INFO_MODULES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Loaded modules and their respective settings.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.info-environment">
+   <term>
+    <constant>INFO_ENVIRONMENT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Environment Variable information that's also available in
+     <varname xmlns="http://docbook.org/ns/docbook">$_ENV</varname>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.info-variables">
+   <term>
+    <constant>INFO_VARIABLES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Shows all <link xmlns="http://docbook.org/ns/docbook" linkend="language.variables.predefined">
+     predefined variables</link> from <literal xmlns="http://docbook.org/ns/docbook">EGPCS</literal> (Environment, GET,
+     POST, Cookie, Server).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.info-license">
+   <term>
+    <constant>INFO_LICENSE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     PHP License information.  See also the <link xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.php.license;">license faq</link>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.info-all">
+   <term>
+    <constant>INFO_ALL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Shows all of the above. This is the default value.
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
 
- <table xml:id="constant.ini-mode">
+ <variablelist xml:id="constant.ini-mode" role="constant_list">
   <title>INI mode constants</title>
-  <tgroup cols="2">
-   <thead>
-    <row>
-     <entry>&Constants;</entry>
-     <entry>&Description;</entry>
-    </row>
-   </thead>
-   <tbody>
-    <row>
-     <entry>
-      <constant>INI_USER</constant>
-      (<type>int</type>)
-     </entry>
-     <entry>
-      Entry can be set in user scripts (like with <function>ini_set</function>)
-      or in the <link linkend="configuration.changes.windows">Windows registry</link>.
-      Entry can be set in &user-ini;
-     </entry>
-    </row>
-    <row>
-     <entry>
-      <constant>INI_PERDIR</constant>
-      (<type>int</type>)
-     </entry>
-     <entry>
-      Entry can be set in &php.ini;, &htaccess;, &httpd.conf; or &user-ini;
-     </entry>
-    </row>
-    <row>
-     <entry>
-      <constant>INI_SYSTEM</constant>
-      (<type>int</type>)
-     </entry>
-     <entry>
-      Entry can be set in &php.ini; or &httpd.conf;
-     </entry>
-    </row>
-    <row>
-     <entry>
-      <constant>INI_ALL</constant>
-      (<type>int</type>)
-     </entry>
-     <entry>
-      Entry can be set anywhere
-     </entry>
-    </row>
-   </tbody>
-  </tgroup>
- </table>
+  <varlistentry>
+   <term>
+    <constant>INI_USER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Entry can be set in user scripts (like with <function xmlns="http://docbook.org/ns/docbook">ini_set</function>)
+     or in the <link xmlns="http://docbook.org/ns/docbook" linkend="configuration.changes.windows">Windows registry</link>.
+     Entry can be set in &user-ini;
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>
+    <constant>INI_PERDIR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Entry can be set in &php.ini;, &htaccess;, &httpd.conf; or &user-ini;
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>
+    <constant>INI_SYSTEM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Entry can be set in &php.ini; or &httpd.conf;
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>
+    <constant>INI_ALL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Entry can be set anywhere
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
 
  <simpara>
   Assert constants, these values are used to set
   the assertion options in <function>assert_options</function>.
  </simpara>
- <table>
-  <title><function>assert</function> constants</title>
-  <tgroup cols="3">
-   <thead>
-    <row>
-     <entry>&Constants;</entry>
-     <entry>INI Setting</entry>
-     <entry>&Description;</entry>
-    </row>
-   </thead>
-   <tbody>
-    <row xml:id="constant.assert-active">
-     <entry><constant>ASSERT_ACTIVE</constant></entry>
-     <entry><link linkend="ini.assert.active">assert.active</link></entry>
-     <entry>
-      Enable <function>assert</function> evaluation.
-      &warn.deprecated.feature-8-3-0;
-     </entry>
-    </row>
-    <row xml:id="constant.assert-callback">
-     <entry><constant>ASSERT_CALLBACK</constant></entry>
-     <entry><link linkend="ini.assert.callback">assert.callback</link></entry>
-     <entry>
-      Callback to call on failed assertions.
-      &warn.deprecated.feature-8-3-0;
-     </entry>
-    </row>
-    <row xml:id="constant.assert-bail">
-     <entry><constant>ASSERT_BAIL</constant></entry>
-     <entry><link linkend="ini.assert.bail">assert.bail</link></entry>
-     <entry>
-      Terminate execution on failed assertions.
-      &warn.deprecated.feature-8-3-0;
-     </entry>
-    </row>
-    <row xml:id="constant.assert-exception">
-     <entry><constant>ASSERT_EXCEPTION</constant></entry>
-     <entry><link linkend="ini.assert.exception">assert.exception</link></entry>
-     <entry>
-      Issues a PHP warning for each failed assertion
-      &warn.deprecated.feature-8-3-0;
-     </entry>
-    </row>
-    <row xml:id="constant.assert-warning">
-     <entry><constant>ASSERT_WARNING</constant></entry>
-     <entry><link linkend="ini.assert.warning">assert.warning</link></entry>
-     <entry>
-      Issues a PHP warning for each failed assertion
-      &warn.deprecated.feature-8-3-0;
-     </entry>
-    </row>
-    <row xml:id="constant.assert-quiet-eval">
-     <entry><constant>ASSERT_QUIET_EVAL</constant></entry>
-     <entry><link linkend="ini.assert.quiet-eval">assert.quiet_eval</link></entry>
-     <entry>
-      Disable <literal>error_reporting</literal> during assertion expression evaluation.
-      &warn.feature.removed-8-0-0;
-     </entry>
-    </row>
-   </tbody>
-  </tgroup>
- </table>
+ <variablelist xml:id="constant.assert.constants" role="constant_list">
+  <title><function xmlns="http://docbook.org/ns/docbook">assert</function> constants</title>
+  <varlistentry xml:id="constant.assert-active">
+   <term>
+    <constant>ASSERT_ACTIVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Enable <function xmlns="http://docbook.org/ns/docbook">assert</function> evaluation.
+     &warn.deprecated.feature-8-3-0;
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.assert-callback">
+   <term>
+    <constant>ASSERT_CALLBACK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Callback to call on failed assertions.
+     &warn.deprecated.feature-8-3-0;
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.assert-bail">
+   <term>
+    <constant>ASSERT_BAIL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Terminate execution on failed assertions.
+     &warn.deprecated.feature-8-3-0;
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.assert-exception">
+   <term>
+    <constant>ASSERT_EXCEPTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Issues a PHP warning for each failed assertion
+     &warn.deprecated.feature-8-3-0;
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.assert-warning">
+   <term>
+    <constant>ASSERT_WARNING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Issues a PHP warning for each failed assertion
+     &warn.deprecated.feature-8-3-0;
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.assert-quiet-eval">
+   <term>
+    <constant>ASSERT_QUIET_EVAL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Disable <literal xmlns="http://docbook.org/ns/docbook">error_reporting</literal> during assertion expression evaluation.
+     &warn.feature.removed-8-0-0;
+    </para>
+   </listitem>
+  </varlistentry>
+ </variablelist>
 
  <simpara>
   The following constants are only available if the host operating
   system is Windows, and can tell different versioning information
   so its possible to detect various features and make use of them.
  </simpara>
- <table>
+ <variablelist xml:id="constant.windows.constants" role="constant_list">
   <title>Windows specific constants</title>
-  <tgroup cols="3">
-   <thead>
-    <row>
-     <entry>Constant</entry>
-     <entry>Description</entry>
-    </row>
-   </thead>
-   <tbody>
-    <row xml:id="constant.php-windows-version-major">
-     <entry><constant>PHP_WINDOWS_VERSION_MAJOR</constant></entry>
-     <entry>
-      The major version of Windows, this can be either <literal>4</literal> (NT4/Me/98/95),
-      <literal>5</literal> (XP/2003 R2/2003/2000) or <literal>6</literal> (Vista/2008/7/8/8.1).
-    </entry>
-    </row>
-    <row xml:id="constant.php-windows-version-minor">
-     <entry><constant>PHP_WINDOWS_VERSION_MINOR</constant></entry>
-     <entry>
-      The minor version of Windows, this can be either <literal>0</literal> (Vista/2008/2000/NT4/95),
-      <literal>1</literal> (XP), <literal>2</literal> (2003 R2/2003/XP x64), <literal>10</literal> (98)
-      or <literal>90</literal> (ME).</entry>
-    </row>
-    <row xml:id="constant.php-windows-version-build">
-     <entry><constant>PHP_WINDOWS_VERSION_BUILD</constant></entry>
-     <entry>The Windows build number (for example, Windows Vista with SP1 applied is build 6001)</entry>
-    </row>
-    <row xml:id="constant.php-windows-version-platform">
-     <entry><constant>PHP_WINDOWS_VERSION_PLATFORM</constant></entry>
-     <entry>
-      The platform that PHP currently is running on, this value is <literal>2</literal> on Windows
-      Vista/XP/2000/NT4, Server 2008/2003 and on Windows ME/98/95 this value is <literal>1</literal>.
-     </entry>
-    </row>
-    <row xml:id="constant.php-windows-version-sp-major">
-     <entry><constant>PHP_WINDOWS_VERSION_SP_MAJOR</constant></entry>
-     <entry>
-      The major version of the service pack installed, this value is <literal>0</literal>
-      if no service pack is installed. For example, Windows XP with service pack 3 installed
-      will make this value <literal>3</literal>.
-     </entry>
-    </row>
-    <row xml:id="constant.php-windows-version-sp-minor">
-     <entry><constant>PHP_WINDOWS_VERSION_SP_MINOR</constant></entry>
-     <entry>
-      The minor version of the service pack installed, this value is <literal>0</literal>
-      if no service pack is installed.
-     </entry>
-    </row>
-    <row xml:id="constant.php-windows-version-suitemask">
-     <entry><constant>PHP_WINDOWS_VERSION_SUITEMASK</constant></entry>
-     <entry>
-      The suitemask is a bitmask that can tell if various features of Windows is installed,
-      see the table below for possible bitfield values.
-     </entry>
-    </row>
-    <row xml:id="constant.php-windows-version-producttype">
-     <entry><constant>PHP_WINDOWS_VERSION_PRODUCTTYPE</constant></entry>
-     <entry>
-      This contains the value used to determine the <literal>PHP_WINDOWS_NT_*</literal>
-      constants. This value may be one of the <literal>PHP_WINDOWS_NT_*</literal> constants
-      indicating the platform type.
-     </entry>
-    </row>
-    <row xml:id="constant.php-windows-nt-domain-controller">
-     <entry><constant>PHP_WINDOWS_NT_DOMAIN_CONTROLLER</constant></entry>
-     <entry>This is a domain controller</entry>
-    </row>
-    <row xml:id="constant.php-windows-nt-server">
-     <entry><constant>PHP_WINDOWS_NT_SERVER</constant></entry>
-     <entry>
-      This is a server system (eg. Server 2008/2003/2000), note that if this is a
-      domain controller its reported as <constant>PHP_WINDOWS_NT_DOMAIN_CONTROLLER</constant>.
-     </entry>
-    </row>
-    <row xml:id="constant.php-windows-nt-workstation">
-     <entry><constant>PHP_WINDOWS_NT_WORKSTATION</constant></entry>
-     <entry>This is a workstation system (eg. Vista/XP/2000/NT4)</entry>
-    </row>
-   </tbody>
-  </tgroup>
- </table>
+  <varlistentry xml:id="constant.php-windows-version-major">
+   <term>
+    <constant>PHP_WINDOWS_VERSION_MAJOR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The major version of Windows, this can be either <literal xmlns="http://docbook.org/ns/docbook">4</literal> (NT4/Me/98/95),
+     <literal xmlns="http://docbook.org/ns/docbook">5</literal> (XP/2003 R2/2003/2000) or <literal xmlns="http://docbook.org/ns/docbook">6</literal> (Vista/2008/7/8/8.1).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-windows-version-minor">
+   <term>
+    <constant>PHP_WINDOWS_VERSION_MINOR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The minor version of Windows, this can be either <literal xmlns="http://docbook.org/ns/docbook">0</literal> (Vista/2008/2000/NT4/95),
+     <literal xmlns="http://docbook.org/ns/docbook">1</literal> (XP), <literal xmlns="http://docbook.org/ns/docbook">2</literal> (2003 R2/2003/XP x64), <literal xmlns="http://docbook.org/ns/docbook">10</literal> (98)
+     or <literal xmlns="http://docbook.org/ns/docbook">90</literal> (ME).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-windows-version-build">
+   <term>
+    <constant>PHP_WINDOWS_VERSION_BUILD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The Windows build number (for example, Windows Vista with SP1 applied is build 6001)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-windows-version-platform">
+   <term>
+    <constant>PHP_WINDOWS_VERSION_PLATFORM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The platform that PHP currently is running on, this value is <literal xmlns="http://docbook.org/ns/docbook">2</literal> on Windows
+     Vista/XP/2000/NT4, Server 2008/2003 and on Windows ME/98/95 this value is <literal xmlns="http://docbook.org/ns/docbook">1</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-windows-version-sp-major">
+   <term>
+    <constant>PHP_WINDOWS_VERSION_SP_MAJOR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The major version of the service pack installed, this value is <literal xmlns="http://docbook.org/ns/docbook">0</literal>
+     if no service pack is installed. For example, Windows XP with service pack 3 installed
+     will make this value <literal xmlns="http://docbook.org/ns/docbook">3</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-windows-version-sp-minor">
+   <term>
+    <constant>PHP_WINDOWS_VERSION_SP_MINOR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The minor version of the service pack installed, this value is <literal xmlns="http://docbook.org/ns/docbook">0</literal>
+     if no service pack is installed.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-windows-version-suitemask">
+   <term>
+    <constant>PHP_WINDOWS_VERSION_SUITEMASK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The suitemask is a bitmask that can tell if various features of Windows is installed,
+     see the table below for possible bitfield values.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-windows-version-producttype">
+   <term>
+    <constant>PHP_WINDOWS_VERSION_PRODUCTTYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     This contains the value used to determine the <literal xmlns="http://docbook.org/ns/docbook">PHP_WINDOWS_NT_*</literal>
+     constants. This value may be one of the <literal xmlns="http://docbook.org/ns/docbook">PHP_WINDOWS_NT_*</literal> constants
+     indicating the platform type.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-windows-nt-domain-controller">
+   <term>
+    <constant>PHP_WINDOWS_NT_DOMAIN_CONTROLLER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     This is a domain controller
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-windows-nt-server">
+   <term>
+    <constant>PHP_WINDOWS_NT_SERVER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     This is a server system (eg. Server 2008/2003/2000), note that if this is a
+     domain controller its reported as <constant xmlns="http://docbook.org/ns/docbook">PHP_WINDOWS_NT_DOMAIN_CONTROLLER</constant>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-windows-nt-workstation">
+   <term>
+    <constant>PHP_WINDOWS_NT_WORKSTATION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     This is a workstation system (eg. Vista/XP/2000/NT4)
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
  <simpara>
   This table shows a list of features that can be checked for using the
   <constant>PHP_WINDOWS_VERSION_SUITEMASK</constant> bitmask.


### PR DESCRIPTION
Convert info constant `<table>`s (and a table that XIncluded one of these `<table>`s) to `<variablelist>`s.

Conversion was done with [this script](https://gist.github.com/haszi/5b6815c63b0512cfa73e375562235de4) that can also be used for converting the same tables in all translations.