### PR TITLE
Make PDO CUBRID DocBook 5.2 conformant

### DIFF
--- a/reference/pdo_cubrid/reference.xml
+++ b/reference/pdo_cubrid/reference.xml
@@ -1,87 +1,98 @@
 <?xml version="1.0" encoding="utf-8"?>
- <reference xml:id="ref.pdo-cubrid" xmlns="http://docbook.org/ns/docbook">
- <?phpdoc extension-membership="pecl" ?>
-  <title>CUBRID Functions (PDO_CUBRID)</title>
-  <titleabbrev>CUBRID (PDO)</titleabbrev>
-  <partintro>
+<reference xml:id="ref.pdo-cubrid" xmlns="http://docbook.org/ns/docbook"><?phpdoc extension-membership="pecl" ?>
+ <title>CUBRID Functions (PDO_CUBRID)</title>
+ <titleabbrev>CUBRID (PDO)</titleabbrev>
+ <partintro>
 
-   <section xml:id="pdo-cubrid.intro">
-   &reftitle.intro;
-    <para>
-     PDO_CUBRID is a driver that implements the <link linkend="intro.pdo">PHP Data Objects (PDO) interface</link> to 
-     enable access from PHP to CUBRID databases.
-    </para>
-    <note>
-    <para>
-     Current version of PDO_CUBRID doesn't support persistent connection now.
-    </para>
-   </note>
+  <section xml:id="pdo-cubrid.intro">&reftitle.intro;
+   <para>
+    PDO_CUBRID is a driver that implements the
+    <link linkend="intro.pdo">PHP Data Objects (PDO) interface</link>
+    to enable access from PHP to CUBRID databases.
+   </para>
+   <note><para>
+    Current version of PDO_CUBRID doesn't support persistent connection now.
+   </para></note>
+  </section>
+
+  <!-- Information found in configure.xml -->
+  &reference.pdo-cubrid.configure;
+
+  <section xml:id="ref.pdo-cubrid.features">
+   <title>PDO_CUBRID Features</title>
+
+   <section>
+    <title>Scrollable cursors</title>
+    <simpara>
+     PDO_CUBRID supports scrollable cursors. The default cursor type is
+     forward only, and you can use parameter driver_options in
+     <methodname>PDO::prepare</methodname> to change cursor type.
+    </simpara>
    </section>
+
+   <section>
+    <title>Timeout</title>
+    <simpara>
+     PDO_CUBRID supports sql statement execution timeout setting;
+     You can use <methodname>PDO::setAttribute</methodname> to set timeout value.
+    </simpara>
+   </section>
+
+   <section>
+    <title>Autocommit_mode and Transaction</title>
+
+    <simpara>
+     PDO_CUBRID supports both autocommit_mode and transaction, and
+     autocommit_mode is enabled by default. You can use
+     <methodname>PDO::setAttribute</methodname> to change its state.
+    </simpara>
+
+    <simpara>
+     If you use <methodname>PDO::beginTransaction</methodname> to begin a
+     transaction, it will disable autocommit_mode automatically and
+     restore it after <methodname>PDO::commit</methodname> or
+     <methodname>PDO::rollBack</methodname>.
+    </simpara>
+
+    <note>
+     <simpara>
+      Prior do disabling autocommit_mode
+      any pending work is automatically committed.
+     </simpara>
+    </note>
+   </section>
+
+   <section>
+    <title>Multiple SQL Statements</title>
     
-   <!-- Information found in configure.xml -->
-   &reference.pdo-cubrid.configure;
+    <simpara>
+     PDO_CUBRID supports Multiple SQL statements.
+     Multiple SQL statements are separated by semicolons (<literal>;</literal>).
+    </simpara>
+   </section>
 
-   <section xml:id="ref.pdo-cubrid.features">
-    <title>Features</title>
-    <table>
-     <title>PDO_CUBRID Features</title>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>Feature</entry>
-        <entry>Description</entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>Scrollable cursors</entry>
-        <entry>
-         PDO_CUBRID supports scrollable cursors. The default cursor type is
-         forward only, and you can use parameter driver_options in
-         <function>PDO::prepare</function> to change cursor type.
-        </entry>
-       </row>
-       <row>
-        <entry>Timeout</entry>
-        <entry>PDO_CUBRID supports sql statement execution timeout setting;
-         You can use <function>PDO::setAttribute</function> to set timeout value.</entry>
-       </row>
-       <row>
-        <entry>Autocommit_mode and Transaction</entry>
-        <entry>
-         PDO_CUBRID supports both autocommit_mode and transaction, and
-         autocommit_mode is enabled by default. You can use
-         <function>PDO::setAttribute</function> to change its state. 
-         
-         <para>
-          If you use <function>PDO::beginTransaction</function> to begin a
-          transaction, it will disable autocommit_mode automatically and
-          restore it after <function>PDO::commit</function> or
-          <function>PDO::rollBack</function>. Note that before disabling the
-          autocommit_mode, any pending work is automatically committed. 
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>Multiple SQL Statements</entry>
-        <entry>PDO_CUBRID supports Multiple SQL statements. Multiple SQL
-         statements are separated by semicolons (;)</entry>
-       </row>
-       <row>
-        <entry>Schema Information</entry>
-        <entry>PDO_CUBRID implements a function
-         <function>PDO::cubrid_schema</function> to get schema information.
-        </entry>
-       </row>
-       <row>
-        <entry>LOBs</entry>
-        <entry>PDO_CUBRID supports BLOB/CLOB data type. The LOB in PDO is
-         represented as a stream, so you can insert LOBs by binding a stream, 
-         and get LOBs by reading a stream returned by CUBRID PDO. For example:
+   <section>
+    <title>Schema Information</title>
 
-         <para>
-          <example><title>Insert LOBs in CUBRID PDO</title>
-           <programlisting role="php">
+    <simpara>
+     PDO_CUBRID implements <methodname>PDO::cubrid_schema</methodname>
+     to get schema information.
+    </simpara>
+   </section>
+
+   <section>
+    <title>LOBs</title>
+
+    <simpara>
+     PDO_CUBRID supports BLOB/CLOB data type. The LOB in PDO is
+     represented as a stream, so you can insert LOBs by binding a stream,
+     and get LOBs by reading a stream returned by CUBRID PDO.
+     For example:
+    </simpara>
+
+    <example>
+     <title>Insert LOBs in CUBRID PDO</title>
+     <programlisting role="php">
 <![CDATA[
 <?php
 $fp = fopen('lob_test.png', 'rb');
@@ -93,12 +104,12 @@ $ret = $stmt->bindParam(1, $fp, PDO::PARAM_LOB);
 $ret = $stmt->execute();
 ?>
 ]]>
-           </programlisting>
-          </example>
-         </para>
-         <para>
-          <example><title>Fetch LOBs in CUBRID PDO</title>
-           <programlisting role="php">
+     </programlisting>
+    </example>
+
+    <example>
+     <title>Fetch LOBs in CUBRID PDO</title>
+     <programlisting role="php">
 <![CDATA[
 <?php
 $sql_stmt = "SELECT content FROM lob_test WHERE name='lob_test.png'";
@@ -111,41 +122,47 @@ header("Content-Type: image/png");
 fpassthru($result[0]);
 ?>
 ]]>
-           </programlisting>
-          </example>
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>Column meta</entry>
-        <entry>
-         The <function>PDOStatement::getColumnMeta</function> in CUBRID PDO
-         will return an associative array containing the following values:
-         <simplelist>
-          <member>type</member>
-          <member>name</member>
-          <member>table</member>
-          <member>def</member>
-          <member>precision</member>
-          <member>scale</member>
-          <member>not_null</member>
-          <member>auto_increment</member>
-          <member>unique_key</member>
-          <member>multiple_key</member>
-          <member>primary_key</member>
-          <member>foreign_key</member>
-          <member>reverse_index</member>
-          <member>reverse_unique</member>
-         </simplelist>
-        </entry>
-       </row>
-       <row>
-        <entry>Collection Data Type</entry>
-        <entry>PDO_CUBRID supports SET/MULTISET/SEQUENCE data type. If you don't specify data type, 
-        the default data type is char,for example:
-         <para>
-          <example><title>Insert set in CUBRID PDO with default data type.</title>
-           <programlisting role="php">
+     </programlisting>
+    </example>
+   </section>
+
+   <section>
+    <title>Column meta</title>
+
+    <para>
+     The <methodname>PDOStatement::getColumnMeta</methodname> in CUBRID PDO
+     will return an associative array containing the following values:
+     <simplelist>
+      <member>type</member>
+      <member>name</member>
+      <member>table</member>
+      <member>def</member>
+      <member>precision</member>
+      <member>scale</member>
+      <member>not_null</member>
+      <member>auto_increment</member>
+      <member>unique_key</member>
+      <member>multiple_key</member>
+      <member>primary_key</member>
+      <member>foreign_key</member>
+      <member>reverse_index</member>
+      <member>reverse_unique</member>
+     </simplelist>
+    </para>
+   </section>
+
+   <section>
+    <title>Collection Data Type</title>
+
+    <simpara>
+     PDO_CUBRID supports SET/MULTISET/SEQUENCE data type.
+     If you don't specify data type, the default data type is char.
+     For example:
+    </simpara>
+
+    <example>
+     <title>Insert set in CUBRID PDO with default data type.</title>
+     <programlisting role="php">
 <![CDATA[
 <?php
 $conn_str ="cubrid:dbname=demodb;host=localhost;port=33000";
@@ -162,12 +179,12 @@ $ret = $stmt->execute();
 var_Dump($ret);
 ?>
 ]]>
-           </programlisting>
-          </example>
-         </para>
-         <para>
-          <example><title>Specify data type when insert set in CUBRID PDO</title>
-           <programlisting role="php">
+     </programlisting>
+    </example>
+
+    <example>
+     <title>Specify data type when insert set in CUBRID PDO</title>
+     <programlisting role="php">
 <![CDATA[
 <?php
 $conn_str ="cubrid:dbname=demodb;host=localhost;port=33000";
@@ -184,36 +201,35 @@ $ret = $stmt->execute();
 var_Dump($ret);
 ?>
 ]]>
-           </programlisting>
-          </example>
-         </para>
-         CUBRID Bind Data Types:(The fifth parameter of PDOStatement::bindParam):
-         <simplelist>
-          <member>CHAR</member>
-          <member>STRING</member>
-          <member>NCHAR</member>
-          <member>VARNCHAR</member>
-          <member>BIT</member>
-          <member>VARBIT</member>
-          <member>NUMERIC</member>
-          <member>NUMBER</member>
-          <member>INT</member>
-          <member>SHORT</member>
-          <member>BIGINT</member>
-          <member>MONETARY</member>
-          <member>FLOAT</member>
-          <member>DOUBLE</member>
-          <member>DATE</member>
-          <member>TIME</member>
-          <member>DATETIME</member>
-          <member>TIMESTAMP</member>
-         </simplelist>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
+     </programlisting>
+    </example>
+
+    <para>
+     CUBRID Bind Data Types for the fifth parameter of
+     <methodname>PDOStatement::bindParam</methodname>:
+     <simplelist>
+      <member>CHAR</member>
+      <member>STRING</member>
+      <member>NCHAR</member>
+      <member>VARNCHAR</member>
+      <member>BIT</member>
+      <member>VARBIT</member>
+      <member>NUMERIC</member>
+      <member>NUMBER</member>
+      <member>INT</member>
+      <member>SHORT</member>
+      <member>BIGINT</member>
+      <member>MONETARY</member>
+      <member>FLOAT</member>
+      <member>DOUBLE</member>
+      <member>DATE</member>
+      <member>TIME</member>
+      <member>DATETIME</member>
+      <member>TIMESTAMP</member>
+     </simplelist>
+    </para>
    </section>
+  </section>
 
    <!-- Information found in constants.xml -->
    &reference.pdo-cubrid.constants;


### PR DESCRIPTION
Rewrite this table as a series of sections that describes each feature.

And do some slight markup fixes at the same time.
However, these docs are in a sad state and not up to our standard which is somewhat usual with PECL extension docs