### PR TITLE
Update minimum versions of development tools

### DIFF
--- a/install/unix/index.xml
+++ b/install/unix/index.xml
@@ -61,8 +61,25 @@
     <itemizedlist>
      <listitem>
       <simpara>
-       autoconf: 2.59+ (for PHP &gt;= 7.0.0), 2.64+ (for PHP &gt;= 7.2.0)
+       autoconf:
       </simpara>
+      <itemizedlist>
+       <listitem>
+        <simpara>
+         PHP 7.3 and later: 2.68+
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         PHP 7.2: 2.64+
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         PHP 5.4 - 7.1: 2.59+
+        </simpara>
+       </listitem>
+      </itemizedlist>
      </listitem>
      <listitem>
       <simpara>
@@ -76,8 +93,20 @@
      </listitem>
      <listitem>
       <simpara>
-       re2c: 0.13.4+
+       re2c:
       </simpara>
+      <itemizedlist>
+       <listitem>
+        <simpara>
+         PHP 8.3 and later: 1.0.3+
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         PHP 5.2 - 8.2: 0.13.4+
+        </simpara>
+       </listitem>
+      </itemizedlist>
      </listitem>
      <listitem>
       <simpara>
@@ -86,12 +115,22 @@
       <itemizedlist>
        <listitem>
         <simpara>
-         PHP 7.0 - 7.3: 2.4 or later (including Bison 3.x)
+         PHP 7.4 and later: 3.0.0+
         </simpara>
        </listitem>
        <listitem>
         <simpara>
-         PHP 7.4: &gt; 3.0
+         PHP 7.0 - 7.3: 2.4+ (including Bison 3.x)
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         PHP 5.5 - 5.6: 2.4 to 2.7
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         PHP 5.4: 1.28, 1.35, 1.75, 2.0 to 2.6.4
         </simpara>
        </listitem>
       </itemizedlist>

--- a/install/unix/index.xml
+++ b/install/unix/index.xml
@@ -76,7 +76,7 @@
        </listitem>
        <listitem>
         <simpara>
-         PHP 5.4 - 7.1: 2.59+
+         PHP 7.1 and earlier: 2.59+
         </simpara>
        </listitem>
       </itemizedlist>
@@ -103,7 +103,7 @@
        </listitem>
        <listitem>
         <simpara>
-         PHP 5.2 - 8.2: 0.13.4+
+         PHP 8.2 and earlier: 0.13.4+
         </simpara>
        </listitem>
       </itemizedlist>
@@ -120,17 +120,7 @@
        </listitem>
        <listitem>
         <simpara>
-         PHP 7.0 - 7.3: 2.4+ (including Bison 3.x)
-        </simpara>
-       </listitem>
-       <listitem>
-        <simpara>
-         PHP 5.5 - 5.6: 2.4 to 2.7
-        </simpara>
-       </listitem>
-       <listitem>
-        <simpara>
-         PHP 5.4: 1.28, 1.35, 1.75, 2.0 to 2.6.4
+         PHP 7.3 and earlier: 2.4+ (including Bison 3.x)
         </simpara>
        </listitem>
       </itemizedlist>


### PR DESCRIPTION
This updates the development tools versions required to configure and build PHP across various versions:

* autoconf:
    * PHP 7.3 and later: 2.68+
    * PHP 7.2: 2.64+
    * From PHP 5.4 to 7.1: 2.59+
* re2c:
    * From PHP 8.3 and later 1.0.3+
    * From PHP 5.2 to 8.2: 0.13.4+
    * PHP 5.1 required 0.9.11+ (not noting in the docs due to obsoletion)
* bison:
    * From PHP 7.4 and later: 3.0.0+
    * From PHP 7.0 to 7.3: 2.4+ (including Bison 3.x)
    * From PHP 5.5 to 5.6: 2.4 to 2.7
    * PHP 5.4: 1.28, 1.35, 1.75, 2.0 to 2.6.4

PHP versions are sorted in reverse order from newest to oldest PHP.

This is also a sync with https://github.com/php/web-php/pull/983 because these are listed on two places. In this docs and in here https://www.php.net/git.php

Maybe we could simplify the https://php.net/git.php and link this documentation page there.

Also, from what I see is that PHP 5.x is somehow trying to become removed from the manual. If that's so then maybe these coulb be noted like this `PHP 7.1 and older`  :thinking: