### PR TITLE
Clean-up Parle pattern matching markup

### DIFF
--- a/reference/parle/pattern.matching.xml
+++ b/reference/parle/pattern.matching.xml
@@ -1,16 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-
-<chapter xml:id="parle.pattern.matching" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="parle.pattern.matching" xmlns="http://docbook.org/ns/docbook">
  <title>Parle pattern matching</title>
  <titleabbrev>Pattern matching</titleabbrev>
  <para>
-  Parle supports regex matching similar to flex. Also supported are the following POSIX character sets: <literal>[:alnum:]</literal>, <literal>[:alpha:]</literal>, <literal>[:blank:]</literal>, <literal>[:cntrl:]</literal>, <literal>[:digit:]</literal>, <literal>[:graph:]</literal>, <literal>[:lower:]</literal>, <literal>[:print:]</literal>, <literal>[:punct:]</literal>, <literal>[:space:]</literal>, <literal>[:upper:]</literal> and <literal>[:xdigit:]</literal>.
+  Parle supports regex matching similar to flex.
+  Also supported are the following POSIX character sets:
+  <simplelist type="inline">
+   <member><literal>[:alnum:]</literal></member>
+   <member><literal>[:alpha:]</literal></member>
+   <member><literal>[:blank:]</literal></member>
+   <member><literal>[:cntrl:]</literal></member>
+   <member><literal>[:digit:]</literal></member>
+   <member><literal>[:graph:]</literal></member>
+   <member><literal>[:lower:]</literal></member>
+   <member><literal>[:print:]</literal></member>
+   <member><literal>[:punct:]</literal></member>
+   <member><literal>[:space:]</literal></member>
+   <member><literal>[:upper:]</literal></member>
+   <member><literal>[:xdigit:]</literal></member>
+  </simplelist>
+  .
  </para>
  <para>
-  The Unicode character classes are currently not enabled by default, pass --enable-parle-utf32 to make them available. A particular encoding can be mapped with a correctly constructed regex. For example, to match the EURO symbol encoded in UTF-8, the regular expression <literal>[\xe2][\x82][\xac]</literal> can be used. The pattern for an UTF-8 encoded string could be <literal>[ -\x7f]{+}[\x80-\xbf]{+}[\xc2-\xdf]{+}[\xe0-\xef]{+}[\xf0-\xff]+</literal>.
+  The Unicode character classes are currently not enabled by default, pass --enable-parle-utf32 to make them available.
+  A particular encoding can be mapped with a correctly constructed regex.
+  For example, to match the EURO symbol encoded in UTF-8, the regular expression <literal>[\xe2][\x82][\xac]</literal> can be used.
+  The pattern for an UTF-8 encoded string could be <literal>[ -\x7f]{+}[\x80-\xbf]{+}[\xc2-\xdf]{+}[\xe0-\xef]{+}[\xf0-\xff]+</literal>.
  </para>
- <section xml:id="parle.regex.chars">
+
+ <section xml:id="parle.regex.chars" annotations="chunk:false">
   <title>Character representations</title>
   <para>
    <table>
@@ -60,7 +78,7 @@
    </table>
   </para>
  </section>
- <section xml:id="parle.regex.charclass">
+ <section xml:id="parle.regex.charclass" annotations="chunk:false">
   <title>Character classes</title>
   <para>
    <table>
@@ -104,7 +122,7 @@
    </table>
   </para>
  </section>
- <section xml:id="parle.regex.unicodecharclass">
+ <section xml:id="parle.regex.unicodecharclass" annotations="chunk:false">
   <title>Unicode character classes</title>
   <para>
    <table>
@@ -232,10 +250,10 @@
    </table>
   </para>
   <para>
-   These character clasess are only available, if the option --enable-parle-utf32 was passed at the compilation time.
+   These character classes are only available, if the option --enable-parle-utf32 was passed at the compilation time.
   </para>
  </section>
- <section xml:id="parle.regex.alternation">
+ <section xml:id="parle.regex.alternation" annotations="chunk:false">
   <title>Alternation and repetition</title>
   <para>
    <table>
@@ -248,7 +266,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>...|...</entry><entry>-</entry><entry>Try subpatterns in alternation.</entry>
+       <entry>...|...</entry><entry>-</entry><entry>Try sub-patterns in alternation.</entry>
       </row>
       <row>
        <entry>*</entry><entry>yes</entry><entry>Match 0 or more times.</entry>
@@ -291,7 +309,7 @@
    </table>
   </para>
  </section>
- <section xml:id="parle.regex.anchors">
+ <section xml:id="parle.regex.anchors" annotations="chunk:false">
   <title>Anchors</title>
   <para>
    <table>
@@ -314,7 +332,7 @@
    </table>
   </para>
  </section>
- <section xml:id="parle.regex.grouping">
+ <section xml:id="parle.regex.grouping" annotations="chunk:false">
   <title>Grouping</title>
   <para>
    <table>
@@ -322,49 +340,47 @@
     <tgroup cols="2">
      <thead>
       <row>
-       <entry>Sequence</entry><entry>Description</entry>
+       <entry>Sequence</entry>
+       <entry>Description</entry>
       </row>
      </thead>
      <tbody>
       <row>
-       <entry>(...)</entry><entry>Group a regular expression to override default operator precedence.</entry>
+       <entry>(...)</entry>
+       <entry>Group a regular expression to override default operator precedence.</entry>
       </row>
       <row>
        <entry valign="top">(?r-s:pattern)</entry>
        <entry>
-        Apply option r and omit option s while interpreting pattern. Options may be zero or more of the characters i, s, or x.
-        <table>
-         <title>Options</title>
-          <tgroup cols="2">
-           <thead>
-            <row>
-             <entry>Option</entry><entry>Description</entry>
-            </row>
-           </thead>
-          <tbody>
-            <row>
-             <entry>i</entry><entry>Case insensitive.</entry>
-            </row>
-            <row>
-             <entry>-i</entry><entry>Case sensitive.</entry>
-            </row>
-            <row>
-             <entry>s</entry><entry>Alters the meaning of '.' to match any character whatsoever.</entry>
-            </row>
-            <row>
-             <entry>-s</entry><entry>Alters the meaning of '.' to match any character except '\n'.</entry>
-            </row>
-            <row>
-             <entry>x</entry><entry>Ignores comments and whitespace in patterns. Whitespace is ignored unless it is backslash-escaped, contained within ""s, or appears inside a character range.</entry>
-            </row>
-          </tbody>
-         </tgroup>
-        </table>
-        These options can be applied globally at the rules level by passing a combination of the bit flags to the lexer.
+        <simpara>
+         Apply option r and omit option s while interpreting pattern.
+         Options may be zero or more of the characters i, s, or x.
+        </simpara>
+        <simpara>
+         <literal>i</literal> means case-insensitive.
+        </simpara>
+        <simpara>
+         <literal>-i</literal> means case-sensitive.
+        </simpara>
+        <simpara>
+         <literal>s</literal> alters the meaning of <literal>.</literal> to match any character whatsoever.
+        </simpara>
+        <simpara>
+         <literal>-s</literal> alters the meaning of <literal>.</literal> to match any character except <literal>\n</literal>.
+        </simpara>
+        <simpara>
+         <literal>x</literal> ignores comments and whitespace in patterns.
+         Whitespace is ignored unless it is backslash-escaped, contained within <literal>""s</literal>,
+         or appears inside a character range.
+        </simpara>
+        <simpara>
+         These options can be applied globally at the rules level by passing a combination of the bit flags to the lexer.
+        </simpara>
        </entry>
       </row>
       <row>
-       <entry>(?# comment )</entry><entry>Omit everything within (). The first ) character encountered ends the pattern. It is not possible for the comment to contain a ) character. The comment may span lines.</entry>
+       <entry>(?# comment )</entry>
+       <entry>Omit everything within (). The first ) character encountered ends the pattern. It is not possible for the comment to contain a ) character. The comment may span lines.</entry>
       </row>
      </tbody>
     </tgroup>


### PR DESCRIPTION
This is to make it compliant with DocBook 5.2

Based on http://www.benhanson.net/lexertl.html