### PR TITLE
Fix incorrect reference to non-existent parameter in yaml_parse_file

### DIFF
--- a/reference/yaml/functions/yaml-parse-file.xml
+++ b/reference/yaml/functions/yaml-parse-file.xml
@@ -69,7 +69,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the value encoded in <parameter>input</parameter> in appropriate
+   Returns the value encoded in <parameter>filename</parameter> in appropriate
    PHP type&return.falseforfailure;. If <parameter>pos</parameter> is <literal>-1</literal> an
    <type>array</type> will be returned with one entry for each document found
    in the stream.


### PR DESCRIPTION
It seems like a copy-paste from `yaml_parse`.