### PR TITLE
Rewrite MySQLnd statistic page

### DIFF
--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -1320,6 +1320,9 @@ $res->close();
     <term><literal>active_connections</literal></term>
     <listitem>
      <simpara>
+      This is a process level scope statistic.
+     </simpara>
+     <simpara>
       Total number of active persistent and non-persistent connections.
      </simpara>
      <note>
@@ -1334,6 +1337,9 @@ $res->close();
    <varlistentry xml:id="mysqlnd.stats.statistics.active-persistent-connections">
     <term><literal>active_persistent_connections</literal></term>
     <listitem>
+     <simpara>
+      This is a process level scope statistic.
+     </simpara>
      <simpara>
       Total number of active persistent connections.
      </simpara>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -755,7 +755,6 @@ $res->close();
     </listitem>
    </varlistentry>
 
-   <!-- TODO: Split into two? -->
    <varlistentry xml:id="mysqlnd.stats.statistics.free-result">
     <term><literal>explicit_free_result</literal></term>
     <term><literal>implicit_free_result</literal></term>
@@ -765,11 +764,6 @@ $res->close();
      </simpara>
      <simpara>
       Total number of freed result sets.
-     </simpara>
-     <simpara>
-      The free is always considered explicit but for result sets created by an
-      init command, for example,
-      <code>mysqli_options(MYSQLI_INIT_COMMAND , ...);</code>.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -656,7 +656,7 @@ $res->close();
     <term><literal>rows_buffered_from_client_normal</literal></term>
     <listitem>
      <simpara>
-      Total number of successfully buffered rows originating from a normal query.
+      Total number of buffered rows originating from a normal query.
      </simpara>
      <simpara>
       This is the number of rows that have been fetched from MySQL and buffered on client.

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -567,9 +567,6 @@ $res->close();
       <simpara>
        Flushing happens only with unbuffered result sets.
       </simpara>
-     </note>
-
-     <warning>
       <simpara>
        Unbuffered result sets must be fetched completely before a new query can
        be run on the connection otherwise MySQL will throw an error.
@@ -600,10 +597,7 @@ $res->close();
         </listitem>
        </itemizedlist>
       </para>
-     </warning>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.flushed-normal-sets')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     </note>
     </listitem>
    </varlistentry>
 

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -778,11 +778,6 @@ $res->close();
       If the data are not changed, the fetched data is kept only once in memory.
       However, any modification to the data will require mysqlnd to perform
       a copy-on-write operation.
-      The MySQL Client Library required to duplicate the data upfront.
-      Therefore, in theory, mysqlnd can save up to 40% memory.
-      However, note that the memory saving cannot be measured using
-      <function>memory_get_usage</function>.
-      <!-- TODO: Explain this is because the client lib doesn't use PHP's internal memory tracking? -->
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -53,8 +53,8 @@
   </simpara>
 
   <simpara>
-   Client statistics can be retrieved by calling the
-   <function>mysqli_get_client_stats</function> function.
+   Client statistics can also be retrieved by calling the
+   <function>phpinfo</function> function.
   </simpara>
 
   <simpara>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -1309,12 +1309,11 @@ $res->close();
       connection handle.
      </simpara>
      <para>
-      <!-- TODO: Do not use First Class Callable syntax -->
       The code sequence
-      <code>$link = new mysqli(...); $link-&gt;real_connect(...);</code>
+      <code>$link = new mysqli(/* ... */); $link-&gt;real_connect(/* ... */);</code>
       will cause a reconnect.
-      But <code>$link = new mysqli(...); $link-&gt;connect(...);</code>
-      will not because <code>$link-&gt;connect(...);</code> will
+      But <code>$link = new mysqli(/* ... */); $link-&gt;connect(/* ... */);</code>
+      will not because <code>$link-&gt;connect(/* ... */);</code> will
       explicitly close the existing connection before a new connection
       is established.
      </para>
@@ -1359,19 +1358,17 @@ $res->close();
       <itemizedlist>
        <listitem>
         <programlisting>
-         <!-- TODO: Do not use First Class Callable syntax -->
 <![CDATA[
-$link = new mysqli(...);
-$link->close(...);
+$link = new mysqli(/* ... */);
+$link->close(/* ... */);
 ]]>
         </programlisting>
        </listitem>
        <listitem>
         <programlisting>
-         <!-- TODO: Do not use First Class Callable syntax -->
 <![CDATA[
-$link = new mysqli(...);
-$link->connect(...);
+$link = new mysqli(/* ... */);
+$link->connect(/* ... */);
 ]]>
         </programlisting>
        </listitem>
@@ -1394,10 +1391,9 @@ $link->connect(...);
       <itemizedlist>
        <listitem>
         <programlisting>
-         <!-- TODO: Do not use First Class Callable syntax -->
 <![CDATA[
-$link = new mysqli(...);
-$link->real_connect(...);
+$link = new mysqli(/* ... */);
+$link->real_connect(/* ... */);
 ]]>
         </programlisting>
        </listitem>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -1566,7 +1566,7 @@ $link->real_connect(/* ... */);
      </simpara>
      <note>
       <simpara>
-       A close is always considered explicit but for a failed prepare.
+       A prepared statement is always explicitly closed. The only time it's closed implicitly is when preparing it fails.
       </simpara>
      </note>
     </listitem>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -642,10 +642,9 @@ $res->close();
     <term><literal>rows_fetched_from_server_ps</literal></term>
     <listitem>
      <simpara>
-      Total number of result set rows successfully fetched from MySQL
-      regardless if the client application has consumed them or not.
-      Some of the rows may not have been fetched by the client
-      application but have been flushed implicitly.
+      Total number of result set rows fetched from the server.
+      This includes the rows which were not read by the client but
+      had been implicitly fetched due to flushed unbuffered result sets.
      </simpara>
      <simpara>
       See also <literal>packets_received_rset_row</literal>.

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -505,7 +505,6 @@ $res->close();
       <simplelist type="inline">
        <member><function>mysqli_query</function></member>
        <member><function>mysqli_store_result</function></member>
-       <member><function>mysqli_store_result</function></member>
        <member><function>mysqli_stmt_get_result</function></member>
       </simplelist>
      </para>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -1295,7 +1295,7 @@ $res->close();
     <term><literal>connect_success</literal></term>
     <listitem>
      <simpara>
-      Total number of successful connection attempt.
+      Total number of successful connection attempts.
      </simpara>
      <simpara>
       Reused connections and all other kinds of connections are included.
@@ -1324,7 +1324,7 @@ $res->close();
     <term><literal>connect_failure</literal></term>
     <listitem>
      <simpara>
-      Total number of failed connection attempt.
+      Total number of failed connection attempts.
      </simpara>
      <simpara>
       Reused connections and all other kinds of connections are included..

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -668,19 +668,6 @@ $res->close();
        <member><function>mysqli_store_result</function></member>
       </simplelist>
      </para>
-     <note>
-      <simpara>
-       There are two distinct statistics on rows that have been buffered
-       (MySQL to mysqlnd internal buffer) and buffered rows that have
-       been fetched by the client application (mysqlnd internal buffer to
-       client application).
-      </simpara>
-      <simpara>
-       If the number of buffered rows is higher than the number of fetched
-       buffered rows it can mean that the client application runs queries that
-       cause larger result sets than needed resulting in rows not read by the client.
-      </simpara>
-     </note>
     </listitem>
    </varlistentry>
 

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -586,7 +586,7 @@ $res->close();
      <para>
       Examples of API calls that will buffer result sets on the client:
       <simplelist type="inline">
-       <member><methodname>mysqli_stmt::store_result</methodname></member>
+       <member><function>mysqli_stmt_store_result</function></member>
       </simplelist>
      </para>
      <note>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -1333,9 +1333,6 @@ $res->close();
      <simpara>
       Total number of explicitly closed connections.
      </simpara>
-     <simpara>
-      This statistic is only available with <literal>ext/mysqli</literal>.
-     </simpara>
      <example>
       <title>Examples of code snippets that cause an implicit close</title>
       <itemizedlist>
@@ -1365,9 +1362,6 @@ $link->connect(/* ... */);
     <listitem>
      <simpara>
       Total number of implicitly closed connections.
-     </simpara>
-     <simpara>
-      This statistic is only available with <literal>ext/mysqli</literal>.
      </simpara>
      <example>
       <title>Examples of code snippets that cause an implicit close</title>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -612,10 +612,6 @@ $res->close();
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.flushed-normal-sets')/db:listitem/db:note)">
       <xi:fallback/>
      </xi:include>
-
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.flushed-normal-sets')/db:listitem/db:warning)">
-      <xi:fallback/>
-     </xi:include>
     </listitem>
    </varlistentry>
 

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -1677,7 +1677,7 @@ $link->real_connect(...);
     <term><literal>connection_reused</literal></term>
     <listitem>
      <simpara>
-      <!-- TODO: Document -->
+      The total number of times a persistent connection has been reused.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -633,13 +633,6 @@ $res->close();
      <simpara>
       Number of statements prepared but never executed.
      </simpara>
-
-     <warning>
-      <simpara>
-       Prepared statements occupy server resources.
-       Statements that are not going to be executed should not be prepared.
-      </simpara>
-     </warning>
     </listitem>
    </varlistentry>
 
@@ -649,26 +642,6 @@ $res->close();
      <simpara>
       Number of prepared statements executed only once.
      </simpara>
-
-     <!-- Does this note/warning make any sense? As people might stop using them
-     even if prepared statements are safer than normal concatenated queries.
-     <warning>
-      <simpara>
-       One of the ideas behind prepared statements is that the same query gets
-       executed over and over again (with different parameters) and some
-       parsing and other preparation work can be saved, if statement
-       execution is split up in separate prepare and execute stages. The
-       idea is to prepare once and <quote>cache</quote> results, for
-       example, the parse tree to be reused during multiple statement
-       executions. If you execute a prepared statement only once the two
-       stage processing can be inefficient compared to
-       <quote>normal</quote> queries because all the caching means extra
-       work, and it takes (limited) server resources to hold the cached
-       information. Consequently, prepared statements that are executed
-       only once may cause performance hurts.
-      </simpara>
-     </warning>
-     -->
     </listitem>
    </varlistentry>
 

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -540,11 +540,6 @@ $res->close();
        <member><function>mysqli_stmt_store_result</function></member>
       </simplelist>
      </para>
-     <note>
-      <simpara>
-       By default prepared statements are unbuffered.
-      </simpara>
-     </note>
     </listitem>
    </varlistentry>
 
@@ -554,9 +549,10 @@ $res->close();
      <simpara>
       Number of unbuffered result sets returned by prepared statements.
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.ps-buffered-sets')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <simpara>
+      By default prepared statements are unbuffered,
+      thus most prepared statements will be accounted in this statistic.
+     </simpara>
     </listitem>
    </varlistentry>
 

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -89,11 +89,6 @@
      <simpara>
       Number of bytes sent from PHP to the MySQL server.
      </simpara>
-     <note>
-      <simpara>
-       Can be used to check the efficiency of the compression protocol.
-      </simpara>
-     </note>
     </listitem>
    </varlistentry>
 
@@ -103,9 +98,6 @@
      <simpara>
       Number of bytes received from the MySQL server.
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-sent')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
     </listitem>
    </varlistentry>
 
@@ -115,11 +107,6 @@
      <simpara>
       Number of packets sent by the MySQL Client Server protocol.
      </simpara>
-     <note>
-      <simpara>
-       Used for debugging Client Server protocol implementation
-      </simpara>
-     </note>
     </listitem>
    </varlistentry>
 
@@ -129,9 +116,6 @@
      <simpara>
       Number of packets received from the MySQL Client Server protocol.
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
     </listitem>
    </varlistentry>
 
@@ -143,9 +127,6 @@
       Currently only the Packet Header (4 bytes) is considered as overhead.
       <code>protocol_overhead_in = packets_received * 4</code>
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
     </listitem>
    </varlistentry>
 
@@ -157,9 +138,6 @@
       Currently only the Packet Header (4 bytes) is considered as overhead.
       <code>protocol_overhead_out = packets_received * 4</code>
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
     </listitem>
    </varlistentry>
 
@@ -172,9 +150,6 @@
       The length of the status message can vary and thus the size of an OK
       packet is not fixed.
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
      <note>
       <simpara>
        The total size in bytes includes the size of the header packet.
@@ -190,9 +165,6 @@
      <simpara>
       Number of MySQL Client Server protocol OK packets received.
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
     </listitem>
    </varlistentry>
 
@@ -221,9 +193,6 @@
       increased even if PHP does not receive the expected packet but,
       for example, an error message.
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
     </listitem>
    </varlistentry>
 
@@ -249,9 +218,6 @@
      <simpara>
       Number of MySQL Client Server protocol result set header packets.
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
     </listitem>
    </varlistentry>
 
@@ -278,9 +244,6 @@
       Number of MySQL Client Server protocol result set metadata
       (field information) packets.
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
     </listitem>
    </varlistentry>
 
@@ -309,9 +272,6 @@
       <!-- TODO: Does it really have the total size in bytes? -->
       Number of MySQL Client Server protocol result set row data packets and their total size in bytes.
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
     </listitem>
    </varlistentry>
 
@@ -337,9 +297,6 @@
       Number of MySQL Client Server protocol OK for Prepared Statement
       Initialization packets (prepared statement init packets).
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
     </listitem>
    </varlistentry>
 
@@ -362,9 +319,6 @@
      <simpara>
       Number of MySQL Client Server protocol COM_CHANGE_USER packets.
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
     </listitem>
    </varlistentry>
 
@@ -378,9 +332,6 @@
       There is no way to know which specific commands and how many of
       them have been sent.
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
     </listitem>
    </varlistentry>
 

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -69,38 +69,6 @@
   </simpara>
  </section>
 
- <!-- WTF Does this section do here, this has nothing to do with statistics
- <section>
-  <title>Buffered and Unbuffered Result Sets</title>
-  <para>
-   Result sets can be buffered or unbuffered. Using default settings,
-   <literal>ext/mysql</literal> and <literal>ext/mysqli</literal> work
-   with buffered result sets for normal (non prepared statement) queries.
-   Buffered result sets are cached on the client. After the query
-   execution all results are fetched from the MySQL Server and stored in
-   a cache on the client. The big advantage of buffered result sets is
-   that they allow the server to free all resources allocated to a result
-   set, once the results have been fetched by the client.
-  </para>
-  <para>
-   Unbuffered result sets on the other hand are kept much longer on the
-   server. If you want to reduce memory consumption on the client, but
-   increase load on the server, use unbuffered results. If you experience
-   a high server load and the figures for unbuffered result sets are
-   high, you should consider moving the load to the clients. Clients
-   typically scale better than servers. <quote>Load</quote> does not only
-   refer to memory buffers - the server also needs to keep other
-   resources open, for example file handles and threads, before a result
-   set can be freed.
-  </para>
-  <para>
-   Prepared Statements use unbuffered result sets by default. However,
-   you can use <function>mysqli_stmt_store_result</function> to enable
-   buffered result sets.
-  </para>
- </section>
- -->
-
  <section xml:id="mysqlnd.stats.statistics" annotations="chunk:false">
   <title>MySQL Native Driver Statistics</title>
   <simpara>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -637,7 +637,6 @@ $res->close();
     </listitem>
    </varlistentry>
 
-   <!-- TODO: Should this be split in two? -->
    <varlistentry xml:id="mysqlnd.stats.statistics.rows-fetched-from-server-normal">
     <term><literal>rows_fetched_from_server_normal</literal></term>
     <term><literal>rows_fetched_from_server_ps</literal></term>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -1,478 +1,598 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<chapter xml:id="mysqlnd.stats" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="mysqlnd.stats" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Statistics</title>
- <para>
-  <emphasis role="bold">Using Statistical Data</emphasis>
- </para>
+
  <para>
   MySQL Native Driver contains support for gathering statistics on the
   communication between the client and the server. The statistics
   gathered are of two main types:
+  <itemizedlist>
+   <listitem>
+    <simpara>Client statistics</simpara>
+   </listitem>
+   <listitem>
+    <simpara>Connection statistics</simpara>
+   </listitem>
+  </itemizedlist>
  </para>
- <itemizedlist>
-  <listitem>
-   <para>
-    Client statistics
-   </para>
-  </listitem>
-  <listitem>
-   <para>
-    Connection statistics
-   </para>
-  </listitem>
- </itemizedlist>
  <para>
-  If you are using the <literal>mysqli</literal> extension, these
-  statistics can be obtained through two API calls:
+  When using the <link linkend="book.mysqli">mysqli</link> extension,
+  these statistics can be obtained through two API calls:
+  <itemizedlist>
+   <listitem>
+    <simpara><function>mysqli_get_client_stats</function></simpara>
+   </listitem>
+   <listitem>
+    <simpara><function>mysqli_get_connection_stats</function></simpara>
+   </listitem>
+  </itemizedlist>
  </para>
- <itemizedlist>
-  <listitem>
-   <para>
-    <function>mysqli_get_client_stats</function>
-   </para>
-  </listitem>
-  <listitem>
-   <para>
-    <function>mysqli_get_connection_stats</function>
-   </para>
-  </listitem>
- </itemizedlist>
+
  <note>
-  <para>
-   Statistics are aggregated among all extensions that use MySQL Native
-   Driver. For example, when compiling both <literal>ext/mysql</literal>
-   and <literal>ext/mysqli</literal> against MySQL Native Driver, both
-   function calls of <literal>ext/mysql</literal> and
-   <literal>ext/mysqli</literal> will change the statistics. There is no
-   way to find out how much a certain API call of any extension that has
-   been compiled against MySQL Native Driver has impacted a certain
-   statistic. You can configure the PDO MySQL Driver,
-   <literal>ext/mysql</literal> and <literal>ext/mysqli</literal> to
-   optionally use the MySQL Native Driver. When doing so, all three
-   extensions will change the statistics.
-  </para>
+  <simpara>
+   Statistics are aggregated among all extensions that use the MySQL Native
+   Driver.
+   For example, if the <link linkend="book.mysqli">mysqli</link>
+   extension and the PDO MySQL driver are both set-up to use MySQLnd,
+   then function calls from <link linkend="book.mysqli">mysqli</link>
+   and method calls from PDO will affect the statistics.
+  </simpara>
+  <simpara>
+   There is no way to find out how much a certain API call of any extension
+   that has been compiled against MySQL Native Driver has impacted a certain
+   statistic.
+  </simpara>
  </note>
- <para>
-  <emphasis role="bold">Accessing Client Statistics</emphasis>
- </para>
- <para>
-  To access client statistics, you need to call
-  <function>mysqli_get_client_stats</function>. The function call does
-  not require any parameters.
- </para>
- <para>
-  The function returns an associative array that contains the name of
-  the statistic as the key and the statistical data as the value.
- </para>
- <para>
-  Client statistics can also be accessed by calling the
-  <function>phpinfo</function> function.
- </para>
- <para>
-  <emphasis role="bold">Accessing Connection Statistics</emphasis>
- </para>
- <para>
-  To access connection statistics call
-  <function>mysqli_get_connection_stats</function>. This takes the
-  database connection handle as the parameter.
- </para>
- <para>
-  The function returns an associative array that contains the name of
-  the statistic as the key and the statistical data as the value.
- </para>
- <para>
-  <emphasis role="bold">Buffered and Unbuffered Result Sets</emphasis>
- </para>
- <para>
-  Result sets can be buffered or unbuffered. Using default settings,
-  <literal>ext/mysql</literal> and <literal>ext/mysqli</literal> work
-  with buffered result sets for normal (non prepared statement) queries.
-  Buffered result sets are cached on the client. After the query
-  execution all results are fetched from the MySQL Server and stored in
-  a cache on the client. The big advantage of buffered result sets is
-  that they allow the server to free all resources allocated to a result
-  set, once the results have been fetched by the client.
- </para>
- <para>
-  Unbuffered result sets on the other hand are kept much longer on the
-  server. If you want to reduce memory consumption on the client, but
-  increase load on the server, use unbuffered results. If you experience
-  a high server load and the figures for unbuffered result sets are
-  high, you should consider moving the load to the clients. Clients
-  typically scale better than servers. <quote>Load</quote> does not only
-  refer to memory buffers - the server also needs to keep other
-  resources open, for example file handles and threads, before a result
-  set can be freed.
- </para>
- <para>
-  Prepared Statements use unbuffered result sets by default. However,
-  you can use <function>mysqli_stmt_store_result</function> to enable
-  buffered result sets.
- </para>
- <para>
-  <emphasis role="bold">Statistics returned by MySQL Native
-  Driver</emphasis>
- </para>
- <para>
-  The following tables show a list of statistics returned by the
-  <function>mysqli_get_client_stats</function> and
-  <function>mysqli_get_connection_stats</function> functions.
- </para>
- <table xml:id="mysqlnd.stats.returns">
-  <title>Returned mysqlnd statistics: Network</title>
-  <tgroup cols="4">
-   <colspec colwidth="10*"/>
-   <colspec colwidth="10*"/>
-   <colspec colwidth="40*"/>
-   <colspec colwidth="40*"/>
-   <thead>
-    <row>
-     <entry>Statistic</entry>
-     <entry>Scope</entry>
-     <entry>Description</entry>
-     <entry>Notes</entry>
-    </row>
-   </thead>
-   <tbody>
-    <row>
-     <entry><literal>bytes_sent</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of bytes sent from PHP to the MySQL server</entry>
-     <entry>Can be used to check the efficiency of the compression protocol</entry>
-    </row>
-    <row>
-     <entry><literal>bytes_received</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of bytes received from MySQL server</entry>
-     <entry>Can be used to check the efficiency of the compression protocol</entry>
-    </row>
-    <row>
-     <entry><literal>packets_sent</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of MySQL Client Server protocol packets sent</entry>
-     <entry>Used for debugging Client Server protocol implementation</entry>
-    </row>
-    <row>
-     <entry><literal>packets_received</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of MySQL Client Server protocol packets received</entry>
-     <entry>Used for debugging Client Server protocol implementation</entry>
-    </row>
-    <row>
-     <entry><literal>protocol_overhead_in</literal></entry>
-     <entry>Connection</entry>
-     <entry>MySQL Client Server protocol overhead in bytes for incoming traffic.
-      Currently only the Packet Header (4 bytes) is considered as
-      overhead. protocol_overhead_in = packets_received * 4</entry>
-     <entry>Used for debugging Client Server protocol implementation</entry>
-    </row>
-    <row>
-     <entry><literal>protocol_overhead_out</literal></entry>
-     <entry>Connection</entry>
-     <entry>MySQL Client Server protocol overhead in bytes for outgoing traffic.
-      Currently only the Packet Header (4 bytes) is considered as
-      overhead. protocol_overhead_out = packets_sent * 4</entry>
-     <entry>Used for debugging Client Server protocol implementation</entry>
-    </row>
-    <row>
-     <entry><literal>bytes_received_ok_packet</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total size of bytes of MySQL Client Server protocol OK packets received.
-      OK packets can contain a status message. The length of the status
-      message can vary and thus the size of an OK packet is not fixed.</entry>
-     <entry>Used for debugging CS protocol implementation. Note that the total size
-      in bytes includes the size of the header packet (4 bytes, see
-      protocol overhead).</entry>
-    </row>
-    <row>
-     <entry><literal>packets_received_ok</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of MySQL Client Server protocol OK packets received.</entry>
-     <entry>Used for debugging CS protocol implementation. Note that the total size
-      in bytes includes the size of the header packet (4 bytes, see
-      protocol overhead).</entry>
-    </row>
-    <row>
-     <entry><literal>bytes_received_eof_packet</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total size in bytes of MySQL Client Server protocol EOF packets
-      received. EOF can vary in size depending on the server version.
-      Also, EOF can transport an error message.</entry>
-     <entry>Used for debugging CS protocol implementation. Note that the total size
-      in bytes includes the size of the header packet (4 bytes, see
-      protocol overhead).</entry>
-    </row>
-    <row>
-     <entry><literal>packets_received_eof</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of MySQL Client Server protocol EOF packets. Like with other
-      packet statistics the number of packets will be increased even if
-      PHP does not receive the expected packet but, for example, an
-      error message.</entry>
-     <entry>Used for debugging CS protocol implementation. Note that the total size
-      in bytes includes the size of the header packet (4 bytes, see
-      protocol overhead).</entry>
-    </row>
-    <row>
-     <entry><literal>bytes_received_rset_header_packet</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total size in bytes of MySQL Client Server protocol result set header
-      packets. The size of the packets varies depending on the payload
+
+ <section xml:id="mysqlnd.stats.retrieve" annotations="chunk:false">
+  <title>Retrieving statistics</title>
+
+  <simpara>
+   Client statistics can be retrieved by calling the
+   <function>mysqli_get_client_stats</function> function.
+  </simpara>
+
+  <simpara>
+   Client statistics can be retrieved by calling the
+   <function>mysqli_get_client_stats</function> function.
+  </simpara>
+
+  <simpara>
+   Connection statistics can be retrieved by calling the
+   <function>mysqli_get_connection_stats</function> function.
+  </simpara>
+
+  <simpara>
+   Both functions return an associative array,
+   where the name of a statistic is the key for the corresponding
+   statistical data.
+  </simpara>
+ </section>
+
+ <!-- WTF Does this section do here, this has nothing to do with statistics
+ <section>
+  <title>Buffered and Unbuffered Result Sets</title>
+  <para>
+   Result sets can be buffered or unbuffered. Using default settings,
+   <literal>ext/mysql</literal> and <literal>ext/mysqli</literal> work
+   with buffered result sets for normal (non prepared statement) queries.
+   Buffered result sets are cached on the client. After the query
+   execution all results are fetched from the MySQL Server and stored in
+   a cache on the client. The big advantage of buffered result sets is
+   that they allow the server to free all resources allocated to a result
+   set, once the results have been fetched by the client.
+  </para>
+  <para>
+   Unbuffered result sets on the other hand are kept much longer on the
+   server. If you want to reduce memory consumption on the client, but
+   increase load on the server, use unbuffered results. If you experience
+   a high server load and the figures for unbuffered result sets are
+   high, you should consider moving the load to the clients. Clients
+   typically scale better than servers. <quote>Load</quote> does not only
+   refer to memory buffers - the server also needs to keep other
+   resources open, for example file handles and threads, before a result
+   set can be freed.
+  </para>
+  <para>
+   Prepared Statements use unbuffered result sets by default. However,
+   you can use <function>mysqli_stmt_store_result</function> to enable
+   buffered result sets.
+  </para>
+ </section>
+ -->
+
+ <section xml:id="mysqlnd.stats.statistics" annotations="chunk:false">
+  <title>MySQL Native Driver Statistics</title>
+  <simpara>
+   Most statistics are associated to a connection, but some are associated
+   to the process in which case this will be .
+   <!-- Process running the server? -->
+  </simpara>
+  <simpara>
+   The following statistics are produced by the MySQL Native Driver:
+  </simpara>
+
+  <variablelist>
+   <title>Network Related Statistics</title>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.bytes-sent">
+    <term><literal>bytes_sent</literal></term>
+    <listitem>
+     <simpara>
+      Number of bytes sent from PHP to the MySQL server.
+     </simpara>
+     <note>
+      <simpara>
+       Can be used to check the efficiency of the compression protocol.
+      </simpara>
+     </note>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.bytes-received">
+    <term><literal>bytes_received</literal></term>
+    <listitem>
+     <simpara>
+      Number of bytes received from the MySQL server.
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-sent')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.packets-sent">
+    <term><literal>packets_sent</literal></term>
+    <listitem>
+     <simpara>
+      Number of packets sent by the MySQL Client Server protocol.
+     </simpara>
+     <note>
+      <simpara>
+       Used for debugging Client Server protocol implementation
+      </simpara>
+     </note>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.packets-received">
+    <term><literal>packets_received</literal></term>
+    <listitem>
+     <simpara>
+      Number of packets received from the MySQL Client Server protocol.
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.protocol-overhead-in">
+    <term><literal>protocol_overhead_in</literal></term>
+    <listitem>
+     <simpara>
+      MySQL Client Server protocol overhead in bytes for incoming traffic.
+      Currently only the Packet Header (4 bytes) is considered as overhead.
+      <code>protocol_overhead_in = packets_received * 4</code>
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.protocol-overhead-out">
+    <term><literal>protocol_overhead_out</literal></term>
+    <listitem>
+     <simpara>
+      MySQL Client Server protocol overhead in bytes for outgoing traffic.
+      Currently only the Packet Header (4 bytes) is considered as overhead.
+      <code>protocol_overhead_out = packets_received * 4</code>
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.bytes-received-ok-packet">
+    <term><literal>bytes_received_ok_packet</literal></term>
+    <listitem>
+     <simpara>
+      Total size of bytes of MySQL Client Server protocol OK packets received.
+      OK packets can contain a status message.
+      The length of the status message can vary and thus the size of an OK
+      packet is not fixed.
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+     <note>
+      <simpara>
+       The total size in bytes includes the size of the header packet.
+       (4 bytes, see protocol overhead)
+      </simpara>
+     </note>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.packets-received-ok">
+    <term><literal>packets_received_ok</literal></term>
+    <listitem>
+     <simpara>
+      Number of MySQL Client Server protocol OK packets received.
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.bytes-received-eof-packet">
+    <term><literal>bytes_received_eof_packet</literal></term>
+    <listitem>
+     <simpara>
+      Total size in bytes of MySQL Client Server protocol EOF packets received.
+      EOF can vary in size depending on the server version.
+      Also, EOF can transport an error message.
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.packets-received-eof">
+    <term><literal>packets_received_eof</literal></term>
+    <listitem>
+     <simpara>
+      Number of MySQL Client Server protocol EOF packets.
+     </simpara>
+     <simpara>
+      Like with other packet statistics the number of packets will be
+      increased even if PHP does not receive the expected packet but,
+      for example, an error message.
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.bytes-received-rset-header-packet">
+    <term><literal>bytes_received_rset_header_packet</literal></term>
+    <listitem>
+     <simpara>
+      Total size in bytes of MySQL Client Server protocol result set header
+      packets.
+      The size of the packets varies depending on the payload
       (<literal>LOAD LOCAL INFILE</literal>, <literal>INSERT</literal>,
-      <literal>UPDATE</literal>, <literal>SELECT</literal>, error
-      message).</entry>
-     <entry>Used for debugging CS protocol implementation. Note that the total size
-      in bytes includes the size of the header packet (4 bytes, see
-      protocol overhead).</entry>
-    </row>
-    <row>
-     <entry><literal>packets_received_rset_header</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of MySQL Client Server protocol result set header packets.</entry>
-     <entry>Used for debugging CS protocol implementation. Note that the total size
-      in bytes includes the size of the header packet (4 bytes, see
-      protocol overhead).</entry>
-    </row>
-    <row>
-     <entry><literal>bytes_received_rset_field_meta_packet</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total size in bytes of MySQL Client Server protocol result set meta data
-      (field information) packets. Of course the size varies with the
-      fields in the result set. The packet may also transport an error
-      or an EOF packet in case of COM_LIST_FIELDS.</entry>
-     <entry>Only useful for debugging CS protocol implementation. Note that the
-      total size in bytes includes the size of the header packet (4
-      bytes, see protocol overhead).</entry>
-    </row>
-    <row>
-     <entry><literal>packets_received_rset_field_meta</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of MySQL Client Server protocol result set meta data (field
-      information) packets.</entry>
-     <entry>Only useful for debugging CS protocol implementation. Note that the
-      total size in bytes includes the size of the header packet (4
-      bytes, see protocol overhead).</entry>
-    </row>
-    <row>
-     <entry><literal>bytes_received_rset_row_packet</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total size in bytes of MySQL Client Server protocol result set row data
-      packets. The packet may also transport an error or an EOF packet.
-      You can reverse engineer the number of error and EOF packets by
-      subtracting <literal>rows_fetched_from_server_normal</literal>
-      and <literal>rows_fetched_from_server_ps</literal> from
-      <literal>bytes_received_rset_row_packet</literal>.</entry>
-     <entry>Only useful for debugging CS protocol implementation. Note that the
-      total size in bytes includes the size of the header packet (4
-      bytes, see protocol overhead).</entry>
-    </row>
-    <row>
-     <entry><literal>packets_received_rset_row</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of MySQL Client Server protocol result set row data packets and
-      their total size in bytes.</entry>
-     <entry>Only useful for debugging CS protocol implementation. Note that the
-      total size in bytes includes the size of the header packet (4
-      bytes, see protocol overhead).</entry>
-    </row>
-    <row>
-     <entry><literal>bytes_received_prepare_response_packet</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total size in bytes of MySQL Client Server protocol OK for Prepared
-      Statement Initialization packets (prepared statement init
-      packets). The packet may also transport an error. The packet size
-      depends on the MySQL version: 9 bytes with MySQL 4.1 and 12 bytes
-      from MySQL 5.0 on. There is no safe way to know how many errors
-      happened. You may be able to guess that an error has occurred if,
-      for example, you always connect to MySQL 5.0 or newer and,
-      <literal>bytes_received_prepare_response_packet</literal> !=
-      <literal>packets_received_prepare_response</literal> * 12. See
-      also <literal>ps_prepared_never_executed</literal>,
-      <literal>ps_prepared_once_executed</literal>.</entry>
-     <entry>Only useful for debugging CS protocol implementation. Note that the
-      total size in bytes includes the size of the header packet (4
-      bytes, see protocol overhead).</entry>
-    </row>
-    <row>
-     <entry><literal>packets_received_prepare_response</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of MySQL Client Server protocol OK for Prepared Statement
-      Initialization packets (prepared statement init packets).</entry>
-     <entry>Only useful for debugging CS protocol implementation. Note that the
-      total size in bytes includes the size of the header packet (4
-      bytes, see protocol overhead).</entry>
-    </row>
-    <row>
-     <entry><literal>bytes_received_change_user_packet</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total size in bytes of MySQL Client Server protocol COM_CHANGE_USER
-      packets. The packet may also transport an error or EOF.</entry>
-     <entry>Only useful for debugging CS protocol implementation. Note that the
-      total size in bytes includes the size of the header packet (4
-      bytes, see protocol overhead).</entry>
-    </row>
-    <row>
-     <entry><literal>packets_received_change_user</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of MySQL Client Server protocol COM_CHANGE_USER packets</entry>
-     <entry>Only useful for debugging CS protocol implementation. Note that the
-      total size in bytes includes the size of the header packet (4
-      bytes, see protocol overhead).</entry>
-    </row>
-    <row>
-     <entry><literal>packets_sent_command</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of MySQL Client Server protocol commands sent from PHP to MySQL.
+      <literal>UPDATE</literal>, <literal>SELECT</literal>, error message).
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.packets-received-rset-header">
+    <term><literal>packets_received_rset_header</literal></term>
+    <listitem>
+     <simpara>
+      Number of MySQL Client Server protocol result set header packets.
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.bytes-received-rset-field-meta-packet">
+    <term><literal>bytes_received_rset_field_meta_packet</literal></term>
+    <listitem>
+     <simpara>
+      Total size in bytes of MySQL Client Server protocol result set metadata
+      (field information) packets.
+      Of course the size varies with the fields in the result set.
+      The packet may also transport an error or an EOF packet in case of
+      COM_LIST_FIELDS.
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.packets-received-rset-field-meta">
+    <term><literal>packets_received_rset_field_meta</literal></term>
+    <listitem>
+     <simpara>
+      Number of MySQL Client Server protocol result set metadata
+      (field information) packets.
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.bytes-received-rset-row-packet">
+    <term><literal>bytes_received_rset_row_packet</literal></term>
+    <listitem>
+     <simpara>
+      Total size in bytes of MySQL Client Server protocol result set row data
+      packets.
+      The packet may also transport an error or an EOF packet.
+      One can compute the number of error and EOF packets by subtracting
+      <literal>rows_fetched_from_server_normal</literal>
+      and <literal>rows_fetched_from_server_ps</literal>
+      from <literal>bytes_received_rset_row_packet</literal>.
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.packets-received-rset-row">
+    <term><literal>packets_received_rset_row</literal></term>
+    <listitem>
+     <simpara>
+      <!-- TODO: Does it really have the total size in bytes? -->
+      Number of MySQL Client Server protocol result set row data packets and their total size in bytes.
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.bytes-received-prepare-response-packet">
+    <term><literal>bytes_received_prepare_response_packet</literal></term>
+    <listitem>
+     <simpara>
+      Total size in bytes of MySQL Client Server protocol OK for Prepared
+      Statement Initialization packets (prepared statement init packets).
+      The packet may also transport an error.
+      The packet size depends on the MySQL version.
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.packets-received-prepare-response">
+    <term><literal>packets_received_prepare_response</literal></term>
+    <listitem>
+     <simpara>
+      Number of MySQL Client Server protocol OK for Prepared Statement
+      Initialization packets (prepared statement init packets).
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.bytes-received-change-user-packet">
+    <term><literal>bytes_received_change_user_packet</literal></term>
+    <listitem>
+     <simpara>
+      Total size in bytes of MySQL Client Server protocol COM_CHANGE_USER packets.
+      The packet may also transport an error or EOF.
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.packets-received-change-user">
+    <term><literal>packets_received_change_user</literal></term>
+    <listitem>
+     <simpara>
+      Number of MySQL Client Server protocol COM_CHANGE_USER packets.
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.packets-sent-command">
+    <term><literal>packets_sent_command</literal></term>
+    <listitem>
+     <simpara>
+      Number of MySQL Client Server protocol commands sent from PHP to MySQL.
+     </simpara>
+     <simpara>
       There is no way to know which specific commands and how many of
-      them have been sent. At its best you can use it to check if PHP
-      has sent any commands to MySQL to know if you can consider to
-      disable MySQL support in your PHP binary. There is also no way to
-      reverse engineer the number of errors that may have occurred while
-      sending data to MySQL. The only error that is recorded is
-      command_buffer_too_small (see below).</entry>
-     <entry>Only useful for debugging CS protocol implementation.</entry>
-    </row>
-    <row>
-     <entry><literal>bytes_received_real_data_normal</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of bytes of payload fetched by the PHP client from
-      <literal>mysqlnd</literal> using the text protocol.</entry>
-     <entry>This is the size of the actual data contained in result sets that do not
-      originate from prepared statements and which have been fetched by
-      the PHP client. Note that although a full result set may have been
-      pulled from MySQL by <literal>mysqlnd</literal>, this statistic
-      only counts actual data pulled from <literal>mysqlnd</literal> by
-      the PHP client. An example of a code sequence that will increase
-      the value is as follows:
-<programlisting>
+      them have been sent.
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.packets-sent')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.bytes-received-real-data_normal">
+    <term><literal>bytes_received_real_data_normal</literal></term>
+    <listitem>
+     <simpara>
+      Number of bytes of payload fetched by the PHP client from
+      <literal>mysqlnd</literal> using the text protocol.
+     </simpara>
+     <simpara>
+      This is the size of the actual data contained in result sets that do not
+      originate from prepared statements and which have been fetched by the PHP client.
+     </simpara>
+     <simpara>
+      Note that although a full result set may have been pulled from MySQL
+      by <literal>mysqlnd</literal>, this statistic only counts actual data
+      pulled from <literal>mysqlnd</literal> by the PHP client.
+     </simpara>
+     <para>
+      An example of a code sequence that will increase the value is as follows:
+      <programlisting>
 <![CDATA[
 $mysqli = new mysqli();
 $res = $mysqli->query("SELECT 'abc'");
 $res->fetch_assoc();
 $res->close();
 ]]>
-</programlisting>
-      <para>
-       Every fetch operation will increase the value.
-      </para>
-
-      <para>
-       The statistic will not be increased if the result set is only
-       buffered on the client, but not fetched, such as in the following
-       example:
-      </para>
-<programlisting>
+      </programlisting>
+      Every fetch operation will increase the value.
+     </para>
+     <para>
+      However, the statistic will not be increased if the result set is only
+      buffered on the client, but not fetched, such as in the following example:
+      <programlisting>
 <![CDATA[
 $mysqli = new mysqli();
 $res = $mysqli->query("SELECT 'abc'");
 $res->close();
 ]]>
-</programlisting>
-      </entry>
-    </row>
-    <row>
-     <entry><literal>bytes_received_real_data_ps</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of bytes of the payload fetched by the PHP client from
-      <literal>mysqlnd</literal> using the prepared statement protocol.</entry>
-     <entry>This is the size of the actual data contained in result sets that
-      originate from prepared statements and which has been fetched by
-      the PHP client. The value will not be increased if the result set
-      is not subsequently read by the PHP client. Note that although a
-      full result set may have been pulled from MySQL by
-      <literal>mysqlnd</literal>, this statistic only counts actual data
-      pulled from <literal>mysqlnd</literal> by the PHP client. See also
-      <literal>bytes_received_real_data_normal</literal>.</entry>
-    </row>
-   </tbody>
-  </tgroup>
- </table>
- <para>
-  <emphasis role="bold">Result Set</emphasis>
- </para>
- <table xml:id="mysqlnd.stats.results">
-  <title>Returned mysqlnd statistics: Result Set</title>
-  <tgroup cols="4">
-   <colspec colwidth="10*"/>
-   <colspec colwidth="10*"/>
-   <colspec colwidth="40*"/>
-   <colspec colwidth="40*"/>
-   <thead>
-    <row>
-     <entry>Statistic</entry>
-     <entry>Scope</entry>
-     <entry>Description</entry>
-     <entry>Notes</entry>
-    </row>
-   </thead>
-   <tbody>
-    <row>
-     <entry><literal>result_set_queries</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of queries that have generated a result set. Examples of queries
-      that generate a result set: <literal>SELECT</literal>,
-      <literal>SHOW</literal>. The statistic will not be incremented if
-      there is an error reading the result set header packet from the
-      line.</entry>
-     <entry>You may use it as an indirect measure for the number of queries PHP has
-      sent to MySQL, for example, to identify a client that causes a
-      high database load.</entry>
-    </row>
-    <row>
-     <entry><literal>non_result_set_queries</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of queries that did not generate a result set. Examples of
-      queries that do not generate a result set:
-      <literal>INSERT</literal>, <literal>UPDATE</literal>,
-      <literal>LOAD DATA</literal>. The
-      statistic will not be incremented if there is an error reading the
-      result set header packet from the line.</entry>
-     <entry>You may use it as an indirect measure for the number of queries PHP has
-      sent to MySQL, for example, to identify a client that causes a
-      high database load.</entry>
-    </row>
-    <row>
-     <entry><literal>no_index_used</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of queries that have generated a result set but did not use an
-      index (see also mysqld start option
-      –log-queries-not-using-indexes). If you want these queries to be
-      reported you can use mysqli_report(MYSQLI_REPORT_INDEX) to make
-      ext/mysqli throw an exception. If you prefer a warning instead of
-      an exception use mysqli_report(MYSQLI_REPORT_INDEX ^
-      MYSQLI_REPORT_STRICT).</entry>
-     <entry></entry>
-    </row>
-    <row>
-     <entry><literal>bad_index_used</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of queries that have generated a result set and did not use a
-      good index (see also mysqld start option –log-slow-queries).</entry>
-     <entry>If you want these queries to be reported you can use
-      mysqli_report(MYSQLI_REPORT_INDEX) to make ext/mysqli throw an
-      exception. If you prefer a warning instead of an exception use
-      mysqli_report(MYSQLI_REPORT_INDEX ^ MYSQLI_REPORT_STRICT)</entry>
-    </row>
-    <row>
-     <entry><literal>slow_queries</literal></entry>
-     <entry>Connection</entry>
-     <entry>SQL statements that took more than <literal>long_query_time</literal>
+      </programlisting>
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.bytes-received-real-data-ps">
+    <term><literal>bytes_received_real_data_ps</literal></term>
+    <listitem>
+     <simpara>
+      Number of bytes of the payload fetched by the PHP client from
+      <literal>mysqlnd</literal> using the prepared statement protocol.
+     </simpara>
+     <simpara>
+      This is the size of the actual data contained in result sets that
+      originate from prepared statements and which have been fetched by the PHP client.
+     </simpara>
+     <simpara>
+      The value will not be increased if the result set is not subsequently read by the PHP client.
+     </simpara>
+     <simpara>
+      Note that although a full result set may have been pulled from MySQL
+      by <literal>mysqlnd</literal>, this statistic only counts actual data
+      pulled from <literal>mysqlnd</literal> by the PHP client.
+     </simpara>
+     <simpara>
+      See also <literal>bytes_received_real_data_normal</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <variablelist>
+   <title>Result Set Related Statistics</title>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.result-set-queries">
+    <term><literal>result_set_queries</literal></term>
+    <listitem>
+     <simpara>
+      Number of queries that have generated a result set.
+      Examples of queries that generate a result set:
+      <literal>SELECT</literal>, <literal>SHOW</literal>.
+     </simpara>
+     <simpara>
+      The statistic will not be incremented if there is an error reading
+      the result set header packet from the line.
+     </simpara>
+     <note>
+      <simpara>
+       This statistic can be used as an indirect measure for the number of
+       queries PHP has sent to MySQL.
+       This could help identifying a client that causes a high database load.
+      </simpara>
+     </note>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.non-result-set-queries">
+    <term><literal>non_result_set_queries</literal></term>
+    <listitem>
+     <simpara>
+      Number of queries that did not generate a result set.
+      Examples of queries that do not generate a result set:
+      <literal>INSERT</literal>, <literal>UPDATE</literal>, <literal>LOAD DATA</literal>.
+     </simpara>
+     <simpara>
+      The statistic will not be incremented if there is an error reading
+      the result set header packet from the line.
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.result-set-queries')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.no-index-used">
+    <term><literal>no_index_used</literal></term>
+    <listitem>
+     <simpara>
+      Number of queries that have generated a result set but did not use an index.
+      (See also the mysqld start option <literal>–log-queries-not-using-indexes</literal>).
+     </simpara>
+     <note>
+      <simpara>
+       Those queries can be reported via an exception by calling
+       <code>mysqli_report(MYSQLI_REPORT_INDEX);</code>.
+       It is possible to have them be reported via a warning instead by calling
+       <code>mysqli_report(MYSQLI_REPORT_INDEX ^ MYSQLI_REPORT_STRICT);</code>.
+      </simpara>
+     </note>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.bad-index-used">
+    <term><literal>bad_index_used</literal></term>
+    <listitem>
+     <simpara>
+      Number of queries that have generated a result set and did not use a good index.
+      (See also the mysqld start option <literal>–log-slow-queries</literal>).
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.no-index-used')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.slow-queries">
+    <term><literal>slow_queries</literal></term>
+    <listitem>
+     <simpara>
+      SQL statements that took more than <literal>long_query_time</literal>
       seconds to execute and required at least
-      <literal>min_examined_row_limit</literal> rows to be examined.</entry>
-     <entry>Not reported through <function>mysqli_report</function></entry>
-    </row>
-    <row>
-     <entry><literal>buffered_sets</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of buffered result sets returned by <quote>normal</quote>
-      queries. <quote>Normal</quote> means <quote>not prepared
-      statement</quote> in the following notes.</entry>
-     <entry>Examples of API calls that will buffer result sets on the client:
-      <function>mysql_query</function>,
-      <function>mysqli_query</function>,
-      <function>mysqli_store_result</function>,
-      <function>mysqli_stmt_get_result</function>. Buffering result sets
+      <literal>min_examined_row_limit</literal> rows to be examined.
+     </simpara>
+     <caution>
+      <simpara>
+       Not reported through <function>mysqli_report</function>.
+      </simpara>
+     </caution>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.buffered-sets">
+    <term><literal>buffered_sets</literal></term>
+    <listitem>
+     <simpara>
+      Number of buffered result sets returned by normal
+      (i.e. not via a prepared statement) queries.
+     </simpara>
+     <para>
+      Examples of API calls that will buffer result sets on the client:
+      <simplelist type="inline">
+       <member><function>mysqli_query</function></member>
+       <member><function>mysqli_store_result</function></member>
+       <member><function>mysqli_store_result</function></member>
+       <member><function>mysqli_stmt_get_result</function></member>
+      </simplelist>
+     </para>
+     <!-- TODO: Is this paragraph actually useful?
+     <simpara>
+      Buffering result sets
       on the client ensures that server resources are freed as soon as
       possible and it makes result set scrolling easier. The downside is
       the additional memory consumption on the client for buffering
@@ -484,586 +604,1104 @@ $res->close();
       Library. <function>memory_get_usage</function> does not measure
       the memory consumption of the MySQL Client Library at all because
       the MySQL Client Library does not use PHP internal memory
-      management functions monitored by the function!</entry>
-    </row>
-    <row>
-     <entry><literal>unbuffered_sets</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of unbuffered result sets returned by normal (non prepared
-      statement) queries.</entry>
-     <entry>Examples of API calls that will not buffer result sets on the client:
-      <function>mysqli_use_result</function></entry>
-    </row>
-    <row>
-     <entry><literal>ps_buffered_sets</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of buffered result sets returned by prepared statements. By
-      default prepared statements are unbuffered.</entry>
-     <entry>Examples of API calls that will buffer result sets on the client:
-      <literal>mysqli_stmt_store_result</literal></entry>
-    </row>
-    <row>
-     <entry><literal>ps_unbuffered_sets</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of unbuffered result sets returned by prepared statements.</entry>
-     <entry>By default prepared statements are unbuffered.</entry>
-    </row>
-    <row>
-     <entry><literal>flushed_normal_sets</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of result sets from normal (non prepared statement) queries with
-      unread data which have been flushed silently for you. Flushing
-      happens only with unbuffered result sets.</entry>
-     <entry>Unbuffered result sets must be fetched completely before a new query can
-      be run on the connection otherwise MySQL will throw an error. If
-      the application does not fetch all rows from an unbuffered result
-      set, mysqlnd does implicitly fetch the result set to clear the
-      line. See also <literal>rows_skipped_normal</literal>,
-      <literal>rows_skipped_ps</literal>. Some possible causes for an
-      implicit flush:
-      <itemizedlist>
-       <listitem>
-        <para>
-         Faulty client application
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         Client stopped reading after it found what it was looking for
-         but has made MySQL calculate more records than needed
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         Client application has stopped unexpectedly
-        </para>
-       </listitem>
-      </itemizedlist></entry>
-    </row>
-    <row>
-     <entry><literal>flushed_ps_sets</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of result sets from prepared statements with unread data which
-      have been flushed silently for you. Flushing happens only with
-      unbuffered result sets.</entry>
-     <entry>Unbuffered result sets must be fetched completely before a new query can
-      be run on the connection otherwise MySQL will throw an error. If
-      the application does not fetch all rows from an unbuffered result
-      set, mysqlnd does implicitly fetch the result set to clear the
-      line. See also <literal>rows_skipped_normal</literal>,
-      <literal>rows_skipped_ps</literal>. Some possible causes for an
-      implicit flush:
-      <itemizedlist>
-       <listitem>
-        <para>
-         Faulty client application
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         Client stopped reading after it found what it was looking for
-         but has made MySQL calculate more records than needed
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         Client application has stopped unexpectedly
-        </para>
-       </listitem>
-      </itemizedlist></entry>
-    </row>
-    <row>
-     <entry><literal>ps_prepared_never_executed</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of statements prepared but never executed.</entry>
-     <entry>Prepared statements occupy server resources. You should not prepare a
-      statement if you do not plan to execute it.</entry>
-    </row>
-    <row>
-     <entry><literal>ps_prepared_once_executed</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of prepared statements executed only one.</entry>
-     <entry>One of the ideas behind prepared statements is that the same query gets
-      executed over and over again (with different parameters) and some
-      parsing and other preparation work can be saved, if statement
-      execution is split up in separate prepare and execute stages. The
-      idea is to prepare once and <quote>cache</quote> results, for
-      example, the parse tree to be reused during multiple statement
-      executions. If you execute a prepared statement only once the two
-      stage processing can be inefficient compared to
-      <quote>normal</quote> queries because all the caching means extra
-      work and it takes (limited) server resources to hold the cached
-      information. Consequently, prepared statements that are executed
-      only once may cause performance hurts.</entry>
-    </row>
-    <row>
-     <entry><literal>rows_fetched_from_server_normal</literal>,
-      <literal>rows_fetched_from_server_ps</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total number of result set rows successfully fetched from MySQL
+      management functions monitored by the function!
+     </simpara>
+     -->
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.unbuffered-sets">
+    <term><literal>unbuffered_sets</literal></term>
+    <listitem>
+     <simpara>
+      Number of unbuffered result sets returned by normal
+      (i.e. not via a prepared statement) queries.
+     </simpara>
+     <para>
+      Examples of API calls that will not buffer result sets on the client:
+      <simplelist type="inline">
+       <member><function>mysqli_use_result</function></member>
+      </simplelist>
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.ps-buffered-sets">
+    <term><literal>ps_buffered_sets</literal></term>
+    <listitem>
+     <simpara>
+      Number of buffered result sets returned by prepared statements.
+     </simpara>
+     <para>
+      Examples of API calls that will buffer result sets on the client:
+      <simplelist type="inline">
+       <member><methodname>mysqli_stmt::store_result</methodname></member>
+      </simplelist>
+     </para>
+     <note>
+      <simpara>
+       By default prepared statements are unbuffered.
+      </simpara>
+     </note>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.ps-unbuffered-sets">
+    <term><literal>ps_unbuffered_sets</literal></term>
+    <listitem>
+     <simpara>
+      Number of unbuffered result sets returned by prepared statements.
+     </simpara>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.ps-buffered-sets')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.flushed-normal-sets">
+    <term><literal>flushed_normal_sets</literal></term>
+    <listitem>
+     <simpara>
+      Number of result sets returned by normal
+      (i.e. not via a prepared statement) queries
+      with unread data that have been silently flushed.
+     </simpara>
+
+     <note>
+      <simpara>
+       Flushing happens only with unbuffered result sets.
+      </simpara>
+     </note>
+
+     <warning>
+      <simpara>
+       Unbuffered result sets must be fetched completely before a new query can
+       be run on the connection otherwise MySQL will throw an error.
+       If the application does not fetch all rows from an unbuffered result set,
+       mysqlnd does implicitly fetch the result set to clear the line.
+      </simpara>
+      <simpara>
+       See also <literal>rows_skipped_normal</literal>, <literal>rows_skipped_ps</literal>.
+      </simpara>
+      <para>
+       Some possible causes for an implicit flush:
+       <itemizedlist>
+        <listitem>
+         <simpara>
+          Faulty client application
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          Client stopped reading after it found what it was looking for
+          but has made MySQL calculate more records than needed
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          Client application has stopped unexpectedly
+         </simpara>
+        </listitem>
+       </itemizedlist>
+      </para>
+     </warning>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.flushed-normal-sets')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.flushed-ps-sets">
+    <term><literal>flushed_ps_sets</literal></term>
+    <listitem>
+     <simpara>
+      Number of result sets from prepared statements
+      with unread data that have been silently flushed.
+     </simpara>
+
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.flushed-normal-sets')/db:listitem/db:note)">
+      <xi:fallback/>
+     </xi:include>
+
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.flushed-normal-sets')/db:listitem/db:warning)">
+      <xi:fallback/>
+     </xi:include>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.ps-prepared-never-executed">
+    <term><literal>ps_prepared_never_executed</literal></term>
+    <listitem>
+     <simpara>
+      Number of statements prepared but never executed.
+     </simpara>
+
+     <warning>
+      <simpara>
+       Prepared statements occupy server resources.
+       Statements that are not going to be executed should not be prepared.
+      </simpara>
+     </warning>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.ps-prepared-once-executed">
+    <term><literal>ps_prepared_once_executed</literal></term>
+    <listitem>
+     <simpara>
+      Number of prepared statements executed only once.
+     </simpara>
+
+     <!-- Does this note/warning make any sense? As people might stop using them
+     even if prepared statements are safer than normal concatenated queries.
+     <warning>
+      <simpara>
+       One of the ideas behind prepared statements is that the same query gets
+       executed over and over again (with different parameters) and some
+       parsing and other preparation work can be saved, if statement
+       execution is split up in separate prepare and execute stages. The
+       idea is to prepare once and <quote>cache</quote> results, for
+       example, the parse tree to be reused during multiple statement
+       executions. If you execute a prepared statement only once the two
+       stage processing can be inefficient compared to
+       <quote>normal</quote> queries because all the caching means extra
+       work, and it takes (limited) server resources to hold the cached
+       information. Consequently, prepared statements that are executed
+       only once may cause performance hurts.
+      </simpara>
+     </warning>
+     -->
+    </listitem>
+   </varlistentry>
+
+   <!-- TODO: Should this be split in two? -->
+   <varlistentry xml:id="mysqlnd.stats.statistics.rows-fetched-from-server-normal">
+    <term><literal>rows_fetched_from_server_normal</literal></term>
+    <term><literal>rows_fetched_from_server_ps</literal></term>
+    <listitem>
+     <simpara>
+      Total number of result set rows successfully fetched from MySQL
       regardless if the client application has consumed them or not.
       Some of the rows may not have been fetched by the client
-      application but have been flushed implicitly.</entry>
-     <entry>See also <literal>packets_received_rset_row</literal></entry>
-    </row>
-    <row>
-     <entry><literal>rows_buffered_from_client_normal</literal>,
-      <literal>rows_buffered_from_client_ps</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total number of successfully buffered rows originating from a "normal"
-      query or a prepared statement. This is the number of rows that
-      have been fetched from MySQL and buffered on client. Note that
-      there are two distinct statistics on rows that have been buffered
-      (MySQL to mysqlnd internal buffer) and buffered rows that have
-      been fetched by the client application (mysqlnd internal buffer to
-      client application). If the number of buffered rows is higher than
-      the number of fetched buffered rows it can mean that the client
-      application runs queries that cause larger result sets than needed
-      resulting in rows not read by the client.</entry>
-     <entry>Examples of queries that will buffer results:
-      <function>mysqli_query</function>,
-      <function>mysqli_store_result</function></entry>
-    </row>
-    <row>
-     <entry><literal>rows_fetched_from_client_normal_buffered</literal>,
-      <literal>rows_fetched_from_client_ps_buffered</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total number of rows fetched by the client from a buffered result set
-      created by a normal query or a prepared statement.</entry>
-     <entry></entry>
-    </row>
-    <row>
-     <entry><literal>rows_fetched_from_client_normal_unbuffered</literal>,
-      <literal>rows_fetched_from_client_ps_unbuffered</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total number of rows fetched by the client from a unbuffered result set
-      created by a "normal" query or a prepared statement.</entry>
-     <entry></entry>
-    </row>
-    <row>
-     <entry><literal>rows_fetched_from_client_ps_cursor</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total number of rows fetch by the client from a cursor created by a
-      prepared statement.</entry>
-     <entry></entry>
-    </row>
-    <row>
-     <entry><literal>rows_skipped_normal</literal>,
-      <literal>rows_skipped_ps</literal></entry>
-     <entry>Connection</entry>
-     <entry>Reserved for future use (currently not supported)</entry>
-     <entry></entry>
-    </row>
-    <row>
-     <entry><literal>copy_on_write_saved</literal>,
-      <literal>copy_on_write_performed</literal></entry>
-     <entry>Process</entry>
-     <entry>With mysqlnd, variables returned by the extensions point into mysqlnd
-      internal network result buffers. If you do not change the
-      variables, fetched data will be kept only once in memory. If you
-      change the variables, mysqlnd has to perform a copy-on-write to
-      protect the internal network result buffers from being changed.
-      With the MySQL Client Library you always hold fetched data twice
-      in memory. Once in the internal MySQL Client Library buffers and
-      once in the variables returned by the extensions. In theory
-      mysqlnd can save up to 40% memory. However, note that the memory
-      saving cannot be measured using
-      <function>memory_get_usage</function>.</entry>
-     <entry></entry>
-    </row>
-    <row>
-     <entry><literal>explicit_free_result</literal>,
-      <literal>implicit_free_result</literal></entry>
-     <entry>Connection, Process (only during prepared statement cleanup)</entry>
-     <entry>Total number of freed result sets.</entry>
-     <entry>The free is always considered explicit but for result sets created by an
+      application but have been flushed implicitly.
+     </simpara>
+     <simpara>
+      See also <literal>packets_received_rset_row</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.rows-buffered-from-server-normal">
+    <term><literal>rows_buffered_from_client_normal</literal></term>
+    <listitem>
+     <simpara>
+      Total number of successfully buffered rows originating from a normal query.
+     </simpara>
+     <simpara>
+      This is the number of rows that have been fetched from MySQL and buffered on client.
+     </simpara>
+     <para>
+      Examples of queries that will buffer results:
+      <simplelist>
+       <member><function>mysqli_query</function></member>
+       <member><function>mysqli_store_result</function></member>
+      </simplelist>
+     </para>
+     <note>
+      <simpara>
+       There are two distinct statistics on rows that have been buffered
+       (MySQL to mysqlnd internal buffer) and buffered rows that have
+       been fetched by the client application (mysqlnd internal buffer to
+       client application).
+      </simpara>
+      <simpara>
+       If the number of buffered rows is higher than the number of fetched
+       buffered rows it can mean that the client application runs queries that
+       cause larger result sets than needed resulting in rows not read by the client.
+      </simpara>
+     </note>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.rows-buffered-from-server-ps">
+    <term><literal>rows_fetched_from_server_ps</literal></term>
+    <listitem>
+     <simpara>
+      Same as <literal>rows_buffered_from_client_normal</literal>
+      but for prepared statements.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.rows-fetched-from-client-normal-buffered">
+    <term><literal>rows_fetched_from_client_normal_buffered</literal></term>
+    <listitem>
+     <simpara>
+      Total number of rows fetched by the client from a buffered result set
+      created by a normal query.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.rows-fetched-from-client-ps-buffered">
+    <term><literal>rows_fetched_from_client_ps_buffered</literal></term>
+    <listitem>
+     <simpara>
+      Total number of rows fetched by the client from a buffered result set
+      created by a prepared statement.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.rows-fetched-from-client-normal-unbuffered">
+    <term><literal>rows_fetched_from_client_normal_unbuffered</literal></term>
+    <listitem>
+     <simpara>
+      Total number of rows fetched by the client from an unbuffered result set
+      created by a normal query.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.rows-fetched-from-client-ps-unbuffered">
+    <term><literal>rows_fetched_from_client_ps_unbuffered</literal></term>
+    <listitem>
+     <simpara>
+      Total number of rows fetched by the client from an unbuffered result set
+      created by a prepared statement.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.rows-fetched-from-client-ps-cursor">
+    <term><literal>rows_fetched_from_client_ps_cursor</literal></term>
+    <listitem>
+     <simpara>
+      Total number of rows fetch by the client from a cursor created by a
+      prepared statement.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <!-- TODO: Remove if unused? -->
+   <varlistentry xml:id="mysqlnd.stats.statistics.rows-skipped-normal">
+    <term><literal>rows_skipped_normal</literal></term>
+    <term><literal>rows_skipped_ps</literal></term>
+    <listitem>
+     <simpara>
+      Reserved for future use (currently not supported).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.copy-on-write">
+    <term><literal>copy_on_write_saved</literal></term>
+    <term><literal>copy_on_write_performed</literal></term>
+    <listitem>
+     <simpara>
+      This is a process level scope statistic.
+     </simpara>
+     <simpara>
+      With mysqlnd, variables returned by the extensions point into mysqlnd
+      internal network result buffers.
+      If the data are not changed, the fetched data is kept only once in memory.
+      However, any modification to the data will require mysqlnd to perform
+      a copy-on-write operation.
+      The MySQL Client Library required to duplicate the data upfront.
+      Therefore, in theory, mysqlnd can save up to 40% memory.
+      However, note that the memory saving cannot be measured using
+      <function>memory_get_usage</function>.
+      <!-- TODO: Explain this is because the client lib doesn't use PHP's internal memory tracking? -->
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <!-- TODO: Split into two? -->
+   <varlistentry xml:id="mysqlnd.stats.statistics.free-result">
+    <term><literal>explicit_free_result</literal></term>
+    <term><literal>implicit_free_result</literal></term>
+    <listitem>
+     <simpara>
+      This is a connection and process level scope statistic.
+     </simpara>
+     <simpara>
+      Total number of freed result sets.
+     </simpara>
+     <simpara>
+      The free is always considered explicit but for result sets created by an
       init command, for example,
-      <literal>mysqli_options(MYSQLI_INIT_COMMAND , ...)</literal></entry>
-    </row>
-    <row>
-     <entry><literal>proto_text_fetched_null</literal>,
-      <literal>proto_text_fetched_bit</literal>,
-      <literal>proto_text_fetched_tinyint</literal>
-      <literal>proto_text_fetched_short</literal>,
-      <literal>proto_text_fetched_int24</literal>,
-      <literal>proto_text_fetched_int</literal>
-      <literal>proto_text_fetched_bigint</literal>,
-      <literal>proto_text_fetched_decimal</literal>,
-      <literal>proto_text_fetched_float</literal>
-      <literal>proto_text_fetched_double</literal>,
-      <literal>proto_text_fetched_date</literal>,
-      <literal>proto_text_fetched_year</literal>
-      <literal>proto_text_fetched_time</literal>,
-      <literal>proto_text_fetched_datetime</literal>,
-      <literal>proto_text_fetched_timestamp</literal>
-      <literal>proto_text_fetched_string</literal>,
-      <literal>proto_text_fetched_blob</literal>,
-      <literal>proto_text_fetched_enum</literal>
-      <literal>proto_text_fetched_set</literal>,
-      <literal>proto_text_fetched_geometry</literal>,
-      <literal>proto_text_fetched_other</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total number of columns of a certain type fetched from a normal query
-      (MySQL text protocol).</entry>
-     <entry>Mapping from C API / MySQL meta data type to statistics name:
+      <code>mysqli_options(MYSQLI_INIT_COMMAND , ...);</code>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-null">
+    <term><literal>proto_text_fetched_null</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_NULL</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-null">
+    <term><literal>proto_binary_fetched_null</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_NULL</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-bit">
+    <term><literal>proto_text_fetched_bit</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_BIT</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-bit">
+    <term><literal>proto_binary_fetched_bit</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_BIT</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-tinyint">
+    <term><literal>proto_text_fetched_tinyint</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_TINY</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-tinyint">
+    <term><literal>proto_binary_fetched_tinyint</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_TINY</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-short">
+    <term><literal>proto_text_fetched_short</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_SHORT</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-short">
+    <term><literal>proto_binary_fetched_short</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_SHORT</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-int24">
+    <term><literal>proto_text_fetched_int24</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_INT24</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-int24">
+    <term><literal>proto_binary_fetched_int24</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_INT24</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-int">
+    <term><literal>proto_text_fetched_int</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_LONG</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-int">
+    <term><literal>proto_binary_fetched_int</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_LONG</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-bigint">
+    <term><literal>proto_text_fetched_bigint</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_LONGLONG</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-bigint">
+    <term><literal>proto_binary_fetched_bigint</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_LONGLONG</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-decimal">
+    <term><literal>proto_text_fetched_decimal</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_DECIMAL</literal>, or <literal>MYSQL_TYPE_NEWDECIMAL</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-decimal">
+    <term><literal>proto_binary_fetched_decimal</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_DECIMAL</literal>, or <literal>MYSQL_TYPE_NEWDECIMAL</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-float">
+    <term><literal>proto_text_fetched_float</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_FLOAT</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-float">
+    <term><literal>proto_binary_fetched_float</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_FLOAT</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-double">
+    <term><literal>proto_text_fetched_double</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_DOUBLE</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-double">
+    <term><literal>proto_binary_fetched_double</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_DOUBLE</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-date">
+    <term><literal>proto_text_fetched_date</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_DATE</literal>, or <literal>MYSQL_TYPE_NEWDATE</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-date">
+    <term><literal>proto_binary_fetched_date</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_DATE</literal>, or <literal>MYSQL_TYPE_NEWDATE</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-year">
+    <term><literal>proto_text_fetched_year</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_YEAR</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-year">
+    <term><literal>proto_binary_fetched_year</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_YEAR</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-time">
+    <term><literal>proto_text_fetched_time</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_TIME</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-time">
+    <term><literal>proto_binary_fetched_time</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_TIME</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-datetime">
+    <term><literal>proto_text_fetched_datetime</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_DATETIME</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-datetime">
+    <term><literal>proto_binary_fetched_datetime</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_DATETIME</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-timestamp">
+    <term><literal>proto_text_fetched_timestamp</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_TIMESTAMP</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-timestamp">
+    <term><literal>proto_binary_fetched_timestamp</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_TIMESTAMP</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-string">
+    <term><literal>proto_text_fetched_string</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_STRING</literal>, <literal>MYSQL_TYPE_VARSTRING</literal>, or <literal>MYSQL_TYPE_VARCHAR</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-string">
+    <term><literal>proto_binary_fetched_string</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_STRING</literal>, <literal>MYSQL_TYPE_VARSTRING</literal>, or <literal>MYSQL_TYPE_VARCHAR</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-blob">
+    <term><literal>proto_text_fetched_blob</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_TINY_BLOB</literal>,
+      <literal>MYSQL_TYPE_MEDIUM_BLOB</literal>,
+      <literal>MYSQL_TYPE_LONG_BLOB</literal>,
+      or <literal>MYSQL_TYPE_BLOB</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-blob">
+    <term><literal>proto_binary_fetched_blob</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_TINY_BLOB</literal>,
+      <literal>MYSQL_TYPE_MEDIUM_BLOB</literal>,
+      <literal>MYSQL_TYPE_LONG_BLOB</literal>,
+      or <literal>MYSQL_TYPE_BLOB</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-enum">
+    <term><literal>proto_text_fetched_enum</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_ENUM</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-enum">
+    <term><literal>proto_binary_fetched_enum</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_ENUM</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-set">
+    <term><literal>proto_text_fetched_set</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_SET</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-set">
+    <term><literal>proto_binary_fetched_set</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_SET</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-geometry">
+    <term><literal>proto_text_fetched_geometry</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_GEOMETRY</literal>
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-geometry">
+    <term><literal>proto_binary_fetched_geometry</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_GEOMETRY</literal>
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-text-fetched-other">
+    <term><literal>proto_text_fetched_other</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of types
+      <literal>MYSQL_TYPE_<replaceable>*</replaceable></literal>
+      not listed previously
+      fetched from a normal query (MySQL text protocol).
+     </simpara>
+     <note>
+      <simpara>
+       In theory, this should always be <literal>0</literal>.
+      </simpara>
+     </note>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.proto-binary-fetched-other">
+    <term><literal>proto_binary_fetched_other</literal></term>
+    <listitem>
+     <simpara>
+      Total number of columns of type
+      <literal>MYSQL_TYPE_<replaceable>*</replaceable></literal>
+      not listed previously
+      fetched from a prepared statement (MySQL binary protocol).
+     </simpara>
+     <note>
+      <simpara>
+       In theory, this should always be <literal>0</literal>.
+      </simpara>
+     </note>
+    </listitem>
+   </varlistentry>
+
+  </variablelist>
+
+  <variablelist>
+   <title>Connection Related Statistics</title>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.connect-success">
+    <term><literal>connect_success</literal></term>
+    <listitem>
+     <simpara>
+      Total number of successful connection attempt.
+     </simpara>
+     <simpara>
+      Reused connections and all other kinds of connections are included.
+     </simpara>
+     <note>
+      <simpara>
+       <literal>connect_success</literal> holds the sum of successful
+       persistent and non-persistent connection attempts.
+       Therefore, the number of successful non-persistent connection attempts
+       is <literal>connect_success - pconnect_success</literal>.
+      </simpara>
+     </note>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.pconnect-success">
+    <term><literal>pconnect_success</literal></term>
+    <listitem>
+     <simpara>
+      Total number of successful persistent connection attempts.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.connect-failure">
+    <term><literal>connect_failure</literal></term>
+    <listitem>
+     <simpara>
+      Total number of failed connection attempt.
+     </simpara>
+     <simpara>
+      Reused connections and all other kinds of connections are included..
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.reconnect">
+    <term><literal>reconnect</literal></term>
+    <listitem>
+     <simpara>
+      This is a process level scope statistic.
+     </simpara>
+     <simpara>
+      Total number of (real_)connect attempts made on an already opened
+      connection handle.
+     </simpara>
+     <para>
+      <!-- TODO: Do not use First Class Callable syntax -->
+      The code sequence
+      <code>$link = new mysqli(...); $link-&gt;real_connect(...);</code>
+      will cause a reconnect.
+      But <code>$link = new mysqli(...); $link-&gt;connect(...);</code>
+      will not because <code>$link-&gt;connect(...);</code> will
+      explicitly close the existing connection before a new connection
+      is established.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.active-connections">
+    <term><literal>active_connections</literal></term>
+    <listitem>
+     <simpara>
+      Total number of active persistent and non-persistent connections.
+     </simpara>
+     <note>
+      <simpara>
+       The total number of active non-persistent connections is
+       <literal>active_connections - active_persistent_connections</literal>.
+      </simpara>
+     </note>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.active-persistent-connections">
+    <term><literal>active_persistent_connections</literal></term>
+    <listitem>
+     <simpara>
+      Total number of active persistent connections.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.explicit-close">
+    <term><literal>explicit_close</literal></term>
+    <listitem>
+     <simpara>
+      Total number of explicitly closed connections.
+     </simpara>
+     <simpara>
+      This statistic is only available with <literal>ext/mysqli</literal>.
+     </simpara>
+     <example>
+      <title>Examples of code snippets that cause an implicit close</title>
       <itemizedlist>
        <listitem>
-        <para>
-         <literal>MYSQL_TYPE_NULL</literal> - proto_text_fetched_null
-        </para>
+        <programlisting>
+         <!-- TODO: Do not use First Class Callable syntax -->
+<![CDATA[
+$link = new mysqli(...);
+$link->close(...);
+]]>
+        </programlisting>
        </listitem>
        <listitem>
-        <para>
-         <literal>MYSQL_TYPE_BIT</literal> - proto_text_fetched_bit
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <literal>MYSQL_TYPE_TINY</literal> - proto_text_fetched_tinyint
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <literal>MYSQL_TYPE_SHORT</literal> - proto_text_fetched_short
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <literal>MYSQL_TYPE_INT24</literal> - proto_text_fetched_int24
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <literal>MYSQL_TYPE_LONG</literal> - proto_text_fetched_int
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <literal>MYSQL_TYPE_LONGLONG</literal> -
-         proto_text_fetched_bigint
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <literal>MYSQL_TYPE_DECIMAL</literal>,
-         <literal>MYSQL_TYPE_NEWDECIMAL</literal> -
-         proto_text_fetched_decimal
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <literal>MYSQL_TYPE_FLOAT</literal> - proto_text_fetched_float
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <literal>MYSQL_TYPE_DOUBLE</literal> -
-         proto_text_fetched_double
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <literal>MYSQL_TYPE_DATE</literal>,
-         <literal>MYSQL_TYPE_NEWDATE</literal> - proto_text_fetched_date
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <literal>MYSQL_TYPE_YEAR</literal> - proto_text_fetched_year
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <literal>MYSQL_TYPE_TIME</literal> - proto_text_fetched_time
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <literal>MYSQL_TYPE_DATETIME</literal> -
-         proto_text_fetched_datetime
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <literal>MYSQL_TYPE_TIMESTAMP</literal> -
-         proto_text_fetched_timestamp
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <literal>MYSQL_TYPE_STRING</literal>,
-         <literal>MYSQL_TYPE_VARSTRING</literal>,
-         <literal>MYSQL_TYPE_VARCHAR</literal> -
-         proto_text_fetched_string
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <literal>MYSQL_TYPE_TINY_BLOB</literal>,
-         <literal>MYSQL_TYPE_MEDIUM_BLOB</literal>,
-         <literal>MYSQL_TYPE_LONG_BLOB</literal>,
-         <literal>MYSQL_TYPE_BLOB</literal> - proto_text_fetched_blob
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <literal>MYSQL_TYPE_ENUM</literal> - proto_text_fetched_enum
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <literal>MYSQL_TYPE_SET</literal> - proto_text_fetched_set
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         <literal>MYSQL_TYPE_GEOMETRY</literal> -
-         proto_text_fetched_geometry
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         Any <literal>MYSQL_TYPE_*</literal> not listed before (there
-         should be none) - proto_text_fetched_other
-        </para>
+        <programlisting>
+         <!-- TODO: Do not use First Class Callable syntax -->
+<![CDATA[
+$link = new mysqli(...);
+$link->connect(...);
+]]>
+        </programlisting>
        </listitem>
       </itemizedlist>
-      <para>
-       Note that the MYSQL_*-type constants may not be associated with
-       the very same SQL column types in every version of MySQL.
-      </para></entry>
-    </row>
-    <row>
-     <entry><literal>proto_binary_fetched_null</literal>,
-      <literal>proto_binary_fetched_bit</literal>,
-      <literal>proto_binary_fetched_tinyint</literal>
-      <literal>proto_binary_fetched_short</literal>,
-      <literal>proto_binary_fetched_int24</literal>,
-      <literal>proto_binary_fetched_int</literal>,
-      <literal>proto_binary_fetched_bigint</literal>,
-      <literal>proto_binary_fetched_decimal</literal>,
-      <literal>proto_binary_fetched_float</literal>,
-      <literal>proto_binary_fetched_double</literal>,
-      <literal>proto_binary_fetched_date</literal>,
-      <literal>proto_binary_fetched_year</literal>,
-      <literal>proto_binary_fetched_time</literal>,
-      <literal>proto_binary_fetched_datetime</literal>,
-      <literal>proto_binary_fetched_timestamp</literal>,
-      <literal>proto_binary_fetched_string</literal>,
-      <literal>proto_binary_fetched_blob</literal>,
-      <literal>proto_binary_fetched_enum</literal>,
-      <literal>proto_binary_fetched_set</literal>,
-      <literal>proto_binary_fetched_geometry</literal>,
-      <literal>proto_binary_fetched_other</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total number of columns of a certain type fetched from a prepared
-      statement (MySQL binary protocol).</entry>
-     <entry>For type mapping see <literal>proto_text_*</literal> described in the
-      preceding text.</entry>
-    </row>
-   </tbody>
-  </tgroup>
- </table>
- <table xml:id="mysqlnd.stats.connection">
-  <title>Returned mysqlnd statistics: Connection</title>
-  <tgroup cols="4">
-   <colspec colwidth="10*"/>
-   <colspec colwidth="10*"/>
-   <colspec colwidth="40*"/>
-   <colspec colwidth="40*"/>
-   <thead>
-    <row>
-     <entry>Statistic</entry>
-     <entry>Scope</entry>
-     <entry>Description</entry>
-     <entry>Notes</entry>
-    </row>
-   </thead>
-   <tbody>
-    <row>
-     <entry><literal>connect_success</literal>, <literal>connect_failure</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total number of successful / failed connection attempt.</entry>
-     <entry>Reused connections and all other kinds of connections are included.</entry>
-    </row>
-    <row>
-     <entry><literal>reconnect</literal></entry>
-     <entry>Process</entry>
-     <entry>Total number of (real_)connect attempts made on an already opened
-      connection handle.</entry>
-     <entry>The code sequence <literal>$link = new mysqli(...);
-      $link-&gt;real_connect(...)</literal> will cause a reconnect. But
-      <literal>$link = new mysqli(...); $link-&gt;connect(...)</literal>
-      will not because <literal>$link-&gt;connect(...)</literal> will
-      explicitly close the existing connection before a new connection
-      is established.</entry>
-    </row>
-    <row>
-     <entry><literal>pconnect_success</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total number of successful persistent connection attempts.</entry>
-     <entry>Note that <literal>connect_success</literal> holds the sum of successful
-      persistent and non-persistent connection attempts. The number of
-      successful non-persistent connection attempts is
-      <literal>connect_success</literal> -
-      <literal>pconnect_success</literal>.</entry>
-    </row>
-    <row>
-     <entry><literal>active_connections</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total number of active persistent and non-persistent connections.</entry>
-     <entry></entry>
-    </row>
-    <row>
-     <entry><literal>active_persistent_connections</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total number of active persistent connections.</entry>
-     <entry>The total number of active non-persistent connections is
-      <literal>active_connections</literal> -
-      <literal>active_persistent_connections</literal>.</entry>
-    </row>
-    <row>
-     <entry><literal>explicit_close</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total number of explicitly closed connections (ext/mysqli only).</entry>
-     <entry>Examples of code snippets that cause an explicit close :
-<programlisting>
-<![CDATA[
-$link = new mysqli(...); $link->close(...)
-$link = new mysqli(...); $link->connect(...)
-]]>
-</programlisting></entry>
-    </row>
-    <row>
-     <entry><literal>implicit_close</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total number of implicitly closed connections (ext/mysqli only).</entry>
-     <entry>Examples of code snippets that cause an implicit close :
+     </example>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.implicit-close">
+    <term><literal>implicit_close</literal></term>
+    <listitem>
+     <simpara>
+      Total number of implicitly closed connections.
+     </simpara>
+     <simpara>
+      This statistic is only available with <literal>ext/mysqli</literal>.
+     </simpara>
+     <example>
+      <title>Examples of code snippets that cause an implicit close</title>
       <itemizedlist>
        <listitem>
-        <para>
-         <literal>$link = new mysqli(...);
-         $link-&gt;real_connect(...)</literal>
-        </para>
+        <programlisting>
+         <!-- TODO: Do not use First Class Callable syntax -->
+<![CDATA[
+$link = new mysqli(...);
+$link->real_connect(...);
+]]>
+        </programlisting>
        </listitem>
        <listitem>
-        <para>
-         <literal>unset($link)</literal>
-        </para>
+        <programlisting>
+         <code>unset($link)</code>
+        </programlisting>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          Persistent connection: pooled connection has been created with
          real_connect and there may be unknown options set - close
          implicitly to avoid returning a connection with unknown options
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          Persistent connection: ping/change_user fails and ext/mysqli
          closes the connection
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          end of script execution: close connections that have not been
          closed by the user
-        </para>
+        </simpara>
        </listitem>
-      </itemizedlist></entry>
-    </row>
-    <row>
-     <entry><literal>disconnect_close</literal></entry>
-     <entry>Connection</entry>
-     <entry>Connection failures indicated by the C API call
-      <function>mysql_real_connect</function> during an attempt to
-      establish a connection.</entry>
-     <entry>It is called <literal>disconnect_close</literal> because the connection
-      handle passed to the C API call will be closed.</entry>
-    </row>
-    <row>
-     <entry><literal>in_middle_of_command_close</literal></entry>
-     <entry>Process</entry>
-     <entry>A connection has been closed in the middle of a command execution
+      </itemizedlist>
+     </example>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.disconnect-close">
+    <term><literal>disconnect_close</literal></term>
+    <listitem>
+     <simpara>
+      Connection failures indicated by the C API call
+      <literal>mysql_real_connect</literal> during an attempt to
+      establish a connection.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.in-middle-of-command-close">
+    <term><literal>in_middle_of_command_close</literal></term>
+    <listitem>
+     <simpara>
+      This is a process level scope statistic.
+     </simpara>
+     <simpara>
+      A connection has been closed in the middle of a command execution
       (outstanding result sets not fetched, after sending a query and
       before retrieving an answer, while fetching data, while
-      transferring data with LOAD DATA).</entry>
-     <entry>Unless you use asynchronous queries this should only happen if your
-      script stops unexpectedly and PHP shuts down the connections for
-      you.</entry>
-    </row>
-    <row>
-     <entry><literal>init_command_executed_count</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total number of init command executions, for example,
-      <literal>mysqli_options(MYSQLI_INIT_COMMAND , ...)</literal>.</entry>
-     <entry>The number of successful executions is
-      <literal>init_command_executed_count</literal> -
-      <literal>init_command_failed_count</literal>.</entry>
-    </row>
-    <row>
-     <entry><literal>init_command_failed_count</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total number of failed init commands.</entry>
-     <entry></entry>
-    </row>
-   </tbody>
-  </tgroup>
- </table>
- <table xml:id="mysqlnd.stats.com">
-  <title>Returned mysqlnd statistics: COM_* Command</title>
-  <tgroup cols="4">
-   <colspec colwidth="10*"/>
-   <colspec colwidth="10*"/>
-   <colspec colwidth="40*"/>
-   <colspec colwidth="40*"/>
-   <thead>
-    <row>
-     <entry>Statistic</entry>
-     <entry>Scope</entry>
-     <entry>Description</entry>
-     <entry>Notes</entry>
-    </row>
-   </thead>
-   <tbody>
-    <row>
-     <entry><literal>com_quit</literal>, <literal>com_init_db</literal>,
-      <literal>com_query</literal>, <literal>com_field_list</literal>,
-      <literal>com_create_db</literal>, <literal>com_drop_db</literal>,
-      <literal>com_refresh</literal>, <literal>com_shutdown</literal>,
-      <literal>com_statistics</literal>,
-      <literal>com_process_info</literal>,
-      <literal>com_connect</literal>,
-      <literal>com_process_kill</literal>, <literal>com_debug</literal>,
-      <literal>com_ping</literal>, <literal>com_time</literal>,
-      <literal>com_delayed_insert</literal>,
-      <literal>com_change_user</literal>,
-      <literal>com_binlog_dump</literal>,
-      <literal>com_table_dump</literal>,
-      <literal>com_connect_out</literal>,
-      <literal>com_register_slave</literal>,
-      <literal>com_stmt_prepare</literal>,
-      <literal>com_stmt_execute</literal>,
-      <literal>com_stmt_send_long_data</literal>,
-      <literal>com_stmt_close</literal>,
-      <literal>com_stmt_reset</literal>,
-      <literal>com_stmt_set_option</literal>,
-      <literal>com_stmt_fetch</literal>, <literal>com_daemon</literal></entry>
-     <entry>Connection</entry>
-     <entry>Total number of attempts to send a certain COM_* command from PHP to
-      MySQL.</entry>
-     <entry><para>
-       The statistics are incremented after checking the line and
-       immediately before sending the corresponding MySQL client server
-       protocol packet. If mysqlnd fails to send the packet over the
-       wire the statistics will not be decremented. In case of a failure
-       mysqlnd emits a PHP warning <quote>Error while sending %s packet.
-       PID=%d.</quote>
-      </para>
+      transferring data with LOAD DATA).
+     </simpara>
+     <warning>
+      <simpara>
+       Unless asynchronous queries are used,
+       this should only happen if the PHP application terminated unexpectedly,
+       and PHP shuts down the connection automatically.
+      </simpara>
+     </warning>
+    </listitem>
+   </varlistentry>
 
-      <para>
-       Usage examples:
-      </para>
+   <varlistentry xml:id="mysqlnd.stats.statistics.init-command-executed-count">
+    <term><literal>init_command_executed_count</literal></term>
+    <listitem>
+     <simpara>
+      Total number of init command executions.
+      For example: <code>mysqli_options(MYSQLI_INIT_COMMAND , $value)</code>.
+     </simpara>
+     <simpara>
+      The number of successful executions is
+      <literal>init_command_executed_count - init_command_failed_count</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.init-command-failed-count">
+    <term><literal>init_command_failed_count</literal></term>
+    <listitem>
+     <simpara>
+      Total number of failed init commands.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <variablelist>
+   <title><literal>COM_*</literal> Command Related Statistics</title>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.com">
+    <term><literal>com_quit</literal></term>
+    <term><literal>com_init_db</literal></term>
+    <term><literal>com_query</literal></term>
+    <term><literal>com_field_list</literal></term>
+    <term><literal>com_create_db</literal></term>
+    <term><literal>com_drop_db</literal></term>
+    <term><literal>com_refresh</literal></term>
+    <term><literal>com_shutdown</literal></term>
+    <term><literal>com_statistics</literal></term>
+    <term><literal>com_process_info</literal></term>
+    <term><literal>com_connect</literal></term>
+    <term><literal>com_process_kill</literal></term>
+    <term><literal>com_debug</literal></term>
+    <term><literal>com_ping</literal></term>
+    <term><literal>com_time</literal></term>
+    <term><literal>com_delayed_insert</literal></term>
+    <term><literal>com_change_user</literal></term>
+    <term><literal>com_binlog_dump</literal></term>
+    <term><literal>com_table_dump</literal></term>
+    <term><literal>com_connect_out</literal></term>
+    <term><literal>com_register_slave</literal></term>
+    <term><literal>com_stmt_prepare</literal></term>
+    <term><literal>com_stmt_execute</literal></term>
+    <term><literal>com_stmt_send_long_data</literal></term>
+    <term><literal>com_stmt_close</literal></term>
+    <term><literal>com_stmt_reset</literal></term>
+    <term><literal>com_stmt_set_option</literal></term>
+    <term><literal>com_stmt_fetch</literal></term>
+    <term><literal>com_daemon</literal></term>
+    <listitem>
+     <simpara>
+      Total number of attempts to send a certain <literal>COM_*</literal>
+      command from PHP to MySQL.
+     </simpara>
+     <simpara>
+      The statistics are incremented after checking the line and immediately
+      before sending the corresponding MySQL client server protocol packet.
+     </simpara>
+     <caution>
+      <simpara>
+       If MySQLnd fails to send the packet over the wire the statistics will not be decremented.
+       In case of a failure MySQLnd emits a PHP warning
+       <quote>Error while sending %s packet. PID=%d.</quote>
+      </simpara>
+     </caution>
+
+     <example>
+      <title>Usage examples</title>
       <itemizedlist>
        <listitem>
         <para>
@@ -1091,98 +1729,101 @@ $link = new mysqli(...); $link->connect(...)
          <literal>COM_EXECUTE</literal>
         </para>
        </listitem>
-      </itemizedlist></entry>
-    </row>
-   </tbody>
-  </tgroup>
- </table>
- <para>
-  <emphasis role="bold">Miscellaneous</emphasis>
- </para>
- <table xml:id="mysqlnd.stats.misc">
-  <title>Returned mysqlnd statistics: Miscellaneous</title>
-  <tgroup cols="4">
-   <colspec colwidth="10*"/>
-   <colspec colwidth="10*"/>
-   <colspec colwidth="40*"/>
-   <colspec colwidth="40*"/>
-   <thead>
-    <row>
-     <entry>Statistic</entry>
-     <entry>Scope</entry>
-     <entry>Description</entry>
-     <entry>Notes</entry>
-    </row>
-   </thead>
-   <tbody>
-    <row>
-     <entry><literal>explicit_stmt_close</literal>,
-      <literal>implicit_stmt_close</literal></entry>
-     <entry>Process</entry>
-     <entry>Total number of close prepared statements.</entry>
-     <entry>A close is always considered explicit but for a failed prepare.</entry>
-    </row>
-    <row>
-     <entry><literal>mem_emalloc_count</literal>,
-      <literal>mem_emalloc_ammount</literal>,
-      <literal>mem_ecalloc_count</literal>,
-      <literal>mem_ecalloc_ammount</literal>,
-      <literal>mem_erealloc_count</literal>,
-      <literal>mem_erealloc_ammount</literal>,
-      <literal>mem_efree_count</literal>,
-      <literal>mem_malloc_count</literal>,
-      <literal>mem_malloc_ammount</literal>,
-      <literal>mem_calloc_count</literal>,
-      <literal>mem_calloc_ammount</literal>,
-      <literal>mem_realloc_count</literal>,
-      <literal>mem_realloc_ammount</literal>,
-      <literal>mem_free_count</literal></entry>
-     <entry>Process</entry>
-     <entry>Memory management calls.</entry>
-     <entry>Development only.</entry>
-    </row>
-    <row>
-     <entry><literal>command_buffer_too_small</literal></entry>
-     <entry>Connection</entry>
-     <entry>Number of network command buffer extensions while sending commands from
-      PHP to MySQL.</entry>
-     <entry><para>
-       mysqlnd allocates an internal command/network buffer of
-       <literal>mysqlnd.net_cmd_buffer_size</literal>
-       (<filename>php.ini</filename>) bytes for every connection. If a
-       MySQL Client Server protocol command, for example,
-       <literal>COM_QUERY</literal> (normal query), does not fit into
-       the buffer, mysqlnd will grow the buffer to what is needed for
-       sending the command. Whenever the buffer gets extended for one
-       connection <literal>command_buffer_too_small</literal> will be
-       incremented by one.
-      </para>
+      </itemizedlist>
+     </example>
+    </listitem>
+   </varlistentry>
+  </variablelist>
 
-      <para>
-       If mysqlnd has to grow the buffer beyond its initial size of
-       <literal>mysqlnd.net_cmd_buffer_size</literal>
-       (<filename>php.ini</filename>) bytes for almost every connection,
-       you should consider to increase the default size to avoid
-       re-allocations.
-      </para>
+  <variablelist>
+   <title>Miscellaneous Statistics</title>
 
-      <para>
-       The default buffer size is 4096 bytes, which is the smallest value possible. The default can
-       changed either through the <filename>php.ini</filename> setting
-       <literal>mysqlnd.net_cmd_buffer_size</literal> or using
-       <literal>mysqli_options(MYSQLI_OPT_NET_CMD_BUFFER_SIZE, int
-       size)</literal>.
-      </para></entry>
-    </row>
-    <row>
-     <entry><literal>connection_reused</literal></entry>
-     <entry></entry>
-     <entry></entry>
-     <entry></entry>
-    </row>
-   </tbody>
-  </tgroup>
- </table>
+   <varlistentry xml:id="mysqlnd.stats.statistics.stmt-close">
+    <term><literal>explicit_stmt_close</literal></term>
+    <term><literal>implicit_stmt_close</literal></term>
+    <listitem>
+     <simpara>
+      This is a process level scope statistic.
+     </simpara>
+     <simpara>
+      Total number of close prepared statements.
+     </simpara>
+     <note>
+      <simpara>
+       A close is always considered explicit but for a failed prepare.
+      </simpara>
+     </note>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.memory-management">
+    <term><literal>mem_emalloc_count</literal></term>
+    <term><literal>mem_emalloc_ammount</literal></term>
+    <term><literal>mem_ecalloc_count</literal></term>
+    <term><literal>mem_ecalloc_ammount</literal></term>
+    <term><literal>mem_realloc_count</literal></term>
+    <term><literal>mem_realloc_ammount</literal></term>
+    <term><literal>mem_efree_count</literal></term>
+    <term><literal>mem_malloc_count</literal></term>
+    <term><literal>mem_malloc_ammount</literal></term>
+    <term><literal>mem_calloc_count</literal></term>
+    <term><literal>mem_calloc_ammount</literal></term>
+    <term><literal>mem_ealloc_count</literal></term>
+    <term><literal>mem_ealloc_ammount</literal></term>
+    <term><literal>mem_free_count</literal></term>
+    <listitem>
+     <simpara>
+      This is a process level scope statistic.
+     </simpara>
+     <simpara>
+      Memory management calls.
+      This is only useful for development of the driver.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.command-buffer-too-small">
+    <term><literal>command_buffer_too_small</literal></term>
+    <!-- TODO: XInclude/sync description of INI setting
+     ini.mysqlnd.net-cmd-buffer-size with this statistic -->
+    <listitem>
+     <simpara>
+      Number of network command buffer extensions while sending commands from
+      PHP to MySQL.
+     </simpara>
+     <simpara>
+      MySQLnd allocates an internal command/network buffer of
+      <link linkend="ini.mysqlnd.net-cmd-buffer-size">mysqlnd.net_cmd_buffer_size</link>
+      bytes for every connection.
+     </simpara>
+     <simpara>
+      If a MySQL Client Server protocol command,
+      e.g. <literal>COM_QUERY</literal> (normal query),
+      does not fit into the buffer.
+      MySQLnd will grow the buffer to what is needed for sending the command.
+      Whenever the buffer gets extended for one connection
+      <literal>command_buffer_too_small</literal> will be incremented by one.
+     </simpara>
+     <simpara>
+      If MySQLnd has to grow the buffer beyond its initial size of
+      <link linkend="ini.mysqlnd.net-cmd-buffer-size">mysqlnd.net_cmd_buffer_size</link>
+      bytes for almost every connection,
+      considerations to increase the default size should be made to avoid
+      re-allocations.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="mysqlnd.stats.statistics.connection-reused">
+    <term><literal>connection_reused</literal></term>
+    <listitem>
+     <simpara>
+      <!-- TODO: Document -->
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </section>
 </chapter>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -695,7 +695,7 @@ $res->close();
    </varlistentry>
 
    <varlistentry xml:id="mysqlnd.stats.statistics.rows-buffered-from-server-ps">
-    <term><literal>rows_fetched_from_server_ps</literal></term>
+    <term><literal>rows_buffered_from_server_ps</literal></term>
     <listitem>
      <simpara>
       Same as <literal>rows_buffered_from_client_normal</literal>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -1579,7 +1579,7 @@ $link->real_connect(/* ... */);
       This is a process level scope statistic.
      </simpara>
      <simpara>
-      Total number of close prepared statements.
+      Total number of closed prepared statements.
      </simpara>
      <note>
       <simpara>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -1294,19 +1294,6 @@ $res->close();
      <simpara>
       This is a process level scope statistic.
      </simpara>
-     <simpara>
-      Total number of (real_)connect attempts made on an already opened
-      connection handle.
-     </simpara>
-     <para>
-      The code sequence
-      <code>$link = new mysqli(/* ... */); $link-&gt;real_connect(/* ... */);</code>
-      will cause a reconnect.
-      But <code>$link = new mysqli(/* ... */); $link-&gt;connect(/* ... */);</code>
-      will not because <code>$link-&gt;connect(/* ... */);</code> will
-      explicitly close the existing connection before a new connection
-      is established.
-     </para>
     </listitem>
    </varlistentry>
 

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -73,7 +73,7 @@
   <title>MySQL Native Driver Statistics</title>
   <simpara>
    Most statistics are associated to a connection, but some are associated
-   to the process in which case this will be .
+   to the process in which case this will be mentioned.
    <!-- Process running the server? -->
   </simpara>
   <simpara>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -558,23 +558,6 @@ $res->close();
        <member><function>mysqli_stmt_get_result</function></member>
       </simplelist>
      </para>
-     <!-- TODO: Is this paragraph actually useful?
-     <simpara>
-      Buffering result sets
-      on the client ensures that server resources are freed as soon as
-      possible and it makes result set scrolling easier. The downside is
-      the additional memory consumption on the client for buffering
-      data. Note that mysqlnd (unlike the MySQL Client Library) respects
-      the PHP memory limit because it uses PHP internal memory
-      management functions to allocate memory. This is also the reason
-      why <function>memory_get_usage</function> reports a higher memory
-      consumption when using mysqlnd instead of the MySQL Client
-      Library. <function>memory_get_usage</function> does not measure
-      the memory consumption of the MySQL Client Library at all because
-      the MySQL Client Library does not use PHP internal memory
-      management functions monitored by the function!
-     </simpara>
-     -->
     </listitem>
    </varlistentry>
 

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -269,8 +269,7 @@
     <term><literal>packets_received_rset_row</literal></term>
     <listitem>
      <simpara>
-      <!-- TODO: Does it really have the total size in bytes? -->
-      Number of MySQL Client Server protocol result set row data packets and their total size in bytes.
+      Number of MySQL Client Server protocol result set row data packets.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -754,7 +754,7 @@ $res->close();
     </listitem>
    </varlistentry>
 
-   <!-- TODO: Remove if unused? -->
+   <!-- TODO: This seems to actually be supported, check and document -->
    <varlistentry xml:id="mysqlnd.stats.statistics.rows-skipped-normal">
     <term><literal>rows_skipped_normal</literal></term>
     <term><literal>rows_skipped_ps</literal></term>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -53,8 +53,8 @@
   </simpara>
 
   <simpara>
-   Client statistics can also be retrieved by calling the
-   <function>phpinfo</function> function.
+   Client statistics can be retrieved by calling the
+   <function>mysqli_get_client_stats</function> function.
   </simpara>
 
   <simpara>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -1637,7 +1637,6 @@ $link->real_connect(...);
      </simpara>
      <simpara>
       Memory management calls.
-      This is only useful for development of the driver.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -1297,9 +1297,6 @@ $res->close();
      <simpara>
       Total number of successful connection attempts.
      </simpara>
-     <simpara>
-      Reused connections and all other kinds of connections are included.
-     </simpara>
      <note>
       <simpara>
        <literal>connect_success</literal> holds the sum of successful
@@ -1325,9 +1322,6 @@ $res->close();
     <listitem>
      <simpara>
       Total number of failed connection attempts.
-     </simpara>
-     <simpara>
-      Reused connections and all other kinds of connections are included..
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
- Remove personalization
- Improve document structure
- DocBook 5.2 conformance


This is probably easier by comparing to the actual live page: https://www.php.net/manual/en/mysqlnd.stats.php

The only things that really ought to be looked at, are my `TODO` comments.