### PR TITLE
Update new-features.xml due to typo

### DIFF
--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -115,7 +115,7 @@ echo $user_ini['listen']; // localhost:9000
    and <property>DOMElement::$id</property>.
    These are not binary-safe at the moment because of underlying limitations
    of libxml2.
-   This means that the property values will be cut off at a NUL byte.
+   This means that the property values will be cut off at a NULL byte.
   </para>
 
   <para>


### PR DESCRIPTION
I found typo.
https://www.php.net/manual/en/migration83.new-features.php#migration83.new-features.dom
Fixed typo "NUL" -> "NULL"