### PR TITLE
Remove outdated header fields of `session_cache_limiter`

### DIFF
--- a/reference/session/functions/session-cache-limiter.xml
+++ b/reference/session/functions/session-cache-limiter.xml
@@ -82,7 +82,7 @@ Last-Modified: (the timestamp of when the session was last saved)
           <entry>
            <programlisting role="header">
 <![CDATA[
-Cache-Control: private, max-age=(session.cache_expire in the future), pre-check=(session.cache_expire in the future)
+Cache-Control: private, max-age=(session.cache_expire in the future)
 Last-Modified: (the timestamp of when the session was last saved)
 ]]>
            </programlisting>
@@ -94,7 +94,7 @@ Last-Modified: (the timestamp of when the session was last saved)
            <programlisting role="header">
 <![CDATA[
 Expires: Thu, 19 Nov 1981 08:52:00 GMT
-Cache-Control: private, max-age=(session.cache_expire in the future), pre-check=(session.cache_expire in the future)
+Cache-Control: private, max-age=(session.cache_expire in the future)
 Last-Modified: (the timestamp of when the session was last saved)
 ]]>
            </programlisting>
@@ -106,7 +106,7 @@ Last-Modified: (the timestamp of when the session was last saved)
            <programlisting role="header">
 <![CDATA[
 Expires: Thu, 19 Nov 1981 08:52:00 GMT
-Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+Cache-Control: no-store, no-cache, must-revalidate
 Pragma: no-cache
 ]]>
            </programlisting>


### PR DESCRIPTION
IE5-specific fields of `Cache-Control` header were removed in PHP 7.0.
https://github.com/php/php-src/commit/413d23f6f0d5e56bda3c01d3951590c05ed4d7fc