### PR TITLE
Document overloads of XMLReader::open and ::XML

### DIFF
--- a/reference/xmlreader/xmlreader/open.xml
+++ b/reference/xmlreader/xmlreader/open.xml
@@ -9,7 +9,13 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="XMLReader">
-   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>bool</type><type>XMLReader</type></type><methodname>XMLReader::open</methodname>
+   <modifier>public</modifier> <modifier>static</modifier> <type>XMLReader</type><methodname>XMLReader::open</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>encoding</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <methodsynopsis role="XMLReader">
+   <modifier>public</modifier> <type>bool</type><methodname>XMLReader::open</methodname>
    <methodparam><type>string</type><parameter>uri</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>encoding</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>

--- a/reference/xmlreader/xmlreader/xml.xml
+++ b/reference/xmlreader/xmlreader/xml.xml
@@ -9,7 +9,13 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="XMLReader">
-   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>bool</type><type>XMLReader</type></type><methodname>XMLReader::XML</methodname>
+   <modifier>public</modifier> <modifier>static</modifier> <type>XMLReader</type><methodname>XMLReader::XML</methodname>
+   <methodparam><type>string</type><parameter>source</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>encoding</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <methodsynopsis role="XMLReader">
+   <modifier>public</modifier> <type>bool</type><methodname>XMLReader::XML</methodname>
    <methodparam><type>string</type><parameter>source</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>encoding</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>


### PR DESCRIPTION
Since these aren't deprecated or anything, I think we should document what exists now.