### PR TITLE
Fix function flock example

### DIFF
--- a/reference/filesystem/functions/flock.xml
+++ b/reference/filesystem/functions/flock.xml
@@ -104,6 +104,7 @@ $fp = fopen("/tmp/lock.txt", "r+");
 
 if (flock($fp, LOCK_EX)) {  // acquire an exclusive lock
     ftruncate($fp, 0);      // truncate file
+    rewind($fp);
     fwrite($fp, "Write something here\n");
     fflush($fp);            // flush output before releasing the lock
     flock($fp, LOCK_UN);    // release the lock


### PR DESCRIPTION
 When I `fwrite` after `ftruncate`, the control characters `           ` has appended.
![image](https://github.com/php/doc-en/assets/16044565/e7b10675-b499-4468-bea1-7731e759aac6)

You can reproduce this by:

```
$fp = fopen("file.txt", "r+b");
ftruncate($fp, 0);
// rewind($fp);
fwrite($fp, "contents");
```

Also I can confirm that do `rewind` after `ftruncate` would fix the issue, therefore this PR is for it.

References:
- https://www.php.net/manual/en/function.ftruncate.php
- https://www.php.net/manual/en/function.flock.php#116782
- https://stackoverflow.com/questions/18255780/fwrite-writes-nul