### PR TITLE
Make Intl constant pages DocBook 5.2 conformant

### DIFF
--- a/reference/intl/locale-constants.xml
+++ b/reference/intl/locale-constants.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<section xml:id="intl.locale-constants" xmlns="http://docbook.org/ns/docbook"
- xmlns:xlink="http://www.w3.org/1999/xlink">
+<section xml:id="intl.locale-constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  <para>
   <variablelist>
@@ -45,6 +44,7 @@
  </para>
 
  <section xml:id="intl.locale-constants.subtags">
+  <title>Locale Subtags</title>
   <para>
    These constants define how the Locales are parsed or composed. They should
    be used as keys in the argument array to <function>locale_compose</function>

--- a/reference/intl/numberformatter-constants.xml
+++ b/reference/intl/numberformatter-constants.xml
@@ -4,6 +4,7 @@
  &reftitle.constants;
 
  <section xml:id="intl.numberformatter-constants.unumberformatstyle">
+  <title>Format Types</title>
   <para>
    These styles are used by the <function>numfmt_create</function>
    to define the type of the formatter.
@@ -120,14 +121,11 @@
     </varlistentry>
    </variablelist>
 
-
-
-
-
   </para>
  </section>
 
  <section xml:id="intl.numberformatter-constants.types">
+  <title>Number Format Specifiers</title>
   <para>
    These constants define how the numbers are parsed or formatted. They should
    be used as arguments to <function>numfmt_format</function>
@@ -182,6 +180,7 @@
  </section>
 
  <section xml:id="intl.numberformatter-constants.unumberformatattribute">
+  <title>Number Format Attributes</title>
   <para>
    Number format attribute used by
    <function>numfmt_get_attribute</function>
@@ -374,8 +373,8 @@
   </para>
  </section>
 
- <section
-  xml:id="intl.numberformatter-constants.unumberformattextattribute">
+ <section xml:id="intl.numberformatter-constants.unumberformattextattribute">
+  <title>Number Format Text Attributes</title>
   <para>
    Number format text attribute used by
    <function>numfmt_get_text_attribute</function> and
@@ -465,6 +464,7 @@
  </section>
 
  <section xml:id="intl.numberformatter-constants.unumberformatsymbol">
+  <title>Symbol Format Specifiers</title>
   <para>
    Number format symbols used by <function>numfmt_get_symbol</function>
    and <function>numfmt_set_symbol</function>.
@@ -635,6 +635,7 @@
  </section>
 
  <section xml:id="intl.numberformatter-constants.unumberformatroundingmode">
+  <title>Rounding Modes</title>
   <para>
    Rounding mode values used by <function>numfmt_get_attribute</function>
    and <function>numfmt_set_attribute</function> with
@@ -717,6 +718,7 @@
  </section>
 
  <section xml:id="intl.numberformatter-constants.unumberformatpadposition">
+  <title>Padding Specifiers</title>
   <para>
    Pad position values used by <function>numfmt_get_attribute</function>
    and <function>numfmt_set_attribute</function> with


### PR DESCRIPTION
Basically add required title tags.

Part of #3326