### PR TITLE
Fixes to mysqlnd statistics text

### DIFF
--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -445,7 +445,7 @@ $res->close();
     <listitem>
      <simpara>
       Number of queries that have generated a result set but did not use an index.
-      (See also the mysqld start option <literal>–log-queries-not-using-indexes</literal>).
+      (See also the mysqld start option <literal>--log-queries-not-using-indexes</literal>).
      </simpara>
      <note>
       <simpara>
@@ -463,7 +463,7 @@ $res->close();
     <listitem>
      <simpara>
       Number of queries that have generated a result set and did not use a good index.
-      (See also the mysqld start option <literal>–log-slow-queries</literal>).
+      (See also the mysqld start option <literal>--log-slow-queries</literal>).
      </simpara>
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.no-index-used')/db:listitem/db:note)">
       <xi:fallback/>
@@ -1329,7 +1329,7 @@ $res->close();
       Total number of explicitly closed connections.
      </simpara>
      <example>
-      <title>Examples of code snippets that cause an implicit close</title>
+      <title>Examples of code snippets that cause an explicit close</title>
       <itemizedlist>
        <listitem>
         <programlisting>


### PR DESCRIPTION
- Use of leading double dashes in mysqld option instead of U+2013 char
- Correction of 'implicit' to 'explicit' in example title