### PR TITLE
Note that no-capture modifier (/n) support for preg_* was added in PHP 8.2

### DIFF
--- a/reference/pcre/pattern.modifiers.xml
+++ b/reference/pcre/pattern.modifiers.xml
@@ -182,7 +182,7 @@
         Only named groups like <code>(?&lt;name&gt;xyz)</code> are capturing.
         This only affects which groups are capturing, it is still possible to
         use numbered subpattern references, and the matches array will still
-        contain numbered results.
+        contain numbered results. Available since PHP 8.2.
        </simpara>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
as documented on https://php.watch/versions/8.2/preg-n-no-capture-modifier