### PR TITLE
Add missing libxml related constants

### DIFF
--- a/reference/dom/constants.xml
+++ b/reference/dom/constants.xml
@@ -271,7 +271,7 @@
       </entry>
       <entry>2</entry>
       <entry>
-       If the specified range of text does not fit into a 
+       If the specified range of text does not fit into a
        <classname>DOMString</classname>.
       </entry>
      </row>
@@ -386,7 +386,7 @@
       </entry>
       <entry>14</entry>
       <entry>
-       If an attempt is made to create or change an object in a way which is 
+       If an attempt is made to create or change an object in a way which is
        incorrect with regard to namespaces.
       </entry>
      </row>
@@ -408,7 +408,7 @@
       <entry>16</entry>
       <entry>
        If a call to a method such as insertBefore or removeChild would make the Node
-       invalid with respect to "partial validity", this exception would be raised and 
+       invalid with respect to "partial validity", this exception would be raised and
        the operation would not be done.
       </entry>
      </row>

--- a/reference/dom/constants.xml
+++ b/reference/dom/constants.xml
@@ -230,6 +230,22 @@
       <entry>10</entry>
       <entry/>
      </row>
+     <row xml:id="constant.xml-local-namespace">
+      <entry>
+       <constant>XML_LOCAL_NAMESPACE</constant>
+       (<type>int</type>)
+      </entry>
+      <entry></entry>
+      <entry>A namespace declaration node.</entry>
+     </row>
+     <row xml:id="constant.xml-global-namespace">
+      <entry>
+       <constant>XML_GLOBAL_NAMESPACE</constant>
+       (<type>int</type>)
+      </entry>
+      <entry></entry>
+      <entry>Global namespace type. Removed from libXML.</entry>
+     </row>
     </tbody>
    </tgroup>
   </table>

--- a/reference/libxml/constants.xml
+++ b/reference/libxml/constants.xml
@@ -233,15 +233,15 @@
    </term>
    <listitem>
     <simpara>
-     Sets XML_PARSE_HUGE flag, which relaxes any hardcoded limit from the parser. This affects 
-     limits like maximum depth of a document or the entity recursion, as well as limits of the 
+     Sets XML_PARSE_HUGE flag, which relaxes any hardcoded limit from the parser. This affects
+     limits like maximum depth of a document or the entity recursion, as well as limits of the
      size of text nodes.
     </simpara>
     <note>
      <para>
       Only available in Libxml &gt;= 2.7.0 (as of PHP &gt;= 5.3.2 and PHP &gt;= 5.2.12)
      </para>
-    </note>    
+    </note>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.libxml-pedantic">
@@ -350,7 +350,7 @@
      <para>
       Only available in Libxml &gt;= 2.6.14 (as of PHP &gt;= 5.5.2)
      </para>
-    </note>    
+    </note>
    </listitem>
   </varlistentry>
  </variablelist>

--- a/reference/libxml/constants.xml
+++ b/reference/libxml/constants.xml
@@ -109,6 +109,17 @@
     </note>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.libxml-loaded-version">
+   <term>
+    <constant>LIBXML_LOADED_VERSION</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Version of libxml's core parser module.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.libxml-noblanks">
    <term>
     <constant>LIBXML_NOBLANKS</constant>


### PR DESCRIPTION
Add missing libxml related constants to ext/DOM and ext/libxml.

The references for these constants are:
- [XML_LOCAL_NAMESPACE](https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/include/libxml/tree.h?ref_type=heads)
- [XML_GLOBAL_NAMESPACE](https://github.com/GNOME/libxml2/commit/a4964b75003d138d4643ab03e3e116a8453f8308#diff-4d724327c74c8e7b349eb38258524a6228cc3e06b5d10f783557a8f38bcf737b) - Please note that this has been removed from libxml in October 2000 and should probably be dropped from PHP as well
- [LIBXML_LOADED_VERSION](https://github.com/GNOME/libxml2/blob/4fefba4cf63acbb17c9f9cee90b8a3b5213a2b8c/parser.c#L184-L189) - [the line in the arginfo file](https://github.com/php/php-src/blob/09d0e38ecffcae767505452a8ee853e4ed4ec6d3/ext/libxml/libxml_arginfo.h#L61) and [the internal PHP macro definition](https://github.com/php/php-src/blob/09d0e38ecffcae767505452a8ee853e4ed4ec6d3/ext/libxml/libxml.c#L47)