### PR TITLE
Remove global namespace entry

### DIFF
--- a/reference/dom/constants.xml
+++ b/reference/dom/constants.xml
@@ -238,14 +238,6 @@
       <entry></entry>
       <entry>A namespace declaration node.</entry>
      </row>
-     <row xml:id="constant.xml-global-namespace">
-      <entry>
-       <constant>XML_GLOBAL_NAMESPACE</constant>
-       (<type>int</type>)
-      </entry>
-      <entry></entry>
-      <entry>Global namespace type. Removed from libXML.</entry>
-     </row>
     </tbody>
    </tgroup>
   </table>


### PR DESCRIPTION
The libxml2 versions used by PHP don't have this anymore.