### PR TITLE
Add some missing intl constants

### DIFF
--- a/reference/intl/constants.xml
+++ b/reference/intl/constants.xml
@@ -4,6 +4,17 @@
  &reftitle.constants;
  <para>
   <variablelist>
+   <varlistentry xml:id="constant.intl-icu-data-version">
+    <term>
+     <constant>INTL_ICU_DATA_VERSION</constant>
+     (<type>string</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Data version in ICU4C.
+     </simpara>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="constant.intl-icu-version">
     <term>
      <constant>INTL_ICU_VERSION</constant>
@@ -270,6 +281,28 @@
     </term>
     <listitem>
      <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.uloc-actual-locale">
+    <term>
+     <constant>ULOC_ACTUAL_LOCALE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      The locale the data actually comes from.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.uloc-valid-locale">
+    <term>
+     <constant>ULOC_VALID_LOCALE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      The most specific locale supported by ICU.
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
References:

- [INTL_ICU_DATA_VERSION](https://github.com/unicode-org/icu/blob/main/icu4c/source/common/unicode/uvernum.h#L151-L154)
- [ULOC_ACTUAL_LOCALE and ULOC_VALID_LOCALE](https://github.com/unicode-org/icu/blob/main/icu4c/source/common/unicode/uloc.h#L339-L346)