### PR TITLE
Add missing UODBC constants

### DIFF
--- a/reference/uodbc/constants.xml
+++ b/reference/uodbc/constants.xml
@@ -246,6 +246,40 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.sql-wchar">
+   <term>
+    <constant>SQL_WCHAR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Unicode character string of fixed string length.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sql-wvarchar">
+   <term>
+    <constant>SQL_WVARCHAR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Unicode variable-length character string.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sql-wlongvarchar">
+   <term>
+    <constant>SQL_WLONGVARCHAR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Unicode variable-length character data.
+     Maximum length is data source-dependent.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.sql-decimal">
    <term>
     <constant>SQL_DECIMAL</constant>
@@ -573,6 +607,28 @@
    <listitem>
     <simpara>
 
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sql-fetch-first">
+   <term>
+    <constant>SQL_FETCH_FIRST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Return the first rowset.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sql-fetch-next">
+   <term>
+    <constant>SQL_FETCH_NEXT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Return the next rowset.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/uodbc/constants.xml
+++ b/reference/uodbc/constants.xml
@@ -11,7 +11,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -22,7 +22,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -33,7 +33,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -44,7 +44,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -55,7 +55,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -66,7 +66,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -77,7 +77,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -88,7 +88,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -99,7 +99,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -110,7 +110,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -121,7 +121,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -132,7 +132,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -143,7 +143,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -154,7 +154,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -165,7 +165,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -176,7 +176,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -187,7 +187,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -198,7 +198,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -209,7 +209,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -220,7 +220,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -231,7 +231,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -242,7 +242,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -253,7 +253,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -264,7 +264,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -275,7 +275,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -286,7 +286,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -297,7 +297,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -308,7 +308,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -319,7 +319,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -330,7 +330,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -341,7 +341,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -352,7 +352,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -363,7 +363,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -374,7 +374,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -385,7 +385,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -396,7 +396,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -407,7 +407,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -418,7 +418,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -429,7 +429,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -440,7 +440,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -451,7 +451,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -462,7 +462,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -473,7 +473,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -484,7 +484,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -495,7 +495,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -506,7 +506,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -517,7 +517,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -528,7 +528,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -539,7 +539,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -550,7 +550,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -561,7 +561,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -572,7 +572,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
References for [SQL_FETCH_FIRST and SQL_FETCH_NEXT](https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlfetchscroll-function?view=sql-server-ver16#positioning-the-cursor) and the [SQL_W*CHAR types](https://learn.microsoft.com/en-us/sql/odbc/reference/develop-app/unicode-data?view=sql-server-ver16).