### PR TITLE
Add missing PCNTL error constants

### DIFF
--- a/reference/pcntl/constants.xml
+++ b/reference/pcntl/constants.xml
@@ -1297,8 +1297,10 @@
    </term>
    <listitem>
     <simpara>
-     Too many open files. Commonly caused by exceeding the RLIMIT_NOFILE resource limit.
-     Can also be caused by exceeding the limit specified in /proc/sys/fs/nr_open.
+     Too many open files. Commonly caused by exceeding
+     the <literal>RLIMIT_NOFILE</literal> resource limit.
+     Can also be caused by exceeding the limit specified in
+     <filename>/proc/sys/fs/nr_open</filename>.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1321,7 +1323,8 @@
    <listitem>
     <simpara>
      Too many open files in system.
-     On Linux, this is probably a result of encountering the /proc/sys/fs/file-max limit.
+     On Linux, this is probably a result of encountering
+     the <filename>/proc/sys/fs/file-max</filename> limit.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/pcntl/constants.xml
+++ b/reference/pcntl/constants.xml
@@ -1155,6 +1155,280 @@
    </listitem>
   </varlistentry>
  </variablelist>
+ <variablelist xml:id="constant.pcntl-error.constants" role="constant_list">
+  <title>Process Control error constants</title>
+  <varlistentry xml:id="constant.pcntl-e2big">
+   <term>
+    <constant>PCNTL_E2BIG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Argument list too long
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-eacces">
+   <term>
+    <constant>PCNTL_EACCES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Permission denied
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-eagain">
+   <term>
+    <constant>PCNTL_EAGAIN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Resource temporarily unavailable
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-ecapmode">
+   <term>
+    <constant>PCNTL_ECAPMODE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The process attempted an operation not permitted in capability  mode
+     while running in capability mode.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-echild">
+   <term>
+    <constant>PCNTL_ECHILD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     No child processes
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-efault">
+   <term>
+    <constant>PCNTL_EFAULT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Bad address
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-eintr">
+   <term>
+    <constant>PCNTL_EINTR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Interrupted function call
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-einval">
+   <term>
+    <constant>PCNTL_EINVAL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Invalid argument
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-eio">
+   <term>
+    <constant>PCNTL_EIO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Input/output error
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-eisdir">
+   <term>
+    <constant>PCNTL_EISDIR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Is a directory
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-elibbad">
+   <term>
+    <constant>PCNTL_ELIBBAD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Accessing a corrupted shared library.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-eloop">
+   <term>
+    <constant>PCNTL_ELOOP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Too many levels of symbolic links
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-emfile">
+   <term>
+    <constant>PCNTL_EMFILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Too many open files. Commonly caused by exceeding the RLIMIT_NOFILE resource limit.
+     Can also be caused by exceeding the limit specified in /proc/sys/fs/nr_open.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-enametoolong">
+   <term>
+    <constant>PCNTL_ENAMETOOLONG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Filename too long
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-enfile">
+   <term>
+    <constant>PCNTL_ENFILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Too many open files in system.
+     On Linux, this is probably a result of encountering the /proc/sys/fs/file-max limit.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-enoent">
+   <term>
+    <constant>PCNTL_ENOENT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     No such file or directory.
+     Typically, this error results when a specified pathname
+     does not exist, or one of the components in the directory
+     prefix of a pathname does not exist, or the specified
+     pathname is a dangling symbolic link.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-enoexec">
+   <term>
+    <constant>PCNTL_ENOEXEC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Exec format error
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-enomem">
+   <term>
+    <constant>PCNTL_ENOMEM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Not enough space/cannot allocate memory
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-enospc">
+   <term>
+    <constant>PCNTL_ENOSPC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     No space left on device
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-enotdir">
+   <term>
+    <constant>PCNTL_ENOTDIR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Not a directory
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-eperm">
+   <term>
+    <constant>PCNTL_EPERM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Operation not permitted
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-esrch">
+   <term>
+    <constant>PCNTL_ESRCH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     No such process
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-etxtbsy">
+   <term>
+    <constant>PCNTL_ETXTBSY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Text file busy
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pcntl-eusers">
+   <term>
+    <constant>PCNTL_EUSERS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Too many users
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
 </appendix>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Descriptions are from [this man page](https://www.man7.org/linux/man-pages/man3/errno.3.html) with the exception of the `ECAPMODE` constant which is from [some](https://man.freebsd.org/cgi/man.cgi?query=open&sektion=2&n=1) [BSD](https://man.freebsd.org/cgi/man.cgi?query=rename) [pages](https://man.freebsd.org/cgi/man.cgi?memfd_create).