### PR TITLE
8.3: Document Random\IntervalBoundary

### DIFF
--- a/reference/random/book.xml
+++ b/reference/random/book.xml
@@ -16,6 +16,7 @@
  &reference.random.reference;
 
  &reference.random.random.randomizer;
+ &reference.random.random.intervalboundary;
 
  &reference.random.random.engine;
  &reference.random.random.cryptosafeengine;

--- a/reference/random/random.intervalboundary.xml
+++ b/reference/random/random.intervalboundary.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<reference xmlns="http://docbook.org/ns/docbook" xml:id="enum.intervalboundary" role="enum">
+ <title>IntervalBoundary</title>
+ <titleabbrev>IntervalBoundary</titleabbrev>
+
+ <partintro>
+  <section xml:id="enum.intervalboundary.intro">
+   &reftitle.intro;
+   <simpara>
+    Intro
+   </simpara>
+  </section>
+
+  <section xml:id="enum.intervalboundary.synopsis">
+   <!-- TODO New Reftitle entity -->
+   &reftitle.classsynopsis;
+
+   <enumsynopsis>
+    <enumname>IntervalBoundary</enumname>
+    <!-- <modifier role="enum_backing_type">string|int</modifier> -->
+    
+    <enumitem>
+     <enumidentifier>ClosedOpen</enumidentifier>
+     <!--
+     <enumvalue>
+      <literal>"string value"</literal>
+      <literal>25</literal>
+     </enumvalue>
+     -->
+     <enumitemdescription>
+      Description of enum case.
+     </enumitemdescription>
+    </enumitem>
+
+    <enumitem>
+     <enumidentifier>ClosedClosed</enumidentifier>
+     <!--
+     <enumvalue>
+      <literal>"string value"</literal>
+      <literal>25</literal>
+     </enumvalue>
+     -->
+     <enumitemdescription>
+      Description of enum case.
+     </enumitemdescription>
+    </enumitem>
+
+    <enumitem>
+     <enumidentifier>OpenClosed</enumidentifier>
+     <!--
+     <enumvalue>
+      <literal>"string value"</literal>
+      <literal>25</literal>
+     </enumvalue>
+     -->
+     <enumitemdescription>
+      Description of enum case.
+     </enumitemdescription>
+    </enumitem>
+
+    <enumitem>
+     <enumidentifier>OpenOpen</enumidentifier>
+     <!--
+     <enumvalue>
+      <literal>"string value"</literal>
+      <literal>25</literal>
+     </enumvalue>
+     -->
+     <enumitemdescription>
+      Description of enum case.
+     </enumitemdescription>
+    </enumitem>
+
+   </enumsynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/random/random.intervalboundary.xml
+++ b/reference/random/random.intervalboundary.xml
@@ -7,9 +7,9 @@
   <section xml:id="enum.random.intervalboundary.intro">
    &reftitle.intro;
    <simpara>
-    The <enumname>Random\IntervalBoundary</enumname> cases determines if the
-    boundary values can be returned or not by
-    <methodname>Random\Randomizer::getFloat</methodname>.
+    The <enumname>Random\IntervalBoundary</enumname> enum specifies
+    whether an interval includes the boundary values within the set of values
+    lying in the interval.
    </simpara>
   </section>
 
@@ -22,30 +22,34 @@
     <enumitem>
      <enumidentifier>ClosedOpen</enumidentifier>
      <enumitemdescription>
-      The <parameter>min</parameter> value may be returned.
-      However, the <parameter>max</parameter> value will never be returned.
+      A left-open interval.
+      The lower boundary is included in the interval,
+      the upper boundary is not.
      </enumitemdescription>
     </enumitem>
 
     <enumitem>
      <enumidentifier>ClosedClosed</enumidentifier>
      <enumitemdescription>
-      Both the <parameter>min</parameter> and <parameter>max</parameter> value may be returned.
+      A closed interval.
+      Both boundary values are included in the interval.
      </enumitemdescription>
     </enumitem>
 
     <enumitem>
      <enumidentifier>OpenClosed</enumidentifier>
      <enumitemdescription>
-      The <parameter>max</parameter> value may be returned.
-      However, the <parameter>min</parameter> value will never be returned.
+      A right-open interval.
+      The upper boundary is included in the interval,
+      the lower boundary is not.
      </enumitemdescription>
     </enumitem>
 
     <enumitem>
      <enumidentifier>OpenOpen</enumidentifier>
      <enumitemdescription>
-      Neither the <parameter>min</parameter> or <parameter>max</parameter> will ever be returned.
+      An open interval.
+      Neither boundary value is included in the interval.
      </enumitemdescription>
     </enumitem>
 

--- a/reference/random/random.intervalboundary.xml
+++ b/reference/random/random.intervalboundary.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="enum.random.intervalboundary" role="enum">
- <title>Random\IntervalBoundary</title>
+ <title>The Random\IntervalBoundary Enum</title>
  <titleabbrev>Random\IntervalBoundary</titleabbrev>
 
  <partintro>

--- a/reference/random/random.intervalboundary.xml
+++ b/reference/random/random.intervalboundary.xml
@@ -1,73 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
-<reference xmlns="http://docbook.org/ns/docbook" xml:id="enum.intervalboundary" role="enum">
- <title>IntervalBoundary</title>
- <titleabbrev>IntervalBoundary</titleabbrev>
+<reference xmlns="http://docbook.org/ns/docbook" xml:id="enum.random.intervalboundary" role="enum">
+ <title>Random\IntervalBoundary</title>
+ <titleabbrev>Random\IntervalBoundary</titleabbrev>
 
  <partintro>
-  <section xml:id="enum.intervalboundary.intro">
+  <section xml:id="enum.random.intervalboundary.intro">
    &reftitle.intro;
    <simpara>
-    Intro
+    The <enumname>Random\IntervalBoundary</enumname> cases determines if the
+    boundary values can be returned or not by
+    <methodname>Random\Randomizer::getFloat</methodname>.
    </simpara>
   </section>
 
-  <section xml:id="enum.intervalboundary.synopsis">
-   <!-- TODO New Reftitle entity -->
-   &reftitle.classsynopsis;
+  <section xml:id="enum.random.intervalboundary.synopsis">
+   &reftitle.enumsynopsis;
 
    <enumsynopsis>
-    <enumname>IntervalBoundary</enumname>
-    <!-- <modifier role="enum_backing_type">string|int</modifier> -->
-    
+    <enumname>Random\IntervalBoundary</enumname>
+
     <enumitem>
      <enumidentifier>ClosedOpen</enumidentifier>
-     <!--
-     <enumvalue>
-      <literal>"string value"</literal>
-      <literal>25</literal>
-     </enumvalue>
-     -->
      <enumitemdescription>
-      Description of enum case.
+      The <parameter>min</parameter> value may be returned.
+      However, the <parameter>max</parameter> value will never be returned.
      </enumitemdescription>
     </enumitem>
 
     <enumitem>
      <enumidentifier>ClosedClosed</enumidentifier>
-     <!--
-     <enumvalue>
-      <literal>"string value"</literal>
-      <literal>25</literal>
-     </enumvalue>
-     -->
      <enumitemdescription>
-      Description of enum case.
+      Both the <parameter>min</parameter> and <parameter>max</parameter> value may be returned.
      </enumitemdescription>
     </enumitem>
 
     <enumitem>
      <enumidentifier>OpenClosed</enumidentifier>
-     <!--
-     <enumvalue>
-      <literal>"string value"</literal>
-      <literal>25</literal>
-     </enumvalue>
-     -->
      <enumitemdescription>
-      Description of enum case.
+      The <parameter>max</parameter> value may be returned.
+      However, the <parameter>min</parameter> value will never be returned.
      </enumitemdescription>
     </enumitem>
 
     <enumitem>
      <enumidentifier>OpenOpen</enumidentifier>
-     <!--
-     <enumvalue>
-      <literal>"string value"</literal>
-      <literal>25</literal>
-     </enumvalue>
-     -->
      <enumitemdescription>
-      Description of enum case.
+      Neither the <parameter>min</parameter> or <parameter>max</parameter> will ever be returned.
      </enumitemdescription>
     </enumitem>
 

--- a/reference/random/versions.xml
+++ b/reference/random/versions.xml
@@ -95,6 +95,9 @@
  <function name='random\randomizer::getbytesfromstring' from='PHP 8 &gt;= 8.3.0'/>
  <function name='random\randomizer::getfloat' from='PHP 8 &gt;= 8.3.0'/>
  <function name='random\randomizer::nextfloat' from='PHP 8 &gt;= 8.3.0'/>
+
+ <!-- RoundingMode enum -->
+ <function name='random\intervalboundary' from='PHP 8 &gt;= 8.3.0'/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Part of: https://github.com/php/doc-en/issues/2796

Fixes:
 - https://github.com/php/doc-en/issues/3074

Requires:
 - https://github.com/php/doc-en/issues/3326
 - PhD support to render it like an enum (https://github.com/php/phd/issues/89)

I kinda wish I could use a `<refentry>` tag instead, but we need to insert this into a `<book>` element which requires an intermediate tag anyway, so steal the suboptimal markup from classes.

@haszi do you think this makes sense, and is this not too complicated to add support to PhD for it?