### PR TITLE
Add `ArrayAccess` methods for ext-mongodb BSON classes

### DIFF
--- a/reference/mongodb/bson/document.xml
+++ b/reference/mongodb/bson/document.xml
@@ -37,6 +37,10 @@
      </oointerface>
 
      <oointerface>
+      <interfacename>ArrayAccess</interfacename>
+     </oointerface>
+
+     <oointerface>
       <interfacename>IteratorAggregate</interfacename>
      </oointerface>
 

--- a/reference/mongodb/bson/document/offsetexists.xml
+++ b/reference/mongodb/bson/document/offsetexists.xml
@@ -3,12 +3,12 @@
 <refentry xml:id="mongodb-bson-document.offsetexists" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>MongoDB\BSON\Document::offsetExists</refname>
-  <refpurpose>Returns whether the requested index exists</refpurpose>
+  <refpurpose>Returns whether a key is present in the document</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="MongoDB\BSON\Document">
-   <modifier>public</modifier> <type>bool</type><methodname>MongoDB\BSON\Document::offsetExists</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\BSON\Document::offsetExists</methodname>
    <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
  </refsect1>
@@ -21,7 +21,7 @@
      <term><parameter>key</parameter></term>
      <listitem>
       <para>
-       The index being checked.
+      The key to look for in the document.
       </para>
      </listitem>
     </varlistentry>
@@ -32,7 +32,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &true; if the requested index exists, otherwise &false;
+   Returns &true; if the key is present in the document and &false; otherwise.
   </para>
  </refsect1>
 

--- a/reference/mongodb/bson/document/offsetexists.xml
+++ b/reference/mongodb/bson/document/offsetexists.xml
@@ -21,7 +21,7 @@
      <term><parameter>key</parameter></term>
      <listitem>
       <para>
-      The key to look for in the document.
+       The key to look for in the document.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mongodb/bson/document/offsetexists.xml
+++ b/reference/mongodb/bson/document/offsetexists.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="mongodb-bson-document.offsetexists" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::offsetExists</refname>
+  <refpurpose>Returns whether the requested index exists</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="MongoDB\BSON\Document">
+   <modifier>public</modifier> <type>bool</type><methodname>MongoDB\BSON\Document::offsetExists</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       The index being checked.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &true; if the requested index exists, otherwise &false;
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ArrayAccess::offsetExists</methodname></member>
+    <member><methodname>MongoDB\BSON\Document::has</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-Document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/offsetget.xml
+++ b/reference/mongodb/bson/document/offsetget.xml
@@ -21,7 +21,7 @@
      <term><parameter>key</parameter></term>
      <listitem>
       <para>
-      The key to retrieve from the document.
+       The key to retrieve from the document.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mongodb/bson/document/offsetget.xml
+++ b/reference/mongodb/bson/document/offsetget.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="mongodb-bson-document.offsetget" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::offsetGet</refname>
+  <refpurpose>Returns the value at the specified index</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="MongoDB\BSON\Document">
+   <modifier>public</modifier> <type>mixed</type><methodname>MongoDB\BSON\Document::offsetGet</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       The index with the value.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   The value at the specified index.
+  </para>
+ </refsect1>
+
+ <refsect1 role="exceptions">
+  <title>Exceptions</title>
+  <warning>
+   <para>
+    Shall throw <type>MongoDB\Driver\Exception\RuntimeException</type> when the
+    specified index does not exist.
+   </para>
+  </warning>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ArrayAccess::offsetGet</methodname></member>
+    <member><methodname>MongoDB\BSON\Document::get</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/offsetget.xml
+++ b/reference/mongodb/bson/document/offsetget.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="MongoDB\BSON\Document">
-   <modifier>public</modifier> <type>mixed</type><methodname>MongoDB\BSON\Document::offsetGet</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type>mixed</type><methodname>MongoDB\BSON\Document::offsetGet</methodname>
    <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/bson/document/offsetget.xml
+++ b/reference/mongodb/bson/document/offsetget.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="mongodb-bson-document.offsetget" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>MongoDB\BSON\Document::offsetGet</refname>
-  <refpurpose>Returns the value at the specified index</refpurpose>
+  <refpurpose>Returns the value of a key in the document</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -21,7 +21,7 @@
      <term><parameter>key</parameter></term>
      <listitem>
       <para>
-       The index with the value.
+      The key to retrieve from the document.
       </para>
      </listitem>
     </varlistentry>
@@ -32,18 +32,24 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The value at the specified index.
+   Returns the value associated with the given key. If the key is not present in
+   the document, an exception is thrown.
   </para>
+  <note>
+   <simpara>
+    When encountering a value encoded as 64-bit integer in the BSON document,
+    the return value of this method will be a
+    <classname>MongoDB\BSON\Int64</classname> instance.
+   </simpara>
+  </note>
  </refsect1>
 
- <refsect1 role="exceptions">
-  <title>Exceptions</title>
-  <warning>
-   <para>
-    Shall throw <type>MongoDB\Driver\Exception\RuntimeException</type> when the
-    specified index does not exist.
-   </para>
-  </warning>
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Throws <classname>MongoDB\Driver\Exception\RuntimeException</classname> if the key is not present in the document.</member>
+  </simplelist>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/bson/document/offsetset.xml
+++ b/reference/mongodb/bson/document/offsetset.xml
@@ -14,7 +14,7 @@
   </methodsynopsis>
 
   <para>
-   Sets the value at the specified index to newval.
+   Sets the value at the specified <parameter>key</parameter> to <parameter>value</parameter>.
   </para>
  </refsect1>
 
@@ -49,13 +49,11 @@
   </para>
  </refsect1>
 
- <refsect1 role="exceptions">
-  <title>Exceptions</title>
-  <warning>
-   <para>
-    Always throw <type>MongoDB\Driver\Exception\LogicException</type>.
-   </para>
-  </warning>
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   <member>Always throws a <classname>MongoDB\Driver\Exception\LogicException</classname>.</member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/mongodb/bson/document/offsetset.xml
+++ b/reference/mongodb/bson/document/offsetset.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="mongodb-bson-document.offsetset" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::offsetSet</refname>
+  <refpurpose>Implementation of <type>ArrayAccess</type></refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="MongoDB\BSON\Document">
+   <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\Document::offsetSet</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+
+  <para>
+   Sets the value at the specified index to newval.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       The index being set.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>value</parameter></term>
+     <listitem>
+      <para>
+       The new value for the <parameter>key</parameter>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="exceptions">
+  <title>Exceptions</title>
+  <warning>
+   <para>
+    Always throw <type>MongoDB\Driver\Exception\LogicException</type>.
+   </para>
+  </warning>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/offsetset.xml
+++ b/reference/mongodb/bson/document/offsetset.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="MongoDB\BSON\Document">
-   <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\Document::offsetSet</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\Document::offsetSet</methodname>
    <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>

--- a/reference/mongodb/bson/document/offsetunset.xml
+++ b/reference/mongodb/bson/document/offsetunset.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="MongoDB\BSON\Document">
-   <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\Document::offsetUnset</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\Document::offsetUnset</methodname>
    <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/mongodb/bson/document/offsetunset.xml
+++ b/reference/mongodb/bson/document/offsetunset.xml
@@ -39,13 +39,11 @@
   </para>
  </refsect1>
 
- <refsect1 role="exceptions">
-  <title>Exceptions</title>
-  <warning>
-   <para>
-    Always throw <type>MongoDB\Driver\Exception\LogicException</type>.
-   </para>
-  </warning>
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   <member>Always throws a <classname>MongoDB\Driver\Exception\LogicException</classname>.</member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/mongodb/bson/document/offsetunset.xml
+++ b/reference/mongodb/bson/document/offsetunset.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="mongodb-bson-document.offsetunset" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::offsetUnset</refname>
+  <refpurpose>Implementation of <type>ArrayAccess</type></refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="MongoDB\BSON\Document">
+   <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\Document::offsetUnset</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Unsets the value at the specified index.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       The index being unset.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="exceptions">
+  <title>Exceptions</title>
+  <warning>
+   <para>
+    Always throw <type>MongoDB\Driver\Exception\LogicException</type>.
+   </para>
+  </warning>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/packedarray.xml
+++ b/reference/mongodb/bson/packedarray.xml
@@ -37,6 +37,10 @@
      </oointerface>
 
      <oointerface>
+      <interfacename>ArrayAccess</interfacename>
+     </oointerface>
+
+     <oointerface>
       <interfacename>IteratorAggregate</interfacename>
      </oointerface>
 

--- a/reference/mongodb/bson/packedarray/get.xml
+++ b/reference/mongodb/bson/packedarray/get.xml
@@ -33,7 +33,7 @@
   &reftitle.returnvalues;
   <para>
    Returns the value associated with the given index. If the index is not
-   present in the document, an exception is thrown.
+   present in the array, an exception is thrown.
   </para>
   <note>
    <simpara>

--- a/reference/mongodb/bson/packedarray/offsetexists.xml
+++ b/reference/mongodb/bson/packedarray/offsetexists.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="MongoDB\BSON\PackedArray">
-   <modifier>public</modifier> <type>bool</type><methodname>MongoDB\BSON\PackedArray::offsetExists</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\BSON\PackedArray::offsetExists</methodname>
    <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/bson/packedarray/offsetexists.xml
+++ b/reference/mongodb/bson/packedarray/offsetexists.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="mongodb-bson-packedarray.offsetexists" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>MongoDB\BSON\PackedArray::offsetExists</refname>
+  <refpurpose>Returns whether the requested index exists</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="MongoDB\BSON\PackedArray">
+   <modifier>public</modifier> <type>bool</type><methodname>MongoDB\BSON\PackedArray::offsetExists</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       The index being checked.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &true; if the requested index exists, otherwise &false;
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ArrayAccess::offsetExists</methodname></member>
+    <member><methodname>MongoDB\BSON\PackedArray::has</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-packedarray:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/packedarray/offsetexists.xml
+++ b/reference/mongodb/bson/packedarray/offsetexists.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="mongodb-bson-packedarray.offsetexists" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>MongoDB\BSON\PackedArray::offsetExists</refname>
-  <refpurpose>Returns whether the requested index exists</refpurpose>
+  <refpurpose>Returns whether a index is present in the array</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -21,7 +21,7 @@
      <term><parameter>key</parameter></term>
      <listitem>
       <para>
-       The index being checked.
+       The index to look for in the array.
       </para>
      </listitem>
     </varlistentry>
@@ -32,7 +32,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &true; if the requested index exists, otherwise &false;
+   Returns &true; if the index is present in the array and &false; otherwise.
   </para>
  </refsect1>
 

--- a/reference/mongodb/bson/packedarray/offsetget.xml
+++ b/reference/mongodb/bson/packedarray/offsetget.xml
@@ -21,7 +21,7 @@
      <term><parameter>key</parameter></term>
      <listitem>
       <para>
-       The index with the value. Only <type>int</type> are supported.
+       The index to retrieve from the array. Only <type>int</type> are supported.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mongodb/bson/packedarray/offsetget.xml
+++ b/reference/mongodb/bson/packedarray/offsetget.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="mongodb-bson-packedarray.offsetget" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>MongoDB\BSON\PackedArray::offsetGet</refname>
-  <refpurpose>Returns the value at the specified index</refpurpose>
+  <refpurpose>Returns the value of an index in the array</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -32,18 +32,24 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The value at the specified index;.
+   Returns the value associated with the given index. If the index is not
+   present in the document, an exception is thrown.
   </para>
+  <note>
+   <simpara>
+    When encountering a value encoded as 64-bit integer in the BSON array,
+    the return value of this method will be a
+    <classname>MongoDB\BSON\Int64</classname> instance.
+   </simpara>
+  </note>
  </refsect1>
 
- <refsect1 role="exceptions">
-  <title>Exceptions</title>
-  <warning>
-   <para>
-    Shall throw <type>MongoDB\Driver\Exception\RuntimeException</type> when the
-    specified index does not exist.
-   </para>
-  </warning>
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Throws <classname>MongoDB\Driver\Exception\RuntimeException</classname> if the index is not present in the array.</member>
+  </simplelist>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/bson/packedarray/offsetget.xml
+++ b/reference/mongodb/bson/packedarray/offsetget.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="MongoDB\BSON\PackedArray">
-   <modifier>public</modifier> <type>mixed</type><methodname>MongoDB\BSON\PackedArray::offsetGet</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type>mixed</type><methodname>MongoDB\BSON\PackedArray::offsetGet</methodname>
    <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/bson/packedarray/offsetget.xml
+++ b/reference/mongodb/bson/packedarray/offsetget.xml
@@ -21,7 +21,7 @@
      <term><parameter>key</parameter></term>
      <listitem>
       <para>
-       The index to retrieve from the array. Only <type>int</type> are supported.
+       The index to retrieve from the array. Only <type>int</type> is supported.
       </para>
      </listitem>
     </varlistentry>
@@ -33,7 +33,7 @@
   &reftitle.returnvalues;
   <para>
    Returns the value associated with the given index. If the index is not
-   present in the document, an exception is thrown.
+   present in the array, an exception is thrown.
   </para>
   <note>
    <simpara>

--- a/reference/mongodb/bson/packedarray/offsetget.xml
+++ b/reference/mongodb/bson/packedarray/offsetget.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="mongodb-bson-packedarray.offsetget" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>MongoDB\BSON\PackedArray::offsetGet</refname>
+  <refpurpose>Returns the value at the specified index</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="MongoDB\BSON\PackedArray">
+   <modifier>public</modifier> <type>mixed</type><methodname>MongoDB\BSON\PackedArray::offsetGet</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       The index with the value. Only <type>int</type> are supported.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   The value at the specified index;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="exceptions">
+  <title>Exceptions</title>
+  <warning>
+   <para>
+    Shall throw <type>MongoDB\Driver\Exception\RuntimeException</type> when the
+    specified index does not exist.
+   </para>
+  </warning>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ArrayAccess::offsetGet</methodname></member>
+    <member><methodname>MongoDB\BSON\PackedArray::get</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/packedarray/offsetset.xml
+++ b/reference/mongodb/bson/packedarray/offsetset.xml
@@ -14,7 +14,7 @@
   </methodsynopsis>
 
   <para>
-   Sets the value at the specified index to newval.
+   Sets the value at the specified <parameter>key</parameter> to <parameter>value</parameter>.
   </para>
  </refsect1>
 
@@ -49,13 +49,11 @@
   </para>
  </refsect1>
 
- <refsect1 role="exceptions">
-  <title>Exceptions</title>
-  <warning>
-   <para>
-    Always throw <type>MongoDB\Driver\Exception\LogicException</type>.
-   </para>
-  </warning>
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   <member>Always throws a <classname>MongoDB\Driver\Exception\LogicException</classname>.</member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/mongodb/bson/packedarray/offsetset.xml
+++ b/reference/mongodb/bson/packedarray/offsetset.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="MongoDB\BSON\PackedArray">
-   <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\PackedArray::offsetSet</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\PackedArray::offsetSet</methodname>
    <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>

--- a/reference/mongodb/bson/packedarray/offsetset.xml
+++ b/reference/mongodb/bson/packedarray/offsetset.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="mongodb-bson-packedarray.offsetset" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>MongoDB\BSON\PackedArray::offsetSet</refname>
+  <refpurpose>Implementation of <type>ArrayAccess</type></refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="MongoDB\BSON\PackedArray">
+   <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\PackedArray::offsetSet</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+
+  <para>
+   Sets the value at the specified index to newval.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       The index being set.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>value</parameter></term>
+     <listitem>
+      <para>
+       The new value for the <parameter>key</parameter>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="exceptions">
+  <title>Exceptions</title>
+  <warning>
+   <para>
+    Always throw <type>MongoDB\Driver\Exception\LogicException</type>.
+   </para>
+  </warning>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/packedarray/offsetunset.xml
+++ b/reference/mongodb/bson/packedarray/offsetunset.xml
@@ -39,13 +39,11 @@
   </para>
  </refsect1>
 
- <refsect1 role="exceptions">
-  <title>Exceptions</title>
-  <warning>
-   <para>
-    Always throw <type>MongoDB\Driver\Exception\LogicException</type>.
-   </para>
-  </warning>
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   <member>Always throws a <classname>MongoDB\Driver\Exception\LogicException</classname>.</member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/mongodb/bson/packedarray/offsetunset.xml
+++ b/reference/mongodb/bson/packedarray/offsetunset.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="MongoDB\BSON\PackedArray">
-   <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\PackedArray::offsetUnset</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\PackedArray::offsetUnset</methodname>
    <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/mongodb/bson/packedarray/offsetunset.xml
+++ b/reference/mongodb/bson/packedarray/offsetunset.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="mongodb-bson-packedarray.offsetunset" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>MongoDB\BSON\PackedArray::offsetUnset</refname>
+  <refpurpose>Implementation of <type>ArrayAccess</type></refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="MongoDB\BSON\PackedArray">
+   <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\PackedArray::offsetUnset</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Unsets the value at the specified index.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       The index being unset.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="exceptions">
+  <title>Exceptions</title>
+  <warning>
+   <para>
+    Always throw <type>MongoDB\Driver\Exception\LogicException</type>.
+   </para>
+  </warning>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/versions.xml
+++ b/reference/mongodb/versions.xml
@@ -26,7 +26,6 @@
  <function name='mongodb\driver\cursorinterface::toarray' from='mongodb &gt;=1.6.0'/>
 
  <!-- Classes and Methods -->
-
  <function name='mongodb\driver\clientencryption' from='mongodb &gt;=1.7.0'/>
  <function name='mongodb\driver\clientencryption::__construct' from='mongodb &gt;=1.14.0'/>
  <function name='mongodb\driver\clientencryption::addkeyaltname' from='mongodb &gt;=1.15.0'/>
@@ -389,20 +388,20 @@
  <function name='mongodb\bson\document' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\document::__construct' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\document::__tostring' from='mongodb &gt;=1.16.0'/>
- <function name='mongodb\bson\document::fromBSON' from='mongodb &gt;=1.16.0'/>
- <function name='mongodb\bson\document::fromJSON' from='mongodb &gt;=1.16.0'/>
- <function name='mongodb\bson\document::fromPHP' from='mongodb &gt;=1.16.0'/>
+ <function name='mongodb\bson\document::frombson' from='mongodb &gt;=1.16.0'/>
+ <function name='mongodb\bson\document::fromjson' from='mongodb &gt;=1.16.0'/>
+ <function name='mongodb\bson\document::fromphp' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\document::get' from='mongodb &gt;=1.16.0'/>
- <function name='mongodb\bson\document::getIterator' from='mongodb &gt;=1.16.0'/>
+ <function name='mongodb\bson\document::getiterator' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\document::has' from='mongodb &gt;=1.16.0'/>
- <function name='mongodb\bson\document::offsetExists' from='mongodb &gt;=1.17.0'/>
- <function name='mongodb\bson\document::offsetGet' from='mongodb &gt;=1.17.0'/>
- <function name='mongodb\bson\document::offsetSet' from='mongodb &gt;=1.17.0'/>
- <function name='mongodb\bson\document::offsetUnser' from='mongodb &gt;=1.17.0'/>
+ <function name='mongodb\bson\document::offsetexists' from='mongodb &gt;=1.17.0'/>
+ <function name='mongodb\bson\document::offsetget' from='mongodb &gt;=1.17.0'/>
+ <function name='mongodb\bson\document::offsetset' from='mongodb &gt;=1.17.0'/>
+ <function name='mongodb\bson\document::offsetunset' from='mongodb &gt;=1.17.0'/>
  <function name='mongodb\bson\document::serialize' from='mongodb &gt;=1.16.0'/>
- <function name='mongodb\bson\document::toCanonicalExtendedJSON' from='mongodb &gt;=1.16.0'/>
- <function name='mongodb\bson\document::toPHP' from='mongodb &gt;=1.16.0'/>
- <function name='mongodb\bson\document::toRelaxedExtendedJSON' from='mongodb &gt;=1.16.0'/>
+ <function name='mongodb\bson\document::tocanonicalextendedjson' from='mongodb &gt;=1.16.0'/>
+ <function name='mongodb\bson\document::to' from='mongodb &gt;=1.16.0'/>
+ <function name='mongodb\bson\document::torelaxedextendedjson' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\document::unserialize' from='mongodb &gt;=1.16.0'/>
 
  <function name='mongodb\bson\int64' from='mongodb &gt;=1.5.0'/>
@@ -451,16 +450,16 @@
  <function name='mongodb\bson\packedarray' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\packedarray::__construct' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\packedarray::__tostring' from='mongodb &gt;=1.16.0'/>
- <function name='mongodb\bson\packedarray::fromPHP' from='mongodb &gt;=1.16.0'/>
+ <function name='mongodb\bson\packedarray::fromphp' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\packedarray::get' from='mongodb &gt;=1.16.0'/>
- <function name='mongodb\bson\packedarray::getIterator' from='mongodb &gt;=1.16.0'/>
+ <function name='mongodb\bson\packedarray::getiterator' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\packedarray::has' from='mongodb &gt;=1.16.0'/>
- <function name='mongodb\bson\packedarray::offsetExists' from='mongodb &gt;=1.17.0'/>
- <function name='mongodb\bson\packedarray::offsetGet' from='mongodb &gt;=1.17.0'/>
- <function name='mongodb\bson\packedarray::offsetSet' from='mongodb &gt;=1.17.0'/>
- <function name='mongodb\bson\packedarray::offsetUnser' from='mongodb &gt;=1.17.0'/>
+ <function name='mongodb\bson\packedarray::offsetexists' from='mongodb &gt;=1.17.0'/>
+ <function name='mongodb\bson\packedarray::offsetget' from='mongodb &gt;=1.17.0'/>
+ <function name='mongodb\bson\packedarray::offsetset' from='mongodb &gt;=1.17.0'/>
+ <function name='mongodb\bson\packedarray::offsetunset' from='mongodb &gt;=1.17.0'/>
  <function name='mongodb\bson\packedarray::serialize' from='mongodb &gt;=1.16.0'/>
- <function name='mongodb\bson\packedarray::toPHP' from='mongodb &gt;=1.16.0'/>
+ <function name='mongodb\bson\packedarray::tophp' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\packedarray::unserialize' from='mongodb &gt;=1.16.0'/>
 
  <function name='mongodb\bson\regex' from='mongodb &gt;=1.0.0'/>

--- a/reference/mongodb/versions.xml
+++ b/reference/mongodb/versions.xml
@@ -395,6 +395,10 @@
  <function name='mongodb\bson\document::get' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\document::getIterator' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\document::has' from='mongodb &gt;=1.16.0'/>
+ <function name='mongodb\bson\document::offsetExists' from='mongodb &gt;=1.17.0'/>
+ <function name='mongodb\bson\document::offsetGet' from='mongodb &gt;=1.17.0'/>
+ <function name='mongodb\bson\document::offsetSet' from='mongodb &gt;=1.17.0'/>
+ <function name='mongodb\bson\document::offsetUnser' from='mongodb &gt;=1.17.0'/>
  <function name='mongodb\bson\document::serialize' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\document::toCanonicalExtendedJSON' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\document::toPHP' from='mongodb &gt;=1.16.0'/>
@@ -451,6 +455,10 @@
  <function name='mongodb\bson\packedarray::get' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\packedarray::getIterator' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\packedarray::has' from='mongodb &gt;=1.16.0'/>
+ <function name='mongodb\bson\packedarray::offsetExists' from='mongodb &gt;=1.17.0'/>
+ <function name='mongodb\bson\packedarray::offsetGet' from='mongodb &gt;=1.17.0'/>
+ <function name='mongodb\bson\packedarray::offsetSet' from='mongodb &gt;=1.17.0'/>
+ <function name='mongodb\bson\packedarray::offsetUnser' from='mongodb &gt;=1.17.0'/>
  <function name='mongodb\bson\packedarray::serialize' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\packedarray::toPHP' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\packedarray::unserialize' from='mongodb &gt;=1.16.0'/>


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPORM-182

Feature introduced in [ext-mongodb v1.17.0](https://github.com/mongodb/mongo-php-driver/releases/tag/1.17.0) by https://github.com/mongodb/mongo-php-driver/commit/2a3a9d8ce50ce4aa5ce125a2e23cdc5d43e1f625

The method files were copied from `ArrayAccess` files:
- removed examples
- `offsetGet` throws an exception instead of producing a warning
- add "see other" links to `ArrayAccess` methods and `get`/`has`
- `offsetSet` and `offsetUnset` always throw an exception, the return type is more `never` than `void`