### PR TITLE
Remove stream wrappers and context options from function method listing

### DIFF
--- a/language/context/ftp.xml
+++ b/language/context/ftp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="context.ftp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="context.ftp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_context_option">
  <refnamediv>
   <refname>FTP context options</refname>
   <refpurpose>FTP context option listing</refpurpose>

--- a/language/context/http.xml
+++ b/language/context/http.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="context.http" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="context.http" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_context_option">
  <refnamediv>
   <refname>HTTP context options</refname>
   <refpurpose>HTTP context option listing</refpurpose>

--- a/language/context/parameters.xml
+++ b/language/context/parameters.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="context.params" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="context.params" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_context_option">
  <refnamediv>
   <refname>Context parameters</refname>
   <refpurpose>Context parameter listing</refpurpose>

--- a/language/context/phar.xml
+++ b/language/context/phar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="context.phar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="context.phar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_context_option">
  <refnamediv>
   <refname>Phar context options</refname>
   <refpurpose>Phar context option listing</refpurpose>

--- a/language/context/socket.xml
+++ b/language/context/socket.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="context.socket" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="context.socket" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_context_option">
  <refnamediv>
   <refname>Socket context options</refname>
   <refpurpose>Socket context option listing</refpurpose>

--- a/language/context/ssl.xml
+++ b/language/context/ssl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="context.ssl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="context.ssl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_context_option">
  <refnamediv>
   <refname>SSL context options</refname>
   <refpurpose>SSL context option listing</refpurpose>

--- a/language/context/zip.xml
+++ b/language/context/zip.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="context.zip" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="context.zip" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_context_option">
  <refnamediv>
   <refname>Zip context options</refname>
   <refpurpose>Zip context option listing</refpurpose>

--- a/language/context/zlib.xml
+++ b/language/context/zlib.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="context.zlib" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="context.zlib" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_context_option">
  <refnamediv>
   <refname>Zlib context options</refname>
   <refpurpose>Zlib context option listing</refpurpose>

--- a/language/wrappers/audio.xml
+++ b/language/wrappers/audio.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="wrappers.audio" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="wrappers.audio" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_wrapper">
  <refnamediv>
   <refname>ogg://</refname>
   <refpurpose>Audio streams</refpurpose>

--- a/language/wrappers/compression.xml
+++ b/language/wrappers/compression.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="wrappers.compression" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="wrappers.compression" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_wrapper">
  <refnamediv>
   <refname>zlib://</refname>
   <refname>bzip2://</refname>

--- a/language/wrappers/data.xml
+++ b/language/wrappers/data.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="wrappers.data" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="wrappers.data" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_wrapper">
  <refnamediv>
   <refname>data://</refname>
   <refpurpose>Data (RFC 2397)</refpurpose>

--- a/language/wrappers/expect.xml
+++ b/language/wrappers/expect.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="wrappers.expect" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="wrappers.expect" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_wrapper">
  <refnamediv>
   <refname>expect://</refname>
   <refpurpose>Process Interaction Streams</refpurpose>

--- a/language/wrappers/file.xml
+++ b/language/wrappers/file.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="wrappers.file" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="wrappers.file" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_wrapper">
  <refnamediv>
   <refname>file://</refname>
   <refpurpose>Accessing local filesystem</refpurpose>

--- a/language/wrappers/ftp.xml
+++ b/language/wrappers/ftp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="wrappers.ftp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="wrappers.ftp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_wrapper">
  <refnamediv>
   <refname>ftp://</refname>
   <refname>ftps://</refname>

--- a/language/wrappers/glob.xml
+++ b/language/wrappers/glob.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="wrappers.glob" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="wrappers.glob" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_wrapper">
  <refnamediv>
   <refname>glob://</refname>
   <refpurpose>Find pathnames matching pattern</refpurpose>

--- a/language/wrappers/http.xml
+++ b/language/wrappers/http.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="wrappers.http" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="wrappers.http" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_wrapper">
  <refnamediv>
   <refname>http://</refname>
   <refname>https://</refname>

--- a/language/wrappers/phar.xml
+++ b/language/wrappers/phar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="wrappers.phar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="wrappers.phar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_wrapper">
  <refnamediv>
   <refname>phar://</refname>
   <refpurpose>PHP Archive</refpurpose>

--- a/language/wrappers/php.xml
+++ b/language/wrappers/php.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="wrappers.php" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="wrappers.php" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_wrapper">
  <refnamediv>
   <refname>php://</refname>
   <refpurpose>Accessing various I/O streams</refpurpose>

--- a/language/wrappers/rar.xml
+++ b/language/wrappers/rar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="wrappers.rar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="wrappers.rar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_wrapper">
  <refnamediv>
   <refname>rar://</refname>
   <refpurpose>RAR</refpurpose>

--- a/language/wrappers/ssh2.xml
+++ b/language/wrappers/ssh2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="wrappers.ssh2" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false">
+<refentry xml:id="wrappers.ssh2" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_wrapper">
  <refnamediv>
   <refname>ssh2://</refname>
   <refpurpose>Secure Shell 2</refpurpose>


### PR DESCRIPTION
Add a role attribute with an appropriate value to all stream wrappers and context options. PhD is patched also to index these as non-functions/methods and with that these entries are removed from the function method listing.


*Edit:*
The PhD side of this fix is [this one](https://github.com/php/phd/pull/133).