### PR TITLE
apcu: fix types in default configuration options

### DIFF
--- a/reference/apcu/ini.xml
+++ b/reference/apcu/ini.xml
@@ -59,13 +59,13 @@
     <tbody>
      <row>
       <entry><link linkend="ini.apcu.enabled">apc.enabled</link></entry>
-      <entry>"1"</entry>
+      <entry>1</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.shm-segments">apc.shm_segments</link></entry>
-      <entry>"1"</entry>
+      <entry>1</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
@@ -77,19 +77,19 @@
      </row>
      <row>
       <entry><link linkend="ini.apcu.entries-hint">apc.entries_hint</link></entry>
-      <entry>"4096"</entry>
+      <entry>4096</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.ttl">apc.ttl</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.gc-ttl">apc.gc_ttl</link></entry>
-      <entry>"3600"</entry>
+      <entry>3600</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
@@ -101,31 +101,31 @@
      </row>
      <row>
       <entry><link linkend="ini.apcu.slam-defense">apc.slam_defense</link></entry>
-      <entry>"1"</entry>
+      <entry>1</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.enable-cli">apc.enable_cli</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.use-request-time">apc.use_request_time</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Prior to APCu 5.1.19, the default was "1".</entry>
+      <entry>Prior to APCu 5.1.19, the default was <literal>1</literal>.</entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.serializer">apc.serializer</link></entry>
       <entry>"php"</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
-      <entry>Prior to APCu 5.1.15, the default was "default".</entry>
+      <entry>Prior to APCu 5.1.15, the default was <literal>"default"</literal>.</entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.coredump-unmap">apc.coredump_unmap</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>


### PR DESCRIPTION
Additionally, use `<literal>` when mentioning values.