### PR TITLE
apcu: fix and update apc.slam_defense documentation

### DIFF
--- a/reference/apcu/ini.xml
+++ b/reference/apcu/ini.xml
@@ -101,7 +101,7 @@
      </row>
      <row>
       <entry><link linkend="ini.apcu.slam-defense">apc.slam_defense</link></entry>
-      <entry>"1"</entry>
+      <entry>"0"</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
@@ -264,22 +264,20 @@
    <varlistentry xml:id="ini.apcu.slam-defense">
     <term>
      <parameter>apc.slam_defense</parameter>
-     <type>int</type>
+     <type>bool</type>
     </term>
     <listitem>
      <para>
       On very busy servers whenever you start the server or
       modify files you can create a race of many processes
       all trying to cache the same file at the same time.
-      This option sets the percentage of processes that will
-      skip trying to cache an uncached file.  Or think of it
-      as the probability of a single process to skip caching.
-      For example, setting <literal>apc.slam_defense</literal>
-      to <literal>75</literal> would mean that there is
-      a 75% chance that the process will not cache an uncached
-      file. So, the higher the setting the greater the defense
-      against cache slams.  Setting this to <literal>0</literal>
-      disables this feature.
+      Setting <literal>apc.slam_defense</literal> to <literal>1</literal>
+      can help prevent multiple processes from caching the
+      same file simultaneously by introducing a probability
+      mechanism. If the same key is attempted to be cached
+      within a short period by different processes, it skips
+      the caching for the current process to mitigate potential
+      cache slams.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
`apc.slam_defense` was disabled by default a few years ago, in https://github.com/krakjoe/apcu/commit/c510a5ff4035647f61d24dd723e9f8e02ac9cf9b

Also, the implementation has changed significantly, and now the setting is a boolean.

This tries to update the documentation based on [the current implementation](https://github.com/krakjoe/apcu/blob/1ba5a2dade72d44ded54ebcb56b5392e2960c436/apc_cache.c#L1195).

I am happy to rebase this if https://github.com/php/doc-en/pull/3425 gets merged before.

