### PR TITLE
Variable Scope Globals Example #2 8.1.0 disclaimer

### DIFF
--- a/language/variables.xml
+++ b/language/variables.xml
@@ -326,7 +326,7 @@ echo $b;
    </simpara>
    <para>
     <example>
-     <title>Using <varname>$GLOBALS</varname> instead of global</title>
+     <title>Using <varname>$GLOBALS</varname> instead of global (prior to PHP 8.1.0)</title>
      <programlisting role="php">
 <![CDATA[
 <?php


### PR DESCRIPTION
This PR adds a disclaimer as writing to `$GLOBALS` is no longer supported in PHP 8.1.0