### PR TITLE
[skip-revcheck] Fix whitespace in stream wrapper and context options files

### DIFF
--- a/language/context/ftp.xml
+++ b/language/context/ftp.xml
@@ -6,7 +6,7 @@
   <refname>FTP context options</refname>
   <refpurpose>FTP context option listing</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <para>
@@ -91,7 +91,7 @@
  </refsect1>
 
 </refentry>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/context/http.xml
+++ b/language/context/http.xml
@@ -6,7 +6,7 @@
   <refname>HTTP context options</refname>
   <refpurpose>HTTP context option listing</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <para>
@@ -313,7 +313,7 @@ array (
  </refsect1>
 
 </refentry>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/context/parameters.xml
+++ b/language/context/parameters.xml
@@ -6,7 +6,7 @@
   <refname>Context parameters</refname>
   <refpurpose>Context parameter listing</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <para>
@@ -39,7 +39,7 @@
  </refsect1><!-- }}} -->
 
 </refentry>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/context/phar.xml
+++ b/language/context/phar.xml
@@ -6,7 +6,7 @@
   <refname>Phar context options</refname>
   <refpurpose>Phar context option listing</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <para>
@@ -43,7 +43,7 @@
    </variablelist>
   </para>
  </refsect1><!-- }}} -->
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -55,7 +55,7 @@
  </refsect1>
 
 </refentry>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/context/socket.xml
+++ b/language/context/socket.xml
@@ -6,7 +6,7 @@
   <refname>Socket context options</refname>
   <refpurpose>Socket context option listing</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
   <para>
@@ -15,7 +15,7 @@
    <literal>ftp</literal>.
   </para>
  </refsect1><!-- }}} -->
- 
+
  <refsect1 role="options"><!-- {{{ -->
   &reftitle.options;
   <para>
@@ -108,7 +108,7 @@
    </variablelist>
   </para>
  </refsect1><!-- }}} -->
- 
+
  <refsect1 role="changelog"><!-- {{{ -->
   &reftitle.changelog;
   <para>
@@ -138,7 +138,7 @@
    </informaltable>
   </para>
  </refsect1><!-- }}} -->
- 
+
  <refsect1 role="examples"><!-- {{{ -->
   &reftitle.examples;
   <para>
@@ -192,9 +192,9 @@ echo file_get_contents('http://www.example.com', false, $context);
    </example><!-- }}} -->
   </para>
  </refsect1><!-- }}} -->
- 
+
 </refentry>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/context/ssl.xml
+++ b/language/context/ssl.xml
@@ -6,7 +6,7 @@
   <refname>SSL context options</refname>
   <refpurpose>SSL context option listing</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <para>
@@ -95,7 +95,7 @@
      <listitem>
       <para>
        If <literal>cafile</literal> is not specified or if the certificate
-       is not found there, the directory pointed to by <literal>capath</literal> 
+       is not found there, the directory pointed to by <literal>capath</literal>
        is searched for a suitable certificate.  <literal>capath</literal>
        must be a correctly hashed certificate directory.
       </para>
@@ -200,7 +200,7 @@
      </term>
      <listitem>
       <para>
-       If set to &true; server name indication will be enabled. Enabling SNI 
+       If set to &true; server name indication will be enabled. Enabling SNI
        allows multiple certificates on the same IP address.
       </para>
      </listitem>
@@ -213,7 +213,7 @@
      <listitem>
       <para>
        If set, disable TLS compression. This can help mitigate the CRIME attack
-       vector. 
+       vector.
       </para>
      </listitem>
     </varlistentry>
@@ -245,7 +245,7 @@
      <listitem>
       <para>
        Sets the security level. If not specified the library default security level is used.
-       The security levels are described in 
+       The security levels are described in
        <link xlink:href="&url.openssl.security-level;">SSL_CTX_get_security_level(3)</link>.
       </para>
       <para>
@@ -256,7 +256,7 @@
    </variablelist>
   </para>
  </refsect1><!-- }}} -->
- 
+
  <refsect1 role="changelog"><!-- {{{ -->
   &reftitle.changelog;
   <para>
@@ -287,16 +287,16 @@
    <simpara>
     Because <literal>ssl://</literal> is the underlying transport for the
     <link linkend="wrappers.http"><literal>https://</literal></link> and
-    <link linkend="wrappers.ftp"><literal>ftps://</literal></link> wrappers, 
+    <link linkend="wrappers.ftp"><literal>ftps://</literal></link> wrappers,
     any context options which apply to <literal>ssl://</literal> also apply to
     <literal>https://</literal> and <literal>ftps://</literal>.
    </simpara>
   </note>
   <note>
    <simpara>
-    For SNI (Server Name Indication) to be available, then PHP must be compiled 
-    with OpenSSL 0.9.8j or greater. Use the 
-    <constant>OPENSSL_TLSEXT_SERVER_NAME</constant> to determine whether SNI is 
+    For SNI (Server Name Indication) to be available, then PHP must be compiled
+    with OpenSSL 0.9.8j or greater. Use the
+    <constant>OPENSSL_TLSEXT_SERVER_NAME</constant> to determine whether SNI is
     supported.
    </simpara>
   </note>
@@ -312,7 +312,7 @@
  </refsect1>
 
 </refentry>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/context/zip.xml
+++ b/language/context/zip.xml
@@ -6,14 +6,14 @@
   <refname>Zip context options</refname>
   <refpurpose>Zip context option listing</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
   <para>
    Zip context options are available for <literal>zip</literal> wrappers.
   </para>
  </refsect1><!-- }}} -->
- 
+
  <refsect1 role="options"><!-- {{{ -->
   &reftitle.options;
   <para>
@@ -29,7 +29,7 @@
    </variablelist>
   </para>
  </refsect1><!-- }}} -->
- 
+
  <refsect1 role="changelog"><!-- {{{ -->
   &reftitle.changelog;
   <para>
@@ -53,7 +53,7 @@
    </informaltable>
   </para>
  </refsect1><!-- }}} -->
- 
+
  <refsect1 role="examples"><!-- {{{ -->
   &reftitle.examples;
   <para>
@@ -80,9 +80,9 @@ echo file_get_contents('zip://test.zip#test.txt', false, $context);
    </example><!-- }}} -->
   </para>
  </refsect1><!-- }}} -->
- 
+
 </refentry>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/wrappers/compression.xml
+++ b/language/wrappers/compression.xml
@@ -30,9 +30,9 @@
   </simpara>
 
   <simpara>
-   <link linkend="book.zip">ZIP extension</link> registers <filename>zip:</filename> wrapper. As of 
-   PHP 7.2.0 and libzip 1.2.0+, support for the passwords for encrypted archives were added, allowing 
-   passwords to be supplied by stream contexts. Passwords can be set using the <literal>'password'</literal> 
+   <link linkend="book.zip">ZIP extension</link> registers <filename>zip:</filename> wrapper. As of
+   PHP 7.2.0 and libzip 1.2.0+, support for the passwords for encrypted archives were added, allowing
+   passwords to be supplied by stream contexts. Passwords can be set using the <literal>'password'</literal>
    stream context option.
   </simpara>
  </refsect1><!-- }}} -->

--- a/language/wrappers/php.xml
+++ b/language/wrappers/php.xml
@@ -264,7 +264,7 @@
        <entry>Supports <function>stream_select</function></entry>
        <entry>
         <literal>php://stdin</literal>,
-        <literal>php://stdout</literal>, 
+        <literal>php://stdout</literal>,
         <literal>php://stderr</literal>,
         <literal>php://fd</literal> and
         <literal>php://temp</literal> only.

--- a/language/wrappers/rar.xml
+++ b/language/wrappers/rar.xml
@@ -16,7 +16,7 @@
    archive. Specifying an entry name requires the number sign; a leading forward
    slash in the entry name is optional.
   </para>
-  
+
   <simpara>
    This wrapper can open both files and directories. When opening directories, the
    asterisk sign forces the directory entries names to be returned unencoded. If it's
@@ -25,7 +25,7 @@
    <classname>RecursiveDirectoryIterator</classname> in the presence of file names that seem like
    url encoded data.
   </simpara>
-  
+
   <simpara>
    If the pound sign and the entry name part are not included, the root of the archive
    will be displayed. This differs  from regular directories in that the resulting

--- a/language/wrappers/ssh2.xml
+++ b/language/wrappers/ssh2.xml
@@ -267,9 +267,9 @@ $stream = fopen($connection_string . "path/to/file", 'r');
 ]]>
    </programlisting>
    <simpara>
-    unset() closes the session, because <varname>$connection_string</varname> does not 
-    hold a reference to the <varname>$session</varname> variable, just a string cast 
-    derived from it. This also happens when the <function>unset</function> is implicit 
+    unset() closes the session, because <varname>$connection_string</varname> does not
+    hold a reference to the <varname>$session</varname> variable, just a string cast
+    derived from it. This also happens when the <function>unset</function> is implicit
     because of leaving scope (like in a function).
    </simpara>
   </example>


### PR DESCRIPTION
@Girgias Splitting this off #3422 as [requested](https://github.com/php/doc-en/pull/3422#issuecomment-2137142889).