### PR TITLE
opcache: misc fixes

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1091,7 +1091,7 @@
       Debugging option that disables JIT compilation after compiling a certain number of functions.
       This may be helpful to bisect the source of a JIT miscompilation. Note: this option only works
       when JIT trigger is set to 0 (compile on script load) or 1 (compile on first execution),
-      e.g., <code>opcache.jit=1215</code>. See more in <link linkend="ini.opcache.jit">opcache.jit</link> option.
+      e.g. <code>opcache.jit=1215</code>. See more in <link linkend="ini.opcache.jit">opcache.jit</link> option.
      </para>
     </listitem>
    </varlistentry>
@@ -1169,7 +1169,7 @@
      <para>
       After how many calls a function is considered hot.
       Valid value range is <code>[0,255]</code>; for any setting out of this range,
-      e.g., <literal>-1</literal> or <literal>256</literal>, default value will be
+      e.g. <literal>-1</literal> or <literal>256</literal>, default value will be
       used instead. Specially, a zero value will disable JIT to trace and compile any functions.
      </para>
     </listitem>
@@ -1183,7 +1183,7 @@
      <para>
       After how many returns a return is considered hot.
       Valid value range is <code>[0,255]</code>; for any setting out of this range,
-      e.g., <literal>-1</literal> or <literal>256</literal>, default value will be
+      e.g. <literal>-1</literal> or <literal>256</literal>, default value will be
       used instead. Specially, a zero value will disable JIT to trace and compile any returns.
      </para>
     </listitem>
@@ -1197,7 +1197,7 @@
      <para>
       After how many exits a side exit is considered hot.
       Valid value range is <code>[0,255]</code>; for any setting out of this range,
-      e.g., <literal>-1</literal> or <literal>256</literal>, default value will be
+      e.g. <literal>-1</literal> or <literal>256</literal>, default value will be
       used instead. Specially, a zero value will disable JIT to trace and compile any side exits.
      </para>
     </listitem>

--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1155,7 +1155,7 @@
      <para>
       After how many iterations a loop is considered hot.
       Valid value range is <code>[0,255]</code>; for any setting out of this range,
-      e.g., <literal>-1</literal> or <literal>256</literal>, default value will be
+      e.g. <literal>-1</literal> or <literal>256</literal>, default value will be
       used instead. Specially, a zero value will disable JIT to trace and compile any loops.
      </para>
     </listitem>

--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1156,7 +1156,7 @@
       After how many iterations a loop is considered hot.
       Valid value range is <code>[0,255]</code>; for any setting out of this range,
       e.g. <literal>-1</literal> or <literal>256</literal>, default value will be
-      used instead. Specially, a zero value will disable JIT to trace and compile any loops.
+      used instead. <literal>0</literal> will disable JIT to trace and compile any loops.
      </para>
     </listitem>
    </varlistentry>
@@ -1170,7 +1170,7 @@
       After how many calls a function is considered hot.
       Valid value range is <code>[0,255]</code>; for any setting out of this range,
       e.g. <literal>-1</literal> or <literal>256</literal>, default value will be
-      used instead. Specially, a zero value will disable JIT to trace and compile any functions.
+      used instead. <literal>0</literal> will disable JIT to trace and compile any functions.
      </para>
     </listitem>
    </varlistentry>
@@ -1184,7 +1184,7 @@
       After how many returns a return is considered hot.
       Valid value range is <code>[0,255]</code>; for any setting out of this range,
       e.g. <literal>-1</literal> or <literal>256</literal>, default value will be
-      used instead. Specially, a zero value will disable JIT to trace and compile any returns.
+      used instead. <literal>0</literal> will disable JIT to trace and compile any returns.
      </para>
     </listitem>
    </varlistentry>
@@ -1198,7 +1198,7 @@
       After how many exits a side exit is considered hot.
       Valid value range is <code>[0,255]</code>; for any setting out of this range,
       e.g. <literal>-1</literal> or <literal>256</literal>, default value will be
-      used instead. Specially, a zero value will disable JIT to trace and compile any side exits.
+      used instead. <literal>0</literal> will disable JIT to trace and compile any side exits.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -18,98 +18,98 @@
     <tbody xml:id="opcache.configuration.list">
      <row>
       <entry><link linkend="ini.opcache.enable">opcache.enable</link></entry>
-      <entry>"1"</entry>
+      <entry>1</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.enable-cli">opcache.enable_cli</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
-      <entry>Between PHP 7.1.2 and 7.1.6 inclusive, the default was "1"</entry>
+      <entry>Between PHP 7.1.2 and 7.1.6 inclusive, the default was <literal>1</literal></entry>
      </row>
      <row>
       <entry><link
       linkend="ini.opcache.memory-consumption">opcache.memory_consumption</link></entry>
-      <entry>"128"</entry>
+      <entry>128</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.interned-strings-buffer">opcache.interned_strings_buffer</link></entry>
-      <entry>"8"</entry>
+      <entry>8</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.max-accelerated-files">opcache.max_accelerated_files</link></entry>
-      <entry>"10000"</entry>
+      <entry>10000</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.max-wasted-percentage">opcache.max_wasted_percentage</link></entry>
-      <entry>"5"</entry>
+      <entry>5</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.use-cwd">opcache.use_cwd</link></entry>
-      <entry>"1"</entry>
+      <entry>1</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.validate-timestamps">opcache.validate_timestamps</link></entry>
-      <entry>"1"</entry>
+      <entry>1</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.revalidate-freq">opcache.revalidate_freq</link></entry>
-      <entry>"2"</entry>
+      <entry>2</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.revalidate-path">opcache.revalidate_path</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.save-comments">opcache.save_comments</link></entry>
-      <entry>"1"</entry>
+      <entry>1</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.fast-shutdown">opcache.fast_shutdown</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Removed in PHP 7.2.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.enable-file-override">opcache.enable_file_override</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.optimization-level">opcache.optimization_level</link></entry>
-      <entry>"0x7FFEBFFF"</entry>
+      <entry>0x7FFEBFFF</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
-      <entry>Changed from 0x7FFFBFFF in PHP 7.3.0</entry>
+      <entry>Changed from <literal>0x7FFFBFFF</literal> in PHP 7.3.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.inherited-hack">opcache.inherited_hack</link></entry>
-      <entry>"1"</entry>
+      <entry>1</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Removed in PHP 7.3.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.dups-fix">opcache.dups_fix</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
@@ -121,19 +121,19 @@
      </row>
      <row>
       <entry><link linkend="ini.opcache.max-file-size">opcache.max_file_size</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.consistency-checks">opcache.consistency_checks</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>Disabled as of 8.1.18 and 8.2.5. Removed as of PHP 8.3.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.force-restart-timeout">opcache.force_restart_timeout</link></entry>
-      <entry>"180"</entry>
+      <entry>180</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
@@ -145,13 +145,13 @@
      </row>
      <row>
       <entry><link linkend="ini.opcache.log-verbosity-level">opcache.log_verbosity_level</link></entry>
-      <entry>"1"</entry>
+      <entry>1</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.record-warnings">opcache.record_warnings</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
@@ -163,7 +163,7 @@
      </row>
      <row>
       <entry><link linkend="ini.opcache.protect-memory">opcache.protect_memory</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
@@ -171,7 +171,7 @@
       <entry><link linkend="ini.opcache.mmap-base">opcache.mmap_base</link></entry>
       <entry>&null;</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
-      <entry></entry>
+      <entry>Windows only.</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.restrict-api">opcache.restrict_api</link></entry>
@@ -181,13 +181,13 @@
      </row>
      <row>
       <entry><link linkend="ini.opcache.file_update_protection">opcache.file_update_protection</link></entry>
-      <entry>"2"</entry>
+      <entry>2</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.huge_code_pages">opcache.huge_code_pages</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
@@ -199,43 +199,43 @@
      </row>
      <row>
       <entry><link linkend="ini.opcache.opt_debug_level">opcache.opt_debug_level</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 7.1.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.file-cache">opcache.file_cache</link></entry>
-      <entry>NULL</entry>
+      <entry>&null;</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.file-cache-only">opcache.file_cache_only</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.file-cache-consistency-checks">opcache.file_cache_consistency_checks</link></entry>
-      <entry>"1"</entry>
+      <entry>1</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.file-cache-fallback">opcache.file_cache_fallback</link></entry>
-      <entry>"1"</entry>
+      <entry>1</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Windows only.</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.validate-permission">opcache.validate_permission</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 7.0.14</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.validate-root">opcache.validate_root</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 7.0.14</entry>
      </row>
@@ -265,103 +265,103 @@
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-buffer-size">opcache.jit_buffer_size</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-debug">opcache.jit_debug</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-bisect-limit">opcache.jit_bisect_limit</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-prof-threshold">opcache.jit_prof_threshold</link></entry>
-      <entry>"0.005"</entry>
+      <entry>0.005</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-max-root-traces">opcache.jit_max_root_traces</link></entry>
-      <entry>"1024"</entry>
+      <entry>1024</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-max-side-traces">opcache.jit_max_side_traces</link></entry>
-      <entry>"128"</entry>
+      <entry>128</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-max-exit-counters">opcache.jit_max_exit_counters</link></entry>
-      <entry>"8192"</entry>
+      <entry>8192</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-hot-loop">opcache.jit_hot_loop</link></entry>
-      <entry>"64"</entry>
+      <entry>64</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-hot-func">opcache.jit_hot_func</link></entry>
-      <entry>"127"</entry>
+      <entry>127</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-hot-return">opcache.jit_hot_return</link></entry>
-      <entry>"8"</entry>
+      <entry>8</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-hot-side-exit">opcache.jit_hot_side_exit</link></entry>
-      <entry>"8"</entry>
+      <entry>8</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-blacklist-root-trace">opcache.jit_blacklist_root_trace</link></entry>
-      <entry>"16"</entry>
+      <entry>16</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-blacklist-side-trace">opcache.jit_blacklist_side_trace</link></entry>
-      <entry>"8"</entry>
+      <entry>8</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-max-loop-unrolls">opcache.jit_max_loop_unrolls</link></entry>
-      <entry>"8"</entry>
+      <entry>8</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-max-recursive-calls">opcache.jit_max_recursive_calls</link></entry>
-      <entry>"2"</entry>
+      <entry>2</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-max-recursive-return">opcache.jit_max_recursive_returns</link></entry>
-      <entry>"2"</entry>
+      <entry>2</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-max-polymorphic-calls">opcache.jit_max_polymorphic_calls</link></entry>
-      <entry>"2"</entry>
+      <entry>2</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>Available as of PHP 8.0.0</entry>
      </row>
@@ -784,7 +784,8 @@
     <listitem>
      <para>
       Allows calling OPcache API functions only from PHP scripts which path
-      is started from specified string. The default "" means no restriction.
+      is started from specified string. The default <literal>""</literal>
+      means no restriction.
      </para>
     </listitem>
    </varlistentry>
@@ -848,7 +849,7 @@
      <para>
       Enables and sets the second level cache directory. It should improve
       performance when SHM memory is full, at server restart or SHM reset. The
-      default "" disables file based caching.
+      default <literal>""</literal> disables file based caching.
      </para>
     </listitem>
    </varlistentry>
@@ -887,9 +888,9 @@
     </term>
     <listitem>
      <para>
-      Implies opcache.file_cache_only=1 for a certain process that failed to
-      reattach to the shared memory (for Windows only). Explicitly enabled file
-      cache is required.
+      Implies <code>opcache.file_cache_only=1</code> for a certain process that
+      failed to reattach to shared memory (Windows only). Explicitly enabling
+      the file cache is required.
      </para>
      <caution>
       <simpara>
@@ -1154,8 +1155,8 @@
      <para>
       After how many iterations a loop is considered hot.
       Valid value range is <code>[0,255]</code>; for any setting out of this range,
-      e.g., -1 or 256, default value will be used instead. Specially, a zero value
-      will disable JIT to trace and compile any loops.
+      e.g., <literal>-1</literal> or <literal>256</literal>, default value will be
+      used instead. Specially, a zero value will disable JIT to trace and compile any loops.
      </para>
     </listitem>
    </varlistentry>
@@ -1168,8 +1169,8 @@
      <para>
       After how many calls a function is considered hot.
       Valid value range is <code>[0,255]</code>; for any setting out of this range,
-      e.g., -1 or 256, default value will be used instead. Specially, a zero value
-      will disable JIT to trace and compile any functions.
+      e.g., <literal>-1</literal> or <literal>256</literal>, default value will be
+      used instead. Specially, a zero value will disable JIT to trace and compile any functions.
      </para>
     </listitem>
    </varlistentry>
@@ -1182,8 +1183,8 @@
      <para>
       After how many returns a return is considered hot.
       Valid value range is <code>[0,255]</code>; for any setting out of this range,
-      e.g., -1 or 256, default value will be used instead. Specially, a zero value
-      will disable JIT to trace and compile any returns.
+      e.g., <literal>-1</literal> or <literal>256</literal>, default value will be
+      used instead. Specially, a zero value will disable JIT to trace and compile any returns.
      </para>
     </listitem>
    </varlistentry>
@@ -1196,8 +1197,8 @@
      <para>
       After how many exits a side exit is considered hot.
       Valid value range is <code>[0,255]</code>; for any setting out of this range,
-      e.g., -1 or 256, default value will be used instead. Specially, a zero value
-      will disable JIT to trace and compile any side exits.
+      e.g., <literal>-1</literal> or <literal>256</literal>, default value will be
+      used instead. Specially, a zero value will disable JIT to trace and compile any side exits.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
- Use correct type for default configuration options
- Use `<literal>` and `<code>` tags consistently
- Mark all windows-only options in the Changelog column, for consistency
- Slightly improve wording in opcache.file_cache_fallback
- Use `&null;` consistently.