### PR TITLE
README: add link to manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ and the [README file](https://github.com/php/doc-base/blob/master/README.md)
 within the [doc-base repository](https://github.com/php/doc-base)
 for details on how to contribute to PHP's documentation.
 
+The PHP manual is available at [php.net/docs](https://php.net/docs).
+
 ## Creating this setup
 
 For information related to creating this setup,


### PR DESCRIPTION
I added a shortcut from this repo to the doc, it's handy when you just want to get back to the doc.

I took the same link that the on the PHP repo: https://github.com/php/php-src/blob/89c4e4c4cbf14268b71d5a340d50f8e465de2a09/README.md?plain=1#L23