### PR TITLE
mongodb/architecture.xml: The code of the examples seems invalid

### DIFF
--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -424,39 +424,90 @@ class AnotherClass3 implements MongoDB\BSON\Serializable
 {
     private $elements = ['foo', 'bar'];
 
-    public function bsonSerialize(): array;
+    public function bsonSerialize(): array
     {
         return $this->elements;
     }
 } // => {"0": "foo", "1": "bar"}
 
+/**
+ * Containered classes
+ */
+
 class AnotherClass4 implements MongoDB\BSON\Serializable
 {
-    private $things = [0 => 'foo', 2 => 'bar'];
+    private $elements = [0 => 'foo', 2 => 'bar'];
 
     public function bsonSerialize(): array
+    {
+        return $this->elements;
+    }
+}
+
+class ContainerClass1 implements MongoDB\BSON\Serializable
+{
+    public $things;
+
+    public function __construct()
+    {
+        $this->things = new AnotherClass4();
+    }
+
+    function bsonSerialize(): array
     {
         return ['things' => $this->things];
     }
 } // => {"things": {"0": "foo", "2": "bar"}}
 
+
 class AnotherClass5 implements MongoDB\BSON\Serializable
 {
-    private $things = [0 => 'foo', 2 => 'bar'];
+    private $elements = [0 => 'foo', 2 => 'bar'];
 
     public function bsonSerialize(): array
     {
-        return ['things' => array_values($this->elements)];
+        return array_values($this->elements);
+    }
+}
+
+class ContainerClass2 implements MongoDB\BSON\Serializable
+{
+    public $things;
+
+    public function __construct()
+    {
+        $this->things = new AnotherClass5();
+    }
+
+    public function bsonSerialize(): array
+    {
+        return ['things' => $this->things];
     }
 } // => {"things": ["foo", "bar"]}
 
+
 class AnotherClass6 implements MongoDB\BSON\Serializable
 {
-    private $things = ['foo', 'bar'];
+    private $elements = ['foo', 'bar'];
+
+    function bsonSerialize(): object
+    {
+        return (object) $this->elements;
+    }
+}
+
+class ContainerClass3 implements MongoDB\BSON\Serializable
+{
+    public $things;
+
+    public function __construct()
+    {
+        $this->things = new AnotherClass6();
+    }
 
     public function bsonSerialize(): array
     {
-        return ['things' => (object) $this->elements];
+        return ['things' => $this->things];
     }
 } // => {"things": {"0": "foo", "1": "bar"}}
 
@@ -465,6 +516,13 @@ class UpperClass implements MongoDB\BSON\Persistable
     public $foo = 42;
     protected $prot = 'wine';
     private $fpr = 'cheese';
+
+    private $data;
+
+    public function bsonUnserialize(array $data): void
+    {
+        $this->data = $data;
+    }
 
     public function bsonSerialize(): array
     {

--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -463,8 +463,8 @@ class AnotherClass6 implements MongoDB\BSON\Serializable
 class UpperClass implements MongoDB\BSON\Persistable
 {
     public $foo = 42;
-    protected $prot = "wine";
-    private $fpr = "cheese";
+    protected $prot = 'wine';
+    private $fpr = 'cheese';
 
     public function bsonSerialize(): array
     {

--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -386,83 +386,93 @@ foreach ($managers as $manager) {
 <![CDATA[
 <?php
 
-class stdClass {
-  public $foo = 42;
-} // => { "foo" : 42 }
+class stdClass
+{
+    public $foo = 42;
+} // => {"foo": 42}
 
-class MyClass {
-  public $foo = 42;
-  protected $prot = "wine";
-  private $fpr = "cheese";
-} // => { "foo" : 42 }
+class MyClass
+{
+    public $foo = 42;
+    protected $prot = "wine";
+    private $fpr = "cheese";
+} // => {"foo": 42}
 
-class AnotherClass1 implements MongoDB\BSON\Serializable {
-  public $foo = 42;
-  protected $prot = "wine";
-  private $fpr = "cheese";
-  function bsonSerialize(): array {
-      return [ 'foo' => $this->foo, 'prot' => $this->prot ];
-  }
-} // => { "foo" : 42, "prot" : "wine" }
+class AnotherClass1 implements MongoDB\BSON\Serializable
+{
+    public $foo = 42;
+    protected $prot = "wine";
+    private $fpr = "cheese";
 
-class AnotherClass2 implements MongoDB\BSON\Serializable {
-  public $foo = 42;
-  function bsonSerialize(): self {
-      return $this;
-  }
+    public function bsonSerialize(): array
+    {
+        return ['foo' => $this->foo, 'prot' => $this->prot];
+    }
+} // => {"foo": 42, "prot": "wine"}
+
+class AnotherClass2 implements MongoDB\BSON\Serializable
+{
+    public $foo = 42;
+
+    public function bsonSerialize(): self
+    {
+        return $this;
+    }
 } // => MongoDB\Driver\Exception\UnexpectedValueException("bsonSerialize() did not return an array or stdClass")
 
-class AnotherClass3 implements MongoDB\BSON\Serializable {
-  private $elements = [ 'foo', 'bar' ];
-  function bsonSerialize(): array {
-      return $this->elements;
-  }
-} // => { "0" : "foo", "1" : "bar" }
+class AnotherClass3 implements MongoDB\BSON\Serializable
+{
+    private $elements = ['foo', 'bar'];
 
-class ContainerClass implements MongoDB\BSON\Serializable {
-  public $things = AnotherClass4 implements MongoDB\BSON\Serializable {
-    private $elements = [ 0 => 'foo', 2 => 'bar' ];
-    function bsonSerialize(): array {
-      return $this->elements;
+    public function bsonSerialize(): array;
+    {
+        return $this->elements;
     }
-  }
-  function bsonSerialize(): array {
-      return [ 'things' => $this->things ];
-  }
-} // => { "things" : { "0" : "foo", "2" : "bar" } }
+} // => {"0": "foo", "1": "bar"}
 
-class ContainerClass implements MongoDB\BSON\Serializable {
-  public $things = AnotherClass5 implements MongoDB\BSON\Serializable {
-    private $elements = [ 0 => 'foo', 2 => 'bar' ];
-    function bsonSerialize(): array {
-      return array_values($this->elements);
+class AnotherClass4 implements MongoDB\BSON\Serializable
+{
+    private $things = [0 => 'foo', 2 => 'bar'];
+
+    public function bsonSerialize(): array
+    {
+        return ['things' => $this->things];
     }
-  }
-  function bsonSerialize(): array {
-      return [ 'things' => $this->things ];
-  }
-} // => { "things" : [ "foo", "bar" ] }
+} // => {"things": {"0": "foo", "2": "bar"}}
 
-class ContainerClass implements MongoDB\BSON\Serializable {
-  public $things = AnotherClass6 implements MongoDB\BSON\Serializable {
-    private $elements = [ 'foo', 'bar' ];
-    function bsonSerialize(): array {
-      return (object) $this->elements;
+class AnotherClass5 implements MongoDB\BSON\Serializable
+{
+    private $things = [0 => 'foo', 2 => 'bar'];
+
+    public function bsonSerialize(): array
+    {
+        return ['things' => array_values($this->elements)];
     }
-  }
-  function bsonSerialize(): array {
-      return [ 'things' => $this->things ];
-  }
-} // => { "things" : { "0" : "foo", "1" : "bar" } }
+} // => {"things": ["foo", "bar"]}
 
-class UpperClass implements MongoDB\BSON\Persistable {
-  public $foo = 42;
-  protected $prot = "wine";
-  private $fpr = "cheese";
-  function bsonSerialize(): array {
-      return [ 'foo' => $this->foo, 'prot' => $this->prot ];
-  }
-} // => { "foo" : 42, "prot" : "wine", "__pclass" : { "$type" : "80", "$binary" : "VXBwZXJDbGFzcw==" } }
+class AnotherClass6 implements MongoDB\BSON\Serializable
+{
+    private $things = ['foo', 'bar'];
+
+    public function bsonSerialize(): array
+    {
+        return ['things' => (object) $this->elements];
+    }
+} // => {"things": {"0": "foo", "1": "bar"}}
+
+class UpperClass implements MongoDB\BSON\Persistable
+{
+    public $foo = 42;
+    protected $prot = "wine";
+    private $fpr = "cheese";
+
+    public function bsonSerialize(): array
+    {
+        return ['foo' => $this->foo, 'prot' => $this->prot];
+    }
+} // => {"foo": 42, "prot": "wine", "__pclass": {"$type": "80", "$binary": "VXBwZXJDbGFzcw=="}}
+
+?>
 ]]>
      </programlisting>
     </section>

--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -394,8 +394,8 @@ class stdClass
 class MyClass
 {
     public $foo = 42;
-    protected $prot = "wine";
-    private $fpr = "cheese";
+    protected $prot = 'wine';
+    private $fpr = 'cheese';
 } // => {"foo": 42}
 
 class AnotherClass1 implements MongoDB\BSON\Serializable

--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -401,8 +401,8 @@ class MyClass
 class AnotherClass1 implements MongoDB\BSON\Serializable
 {
     public $foo = 42;
-    protected $prot = "wine";
-    private $fpr = "cheese";
+    protected $prot = 'wine';
+    private $fpr = 'cheese';
 
     public function bsonSerialize(): array
     {
@@ -431,7 +431,7 @@ class AnotherClass3 implements MongoDB\BSON\Serializable
 } // => {"0": "foo", "1": "bar"}
 
 /**
- * Containered classes
+ * Nesting Serializable classes
  */
 
 class AnotherClass4 implements MongoDB\BSON\Serializable
@@ -442,7 +442,7 @@ class AnotherClass4 implements MongoDB\BSON\Serializable
     {
         return $this->elements;
     }
-}
+} // => {"0": "foo", "2": "bar"}
 
 class ContainerClass1 implements MongoDB\BSON\Serializable
 {
@@ -468,7 +468,8 @@ class AnotherClass5 implements MongoDB\BSON\Serializable
     {
         return array_values($this->elements);
     }
-}
+} // => {"0": "foo", "1": "bar"} as a root class
+        ["foo", "bar"] as a nested value
 
 class ContainerClass2 implements MongoDB\BSON\Serializable
 {
@@ -494,7 +495,7 @@ class AnotherClass6 implements MongoDB\BSON\Serializable
     {
         return (object) $this->elements;
     }
-}
+} // => {"0": "foo", "1": "bar"}
 
 class ContainerClass3 implements MongoDB\BSON\Serializable
 {


### PR DESCRIPTION
Lines: 422-456.

In particular:

```
class ContainerClass implements MongoDB\BSON\Serializable {
  public $things = AnotherClass4 implements MongoDB\BSON\Serializable {
    private $elements = [ 0 => 'foo', 2 => 'bar' ];
    function bsonSerialize(): array {
      return $this->elements;
    }
  }
  function bsonSerialize(): array {
      return [ 'things' => $this->things ];
  }
} // => { "things" : { "0" : "foo", "2" : "bar" } }
```

Wrong `$things` definition and two `bsonSerialize()` method instead one. And `$elements` doesn't seem to be supposed to be in this example.

Etc.

I suggest replacing the code of the examples like this.

Or replace `AnotherClass4 — AnotherClass6` class names to `ContainerClass1 — ContainerClass3`