### PR TITLE
Add replaceable tag to the appropriate nl_langinfo constants

### DIFF
--- a/reference/strings/functions/nl-langinfo.xml
+++ b/reference/strings/functions/nl-langinfo.xml
@@ -5,7 +5,7 @@
   <refname>nl_langinfo</refname>
   <refpurpose>Query language and locale information</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -49,19 +49,19 @@
            <entry namest="c1" nameend="c2" align="center"><emphasis><constant>LC_TIME</constant> Category Constants</emphasis></entry>
           </row>
           <row>
-           <entry><constant>ABDAY_(1-7)</constant></entry>
+           <entry><constant>ABDAY_<replaceable>(1-7)</replaceable></constant></entry>
            <entry>Abbreviated name of n-th day of the week.</entry>
           </row>
           <row>
-           <entry><constant>DAY_(1-7)</constant></entry>
+           <entry><constant>DAY_<replaceable>(1-7)</replaceable></constant></entry>
            <entry>Name of the n-th day of the week (DAY_1 = Sunday).</entry>
           </row>
           <row>
-           <entry><constant>ABMON_(1-12)</constant></entry>
+           <entry><constant>ABMON_<replaceable>(1-12)</replaceable></constant></entry>
            <entry>Abbreviated name of the n-th month of the year.</entry>
           </row>
           <row>
-           <entry><constant>MON_(1-12)</constant></entry>
+           <entry><constant>MON_<replaceable>(1-12)</replaceable></constant></entry>
            <entry>Name of the n-th month of the year.</entry>
           </row>
           <row>


### PR DESCRIPTION
Add `<replaceable>` tag to the appropriate constants. 

Maybe adding some formatting to the `replaceable` class in the css file in `web-php` would be nice (e.g. making these italic **ABDAY_***(1-7)* instead of **ABDAY_(1-7)**). 