### PR TITLE
Added CVEs to crypt

### DIFF
--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -69,7 +69,7 @@
    <listitem>
     <simpara>
      <constant>CRYPT_MD5</constant> - MD5 hashing with a twelve character salt starting with
-     $1$ (CVE-2012-3287)
+     $1$
     </simpara>
    </listitem>
    <listitem>
@@ -92,7 +92,7 @@
      is used to indicate how many times the hashing loop should be executed, much like the cost
      parameter on Blowfish. The default number of rounds is 5000, there is a minimum of
      1000 and a maximum of 999,999,999. Any selection of N outside this range will be truncated to
-     the nearest limit. (CVE-2016-20013)
+     the nearest limit.
     </simpara>
    </listitem>
    <listitem>
@@ -102,10 +102,18 @@
      is used to indicate how many times the hashing loop should be executed, much like the cost
      parameter on Blowfish. The default number of rounds is 5000, there is a minimum of
      1000 and a maximum of 999,999,999. Any selection of N outside this range will be truncated to
-     the nearest limit. (CVE-2016-20013)
+     the nearest limit.
     </simpara>
    </listitem>
   </itemizedlist>
+  <warning>
+   <simpara>
+    <constant>CRYPT_MD5</constant> reached end of life because it is too fast for password hashing
+    (CVE-2012-3287). <constant>CRYPT_STD_DES</constant> is about 100 times faster for an attacker and
+    should also not be used. <constant>CRYPT_SHA256</constant> and <constant>CRYPT_SHA512</constant>
+    have a DoS attack and should not be used (CVE-2016-20013).
+   </simpara>
+  </warning>
  </refsect1>
  
  <refsect1 role="parameters">

--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -69,7 +69,7 @@
    <listitem>
     <simpara>
      <constant>CRYPT_MD5</constant> - MD5 hashing with a twelve character salt starting with
-     $1$
+     $1$ (CVE-2012-3287)
     </simpara>
    </listitem>
    <listitem>
@@ -92,7 +92,7 @@
      is used to indicate how many times the hashing loop should be executed, much like the cost
      parameter on Blowfish. The default number of rounds is 5000, there is a minimum of
      1000 and a maximum of 999,999,999. Any selection of N outside this range will be truncated to
-     the nearest limit.
+     the nearest limit. (CVE-2016-20013)
     </simpara>
    </listitem>
    <listitem>
@@ -102,7 +102,7 @@
      is used to indicate how many times the hashing loop should be executed, much like the cost
      parameter on Blowfish. The default number of rounds is 5000, there is a minimum of
      1000 and a maximum of 999,999,999. Any selection of N outside this range will be truncated to
-     the nearest limit.
+     the nearest limit. (CVE-2016-20013)
     </simpara>
    </listitem>
   </itemizedlist>

--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -46,6 +46,20 @@
    that start with the same eight characters will generate the same result
    (when the same salt is used).
   </para>
+  <warning>
+   <simpara>
+    None of the algorithms listed below are suitable for hashing new passwords.
+    <constant>CRYPT_STD_DES</constant>, <constant>CRYPT_EXT_DES</constant> and
+    <constant>CRYPT_MD5</constant> are far too fast to resist offline cracking;
+    md5crypt was declared end of life for that reason (CVE-2012-3287).
+    The runtime of <constant>CRYPT_SHA256</constant> and
+    <constant>CRYPT_SHA512</constant> grows with the square of the length of
+    <parameter>string</parameter>, so unbounded input can be used to exhaust CPU
+    (CVE-2016-20013).
+    Use <function>password_hash</function> instead, which selects a suitable
+    algorithm and cost automatically.
+   </simpara>
+  </warning>
   <simpara>
    The following hash types are supported:
   </simpara>
@@ -106,14 +120,6 @@
     </simpara>
    </listitem>
   </itemizedlist>
-  <warning>
-   <simpara>
-    <constant>CRYPT_MD5</constant> reached end of life because it is too fast for password hashing
-    (CVE-2012-3287). <constant>CRYPT_STD_DES</constant> is about 100 times faster for an attacker and
-    should also not be used. <constant>CRYPT_SHA256</constant> and <constant>CRYPT_SHA512</constant>
-    have a DoS attack and should not be used (CVE-2016-20013).
-   </simpara>
-  </warning>
  </refsect1>
  
  <refsect1 role="parameters">


### PR DESCRIPTION
Also there should maybe be a note on `CRYPT_STD_DES` to state it's worse than `CRYPT_MD5` and `CRYPT_MD5` was EOLed because it was not good enough.

`CRYPT_STD_DES` has a fixed 25 iterations of DES.
`CRYPT_MD5` has a fixed 1000 iterations of MD5.

`CRYPT_STD_DES` is 102x faster to crack than `CRYPT_MD5` on a [RTX 4090](https://gist.github.com/Chick3nman/32e662a5bb63bc4f51b847bb422222fd).