### PR TITLE
Update ext-mongodb docs for queryable encryption range V2

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -3377,7 +3377,7 @@ local: {
             <member><constant>MongoDB\Driver\ClientEncryption::AEAD_AES_256_CBC_HMAC_SHA_512_RANDOM</constant></member>
             <member><constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant></member>
             <member><constant>MongoDB\Driver\ClientEncryption::ALGORITHM_UNINDEXED</constant></member>
-            <member><constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW</constant></member>
+            <member><constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant></member>
            </simplelist>
           </entry>
          </row>
@@ -3394,7 +3394,7 @@ local: {
             <literal>algorithm</literal> is
             <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant>
             or
-            <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW</constant>.
+            <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant>.
            </para>
           </entry>
          </row>
@@ -3431,12 +3431,13 @@ local: {
            </para>
            <simplelist>
             <member><constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_EQUALITY</constant></member>
-            <member><constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE_PREVIEW</constant></member>
+            <member><constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE</constant></member>
            </simplelist>
-           <para>This option only applies and may only be specified when
+           <para>
+            This option only applies and may only be specified when
             <literal>algorithm</literal> is
             <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant>
-            or <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW</constant>.
+            or <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant>.
            </para>
           </entry>
          </row>
@@ -3445,10 +3446,10 @@ local: {
           <entry><type>array</type></entry>
           <entry>
            <para>
-            Index options for a queryable encryption field supporting
-            "rangePreview" queries. The options below must match the values set
-            in the <literal>encryptedFields</literal> of the target collection.
-            For double and decimal128 BSON field types, <literal>min</literal>,
+            Index options for a queryable encryption field supporting "range"
+            queries. The options below must match the values set in the
+            <literal>encryptedFields</literal> of the target collection. For
+            double and decimal128 BSON field types, <literal>min</literal>,
             <literal>max</literal>, and <literal>precision</literal> must all be
             set, or all be unset.
            </para>
@@ -3467,22 +3468,37 @@ local: {
                <row>
                 <entry>min</entry>
                 <entry><type>mixed</type></entry>
-                <entry>Required if <literal>precision</literal> is set.</entry>
+                <entry>
+                 Required if <literal>precision</literal> is set. The minimum
+                 BSON value of the range.
+                </entry>
                </row>
                <row>
                 <entry>max</entry>
                 <entry><type>mixed</type></entry>
-                <entry>Required if <literal>precision</literal> is set.</entry>
+                <entry>
+                 Required if <literal>precision</literal> is set. The maximum
+                 BSON value of the range.
+                </entry>
                </row>
                <row>
                 <entry>sparsity</entry>
                 <entry><type>int</type></entry>
-                <entry>Required.</entry>
+                <entry>Required. Positive 64-bit integer.</entry>
                </row>
                <row>
                 <entry>precision</entry>
                 <entry><type>int</type></entry>
-                <entry>Optional. May only be set for double or decimal128 BSON field types.</entry>
+                <entry>
+                 Optional. Positive 32-bit integer specifying precision to use
+                 for explicit encryption. May only be set for double or
+                 decimal128 BSON field types.
+                </entry>
+               </row>
+               <row>
+                <entry>trimFactor</entry>
+                <entry><type>int</type></entry>
+                <entry>Required. Positive 32-bit integer.</entry>
                </row>
               </tbody>
              </tgroup>

--- a/reference/mongodb/mongodb/driver/clientencryption.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption.xml
@@ -64,6 +64,12 @@
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>string</type>
+     <varname linkend="mongodb-driver-clientencryption.constants.algorithm-range">MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</varname>
+     <initializer>Range</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>string</type>
      <varname linkend="mongodb-driver-clientencryption.constants.algorithm-range-preview">MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW</varname>
      <initializer>RangePreview</initializer>
     </fieldsynopsis>
@@ -72,6 +78,12 @@
      <type>string</type>
      <varname linkend="mongodb-driver-clientencryption.constants.query-type-equality">MongoDB\Driver\ClientEncryption::QUERY_TYPE_EQUALITY</varname>
      <initializer>equality</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-clientencryption.constants.query-type-range">MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE</varname>
+     <initializer>range</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>const</modifier>
@@ -121,11 +133,21 @@
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="mongodb-driver-clientencryption.constants.algorithm-range-preview">
-     <term><constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW</constant></term>
+    <varlistentry xml:id="mongodb-driver-clientencryption.constants.algorithm-range">
+     <term><constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant></term>
      <listitem>
-      <para>Specifies an algorithm for a range, encrypted payload, which can be used with queryable encryption.</para>
-      <para>To query with a range encrypted payload, the <classname>MongoDB\Driver\Manager</classname> must be configured with the <literal>"autoEncryption"</literal> driver option. The <literal>"bypassQueryAnalysis"</literal> auto encryption option may be &true;. The <literal>"bypassAutoEncryption"</literal> auto encryption option must be &false;.</para>
+      <para>
+       Specifies an algorithm for a range encrypted payload, which can be used
+       with queryable encryption.
+      </para>
+      <para>
+       To query with a range encrypted payload, the
+       <classname>MongoDB\Driver\Manager</classname> must be configured with the
+       <literal>"autoEncryption"</literal> driver option. The
+       <literal>"bypassQueryAnalysis"</literal> auto encryption option may be
+       &true;. The <literal>"bypassAutoEncryption"</literal> auto encryption
+       option must be &false;.
+      </para>
       <note>
        <para>The range algorithm is experimental only. It is not intended for public use.</para>
        <para>The extension does not yet support range queries for Decimal128 BSON field types.</para>
@@ -133,17 +155,37 @@
      </listitem>
     </varlistentry>
 
+    <varlistentry xml:id="mongodb-driver-clientencryption.constants.algorithm-range-preview">
+     <term><constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW</constant></term>
+     <listitem>
+      <para>This constant is deprecated and will be removed in a future major version.</para>
+     </listitem>
+    </varlistentry>
+
     <varlistentry xml:id="mongodb-driver-clientencryption.constants.query-type-equality">
      <term><constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_EQUALITY</constant></term>
      <listitem>
-      <para>Specifies an equality query type, which is used in conjunction with <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant>.</para>
+      <para>
+       Specifies an equality query type, which is used in conjunction with
+       <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant>.
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-clientencryption.constants.query-type-range">
+     <term><constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE</constant></term>
+     <listitem>
+      <para>
+       Specifies a range query type, which is used in conjunction with
+       <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant>.
+      </para>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-clientencryption.constants.query-type-range-preview">
      <term><constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE_PREVIEW</constant></term>
      <listitem>
-      <para>Specifies a range query type, which is used in conjunction with <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW</constant>.</para>
+      <para>This constant is deprecated and will be removed in a future major version.</para>
      </listitem>
     </varlistentry>
 
@@ -164,15 +206,31 @@
       </thead>
       <tbody>
        <row>
+        <entry>PECL mongodb 1.20.0</entry>
+        <entry>
+         <para>
+          Added <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant>
+          and <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE</constant>.
+         </para>
+         <para>
+          Deprecated <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW</constant>
+          and <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE_PREVIEW</constant>.
+         </para>
+        </entry>
+       </row>
+       <row>
         <entry>PECL mongodb 1.16.0</entry>
         <entry>
-          Added <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW</constant> and <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE_PREVIEW</constant>.
+         Added <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW</constant>
+         and <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE_PREVIEW</constant>.
         </entry>
        </row>
        <row>
         <entry>PECL mongodb 1.14.0</entry>
         <entry>
-          Added <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant>, <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_UNINDEXED</constant>, and <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_EQUALITY</constant>
+         Added <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant>,
+         <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_UNINDEXED</constant>,
+         and <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_EQUALITY</constant>.
         </entry>
        </row>
       </tbody>


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2401

 * Documents new ClientEncryption constants in ext-mongodb 1.20, and deprecation of existing constants.
 * Documents new trimFactor range option.
 * Adds more detail for existing range options and wraps long lines in the constant/option docs.