### PR TITLE
Add missing CURLINFO constants

### DIFF
--- a/reference/curl/constants_curl_getinfo.xml
+++ b/reference/curl/constants_curl_getinfo.xml
@@ -161,6 +161,17 @@
    </simpara>
   </listitem>
  </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-effective-method">
+  <term>
+   <constant>CURLINFO_EFFECTIVE_METHOD</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Get the last used HTTP method.
+   </simpara>
+  </listitem>
+ </varlistentry>
  <varlistentry xml:id="constant.curlinfo-effective-url">
   <term>
    <constant>CURLINFO_EFFECTIVE_URL</constant>
@@ -271,6 +282,18 @@
    <simpara>
     The version used in the last HTTP connection. The return value will be one of the defined <constant>CURL_HTTP_VERSION_<replaceable>*</replaceable></constant> constants or 0 if the version can't be determined.
     Available as of PHP 7.3.0 and cURL 7.50.0
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-lastone">
+  <term>
+   <constant>CURLINFO_LASTONE</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    The last enum value in the underlying <literal>CURLINFO</literal> enum
+    in <literal>libcurl</literal>.
    </simpara>
   </listitem>
  </varlistentry>


### PR DESCRIPTION
#3289 and this PR adds all missing CURLINFO constants listed on the [missing internal global constants](https://github.com/php/doc-en/issues/2747) list.