### PR TITLE
Add curl_share_setopt() constants to constants page

### DIFF
--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -4135,28 +4135,6 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curl-lock-data-connect">
-   <term>
-    <constant>CURL_LOCK_DATA_CONNECT</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.3.0 and cURL 7.10.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-lock-data-psl">
-   <term>
-    <constant>CURL_LOCK_DATA_PSL</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.3.0 and cURL 7.61.0
-    </simpara>
-   </listitem>
-  </varlistentry>
   <varlistentry xml:id="constant.curlopt-disallow-username-in-url">
    <term>
     <constant>CURLOPT_DISALLOW_USERNAME_IN_URL</constant>
@@ -4334,6 +4312,7 @@
    </listitem>
   </varlistentry>
  </variablelist>
+ &reference.curl.constants-curl-share-setopt;
  &reference.curl.constants-curl-getinfo;
  &reference.curl.constants-curl-error;
 </appendix>

--- a/reference/curl/constants_curl_share_setopt.xml
+++ b/reference/curl/constants_curl_share_setopt.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<variablelist xml:id="constant.curl-share-setopt.constants" role="constant_list">
+ <title><function>curl_share_setopt</function></title>
+ <varlistentry xml:id="constant.curl-lock-data-connect">
+  <term>
+   <constant>CURL_LOCK_DATA_CONNECT</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Shares/unshares the connection cache.
+    Available as of PHP 7.3.0 and cURL 7.10.0
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curl-lock-data-cookie">
+  <term>
+   <constant>CURL_LOCK_DATA_COOKIE</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Shares/unshares cookie data.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curl-lock-data-dns">
+  <term>
+   <constant>CURL_LOCK_DATA_DNS</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Shares/unshares DNS cache.
+    Note that when you use cURL multi handles,
+    all handles added to the same multi handle will share DNS cache by default.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curl-lock-data-psl">
+  <term>
+   <constant>CURL_LOCK_DATA_PSL</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Shares/unshares the Public Suffix List.
+    Available as of PHP 7.3.0 and cURL 7.61.0
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curl-lock-data-ssl-session">
+  <term>
+   <constant>CURL_LOCK_DATA_SSL_SESSION</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Shares/unshares SSL session IDs, reducing the time spent
+    on the SSL handshake when reconnecting to the same server.
+    Note that SSL session IDs are reused within the same handle by default.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlshopt-none">
+  <term>
+   <constant>CURLSHOPT_NONE</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlshopt-share">
+  <term>
+   <constant>CURLSHOPT_SHARE</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Specifies a type of data that should be shared.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlshopt-unshare">
+  <term>
+   <constant>CURLSHOPT_UNSHARE</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Specifies a type of data that will be no longer shared.
+   </simpara>
+  </listitem>
+ </varlistentry>
+</variablelist>


### PR DESCRIPTION
Add `curl_share_setopt()` constants (`CURLSHOPT_*` and `CURL_LOCK_DATA_*` constants) to their own dedicated constant list on the cURL constant page.

Note: `CURLSHOPT_NONE` is deliberately missing a description as the comment in the cURL source code simply says `don't use` (i.e. it probably should not be exposed by PHP).