### PR TITLE
Move curl_multi_setopt() constants to a dedicated variablelist

### DIFF
--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -3299,105 +3299,6 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curlmopt-pipelining">
-   <term>
-    <constant>CURLMOPT_PIPELINING</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of cURL 7.16.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlmopt-maxconnects">
-   <term>
-    <constant>CURLMOPT_MAXCONNECTS</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of cURL 7.16.3.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlmopt-max-concurrent-streams">
-   <term>
-    <constant>CURLMOPT_MAX_CONCURRENT_STREAMS</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 8.2.0 and cURL 7.67.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlmopt-chunk-length-penalty-size">
-   <term>
-    <constant>CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.0.7 and cURL 7.30.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlmopt-content-length-penalty-size">
-   <term>
-    <constant>CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.0.7 and cURL 7.30.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlmopt-max-host-connections">
-   <term>
-    <constant>CURLMOPT_MAX_HOST_CONNECTIONS</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.0.7 and cURL 7.30.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlmopt-max-pipeline-length">
-   <term>
-    <constant>CURLMOPT_MAX_PIPELINE_LENGTH</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.0.7 and cURL 7.30.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlmopt-max-total-connections">
-   <term>
-    <constant>CURLMOPT_MAX_TOTAL_CONNECTIONS</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.0.7 and cURL 7.30.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlmopt-pushfunction">
-   <term>
-    <constant>CURLMOPT_PUSHFUNCTION</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.1.0 and cURL 7.44.0
-    </simpara>
-   </listitem>
-  </varlistentry>
   <varlistentry xml:id="constant.curlssh-auth-agent">
    <term>
     <constant>CURLSSH_AUTH_AGENT</constant>
@@ -4215,6 +4116,7 @@
  </variablelist>
  &reference.curl.constants-curl-share-setopt;
  &reference.curl.constants-curl-getinfo;
+ &reference.curl.constants-curl-multi-setopt;
  &reference.curl.constants-curlproto;
  &reference.curl.constants-curl-error;
  &reference.curl.constants-curl-multi;

--- a/reference/curl/constants_curl_multi_setopt.xml
+++ b/reference/curl/constants_curl_multi_setopt.xml
@@ -134,29 +134,29 @@
       <methodparam><type>resource</type><parameter>pushed_ch</parameter></methodparam>
       <methodparam><type>array</type><parameter>headers</parameter></methodparam>
      </methodsynopsis>
-     <variablelist>
+     <variablelist role="function_parameters">
       <varlistentry>
        <term><parameter>parent_ch</parameter></term>
        <listitem>
-        <para>
+        <simpara>
          The parent cURL handle (the request the client made).
-        </para>
+        </simpara>
        </listitem>
       </varlistentry>
       <varlistentry>
        <term><parameter>pushed_ch</parameter></term>
        <listitem>
-        <para>
+        <simpara>
          A new cURL handle for the pushed request.
-        </para>
+        </simpara>
        </listitem>
       </varlistentry>
       <varlistentry>
        <term><parameter>headers</parameter></term>
        <listitem>
-        <para>
+        <simpara>
          The push promise headers.
-        </para>
+        </simpara>
        </listitem>
       </varlistentry>
      </variablelist>

--- a/reference/curl/constants_curl_multi_setopt.xml
+++ b/reference/curl/constants_curl_multi_setopt.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<variablelist xml:id="constant.curl-multi-setopt.constants" role="constant_list">
+ <title><function>curl_multi_setopt</function></title>
+  <varlistentry xml:id="constant.curlmopt-chunk-length-penalty-size">
+   <term>
+    <constant>CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Specifies the chunk length threshold for pipelining in bytes.
+     Available as of PHP 7.0.7 and cURL 7.30.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlmopt-content-length-penalty-size">
+   <term>
+    <constant>CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Specifies the size threshold for pipelining penalty in bytes.
+     Available as of PHP 7.0.7 and cURL 7.30.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlmopt-maxconnects">
+   <term>
+    <constant>CURLMOPT_MAXCONNECTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Specifies the maximum amount of simultaneously open connections
+     that libcurl may cache.
+     By default the size will be enlarged to fit four times the number
+     of handles added via <function>curl_multi_add_handle</function>.
+     When the cache is full, curl closes the oldest one in the cache
+     to prevent the number of open connections from increasing.
+     Available as of cURL 7.16.3.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlmopt-max-concurrent-streams">
+   <term>
+    <constant>CURLMOPT_MAX_CONCURRENT_STREAMS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Specifies the maximum number of concurrent streams for connections
+     that cURL should support on connections using HTTP/2.
+     Valid values range from <literal>1</literal>
+     to <literal>2147483647</literal> (<literal>2^31 - 1</literal>).
+     The value passed here would be honored
+     based on other system resources properties.
+     Default is <literal>100</literal>.
+     Available as of PHP 8.2.0 and cURL 7.67.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlmopt-max-host-connections">
+   <term>
+    <constant>CURLMOPT_MAX_HOST_CONNECTIONS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Specifies the maximum number of connections to a single host.
+     Available as of PHP 7.0.7 and cURL 7.30.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlmopt-max-pipeline-length">
+   <term>
+    <constant>CURLMOPT_MAX_PIPELINE_LENGTH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Specifies the maximum number of requests in a pipeline.
+     Available as of PHP 7.0.7 and cURL 7.30.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlmopt-max-total-connections">
+   <term>
+    <constant>CURLMOPT_MAX_TOTAL_CONNECTIONS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Specifies the maximum number of simultaneously open connections.
+     Available as of PHP 7.0.7 and cURL 7.30.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlmopt-pipelining">
+   <term>
+    <constant>CURLMOPT_PIPELINING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Pass 1 to enable or 0 to disable. Enabling pipelining on a multi
+     handle will make it attempt to perform HTTP Pipelining as far as
+     possible for transfers using this handle. This means that adding
+     a second request that can use an already existing connection will "pipe"
+     the second request on the same connection.
+     As of cURL 7.43.0, the value is a bitmask,
+     and passing 2 will try to multiplex the new
+     transfer over an existing HTTP/2 connection.
+     Passing 3 instructs cURL to ask for pipelining and multiplexing
+     independently of each other.
+     As of cURL 7.62.0, setting the pipelining bit has no effect.
+     Instead of integer literals, the CURLPIPE_* constants can also be used.
+     Available as of cURL 7.16.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlmopt-pushfunction">
+   <term>
+    <constant>CURLMOPT_PUSHFUNCTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Pass a <type>callable</type> that will be registered to handle server
+     pushes and should have the following signature:
+     <methodsynopsis>
+      <type>int</type><methodname><replaceable>pushfunction</replaceable></methodname>
+      <methodparam><type>resource</type><parameter>parent_ch</parameter></methodparam>
+      <methodparam><type>resource</type><parameter>pushed_ch</parameter></methodparam>
+      <methodparam><type>array</type><parameter>headers</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist>
+      <varlistentry>
+       <term><parameter>parent_ch</parameter></term>
+       <listitem>
+        <para>
+         The parent cURL handle (the request the client made).
+        </para>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>pushed_ch</parameter></term>
+       <listitem>
+        <para>
+         A new cURL handle for the pushed request.
+        </para>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>headers</parameter></term>
+       <listitem>
+        <para>
+         The push promise headers.
+        </para>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     The push function is supposed to return either
+     <constant>CURL_PUSH_OK</constant> if it can handle the push, or
+     <constant>CURL_PUSH_DENY</constant> to reject it.
+     Available as of PHP 7.1.0 and cURL 7.44.0
+    </para>
+   </listitem>
+  </varlistentry>
+</variablelist>


### PR DESCRIPTION
…and add descriptions. Descriptions were copied from the page of `curl_multi_setopt()`.