### PR TITLE
Move CURLPROTO constants to dedicated variablelist

### DIFF
--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -3695,39 +3695,6 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curlproto-smb">
-   <term>
-    <constant>CURLPROTO_SMB</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.0.7 and cURL 7.40.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlproto-smbs">
-   <term>
-    <constant>CURLPROTO_SMBS</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.0.7 and cURL 7.40.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlproto-mqtt">
-   <term>
-    <constant>CURLPROTO_MQTT</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 8.2.0 and cURL 7.71.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
   <varlistentry xml:id="constant.curlopt-redir-protocols-str">
    <term>
     <constant>CURLOPT_REDIR_PROTOCOLS_STR</constant>
@@ -4335,6 +4302,7 @@
   </varlistentry>
  </variablelist>
  &reference.curl.constants-curl-getinfo;
+ &reference.curl.constants-curlproto;
  &reference.curl.constants-curl-error;
 </appendix>
 <!-- Keep this comment at the end of the file

--- a/reference/curl/constants_curlproto.xml
+++ b/reference/curl/constants_curlproto.xml
@@ -1,0 +1,334 @@
+<?xml version="1.0" encoding="utf-8"?>
+<variablelist xml:id="constant.curlproto.constants" role="constant_list">
+ <title>cURL protocol constants</title>
+ <varlistentry xml:id="constant.curlproto-all">
+  <term>
+   <constant>CURLPROTO_ALL</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-dict">
+  <term>
+   <constant>CURLPROTO_DICT</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-file">
+  <term>
+   <constant>CURLPROTO_FILE</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-ftp">
+  <term>
+   <constant>CURLPROTO_FTP</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-ftps">
+  <term>
+   <constant>CURLPROTO_FTPS</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-gopher">
+  <term>
+   <constant>CURLPROTO_GOPHER</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-http">
+  <term>
+   <constant>CURLPROTO_HTTP</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-https">
+  <term>
+   <constant>CURLPROTO_HTTPS</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-imap">
+  <term>
+   <constant>CURLPROTO_IMAP</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-imaps">
+  <term>
+   <constant>CURLPROTO_IMAPS</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-ldap">
+  <term>
+   <constant>CURLPROTO_LDAP</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-ldaps">
+  <term>
+   <constant>CURLPROTO_LDAPS</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-mqtt">
+  <term>
+   <constant>CURLPROTO_MQTT</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+     Available as of PHP 8.2.0 and cURL 7.71.0.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-pop3">
+  <term>
+   <constant>CURLPROTO_POP3</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-pop3s">
+  <term>
+   <constant>CURLPROTO_POP3S</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-rtmp">
+  <term>
+   <constant>CURLPROTO_RTMP</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-rtmpe">
+  <term>
+   <constant>CURLPROTO_RTMPE</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-rtmps">
+  <term>
+   <constant>CURLPROTO_RTMPS</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-rtmpt">
+  <term>
+   <constant>CURLPROTO_RTMPT</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-rtmpte">
+  <term>
+   <constant>CURLPROTO_RTMPTE</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-rtmpts">
+  <term>
+   <constant>CURLPROTO_RTMPTS</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-rtsp">
+  <term>
+   <constant>CURLPROTO_RTSP</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-scp">
+  <term>
+   <constant>CURLPROTO_SCP</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-sftp">
+  <term>
+   <constant>CURLPROTO_SFTP</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-smb">
+  <term>
+   <constant>CURLPROTO_SMB</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+     Available as of PHP 7.0.7 and cURL 7.40.0.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-smbs">
+  <term>
+   <constant>CURLPROTO_SMBS</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+     Available as of PHP 7.0.7 and cURL 7.40.0.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-smtp">
+  <term>
+   <constant>CURLPROTO_SMTP</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-smtps">
+  <term>
+   <constant>CURLPROTO_SMTPS</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-telnet">
+  <term>
+   <constant>CURLPROTO_TELNET</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlproto-tftp">
+  <term>
+   <constant>CURLPROTO_TFTP</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+
+   </simpara>
+  </listitem>
+ </varlistentry>
+</variablelist>


### PR DESCRIPTION
Make a dedicated `<variablelist>` for `CURLPROTO_*` constants and copy all of them into this new `<variablelist>`.