### PR TITLE
Move cURL multi handle status constants to their own variablelist

### DIFF
--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -2826,72 +2826,6 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curlm-call-multi-perform">
-   <term>
-    <constant>CURLM_CALL_MULTI_PERFORM</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlm-ok">
-   <term>
-    <constant>CURLM_OK</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlm-bad-handle">
-   <term>
-    <constant>CURLM_BAD_HANDLE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlm-bad-easy-handle">
-   <term>
-    <constant>CURLM_BAD_EASY_HANDLE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlm-out-of-memory">
-   <term>
-    <constant>CURLM_OUT_OF_MEMORY</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlm-internal-error">
-   <term>
-    <constant>CURLM_INTERNAL_ERROR</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
   <varlistentry xml:id="constant.curlmsg-done">
    <term>
     <constant>CURLMSG_DONE</constant>
@@ -4336,6 +4270,7 @@
  </variablelist>
  &reference.curl.constants-curl-getinfo;
  &reference.curl.constants-curl-error;
+ &reference.curl.constants-curl-multi;
 </appendix>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/curl/constants_curl_multi.xml
+++ b/reference/curl/constants_curl_multi.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<variablelist xml:id="constant.curl-multi.constants" role="constant_list">
+ <title>curl_multi_<replaceable>*</replaceable> status constants</title>
+ <varlistentry xml:id="constant.curlm-added-already">
+  <term>
+   <constant>CURLM_ADDED_ALREADY</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    An easy handle already added to a multi handle was attempted to get added a second time.
+    Available as of cURL 7.32.1
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlm-bad-easy-handle">
+  <term>
+   <constant>CURLM_BAD_EASY_HANDLE</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    An easy handle was not good/valid. It could mean that it is not an easy handle at all, or possibly that the handle already is in use by this or another multi handle.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlm-bad-handle">
+  <term>
+   <constant>CURLM_BAD_HANDLE</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    The passed-in handle is not a valid multi handle.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlm-call-multi-perform">
+  <term>
+   <constant>CURLM_CALL_MULTI_PERFORM</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    As of cURL 7.20.0, this constant is not used.
+    Before cURL 7.20.0, this status could be returned by
+    <function>curl_multi_exec</function> when <function>curl_multi_select</function>
+    or a similar function was called before it returned any other constant.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlm-internal-error">
+  <term>
+   <constant>CURLM_INTERNAL_ERROR</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Internal <literal>libcurl</literal> error.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlm-ok">
+  <term>
+   <constant>CURLM_OK</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    No errors.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlm-out-of-memory">
+  <term>
+   <constant>CURLM_OUT_OF_MEMORY</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Ran out of memory while processing multi handles.
+   </simpara>
+  </listitem>
+ </varlistentry>
+</variablelist>


### PR DESCRIPTION
Move cURL multi handle status constants to their own variablelist. 
Add missing constant.
Add descriptions.