### PR TITLE
Remove empty installation pages

### DIFF
--- a/reference/array/setup.xml
+++ b/reference/array/setup.xml
@@ -9,11 +9,6 @@
   &no.requirement;
  </section>
 
- <section xml:id="array.installation">
-  &reftitle.install;
-  &no.install;
- </section>
-
  <section xml:id="array.configuration">
   &reftitle.runtime;
   &no.config;

--- a/reference/classobj/setup.xml
+++ b/reference/classobj/setup.xml
@@ -9,11 +9,6 @@
   &no.requirement;
  </section>
 
- <section xml:id="classobj.installation">
-  &reftitle.install;
-  &no.install;
- </section>
-
  <section xml:id="classobj.configuration">
   &reftitle.runtime;
   &no.config;

--- a/reference/dir/setup.xml
+++ b/reference/dir/setup.xml
@@ -11,13 +11,6 @@
  </section>
  <!-- }}} -->
 
- <!-- {{{ Installation -->
- <section xml:id="dir.installation">
-  &reftitle.install;
-  &no.install;
- </section>
- <!-- }}} -->
-
  <!-- {{{ Configuration -->
  <section xml:id="dir.configuration">
   &reftitle.runtime;

--- a/reference/errorfunc/setup.xml
+++ b/reference/errorfunc/setup.xml
@@ -8,11 +8,6 @@
   &no.requirement;
  </section>
 
- <section xml:id="errorfunc.installation">
-  &reftitle.install;
-  &no.install;
- </section>
-
  &reference.errorfunc.ini;
 
  <section xml:id="errorfunc.resources">
@@ -42,4 +37,4 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
- 
+

--- a/reference/exec/setup.xml
+++ b/reference/exec/setup.xml
@@ -11,13 +11,6 @@
  </section>
  <!-- }}} -->
 
- <!-- {{{ Installation -->
- <section xml:id="exec.installation">
-  &reftitle.install;
-  &no.install;
- </section>
- <!-- }}} -->
-
  <!-- {{{ Configuration -->
  <section xml:id="exec.configuration">
   &reftitle.runtime;

--- a/reference/filesystem/setup.xml
+++ b/reference/filesystem/setup.xml
@@ -11,13 +11,6 @@
  </section>
  <!-- }}} -->
 
- <!-- {{{ Installation -->
- <section xml:id="filesystem.installation">
-  &reftitle.install;
-  &no.install;
- </section>
- <!-- }}} -->
-
  <!-- {{{ Configuration -->
  &reference.filesystem.ini;
  <!-- }}} -->
@@ -26,7 +19,7 @@
  <section xml:id="filesystem.resources">
   &reftitle.resources;
   <para>
-   The file system uses <literal>streams</literal> as their resource type. Streams 
+   The file system uses <literal>streams</literal> as their resource type. Streams
    are documented in its own reference chapter, <link linkend="book.stream">Streams</link>.
   </para>
  </section>

--- a/reference/funchand/setup.xml
+++ b/reference/funchand/setup.xml
@@ -9,11 +9,6 @@
   &no.requirement;
  </section>
 
- <section xml:id="funchand.installation">
-  &reftitle.install;
-  &no.install;
- </section>
-
  <section xml:id="funchand.configuration">
   &reftitle.runtime;
   &no.config;

--- a/reference/hash/setup.xml
+++ b/reference/hash/setup.xml
@@ -4,13 +4,6 @@
 <chapter xml:id="hash.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
 
- <!-- {{{ Requirements -->
- <section xml:id="hash.requirements">
-  &reftitle.required;
-  &no.install;
- </section>
- <!-- }}} -->
-
  <!-- {{{ Installation -->
  <section xml:id="hash.installation">
   &reftitle.install;
@@ -21,7 +14,7 @@
   <para>
    It may be explicitly disabled by using the --disable-hash switch to
    configure.  Earlier versions of PHP may incorporate the Hash extension by
-   installing the 
+   installing the
    <link xlink:href="&url.pecl.package;hash">PECL module</link>.
   </para>
   <para>

--- a/reference/info/setup.xml
+++ b/reference/info/setup.xml
@@ -9,11 +9,6 @@
   &no.requirement;
  </section>
 
- <section xml:id="info.installation">
-  &reftitle.install;
-  &no.install;
- </section>
-
  &reference.info.ini;
 
  <section xml:id="info.resources">
@@ -22,7 +17,7 @@
  </section>
 
 </chapter>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
@@ -43,4 +38,4 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
- 
+

--- a/reference/json/setup.xml
+++ b/reference/json/setup.xml
@@ -4,22 +4,17 @@
 <chapter xml:id="json.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
 
- <section xml:id="json.requirements">
-  &reftitle.required;
-  &no.install;
- </section>
-
  <section xml:id="json.installation">
   &reftitle.install;
   <para>
-   The JSON extension is bundled and compiled into PHP by 
+   The JSON extension is bundled and compiled into PHP by
    default.
   </para>
   <para>
    As of PHP 8.0.0, the JSON extension is a core PHP extension, so it is always enabled.
   </para>
   <para>
-   &pecl.info; 
+   &pecl.info;
    <link xlink:href="&url.pecl.package;json">&url.pecl.package;json</link>
   </para>
  </section>
@@ -35,7 +30,7 @@
  </section>
 
 </chapter>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/mail/setup.xml
+++ b/reference/mail/setup.xml
@@ -23,13 +23,6 @@
  </section>
  <!-- }}} -->
 
- <!-- {{{ Installation -->
- <section xml:id="mail.installation">
-  &reftitle.install;
-  &no.install;
- </section>
- <!-- }}} -->
-
  <!-- {{{ Configuration -->
  &reference.mail.ini;
  <!-- }}} -->

--- a/reference/math/setup.xml
+++ b/reference/math/setup.xml
@@ -11,13 +11,6 @@
  </section>
  <!-- }}} -->
 
- <!-- {{{ Installation -->
- <section xml:id="math.installation">
-  &reftitle.install;
-  &no.install;
- </section>
- <!-- }}} -->
-
  <!-- {{{ Configuration -->
  <section xml:id="math.configuration">
   &reftitle.runtime;

--- a/reference/misc/setup.xml
+++ b/reference/misc/setup.xml
@@ -9,11 +9,6 @@
   &no.requirement;
  </section>
 
- <section xml:id="misc.installation">
-  &reftitle.install;
-  &no.install;
- </section>
-
  &reference.misc.ini;
 
  <section xml:id="misc.resources">
@@ -43,4 +38,4 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
- 
+

--- a/reference/network/setup.xml
+++ b/reference/network/setup.xml
@@ -14,13 +14,6 @@
  </section>
  <!-- }}} -->
 
- <!-- {{{ Installation -->
- <section xml:id="network.installation">
-  &reftitle.install;
-  &no.install;
- </section>
- <!-- }}} -->
-
  <!-- {{{ Configuration -->
  <section xml:id="network.configuration">
   &reftitle.runtime;

--- a/reference/outcontrol/setup.xml
+++ b/reference/outcontrol/setup.xml
@@ -8,11 +8,6 @@
   &no.requirement;
  </section>
 
- <section xml:id="outcontrol.installation">
-  &reftitle.install;
-  &no.install;
- </section>
-
  &reference.outcontrol.ini;
 
  <section xml:id="outcontrol.resources">
@@ -42,4 +37,4 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
- 
+

--- a/reference/random/setup.xml
+++ b/reference/random/setup.xml
@@ -7,11 +7,6 @@
   &no.requirement;
  </section>
 
- <section xml:id="random.installation">
-  &reftitle.install;
-  &no.install;
- </section>
-
  <section xml:id="random.configuration">
   &reftitle.runtime;
   &no.config;

--- a/reference/reflection/setup.xml
+++ b/reference/reflection/setup.xml
@@ -9,13 +9,6 @@
   &no.requirement;
  </section>
 
- <!-- {{{ Installation -->
- <section xml:id="reflection.installation">
-  &reftitle.install;
-  &no.install;
- </section>
- <!-- }}} -->
-
  <!-- {{{ Configuration -->
  <section xml:id="reflection.configuration">
   &reftitle.runtime;

--- a/reference/spl/setup.xml
+++ b/reference/spl/setup.xml
@@ -11,13 +11,6 @@
  </section>
  <!-- }}} -->
 
- <!-- {{{ Installation -->
- <section xml:id="spl.installation">
-  &reftitle.install;
-  &no.install;
- </section>
- <!-- }}} -->
-
  <!-- {{{ Configuration -->
  <section xml:id="spl.configuration">
   &reftitle.runtime;

--- a/reference/stream/setup.xml
+++ b/reference/stream/setup.xml
@@ -8,11 +8,6 @@
   &no.requirement;
  </section>
 
- <section xml:id="stream.installation">
-  &reftitle.install;
-  &no.install;
- </section>
-
  <section xml:id="stream.configuration">
   &reftitle.runtime;
   &no.config;
@@ -54,4 +49,4 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
- 
+

--- a/reference/url/setup.xml
+++ b/reference/url/setup.xml
@@ -9,11 +9,6 @@
   &no.requirement;
  </section>
 
- <section xml:id="url.installation">
-  &reftitle.install;
-  &no.install;
- </section>
-
  <section xml:id="url.configuration">
   &reftitle.runtime;
   &no.config;

--- a/reference/var/setup.xml
+++ b/reference/var/setup.xml
@@ -9,11 +9,6 @@
   &no.requirement;
  </section>
 
- <section xml:id="var.installation">
-  &reftitle.install;
-  &no.install;
- </section>
-
  &reference.var.ini;
 
  <section xml:id="var.resources">


### PR DESCRIPTION
This PR removes the installation pages for every extension that doesn't need to be installed (ie. is part of PHP's core extensions).
