### PR TITLE
Add documentation for `array_find` RFC

### DIFF
--- a/reference/array/functions/array-all.xml
+++ b/reference/array/functions/array-all.xml
@@ -13,11 +13,11 @@
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>array_all</function> returns &true;, if the given
    <parameter>callback</parameter> returns &true; for all elements. Otherwise
    the function returns &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/array/functions/array-all.xml
+++ b/reference/array/functions/array-all.xml
@@ -1,22 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="function.array-find" xmlns="http://docbook.org/ns/docbook">
+<refentry xml:id="function.array-all" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
-  <refname>array_find</refname>
-  <refpurpose>Returns the value of the first element of an &array; for which a callback returns &true;.</refpurpose>
+  <refname>array_all</refname>
+  <refpurpose>Returns &true;, if a callback returns &true; for all elements in an array.</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>mixed</type><methodname>array_find</methodname>
+   <type>mixed</type><methodname>array_all</methodname>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>array_find</function> returns the value of the first element of an
-   &array; for which the given callback returns &true;. If no matching element
-   is found the function returns &null;.
+   <function>array_all</function> returns &true;, if the given $callback returns
+   &true; for all elements. Otherwise the function returns &false;.
   </para>
  </refsect1>
 
@@ -38,8 +37,8 @@
       <para>
        The callback function to call to check each element. The first parameter
        contains the value, the second parameter contains the corresponding key.
-       If this function returns &true;, the value is returned from
-       <function>array_find</function> and the callback will not be called for
+       If this function returns &false;, &false; is returned from
+       <function>array_all</function> and the callback will not be called for
        further elements.
       </para>
      </listitem>
@@ -51,9 +50,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The function returns the value of the first element for which the
-   <parameter>callback</parameter> returns &true;. If no matching element is
-   found the function returns &null;.
+   The function returns &true;, if <parameter>callback</parameter> returns
+   &true; for all elements. Otherwise the function returns &false;.
   </para>
  </refsect1>
 
@@ -61,7 +59,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title><function>array_find</function> example</title>
+    <title><function>array_all</function> example</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -74,24 +72,19 @@ $array = [
     'f' => 'elephant'
 ];
 
-// Find the first animal with a name longer than 4 characters.
-var_dump(array_find($array, function (string $value) {
-    return strlen($value) > 4;
+// Check, if all animal names are shorter than 12 letters.
+var_dump(array_all($array, function (string $value) {
+    return strlen($value) < 12;
 }));
 
-// Find the first animal whose name begins with f.
-var_dump(array_find($array, function (string $value) {
-    return str_starts_with($value, 'f');
+// Check, if all animal names are longer than 5 letters.
+var_dump(array_all($array, function (string $value) {
+    return strlen($value) > 5;
 }));
 
-// Find the first animal where the array key is the first symbol of the animal.
-var_dump(array_find($array, function (string $value, $key) {
-   return $value[0] === $key;
-}));
-
-// Find the first animal where the array key matching a RegEx.
-var_dump(array_find($array, function ($value, $key) {
-   return preg_match('/^([a-f])$/', $key);
+// Check, if all array keys are strings.
+var_dump(array_all($array, function (string $value, $key) {
+   return is_string($key);
 }));
 ?>
 ]]>
@@ -101,10 +94,9 @@ var_dump(array_find($array, function ($value, $key) {
     </para>
     <screen>
 <![CDATA[
-string(5) "goose"
-NULL
-string(3) "cow"
-string(3) "dog"
+bool(true)
+bool(false)
+bool(true)
 ]]>
     </screen>
    </example>
@@ -115,11 +107,10 @@ string(3) "dog"
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>array_find_key</function></member>
-    <member><function>array_all</function></member>
     <member><function>array_any</function></member>
     <member><function>array_filter</function></member>
-    <member><function>array_reduce</function></member>
+    <member><function>array_find</function></member>
+    <member><function>array_find_key</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/array/functions/array-all.xml
+++ b/reference/array/functions/array-all.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.array-all" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_all</refname>
-  <refpurpose>Returns &true;, if a callback returns &true; for all elements in an array.</refpurpose>
+  <refpurpose>Checks if all &array; elements satisfy a callback function</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -22,42 +22,40 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>array</parameter></term>
-     <listitem>
-      <para>
-       The &array; that should be searched.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>callback</parameter></term>
-     <listitem>
-      <para>
-       The callback function to call to check each element, which must be
-       <methodsynopsis>
-        <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
-        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
-        <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
-       </methodsynopsis>
-       If this function returns &false;, &false; is returned from
-       <function>array_all</function> and the callback will not be called for
-       further elements.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>array</parameter></term>
+    <listitem>
+     <simpara>
+      The &array; that should be searched.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     <para>
+      The callback function to call to check each element, which must be
+      <methodsynopsis>
+       <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+      </methodsynopsis>
+      If this function returns &false;, &false; is returned from
+      <function>array_all</function> and the callback will not be called for
+      further elements.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The function returns &true;, if <parameter>callback</parameter> returns
    &true; for all elements. Otherwise the function returns &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -93,9 +91,7 @@ var_dump(array_all($array, function (string $value, $key) {
 ?>
 ]]>
    </programlisting>
-   <para>
-    The above example will output:
-   </para>
+   &example.outputs;
    <screen>
 <![CDATA[
 bool(true)
@@ -108,14 +104,12 @@ bool(true)
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>array_any</function></member>
-    <member><function>array_filter</function></member>
-    <member><function>array_find</function></member>
-    <member><function>array_find_key</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>array_any</function></member>
+   <member><function>array_filter</function></member>
+   <member><function>array_find</function></member>
+   <member><function>array_find_key</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/array/functions/array-all.xml
+++ b/reference/array/functions/array-all.xml
@@ -14,8 +14,9 @@
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>array_all</function> returns &true;, if the given $callback returns
-   &true; for all elements. Otherwise the function returns &false;.
+   <function>array_all</function> returns &true;, if the given
+   <parameter>callback</parameter> returns &true; for all elements. Otherwise
+   the function returns &false;.
   </para>
  </refsect1>
 
@@ -35,8 +36,12 @@
      <term><parameter>callback</parameter></term>
      <listitem>
       <para>
-       The callback function to call to check each element. The first parameter
-       contains the value, the second parameter contains the corresponding key.
+       The callback function to call to check each element, which must be
+       <methodsynopsis>
+        <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
+        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+        <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+       </methodsynopsis>
        If this function returns &false;, &false; is returned from
        <function>array_all</function> and the callback will not be called for
        further elements.

--- a/reference/array/functions/array-all.xml
+++ b/reference/array/functions/array-all.xml
@@ -62,10 +62,9 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title><function>array_all</function> example</title>
-    <programlisting role="php">
+  <example>
+   <title><function>array_all</function> example</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $array = [
@@ -93,19 +92,18 @@ var_dump(array_all($array, function (string $value, $key) {
 }));
 ?>
 ]]>
-    </programlisting>
-    <para>
-     The above example will output:
-    </para>
-    <screen>
+   </programlisting>
+   <para>
+    The above example will output:
+   </para>
+   <screen>
 <![CDATA[
 bool(true)
 bool(false)
 bool(true)
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/array/functions/array-all.xml
+++ b/reference/array/functions/array-all.xml
@@ -15,8 +15,8 @@
   </methodsynopsis>
   <simpara>
    <function>array_all</function> returns &true;, if the given
-   <parameter>callback</parameter> returns &true; for all elements. Otherwise
-   the function returns &false;.
+   <parameter>callback</parameter> returns &true; for all elements.
+   Otherwise the function returns &false;.
   </simpara>
  </refsect1>
 

--- a/reference/array/functions/array-any.xml
+++ b/reference/array/functions/array-any.xml
@@ -108,6 +108,7 @@ bool(false)
   &reftitle.seealso;
   <para>
    <simplelist>
+    <member><function>array_all</function></member>
     <member><function>array_filter</function></member>
     <member><function>array_find</function></member>
     <member><function>array_find_key</function></member>

--- a/reference/array/functions/array-any.xml
+++ b/reference/array/functions/array-any.xml
@@ -63,10 +63,9 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title><function>array_any</function> example</title>
-    <programlisting role="php">
+  <example>
+   <title><function>array_any</function> example</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $array = [
@@ -94,19 +93,18 @@ var_dump(array_any($array, function (string $value, $key) {
 }));
 ?>
 ]]>
-    </programlisting>
-    <para>
-     The above example will output:
-    </para>
-    <screen>
+   </programlisting>
+   <para>
+    The above example will output:
+   </para>
+   <screen>
 <![CDATA[
 bool(true)
 bool(false)
 bool(false)
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/array/functions/array-any.xml
+++ b/reference/array/functions/array-any.xml
@@ -15,8 +15,8 @@
   </methodsynopsis>
   <simpara>
    <function>array_any</function> returns &true;, if the given
-   <parameter>callback</parameter> returns &true; for any element. Otherwise the
-   function returns &false;.
+   <parameter>callback</parameter> returns &true; for any element.
+   Otherwise the function returns &false;.
   </simpara>
  </refsect1>
 

--- a/reference/array/functions/array-any.xml
+++ b/reference/array/functions/array-any.xml
@@ -14,8 +14,9 @@
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>array_any</function> returns &true;, if the given $callback returns
-   &true; for any element. Otherwise the function returns &false;.
+   <function>array_any</function> returns &true;, if the given
+   <parameter>callback</parameter> returns &true; for any element. Otherwise the
+   function returns &false;.
   </para>
  </refsect1>
 
@@ -35,8 +36,12 @@
      <term><parameter>callback</parameter></term>
      <listitem>
       <para>
-       The callback function to call to check each element. The first parameter
-       contains the value, the second parameter contains the corresponding key.
+       The callback function to call to check each element, which must be
+       <methodsynopsis>
+        <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
+        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+        <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+       </methodsynopsis>
        If this function returns &true;, &true; is returned from
        <function>array_any</function> and the callback will not be called for
        further elements.

--- a/reference/array/functions/array-any.xml
+++ b/reference/array/functions/array-any.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.array-any" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_any</refname>
-  <refpurpose>Returns &true;, if a callback returns &true; for any element in an array.</refpurpose>
+  <refpurpose>Checks if at least one &array; element satisfies a callback function</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -22,43 +22,41 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>array</parameter></term>
-     <listitem>
-      <para>
-       The &array; that should be searched.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>callback</parameter></term>
-     <listitem>
-      <para>
-       The callback function to call to check each element, which must be
-       <methodsynopsis>
-        <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
-        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
-        <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
-       </methodsynopsis>
-       If this function returns &true;, &true; is returned from
-       <function>array_any</function> and the callback will not be called for
-       further elements.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>array</parameter></term>
+    <listitem>
+     <simpara>
+      The &array; that should be searched.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     <para>
+      The callback function to call to check each element, which must be
+      <methodsynopsis>
+       <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+      </methodsynopsis>
+      If this function returns &true;, &true; is returned from
+      <function>array_any</function> and the callback will not be called for
+      further elements.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The function returns &true;, if there is at least one element for which
    <parameter>callback</parameter> returns &true;. Otherwise the function
    returns &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -94,9 +92,7 @@ var_dump(array_any($array, function (string $value, $key) {
 ?>
 ]]>
    </programlisting>
-   <para>
-    The above example will output:
-   </para>
+   &example.outputs;
    <screen>
 <![CDATA[
 bool(true)
@@ -109,14 +105,12 @@ bool(false)
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>array_all</function></member>
-    <member><function>array_filter</function></member>
-    <member><function>array_find</function></member>
-    <member><function>array_find_key</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>array_all</function></member>
+   <member><function>array_filter</function></member>
+   <member><function>array_find</function></member>
+   <member><function>array_find_key</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/array/functions/array-any.xml
+++ b/reference/array/functions/array-any.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.array-any" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>array_any</refname>
+  <refpurpose>Returns &true;, if a callback returns &true; for any element in an array.</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>mixed</type><methodname>array_any</methodname>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>array_any</function> returns &true;, if the given $callback returns
+   &true; for any element. Otherwise the function returns &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>array</parameter></term>
+     <listitem>
+      <para>
+       The &array; that should be searched.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>callback</parameter></term>
+     <listitem>
+      <para>
+       The callback function to call to check each element. The first parameter
+       contains the value, the second parameter contains the corresponding key.
+       If this function returns &true;, &true; is returned from
+       <function>array_any</function> and the callback will not be called for
+       further elements.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   The function returns &true;, if there is at least one element for which
+   <parameter>callback</parameter> returns &true;. Otherwise the function
+   returns &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>array_any</function> example</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$array = [
+    'a' => 'dog',
+    'b' => 'cat',
+    'c' => 'cow',
+    'd' => 'duck',
+    'e' => 'goose',
+    'f' => 'elephant'
+];
+
+// Check, if any animal name is longer than 5 letters.
+var_dump(array_any($array, function (string $value) {
+    return strlen($value) > 5;
+}));
+
+// Check, if any animal name is shorter than 3 letters.
+var_dump(array_any($array, function (string $value) {
+    return strlen($value) < 3;
+}));
+
+// Check, if any array key is not a string.
+var_dump(array_any($array, function (string $value, $key) {
+   return !is_string($key);
+}));
+?>
+]]>
+    </programlisting>
+    <para>
+     The above example will output:
+    </para>
+    <screen>
+<![CDATA[
+bool(true)
+bool(false)
+bool(false)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>array_filter</function></member>
+    <member><function>array_find</function></member>
+    <member><function>array_find_key</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/array/functions/array-any.xml
+++ b/reference/array/functions/array-any.xml
@@ -13,11 +13,11 @@
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>array_any</function> returns &true;, if the given
    <parameter>callback</parameter> returns &true; for any element. Otherwise the
    function returns &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/array/functions/array-filter.xml
+++ b/reference/array/functions/array-filter.xml
@@ -253,10 +253,10 @@ array(2) {
   <para>
    <simplelist>
     <member><function>array_intersect</function></member>
+    <member><function>array_find</function></member>
     <member><function>array_any</function></member>
     <member><function>array_map</function></member>
     <member><function>array_reduce</function></member>
-    <member><function>array_walk</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/array/functions/array-filter.xml
+++ b/reference/array/functions/array-filter.xml
@@ -5,7 +5,7 @@
   <refname>array_filter</refname>
   <refpurpose>Filters elements of an array using a callback function</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -201,7 +201,7 @@ Array
     </screen>
    </example>
    <example>
-    <title><function>array_filter</function> with 
+    <title><function>array_filter</function> with
     <parameter>mode</parameter></title>
     <programlisting role="php">
 <![CDATA[
@@ -253,6 +253,7 @@ array(2) {
   <para>
    <simplelist>
     <member><function>array_intersect</function></member>
+    <member><function>array_any</function></member>
     <member><function>array_map</function></member>
     <member><function>array_reduce</function></member>
     <member><function>array_walk</function></member>

--- a/reference/array/functions/array-find-key.xml
+++ b/reference/array/functions/array-find-key.xml
@@ -63,9 +63,9 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-    <title><function>array_find_key</function> example</title>
-    <programlisting role="php">
+  <example>
+   <title><function>array_find_key</function> example</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $array = [
@@ -98,19 +98,19 @@ var_dump(array_find_key($array, function ($value, $key) {
 }));
 ?>
 ]]>
-    </programlisting>
-    <para>
-     The above example will output:
-    </para>
-    <screen>
+   </programlisting>
+   <para>
+    The above example will output:
+   </para>
+   <screen>
 <![CDATA[
 string(1) "e"
 NULL
 string(1) "c"
 string(1) "a"
 ]]>
-    </screen>
-  </para>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/array/functions/array-find-key.xml
+++ b/reference/array/functions/array-find-key.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.array-find-key" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_find_key</refname>
-  <refpurpose>Returns the key of the first element of an &array; for which a callback returns &true;.</refpurpose>
+  <refpurpose>Returns the key of the first element satisfying a callback function</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,52 +13,50 @@
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>array_find_key</function> returns the key of the first element of an
    &array; for which the given <parameter>callback</parameter> returns &true;.
    If no matching element is found the function returns &null;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>array</parameter></term>
-     <listitem>
-      <para>
-       The &array; that should be searched.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>callback</parameter></term>
-     <listitem>
-      <para>
-       The callback function to call to check each element, which must be
-       <methodsynopsis>
-        <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
-        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
-        <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
-       </methodsynopsis>
-       If this function returns &true;, the key is returned from
-       <function>array_find_key</function> and the callback will not be called
-       for further elements.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>array</parameter></term>
+    <listitem>
+     <simpara>
+      The &array; that should be searched.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     <para>
+      The callback function to call to check each element, which must be
+      <methodsynopsis>
+       <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+      </methodsynopsis>
+      If this function returns &true;, the key is returned from
+      <function>array_find_key</function> and the callback will not be called
+      for further elements.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The function returns the key of the first element for which the
    <parameter>callback</parameter> returns &true;. If no matching element is
    found the function returns &null;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -99,9 +97,7 @@ var_dump(array_find_key($array, function ($value, $key) {
 ?>
 ]]>
    </programlisting>
-   <para>
-    The above example will output:
-   </para>
+   &example.outputs;
    <screen>
 <![CDATA[
 string(1) "e"
@@ -115,15 +111,13 @@ string(1) "a"
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>array_find</function></member>
-    <member><function>array_all</function></member>
-    <member><function>array_any</function></member>
-    <member><function>array_filter</function></member>
-    <member><function>array_reduce</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>array_find</function></member>
+   <member><function>array_all</function></member>
+   <member><function>array_any</function></member>
+   <member><function>array_filter</function></member>
+   <member><function>array_reduce</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/array/functions/array-find-key.xml
+++ b/reference/array/functions/array-find-key.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="function.array-find" xmlns="http://docbook.org/ns/docbook">
+<refentry xml:id="function.array-find-key" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
-  <refname>array_find</refname>
-  <refpurpose>Returns the value of the first element of an &array; for which a callback returns &true;.</refpurpose>
+  <refname>array_find_key</refname>
+  <refpurpose>Returns the key of the first element of an &array; for which a callback returns &true;.</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>mixed</type><methodname>array_find</methodname>
+   <type>mixed</type><methodname>array_find_key</methodname>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>array_find</function> returns the value of the first element of an
+   <function>array_find_key</function> returns the key of the first element of an
    &array; for which the given callback returns &true;. If no matching element
    is found the function returns &null;.
   </para>
@@ -38,9 +38,9 @@
       <para>
        The callback function to call to check each element. The first parameter
        contains the value, the second parameter contains the corresponding key.
-       If this function returns &true;, the value is returned from
-       <function>array_find</function> and the callback will not be called for
-       further elements.
+       If this function returns &true;, the key is returned from
+       <function>array_find_key</function> and the callback will not be called
+       for further elements.
       </para>
      </listitem>
     </varlistentry>
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The function returns the value of the first element for which the
+   The function returns the key of the first element for which the
    <parameter>callback</parameter> returns &true;. If no matching element is
    found the function returns &null;.
   </para>
@@ -61,7 +61,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title><function>array_find</function> example</title>
+    <title><function>array_find_key</function> example</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -75,22 +75,22 @@ $array = [
 ];
 
 // Find the first animal with a name longer than 4 characters.
-var_dump(array_find($array, function (string $value) {
+var_dump(array_find_key($array, function (string $value) {
     return strlen($value) > 4;
 }));
 
 // Find the first animal whose name begins with f.
-var_dump(array_find($array, function (string $value) {
+var_dump(array_find_key($array, function (string $value) {
     return str_starts_with($value, 'f');
 }));
 
 // Find the first animal where the array key is the first symbol of the animal.
-var_dump(array_find($array, function (string $value, $key) {
+var_dump(array_find_key($array, function (string $value, $key) {
    return $value[0] === $key;
 }));
 
 // Find the first animal where the array key matching a RegEx.
-var_dump(array_find($array, function ($value, $key) {
+var_dump(array_find_key($array, function ($value, $key) {
    return preg_match('/^([a-f])$/', $key);
 }));
 ?>
@@ -101,10 +101,10 @@ var_dump(array_find($array, function ($value, $key) {
     </para>
     <screen>
 <![CDATA[
-string(5) "goose"
+string(1) "e"
 NULL
-string(3) "cow"
-string(3) "dog"
+string(1) "c"
+string(1) "a"
 ]]>
     </screen>
    </example>
@@ -115,7 +115,7 @@ string(3) "dog"
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>array_find_key</function></member>
+    <member><function>array_find</function></member>
     <member><function>array_filter</function></member>
     <member><function>array_reduce</function></member>
    </simplelist>

--- a/reference/array/functions/array-find-key.xml
+++ b/reference/array/functions/array-find-key.xml
@@ -116,6 +116,8 @@ string(1) "a"
   <para>
    <simplelist>
     <member><function>array_find</function></member>
+    <member><function>array_all</function></member>
+    <member><function>array_any</function></member>
     <member><function>array_filter</function></member>
     <member><function>array_reduce</function></member>
    </simplelist>

--- a/reference/array/functions/array-find-key.xml
+++ b/reference/array/functions/array-find-key.xml
@@ -15,8 +15,8 @@
   </methodsynopsis>
   <para>
    <function>array_find_key</function> returns the key of the first element of an
-   &array; for which the given callback returns &true;. If no matching element
-   is found the function returns &null;.
+   &array; for which the given <parameter>callback</parameter> returns &true;.
+   If no matching element is found the function returns &null;.
   </para>
  </refsect1>
 
@@ -36,8 +36,12 @@
      <term><parameter>callback</parameter></term>
      <listitem>
       <para>
-       The callback function to call to check each element. The first parameter
-       contains the value, the second parameter contains the corresponding key.
+       The callback function to call to check each element, which must be
+       <methodsynopsis>
+        <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
+        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+        <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+       </methodsynopsis>
        If this function returns &true;, the key is returned from
        <function>array_find_key</function> and the callback will not be called
        for further elements.
@@ -60,7 +64,6 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-   <example>
     <title><function>array_find_key</function> example</title>
     <programlisting role="php">
 <![CDATA[
@@ -107,7 +110,6 @@ string(1) "c"
 string(1) "a"
 ]]>
     </screen>
-   </example>
   </para>
  </refsect1>
 

--- a/reference/array/functions/array-find.xml
+++ b/reference/array/functions/array-find.xml
@@ -13,11 +13,11 @@
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>array_find</function> returns the value of the first element of an
    &array; for which the given <parameter>callback</parameter> returns &true;.
    If no matching element is found the function returns &null;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/array/functions/array-find.xml
+++ b/reference/array/functions/array-find.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.array-find" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>array_find</refname>
+  <refpurpose>Returns the value of the first element of an &array; for which a callback returns &true;.</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>mixed</type><methodname>array_find</methodname>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>array_find</function> returns the value of the first element of an
+   &array; for which the given callback returns &true;. If no matching element
+   is found the function returns &null;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>array</parameter></term>
+     <listitem>
+      <para>
+       The &array; that should be searched.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>callback</parameter></term>
+     <listitem>
+      <para>
+       The callback function to call to check each element. The first parameter
+       contains the value, the second parameter contains the corresponding key.
+       If this function returns &true;, the value is returned from
+       <function>array_find</function> and the callback will not be called for
+       further elements.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   The function returns the value of the first element for which the
+   <parameter>callback</parameter> returns &true;. If no matching element is
+   found the function returns &null;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>array_find</function> example</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$array = [
+    'a' => 'dog',
+    'b' => 'cat',
+    'c' => 'cow',
+    'd' => 'duck',
+    'e' => 'goose',
+    'f' => 'elephant'
+];
+
+// Find the first animal with a name longer than 4 characters.
+var_dump(array_find($array, function (string $value) {
+    return strlen($value) > 4;
+}));
+
+// Find the first animal whose name begins with f.
+var_dump(array_find($array, function (string $value) {
+    return str_starts_with($value, 'f');
+}));
+
+// Find the first animal where the array key is the first symbol of the animal.
+var_dump(array_find($array, function (string $value, $key) {
+   return $value[0] === $key;
+}));
+
+// Find the first animal where the array key matching a RegEx.
+var_dump(array_find($array, function ($value, $key) {
+   return preg_match('/^([a-f])$/', $key);
+}));
+?>
+]]>
+    </programlisting>
+    <para>
+     The above example will output:
+    </para>
+    <screen>
+<![CDATA[
+string(5) "goose"
+NULL
+string(3) "cow"
+string(3) "dog"
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>array_filter</function></member>
+    <member><function>array_reduce</function></member>
+    <!-- @TODO: Add `array_find_key` -->
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/array/functions/array-find.xml
+++ b/reference/array/functions/array-find.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.array-find" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_find</refname>
-  <refpurpose>Returns the value of the first element of an &array; for which a callback returns &true;.</refpurpose>
+  <refpurpose>Returns the first element satisfying a callback function</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -22,43 +22,41 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>array</parameter></term>
-     <listitem>
-      <para>
-       The &array; that should be searched.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>callback</parameter></term>
-     <listitem>
-      <para>
-       The callback function to call to check each element, which must be
-       <methodsynopsis>
-        <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
-        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
-        <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
-       </methodsynopsis>
-       If this function returns &true;, the value is returned from
-       <function>array_find</function> and the callback will not be called for
-       further elements.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>array</parameter></term>
+    <listitem>
+     <simpara>
+      The &array; that should be searched.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     <para>
+      The callback function to call to check each element, which must be
+      <methodsynopsis>
+       <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+      </methodsynopsis>
+      If this function returns &true;, the value is returned from
+      <function>array_find</function> and the callback will not be called for
+      further elements.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The function returns the value of the first element for which the
    <parameter>callback</parameter> returns &true;. If no matching element is
    found the function returns &null;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -99,9 +97,7 @@ var_dump(array_find($array, function ($value, $key) {
 ?>
 ]]>
    </programlisting>
-   <para>
-    The above example will output:
-   </para>
+   &example.outputs;
    <screen>
 <![CDATA[
 string(5) "goose"
@@ -115,15 +111,13 @@ string(3) "dog"
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>array_find_key</function></member>
-    <member><function>array_all</function></member>
-    <member><function>array_any</function></member>
-    <member><function>array_filter</function></member>
-    <member><function>array_reduce</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>array_find_key</function></member>
+   <member><function>array_all</function></member>
+   <member><function>array_any</function></member>
+   <member><function>array_filter</function></member>
+   <member><function>array_reduce</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/array/functions/array-find.xml
+++ b/reference/array/functions/array-find.xml
@@ -15,8 +15,8 @@
   </methodsynopsis>
   <para>
    <function>array_find</function> returns the value of the first element of an
-   &array; for which the given callback returns &true;. If no matching element
-   is found the function returns &null;.
+   &array; for which the given <parameter>callback</parameter> returns &true;.
+   If no matching element is found the function returns &null;.
   </para>
  </refsect1>
 
@@ -36,8 +36,12 @@
      <term><parameter>callback</parameter></term>
      <listitem>
       <para>
-       The callback function to call to check each element. The first parameter
-       contains the value, the second parameter contains the corresponding key.
+       The callback function to call to check each element, which must be
+       <methodsynopsis>
+        <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
+        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+        <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+       </methodsynopsis>
        If this function returns &true;, the value is returned from
        <function>array_find</function> and the callback will not be called for
        further elements.

--- a/reference/array/functions/array-find.xml
+++ b/reference/array/functions/array-find.xml
@@ -63,10 +63,9 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title><function>array_find</function> example</title>
-    <programlisting role="php">
+  <example>
+   <title><function>array_find</function> example</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $array = [
@@ -99,20 +98,19 @@ var_dump(array_find($array, function ($value, $key) {
 }));
 ?>
 ]]>
-    </programlisting>
-    <para>
-     The above example will output:
-    </para>
-    <screen>
+   </programlisting>
+   <para>
+    The above example will output:
+   </para>
+   <screen>
 <![CDATA[
 string(5) "goose"
 NULL
 string(3) "cow"
 string(3) "dog"
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/array/versions.xml
+++ b/reference/array/versions.xml
@@ -5,6 +5,7 @@
 -->
 <versions>
  <function name='array' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_all' from='PHP 8 &gt;= 8.4.0'/>
  <function name='array_any' from='PHP 8 &gt;= 8.4.0'/>
  <function name='array_change_key_case' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8'/>
  <function name='array_chunk' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8'/>

--- a/reference/array/versions.xml
+++ b/reference/array/versions.xml
@@ -18,6 +18,7 @@
  <function name='array_fill' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8'/>
  <function name='array_fill_keys' from='PHP 5 &gt;= 5.2.0, PHP 7, PHP 8'/>
  <function name='array_filter' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_find' from='PHP 8 &gt;= 8.4.0'/>
  <function name='array_flip' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
  <function name='array_intersect' from='PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8'/>
  <function name='array_intersect_assoc' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8'/>

--- a/reference/array/versions.xml
+++ b/reference/array/versions.xml
@@ -19,6 +19,7 @@
  <function name='array_fill_keys' from='PHP 5 &gt;= 5.2.0, PHP 7, PHP 8'/>
  <function name='array_filter' from='PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8'/>
  <function name='array_find' from='PHP 8 &gt;= 8.4.0'/>
+ <function name='array_find_key' from='PHP 8 &gt;= 8.4.0'/>
  <function name='array_flip' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
  <function name='array_intersect' from='PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8'/>
  <function name='array_intersect_assoc' from='PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8'/>

--- a/reference/array/versions.xml
+++ b/reference/array/versions.xml
@@ -5,6 +5,7 @@
 -->
 <versions>
  <function name='array' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
+ <function name='array_any' from='PHP 8 &gt;= 8.4.0'/>
  <function name='array_change_key_case' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8'/>
  <function name='array_chunk' from='PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8'/>
  <function name='array_column' from='PHP 5 &gt;= 5.5.0, PHP 7, PHP 8'/>


### PR DESCRIPTION
This pull request adds the documentation for the [array_find RFC](https://wiki.php.net/rfc/array_find) which introduced the methods `array_find`, `array_find_key`, `array_all` and `array_any`. 