### PR TITLE
Add authors and editors from front page to list

### DIFF
--- a/contributors.xml
+++ b/contributors.xml
@@ -13,7 +13,7 @@
 
  <section>
   <info><title>&Credit.Authors.and.Editors;</title></info>
-  
+
   <para>
    &Credit.Past.Authors.Text;
    Bill Abt,                <!-- pdo howto via ibm -->
@@ -66,7 +66,7 @@
    Jeroen van Wolffelaar&listendand;  <!-- jeroen -->
    Andrei Zmievski.         <!-- andrei -->
   </para>
-  
+
   <para>
    &Credit.Past.Editors.Text;
    Stig Bakken,                    <!-- ssb -->
@@ -76,10 +76,10 @@
    Egon Schmid.                    <!-- eschmid -->
   </para>
  </section>
- 
+
  <section>
   <info><title>&Credit.Note.Editors.Title;</title></info>
- 
+
   <para>
    &Credit.Note.Editors.Active;
    Daniel Brown,                <!-- danbrown -->
@@ -88,7 +88,7 @@
    Thiago Pojda&listendand;     <!-- thiago -->
    Maciek Sokolewicz.           <!-- tularis -->
   </para>
- 
+
   <para>
    &Credit.Note.Editors.Inactive;
    Mehdi Achour,           <!-- didou -->
@@ -127,13 +127,13 @@
    Jakub Vrana,            <!-- vrana -->
    Lars Torben Wilson,     <!-- torben -->
    Jim Winstead,           <!-- jimw -->
-   Jared Wyles&listendand; <!-- rioter --> 
+   Jared Wyles&listendand; <!-- rioter -->
    Jeroen van Wolffelaar.  <!-- jeroen -->
   </para>
  </section>
 
 </section>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/contributors.xml
+++ b/contributors.xml
@@ -30,6 +30,7 @@
    John Coggeshall,         <!-- john -->
    Simone Cortesi,          <!-- cortesi -->
    Peter Cowburn,           <!-- salathe -->
+   Antony Dovgal,
    Daniel Egeberg,          <!-- degeberg -->
    Markus Fischer,          <!-- mfischer -->
    Wez Furlong,             <!-- wez -->
@@ -52,6 +53,7 @@
    Richard Quadling,        <!-- rquadling -->
    Derick Rethans,          <!-- derick -->
    Rob Richards,            <!-- rrichards -->
+   Georg Richter,
    Sander Roobol,           <!-- sander -->
    Egon Schmid,             <!-- eschmid -->
    Thomas Schoefbeck,       <!-- tom -->


### PR DESCRIPTION
This PR adds two contributors from the [frontpage](https://www.php.net/manual/en/) of the docs to the [contributors list](https://www.php.net/manual/en/preface.php#contributors).