### PR TITLE
Add links to INI_* constants

### DIFF
--- a/install/ini.xml
+++ b/install/ini.xml
@@ -262,6 +262,14 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
 
   <para>
    <variablelist>
+<!--
+Replace everything inside the <variablelist> element with an <xi:include>
+once libxml2 gets XInclude 1.1 attribute copying support.
+The below <xi:include> will include the appropriate elements
+but needs all top-level xml:id's removed (see XInclude 1.1 set-xml-id).
+
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('constant.ini-mode')/*)"><xi:fallback/></xi:include>
+-->
     <title>INI mode constants</title>
     <varlistentry>
      <term>

--- a/install/ini.xml
+++ b/install/ini.xml
@@ -262,7 +262,53 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
 
   <para>
    <variablelist>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('constant.ini-mode')/*)"><xi:fallback/></xi:include>
+    <title>INI mode constants</title>
+    <varlistentry>
+     <term>
+      <constant>INI_USER</constant>
+      (<type>int</type>)
+     </term>
+     <listitem>
+      <simpara>
+       Entry can be set in user scripts (like with <function xmlns="http://docbook.org/ns/docbook">ini_set</function>)
+       or in the <link xmlns="http://docbook.org/ns/docbook" linkend="configuration.changes.windows">Windows registry</link>.
+       Entry can be set in &user-ini;
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>
+      <constant>INI_PERDIR</constant>
+      (<type>int</type>)
+     </term>
+     <listitem>
+      <simpara>
+       Entry can be set in &php.ini;, &htaccess;, &httpd.conf; or &user-ini;
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>
+      <constant>INI_SYSTEM</constant>
+      (<type>int</type>)
+     </term>
+     <listitem>
+      <simpara>
+       Entry can be set in &php.ini; or &httpd.conf;
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>
+      <constant>INI_ALL</constant>
+      (<type>int</type>)
+     </term>
+     <listitem>
+      <simpara>
+       Entry can be set anywhere
+      </simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
  </sect1>

--- a/reference/info/constants.xml
+++ b/reference/info/constants.xml
@@ -201,7 +201,7 @@
 
  <variablelist xml:id="constant.ini-mode" role="constant_list">
   <title>INI mode constants</title>
-  <varlistentry>
+  <varlistentry xml:id="constant.ini-user">
    <term>
     <constant>INI_USER</constant>
     (<type>int</type>)
@@ -214,7 +214,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.ini-perdir">
    <term>
     <constant>INI_PERDIR</constant>
     (<type>int</type>)
@@ -225,7 +225,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.ini-system">
    <term>
     <constant>INI_SYSTEM</constant>
     (<type>int</type>)
@@ -236,7 +236,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.ini-all">
    <term>
     <constant>INI_ALL</constant>
     (<type>int</type>)


### PR DESCRIPTION
Replace XInclude'd variablelist with a duplicate which does not have any IDs for the constants. Add IDs to the variablelist on the constant page.