### PR TITLE
Clean up “See Also” for `hash*()`

### DIFF
--- a/reference/hash/functions/hash-algos.xml
+++ b/reference/hash/functions/hash-algos.xml
@@ -154,6 +154,7 @@ Array
  <refsect1 role="seealso"><!-- {{{ -->
   &reftitle.seealso;
   <simplelist>
+   <member><function>hash</function></member>
    <member><function>hash_hmac_algos</function></member>
   </simplelist>
  </refsect1><!-- }}} -->

--- a/reference/hash/functions/hash-file.xml
+++ b/reference/hash/functions/hash-file.xml
@@ -120,11 +120,8 @@ echo hash_file('sha256', 'example.txt');
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>hash</function></member>
+    <member><function>hash_init</function></member>
     <member><function>hash_hmac_file</function></member>
-    <member><function>hash_update_file</function></member>
-    <member><function>md5_file</function></member>
-    <member><function>sha1_file</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/hash/functions/hash-hmac-file.xml
+++ b/reference/hash/functions/hash-hmac-file.xml
@@ -134,9 +134,10 @@ echo hash_hmac_file('sha256', 'example.txt', 'secret');
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>hash_hmac_algos</function></member>
     <member><function>hash_hmac</function></member>
-    <member><function>hash_file</function></member>
+    <member><function>hash_hmac_algos</function></member>
+    <member><function>hash_init</function></member>
+    <member><function>hash_equals</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/hash/functions/hash-hmac.xml
+++ b/reference/hash/functions/hash-hmac.xml
@@ -131,9 +131,7 @@ echo hash_hmac('sha256', 'The quick brown fox jumped over the lazy dog.', 'secre
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>hash</function></member>
     <member><function>hash_hmac_algos</function></member>
-    <member><function>hash_init</function></member>
     <member><function>hash_hmac_file</function></member>
     <member><function>hash_equals</function></member>
    </simplelist>

--- a/reference/hash/functions/hash-init.xml
+++ b/reference/hash/functions/hash-init.xml
@@ -158,11 +158,11 @@ bool(true)
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>hash</function></member>
     <member><function>hash_algos</function></member>
-    <member><function>hash_file</function></member>
-    <member><function>hash_hmac</function></member>
-    <member><function>hash_hmac_file</function></member>
+    <member><function>hash_update</function></member>
+    <member><function>hash_update_file</function></member>
+    <member><function>hash_update_stream</function></member>
+    <member><function>hash_final</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/hash/functions/hash-update-file.xml
+++ b/reference/hash/functions/hash-update-file.xml
@@ -92,7 +92,6 @@
     <member><function>hash_update</function></member>
     <member><function>hash_update_stream</function></member>
     <member><function>hash_final</function></member>
-    <member><function>hash</function></member>
     <member><function>hash_file</function></member>
    </simplelist>
   </para>

--- a/reference/hash/functions/hash-update-stream.xml
+++ b/reference/hash/functions/hash-update-stream.xml
@@ -114,9 +114,8 @@ echo hash_final($ctx);
    <simplelist>
     <member><function>hash_init</function></member>
     <member><function>hash_update</function></member>
+    <member><function>hash_update_stream</function></member>
     <member><function>hash_final</function></member>
-    <member><function>hash</function></member>
-    <member><function>hash_file</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/hash/functions/hash.xml
+++ b/reference/hash/functions/hash.xml
@@ -123,11 +123,9 @@ echo hash('sha256', 'The quick brown fox jumped over the lazy dog.');
   &reftitle.seealso;
   <para>
    <simplelist>
+    <member><function>hash_init</function></member>
     <member><function>hash_file</function></member>
     <member><function>hash_hmac</function></member>
-    <member><function>hash_init</function></member>
-    <member><function>md5</function></member>
-    <member><function>sha1</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/strings/functions/md5-file.xml
+++ b/reference/strings/functions/md5-file.xml
@@ -76,9 +76,9 @@ echo 'MD5 file hash of ' . $file . ': ' . md5_file($file);
   &reftitle.seealso;
   <para>
    <simplelist>
+    <member><function>hash_file</function></member>
+    <member><function>hash_init</function></member>
     <member><function>md5</function></member>
-    <member><function>sha1_file</function></member>
-    <member><function>crc32</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/strings/functions/md5.xml
+++ b/reference/strings/functions/md5.xml
@@ -81,12 +81,7 @@ if (md5($str) === '1f3870be274f6c49b3e31a0c6728957f') {
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>md5_file</function></member>
-    <member><function>sha1_file</function></member>
-    <member><function>crc32</function></member>
-    <member><function>sha1</function></member>
     <member><function>hash</function></member>
-    <member><function>crypt</function></member>
     <member><function>password_hash</function></member>
    </simplelist>
   </para>

--- a/reference/strings/functions/sha1-file.xml
+++ b/reference/strings/functions/sha1-file.xml
@@ -80,9 +80,9 @@ foreach(glob('/home/Kalle/myproject/*.php') as $ent)
   &reftitle.seealso;
   <para>
    <simplelist>
+    <member><function>hash_file</function></member>
+    <member><function>hash_init</function></member>
     <member><function>sha1</function></member>
-    <member><function>md5_file</function></member>
-    <member><function>crc32</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/strings/functions/sha1.xml
+++ b/reference/strings/functions/sha1.xml
@@ -81,11 +81,7 @@ if (sha1($str) === 'd0be2dc421be4fcd0172e5afceea3970e2f3d940') {
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>sha1_file</function></member>
-    <member><function>crc32</function></member>
-    <member><function>md5</function></member>
     <member><function>hash</function></member>
-    <member><function>crypt</function></member>
     <member><function>password_hash</function></member>
    </simplelist>
   </para>


### PR DESCRIPTION
Specifically remove the `md5*()` and `sha1*()` references, but also shorten the lists in general: All hash functions are somewhat related, that does not mean that each should reference each other.

see https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_md5_sha1_md5_file_and_sha1_file
see php/doc-en#2822