### PR TITLE
fgets.xml: place each file line on new line by PHP_EOL

### DIFF
--- a/reference/filesystem/functions/fgets.xml
+++ b/reference/filesystem/functions/fgets.xml
@@ -63,16 +63,21 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+
 $fp = @fopen("/tmp/inputfile.txt", "r");
+
 if ($fp) {
     while (($buffer = fgets($fp, 4096)) !== false) {
-        echo $buffer;
+        echo $buffer, PHP_EOL;
     }
+
     if (!feof($fp)) {
         echo "Error: unexpected fgets() fail\n";
     }
+
     fclose($fp);
 }
+
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
In the test with multiline file, all lines of the file are outputed as one line. Let's add end-of-line symbol to the example ;-)