### PR TITLE
socket-getpeername.xml: remove excessive length of refpurpose

### DIFF
--- a/reference/sockets/functions/socket-getpeername.xml
+++ b/reference/sockets/functions/socket-getpeername.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.socket-getpeername" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>socket_getpeername</refname>
-  <refpurpose>Queries the remote side of the given socket which may either result in host/port or in a Unix filesystem path, dependent on its type</refpurpose>
+  <refpurpose>Queries the remote side of the given socket</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">


### PR DESCRIPTION
Or at least no longer than that, as example: `Queries the remote side of the given socket for a host/port or a file system path`