### PR TITLE
transports.xml: amend the link text

### DIFF
--- a/appendices/transports.xml
+++ b/appendices/transports.xml
@@ -8,7 +8,7 @@
   functions such as <function>fsockopen</function>, and
   <function>stream_socket_client</function>.  These transports do
   <emphasis>not</emphasis> apply to the 
-  <link linkend="ref.sockets">Sockets Extension</link>.
+  <link linkend="ref.sockets">Socket Functions</link> of the Sockets extension.
  </para>
 
  <para>


### PR DESCRIPTION
The link text talks about the `Sockets Extension`, and the actual link leads to the list of functions of the `Socket class` (of Sockets Extension).

If I haven't got confused myself yet, and I understand correctly that the Sockets extension contains a Socket class that defines a list of socket functions, then I think it would be useful to correct the link text and add the extension name after it