### PR TITLE
constants.xml: add constant description

### DIFF
--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -11,7 +11,7 @@
    </term>
    <listitem>
     <simpara>
-     
+     Socket address family of filesystem pathnames in the Unix Domain.
     </simpara>
    </listitem>
   </varlistentry>
@@ -22,7 +22,7 @@
    </term>
    <listitem>
     <simpara>
-     
+     Socket address family of IPv4 in the Internet Domain.
     </simpara>
    </listitem>
   </varlistentry>
@@ -33,7 +33,7 @@
    </term>
    <listitem>
     <simpara>
-     Only available if compiled with IPv6 support.
+     Socket address family of IPv6 in the Internet Domain. Only available if compiled with IPv6 support.
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
Can we add a few words about these constants? The [socket_getpeername()](https://www.php.net/manual/en/function.socket-getpeername.php) function page mentions these constants, but there is not a word about them in the documentation