### PR TITLE
Change the T_PAAMAYIM_NEKUDOTAYIM link text in tokens doc

### DIFF
--- a/appendices/tokens.xml
+++ b/appendices/tokens.xml
@@ -669,7 +669,7 @@ defined('T_FN') || define('T_FN', 10001);
     <row xml:id="constant.t-paamayim-nekudotayim">
      <entry><constant>T_PAAMAYIM_NEKUDOTAYIM</constant></entry>
      <entry>::</entry>
-     <entry><link linkend="language.oop5.paamayim-nekudotayim">::</link>. Also defined as
+     <entry><link linkend="language.oop5.paamayim-nekudotayim">scope resolution</link>. Also defined as
       <constant>T_DOUBLE_COLON</constant>.</entry>
     </row>
     <row xml:id="constant.t-plus-equal">


### PR DESCRIPTION
Original "::" is repetitive and difficult to see.

Changed to "scope resolution" for clarity.