### PR TITLE
Add missing mysqli constants

### DIFF
--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -36,6 +36,7 @@
      <simpara>
       Indicates to the server that the client can handle sandbox mode
       for expired passwords.
+      Can be used with <function>mysqli_options</function>.
      </simpara>
     </listitem>
    </varlistentry>
@@ -150,6 +151,7 @@
      <simpara>
       Indicates to the server that the client can handle sandbox mode
       for expired passwords.
+      Can be used with <function>mysqli_real_connect</function>.
      </simpara>
     </listitem>
    </varlistentry>
@@ -261,7 +263,9 @@
     </term>
     <listitem>
      <simpara>
-      Copy results from the internal <literal>mysqlnd</literal> buffer
+      As of PHP 8.1, this constants no longer has any effect.
+      Before PHP 8.1, this constant is used to copy results
+      from the internal <literal>mysqlnd</literal> buffer
       into the PHP variables fetched.
       By default, <literal>mysqlnd</literal> will use a reference logic
       to avoid copying and duplicating results held in memory.
@@ -804,28 +808,6 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.mysqli-no-data">
-    <term>
-     <constant>MYSQLI_NO_DATA</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <para>
-      No more data available for bind variable
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.mysqli-data-truncated">
-    <term>
-     <constant>MYSQLI_DATA_TRUNCATED</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <para>
-      Data truncation occurred. Available since MySQL 5.0.5.
-     </para>
-    </listitem>
-   </varlistentry>
    <varlistentry xml:id="constant.mysqli-enum-flag">
     <term>
      <constant>MYSQLI_ENUM_FLAG</constant>
@@ -928,17 +910,6 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.mysqli-set-charset-dir">
-    <term>
-     <constant>MYSQLI_SET_CHARSET_DIR</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      The path name to the directory that contains character set definition files.
-     </simpara>
-    </listitem>
-   </varlistentry>
    <varlistentry xml:id="constant.mysqli-report-index">
     <term>
      <constant>MYSQLI_REPORT_INDEX</constant>
@@ -1005,26 +976,6 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.mysqli-server-query-no-good-index-used">
-    <term>
-     <constant>MYSQLI_SERVER_QUERY_NO_GOOD_INDEX_USED</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <para>
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.mysqli-server-query-no-index-used">
-    <term>
-     <constant>MYSQLI_SERVER_QUERY_NO_INDEX_USED</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <para>
-     </para>
-    </listitem>
-   </varlistentry>
    <varlistentry xml:id="constant.mysqli-server-public-key">
     <term>
      <constant>MYSQLI_SERVER_PUBLIC_KEY</constant>
@@ -1033,29 +984,6 @@
     <listitem>
      <para>
      </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.mysqli-server-ps-out_params">
-    <term>
-     <constant>MYSQLI_SERVER_PS_OUT_PARAMS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Mark resultset containing output parameter values.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.mysqli-server-query-was_slow">
-    <term>
-     <constant>MYSQLI_SERVER_QUERY_WAS_SLOW</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     Last statement took more than the time value specified
-     in server variable <literal>long_query_time</literal>.
-     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.mysqli-refresh-grant">

--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -27,6 +27,31 @@
      </para>
     </listitem>
    </varlistentry>
+   <varlistentry xml:id="constant.mysqli-opt-can-handle_expired_passwords">
+    <term>
+     <constant>MYSQLI_OPT_CAN_HANDLE_EXPIRED_PASSWORDS</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Indicates to the server that the client can handle sandbox mode
+      for expired passwords.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mysqli-opt-load-data_local_dir">
+    <term>
+     <constant>MYSQLI_OPT_LOAD_DATA_LOCAL_DIR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      If enabled, this option specifies the directory
+      from which client-side <literal>LOCAL</literal> data loading is permitted
+      in <literal>LOAD DATA LOCAL</literal> statements.
+     </simpara>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="constant.mysqli-opt-connect-timeout">
     <term>
      <constant>MYSQLI_OPT_CONNECT_TIMEOUT</constant>
@@ -116,6 +141,40 @@
      </para>
     </listitem>
    </varlistentry>
+   <varlistentry xml:id="constant.mysqli-client-can-handle_expired_passwords">
+    <term>
+     <constant>MYSQLI_CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS</constant>
+    (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Indicates to the server that the client can handle sandbox mode
+      for expired passwords.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mysqli-client-found-rows">
+    <term>
+     <constant>MYSQLI_CLIENT_FOUND_ROWS</constant>
+    (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Return number of matched rows, not the number of affected rows.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mysqli-client-ssl-verify_server_cert">
+    <term>
+     <constant>MYSQLI_CLIENT_SSL_VERIFY_SERVER_CERT</constant>
+    (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Verify server certificate.
+     </simpara>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="constant.mysqli-client-ssl">
     <term>
      <constant>MYSQLI_CLIENT_SSL</constant>
@@ -193,6 +252,24 @@
      <para>
       For using buffered result sets. It has a value of <literal>0</literal>.
      </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mysqli-store-result-copy_data">
+    <term>
+     <constant>MYSQLI_STORE_RESULT_COPY_DATA</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Copy results from the internal <literal>mysqlnd</literal> buffer
+      into the PHP variables fetched.
+      By default, <literal>mysqlnd</literal> will use a reference logic
+      to avoid copying and duplicating results held in memory.
+      For certain result sets, for example, result sets with many small rows,
+      the copy approach can reduce the overall memory usage
+      because PHP variables holding results may be released earlier.
+      Available with <literal>mysqlnd</literal> only.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.mysqli-use-result">
@@ -381,6 +458,21 @@
      <para>
       Field is part of <literal>GROUP BY</literal>
      </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mysqli-no-default-value_flag">
+    <term>
+     <constant>MYSQLI_NO_DEFAULT_VALUE_FLAG</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A column has no <literal>DEFAULT</literal> clause in its definition.
+      This does not apply to <literal>NULL</literal>
+      or to <literal>AUTO_INCREMENT</literal> columns
+      because such columns have a default value of <literal>NULL</literal>
+      and an implied default value respectively.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.mysqli-type-decimal">
@@ -836,6 +928,17 @@
      </para>
     </listitem>
    </varlistentry>
+   <varlistentry xml:id="constant.mysqli-set-charset-dir">
+    <term>
+     <constant>MYSQLI_SET_CHARSET_DIR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      The path name to the directory that contains character set definition files.
+     </simpara>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="constant.mysqli-report-index">
     <term>
      <constant>MYSQLI_REPORT_INDEX</constant>
@@ -930,6 +1033,29 @@
     <listitem>
      <para>
      </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mysqli-server-ps-out_params">
+    <term>
+     <constant>MYSQLI_SERVER_PS_OUT_PARAMS</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Mark resultset containing output parameter values.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mysqli-server-query-was_slow">
+    <term>
+     <constant>MYSQLI_SERVER_QUERY_WAS_SLOW</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     Last statement took more than the time value specified
+     in server variable <literal>long_query_time</literal>.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.mysqli-refresh-grant">
@@ -1040,6 +1166,17 @@
      </para>
     </listitem>
    </varlistentry>
+   <varlistentry xml:id="constant.mysqli-refresh-backup-log">
+    <term>
+     <constant>MYSQLI_REFRESH_BACKUP_LOG</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Closes and reopens the backup log files.
+     </simpara>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="constant.mysqli-trans-cor-and-chain">
     <term>
      <constant>MYSQLI_TRANS_COR_AND_CHAIN</constant>
@@ -1113,11 +1250,10 @@
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.mysqli-trans-start-consistent-snapshot">
-    <term><constant>MYSQLI_TRANS_START_CONSISTENT_SNAPSHOT</constant></term>
+    <term><constant>MYSQLI_TRANS_START_WITH_CONSISTENT_SNAPSHOT</constant></term>
     <listitem>
      <para>
-      Start the transaction as "START TRANSACTION WITH CONSISTENT SNAPSHOT" with
-      <function>mysqli_begin_transaction</function>.
+      Start the transaction as "START TRANSACTION WITH CONSISTENT SNAPSHOT".
      </para>
     </listitem>
    </varlistentry>
@@ -1142,6 +1278,29 @@
       Whether the mysqli extension has been built against a MariaDB client library.
       Available as of PHP 8.1.2.
      </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mysqli-async">
+    <term>
+     <constant>MYSQLI_ASYNC</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      The query is performed asynchronously and no result set is immediately returned.
+      Available with <literal>mysqlnd</literal> only.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mysqli-on-update-now_flag">
+    <term>
+     <constant>MYSQLI_ON_UPDATE_NOW_FLAG</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      If a field is updated it will get the current time value.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>


### PR DESCRIPTION
Add missing mysqli constants.
Rename mistyped `MYSQLI_TRANS_START_CONSISTENT_SNAPSHOT` constant to `MYSQLI_TRANS_START_WITH_CONSISTENT_SNAPSHOT`.