### PR TITLE
Add LDAP constants

### DIFF
--- a/reference/ldap/constants.xml
+++ b/reference/ldap/constants.xml
@@ -998,6 +998,10 @@
    </term>
    <listitem>
     <simpara>
+     The peer certificate is requested.
+     If no certificate is provided, the session proceeds normally.
+     If a bad certificate is provided,
+     it will be ignored and the session proceeds normally.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1008,6 +1012,9 @@
    </term>
    <listitem>
     <simpara>
+     The peer certificate is requested.
+     If no certificate is provided, or a bad certificate is provided,
+     the session is immediately terminated.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1018,6 +1025,7 @@
    </term>
    <listitem>
     <simpara>
+     &Alias; <constant>LDAP_OPT_X_TLS_DEMAND</constant>.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1028,6 +1036,7 @@
    </term>
    <listitem>
     <simpara>
+     The peer certificate is not requested or checked.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1038,6 +1047,9 @@
    </term>
    <listitem>
     <simpara>
+     The peer certificate is requested.
+     If no certificate is provided, the session proceeds normally.
+     If a bad certificate is provided, the session is immediately terminated.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1049,6 +1061,7 @@
    </term>
    <listitem>
     <simpara>
+     Check the CRL for a whole certificate chain.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1059,6 +1072,7 @@
    </term>
    <listitem>
     <simpara>
+     No CRL checks are performed.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1069,6 +1083,7 @@
    </term>
    <listitem>
     <simpara>
+     Check the CRL of the peer certificate.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/ldap/constants.xml
+++ b/reference/ldap/constants.xml
@@ -803,6 +803,344 @@
     </simpara>
    </listitem>
   </varlistentry>
+
+  <varlistentry xml:id="constant.ldap-escape-dn">
+   <term>
+    <constant>LDAP_ESCAPE_DN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Escape a string for use in an LDAP DN.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-escape-filter">
+   <term>
+    <constant>LDAP_ESCAPE_FILTER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Escape a string for use in an LDAP filter.
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+  <varlistentry xml:id="constant.ldap-modify-batch-attrib">
+   <term>
+    <constant>LDAP_MODIFY_BATCH_ATTRIB</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The key of the modifications array containing the attributes:
+     <literal>attrib</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-modify-batch-modtype">
+   <term>
+    <constant>LDAP_MODIFY_BATCH_MODTYPE</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The key of the modifications array containing the type of modification:
+     <literal>modtype</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-modify-batch-values">
+   <term>
+    <constant>LDAP_MODIFY_BATCH_VALUES</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The key of the modifications array containing the values:
+     <literal>values</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+   <varlistentry xml:id="constant.ldap-modify-batch-add">
+   <term>
+    <constant>LDAP_MODIFY_BATCH_ADD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Add values to an attribute of an LDAP entry.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-modify-batch-remove">
+   <term>
+    <constant>LDAP_MODIFY_BATCH_REMOVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Remove values from an attribute of an LDAP entry.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-modify-batch-remove-all">
+   <term>
+    <constant>LDAP_MODIFY_BATCH_REMOVE_ALL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Remove all values from an attribute of an LDAP entry.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-modify-batch-replace">
+   <term>
+    <constant>LDAP_MODIFY_BATCH_REPLACE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Replace all current values of an LDAP entry attribute with the specified values.
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+  <varlistentry xml:id="constant.ldap-opt-timeout">
+   <term>
+    <constant>LDAP_OPT_TIMEOUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Specifies a timeout (in seconds) after which calls to synchronous LDAP APIs
+     will abort if no response is received.
+     Also controls the timeout when communicating with the KDC in case of SASL bind.
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+  <varlistentry xml:id="constant.ldap-opt-x-sasl-authcid">
+   <term>
+    <constant>LDAP_OPT_X_SASL_AUTHCID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Return the SASL authentication identity.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-sasl-authzid">
+   <term>
+    <constant>LDAP_OPT_X_SASL_AUTHZID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Return the SASL authorization identity.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-sasl-mech">
+   <term>
+    <constant>LDAP_OPT_X_SASL_MECH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Return the SASL mechanism.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-sasl-nocanon">
+   <term>
+    <constant>LDAP_OPT_X_SASL_NOCANON</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Set/get the <literal>NOCANON</literal> flag.
+     When unset, the hostname is canonicalized.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-sasl-realm">
+   <term>
+    <constant>LDAP_OPT_X_SASL_REALM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Return the SASL realm.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-sasl-username">
+   <term>
+    <constant>LDAP_OPT_X_SASL_USERNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Return the SASL username.
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+  <varlistentry xml:id="constant.ldap-opt-x-tls-allow">
+   <term>
+    <constant>LDAP_OPT_X_TLS_ALLOW</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-tls-demand">
+   <term>
+    <constant>LDAP_OPT_X_TLS_DEMAND</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-tls-hard">
+   <term>
+    <constant>LDAP_OPT_X_TLS_HARD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-tls-never">
+   <term>
+    <constant>LDAP_OPT_X_TLS_NEVER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-tls-try">
+   <term>
+    <constant>LDAP_OPT_X_TLS_TRY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+  <varlistentry xml:id="constant.ldap-opt-x-tls-crl-all">
+   <term>
+    <constant>LDAP_OPT_X_TLS_CRL_ALL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-tls-crl-none">
+   <term>
+    <constant>LDAP_OPT_X_TLS_CRL_NONE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-tls-crl-peer">
+   <term>
+    <constant>LDAP_OPT_X_TLS_CRL_PEER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+  <varlistentry xml:id="constant.ldap-opt-x-tls-package">
+   <term>
+    <constant>LDAP_OPT_X_TLS_PACKAGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Return the name of the underlying TLS implementation.
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+  <varlistentry xml:id="constant.ldap-opt-x-tls-protocol-ssl2">
+   <term>
+    <constant>LDAP_OPT_X_TLS_PROTOCOL_SSL2</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The SSL 2.0 protocol.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-tls-protocol-ssl3">
+   <term>
+    <constant>LDAP_OPT_X_TLS_PROTOCOL_SSL3</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The SSL 3 protocol.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-tls-protocol-tls1-0">
+   <term>
+    <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_0</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The TLS 1.0 protocol.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-tls-protocol-tls1-1">
+   <term>
+    <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_1</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The TLS 1.1 protocol.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-tls-protocol-tls1-2">
+   <term>
+    <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_2</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The TLS 1.2 protocol.
+    </simpara>
+   </listitem>
+  </varlistentry>
+
  </variablelist>
 </appendix>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
I did not write any descriptions for the peer certificate checking and CRL evaluation strategy constants as I could not find any references discussing these in detail.

Peer certificate checking strategies:
`LDAP_OPT_X_TLS_ALLOW`
`LDAP_OPT_X_TLS_DEMAND`
`LDAP_OPT_X_TLS_HARD`
`LDAP_OPT_X_TLS_NEVER`
`LDAP_OPT_X_TLS_TRY`

CRL evaluation strategies:
`LDAP_OPT_X_TLS_CRL_ALL`
`LDAP_OPT_X_TLS_CRL_NONE`
`LDAP_OPT_X_TLS_CRL_PEER`