### PR TITLE
Simplify Stringable example with PHP 8 syntax

### DIFF
--- a/language/predefined/stringable.xml
+++ b/language/predefined/stringable.xml
@@ -52,17 +52,12 @@
 <![CDATA[
 <?php
 class IPv4Address implements Stringable {
-    private string $oct1;
-    private string $oct2;
-    private string $oct3;
-    private string $oct4;
-
-    public function __construct(string $oct1, string $oct2, string $oct3, string $oct4) {
-        $this->oct1 = $oct1;
-        $this->oct2 = $oct2;
-        $this->oct3 = $oct3;
-        $this->oct4 = $oct4;
-    }
+    public function __construct(
+        private string $oct1,
+        private string $oct2,
+        private string $oct3,
+        private string $oct4,
+    ) {}
 
     public function __toString(): string {
         return "$this->oct1.$this->oct2.$this->oct3.$this->oct4";
@@ -70,8 +65,7 @@ class IPv4Address implements Stringable {
 }
 
 function showStuff(string|Stringable $value) {
-    // A Stringable will get converted to a string here by calling
-    // __toString.
+    // For a Stringable, this will implicitliy call __toString().
     print $value;
 }
 


### PR DESCRIPTION
Stringable is introduced in PHP 8.0, so constructor promotion can be assumed.