### PR TITLE
setcookie.xml: amend the argument type to bool

### DIFF
--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -236,11 +236,13 @@
     <programlisting role="php">
      <![CDATA[
 <?php
+
 $value = 'something from somewhere';
 
 setcookie("TestCookie", $value);
 setcookie("TestCookie", $value, time()+3600);  /* expire in 1 hour */
-setcookie("TestCookie", $value, time()+3600, "/~rasmus/", "example.com", 1);
+setcookie("TestCookie", $value, time()+3600, "/~rasmus/", "example.com", true);
+
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
In strict types mode: `Fatal error: Uncaught TypeError: setcookie(): Argument #6 ($secure) must be of type bool, int given`