### PR TITLE
Documents "No such file or directory" warning when calling `disk_*_space` functions.

### DIFF
--- a/reference/filesystem/functions/disk-free-space.xml
+++ b/reference/filesystem/functions/disk-free-space.xml
@@ -48,6 +48,14 @@
    Returns the number of available bytes as a float
    &return.falseforfailure;.
   </para>
+
+  <note>
+   <para>
+    When attempting to read a file system or disk partition that does not exist,
+    an <constant>E_WARNING</constant>-level error message will be issued and 
+    the result will be &false;.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/filesystem/functions/disk-free-space.xml
+++ b/reference/filesystem/functions/disk-free-space.xml
@@ -52,7 +52,7 @@
   <note>
    <para>
     When attempting to read a file system or disk partition that does not exist,
-    an <constant>E_WARNING</constant>-level error message will be issued and 
+    an <constant>E_WARNING</constant>-level error message will be issued and
     the result will be &false;.
    </para>
   </note>

--- a/reference/filesystem/functions/disk-total-space.xml
+++ b/reference/filesystem/functions/disk-total-space.xml
@@ -40,6 +40,14 @@
    Returns the total number of bytes as a float
    &return.falseforfailure;.
   </para>
+
+  <note>
+   <para>
+    When attempting to read a file system or disk partition that does not exist,
+    an <constant>E_WARNING</constant>-level error message will be issued and 
+    the result will be &false;.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/filesystem/functions/disk-total-space.xml
+++ b/reference/filesystem/functions/disk-total-space.xml
@@ -44,7 +44,7 @@
   <note>
    <para>
     When attempting to read a file system or disk partition that does not exist,
-    an <constant>E_WARNING</constant>-level error message will be issued and 
+    an <constant>E_WARNING</constant>-level error message will be issued and
     the result will be &false;.
    </para>
   </note>


### PR DESCRIPTION
Documenting that both `disk_total_space` and `disk_free_space` will trigger a warning when specifying a disk that does not exist.

<img width="569" alt="Screenshot 2024-07-03 at 10 20 27" src="https://github.com/php/doc-en/assets/24803032/2cbeef3e-09bd-4d57-be4d-9372cc86cac1">
