### PR TITLE
Correct the type of $tidy->errorBuffer

### DIFF
--- a/reference/tidy/tidy/errorbuffer.xml
+++ b/reference/tidy/tidy/errorbuffer.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop; (property):</para>
-  <fieldsynopsis><modifier>public</modifier> <type>string</type><varname linkend="tidy.props.errorbuffer">tidy-&gt;errorBuffer</varname></fieldsynopsis>
+  <fieldsynopsis><modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><varname linkend="tidy.props.errorbuffer">tidy-&gt;errorBuffer</varname></fieldsynopsis>
   <para>&style.procedural;:</para>
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>tidy_get_error_buffer</methodname>


### PR DESCRIPTION
This is a nullable string: https://github.com/php/php-src/blob/e9254494ffde88af0160a30cee53c3dfce226edf/ext/tidy/tidy.stub.php#L866