### PR TITLE
Update use cases for the mode parameter in PDOStatement::fetchAll()

### DIFF
--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -54,14 +54,22 @@
        <parameter>column</parameter> parameter.
       </para>
       <para>
-       To fetch only the unique values of a single column from the result set,
-       bitwise-OR <constant>PDO::FETCH_COLUMN</constant> with
-       <constant>PDO::FETCH_UNIQUE</constant>.
+       To index the resulting array by certain column's value (instead of
+       consecutive numbers), put this column's name first in the column
+       list in SQL, and use <constant>PDO::FETCH_UNIQUE</constant>.
+       This column must contain only unique values or some data will be lost.
       </para>
       <para>
-       To return an associative array grouped by the values of a specified
-       column, bitwise-OR <constant>PDO::FETCH_COLUMN</constant> with
-       <constant>PDO::FETCH_GROUP</constant>.
+       To group results in the form of 3-dimensional array indexed by values
+       of a specified column, put this column's name first in
+       the column list in SQL and use <constant>PDO::FETCH_GROUP</constant>.
+      </para>
+      <para>
+       To group results in the form of 2-dimensional array (which indices will
+       be values of one column and values will be list arrays of values
+       from another column, list only these 2 columns in the column list in SQL
+       and use bitwise-OR <constant>PDO::FETCH_GROUP</constant> with
+       <constant>PDO::FETCH_COLUMN</constant>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -54,13 +54,13 @@
        <parameter>column</parameter> parameter.
       </para>
       <para>
-       To index the resulting array by certain column's value (instead of
+       To index the resulting array by a certain column's value (instead of
        consecutive numbers), put this column's name first in the column
        list in SQL, and use <constant>PDO::FETCH_UNIQUE</constant>.
        This column must contain only unique values or some data will be lost.
       </para>
       <para>
-       To group results in the form of 3-dimensional array indexed by values
+       To group results in the form of a 3-dimensional array indexed by values
        of a specified column, put this column's name first in
        the column list in SQL and use <constant>PDO::FETCH_GROUP</constant>.
       </para>

--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -65,11 +65,11 @@
        the column list in SQL and use <constant>PDO::FETCH_GROUP</constant>.
       </para>
       <para>
-       To group results in the form of 2-dimensional array (which indices will
-       be values of one column and values will be list arrays of values
-       from another column, list only these 2 columns in the column list in SQL
-       and use bitwise-OR <constant>PDO::FETCH_GROUP</constant> with
-       <constant>PDO::FETCH_COLUMN</constant>.
+       To group results in the form of a 2-dimensional array
+       use bitwise-OR <constant>PDO::FETCH_GROUP</constant> with
+       <constant>PDO::FETCH_COLUMN</constant>. 
+       The results will be grouped by the first column, with the array element's value
+       being a list array of the corresponding entries from the second column. 
       </para>
      </listitem>
     </varlistentry>

--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -67,9 +67,9 @@
       <para>
        To group results in the form of a 2-dimensional array
        use bitwise-OR <constant>PDO::FETCH_GROUP</constant> with
-       <constant>PDO::FETCH_COLUMN</constant>. 
+       <constant>PDO::FETCH_COLUMN</constant>.
        The results will be grouped by the first column, with the array element's value
-       being a list array of the corresponding entries from the second column. 
+       being a list array of the corresponding entries from the second column.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Currently, case 3 makes no sense (PDO::FETCH_COLUMN|PDO::FETCH_UNIQUE would result in error) and case 4 is misleading (describing rather vanilla PDO::FETCH_GROUP's behavior). I added vanilla PDO::FETCH_UNIQUE and PDO::FETCH_GROUP cases and fixed PDO::FETCH_GROUP|PDO::FETCH_COLUMN.

Also, how does one remove a comment? 
- [88699](https://www.php.net/manual/en/pdostatement.fetchall.php#88699) is bogus, they need PDO::FETCH_UNIQUE but using PDO::FETCH_GROUP
- [122299](https://www.php.net/manual/en/pdostatement.fetchall.php#122299) same as above
- [115175](https://www.php.net/manual/en/pdostatement.fetchall.php#115175) is bogus, PDO::FETCH_UNIQUE|PDO::FETCH_GROUP makes no sense and effectively just PDO::FETCH_UNIQUE