### PR TITLE
setup.xml: replace the broken URL

### DIFF
--- a/reference/win32service/setup.xml
+++ b/reference/win32service/setup.xml
@@ -47,7 +47,8 @@
    You can set the ACL on the service after adding it into SCM to delegate the
    current administration tasks to an non administrator account or service account.
    For further instructions, see the
-   <link xlink:href="https://support.microsoft.com/en-us/help/914392/best-practices-and-guidance-for-writers-of-service-discretionary-acces">Microsoft Knowledge Base</link>.
+   <link xlink:href="https://www.betaarchive.com/wiki/index.php?title=Microsoft_KB_Archive/914392">an archive copy</link>
+   of the Microsoft Knowledge Base page.
   </para>
  </section>
 


### PR DESCRIPTION
The Microsoft Knowledge Base does not contain the "Best Practices and Recommendations for authors of Discretionary Access Control Service Lists" page. And I couldn't find a copy of the material on the MKB website. I have replaced the link to the most reputable, in my humble opinion, site, which still keeps a copy of the original article