### PR TITLE
Create reference/gettext/functions/-.xml

### DIFF
--- a/reference/gettext/functions/-.xml
+++ b/reference/gettext/functions/-.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.-" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>_</refname>
+  <refpurpose>&Alias; <function>gettext</function></refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <simpara>
+   &info.function.alias;
+   <function>gettext</function>.
+  </simpara>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/gettext/functions/gettext.xml
+++ b/reference/gettext/functions/gettext.xml
@@ -93,6 +93,7 @@ echo _("Have a nice day");
   &reftitle.seealso;
   <para>
    <simplelist>
+    <member><function>_</function></member>
     <member><function>setlocale</function></member>
    </simplelist>
   </para>

--- a/reference/gettext/versions.xml
+++ b/reference/gettext/versions.xml
@@ -5,6 +5,7 @@
 -->
 
 <versions>
+ <function name="_" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="bind_textdomain_codeset" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
  <function name="bindtextdomain" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="dcgettext" from="PHP 4, PHP 5, PHP 7, PHP 8"/>


### PR DESCRIPTION
The `_()` function is an alias of the `gettext()` function.

Adding a dedicated manual page for this function will remove the need for the special cases created for it when generating the manual.

See:
- https://bugs.php.net/bug.php?id=63490
- https://github.com/php/systems/commit/b67fa163ba95deb68e3d51c4b4a3b6b74fafca71
- https://github.com/php/web-php/commit/fdec771e1f20751f1eb97d94b4cd4c1fb937632b
- https://github.com/php/web-php/commit/8abf4eee4028b14c50fe61578fd0085a1436f536
- https://github.com/php/php-src/blob/PHP-4.0/ext/gettext/gettext.c#L39