### PR TITLE
eio-seek.xml: amend `whence` parameter and shorten the `refpurpose`

### DIFF
--- a/reference/eio/functions/eio-seek.xml
+++ b/reference/eio/functions/eio-seek.xml
@@ -4,10 +4,7 @@
 <refentry xml:id="function.eio-seek" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>eio_seek</refname>
-  <refpurpose>
-   Repositions the offset of the open file associated with the <parameter>fd</parameter> argument to
-   the argument <parameter>offset</parameter> according to the directive <parameter>whence</parameter>
-  </refpurpose>
+  <refpurpose>Seek to a position</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/eio/functions/eio-seek.xml
+++ b/reference/eio/functions/eio-seek.xml
@@ -4,7 +4,10 @@
 <refentry xml:id="function.eio-seek" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>eio_seek</refname>
-  <refpurpose>Repositions the offset of the open file associated with the <parameter>fd</parameter> argument to the argument <parameter>offset</parameter> according to the directive <parameter>whence</parameter></refpurpose>
+  <refpurpose>
+   Repositions the offset of the open file associated with the <parameter>fd</parameter> argument to
+   the argument <parameter>offset</parameter> according to the directive <parameter>whence</parameter>
+  </refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -23,12 +26,9 @@
   </methodsynopsis>
   <para>
    <function>eio_seek</function> repositions the offset of the open file associated with 
-   stream, Socket resource, or file descriptor specified by <parameter>fd</parameter> to the argument <parameter>offset</parameter> according to the directive <parameter>whence</parameter> as follows:
-   <simplelist>
-    <member><constant>EIO_SEEK_SET</constant> - Set position equal to <parameter>offset</parameter> bytes.</member>
-    <member><constant>EIO_SEEK_CUR</constant> - Set position to current location plus <parameter>offset</parameter>.</member>
-    <member><constant>EIO_SEEK_END</constant> - Set position to end-of-file plus <parameter>offset</parameter>.</member>
-   </simplelist>
+   stream, Socket resource, or file descriptor specified by <parameter>fd</parameter> to
+   the argument <parameter>offset</parameter> according to
+   the directive <parameter>whence</parameter>.
   </para>
  </refsect1>
 
@@ -52,11 +52,19 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>length</parameter></term>
+    <term><parameter>whence</parameter></term>
     <listitem>
      <para>
-     Number of bytes to be read.
-     </para>
+       <parameter>whence</parameter> values are:
+       <simplelist>
+        <member><constant>SEEK_SET</constant> - Set position equal to <parameter>offset</parameter> bytes.</member>
+        <member><constant>SEEK_CUR</constant> - Set position to current location plus <parameter>offset</parameter>.</member>
+        <member><constant>SEEK_END</constant> - Set position to end-of-file plus <parameter>offset</parameter>.</member>
+       </simplelist>
+      </para>
+      <para>
+       If <parameter>whence</parameter> is not specified, it is assumed to be <constant>SEEK_SET</constant>.
+      </para>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/eio/functions/eio-seek.xml
+++ b/reference/eio/functions/eio-seek.xml
@@ -59,9 +59,6 @@
         <member><constant>EIO_SEEK_END</constant> - Set position to end-of-file plus <parameter>offset</parameter>.</member>
        </simplelist>
       </para>
-      <para>
-       If <parameter>whence</parameter> is not specified, it is assumed to be <constant>EIO_SEEK_SET</constant>.
-      </para>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/eio/functions/eio-seek.xml
+++ b/reference/eio/functions/eio-seek.xml
@@ -60,7 +60,7 @@
        </simplelist>
       </para>
       <para>
-       If <parameter>whence</parameter> is not specified, it is assumed to be <constant>SEEK_SET</constant>.
+       If <parameter>whence</parameter> is not specified, it is assumed to be <constant>EIO_SEEK_SET</constant>.
       </para>
     </listitem>
    </varlistentry>

--- a/reference/eio/functions/eio-seek.xml
+++ b/reference/eio/functions/eio-seek.xml
@@ -23,7 +23,7 @@
   </methodsynopsis>
   <para>
    <function>eio_seek</function> repositions the offset of the open file associated with 
-   stream, Socket resource, or file descriptor specified by <parameter>fd</parameter> to
+   stream, Socket instance, or file descriptor specified by <parameter>fd</parameter> to
    the argument <parameter>offset</parameter> according to
    the directive <parameter>whence</parameter>.
   </para>
@@ -36,7 +36,7 @@
     <term><parameter>fd</parameter></term>
     <listitem>
      <para>
-     Stream, Socket resource, or numeric file descriptor.
+     Stream, Socket instance, or numeric file descriptor.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/eio/functions/eio-seek.xml
+++ b/reference/eio/functions/eio-seek.xml
@@ -36,7 +36,7 @@
     <term><parameter>fd</parameter></term>
     <listitem>
      <para>
-     Stream, Socket resource, or numeric file descriptor
+     Stream, Socket resource, or numeric file descriptor.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/eio/functions/eio-seek.xml
+++ b/reference/eio/functions/eio-seek.xml
@@ -57,9 +57,9 @@
      <para>
        <parameter>whence</parameter> values are:
        <simplelist>
-        <member><constant>SEEK_SET</constant> - Set position equal to <parameter>offset</parameter> bytes.</member>
-        <member><constant>SEEK_CUR</constant> - Set position to current location plus <parameter>offset</parameter>.</member>
-        <member><constant>SEEK_END</constant> - Set position to end-of-file plus <parameter>offset</parameter>.</member>
+        <member><constant>EIO_SEEK_SET</constant> - Set position equal to <parameter>offset</parameter> bytes.</member>
+        <member><constant>EIO_SEEK_CUR</constant> - Set position to current location plus <parameter>offset</parameter>.</member>
+        <member><constant>EIO_SEEK_END</constant> - Set position to end-of-file plus <parameter>offset</parameter>.</member>
        </simplelist>
       </para>
       <para>

--- a/reference/eio/functions/eio-seek.xml
+++ b/reference/eio/functions/eio-seek.xml
@@ -23,7 +23,7 @@
   </methodsynopsis>
   <para>
    <function>eio_seek</function> repositions the offset of the open file associated with 
-   stream, Socket instance, or file descriptor specified by <parameter>fd</parameter> to
+   stream, <classname>Socket</classname> instance, or file descriptor specified by <parameter>fd</parameter> to
    the argument <parameter>offset</parameter> according to
    the directive <parameter>whence</parameter>.
   </para>
@@ -36,7 +36,7 @@
     <term><parameter>fd</parameter></term>
     <listitem>
      <para>
-     Stream, Socket instance, or numeric file descriptor.
+     Stream, <classname>Socket</classname> instance, or numeric file descriptor.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
The  signature of the `eio_seek` function does not have the `length` parameter, `whence` instead, and function does not read bytes. There is no need to specify the `length` parameter ;)