### PR TITLE
Use "unique" less in describing `uniqid()`

### DIFF
--- a/reference/misc/functions/uniqid.xml
+++ b/reference/misc/functions/uniqid.xml
@@ -14,8 +14,9 @@
    <methodparam choice="opt"><type>bool</type><parameter>more_entropy</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Gets an identifier based on the current time in microseconds with an
-   optional prefix and/or a random value appended.
+   Gets an identifier based on the current time with microsecond precision,
+   prefixed with the given <parameter>prefix</parameter> and optionally
+   appending a randomly generated value.
   </para>
   &caution.cryptographically-insecure;
   <warning>
@@ -38,7 +39,9 @@
       <para>
        Can be useful, for instance, if you generate identifiers
        simultaneously on several hosts that could generate the
-       same identifier at the same microsecond.
+       same identifier at the same microsecond. (This can happen
+       even on a single host if the system clock is moved backwards,
+       such as by an NTP adjustment.)
       </para>
       <para>
        With an empty <parameter>prefix</parameter>, the returned string will

--- a/reference/misc/functions/uniqid.xml
+++ b/reference/misc/functions/uniqid.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.uniqid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>uniqid</refname>
-  <refpurpose>Generate a unique ID</refpurpose>
+  <refpurpose>Generate a time-based identifier</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">
@@ -14,18 +14,16 @@
    <methodparam choice="opt"><type>bool</type><parameter>more_entropy</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Gets a prefixed unique identifier based on the current time in
-   microseconds.
+   Gets an identifier based on the current time in microseconds with an
+   optional prefix and/or a random value appended.
   </para>
   &caution.cryptographically-insecure;
   <warning>
     <para>
-     This function does not guarantee uniqueness of return
-     value. Since most systems adjust system clock by NTP or like,
-     system time is changed constantly. Therefore, it is possible that
-     this function does not return unique ID for the
-     process/thread. Use <parameter>more_entropy</parameter> to
-     increase likelihood of uniqueness.
+     This function does not guarantee the uniqueness of the return
+     value because the value is based on the current time in microseconds
+     or the current time with a small amount of random data appended
+     if <parameter>more_entropy</parameter> is &true;.
     </para>
   </warning>
  </refsect1>
@@ -39,8 +37,8 @@
      <listitem>
       <para>
        Can be useful, for instance, if you generate identifiers
-       simultaneously on several hosts that might happen to generate the
-       identifier at the same microsecond.
+       simultaneously on several hosts that could generate the
+       same identifier at the same microsecond.
       </para>
       <para>
        With an empty <parameter>prefix</parameter>, the returned string will
@@ -67,12 +65,11 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns timestamp based unique identifier as a string.
+   Returns timestamp based identifier as a string.
   </para>
   <warning>
    <para>
-     This function tries to create unique identifier, but it does not
-     guarantee 100% uniqueness of return value.
+     This function does not guarantee the uniqueness of the return value.
    </para>
   </warning>
  </refsect1>


### PR DESCRIPTION
The identifier generated is time-based either in its entirety (with default options) or with some random data (with `more_entropy` enabled) so avoid describing it as unique without immediate caveats.

It's not much more than a fancy timestamp when called without any parameters, so let's not make "unique" such a central part of its description.