### PR TITLE
Add method `MongoDB\BSON\UTCDateTime::toDateTimeImmutable`

### DIFF
--- a/reference/mongodb/bson/utcdatetime/todatetimeimmutable.xml
+++ b/reference/mongodb/bson/utcdatetime/todatetimeimmutable.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="mongodb-bson-utcdatetime.todatetime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="mongodb-bson-utcdatetime.todatetimeimmutable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
-  <refname>MongoDB\BSON\UTCDateTime::toDateTime</refname>
-  <refpurpose>Returns the DateTime representation of this UTCDateTime</refpurpose>
+  <refname>MongoDB\BSON\UTCDateTime::toDateTimeImmutable</refname>
+  <refpurpose>Returns the DateTimeImmutable representation of this UTCDateTime</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>DateTime</type><methodname>MongoDB\BSON\UTCDateTime::toDateTime</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>MongoDB\BSON\UTCDateTime::toDateTimeImmutable</methodname>
    <void />
   </methodsynopsis>
  </refsect1>
@@ -23,8 +23,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the <classname>DateTime</classname> representation of this
-   UTCDateTime. The returned <classname>DateTime</classname> will use the UTC
+   Returns the <classname>DateTimeImmutable</classname> representation of this
+   UTCDateTime. The returned <classname>DateTimeImmutable</classname> will use the UTC
    time zone.
   </para>
  </refsect1>
@@ -40,13 +40,13 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>MongoDB\BSON\UTCDatetime::toDateTime</function> example</title>
+   <title><function>MongoDB\BSON\UTCDatetime::toDateTimeImmutable</function> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
 
 $utcdatetime = new MongoDB\BSON\UTCDateTime(1416445411987);
-$datetime = $utcdatetime->toDateTime();
+$datetime = $utcdatetime->toDateTimeImmutable();
 var_dump($datetime->format('r'));
 var_dump($datetime->format('U.u'));
 var_dump($datetime->getTimezone());
@@ -74,7 +74,7 @@ object(DateTimeZone)#3 (2) {
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><methodname>MongoDB\BSON\UTCDateTime::toDateTimeImmutable</methodname></member>
+   <member><methodname>MongoDB\BSON\UTCDateTime::toDateTime</methodname></member>
    <member><link xlink:href="&url.mongodb.docs.bson;#date">BSON Types: Date</link></member>
   </simplelist>
  </refsect1>

--- a/reference/mongodb/versions.xml
+++ b/reference/mongodb/versions.xml
@@ -485,6 +485,7 @@
  <function name='mongodb\bson\utcdatetime::__tostring' from='mongodb &gt;=1.0.0'/>
  <function name='mongodb\bson\utcdatetime::jsonserialize' from='mongodb &gt;=1.2.0'/>
  <function name='mongodb\bson\utcdatetime::todatetime' from='mongodb &gt;=1.0.0'/>
+ <function name='mongodb\bson\utcdatetime::todatetimeimmutable' from='mongodb &gt;=1.20.0'/>
  <function name='mongodb\bson\utcdatetime::serialize' from='mongodb &gt;=1.2.0'/>
  <function name='mongodb\bson\utcdatetime::unserialize' from='mongodb &gt;=1.2.0'/>
 


### PR DESCRIPTION
The method  `toDateTimeImmutable` is identical to `toDateTime`, except it returns an instance of `DateTimeImmutable`.

Related to https://github.com/mongodb/mongo-php-driver/pull/1611 (not released yet, it will be in extension mongodb 1.20.0).
