### PR TITLE
Use MongoDB's `CommandStartedEvent::getCommandName()` in APM tutorial

### DIFF
--- a/reference/mongodb/tutorial/apm.xml
+++ b/reference/mongodb/tutorial/apm.xml
@@ -125,7 +125,7 @@ class QueryTimeCollector implements \MongoDB\Driver\Monitoring\CommandSubscriber
 
     public function commandStarted( \MongoDB\Driver\Monitoring\CommandStartedEvent $event ): void
     {
-        if ( array_key_exists( 'find', (array) $event->getCommand() ) )
+        if ( 'find' === $event->getCommandName() )
         {
             $queryShape = $this->createQueryShape( (array) $event->getCommand()->filter );
             $this->pendingCommands[$event->getRequestId()] = $queryShape;


### PR DESCRIPTION
The method `$event->getCommandName()` is more explicit in determining the name of the command used.

Fix [PHPC-2327](https://jira.mongodb.org/browse/PHPC-2327)