### PR TITLE
Fix GH-3384

### DIFF
--- a/reference/outcontrol/constants.xml
+++ b/reference/outcontrol/constants.xml
@@ -198,6 +198,7 @@
    <listitem>
     <para>
      Indicates that the output handler successfully processed the buffer.
+     Available as of PHP 8.4.0.
     </para>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
Add a sentence from which PHP version PHP_OUTPUT_HANDLER_PROCESSED is available.

Closes GH-3384