### PR TITLE
digit.xml: add tags, amend example

### DIFF
--- a/reference/intl/intlchar/digit.xml
+++ b/reference/intl/intlchar/digit.xml
@@ -28,10 +28,14 @@
      In this case the value is the character's decimal digit value.
     </member>
     <member>
-     The character is one of the uppercase Latin letters <literal>'A'</literal> through <literal>'Z'</literal>.
+     The character is one of the uppercase
+     Latin letters <literal>'A'</literal> through <literal>'Z'</literal>.
+     In this case the value is <literal>codepoint - 'A' + 10</literal>.
     </member>
     <member>
-     The character is one of the lowercase Latin letters <literal>'a'</literal> through <literal>'z'</literal>.
+     The character is one of the lowercase
+     Latin letters <literal>'a'</literal> through <literal>'z'</literal>.
+     In this case the value is <literal>codepoint - 'a' + 10</literal>.
     </member>
     <member>
      Latin letters from both the ASCII range (<literal>0061..007A</literal>,

--- a/reference/intl/intlchar/digit.xml
+++ b/reference/intl/intlchar/digit.xml
@@ -17,14 +17,28 @@
    Returns the decimal digit value of the code point in the specified radix.
   </para>
   <para>
-   If the radix is not in the range <literal>2&lt;=radix&lt;=36</literal> or if the value of <parameter>codepoint</parameter>
+   If the radix is not in the range <literal>2 &lt;= radix &lt;= 36</literal> or
+   if the value of <parameter>codepoint</parameter>
    is not a valid digit in the specified radix, &false; is returned.
    A character is a valid digit if at least one of the following is true:
    <simplelist>
-    <member>The character has a decimal digit value. Such characters have the general category "Nd" (decimal digit numbers) and a Numeric_Type of Decimal. In this case the value is the character's decimal digit value.</member>
-    <member>The character is one of the uppercase Latin letters 'A' through 'Z'. In this case the value is c-'A'+10.</member>
-    <member>The character is one of the lowercase Latin letters 'a' through 'z'. In this case the value is ch-'a'+10.</member>
-    <member>Latin letters from both the ASCII range (0061..007A, 0041..005A) as well as from the Fullwidth ASCII range (FF41..FF5A, FF21..FF3A) are recognized.</member>
+    <member>
+     The character has a decimal digit value. Such characters have the
+     general category "Nd" (decimal digit numbers) and a Numeric_Type of "Decimal".
+     In this case the value is the character's decimal digit value.
+    </member>
+    <member>
+     The character is one of the uppercase Latin letters <literal>'A'</literal> through <literal>'Z'</literal>.
+    </member>
+    <member>
+     The character is one of the lowercase Latin letters <literal>'a'</literal> through <literal>'z'</literal>.
+    </member>
+    <member>
+     Latin letters from both the ASCII range (<literal>0061..007A</literal>,
+     <literal>0041..005A</literal>) as well as
+     from the Fullwidth ASCII range (<literal>FF41..FF5A</literal>,
+     <literal>FF21..FF3A</literal>) are recognized.
+    </member>
    </simplelist>
   </para>
  </refsect1>
@@ -65,10 +79,13 @@
    <programlisting role="php">
     <![CDATA[
 <?php
+
 var_dump(IntlChar::digit("0"));
 var_dump(IntlChar::digit("3"));
-var_dump(IntlChar::digit("A"));
+
 var_dump(IntlChar::digit("A", 16));
+var_dump(IntlChar::digit("A"));
+
 ?>
 ]]>
    </programlisting>


### PR DESCRIPTION
In the description of the method,

> In this case the value is c-'A'+10 for latin lettera A-Z

and

> In this case the value is ch-'a'+10

— it looks like this text was copied aimlessly from the comment of the ICU source code file:

[source/common/unicode/uchar.h](https://github.com/unicode-org/icu/blob/40b2ec3c3727bca975824fdb9d1f084207d535ff/icu4c/source/common/unicode/uchar.h#L4252)

And these sentences, IMHO, do not make sense in the context of the PHP method description, but only `u_digit` definition:

[source/common/uchar.cpp](https://github.com/unicode-org/icu/blob/40b2ec3c3727bca975824fdb9d1f084207d535ff/icu4c/source/common/uchar.cpp#L452)