### PR TITLE
Added example for void return type in documentation

### DIFF
--- a/language/types/void.xml
+++ b/language/types/void.xml
@@ -17,6 +17,37 @@
   </simpara>
  </note>
 
+ <sect2 xml:id="language.types.void.example">
+  <title>Example: Using void Return Type</title>
+
+  <para>
+   Here is an example of a function that sends an email. The function has a
+   <type>void</type> return type because it does not return any value.
+  </para>
+
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+function sendEmail(string $recipient, string $subject, string $message): void {
+    // Here would be the code to send the email
+    // mail($recipient, $subject, $message);
+    echo "Email sent to $recipient with the subject: $subject\n";
+}
+
+// Calling the function
+sendEmail("example@domain.com", "Test Subject", "Test Message");
+?>
+]]>
+   </programlisting>
+  </informalexample>
+
+  <simpara>
+   This function performs an action (sending an email) but does not return a value,
+   hence the return type is <type>void</type>.
+  </simpara>
+ </sect2>
+
 </sect1>
 <!-- Keep this comment at the end of the file
 Local variables:
@@ -32,7 +63,6 @@ sgml-parent-document:nil
 sgml-default-dtd-file:"~/.phpdoc/manual.ced"
 sgml-exposed-tags:nil
 sgml-local-catalogs:nil
-sgml-local-ecat-files:nil
 End:
 vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml


### PR DESCRIPTION
This added code improves the documentation by providing a practical example of how to use PHP's void.