### PR TITLE
Remove reference to features.xforms (part of php/doc-en#3579)

### DIFF
--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -433,13 +433,6 @@ Hi Joe. You are 22 years old.
     superglobal, if you do not care about the source of your request data. It 
     contains the merged information of GET, POST and COOKIE data.  
    </para>
-   <para>
-    You can also deal with XForms input in PHP, although you will find yourself
-    comfortable with the well supported HTML forms for quite some time.
-    While working with XForms is not for beginners, you might be interested
-    in them. We also have a <link linkend="features.xforms">short introduction
-    to handling data received from XForms</link> in our features section. 
-   </para>
   </section>
 
   <section xml:id="tutorial.whatsnext">


### PR DESCRIPTION
`features/xforms.xml` will be removed once it's no longer referenced from doc-base.