### PR TITLE
Update Unix requirements section

### DIFF
--- a/install/unix/index.xml
+++ b/install/unix/index.xml
@@ -38,7 +38,7 @@
      </listitem> 
      <listitem>
       <simpara>
-       An ANSI C compiler
+       An ANSI C compiler (as of PHP 8.0.0, C99 compatibility is assumed)
       </simpara>
      </listitem> 
      <listitem>


### PR DESCRIPTION
C99 is required as of https://github.com/php/php-src/commit/b51a99ae358b3295de272bb3c3edb6913eeb0fd4.

There is likely more to update on [that page](https://www.php.net/manual/en/install.unix.php). If anybody happens to know which versions exactly, please tell me. Otherwise I'll check that out.

PS: The info about bison and r2c versions is apparently up-to-date.