### PR TITLE
json: added json_last_error_msg to see-also

### DIFF
--- a/reference/json/functions/json-decode.xml
+++ b/reference/json/functions/json-decode.xml
@@ -336,6 +336,7 @@ object(stdClass)#1 (1) {
    <simplelist>
     <member><function>json_encode</function></member>
     <member><function>json_last_error</function></member>
+    <member><function>json_last_error_msg</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/json/functions/json-encode.xml
+++ b/reference/json/functions/json-encode.xml
@@ -393,6 +393,7 @@ string(2) "12"
     <member><interfacename>JsonSerializable</interfacename></member>
     <member><function>json_decode</function></member>
     <member><function>json_last_error</function></member>
+    <member><function>json_last_error_msg</function></member>
     <member><function>serialize</function></member>
    </simplelist>
   </para>


### PR DESCRIPTION
I think `json_last_error_msg()` is more helpful then the older `json_last_error()` variant, therefore adding it to the see-also list