### PR TITLE
Add documentation for Ds\Set::map()

### DIFF
--- a/reference/ds/ds.set.xml
+++ b/reference/ds/ds.set.xml
@@ -126,6 +126,12 @@
          The class now implements <classname>ArrayAccess</classname>.
         </entry>
        </row>
+       <row>
+        <entry>PECL ds 1.2.7</entry>
+        <entry>
+         Added the <methodname>Ds\Set::map</methodname> method.
+        </entry>
+       </row>
       </tbody>
      </tgroup>
     </informaltable>

--- a/reference/ds/ds/set/map.xml
+++ b/reference/ds/ds/set/map.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="ds-set.map" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>Ds\Set::map</refname>
+  <refpurpose>Returns the result of applying a callback to each value</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>Ds\Set</type><methodname>Ds\Set::map</methodname>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Returns the result of applying a <parameter>callback</parameter> function to
+   each value in the set.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     <para>
+      The callback to apply to each value in the set must have the following signature:
+      <methodsynopsis xmlns="http://docbook.org/ns/docbook">
+       <type>mixed</type>
+       <methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+      </methodsynopsis>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns a new <classname>Ds\Set</classname> instance where each value
+   is the result of applying the <parameter>callback</parameter> to each value
+   of the set.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Ds\Set::map</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$set = new \Ds\Set([1, 2, 3]);
+
+var_dump($set->map(function($value) { return $value * 2; }));
+var_dump($set);
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+object(Ds\Set)#3 (3) {
+  [0]=>
+  int(2)
+  [1]=>
+  int(4)
+  [2]=>
+  int(6)
+}
+object(Ds\Set)#1 (3) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ds/versions.xml
+++ b/reference/ds/versions.xml
@@ -211,6 +211,7 @@
  <function name='ds\set::join' from='PECL ds &gt;= 1.0.0'/>
  <function name='ds\set::jsonserialize' from='PECL ds &gt;= 1.0.0'/>
  <function name='ds\set::last' from='PECL ds &gt;= 1.0.0'/>
+ <function name='ds\set::map' from='PECL ds &gt;= 1.2.7'/>
  <function name='ds\set::merge' from='PECL ds &gt;= 1.0.3'/>
  <function name='ds\set::reduce' from='PECL ds &gt;= 1.0.0'/>
  <function name='ds\set::remove' from='PECL ds &gt;= 1.0.0'/>


### PR DESCRIPTION
The method `Ds\Set::map()` was first tagged in version `v1.2.7` of the extension, although it's not mentioned in the Changelog.

* https://github.com/php-ds/ext-ds/commit/ae9ce662360e9f93b4b6c7abb78b938672be1abc

What I did:

* Copied documentation from `ds/vector/map.xml` and basically just changed `vector` -> `set`
* Tested the examples

I verified the documentation and it looks OK, apart from ALL examples which look like this:

![image](https://github.com/user-attachments/assets/32ba1843-c460-4dbe-b746-1552d9a8a6c6)

I guess it's just my environment.