### PR TITLE
phpversion.xml: move replaceable part of constant name

### DIFF
--- a/reference/info/functions/phpversion.xml
+++ b/reference/info/functions/phpversion.xml
@@ -109,7 +109,7 @@ if (!defined('PHP_VERSION_ID')) {
 // may have, this doesn't require to use version_compare() everytime 
 // you check if the current PHP version may not support a feature.
 //
-// For example, we may here define the PHP_VERSION_* constants thats 
+// For example, we may here define the PHP_*_VERSION constants thats 
 // not available in versions prior to 5.2.7
 
 if (PHP_VERSION_ID < 50207) {
@@ -132,7 +132,7 @@ if (PHP_VERSION_ID < 50207) {
    <para>
     This information is also available in the predefined constant
     <constant>PHP_VERSION</constant>. More versioning information 
-    is available using the <constant>PHP_VERSION_*</constant> 
+    is available using the <constant>PHP_<replaceable>*</replaceable>_VERSION</constant> 
     constants.
    </para>
   </note>

--- a/reference/info/functions/phpversion.xml
+++ b/reference/info/functions/phpversion.xml
@@ -75,11 +75,13 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// prints e.g. 'Current PHP version: 4.1.1'
+
+// Prints e.g. 'Current PHP version: 4.1.1'
 echo 'Current PHP version: ' . phpversion();
 
-// prints e.g. '2.0' or nothing if the extension isn't enabled
+// Prints e.g. '2.0' or nothing if the extension isn't enabled
 echo phpversion('tidy');
+
 ?>
 ]]>
     </programlisting>
@@ -91,7 +93,8 @@ echo phpversion('tidy');
     <programlisting role="php">
 <![CDATA[
 <?php
-// PHP_VERSION_ID is available as of PHP 5.2.7, if our 
+
+// PHP_VERSION_ID is available as of PHP 5.2.7, if our
 // version is lower than that, then emulate it
 if (!defined('PHP_VERSION_ID')) {
     $version = explode('.', PHP_VERSION);
@@ -99,18 +102,20 @@ if (!defined('PHP_VERSION_ID')) {
     define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
 }
 
-// PHP_VERSION_ID is defined as a number, where the higher the number 
-// is, the newer a PHP version is used. It's defined as used in the above 
-// expression:
-//
-// $version_id = $major_version * 10000 + $minor_version * 100 + $release_version;
-//
-// Now with PHP_VERSION_ID we can check for features this PHP version 
-// may have, this doesn't require to use version_compare() everytime 
-// you check if the current PHP version may not support a feature.
-//
-// For example, we may here define the PHP_*_VERSION constants thats 
-// not available in versions prior to 5.2.7
+/**
+ * PHP_VERSION_ID is defined as a number, where the higher the number
+ * is, the newer a PHP version is used. It's defined as used in the above
+ * expression:
+ *
+ * $version_id = $major_version * 10000 + $minor_version * 100 + $release_version;
+ *
+ * Now with PHP_VERSION_ID we can check for features this PHP version
+ * may have, this doesn't require to use version_compare() everytime
+ * you check if the current PHP version may not support a feature.
+ *
+ * For example, we may here define the PHP_*_VERSION constants thats
+ * not available in versions prior to 5.2.7
+ */
 
 if (PHP_VERSION_ID < 50207) {
     define('PHP_MAJOR_VERSION',   $version[0]);
@@ -119,6 +124,7 @@ if (PHP_VERSION_ID < 50207) {
 
     // and so on, ...
 }
+
 ?>
 ]]>
     </programlisting>
@@ -131,8 +137,8 @@ if (PHP_VERSION_ID < 50207) {
   <note>
    <para>
     This information is also available in the predefined constant
-    <constant>PHP_VERSION</constant>. More versioning information 
-    is available using the <constant>PHP_<replaceable>*</replaceable>_VERSION</constant> 
+    <constant>PHP_VERSION</constant>. More versioning information
+    is available using the <constant>PHP_<replaceable>*</replaceable>_VERSION</constant>
     constants.
    </para>
   </note>

--- a/reference/info/functions/phpversion.xml
+++ b/reference/info/functions/phpversion.xml
@@ -94,14 +94,6 @@ echo phpversion('zip');
 <![CDATA[
 <?php
 
-// PHP_VERSION_ID is available as of PHP 5.2.7, if our
-// version is lower than that, then emulate it
-if (!defined('PHP_VERSION_ID')) {
-    $version = explode('.', PHP_VERSION);
-
-    define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
-}
-
 /**
  * PHP_VERSION_ID is defined as a number, where the higher the number
  * is, the newer a PHP version is used. It's defined as used in the above

--- a/reference/info/functions/phpversion.xml
+++ b/reference/info/functions/phpversion.xml
@@ -76,11 +76,11 @@
 <![CDATA[
 <?php
 
-// Prints e.g. 'Current PHP version: 4.1.1'
+// Prints e.g. 'Current PHP version: 8.3.12'
 echo 'Current PHP version: ' . phpversion();
 
-// Prints e.g. '2.0' or nothing if the extension isn't enabled
-echo phpversion('tidy');
+// Prints e.g. '1.22.3' or nothing if the extension isn't enabled
+echo phpversion('zip');
 
 ?>
 ]]>


### PR DESCRIPTION
Since the versioning constants names is `PHP_*_VERSION` rather than `PHP_VERSION_*`:

* PHP_MAJOR_VERSION
* PHP_MINOR_VERSION
* PHP_RELEASE_VERSION