### PR TITLE
getbidipairedbracket.xml: add a note about the ICU compatible version

### DIFF
--- a/reference/intl/intlchar/getbidipairedbracket.xml
+++ b/reference/intl/intlchar/getbidipairedbracket.xml
@@ -68,7 +68,7 @@ string(1) "]"
   &reftitle.notes;
   <note>
    <para>
-    This method available with ICU library version 52 and higher.
+    This method is available as of ICU version 52.
    </para>
   </note>
  </refsect1>

--- a/reference/intl/intlchar/getbidipairedbracket.xml
+++ b/reference/intl/intlchar/getbidipairedbracket.xml
@@ -64,6 +64,15 @@ string(1) "]"
   </example>
  </refsect1>
 
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <para>
+    This method available with ICU library version 52 and higher.
+   </para>
+  </note>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>


### PR DESCRIPTION
Based on: https://github.com/php/php-src/issues/15092 and https://github.com/unicode-org/icu/blob/23d9628f88a2d0127c564ad98297061c36d3ce77/icu4j/main/core/src/main/java/com/ibm/icu/lang/UCharacter.java#L5008