### PR TITLE
Extensions/Membership: add MongoDB

### DIFF
--- a/appendices/extensions.xml
+++ b/appendices/extensions.xml
@@ -82,6 +82,7 @@
    <listitem><simpara><xref linkend="book.memcached"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.mhash"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.misc"/></simpara></listitem>
+   <listitem><simpara><xref linkend="set.mongodb"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.mqseries"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.mysql"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.mysql-xdevapi"/></simpara></listitem>
@@ -342,6 +343,7 @@
     <listitem><para><xref linkend="book.mcrypt"/></para></listitem>
     <listitem><para><xref linkend="book.memcache"/></para></listitem>
     <listitem><para><xref linkend="book.memcached"/></para></listitem>
+    <listitem><para><xref linkend="set.mongodb"/></para></listitem>
     <listitem><para><xref linkend="book.mqseries"/></para></listitem>
     <listitem><para><xref linkend="book.mysql"/></para></listitem>
     <listitem><para><xref linkend="book.mysql-xdevapi"/></para></listitem>


### PR DESCRIPTION
Updates:
* https://www.php.net/manual/en/extensions.alphabetical.php
* https://www.php.net/manual/en/extensions.membership.php

The MongoDB extension appears to be missing from the extension pages.

The build for this will fail due to the extension not having a `book.xml` page, but a `set.xml` page instead and the QA script not handling this. Should I rename the XML file ? Or submit an update for the QA script ?

Ref:
* https://www.php.net/manual/en/set.mongodb.php