### PR TITLE
Update examples using md5(...) to use hash('md5', ...)

### DIFF
--- a/reference/mcrypt/functions/mcrypt-module-open.xml
+++ b/reference/mcrypt/functions/mcrypt-module-open.xml
@@ -117,8 +117,8 @@
     $iv = mcrypt_create_iv(mcrypt_enc_get_iv_size($td), MCRYPT_DEV_RANDOM);
     $ks = mcrypt_enc_get_key_size($td);
 
-    /* Create key */
-    $key = substr(md5('very secret key'), 0, $ks);
+    /* Create key (example only: MD5 is not a good hash algorithm for this) */
+    $key = substr(hash('md5', 'very secret key'), 0, $ks);
 
     /* Intialize encryption */
     mcrypt_generic_init($td, $key, $iv);

--- a/reference/pdo_sqlite/PDO/sqliteCreateFunction.xml
+++ b/reference/pdo_sqlite/PDO/sqliteCreateFunction.xml
@@ -146,7 +146,7 @@
 <?php
 function md5_and_reverse($string) 
 {
-    return strrev(md5($string));
+    return strrev(hash('md5', $string));
 }
 
 $db = new PDO('sqlite:sqlitedb');

--- a/reference/radius/constants.xml
+++ b/reference/radius/constants.xml
@@ -317,7 +317,7 @@ $challenge = mt_rand();
 $ident = 1;
 
 // Add the Chap-Password attribute.
-$cp = md5(pack('Ca*', $ident, $password.$challenge), true);
+$cp = hash('md5', pack('Ca*', $ident, $password.$challenge), true);
 radius_put_attr($radh, RADIUS_CHAP_PASSWORD, pack('C', $ident).$cp);
 
 // Add the Chap-Challenge attribute.

--- a/reference/radius/functions/radius-put-attr.xml
+++ b/reference/radius/functions/radius-put-attr.xml
@@ -85,7 +85,7 @@
 <?php
 mt_srand(time());
 $chall = mt_rand();
-$chapval = md5(pack('Ca*',1 , 'sepp' . $chall));
+$chapval = hash('md5', pack('Ca*',1 , 'sepp' . $chall));
 $pass = pack('CH*', 1, $chapval);
 if (!radius_put_attr($res, RADIUS_CHAP_PASSWORD, $pass)) {
     echo 'RadiusError:' . radius_strerror($res). "\n<br />";

--- a/reference/sqlite3/sqlite3/createfunction.xml
+++ b/reference/sqlite3/sqlite3/createfunction.xml
@@ -132,7 +132,7 @@
 <![CDATA[
 <?php
 function my_udf_md5($string) {
-    return md5($string);
+    return hash('md5', $string);
 }
 
 $db = new SQLite3('mysqlitedb.db');


### PR DESCRIPTION
`hash()` has existed since 5.1.2, should be fine to update these old examples now.