### PR TITLE
curl-close.xml: Add a hint on how to destroy the cURL handle

### DIFF
--- a/reference/curl/functions/curl-close.xml
+++ b/reference/curl/functions/curl-close.xml
@@ -72,7 +72,7 @@ curl_setopt($ch, CURLOPT_HEADER, 0);
 curl_exec($ch);
 
 // Close cURL resource, and free up system resources
-curl_close($ch); // As of PHP 8.0.0 use unset($ch)
+curl_close($ch); // As of PHP 8.0.0 use unset($ch) instead
 
 ?>
 ]]>

--- a/reference/curl/functions/curl-close.xml
+++ b/reference/curl/functions/curl-close.xml
@@ -60,18 +60,20 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// create a new cURL resource
+
+// Create a new cURL resource
 $ch = curl_init();
 
-// set URL and other appropriate options
+// Set URL and other appropriate options
 curl_setopt($ch, CURLOPT_URL, "http://www.example.com/");
 curl_setopt($ch, CURLOPT_HEADER, 0);
 
-// grab URL and pass it to the browser
+// Grab URL and pass it to the browser
 curl_exec($ch);
 
-// close cURL resource, and free up system resources
-curl_close($ch);
+// Close cURL resource, and free up system resources
+curl_close($ch); // As of PHP 8.0.0 use unset($ch)
+
 ?>
 ]]>
     </programlisting>

--- a/reference/curl/functions/curl-multi-close.xml
+++ b/reference/curl/functions/curl-multi-close.xml
@@ -63,24 +63,25 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// create both cURL resources
+
+// Create both cURL resources
 $ch1 = curl_init();
 $ch2 = curl_init();
 
-// set URL and other appropriate options
+// Set URL and other appropriate options
 curl_setopt($ch1, CURLOPT_URL, "http://www.example.com/");
 curl_setopt($ch1, CURLOPT_HEADER, 0);
 curl_setopt($ch2, CURLOPT_URL, "http://www.php.net/");
 curl_setopt($ch2, CURLOPT_HEADER, 0);
 
-//create the multiple cURL handle
+// Create the multiple cURL handle
 $mh = curl_multi_init();
 
-//add the two handles
-curl_multi_add_handle($mh,$ch1);
-curl_multi_add_handle($mh,$ch2);
+// Add the two handles
+curl_multi_add_handle($mh, $ch1);
+curl_multi_add_handle($mh, $ch2);
 
-//execute the multi handle
+// Execute the multi handle
 do {
     $status = curl_multi_exec($mh, $active);
     if ($active) {
@@ -88,9 +89,9 @@ do {
     }
 } while ($active && $status == CURLM_OK);
 
-//close the handles
+// Close the handles
 curl_multi_remove_handle($mh, $ch1);
-curl_close($ch1);
+curl_close($ch1); // As of PHP 8.0.0 use unset($ch1)
 curl_multi_remove_handle($mh, $ch2);
 curl_close($ch2);
 curl_multi_close($mh);

--- a/reference/curl/functions/curl-multi-close.xml
+++ b/reference/curl/functions/curl-multi-close.xml
@@ -91,10 +91,12 @@ do {
 
 // Close the handles
 curl_multi_remove_handle($mh, $ch1);
-curl_close($ch1); // As of PHP 8.0.0 use unset($ch1)
+curl_close($ch1); // As of PHP 8.0.0 use unset($ch1) instead
+
 curl_multi_remove_handle($mh, $ch2);
 curl_close($ch2);
-curl_multi_close($mh);
+
+curl_multi_close($mh); // As of PHP 8.0.0 use unset($ch1) instead
 
 ?>
 ]]>

--- a/reference/curl/functions/curl-multi-close.xml
+++ b/reference/curl/functions/curl-multi-close.xml
@@ -94,9 +94,9 @@ curl_multi_remove_handle($mh, $ch1);
 curl_close($ch1); // As of PHP 8.0.0 use unset($ch1) instead
 
 curl_multi_remove_handle($mh, $ch2);
-curl_close($ch2);
+curl_close($ch2); // As of PHP 8.0.0 use unset($ch2) instead
 
-curl_multi_close($mh); // As of PHP 8.0.0 use unset($ch1) instead
+curl_multi_close($mh);
 
 ?>
 ]]>

--- a/reference/curl/functions/curl-share-close.xml
+++ b/reference/curl/functions/curl-share-close.xml
@@ -62,6 +62,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+
 // Create cURL share handle and set it to share cookie data
 $sh = curl_share_init();
 curl_share_setopt($sh, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE);
@@ -77,16 +78,17 @@ curl_exec($ch1);
 $ch2 = curl_init("http://php.net/");
 curl_setopt($ch2, CURLOPT_SHARE, $sh);
 
-// Execute the second cURL handle
-//  all cookies from $ch1 handle are shared with $ch2 handle
+// Execute the second cURL handle.
+// All cookies from $ch1 handle are shared with $ch2 handle
 curl_exec($ch2);
 
 // Close the cURL share handle
-curl_share_close($sh);
+curl_share_close($sh); // As of PHP 8.0.0 use unset($ch1) instead
 
 // Close the cURL handles
-curl_close($ch1);
+curl_close($ch1); // As of PHP 8.0.0 use unset($ch1) instead
 curl_close($ch2);
+
 ?>
 ]]>
     </programlisting>

--- a/reference/curl/functions/curl-share-close.xml
+++ b/reference/curl/functions/curl-share-close.xml
@@ -83,11 +83,11 @@ curl_setopt($ch2, CURLOPT_SHARE, $sh);
 curl_exec($ch2);
 
 // Close the cURL share handle
-curl_share_close($sh); // As of PHP 8.0.0 use unset($ch1) instead
+curl_share_close($sh);
 
 // Close the cURL handles
 curl_close($ch1); // As of PHP 8.0.0 use unset($ch1) instead
-curl_close($ch2);
+curl_close($ch2); // As of PHP 8.0.0 use unset($ch2) instead
 
 ?>
 ]]>


### PR DESCRIPTION
I know that the cURL handle is now an instance of the `CurlHandle` class. I also know that we can free up resources by deleting an object through the `unset()` language construct. Maybe the mention of unset() is redundant. But something tells me that the `curl_close()` page violates the principle: Rejecting — offer! The page warned that the curl_close() function is a no-op as of PHP 8.0.0, but did not offer an alternative (at least in the code example).

What do dear colleagues think about this?