### PR TITLE
curl-init.xml: replace 'resource' to 'session'

### DIFF
--- a/reference/curl/functions/curl-init.xml
+++ b/reference/curl/functions/curl-init.xml
@@ -89,18 +89,20 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// create a new cURL resource
+
+// Create a new cURL session
 $ch = curl_init();
 
-// set URL and other appropriate options
+// Set URL and other appropriate options
 curl_setopt($ch, CURLOPT_URL, "http://www.example.com/");
 curl_setopt($ch, CURLOPT_HEADER, 0);
 
-// grab URL and pass it to the browser
+// Grab URL and pass it to the browser
 curl_exec($ch);
 
-// close cURL resource, and free up system resources
+// Close cURL session, and free up system resources
 curl_close($ch);
+
 ?>
 ]]>
     </programlisting>

--- a/reference/curl/functions/curl-init.xml
+++ b/reference/curl/functions/curl-init.xml
@@ -90,7 +90,7 @@
 <![CDATA[
 <?php
 
-// Create a new cURL session
+// Initializes a new cURL session
 $ch = curl_init();
 
 // Set URL and other appropriate options

--- a/reference/curl/functions/curl-init.xml
+++ b/reference/curl/functions/curl-init.xml
@@ -5,7 +5,7 @@
   <refname>curl_init</refname>
   <refpurpose>Initialize a cURL session</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -14,8 +14,8 @@
   </methodsynopsis>
   <para>
    Initializes a new session and return a cURL handle for use with the
-   <function>curl_setopt</function>, <function>curl_exec</function>,
-   and <function>curl_close</function> functions.  
+   <function>curl_setopt</function> and <function>curl_exec</function>
+   functions.
   </para>
  </refsect1>
 
@@ -28,7 +28,7 @@
      <listitem>
       <para>
        If provided, the <constant>CURLOPT_URL</constant> option will be set
-       to its value. You can manually set this using the 
+       to its value. You can manually set this using the
        <function>curl_setopt</function> function.
       </para>
       <note>
@@ -49,7 +49,7 @@
    Returns a cURL handle on success, &false; on errors.
   </para>
  </refsect1>
- 
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -98,10 +98,7 @@ curl_setopt($ch, CURLOPT_URL, "http://www.example.com/");
 curl_setopt($ch, CURLOPT_HEADER, 0);
 
 // Grab URL and pass it to the browser
-curl_exec($ch);
-
-// Close cURL session, and free up system resources
-curl_close($ch);
+echo curl_exec($ch);
 
 ?>
 ]]>
@@ -114,7 +111,6 @@ curl_close($ch);
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>curl_close</function></member>
     <member><function>curl_multi_init</function></member>
    </simplelist>
   </para>

--- a/reference/curl/functions/curl-init.xml
+++ b/reference/curl/functions/curl-init.xml
@@ -14,8 +14,6 @@
   </methodsynopsis>
   <para>
    Initializes a new session and returns a cURL handle.
-   <function>curl_setopt</function> and <function>curl_exec</function>
-   functions.
   </para>
  </refsect1>
 
@@ -98,7 +96,7 @@ curl_setopt($ch, CURLOPT_URL, "http://www.example.com/");
 curl_setopt($ch, CURLOPT_HEADER, 0);
 
 // Grab URL and pass it to the browser
-echo curl_exec($ch);
+curl_exec($ch);
 
 ?>
 ]]>

--- a/reference/curl/functions/curl-init.xml
+++ b/reference/curl/functions/curl-init.xml
@@ -13,7 +13,7 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>url</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Initializes a new session and return a cURL handle for use with the
+   Initializes a new session and returns a cURL handle.
    <function>curl_setopt</function> and <function>curl_exec</function>
    functions.
   </para>

--- a/reference/curl/functions/curl-init.xml
+++ b/reference/curl/functions/curl-init.xml
@@ -26,7 +26,7 @@
      <listitem>
       <para>
        If provided, the <constant>CURLOPT_URL</constant> option will be set
-       to its value. You can manually set this using the
+       to its value. This can be set manually using the
        <function>curl_setopt</function> function.
       </para>
       <note>


### PR DESCRIPTION
I think that in the context of the curl_init() function, it is appropriate to replace the term "resource" with the term "session", since the resource is no longer relevant since PHP 8.0.0, and the session is relevant for both newer versions of PHP and before PHP 8.0.0