### PR TITLE
http-auth.xml: remove mention of digest

### DIFF
--- a/features/http-auth.xml
+++ b/features/http-auth.xml
@@ -51,7 +51,7 @@ if (!isset($_SERVER['PHP_AUTH_USER'])) {
     uppercase "B", the realm string must be enclosed in double (not single) quotes,
     and exactly one space should precede the <emphasis>401</emphasis> code in the 
     <emphasis>HTTP/1.0 401</emphasis> header line. Authentication parameters have
-    to be comma-separated as seen in the digest example above.
+    to be comma-separated.
    </para>
   </note>
 


### PR DESCRIPTION
Digest HTTP Authentication example has been removed, but the mention of the content of the deleted paragraph remains