### PR TITLE
Added __PHP_Incomplete_Class version info

### DIFF
--- a/language/predefined/versions.xml
+++ b/language/predefined/versions.xml
@@ -177,6 +177,7 @@
  <function name="SensitiveParameterValue::getValue" from="PHP 8 &gt;= 8.2.0"/>
  <function name="Override" from="PHP 8 &gt;= 8.3.0"/>
  <function name="Override::__construct" from="PHP 8 &gt;= 8.3.0"/>
+ <function name="__PHP_Incomplete_Class" from="PHP 4.0.1, PHP 5, PHP 7, PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
I grepped `__PHP_Incomplete_Class` in the source code of PHP musesum.

- Not found
  * https://museum.php.net/php3/php-3.0.18.tar.gz
  *  https://museum.php.net/php4/php-4.0.0.tar.gz
- Found
  * https://museum.php.net/php4/php-4.0.1.tar.gz

refs: #3451