### PR TITLE
Convert MongoDB documentation from a top element of set to book

### DIFF
--- a/appendices/extensions.xml
+++ b/appendices/extensions.xml
@@ -82,6 +82,7 @@
    <listitem><simpara><xref linkend="book.memcached"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.mhash"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.misc"/></simpara></listitem>
+   <listitem><simpara><xref linkend="book.mongodb"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.mqseries"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.mysql"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.mysql-xdevapi"/></simpara></listitem>
@@ -342,6 +343,7 @@
     <listitem><para><xref linkend="book.mcrypt"/></para></listitem>
     <listitem><para><xref linkend="book.memcache"/></para></listitem>
     <listitem><para><xref linkend="book.memcached"/></para></listitem>
+    <listitem><para><xref linkend="book.mongodb"/></para></listitem>
     <listitem><para><xref linkend="book.mqseries"/></para></listitem>
     <listitem><para><xref linkend="book.mysql"/></para></listitem>
     <listitem><para><xref linkend="book.mysql-xdevapi"/></para></listitem>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -3585,7 +3585,7 @@ local: {
      </para>
      <note>
       <simpara>
-       When evaluating query criteria, MongoDB compares types and values according to its own <link xlink:href="&url.mongodb.docs;reference/bson-type-comparison-order/" xmlns:xlink="http://www.w3.org/1999/xlink">comparison rules for BSON types</link>, which differs from PHP&apos;s <link linkend="types.comparisons">comparison</link> and <link linkend="language.types.type-juggling">type juggling</link> rules. When matching a special BSON type the query criteria should use the respective <link linkend="book.bson">BSON class</link> (e.g. use <classname>MongoDB\BSON\ObjectId</classname> to match an <link xlink:href="&url.mongodb.docs.objectid;" xmlns:xlink="http://www.w3.org/1999/xlink">ObjectId</link>).
+       When evaluating query criteria, MongoDB compares types and values according to its own <link xlink:href="&url.mongodb.docs;reference/bson-type-comparison-order/" xmlns:xlink="http://www.w3.org/1999/xlink">comparison rules for BSON types</link>, which differs from PHP&apos;s <link linkend="types.comparisons">comparison</link> and <link linkend="language.types.type-juggling">type juggling</link> rules. When matching a special BSON type the query criteria should use the respective <link linkend="mongodb.bson">BSON class</link> (e.g. use <classname>MongoDB\BSON\ObjectId</classname> to match an <link xlink:href="&url.mongodb.docs.objectid;" xmlns:xlink="http://www.w3.org/1999/xlink">ObjectId</link>).
       </simpara>
      </note>
     </listitem>

--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<book xml:id="mongodb.architecture" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="mongodb.architecture" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <titleabbrev>Driver Architecture and Internals</titleabbrev>
  <title>Explains the driver architecture, and special features</title>
 
- <article xml:id="mongodb.overview">
+ <section xml:id="mongodb.overview">
   <titleabbrev>Architecture</titleabbrev>
   <title>Architecture Overview</title>
 
@@ -87,9 +87,9 @@
     </tgroup>
    </table>
   </para>
- </article>
+ </section>
 
- <article xml:id="mongodb.connection-handling">
+ <section xml:id="mongodb.connection-handling">
   <titleabbrev>Connections</titleabbrev>
   <title>Connection handling and persistence</title>
 
@@ -208,9 +208,9 @@ foreach ($managers as $manager) {
     PHP&apos;s Streams API.
    </para>
   </section>
- </article>
+ </section>
 
- <article xml:id="mongodb.persistence">
+ <section xml:id="mongodb.persistence">
   <titleabbrev>Persisting Data</titleabbrev>
   <title>Serialization and deserialization of PHP variables into MongoDB</title>
 
@@ -967,8 +967,8 @@ function bsonUnserialize( array $map )
    </section>
   </section>
 
- </article>
-</book>
+ </section>
+</chapter>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mongodb/book.xml
+++ b/reference/mongodb/book.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<set xml:id="set.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<book xml:id="book.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>MongoDB Extension</title>
  <titleabbrev>MongoDB</titleabbrev>
 
@@ -16,7 +16,7 @@
     <link linkend="class.mongodb-driver-query">queries</link>,
     <link linkend="class.mongodb-driver-bulkwrite">writes</link>,
     <link linkend="class.mongodb-driver-manager">connection management</link>,
-    and <link linkend="book.bson">BSON serialization</link>.
+    and <link linkend="mongodb.bson">BSON serialization</link>.
    </simpara>
    <simpara>
     Userland PHP libraries that depend on this extension may provide higher
@@ -33,6 +33,7 @@
  </info>
 
   &reference.mongodb.setup;
+  &reference.mongodb.constants;
   &reference.mongodb.tutorial;
   &reference.mongodb.architecture;
   &reference.mongodb.security;
@@ -41,7 +42,7 @@
   &reference.mongodb.bson;
   &reference.mongodb.monitoring;
   &reference.mongodb.exceptions;
-</set>
+</book>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mongodb/book.xml
+++ b/reference/mongodb/book.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
 <book xml:id="book.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>MongoDB Extension</title>
  <titleabbrev>MongoDB</titleabbrev>
 

--- a/reference/mongodb/bson.xml
+++ b/reference/mongodb/bson.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
- <book xml:id="book.bson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <part xml:id="mongodb.bson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="pecl" ?>
   <title>MongoDB BSON Classes and Functions</title>
   <titleabbrev>MongoDB\BSON</titleabbrev>
@@ -44,5 +44,4 @@
   &reference.mongodb.bson.int64;
   &reference.mongodb.bson.symbol;
   &reference.mongodb.bson.undefined;
- </book>
-
+ </part>

--- a/reference/mongodb/configure.xml
+++ b/reference/mongodb/configure.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<article xml:id="mongodb.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<section xml:id="mongodb.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
 
  <section xml:id="mongodb.installation.pecl">
@@ -270,7 +270,7 @@ extension=mongodb.so
   </para>
  </section>
 
-</article>
+</section>
 
 
 <!-- Keep this comment at the end of the file

--- a/reference/mongodb/exceptions.xml
+++ b/reference/mongodb/exceptions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
- <book xml:id="mongodb.exceptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <part xml:id="mongodb.exceptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <titleabbrev>MongoDB\Driver\Exception</titleabbrev>
   <title>Exception classes</title>
 
@@ -66,4 +66,4 @@
    </itemizedlist>
   </article>
 
- </book>
+ </part>

--- a/reference/mongodb/ini.xml
+++ b/reference/mongodb/ini.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<article xml:id="mongodb.configuration" xmlns="http://docbook.org/ns/docbook">
+<section xml:id="mongodb.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;
  <para>
@@ -74,7 +74,7 @@
     </varlistentry>
   </variablelist>
  </para>
-</article>
+</section>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mongodb/mongodb.xml
+++ b/reference/mongodb/mongodb.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
- <book xml:id="book.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <part xml:id="mongodb.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="pecl" ?>
   <title>MongoDB Extension Classes</title>
   <titleabbrev>MongoDB\Driver</titleabbrev>
@@ -29,5 +29,4 @@
   &reference.mongodb.mongodb.driver.writeconcernerror;
   &reference.mongodb.mongodb.driver.writeerror;
   &reference.mongodb.mongodb.driver.writeresult;
- </book>
-
+ </part>

--- a/reference/mongodb/monitoring.xml
+++ b/reference/mongodb/monitoring.xml
@@ -29,4 +29,3 @@
   &reference.mongodb.mongodb.driver.monitoring.sdamsubscriber;
   &reference.mongodb.mongodb.driver.monitoring.subscriber;
  </part>
- 

--- a/reference/mongodb/monitoring.xml
+++ b/reference/mongodb/monitoring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
- <book xml:id="mongodb.monitoring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <part xml:id="mongodb.monitoring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Monitoring classes and subscriber functions</title>
   <titleabbrev>MongoDB\Driver\Monitoring</titleabbrev>
 
@@ -28,5 +28,5 @@
   &reference.mongodb.mongodb.driver.monitoring.logsubscriber;
   &reference.mongodb.mongodb.driver.monitoring.sdamsubscriber;
   &reference.mongodb.mongodb.driver.monitoring.subscriber;
- </book>
-
+ </part>
+ 

--- a/reference/mongodb/security.xml
+++ b/reference/mongodb/security.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<book xml:id="mongodb.security" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="mongodb.security" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Security</title>
 
- <article xml:id="mongodb.security.request_injection">
+ <section xml:id="mongodb.security.request_injection">
   <title>Request Injection Attacks</title>
   <para>
    If you are passing <literal>$_GET</literal> (or <literal>$_POST</literal>)
@@ -44,9 +44,9 @@
    See <link xlink:href="&url.mongodb.dochub.security;">the main documentation</link>
    for more information about SQL-injection-like issues with MongoDB.
   </para>
- </article>
+ </section>
 
- <article xml:id="mongodb.security.script_injection">
+ <section xml:id="mongodb.security.script_injection">
   <title>Script Injection Attacks</title>
   <para>
    If you are using JavaScript, make sure that any variables that cross the PHP-
@@ -157,8 +157,8 @@ $r = $m->executeCommand( 'dramio', $cmd );
    xlink:href="&url.mongodb.docs;reference/command/eval/">eval command</link>
    has been deprecated since MongoDB 3.0, and should also be avoided.
   </para>
- </article>
-</book>
+ </section>
+</chapter>
 
 <!-- Keep this comment at the end of the file
 Local variables:
@@ -180,4 +180,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/mongodb/setup.xml
+++ b/reference/mongodb/setup.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<book xml:id="mongodb.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="mongodb.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
 
- <article xml:id="mongodb.requirements">
+ <section xml:id="mongodb.requirements">
   &reftitle.required;
   <para>
    As of version 1.16.0, the extension requires PHP 7.2 or higher. Previous
@@ -43,21 +43,20 @@
     integer type.
    </simpara>
   </note>
- </article>
+ </section>
 
  &reference.mongodb.configure;
  &reference.mongodb.ini;
 <!--
- <article xml:id="mongodb.resources">
+ <section xml:id="mongodb.resources">
   &reftitle.resources;
   <para>
 
   </para>
- </article>
+ </section>
 -->
-  &reference.mongodb.constants;
 
-</book>
+</chapter>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mongodb/tutorial.xml
+++ b/reference/mongodb/tutorial.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
- <book xml:id="mongodb.tutorial" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <chapter xml:id="mongodb.tutorial" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Tutorials</title>
   <titleabbrev>Tutorials</titleabbrev>
 
@@ -16,7 +16,7 @@
 
   &reference.mongodb.tutorial.library;
   &reference.mongodb.tutorial.apm;
- </book>
+ </chapter>
 
 
 <!-- Keep this comment at the end of the file

--- a/reference/mongodb/tutorial/apm.xml
+++ b/reference/mongodb/tutorial/apm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<chapter xml:id="mongodb.tutorial.apm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<section xml:id="mongodb.tutorial.apm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Application Performance Monitoring (APM)</title>
 
  <para>
@@ -185,7 +185,7 @@ $cursor = $m->executeQuery( 'dramio.whisky', $query );
   </programlisting>
  </section>
 
-</chapter>
+</section>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mongodb/tutorial/library.xml
+++ b/reference/mongodb/tutorial/library.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<chapter xml:id="mongodb.tutorial.library" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<section xml:id="mongodb.tutorial.library" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Using the PHP Library for MongoDB (PHPLIB)</title>
 
  <para>
@@ -155,7 +155,7 @@ foreach ($result as $entry) {
     how values are converted between PHP and BSON.
    </para>
   </section>
-</chapter>
+</section>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
Convert all underlying elements as needed:
 - `<books>` to `<part>`s or `<chapter>`s
 - `<article>`s to `<section>`s

Move the Predefined Constants page from the Installing/Configuring section to its own

Change the following `xml:id`s:
 - `book.mongodb` to `mongodb.mongodb`
 - `set.mongodb` to `book.mongodb`
 - `book.bson` to `mongodb.bson`

Please note that these changes only work when the accompanying `doc-base` changes are merged too (https://github.com/php/doc-base/pull/138).

*Note:*
Please note that because of the difference between `root chunks` and `container chunks` in `PhD` (ie. a `<book>` and a `<part>`), the four pages linked to from the main [MongoDB page](https://www.php.net/manual/en/set.mongodb) ([MongoDB](https://www.php.net/manual/en/book.mongodb.php), [BSON](https://www.php.net/manual/en/book.bson.php), [Monitoring](https://www.php.net/manual/en/mongodb.monitoring.php) and [Exceptions](https://www.php.net/manual/en/mongodb.exceptions.php)) are only going to list their underlying classes without listing each method of each class.
E.g. the [MongoDB Extension Classes page](https://www.php.net/manual/en/book.mongodb.php) will only list the 19 classes belonging to that group of classes instead of listing the 19 classes plus all their 144 methods. As before, the methods are still listed on the pages of their respective classes.