### PR TITLE
Don't link to the direct downloads, but rather to the PECL page

### DIFF
--- a/reference/cmark/setup.xml
+++ b/reference/cmark/setup.xml
@@ -20,7 +20,7 @@
    <link xlink:href="&url.pecl.package;cmark">&url.pecl.package;cmark</link>.
   </para>
   <para>
- Windows users can download prebuilt release binaries from the <link xlink:href="&url.pecl.windows.releases;cmark">PECL</link> website.
+ Windows users can download prebuilt release binaries from the <link xlink:href="&url.pecl.package;cmark">PECL</link> website.
   </para>
   <caution>
    <para>

--- a/reference/imagick/setup.xml
+++ b/reference/imagick/setup.xml
@@ -33,7 +33,7 @@
    <simpara>The official name of this extension is <emphasis>imagick</emphasis>.</simpara>
   </note>
   <para>
-    Windows users can download prebuilt DLL from the <link xlink:href="&url.pecl.windows.releases;imagick">PECL</link> website.
+    Windows users can download prebuilt DLL from the <link xlink:href="&url.pecl.package;imagick">PECL</link> website.
     These packages already contain the extension DLL (<filename>php_imagick.dll</filename>)
     which needs to be put into the <link linkend="ini.extension-dir">extension_dir</link>.
     They also contain the ImageMagick DLLs, which need to be put somewhere in the <envar>PATH</envar>.

--- a/reference/pthreads/setup.xml
+++ b/reference/pthreads/setup.xml
@@ -30,7 +30,7 @@
    <link xlink:href="&url.pecl.package;pthreads">&url.pecl.package;pthreads</link>.
   </para>
   <para>
- Windows users can download prebuilt release binaries from the <link xlink:href="&url.pecl.windows.releases;pthreads">PECL</link> website.
+ Windows users can download prebuilt release binaries from the <link xlink:href="&url.pecl.package;pthreads">PECL</link> website.
   </para>
   <caution>
    <para>

--- a/reference/uopz/setup.xml
+++ b/reference/uopz/setup.xml
@@ -20,7 +20,7 @@
    <link xlink:href="&url.pecl.package;uopz">&url.pecl.package;uopz</link>.
   </para>
   <para>
- Windows users can download prebuilt release binaries from the <link xlink:href="&url.pecl.windows.releases;uopz">PECL</link> website.
+ Windows users can download prebuilt release binaries from the <link xlink:href="&url.pecl.package;uopz">PECL</link> website.
   </para>
   <para>
    As of uopz 5.0.0 the extension must be loaded as


### PR DESCRIPTION
Besides that new builds are no longer placed on that server, users better go to the PECL page, where they can get more information anyway.

See also #3632.