### PR TITLE
Add missing CURLOPT constants

### DIFF
--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -377,7 +377,8 @@
    </term>
    <listitem>
     <para>
-     Pass a <type>string</type> naming a file with the concatenation of CRL (in PEM format)
+     Pass a <type>string</type> naming a file with the concatenation of
+     CRL (Certificate Revocation List) (in PEM format)
      to use in the certificate validation that occurs during the SSL exchange.
      When cURL is built to use GnuTLS,
      there is no way to influence the use of CRL passed

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -17,6 +17,44 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-accept-encoding">
+   <term>
+    <constant>CURLOPT_ACCEPT_ENCODING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the contents of the <literal>Accept-Encoding:</literal> header
+     sent in an HTTP request.
+     Available as of cURL 7.21.6
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-accepttimeout-ms">
+   <term>
+    <constant>CURLOPT_ACCEPTTIMEOUT_MS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The maximum number of milliseconds to wait for a server
+     to connect back to libcurl when an active FTP connection is used.
+     Available as of cURL 7.24.0
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-address-scope">
+   <term>
+    <constant>CURLOPT_ADDRESS_SCOPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The scope id value to use when connecting to IPv6 addresses.
+     Available as of cURL 7.19.0
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-altsvc">
    <term>
     <constant>CURLOPT_ALTSVC</constant>
@@ -47,6 +85,19 @@
      <constant>CURLALTSVC_H3</constant>, and
      <constant>CURLALTSVC_READONLYFILE</constant>.
      Available as of PHP 8.2.0 and cURL 7.64.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-append">
+   <term>
+    <constant>CURLOPT_APPEND</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Setting this option to <literal>1</literal> will cause FTP uploads
+     to append to the remote file instead of overwriting it.
+     Available as of cURL 7.17.0
     </para>
    </listitem>
   </varlistentry>
@@ -312,6 +363,30 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-crlfile">
+   <term>
+    <constant>CURLOPT_CRLFILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Pass a string naming a file with the concatenation of CRL (in PEM format)
+     to use in the certificate validation that occurs during the SSL exchange.
+     When curl is built to use GnuTLS,
+     there is no way to influence the use of CRL passed
+     to help in the verification process.
+     When libcurl is built with OpenSSL support,
+     <literal>X509_V_FLAG_CRL_CHECK</literal>
+     and <literal>X509_V_FLAG_CRL_CHECK_ALL</literal> are both set,
+     requiring CRL check against all the elements of the certificate chain
+     if a CRL file is passed.
+     Also note that <constant>CURLOPT_CRLFILE</constant> implies
+     <constant>CURLSSLOPT_NO_PARTIALCHAIN</constant>
+     as of cURL 7.71.0 due to an OpenSSL bug.
+     Available as of cURL 7.19.0
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-customrequest">
    <term>
     <constant>CURLOPT_CUSTOMREQUEST</constant>
@@ -346,6 +421,25 @@
     <para>
      The default protocol to use if the URL is missing a scheme name.
      Available as of PHP 7.0.7 and cURL 7.45.0
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-dirlistonly">
+   <term>
+    <constant>CURLOPT_DIRLISTONLY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Setting this option to <literal>1</literal> will have different effects
+     based on the protocol it is used with.
+     FTP and SFTP based URLs will list only the names of files in a directory.
+     POP3 will list the email message or messages on the POP3 server.
+     For FILE, this option has no effect
+     as directories are always listed in this mode.
+     Using this option with <constant>CURLOPT_WILDCARDMATCH</constant>
+     will prevent the latter from having any effect.
+     Available as of cURL 7.17.0.
     </para>
    </listitem>
   </varlistentry>
@@ -409,6 +503,20 @@
      Set the local IPv6 address that the resolver should bind to. The argument
      should contain a single numerical IPv6 address as a string.
      Available as of PHP 7.0.7 and cURL 7.33.0
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-dns-servers">
+   <term>
+    <constant>CURLOPT_DNS_SERVERS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Pass a string with a comma-separated list of DNS servers to be used
+     instead of the system default
+     (e.g.: <literal>192.168.1.100,192.168.1.101:8080</literal>).
+     Available as of cURL 7.24.0
     </para>
    </listitem>
   </varlistentry>
@@ -568,6 +676,55 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-fnmatch-function">
+   <term>
+    <constant>CURLOPT_FNMATCH_FUNCTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Pass a callback that will be used for wildcard matching.
+     The signature of the callback should be:
+     <methodsynopsis>
+      <type>int</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>resource</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>string</type><parameter>pattern</parameter></methodparam>
+      <methodparam><type>string</type><parameter>string</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         The cURL handle.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>pattern</parameter></term>
+       <listitem>
+        <simpara>
+         The wildcard pattern.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>string</parameter></term>
+       <listitem>
+        <simpara>
+         The string to run the wildcard pattern matching on.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     The callback should return
+     <constant>CURL_FNMATCHFUNC_MATCH</constant> if pattern matches the string,
+     <constant>CURL_FNMATCHFUNC_NOMATCH</constant> if not
+     or <constant>CURL_FNMATCHFUNC_FAIL</constant> if an error occurred.
+     Available as of cURL 7.21.0.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-followlocation">
    <term>
     <constant>CURLOPT_FOLLOWLOCATION</constant>
@@ -675,6 +832,33 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-account">
+   <term>
+    <constant>CURLOPT_FTP_ACCOUNT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Pass a string that will be sent as account information over FTP
+     (using the ACCT command) after username and password has been provided
+     to the server.
+     Available as of cURL 7.13.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-alternative-to-user">
+   <term>
+    <constant>CURLOPT_FTP_ALTERNATIVE_TO_USER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Pass a string that will be used to try to authenticate over FTP
+     if the USER/PASS negotiation fails.
+     Available as of cURL 7.15.5.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-ftp-create-missing-dirs">
    <term>
     <constant>CURLOPT_FTP_CREATE_MISSING_DIRS</constant>
@@ -703,6 +887,35 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-response-timeout">
+   <term>
+    <constant>CURLOPT_FTP_RESPONSE_TIMEOUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A timeout in seconds libcurl will wait for a response from an FTP server.
+     This option overrides <constant>CURLOPT_TIMEOUT</constant>.
+     Available as of cURL 7.10.8. Deprecated as of cURL 7.85.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-skip-pasv-ip">
+   <term>
+    <constant>CURLOPT_FTP_SKIP_PASV_IP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     If this option is set to <literal>1</literal>
+     libcurl will not use the IP address the server suggests
+     in its 227-response to libcurl's PASV command
+     but will use the IP address it used for the connection.
+     The port number received from the 227-response will not be ignored by libcurl.
+     Available as of cURL 7.15.0.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-ftp-ssl">
    <term>
     <constant>CURLOPT_FTP_SSL</constant>
@@ -711,6 +924,28 @@
    <listitem>
     <para>
 
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-ssl-ccc">
+   <term>
+    <constant>CURLOPT_FTP_SSL_CCC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     This option makes libcurl use CCC (Clear Command Channel)
+     which shuts down the SSL/TLS layer after authenticating
+     making the rest of the control channel communication unencrypted.
+     Use one of the following values:
+     <constant>CURLFTPSSL_CCC_NONE</constant>
+      - do not attempt to use CCC.
+     <constant>CURLFTPSSL_CCC_PASSIVE</constant>
+      - Do not initiate the shutdown, but wait for the server to do it.
+      Do not send a reply.
+     <constant>CURLFTPSSL_CCC_ACTIVE</constant>
+      - Initiate the shutdown and wait for a reply.
+     Available as of cURL 7.16.1.
     </para>
    </listitem>
   </varlistentry>
@@ -737,6 +972,36 @@
      &true; to first try an EPSV command for FTP
      transfers before reverting back to PASV. Set to &false;
      to disable EPSV.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-use-pret">
+   <term>
+    <constant>CURLOPT_FTP_USE_PRET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     If set to <literal>1</literal>, a PRET command is sent
+     before PASV (and EPSV).
+     Has no effect when using the active FTP transfers mode.
+     Available as of cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-gssapi-delegation">
+   <term>
+    <constant>CURLOPT_GSSAPI_DELEGATION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to <constant>CURLGSSAPI_DELEGATION_FLAG</constant>
+     to allow unconditional GSSAPI credential delegation.
+     Set to <constant>CURLGSSAPI_DELEGATION_POLICY_FLAG</constant>
+     to delegate only if the <literal>OK-AS-DELEGATE</literal> flag is set
+     in the service ticket.
+     Available as of cURL 7.22.0.
     </para>
    </listitem>
   </varlistentry>
@@ -936,6 +1201,21 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-http-transfer-decoding">
+   <term>
+    <constant>CURLOPT_HTTP_TRANSFER_DECODING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     If set to <literal>0</literal>, transfer decoding is disabled.
+     If set to <literal>1</literal>, transfer decoding is enabled (default).
+     libcurl does chunked transfer decoding by default
+     unless this option is set to <literal>0</literal>.
+     Available as of cURL 7.16.2.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-http-version">
    <term>
     <constant>CURLOPT_HTTP_VERSION</constant>
@@ -951,6 +1231,20 @@
      <constant>CURL_HTTP_VERSION_2</constant> (alias of <constant>CURL_HTTP_VERSION_2_0</constant>),
      <constant>CURL_HTTP_VERSION_2TLS</constant> (attempts HTTP 2 over TLS (HTTPS) only) or
      <constant>CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE</constant> (issues non-TLS HTTP requests using HTTP/2 without HTTP/1.1 Upgrade).
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ignore-content-length">
+   <term>
+    <constant>CURLOPT_IGNORE_CONTENT_LENGTH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     If set to <literal>1</literal>,
+     ignore the <literal>Content-Length</literal> header in the HTTP response
+     and ignore asking for or relying on it for FTP transfers.
+     Available as of cURL 7.14.1.
     </para>
    </listitem>
   </varlistentry>
@@ -1006,6 +1300,24 @@
      <constant>CURL_IPRESOLVE_V6</constant>, by default
      <constant>CURL_IPRESOLVE_WHATEVER</constant>.
      Available as of cURL 7.10.8.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-issuercert">
+   <term>
+    <constant>CURLOPT_ISSUERCERT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     If set to a string naming a file holding a CA certificate in PEM format,
+     an additional check against the peer certificate is performed
+     to verify the issuer is indeed the one associated
+     with the certificate provided by the option.
+     For the result of the check to be considered a failure,
+     this option should be used in combination with the
+     <constant>CURLOPT_SSL_VERIFYPEER</constant> option.
+     Available as of cURL 7.19.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1069,6 +1381,49 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-krblevel">
+   <term>
+    <constant>CURLOPT_KRBLEVEL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set the kerberos security level for FTP and also enables kerberos awareness.
+     This should be set to one of the following:
+     <literal>clear</literal>, <literal>safe</literal>,
+     <literal>confidential</literal> or <literal>private</literal>.
+     If the string is set but does not match one of these,
+     <literal>private</literal> is used.
+     Setting this option to &null; will disable kerberos support for FTP.
+     Available as of cURL 7.16.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-localport">
+   <term>
+    <constant>CURLOPT_LOCALPORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the local port number of the socket used for the connection.
+     Available as of cURL 7.15.2.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-localportrange">
+   <term>
+    <constant>CURLOPT_LOCALPORTRANGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The number of attempts libcurl makes to find a working local port number,
+     starting with the one set with <constant>CURLOPT_LOCALPORT</constant>.
+     Available as of cURL 7.15.2.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-login-options">
    <term>
     <constant>CURLOPT_LOGIN_OPTIONS</constant>
@@ -1110,6 +1465,57 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-mail-auth">
+   <term>
+    <constant>CURLOPT_MAIL_AUTH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a string with the authentication address (identity)
+     of a submitted message that is being relayed to another server.
+     The address should not be specified within a pair of angled brackets
+     (<literal>&gt;&lt;</literal>).
+     If an empty string is used then a pair of brackets are sent by libcurl
+     as required by RFC 2554.
+     Available as of cURL 7.25.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-mail-from">
+   <term>
+    <constant>CURLOPT_MAIL_FROM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a string with the sender's email address when sending SMTP mail.
+     The email address should be specified with angled brackets
+     (<literal>&gt;&lt;</literal>) around it,
+     which if not specified are added automatically.
+     If this parameter is not specified then an empty address is sent
+     to the SMTP server which might cause the email to be rejected.
+     Available as of cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-mail-rcpt">
+   <term>
+    <constant>CURLOPT_MAIL_RCPT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to an array of recipients to pass to the server in an SMTP mail request.
+     Each recipient should be specified within a pair of angled brackets
+     (<literal>&gt;&lt;</literal>).
+     If an angled bracket is not used as the first character,
+     libcurl assumes a single email address has been provided
+     and encloses that address within brackets.
+     Available as of cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-mail-rcpt-alllowfails">
    <term>
     <constant>CURLOPT_MAIL_RCPT_ALLLOWFAILS</constant>
@@ -1144,6 +1550,30 @@
      The maximum amount of persistent connections that are allowed.
      When the limit is reached, the oldest one in the cache is closed
      to prevent increasing the number of open connections.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-maxfilesize">
+   <term>
+    <constant>CURLOPT_MAXFILESIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the maximum accepted size (in bytes) of a file to download.
+     If the file requested is found larger than this value,
+     the transfer is aborted
+     and <constant>CURLE_FILESIZE_EXCEEDED</constant> is returned.
+     Passing a zero size disables this option,
+     and passing a negative size returns a
+     <constant>CURLE_BAD_FUNCTION_ARGUMENT</constant>.
+     If the file size is not known prior to the start of download,
+     this option has no effect.
+     For setting a size limit above <literal>2GB</literal>,
+     <constant>CURLOPT_MAXFILESIZE_LARGE</constant> should be used.
+     As of cURL 8.4.0, this option also stops ongoing transfers
+     if they reach this threshold.
+     Available as of cURL 7.10.8.
     </para>
    </listitem>
   </varlistentry>
@@ -1259,6 +1689,53 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-netrc-file">
+   <term>
+    <constant>CURLOPT_NETRC_FILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a string containing the full path name to a <literal>.netrc</literal> file.
+     If this option is omitted and <constant>CURLOPT_NETRC</constant> is set,
+     libcurl checks for a <literal>.netrc</literal> file
+     in the current user's home directory.
+     Available as of cURL 7.11.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-new-directory-perms">
+   <term>
+    <constant>CURLOPT_NEW_DIRECTORY_PERMS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the value of the permissions that is set on newly created directories
+     on the remote server. The default value is <literal>0755</literal>.
+     The only protocols that can use this are
+     <literal>sftp://</literal>, <literal>scp://</literal>
+     and <literal>file://</literal>.
+     Available as of cURL 7.16.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-new-file-perms">
+   <term>
+    <constant>CURLOPT_NEW_FILE_PERMS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the value of the permissions that are set on newly created files
+     on the remote server. The default value is <literal>0644</literal>.
+     The only protocols that can use this are
+     <literal>sftp://</literal>, <literal>scp://</literal>
+     and <literal>file://</literal>.
+     Available as of cURL 7.16.4.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-nobody">
    <term>
     <constant>CURLOPT_NOBODY</constant>
@@ -1286,6 +1763,27 @@
        changed for debugging purposes.
       </para>
      </note>
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-noproxy">
+   <term>
+    <constant>CURLOPT_NOPROXY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a string consisting of a comma separated list of hostnames
+     that do not require a proxy to get reached.
+     Each name in this list is matched as either a domain
+     which contains the hostname or the hostname itself.
+     The only wildcard available in the string
+     is a single <literal>*</literal> character which matches all hosts,
+     effectively disabling the proxy.
+     Setting this option to an empty string enables the proxy for all hostnames.
+     Since cURL 7.86.0, IP addresses set with this option
+     can be provided using CIDR notation.
+     Available as of cURL 7.19.4.
     </para>
    </listitem>
   </varlistentry>
@@ -1463,6 +1961,21 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-prequote">
+   <term>
+    <constant>CURLOPT_PREQUOTE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set an array of FTP commands to pass to the server
+     after the transfer type is set.
+     These commands are not performed when a directory listing is performed,
+     only for file transfers.
+     Available as of cURL 7.9.5.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-private">
    <term>
     <constant>CURLOPT_PRIVATE</constant>
@@ -1587,6 +2100,18 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxypassword">
+   <term>
+    <constant>CURLOPT_PROXYPASSWORD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a string with the password to be used for authentication with the proxy.
+     Available as of cURL 7.19.1.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-proxyport">
    <term>
     <constant>CURLOPT_PROXYPORT</constant>
@@ -1612,6 +2137,18 @@
      <constant>CURLPROXY_SOCKS4A</constant> or
      <constant>CURLPROXY_SOCKS5_HOSTNAME</constant>.
      Available as of cURL 7.10.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxyusername">
+   <term>
+    <constant>CURLOPT_PROXYUSERNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a string with the username to be used for authentication with the proxy.
+     Available as of cURL 7.19.1.
     </para>
    </listitem>
   </varlistentry>
@@ -2004,6 +2541,22 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-transfer-mode">
+   <term>
+    <constant>CURLOPT_PROXY_TRANSFER_MODE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     If set to <literal>1</literal>, it set the transfer mode (binary or ASCII)
+     for FTP transfers done via an HTTP proxy, by appending
+     <literal>type=a</literal> or <literal>type=i</literal> to the URL.
+     Without this setting or it being set to <literal>0</literal> (the default), <constant>CURLOPT_TRANSFERTEXT</constant> has no effect
+     when doing FTP via a proxy.
+     Available as of cURL 7.18.0.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-put">
    <term>
     <constant>CURLOPT_PUT</constant>
@@ -2062,6 +2615,19 @@
      <literal>"X-Y"</literal> where X or Y are optional. HTTP transfers
      also support several intervals, separated with commas in the format
      <literal>"X-Y,N-M"</literal>.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-readdata">
+   <term>
+    <constant>CURLOPT_READDATA</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets a file pointer resource that will be used by the file read function
+     set with <constant>CURLOPT_READFUNCTION</constant>.
+     Available as of cURL 7.9.7.
     </para>
    </listitem>
   </varlistentry>
@@ -2177,6 +2743,103 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-rtsp-client-cseq">
+   <term>
+    <constant>CURLOPT_RTSP_CLIENT_CSEQ</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set the CSEQ number to issue for the next RTSP request.
+     Useful if the application is resuming a previously broken connection.
+     The CSEQ increments from this new number henceforth.
+     Available as of cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-rtsp-request">
+   <term>
+    <constant>CURLOPT_RTSP_REQUEST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the kind of RTSP request to make. Must be one of the following:
+     <constant>CURL_RTSPREQ_OPTIONS</constant>,
+     <constant>CURL_RTSPREQ_DESCRIBE</constant>,
+     <constant>CURL_RTSPREQ_ANNOUNCE</constant>,
+     <constant>CURL_RTSPREQ_SETUP</constant>,
+     <constant>CURL_RTSPREQ_PLAY</constant>,
+     <constant>CURL_RTSPREQ_PAUSE</constant>,
+     <constant>CURL_RTSPREQ_TEARDOWN</constant>,
+     <constant>CURL_RTSPREQ_GET_PARAMETER</constant>,
+     <constant>CURL_RTSPREQ_SET_PARAMETER</constant>,
+     <constant>CURL_RTSPREQ_RECORD</constant> or
+     <constant>CURL_RTSPREQ_RECEIVE</constant>.
+     Available as of cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-rtsp-server-cseq">
+   <term>
+    <constant>CURLOPT_RTSP_SERVER_CSEQ</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set the CSEQ number to expect for the next RTSP Server to Client request.
+     This feature (listening for Server requests) is unimplemented.
+     Available as of cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-rtsp-session-id">
+   <term>
+    <constant>CURLOPT_RTSP_SESSION_ID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a string with the value of the current RTSP Session ID for the handle.
+     Once this value is set to any non-&null; value,
+     libcurl returns <constant>CURLE_RTSP_SESSION_ERROR</constant>
+     if the ID received from the server does not match.
+     If set to &null;, libcurl automatically sets the ID
+     the first time the server sets it in a response.
+     Available as of cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-rtsp-stream-uri">
+   <term>
+    <constant>CURLOPT_RTSP_STREAM_URI</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the stream URI to operate on to the supplied string.
+     If not setunset, libcurl defaults to operating on generic server options
+     by passing <literal>*</literal> in the place of the RTSP Stream URI.
+     When working with RTSP, <literal>CURLOPT_RTSP_STREAM_URI</literal>
+     indicates what URL to send to the server in the request header
+     while the <literal>CURLOPT_URL</literal> indicates
+     where to make the connection to.
+     Available as of cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-rtsp-transport">
+   <term>
+    <constant>CURLOPT_RTSP_TRANSPORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set the <literal>Transport:</literal> header for this RTSP session.
+     Available as of cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-safe-upload">
    <term>
     <constant>CURLOPT_SAFE_UPLOAD</constant>
@@ -2266,6 +2929,33 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-socks5-gssapi-nec">
+   <term>
+    <constant>CURLOPT_SOCKS5_GSSAPI_NEC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to <literal>1</literal> to enable and <literal>0</literal> to disable
+     the unprotected exchange of the protection mode negotiation
+     as part of the GSSAPI negotiation.
+     Available as of cURL 7.19.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-socks5-gssapi-service">
+   <term>
+    <constant>CURLOPT_SOCKS5_GSSAPI_SERVICE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a string holding the name of the SOCKS5 service.
+     Available as of cURL 7.19.4. Deprecated as of cURL 7.49.0.
+     Use <constant>CURLOPT_PROXY_SERVICE_NAME</constant> instead.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-ssh-auth-types">
    <term>
     <constant>CURLOPT_SSH_AUTH_TYPES</constant>
@@ -2332,6 +3022,19 @@
      Base64-encoded SHA256 hash of the remote host's public key.
      The transfer will fail if the given hash does not match the hash the remote host provides.
      Available as of PHP 8.2.0 and cURL 7.80.0
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssh-knownhosts">
+   <term>
+    <constant>CURLOPT_SSH_KNOWNHOSTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to the filename of the known_host file to use
+     which should use the OpenSSH file format as supported by libssh2.
+     Available as of cURL 7.19.6.
     </para>
    </listitem>
   </varlistentry>
@@ -2632,6 +3335,20 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssl-sessionid-cache">
+   <term>
+    <constant>CURLOPT_SSL_SESSIONID_CACHE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to <literal>0</literal> to disable and <literal>1</literal> to enable
+     SSL session-ID caching.
+     By default all transfers are done using the cache enabled.
+     Available as of cURL 7.16.0
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-ssl-verifyhost">
    <term>
     <constant>CURLOPT_SSL_VERIFYHOST</constant>
@@ -2784,6 +3501,39 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-telnetoptions">
+   <term>
+    <constant>CURLOPT_TELNETOPTIONS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set an array of strings to pass to the telnet negotiations.
+     The variables should be in the format <literal>&gt;option=value&lt;</literal>.
+     libcurl supports the options <literal>TTYPE</literal>,
+     <literal>XDISPLOC</literal> and <literal>NEW_ENV</literal>.
+     Available as of cURL 7.7.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tftp-blksize">
+   <term>
+    <constant>CURLOPT_TFTP_BLKSIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set the blocksize to use for TFTP data transmission.
+     Valid range is <literal>8</literal>-<literal>65464</literal> bytes.
+     The default of 512 bytes is used if this option is not specified.
+     The specified block size is only used if supported by the remote server.
+     If the server does not return an option acknowledgment
+     or returns an option acknowledgment with no block size,
+     the default of 512 bytes is used.
+     Available as of cURL 7.19.4.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-tftp-no-options">
    <term>
     <constant>CURLOPT_TFTP_NO_OPTIONS</constant>
@@ -2889,6 +3639,67 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tlsauth-password">
+   <term>
+    <constant>CURLOPT_TLSAUTH_PASSWORD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a password to use for the TLS authentication method specified
+     with the <constant>CURLOPT_TLSAUTH_TYPE</constant> option. Requires that
+     the <constant>CURLOPT_TLSAUTH_USERNAME</constant> option also be set.
+     This feature relies on TLS SRP which does not work with TLS 1.3.
+     Available as of cURL 7.21.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tlsauth-type">
+   <term>
+    <constant>CURLOPT_TLSAUTH_TYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a string with the method of the TLS authentication.
+     Supported method is <literal>SRP</literal>
+     (TLS Secure Remote Password authentication).
+     Available as of cURL 7.21.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tlsauth-username">
+   <term>
+    <constant>CURLOPT_TLSAUTH_USERNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a string with the username to use for the TLS authentication method
+     specified with the <constant>CURLOPT_TLSAUTH_TYPE</constant> option.
+     Requires that the <constant>CURLOPT_TLSAUTH_PASSWORD</constant> option
+     also be set.
+     This feature relies on TLS SRP which does not work with TLS 1.3.
+     Available as of cURL 7.21.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-transfer-encoding">
+   <term>
+    <constant>CURLOPT_TRANSFER_ENCODING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to <literal>1</literal> to enable and <literal>0</literal> to disable
+     requesting compressed <literal>Transfer Encoding</literal> in the outgoing
+     HTTP request. If the server responds with a compressed
+     <literal>Transfer Encoding</literal>,
+     libcurl will automatically uncompress it on reception.
+     Available as of cURL 7.21.6.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-transfertext">
    <term>
     <constant>CURLOPT_TRANSFERTEXT</constant>
@@ -2983,6 +3794,26 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-use-ssl">
+   <term>
+    <constant>CURLOPT_USE_SSL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the desired level of SSL/TLS for the transfer
+     when using FTP, SMTP, POP3, IMAP etc.
+     These are all protocols that start out plain text
+     and get "upgraded" to SSL using the STARTTLS command.
+     Set to one of the following:
+     <constant>CURLUSESSL_NONE</constant>,
+     <constant>CURLUSESSL_TRY</constant>,
+     <constant>CURLUSESSL_CONTROL</constant> or
+     <constant>CURLUSESSL_ALL</constant>.
+     Available as of cURL 7.17.0.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-useragent">
    <term>
     <constant>CURLOPT_USERAGENT</constant>
@@ -3030,6 +3861,23 @@
      &true; to output verbose information. Writes
      output to <constant>STDERR</constant>, or the file specified using
      <constant>CURLOPT_STDERR</constant>.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-wildcardmatch">
+   <term>
+    <constant>CURLOPT_WILDCARDMATCH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to <literal>1</literal> to transfer multiple files
+     according to a filename pattern.
+     The pattern can be specified as part of the
+     <constant>CURLOPT_URL</constant> option,
+     using an fnmatch-like pattern (Shell Pattern Matching)
+     in the last part of URL (filename).
+     Available as of cURL 7.21.0.
     </para>
    </listitem>
   </varlistentry>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -24,9 +24,11 @@
    </term>
    <listitem>
     <para>
-     Sets the contents of the <literal>Accept-Encoding:</literal> header
-     sent in an HTTP request.
-     Available as of cURL 7.21.6
+     Sets a <type>string</type> with the contents
+     of the <literal>Accept-Encoding:</literal> header sent in an HTTP request.
+     Set to &null; to disable sending the <literal>Accept-Encoding:</literal> header.
+     Defaults to &null;.
+     Available as of cURL 7.21.6.
     </para>
    </listitem>
   </varlistentry>
@@ -38,8 +40,10 @@
    <listitem>
     <para>
      The maximum number of milliseconds to wait for a server
-     to connect back to libcurl when an active FTP connection is used.
-     Available as of cURL 7.24.0
+     to connect back to cURL when an active FTP connection is used.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Defaults to <literal>60000</literal> milliseconds.
+     Available as of cURL 7.24.0.
     </para>
    </listitem>
   </varlistentry>
@@ -51,7 +55,9 @@
    <listitem>
     <para>
      The scope id value to use when connecting to IPv6 addresses.
-     Available as of cURL 7.19.0
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Defaults to <literal>0</literal>.
+     Available as of cURL 7.19.0.
     </para>
    </listitem>
   </varlistentry>
@@ -97,7 +103,8 @@
     <para>
      Setting this option to <literal>1</literal> will cause FTP uploads
      to append to the remote file instead of overwriting it.
-     Available as of cURL 7.17.0
+     Defaults to <literal>0</literal>.
+     Available as of cURL 7.17.0.
     </para>
    </listitem>
   </varlistentry>
@@ -370,12 +377,12 @@
    </term>
    <listitem>
     <para>
-     Pass a string naming a file with the concatenation of CRL (in PEM format)
+     Pass a <type>string</type> naming a file with the concatenation of CRL (in PEM format)
      to use in the certificate validation that occurs during the SSL exchange.
-     When curl is built to use GnuTLS,
+     When cURL is built to use GnuTLS,
      there is no way to influence the use of CRL passed
      to help in the verification process.
-     When libcurl is built with OpenSSL support,
+     When cURL is built with OpenSSL support,
      <literal>X509_V_FLAG_CRL_CHECK</literal>
      and <literal>X509_V_FLAG_CRL_CHECK_ALL</literal> are both set,
      requiring CRL check against all the elements of the certificate chain
@@ -439,6 +446,7 @@
      as directories are always listed in this mode.
      Using this option with <constant>CURLOPT_WILDCARDMATCH</constant>
      will prevent the latter from having any effect.
+     Defaults to <literal>0</literal>.
      Available as of cURL 7.17.0.
     </para>
    </listitem>
@@ -513,7 +521,7 @@
    </term>
    <listitem>
     <para>
-     Pass a string with a comma-separated list of DNS servers to be used
+     Pass a <type>string</type> with a comma-separated list of DNS servers to be used
      instead of the system default
      (e.g.: <literal>192.168.1.100,192.168.1.101:8080</literal>).
      Available as of cURL 7.24.0
@@ -683,7 +691,7 @@
    </term>
    <listitem>
     <para>
-     Pass a callback that will be used for wildcard matching.
+     Pass a <type>callable</type> that will be used for wildcard matching.
      The signature of the callback should be:
      <methodsynopsis>
       <type>int</type><methodname><replaceable>callback</replaceable></methodname>
@@ -712,13 +720,13 @@
        <term><parameter>string</parameter></term>
        <listitem>
         <simpara>
-         The string to run the wildcard pattern matching on.
+         The <type>string</type> to run the wildcard pattern matching on.
         </simpara>
        </listitem>
       </varlistentry>
      </variablelist>
      The callback should return
-     <constant>CURL_FNMATCHFUNC_MATCH</constant> if pattern matches the string,
+     <constant>CURL_FNMATCHFUNC_MATCH</constant> if pattern matches the <type>string</type>,
      <constant>CURL_FNMATCHFUNC_NOMATCH</constant> if not
      or <constant>CURL_FNMATCHFUNC_FAIL</constant> if an error occurred.
      Available as of cURL 7.21.0.
@@ -839,9 +847,11 @@
    </term>
    <listitem>
     <para>
-     Pass a string that will be sent as account information over FTP
-     (using the ACCT command) after username and password has been provided
+     Pass a <type>string</type> that will be sent as account information over FTP
+     (using the <literal>ACCT</literal> command) after username and password has been provided
      to the server.
+     Set to &null; to disable sending the account information.
+     Defaults to &null;.
      Available as of cURL 7.13.0.
     </para>
    </listitem>
@@ -853,8 +863,8 @@
    </term>
    <listitem>
     <para>
-     Pass a string that will be used to try to authenticate over FTP
-     if the USER/PASS negotiation fails.
+     Pass a <type>string</type> that will be used to try to authenticate over FTP
+     if the <literal>USER/PASS</literal> negotiation fails.
      Available as of cURL 7.15.5.
     </para>
    </listitem>
@@ -894,9 +904,10 @@
    </term>
    <listitem>
     <para>
-     A timeout in seconds libcurl will wait for a response from an FTP server.
+     A timeout in seconds cURL will wait for a response from an FTP server.
      This option overrides <constant>CURLOPT_TIMEOUT</constant>.
-     Available as of cURL 7.10.8. Deprecated as of cURL 7.85.0.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of cURL 7.10.8 and deprecated as of cURL 7.85.0.
     </para>
    </listitem>
   </varlistentry>
@@ -908,10 +919,12 @@
    <listitem>
     <para>
      If this option is set to <literal>1</literal>
-     libcurl will not use the IP address the server suggests
-     in its 227-response to libcurl's PASV command
+     cURL will not use the IP address the server suggests
+     in its 227-response to cURL's <literal>PASV</literal> command
      but will use the IP address it used for the connection.
-     The port number received from the 227-response will not be ignored by libcurl.
+     The port number received from the 227-response will not be ignored by cURL.
+     Defaults to <literal>1</literal> as of cURL 7.74.0
+     and <literal>0</literal> prior to that.
      Available as of cURL 7.15.0.
     </para>
    </listitem>
@@ -934,17 +947,11 @@
    </term>
    <listitem>
     <para>
-     This option makes libcurl use CCC (Clear Command Channel)
+     This option makes cURL use CCC (Clear Command Channel)
      which shuts down the SSL/TLS layer after authenticating
      making the rest of the control channel communication unencrypted.
-     Use one of the following values:
-     <constant>CURLFTPSSL_CCC_NONE</constant>
-      - do not attempt to use CCC.
-     <constant>CURLFTPSSL_CCC_PASSIVE</constant>
-      - Do not initiate the shutdown, but wait for the server to do it.
-      Do not send a reply.
-     <constant>CURLFTPSSL_CCC_ACTIVE</constant>
-      - Initiate the shutdown and wait for a reply.
+     Use one of the <constant>CURLFTPSSL_CCC_<replaceable>*</replaceable></constant> constants.
+     Defaults to <constant>CURLFTPSSL_CCC_NONE</constant>.
      Available as of cURL 7.16.1.
     </para>
    </listitem>
@@ -982,9 +989,10 @@
    </term>
    <listitem>
     <para>
-     If set to <literal>1</literal>, a PRET command is sent
-     before PASV (and EPSV).
+     Set to <literal>1</literal> to send a <literal>PRET</literal> command
+     before <literal>PASV</literal> (and <literal>EPSV</literal>).
      Has no effect when using the active FTP transfers mode.
+     Defaults to <literal>0</literal>.
      Available as of cURL 7.20.0.
     </para>
    </listitem>
@@ -1001,6 +1009,7 @@
      Set to <constant>CURLGSSAPI_DELEGATION_POLICY_FLAG</constant>
      to delegate only if the <literal>OK-AS-DELEGATE</literal> flag is set
      in the service ticket.
+     Defaults to <constant>CURLGSSAPI_DELEGATION_NONE</constant>.
      Available as of cURL 7.22.0.
     </para>
    </listitem>
@@ -1209,9 +1218,10 @@
    <listitem>
     <para>
      If set to <literal>0</literal>, transfer decoding is disabled.
-     If set to <literal>1</literal>, transfer decoding is enabled (default).
-     libcurl does chunked transfer decoding by default
+     If set to <literal>1</literal>, transfer decoding is enabled.
+     cURL does chunked transfer decoding by default
      unless this option is set to <literal>0</literal>.
+     Defaults to <literal>1</literal>.
      Available as of cURL 7.16.2.
     </para>
    </listitem>
@@ -1244,6 +1254,7 @@
      If set to <literal>1</literal>,
      ignore the <literal>Content-Length</literal> header in the HTTP response
      and ignore asking for or relying on it for FTP transfers.
+     Defaults to <literal>0</literal>.
      Available as of cURL 7.14.1.
     </para>
    </listitem>
@@ -1310,7 +1321,7 @@
    </term>
    <listitem>
     <para>
-     If set to a string naming a file holding a CA certificate in PEM format,
+     If set to a <type>string</type> naming a file holding a CA certificate in PEM format,
      an additional check against the peer certificate is performed
      to verify the issuer is indeed the one associated
      with the certificate provided by the option.
@@ -1389,12 +1400,18 @@
    <listitem>
     <para>
      Set the kerberos security level for FTP and also enables kerberos awareness.
-     This should be set to one of the following:
-     <literal>clear</literal>, <literal>safe</literal>,
-     <literal>confidential</literal> or <literal>private</literal>.
-     If the string is set but does not match one of these,
+     This should be set to one of the following <type>string</type>s:
+     <simplelist type="inline">
+      <member><literal>clear</literal></member>
+      <member><literal>safe</literal></member>
+      <member><literal>confidential</literal></member>
+      <member><literal>private</literal></member>
+     </simplelist>
+     .
+     If the <type>string</type> is set but does not match one of these,
      <literal>private</literal> is used.
      Setting this option to &null; will disable kerberos support for FTP.
+     Defaults to &null;.
      Available as of cURL 7.16.4.
     </para>
    </listitem>
@@ -1407,6 +1424,8 @@
    <listitem>
     <para>
      Sets the local port number of the socket used for the connection.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Defaults to <literal>0</literal>.
      Available as of cURL 7.15.2.
     </para>
    </listitem>
@@ -1418,8 +1437,10 @@
    </term>
    <listitem>
     <para>
-     The number of attempts libcurl makes to find a working local port number,
+     The number of attempts cURL makes to find a working local port number,
      starting with the one set with <constant>CURLOPT_LOCALPORT</constant>.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Defaults to <literal>1</literal>.
      Available as of cURL 7.15.2.
     </para>
    </listitem>
@@ -1472,11 +1493,11 @@
    </term>
    <listitem>
     <para>
-     Set a string with the authentication address (identity)
+     Set a <type>string</type> with the authentication address (identity)
      of a submitted message that is being relayed to another server.
      The address should not be specified within a pair of angled brackets
      (<literal>&gt;&lt;</literal>).
-     If an empty string is used then a pair of brackets are sent by libcurl
+     If an empty <type>string</type> is used then a pair of brackets are sent by cURL
      as required by RFC 2554.
      Available as of cURL 7.25.0.
     </para>
@@ -1489,7 +1510,7 @@
    </term>
    <listitem>
     <para>
-     Set a string with the sender's email address when sending SMTP mail.
+     Set a <type>string</type> with the sender's email address when sending SMTP mail.
      The email address should be specified with angled brackets
      (<literal>&gt;&lt;</literal>) around it,
      which if not specified are added automatically.
@@ -1506,11 +1527,12 @@
    </term>
    <listitem>
     <para>
-     Set to an array of recipients to pass to the server in an SMTP mail request.
+     Set to an <type>array</type> of <type>string</type>s
+     with the recipients to pass to the server in an SMTP mail request.
      Each recipient should be specified within a pair of angled brackets
      (<literal>&gt;&lt;</literal>).
      If an angled bracket is not used as the first character,
-     libcurl assumes a single email address has been provided
+     cURL assumes a single email address has been provided
      and encloses that address within brackets.
      Available as of cURL 7.20.0.
     </para>
@@ -1564,7 +1586,7 @@
      If the file requested is found larger than this value,
      the transfer is aborted
      and <constant>CURLE_FILESIZE_EXCEEDED</constant> is returned.
-     Passing a zero size disables this option,
+     Passing <literal>0</literal> disables this option,
      and passing a negative size returns a
      <constant>CURLE_BAD_FUNCTION_ARGUMENT</constant>.
      If the file size is not known prior to the start of download,
@@ -1573,6 +1595,8 @@
      <constant>CURLOPT_MAXFILESIZE_LARGE</constant> should be used.
      As of cURL 8.4.0, this option also stops ongoing transfers
      if they reach this threshold.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Defaults to <literal>0</literal>.
      Available as of cURL 7.10.8.
     </para>
    </listitem>
@@ -1696,9 +1720,9 @@
    </term>
    <listitem>
     <para>
-     Set a string containing the full path name to a <literal>.netrc</literal> file.
+     Set a <type>string</type> containing the full path name to a <literal>.netrc</literal> file.
      If this option is omitted and <constant>CURLOPT_NETRC</constant> is set,
-     libcurl checks for a <literal>.netrc</literal> file
+     cURL checks for a <literal>.netrc</literal> file
      in the current user's home directory.
      Available as of cURL 7.11.0.
     </para>
@@ -1711,7 +1735,7 @@
    </term>
    <listitem>
     <para>
-     Sets the value of the permissions that is set on newly created directories
+     Sets the value of the permissions (<type>int</type>) that is set on newly created directories
      on the remote server. The default value is <literal>0755</literal>.
      The only protocols that can use this are
      <literal>sftp://</literal>, <literal>scp://</literal>
@@ -1727,7 +1751,7 @@
    </term>
    <listitem>
     <para>
-     Sets the value of the permissions that are set on newly created files
+     Sets the value of the permissions (as an <type>int</type>) that are set on newly created files
      on the remote server. The default value is <literal>0644</literal>.
      The only protocols that can use this are
      <literal>sftp://</literal>, <literal>scp://</literal>
@@ -1773,14 +1797,14 @@
    </term>
    <listitem>
     <para>
-     Set a string consisting of a comma separated list of hostnames
+     Set a <type>string</type> consisting of a comma separated list of hostnames
      that do not require a proxy to get reached.
      Each name in this list is matched as either a domain
      which contains the hostname or the hostname itself.
-     The only wildcard available in the string
+     The only wildcard available in the <type>string</type>
      is a single <literal>*</literal> character which matches all hosts,
      effectively disabling the proxy.
-     Setting this option to an empty string enables the proxy for all hostnames.
+     Setting this option to an empty <type>string</type> enables the proxy for all hostnames.
      Since cURL 7.86.0, IP addresses set with this option
      can be provided using CIDR notation.
      Available as of cURL 7.19.4.
@@ -1968,7 +1992,7 @@
    </term>
    <listitem>
     <para>
-     Set an array of FTP commands to pass to the server
+     Set an <type>array</type> of FTP command <type>string</type>s to pass to the server
      after the transfer type is set.
      These commands are not performed when a directory listing is performed,
      only for file transfers.
@@ -2107,7 +2131,7 @@
    </term>
    <listitem>
     <para>
-     Set a string with the password to be used for authentication with the proxy.
+     Set a <type>string</type> with the password to be used for authentication with the proxy.
      Available as of cURL 7.19.1.
     </para>
    </listitem>
@@ -2147,7 +2171,7 @@
    </term>
    <listitem>
     <para>
-     Set a string with the username to be used for authentication with the proxy.
+     Set a <type>string</type> with the username to be used for authentication with the proxy.
      Available as of cURL 7.19.1.
     </para>
    </listitem>
@@ -2548,11 +2572,13 @@
    </term>
    <listitem>
     <para>
-     If set to <literal>1</literal>, it set the transfer mode (binary or ASCII)
+     Set to <literal>1</literal> to set the transfer mode (binary or ASCII)
      for FTP transfers done via an HTTP proxy, by appending
      <literal>type=a</literal> or <literal>type=i</literal> to the URL.
-     Without this setting or it being set to <literal>0</literal> (the default), <constant>CURLOPT_TRANSFERTEXT</constant> has no effect
+     Without this setting or it being set to <literal>0</literal>,
+     <constant>CURLOPT_TRANSFERTEXT</constant> has no effect
      when doing FTP via a proxy.
+     Defaults to <literal>0</literal>.
      Available as of cURL 7.18.0.
     </para>
    </listitem>
@@ -2625,7 +2651,7 @@
    </term>
    <listitem>
     <para>
-     Sets a file pointer resource that will be used by the file read function
+     Sets a file pointer <type>resource</type> that will be used by the file read function
      set with <constant>CURLOPT_READFUNCTION</constant>.
      Available as of cURL 7.9.7.
     </para>
@@ -2750,9 +2776,10 @@
    </term>
    <listitem>
     <para>
-     Set the CSEQ number to issue for the next RTSP request.
+     Set an <type>int</type> with the CSEQ number to issue for the next RTSP request.
      Useful if the application is resuming a previously broken connection.
      The CSEQ increments from this new number henceforth.
+     Defaults to <literal>0</literal>.
      Available as of cURL 7.20.0.
     </para>
    </listitem>
@@ -2764,18 +2791,9 @@
    </term>
    <listitem>
     <para>
-     Sets the kind of RTSP request to make. Must be one of the following:
-     <constant>CURL_RTSPREQ_OPTIONS</constant>,
-     <constant>CURL_RTSPREQ_DESCRIBE</constant>,
-     <constant>CURL_RTSPREQ_ANNOUNCE</constant>,
-     <constant>CURL_RTSPREQ_SETUP</constant>,
-     <constant>CURL_RTSPREQ_PLAY</constant>,
-     <constant>CURL_RTSPREQ_PAUSE</constant>,
-     <constant>CURL_RTSPREQ_TEARDOWN</constant>,
-     <constant>CURL_RTSPREQ_GET_PARAMETER</constant>,
-     <constant>CURL_RTSPREQ_SET_PARAMETER</constant>,
-     <constant>CURL_RTSPREQ_RECORD</constant> or
-     <constant>CURL_RTSPREQ_RECEIVE</constant>.
+     Sets the kind of RTSP request to make.
+     Must be one of the <constant>CURL_RTSPREQ_<replaceable>*</replaceable></constant>
+     constants.
      Available as of cURL 7.20.0.
     </para>
    </listitem>
@@ -2787,8 +2805,10 @@
    </term>
    <listitem>
     <para>
-     Set the CSEQ number to expect for the next RTSP Server to Client request.
+     Set an <type>int</type> with the CSEQ number to expect
+     for the next RTSP Server to Client request.
      This feature (listening for Server requests) is unimplemented.
+     Defaults to <literal>0</literal>.
      Available as of cURL 7.20.0.
     </para>
    </listitem>
@@ -2800,12 +2820,13 @@
    </term>
    <listitem>
     <para>
-     Set a string with the value of the current RTSP Session ID for the handle.
+     Set a <type>string</type> with the value of the current RTSP Session ID for the handle.
      Once this value is set to any non-&null; value,
-     libcurl returns <constant>CURLE_RTSP_SESSION_ERROR</constant>
+     cURL returns <constant>CURLE_RTSP_SESSION_ERROR</constant>
      if the ID received from the server does not match.
-     If set to &null;, libcurl automatically sets the ID
+     If set to &null;, cURL automatically sets the ID
      the first time the server sets it in a response.
+     Defaults to &null;
      Available as of cURL 7.20.0.
     </para>
    </listitem>
@@ -2817,8 +2838,8 @@
    </term>
    <listitem>
     <para>
-     Sets the stream URI to operate on to the supplied string.
-     If not setunset, libcurl defaults to operating on generic server options
+     Sets a <type>string</type> with the stream URI to operate on.
+     If not set, cURL defaults to operating on generic server options
      by passing <literal>*</literal> in the place of the RTSP Stream URI.
      When working with RTSP, <literal>CURLOPT_RTSP_STREAM_URI</literal>
      indicates what URL to send to the server in the request header
@@ -2950,8 +2971,9 @@
    </term>
    <listitem>
     <para>
-     Set a string holding the name of the SOCKS5 service.
-     Available as of cURL 7.19.4. Deprecated as of cURL 7.49.0.
+     Set a <type>string</type> holding the name of the SOCKS5 service.
+     Defaults to <literal>rcmd</literal>.
+     Available as of cURL 7.19.4 and deprecated as of cURL 7.49.0.
      Use <constant>CURLOPT_PROXY_SERVICE_NAME</constant> instead.
     </para>
    </listitem>
@@ -3032,7 +3054,7 @@
    </term>
    <listitem>
     <para>
-     Set to the filename of the known_host file to use
+     Set to the filename of the <filename>known_host</filename> file to use
      which should use the OpenSSH file format as supported by libssh2.
      Available as of cURL 7.19.6.
     </para>
@@ -3345,7 +3367,7 @@
      Set to <literal>0</literal> to disable and <literal>1</literal> to enable
      SSL session-ID caching.
      By default all transfers are done using the cache enabled.
-     Available as of cURL 7.16.0
+     Available as of cURL 7.16.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3508,9 +3530,9 @@
    </term>
    <listitem>
     <para>
-     Set an array of strings to pass to the telnet negotiations.
+     Set an <type>array</type> of <type>string</type>s to pass to the telnet negotiations.
      The variables should be in the format <literal>&gt;option=value&lt;</literal>.
-     libcurl supports the options <literal>TTYPE</literal>,
+     cURL supports the options <literal>TTYPE</literal>,
      <literal>XDISPLOC</literal> and <literal>NEW_ENV</literal>.
      Available as of cURL 7.7.
     </para>
@@ -3525,11 +3547,11 @@
     <para>
      Set the blocksize to use for TFTP data transmission.
      Valid range is <literal>8</literal>-<literal>65464</literal> bytes.
-     The default of 512 bytes is used if this option is not specified.
+     The default of <literal>512</literal> bytes is used if this option is not specified.
      The specified block size is only used if supported by the remote server.
      If the server does not return an option acknowledgment
      or returns an option acknowledgment with no block size,
-     the default of 512 bytes is used.
+     the default of <literal>512</literal> bytes is used.
      Available as of cURL 7.19.4.
     </para>
    </listitem>
@@ -3661,7 +3683,7 @@
    </term>
    <listitem>
     <para>
-     Set a string with the method of the TLS authentication.
+     Set a <type>string</type> with the method of the TLS authentication.
      Supported method is <literal>SRP</literal>
      (TLS Secure Remote Password authentication).
      Available as of cURL 7.21.4.
@@ -3675,7 +3697,7 @@
    </term>
    <listitem>
     <para>
-     Set a string with the username to use for the TLS authentication method
+     Set a <type>string</type> with the username to use for the TLS authentication method
      specified with the <constant>CURLOPT_TLSAUTH_TYPE</constant> option.
      Requires that the <constant>CURLOPT_TLSAUTH_PASSWORD</constant> option
      also be set.
@@ -3695,7 +3717,8 @@
      requesting compressed <literal>Transfer Encoding</literal> in the outgoing
      HTTP request. If the server responds with a compressed
      <literal>Transfer Encoding</literal>,
-     libcurl will automatically uncompress it on reception.
+     cURL will automatically uncompress it on reception.
+     Defaults to <literal>0</literal>.
      Available as of cURL 7.21.6.
     </para>
    </listitem>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -3825,7 +3825,7 @@
    <listitem>
     <para>
      Sets the desired level of SSL/TLS for the transfer
-     when using FTP, SMTP, POP3, IMAP etc.
+     when using FTP, SMTP, POP3, IMAP, etc.
      These are all protocols that start out plain text
      and get "upgraded" to SSL using the STARTTLS command.
      Set to one of the following:


### PR DESCRIPTION
Add the 52 missing `CURLOPT_*` constants and their descriptions to the cURL predefined constant list. 

Reference used: https://curl.se/libcurl/c/symbols-in-versions.html