### PR TITLE
session-name.xml: use the correct directive name and add the link to

### DIFF
--- a/reference/session/functions/session-name.xml
+++ b/reference/session/functions/session-name.xml
@@ -22,8 +22,8 @@
    If a new session <parameter>name</parameter> is
    supplied, <function>session_name</function> modifies the HTTP cookie
    (and output content when <link linkend="ini.session.use-trans-sid">session.use_trans_sid</link> is
-   enabled). Once the HTTP cookie is
-   sent, <function>session_name</function> raises error.
+   enabled). Once the HTTP cookie has been
+   sent, calling <function>session_name</function> raises an <constant>E_WARNING</constant>.
    <function>session_name</function> must be called
    before <function>session_start</function> for the session to work
    properly.

--- a/reference/session/functions/session-name.xml
+++ b/reference/session/functions/session-name.xml
@@ -21,7 +21,7 @@
   <para>
    If a new session <parameter>name</parameter> is
    supplied, <function>session_name</function> modifies the HTTP cookie
-   (and output content when <literal>session.transid</literal> is
+   (and output content when <link linkend="ini.session.use-trans-sid">session.use_trans_sid</link> is
    enabled). Once the HTTP cookie is
    sent, <function>session_name</function> raises error.
    <function>session_name</function> must be called

--- a/reference/session/functions/session-name.xml
+++ b/reference/session/functions/session-name.xml
@@ -21,7 +21,7 @@
   <para>
    If a new session <parameter>name</parameter> is
    supplied, <function>session_name</function> modifies the HTTP cookie
-   (and output content when <link linkend="ini.session.use-trans-sid">session.use_trans_sid</link> is
+   (and outputs the content when <link linkend="ini.session.use-trans-sid">session.use_trans_sid</link> is
    enabled). Once the HTTP cookie has been
    sent, calling <function>session_name</function> raises an <constant>E_WARNING</constant>.
    <function>session_name</function> must be called


### PR DESCRIPTION
There is no directive `session.transid` in PHP. It's probably about the `session.use_trans_sid` directive instead `session.transid`, if I got the context right