### PR TITLE
Remove extension state tags which do no longer apply

### DIFF
--- a/appendices/extensions.xml
+++ b/appendices/extensions.xml
@@ -423,12 +423,7 @@
    &extcat.state.experimental;
 
    <itemizedlist>
-    <listitem><para><xref linkend="book.gnupg"/></para></listitem>
     <listitem><para><xref linkend="book.imagick"/></para></listitem>
-    <listitem><para><xref linkend="ref.pdo-dblib"/></para></listitem>
-    <listitem><para><xref linkend="ref.pdo-firebird"/></para></listitem>
-    <listitem><para><xref linkend="ref.pdo-oci"/></para></listitem>
-    <listitem><para><xref linkend="book.svn"/></para></listitem>
    </itemizedlist>
   </section>
  </section>

--- a/reference/gnupg/book.xml
+++ b/reference/gnupg/book.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- State: experimental -->
 
 <book xml:id="book.gnupg" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>

--- a/reference/pdo_dblib/reference.xml
+++ b/reference/pdo_dblib/reference.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- State: experimental -->
 
  <reference xml:id="ref.pdo-dblib" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="bundledexternal" ?>

--- a/reference/pdo_firebird/reference.xml
+++ b/reference/pdo_firebird/reference.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- State: experimental -->
 
  <reference xml:id="ref.pdo-firebird" xmlns="http://docbook.org/ns/docbook">
   <?phpdoc extension-membership="bundledexternal" ?>

--- a/reference/pdo_oci/reference.xml
+++ b/reference/pdo_oci/reference.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- State: experimental -->
 
  <reference xml:id="ref.pdo-oci" xmlns="http://docbook.org/ns/docbook">
   <?phpdoc extension-membership="bundledexternal" ?>

--- a/reference/svn/book.xml
+++ b/reference/svn/book.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- State: experimental -->
 
 <book xml:id="book.svn" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>

--- a/reference/xmlrpc/book.xml
+++ b/reference/xmlrpc/book.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- State: deprecated -->
-<!-- State: experimental -->
 
 <book xml:id="book.xmlrpc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>


### PR DESCRIPTION
Note that I just grepped for the state comments, and removed those which do no longer apply. Almost certainly there are extensions which would need to be tagged, but maybe this PR is a good start to tackle https://github.com/php/doc-en/issues/3643.