### PR TITLE
Maximum length of prefix in session_create_id

### DIFF
--- a/reference/session/functions/session-create-id.xml
+++ b/reference/session/functions/session-create-id.xml
@@ -41,7 +41,7 @@
         is prefixed by <parameter>prefix</parameter>. Not all
         characters are allowed within the session id.  Characters in
         the range <literal>a-z A-Z 0-9 , (comma) and -
-        (minus)</literal> are allowed.
+        (minus)</literal> are allowed. Maximum length is 256 characters.
        </para> 
       </listitem>
      </varlistentry>


### PR DESCRIPTION
Maximum length of prefix is 256 characters.

Reference:
https://github.com/php/php-src/blob/master/ext/session/session.c#L379
https://github.com/php/php-src/blob/master/ext/session/session.c#L75
