### PR TITLE
session-create-id.xml: preg_* functions style for range

### DIFF
--- a/reference/session/functions/session-create-id.xml
+++ b/reference/session/functions/session-create-id.xml
@@ -40,8 +40,7 @@
         If <parameter>prefix</parameter> is specified, new session id
         is prefixed by <parameter>prefix</parameter>. Not all
         characters are allowed within the session id.  Characters in
-        the range <literal>a-z A-Z 0-9 , (comma) and -
-        (minus)</literal> are allowed. Maximum length is 256 characters.
+        the range <literal>[a-zA-Z0-9,-]</literal> are allowed. Maximum length is 256 characters.
        </para> 
       </listitem>
      </varlistentry>

--- a/reference/session/functions/session-id.xml
+++ b/reference/session/functions/session-id.xml
@@ -36,7 +36,7 @@
         <function>session_start</function> for that purpose. Depending on the
         session handler, not all characters are allowed within the session id.
         For example, the file session handler only allows characters in the
-        range <literal>a-z A-Z 0-9 , (comma) and - (minus)</literal>!
+        range <literal>[a-zA-Z0-9,-]</literal>!
        </para>
        <note>
         <simpara>


### PR DESCRIPTION
Can we specify a range in the pcre-style, without introductory constructions in the sentence?