### PR TITLE
Update invalid values of session gc ini settings.

### DIFF
--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -390,7 +390,7 @@
      <literal>session.gc_probability</literal> in conjunction with
      <literal>session.gc_divisor</literal> is used to manage probability
      that the gc (garbage collection) routine is started.
-     Defaults to <literal>1</literal>. See <link
+     Defaults to <literal>1</literal>. Must be non-negative. See <link
      linkend="ini.session.gc-divisor">session.gc_divisor</link> for details.
     </simpara>
    </listitem>
@@ -410,7 +410,7 @@
      The probability is calculated by using gc_probability/gc_divisor,
      e.g. 1/100 means there is a 1% chance that the GC process starts
      on each request.
-     <literal>session.gc_divisor</literal> defaults to <literal>100</literal>.
+     <literal>session.gc_divisor</literal> defaults to <literal>100</literal>. Must be larger than 0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -390,7 +390,7 @@
      <literal>session.gc_probability</literal> in conjunction with
      <literal>session.gc_divisor</literal> is used to manage probability
      that the gc (garbage collection) routine is started.
-     Defaults to <literal>1</literal>. Must be non-negative. See <link
+     Defaults to <literal>1</literal>. Must be greater than or equal to <literal>0</literal>. See <link
      linkend="ini.session.gc-divisor">session.gc_divisor</link> for details.
     </simpara>
    </listitem>

--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -410,7 +410,8 @@
      The probability is calculated by using gc_probability/gc_divisor,
      e.g. 1/100 means there is a 1% chance that the GC process starts
      on each request.
-     <literal>session.gc_divisor</literal> defaults to <literal>100</literal>. Must be larger than 0.
+     <literal>session.gc_divisor</literal> defaults to <literal>100</literal>.
+     Must be greater than <literal>0</literal>.
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
Related patch: https://github.com/php/php-src/pull/15284

Adds information about invalid values of session.gc_divisor and session.gc_probability.