### PR TITLE
Remove the top-level <copyright>, redundant with the <legalnotice>

### DIFF
--- a/bookinfo.xml
+++ b/bookinfo.xml
@@ -6,11 +6,6 @@
   <pubdate><?dbtimestamp format="Y-m-d"?></pubdate>
   &frontpage.editors;
 
-  <copyright>
-   <year>1997-<?dbtimestamp format="Y"?></year>
-   <holder>the PHP Documentation Group</holder>
-  </copyright>
-
   <legalnotice xml:id="copyright" xmlns:xlink="http://www.w3.org/1999/xlink">
    <info><title>Copyright</title></info>
    <simpara>


### PR DESCRIPTION
I think this was mentioned in the discussion around #3468, the `<copyright>` block is redundant with the information in the `<legalnotice>` which is the first thing in the ToC, so we can just remove it. Will just leave a lonely `pubdate` before the ToC, but we could look at styling that better via CSS on the website, at least. Or maybe just turn it into a `<date>` within `manual.xml.in` so it ends up after the ToC along with a language snippet that actually identifies it as the date the manual was generated.