### PR TITLE
gc.xml objects are passed by references by default

### DIFF
--- a/features/gc.xml
+++ b/features/gc.xml
@@ -330,7 +330,7 @@ a: (refcount=2, is_ref=1)=array (
      algorithms or other things where you have a child point back at a "parent"
      element. The same situation can also happen with objects of course, where
      it actually is more likely to occur, as objects are always implicitly used
-     by reference.
+     "<link linkend="language.oop5.references">by reference</link>".
     </para>
     <para>
      This might not be a problem if this only happens once or twice, but if


### PR DESCRIPTION
This is not completely true:

https://www.php.net/manual/en/language.oop5.references.php