### PR TITLE
New `&Construtor;` entity to avoid translatable text in parts of XML source

### DIFF
--- a/language-defs.ent
+++ b/language-defs.ent
@@ -78,6 +78,7 @@
 <!ENTITY Properties        "Properties">
 <!ENTITY InheritedConstants "Inherited constants">
 <!ENTITY Constants         "Constants">
+<!ENTITY Constructor       "Constructor">
 <!ENTITY NotAvailable      "Not Available">
 
 <!-- These are used in reference/$extname/reference.xml and other

--- a/reference/cmark/commonmark.cql.xml
+++ b/reference/cmark/commonmark.cql.xml
@@ -98,7 +98,7 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
-    <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constructor;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-cql.construct')/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
     
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>

--- a/reference/cmark/commonmark.node.bulletlist.xml
+++ b/reference/cmark/commonmark.node.bulletlist.xml
@@ -52,7 +52,7 @@
      <varname>delimiter</varname>
     </fieldsynopsis>
 
-<classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
+<classsynopsisinfo role="comment">&Constructor;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-node-bulletlist.construct')/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
     
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>

--- a/reference/cmark/commonmark.node.code.xml
+++ b/reference/cmark/commonmark.node.code.xml
@@ -40,7 +40,7 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-node.synopsis')/descendant::db:fieldsynopsis)" />
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-node-text.synopsis')/descendant::db:fieldsynopsis)" />
 
-    <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constructor;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-node-text.construct')/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>

--- a/reference/cmark/commonmark.node.codeblock.xml
+++ b/reference/cmark/commonmark.node.codeblock.xml
@@ -47,7 +47,7 @@
      <varname>fence</varname>
     </fieldsynopsis>
 
-    <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constructor;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-node-text.construct')/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-node-codeblock.construct')/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
     

--- a/reference/cmark/commonmark.node.heading.xml
+++ b/reference/cmark/commonmark.node.heading.xml
@@ -47,7 +47,7 @@
      <varname>level</varname>
     </fieldsynopsis>
 
-    <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constructor;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-node-heading.construct')/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
     
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>

--- a/reference/cmark/commonmark.node.htmlblock.xml
+++ b/reference/cmark/commonmark.node.htmlblock.xml
@@ -40,7 +40,7 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-node.synopsis')/descendant::db:fieldsynopsis)" />
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-node-text.synopsis')/descendant::db:fieldsynopsis)" />
 
-    <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constructor;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-node-text.construct')/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
     
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>

--- a/reference/cmark/commonmark.node.htmlinline.xml
+++ b/reference/cmark/commonmark.node.htmlinline.xml
@@ -40,7 +40,7 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-node.synopsis')/descendant::db:fieldsynopsis)" />
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-node-text.synopsis')/descendant::db:fieldsynopsis)" />
 
-<classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
+<classsynopsisinfo role="comment">&Constructor;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-node-text.construct')/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
     
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>

--- a/reference/cmark/commonmark.node.image.xml
+++ b/reference/cmark/commonmark.node.image.xml
@@ -51,7 +51,7 @@
      <varname>title</varname>
     </fieldsynopsis>
 
-    <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constructor;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-node-image.construct')/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
     
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>

--- a/reference/cmark/commonmark.node.link.xml
+++ b/reference/cmark/commonmark.node.link.xml
@@ -52,7 +52,7 @@
      <varname>title</varname>
     </fieldsynopsis>
 
-    <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constructor;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-node-link.construct')/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
     
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>

--- a/reference/cmark/commonmark.node.orderedlist.xml
+++ b/reference/cmark/commonmark.node.orderedlist.xml
@@ -56,7 +56,7 @@
      <varname>start</varname>
     </fieldsynopsis>
 
-    <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constructor;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-node-orderedlist.construct')/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
     
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>

--- a/reference/cmark/commonmark.node.text.xml
+++ b/reference/cmark/commonmark.node.text.xml
@@ -46,7 +46,7 @@
      <varname>literal</varname>
     </fieldsynopsis>
 
-    <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constructor;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-node-text.construct')/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
     
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>

--- a/reference/cmark/commonmark.parser.xml
+++ b/reference/cmark/commonmark.parser.xml
@@ -33,7 +33,7 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
-    <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constructor;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-parser.construct')/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
     
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>


### PR DESCRIPTION
This make the word "Constructor" automatically translated in `<classsynopsisinfo>`, as is already done in most other `<classsynopsisinfo>` texts.