### PR TITLE
Typo in mysql_xdevapi examples

### DIFF
--- a/reference/mysql_xdevapi/examples.xml
+++ b/reference/mysql_xdevapi/examples.xml
@@ -6,7 +6,7 @@
  <para>
   The central entry point to the X DevAPI is the <function>mysql_xdevapi\getSession</function>
   function, which receives a URI to a MySQL 8.0 Server and returns a
-  <classname>mysql_xdevap\Session</classname> object.
+  <classname>mysql_xdevapi\Session</classname> object.
  </para>
  <example>
   <title>Connecting to a MySQL Server</title>


### PR DESCRIPTION
The extension name is mysql_xdevapi