### PR TITLE
Add missing cURL constants

### DIFF
--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -1828,6 +1828,460 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curl-fnmatchfunc-fail">
+   <term>
+    <constant>CURL_FNMATCHFUNC_FAIL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Returned by the wildcard match callback function if an error occured.
+     Available as of cURL 7.21.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-fnmatchfunc-match">
+   <term>
+    <constant>CURL_FNMATCHFUNC_MATCH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Returned by the wildcard match callback function
+     if pattern matches the string.
+     Available as of cURL 7.21.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-fnmatchfunc-nomatch">
+   <term>
+    <constant>CURL_FNMATCHFUNC_NOMATCH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Returned by the wildcard match callback function
+     if pattern does not match the string.
+     Available as of cURL 7.21.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-ipresolve-v4">
+   <term>
+    <constant>CURL_IPRESOLVE_V4</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Use only IPv4 addresses when establishing a connection
+     or choosing one from the connection pool.
+     Available as of cURL 7.10.8.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-ipresolve-v6">
+   <term>
+    <constant>CURL_IPRESOLVE_V6</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Use only IPv6 addresses when establishing a connection
+     or choosing one from the connection pool.
+     Available as of cURL 7.10.8.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-ipresolve-whatever">
+   <term>
+    <constant>CURL_IPRESOLVE_WHATEVER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Use addresses of all IP versions allowed by the system.
+     Available as of cURL 7.10.8.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-readfunc-pause">
+   <term>
+    <constant>CURL_READFUNC_PAUSE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of cURL 7.18.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-announce">
+   <term>
+    <constant>CURL_RTSPREQ_ANNOUNCE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     When sent by a client, this method changes the description of the session.
+     <literal>ANNOUNCE</literal> acts like an HTTP PUT or POST
+     just like <constant>CURL_RTSPREQ_SET_PARAMETER</constant>.
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-describe">
+   <term>
+    <constant>CURL_RTSPREQ_DESCRIBE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Used to get the low level description of a stream.
+     The application should note what formats it understands
+     in the <literal>Accept:</literal> header. Unless set manually,
+     libcurl automatically adds in <literal>Accept: application/sdp</literal>.
+     Time-condition headers are added to DESCRIBE requests
+     if the <constant>CURLOPT_TIMECONDITION</constant> option is used.
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-get-parameter">
+   <term>
+    <constant>CURL_RTSPREQ_GET_PARAMETER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Retrieve a parameter from the server.
+     By default, libcurl adds a <literal>Content-Type: text/parameters</literal>
+     header on all non-empty requests unless a custom one is set.
+     <literal>GET_PARAMETER</literal> acts just like an HTTP PUT or POST.
+     Applications wishing to send a heartbeat message
+     should use an empty <literal>GET_PARAMETER</literal> request.
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-options">
+   <term>
+    <constant>CURL_RTSPREQ_OPTIONS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Used to retrieve the available methods of the server.
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-pause">
+   <term>
+    <constant>CURL_RTSPREQ_PAUSE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Send a <literal>PAUSE</literal> command to the server.
+     Use the <constant>CURLOPT_RANGE</constant> option with a single value
+     to indicate when the stream should be halted (e.g. npt=25).
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-play">
+   <term>
+    <constant>CURL_RTSPREQ_PLAY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Send a <literal>PLAY</literal> command to the server.
+     Use the <constant>CURLOPT_RANGE</constant> option
+     to modify the playback time (e.g. npt=10-15).
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-receive">
+   <term>
+    <constant>CURL_RTSPREQ_RECEIVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Set the RTSP request type to this value to receive interleaved RTP data.
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-record">
+   <term>
+    <constant>CURL_RTSPREQ_RECORD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Used to tell the server to record a session.
+     Use the <constant>CURLOPT_RANGE</constant> option to modify the record time.
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-set-parameter">
+   <term>
+    <constant>CURL_RTSPREQ_SET_PARAMETER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Set a parameter on the server.
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-setup">
+   <term>
+    <constant>CURL_RTSPREQ_SETUP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Used to initialize the transport layer for the session.
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-teardown">
+   <term>
+    <constant>CURL_RTSPREQ_TEARDOWN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Terminates an RTSP session.
+     Simply closing a connection does not terminate the RTSP session
+     since it is valid to control an RTSP session over different connections.
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-tlsauth-srp">
+   <term>
+    <constant>CURL_TLSAUTH_SRP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of cURL 7.21.4.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-writefunc-pause">
+   <term>
+    <constant>CURL_WRITEFUNC_PAUSE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of cURL 7.18.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlauth-digest-ie">
+   <term>
+    <constant>CURLAUTH_DIGEST_IE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Use HTTP Digest authentication with an IE flavor.
+     Available as of cURL 7.19.3.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlauth-none">
+   <term>
+    <constant>CURLAUTH_NONE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of cURL 7.10.6.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlauth-only">
+   <term>
+    <constant>CURLAUTH_ONLY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     This is a meta symbol. OR this value together
+     with a single specific auth value
+     to force libcurl to probe for unrestricted auth and if not,
+     only that single auth algorithm is acceptable.
+     Available as of cURL 7.21.3.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpmethod-multicwd">
+   <term>
+    <constant>CURLFTPMETHOD_MULTICWD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Do a single <literal>CWD</literal> operation
+     for each path part in the given URL.
+     Available as of cURL 7.15.3.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpmethod-nocwd">
+   <term>
+    <constant>CURLFTPMETHOD_NOCWD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     libcurl makes no <literal>CWD</literal> at all.
+     libcurl does <literal>SIZE</literal>, <literal>RETR</literal>,
+     <literal>STOR</literal> etc.
+     and gives a full path to the server for all these commands.
+     Available as of cURL 7.15.3.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpmethod-singlecwd">
+   <term>
+    <constant>CURLFTPMETHOD_SINGLECWD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     libcurl does one <literal>CWD</literal> with the full target directory
+     and then operates on the file like in the multicwd case.
+     Available as of cURL 7.15.3.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpssl-ccc-active">
+   <term>
+    <constant>CURLFTPSSL_CCC_ACTIVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Initiate the shutdown and wait for a reply.
+     Available as of cURL 7.16.2.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpssl-ccc-none">
+   <term>
+    <constant>CURLFTPSSL_CCC_NONE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Do not attempt to use CCC (Clear Command Channel).
+     Available as of cURL 7.16.2.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpssl-ccc-passive">
+   <term>
+    <constant>CURLFTPSSL_CCC_PASSIVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Do not initiate the shutdown, but wait for the server to do it.
+     Do not send a reply.
+     Available as of cURL 7.16.1.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlgssapi-delegation-flag">
+   <term>
+    <constant>CURLGSSAPI_DELEGATION_FLAG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Allow unconditional GSSAPI credential delegation.
+     Available as of cURL 7.22.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlgssapi-delegation-policy-flag">
+   <term>
+    <constant>CURLGSSAPI_DELEGATION_POLICY_FLAG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Delegate only if the <literal>OK-AS-DELEGATE</literal> flag is set
+     in the service ticket if this feature is supported by the GSS-API implementation
+     and the definition of <literal>GSS_C_DELEG_POLICY_FLAG</literal>
+     was available at compile-time.
+     Available as of cURL 7.22.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlusessl-all">
+   <term>
+    <constant>CURLUSESSL_ALL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Require SSL for all communication
+     or fail with <constant>CURLE_USE_SSL_FAILED</constant>.
+     Available as of cURL 7.17.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlusessl-control">
+   <term>
+    <constant>CURLUSESSL_CONTROL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Require SSL for the control connection
+     or fail with <constant>CURLE_USE_SSL_FAILED</constant>.
+     Available as of cURL 7.17.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlusessl-none">
+   <term>
+    <constant>CURLUSESSL_NONE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Do not attempt to use SSL.
+     Available as of cURL 7.17.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlusessl-try">
+   <term>
+    <constant>CURLUSESSL_TRY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Try using SSL, proceed as normal otherwise.
+     Note that server may close the connection if the negotiation does not succeed.
+     Available as of cURL 7.17.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
  </variablelist>
  &reference.curl.constants-curl-setopt;
  &reference.curl.constants-curl-share-setopt;

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -8,96 +8,7 @@
   <function>curl_setopt</function>, <function>curl_multi_setopt</function> and
   <function>curl_getinfo</function> documentation.
  </para>
- <variablelist>
-
-  <varlistentry xml:id="constant.curlftp-create-dir">
-   <term>
-    <constant>CURLFTP_CREATE_DIR</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.0.7 and cURL 7.19.3
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlftp-create-dir-none">
-   <term>
-    <constant>CURLFTP_CREATE_DIR_NONE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.0.7 and cURL 7.19.3
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlftp-create-dir-retry">
-   <term>
-    <constant>CURLFTP_CREATE_DIR_RETRY</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.0.7 and cURL 7.19.3
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlftpssl-try">
-   <term>
-    <constant>CURLFTPSSL_TRY</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlftpssl-all">
-   <term>
-    <constant>CURLFTPSSL_ALL</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlftpssl-control">
-   <term>
-    <constant>CURLFTPSSL_CONTROL</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlftpssl-none">
-   <term>
-    <constant>CURLFTPSSL_NONE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlftpmethod-default">
-   <term>
-    <constant>CURLFTPMETHOD_DEFAULT</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 8.2.0 and cURL 7.15.3.
-    </simpara>
-   </listitem>
-  </varlistentry>
+ <variablelist role="constant_list">
   <varlistentry xml:id="constant.curlaltsvc-h1">
    <term>
     <constant>CURLALTSVC_H1</constant>
@@ -142,96 +53,413 @@
     </simpara>
    </listitem>
   </varlistentry>
-
-  <varlistentry xml:id="constant.curl-sslversion-default">
+  <varlistentry xml:id="constant.curlauth-any">
    <term>
-    <constant>CURL_SSLVERSION_DEFAULT</constant>
+    <constant>CURLAUTH_ANY</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-
+     
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curl-sslversion-tlsv1">
+  <varlistentry xml:id="constant.curlauth-anysafe">
    <term>
-    <constant>CURL_SSLVERSION_TLSv1</constant>
+    <constant>CURLAUTH_ANYSAFE</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-
+     
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curl-sslversion-sslv2">
+  <varlistentry xml:id="constant.curlauth-aws-sigv4">
    <term>
-    <constant>CURL_SSLVERSION_SSLv2</constant>
+    <constant>CURLAUTH_AWS_SIGV4</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-
+     Available as of PHP 8.2.0 and cURL 7.75.0.
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curl-sslversion-sslv3">
+  <varlistentry xml:id="constant.curlauth-basic">
    <term>
-    <constant>CURL_SSLVERSION_SSLv3</constant>
+    <constant>CURLAUTH_BASIC</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-
+     
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curl-sslversion-tlsv1-0">
+  <varlistentry xml:id="constant.curlauth-bearer">
    <term>
-    <constant>CURL_SSLVERSION_TLSv1_0</constant>
+    <constant>CURLAUTH_BEARER</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-
+     Available as of PHP 7.3.0 and cURL 7.61.0.
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curl-sslversion-tlsv1-1">
+  <varlistentry xml:id="constant.curlauth-digest">
    <term>
-    <constant>CURL_SSLVERSION_TLSv1_1</constant>
+    <constant>CURLAUTH_DIGEST</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-
+     
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curl-sslversion-tlsv1-2">
+  <varlistentry xml:id="constant.curlauth-digest-ie">
    <term>
-    <constant>CURL_SSLVERSION_TLSv1_2</constant>
+    <constant>CURLAUTH_DIGEST_IE</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-
+     Use HTTP Digest authentication with an IE flavor.
+     Available as of cURL 7.19.3.
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curl-sslversion-tlsv1-3">
+  <varlistentry xml:id="constant.curlauth-gssapi">
    <term>
-    <constant>CURL_SSLVERSION_TLSv1_3</constant>
+    <constant>CURLAUTH_GSSAPI</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     Available as of PHP 7.3.0 and cURL 7.54.1
     </simpara>
    </listitem>
   </varlistentry>
-
+  <varlistentry xml:id="constant.curlauth-gssnegotiate">
+   <term>
+    <constant>CURLAUTH_GSSNEGOTIATE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlauth-negotiate">
+   <term>
+    <constant>CURLAUTH_NEGOTIATE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.0.7 and cURL 7.38.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlauth-none">
+   <term>
+    <constant>CURLAUTH_NONE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of cURL 7.10.6.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlauth-ntlm">
+   <term>
+    <constant>CURLAUTH_NTLM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlauth-ntlm-wb">
+   <term>
+    <constant>CURLAUTH_NTLM_WB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.0.7 and cURL 7.22.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlauth-only">
+   <term>
+    <constant>CURLAUTH_ONLY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     This is a meta symbol. OR this value together
+     with a single specific auth value
+     to force libcurl to probe for unrestricted auth and if not,
+     only that single auth algorithm is acceptable.
+     Available as of cURL 7.21.3.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpauth-default">
+   <term>
+    <constant>CURLFTPAUTH_DEFAULT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpauth-ssl">
+   <term>
+    <constant>CURLFTPAUTH_SSL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpauth-tls">
+   <term>
+    <constant>CURLFTPAUTH_TLS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpmethod-default">
+   <term>
+    <constant>CURLFTPMETHOD_DEFAULT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.15.3.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpmethod-multicwd">
+   <term>
+    <constant>CURLFTPMETHOD_MULTICWD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Do a single <literal xmlns="http://docbook.org/ns/docbook">CWD</literal> operation
+     for each path part in the given URL.
+     Available as of cURL 7.15.3.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpmethod-nocwd">
+   <term>
+    <constant>CURLFTPMETHOD_NOCWD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     libcurl makes no <literal xmlns="http://docbook.org/ns/docbook">CWD</literal> at all.
+     libcurl does <literal xmlns="http://docbook.org/ns/docbook">SIZE</literal>, <literal xmlns="http://docbook.org/ns/docbook">RETR</literal>,
+     <literal xmlns="http://docbook.org/ns/docbook">STOR</literal> etc.
+     and gives a full path to the server for all these commands.
+     Available as of cURL 7.15.3.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpmethod-singlecwd">
+   <term>
+    <constant>CURLFTPMETHOD_SINGLECWD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     libcurl does one <literal xmlns="http://docbook.org/ns/docbook">CWD</literal> with the full target directory
+     and then operates on the file like in the multicwd case.
+     Available as of cURL 7.15.3.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpssl-all">
+   <term>
+    <constant>CURLFTPSSL_ALL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpssl-ccc-active">
+   <term>
+    <constant>CURLFTPSSL_CCC_ACTIVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Initiate the shutdown and wait for a reply.
+     Available as of cURL 7.16.2.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpssl-ccc-none">
+   <term>
+    <constant>CURLFTPSSL_CCC_NONE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Do not attempt to use CCC (Clear Command Channel).
+     Available as of cURL 7.16.2.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpssl-ccc-passive">
+   <term>
+    <constant>CURLFTPSSL_CCC_PASSIVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Do not initiate the shutdown, but wait for the server to do it.
+     Do not send a reply.
+     Available as of cURL 7.16.1.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpssl-control">
+   <term>
+    <constant>CURLFTPSSL_CONTROL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpssl-none">
+   <term>
+    <constant>CURLFTPSSL_NONE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftpssl-try">
+   <term>
+    <constant>CURLFTPSSL_TRY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftp-create-dir">
+   <term>
+    <constant>CURLFTP_CREATE_DIR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.0.7 and cURL 7.19.3
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftp-create-dir-none">
+   <term>
+    <constant>CURLFTP_CREATE_DIR_NONE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.0.7 and cURL 7.19.3
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlftp-create-dir-retry">
+   <term>
+    <constant>CURLFTP_CREATE_DIR_RETRY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.0.7 and cURL 7.19.3
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlgssapi-delegation-flag">
+   <term>
+    <constant>CURLGSSAPI_DELEGATION_FLAG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Allow unconditional GSSAPI credential delegation.
+     Available as of cURL 7.22.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlgssapi-delegation-policy-flag">
+   <term>
+    <constant>CURLGSSAPI_DELEGATION_POLICY_FLAG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Delegate only if the <literal xmlns="http://docbook.org/ns/docbook">OK-AS-DELEGATE</literal> flag is set
+     in the service ticket if this feature is supported by the GSS-API implementation
+     and the definition of <literal xmlns="http://docbook.org/ns/docbook">GSS_C_DELEG_POLICY_FLAG</literal>
+     was available at compile-time.
+     Available as of cURL 7.22.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlheader-separate">
+   <term>
+    <constant>CURLHEADER_SEPARATE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.0.7 and cURL 7.37.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlheader-unified">
+   <term>
+    <constant>CURLHEADER_UNIFIED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.0.7 and cURL 7.37.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlhsts-enable">
    <term>
     <constant>CURLHSTS_ENABLE</constant>
@@ -254,101 +482,182 @@
     </simpara>
    </listitem>
   </varlistentry>
-
-  <varlistentry xml:id="constant.curlauth-basic">
+  <varlistentry xml:id="constant.curlkhmatch-last">
    <term>
-    <constant>CURLAUTH_BASIC</constant>
+    <constant>CURLKHMATCH_LAST</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
+     Available as of PHP 8.3.0 and cURL 7.19.6
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curlauth-digest">
+  <varlistentry xml:id="constant.curlkhmatch-mismatch">
    <term>
-    <constant>CURLAUTH_DIGEST</constant>
+    <constant>CURLKHMATCH_MISMATCH</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
+     Available as of PHP 8.3.0 and cURL 7.19.6
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curlauth-gssnegotiate">
+  <varlistentry xml:id="constant.curlkhmatch-missing">
    <term>
-    <constant>CURLAUTH_GSSNEGOTIATE</constant>
+    <constant>CURLKHMATCH_MISSING</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
+     Available as of PHP 8.3.0 and cURL 7.19.6
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curlauth-negotiate">
+  <varlistentry xml:id="constant.curlkhmatch-ok">
    <term>
-    <constant>CURLAUTH_NEGOTIATE</constant>
+    <constant>CURLKHMATCH_OK</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 7.0.7 and cURL 7.38.0.
+     Available as of PHP 8.3.0 and cURL 7.19.6
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curlauth-ntlm">
+  <varlistentry xml:id="constant.curlmimeopt-formescape">
    <term>
-    <constant>CURLAUTH_NTLM</constant>
+    <constant>CURLMIMEOPT_FORMESCAPE</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
+     Available as of PHP 8.3.0 and cURL 7.81.0
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curlauth-ntlm-wb">
+  <varlistentry xml:id="constant.curlmsg-done">
    <term>
-    <constant>CURLAUTH_NTLM_WB</constant>
+    <constant>CURLMSG_DONE</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 7.0.7 and cURL 7.22.0
+     
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curlauth-any">
+  <varlistentry xml:id="constant.curlpipe-http1">
    <term>
-    <constant>CURLAUTH_ANY</constant>
+    <constant>CURLPIPE_HTTP1</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
+     Available as of cURL 7.43.0.
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curlauth-anysafe">
+  <varlistentry xml:id="constant.curlpipe-multiplex">
    <term>
-    <constant>CURLAUTH_ANYSAFE</constant>
+    <constant>CURLPIPE_MULTIPLEX</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
+     Available as of cURL 7.43.0.
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curlauth-aws-sigv4">
+  <varlistentry xml:id="constant.curlpipe-nothing">
    <term>
-    <constant>CURLAUTH_AWS_SIGV4</constant>
+    <constant>CURLPIPE_NOTHING</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0 and cURL 7.75.0.
+     Available as of cURL 7.43.0.
     </simpara>
    </listitem>
   </varlistentry>
-
+  <varlistentry xml:id="constant.curlproxy-http">
+   <term>
+    <constant>CURLPROXY_HTTP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of cURL 7.10.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlproxy-https">
+   <term>
+    <constant>CURLPROXY_HTTPS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.3.0 and cURL 7.52.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlproxy-http-1-0">
+   <term>
+    <constant>CURLPROXY_HTTP_1_0</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.0.7 and cURL 7.19.3
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlproxy-socks4">
+   <term>
+    <constant>CURLPROXY_SOCKS4</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of cURL 7.10.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlproxy-socks4a">
+   <term>
+    <constant>CURLPROXY_SOCKS4A</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of cURL 7.18.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlproxy-socks5">
+   <term>
+    <constant>CURLPROXY_SOCKS5</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of cURL 7.10.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlproxy-socks5-hostname">
+   <term>
+    <constant>CURLPROXY_SOCKS5_HOSTNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of cURL 7.18.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlpx-bad-address-type">
    <term>
     <constant>CURLPX_BAD_ADDRESS_TYPE</constant>
@@ -415,9 +724,9 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curlpx-identd-differ">
+  <varlistentry xml:id="constant.curlpx-identd">
    <term>
-    <constant>CURLPX_IDENTD_DIFFER</constant>
+    <constant>CURLPX_IDENTD</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -426,9 +735,9 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curlpx-identd">
+  <varlistentry xml:id="constant.curlpx-identd-differ">
    <term>
-    <constant>CURLPX_IDENTD</constant>
+    <constant>CURLPX_IDENTD_DIFFER</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -723,14 +1032,438 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curl-push-ok">
+  <varlistentry xml:id="constant.curlssh-auth-agent">
    <term>
-    <constant>CURL_PUSH_OK</constant>
+    <constant>CURLSSH_AUTH_AGENT</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 7.1.0 and cURL 7.44.0
+     Available as of PHP 7.0.7 and cURL 7.28.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlssh-auth-any">
+   <term>
+    <constant>CURLSSH_AUTH_ANY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlssh-auth-default">
+   <term>
+    <constant>CURLSSH_AUTH_DEFAULT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlssh-auth-gssapi">
+   <term>
+    <constant>CURLSSH_AUTH_GSSAPI</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.3.0 and cURL 7.58.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlssh-auth-host">
+   <term>
+    <constant>CURLSSH_AUTH_HOST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlssh-auth-keyboard">
+   <term>
+    <constant>CURLSSH_AUTH_KEYBOARD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlssh-auth-none">
+   <term>
+    <constant>CURLSSH_AUTH_NONE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlssh-auth-password">
+   <term>
+    <constant>CURLSSH_AUTH_PASSWORD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlssh-auth-publickey">
+   <term>
+    <constant>CURLSSH_AUTH_PUBLICKEY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlsslopt-allow-beast">
+   <term>
+    <constant>CURLSSLOPT_ALLOW_BEAST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of cURL 7.25.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlsslopt-auto-client-cert">
+   <term>
+    <constant>CURLSSLOPT_AUTO_CLIENT_CERT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.77.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlsslopt-native-ca">
+   <term>
+    <constant>CURLSSLOPT_NATIVE_CA</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.71.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlsslopt-no-partialchain">
+   <term>
+    <constant>CURLSSLOPT_NO_PARTIALCHAIN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.68.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlsslopt-no-revoke">
+   <term>
+    <constant>CURLSSLOPT_NO_REVOKE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.0.7 and cURL 7.44.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlsslopt-revoke-best-effort">
+   <term>
+    <constant>CURLSSLOPT_REVOKE_BEST_EFFORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.70.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlusessl-all">
+   <term>
+    <constant>CURLUSESSL_ALL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Require SSL for all communication
+     or fail with <constant xmlns="http://docbook.org/ns/docbook">CURLE_USE_SSL_FAILED</constant>.
+     Available as of cURL 7.17.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlusessl-control">
+   <term>
+    <constant>CURLUSESSL_CONTROL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Require SSL for the control connection
+     or fail with <constant xmlns="http://docbook.org/ns/docbook">CURLE_USE_SSL_FAILED</constant>.
+     Available as of cURL 7.17.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlusessl-none">
+   <term>
+    <constant>CURLUSESSL_NONE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Do not attempt to use SSL.
+     Available as of cURL 7.17.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlusessl-try">
+   <term>
+    <constant>CURLUSESSL_TRY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Try using SSL, proceed as normal otherwise.
+     Note that server may close the connection if the negotiation does not succeed.
+     Available as of cURL 7.17.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlversion-now">
+   <term>
+    <constant>CURLVERSION_NOW</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlws-raw-mode">
+   <term>
+    <constant>CURLWS_RAW_MODE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 and cURL 7.86.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-fnmatchfunc-fail">
+   <term>
+    <constant>CURL_FNMATCHFUNC_FAIL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Returned by the wildcard match callback function if an error occured.
+     Available as of cURL 7.21.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-fnmatchfunc-match">
+   <term>
+    <constant>CURL_FNMATCHFUNC_MATCH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Returned by the wildcard match callback function
+     if pattern matches the string.
+     Available as of cURL 7.21.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-fnmatchfunc-nomatch">
+   <term>
+    <constant>CURL_FNMATCHFUNC_NOMATCH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Returned by the wildcard match callback function
+     if pattern does not match the string.
+     Available as of cURL 7.21.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-http-version-1-0">
+   <term>
+    <constant>CURL_HTTP_VERSION_1_0</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-http-version-1-1">
+   <term>
+    <constant>CURL_HTTP_VERSION_1_1</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-http-version-2">
+   <term>
+    <constant>CURL_HTTP_VERSION_2</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.0.7 and cURL 7.43.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-http-version-2tls">
+   <term>
+    <constant>CURL_HTTP_VERSION_2TLS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.0.7 and cURL 7.47.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-http-version-2-0">
+   <term>
+    <constant>CURL_HTTP_VERSION_2_0</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of cURL 7.33.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-http-version-2-prior-knowledge">
+   <term>
+    <constant>CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.0.7 and cURL 7.49.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-http-version-none">
+   <term>
+    <constant>CURL_HTTP_VERSION_NONE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-ipresolve-v4">
+   <term>
+    <constant>CURL_IPRESOLVE_V4</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Use only IPv4 addresses when establishing a connection
+     or choosing one from the connection pool.
+     Available as of cURL 7.10.8.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-ipresolve-v6">
+   <term>
+    <constant>CURL_IPRESOLVE_V6</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Use only IPv6 addresses when establishing a connection
+     or choosing one from the connection pool.
+     Available as of cURL 7.10.8.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-ipresolve-whatever">
+   <term>
+    <constant>CURL_IPRESOLVE_WHATEVER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Use addresses of all IP versions allowed by the system.
+     Available as of cURL 7.10.8.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-max-read-size">
+   <term>
+    <constant>CURL_MAX_READ_SIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.3.0 and cURL 7.53.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-netrc-ignored">
+   <term>
+    <constant>CURL_NETRC_IGNORED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-netrc-optional">
+   <term>
+    <constant>CURL_NETRC_OPTIONAL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-netrc-required">
+   <term>
+    <constant>CURL_NETRC_REQUIRED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
     </simpara>
    </listitem>
   </varlistentry>
@@ -742,6 +1475,28 @@
    <listitem>
     <simpara>
      Available as of PHP 7.1.0 and cURL 7.44.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-push-ok">
+   <term>
+    <constant>CURL_PUSH_OK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.1.0 and cURL 7.44.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-readfunc-pause">
+   <term>
+    <constant>CURL_READFUNC_PAUSE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of cURL 7.18.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -789,14 +1544,308 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curl-timecond-none">
+  <varlistentry xml:id="constant.curl-rtspreq-announce">
    <term>
-    <constant>CURL_TIMECOND_NONE</constant>
+    <constant>CURL_RTSPREQ_ANNOUNCE</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-
+     When sent by a client, this method changes the description of the session.
+     <literal xmlns="http://docbook.org/ns/docbook">ANNOUNCE</literal> acts like an HTTP PUT or POST
+     just like <constant xmlns="http://docbook.org/ns/docbook">CURL_RTSPREQ_SET_PARAMETER</constant>.
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-describe">
+   <term>
+    <constant>CURL_RTSPREQ_DESCRIBE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Used to get the low level description of a stream.
+     The application should note what formats it understands
+     in the <literal xmlns="http://docbook.org/ns/docbook">Accept:</literal> header. Unless set manually,
+     libcurl automatically adds in <literal xmlns="http://docbook.org/ns/docbook">Accept: application/sdp</literal>.
+     Time-condition headers are added to DESCRIBE requests
+     if the <constant xmlns="http://docbook.org/ns/docbook">CURLOPT_TIMECONDITION</constant> option is used.
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-get-parameter">
+   <term>
+    <constant>CURL_RTSPREQ_GET_PARAMETER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Retrieve a parameter from the server.
+     By default, libcurl adds a <literal xmlns="http://docbook.org/ns/docbook">Content-Type: text/parameters</literal>
+     header on all non-empty requests unless a custom one is set.
+     <literal xmlns="http://docbook.org/ns/docbook">GET_PARAMETER</literal> acts just like an HTTP PUT or POST.
+     Applications wishing to send a heartbeat message
+     should use an empty <literal xmlns="http://docbook.org/ns/docbook">GET_PARAMETER</literal> request.
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-options">
+   <term>
+    <constant>CURL_RTSPREQ_OPTIONS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Used to retrieve the available methods of the server.
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-pause">
+   <term>
+    <constant>CURL_RTSPREQ_PAUSE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Send a <literal xmlns="http://docbook.org/ns/docbook">PAUSE</literal> command to the server.
+     Use the <constant xmlns="http://docbook.org/ns/docbook">CURLOPT_RANGE</constant> option with a single value
+     to indicate when the stream should be halted (e.g. npt=25).
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-play">
+   <term>
+    <constant>CURL_RTSPREQ_PLAY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Send a <literal xmlns="http://docbook.org/ns/docbook">PLAY</literal> command to the server.
+     Use the <constant xmlns="http://docbook.org/ns/docbook">CURLOPT_RANGE</constant> option
+     to modify the playback time (e.g. npt=10-15).
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-receive">
+   <term>
+    <constant>CURL_RTSPREQ_RECEIVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Set the RTSP request type to this value to receive interleaved RTP data.
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-record">
+   <term>
+    <constant>CURL_RTSPREQ_RECORD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Used to tell the server to record a session.
+     Use the <constant xmlns="http://docbook.org/ns/docbook">CURLOPT_RANGE</constant> option to modify the record time.
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-setup">
+   <term>
+    <constant>CURL_RTSPREQ_SETUP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Used to initialize the transport layer for the session.
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-set-parameter">
+   <term>
+    <constant>CURL_RTSPREQ_SET_PARAMETER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Set a parameter on the server.
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-rtspreq-teardown">
+   <term>
+    <constant>CURL_RTSPREQ_TEARDOWN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Terminates an RTSP session.
+     Simply closing a connection does not terminate the RTSP session
+     since it is valid to control an RTSP session over different connections.
+     Available as of cURL 7.20.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-sslversion-default">
+   <term>
+    <constant>CURL_SSLVERSION_DEFAULT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-sslversion-max-default">
+   <term>
+    <constant>CURL_SSLVERSION_MAX_DEFAULT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.3.0 and cURL 7.54.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-sslversion-max-none">
+   <term>
+    <constant>CURL_SSLVERSION_MAX_NONE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.3.0 and cURL 7.54.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-sslversion-max-tlsv1-0">
+   <term>
+    <constant>CURL_SSLVERSION_MAX_TLSv1_0</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.3.0 and cURL 7.54.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-sslversion-max-tlsv1-1">
+   <term>
+    <constant>CURL_SSLVERSION_MAX_TLSv1_1</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.3.0 and cURL 7.54.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-sslversion-max-tlsv1-2">
+   <term>
+    <constant>CURL_SSLVERSION_MAX_TLSv1_2</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.3.0 and cURL 7.54.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-sslversion-max-tlsv1-3">
+   <term>
+    <constant>CURL_SSLVERSION_MAX_TLSv1_3</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.3.0 and cURL 7.54.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-sslversion-sslv2">
+   <term>
+    <constant>CURL_SSLVERSION_SSLv2</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-sslversion-sslv3">
+   <term>
+    <constant>CURL_SSLVERSION_SSLv3</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-sslversion-tlsv1">
+   <term>
+    <constant>CURL_SSLVERSION_TLSv1</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-sslversion-tlsv1-0">
+   <term>
+    <constant>CURL_SSLVERSION_TLSv1_0</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-sslversion-tlsv1-1">
+   <term>
+    <constant>CURL_SSLVERSION_TLSv1_1</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-sslversion-tlsv1-2">
+   <term>
+    <constant>CURL_SSLVERSION_TLSv1_2</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-sslversion-tlsv1-3">
+   <term>
+    <constant>CURL_SSLVERSION_TLSv1_3</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.3.0 and cURL 7.52.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -807,7 +1856,7 @@
    </term>
    <listitem>
     <simpara>
-
+     
     </simpara>
    </listitem>
   </varlistentry>
@@ -818,7 +1867,7 @@
    </term>
    <listitem>
     <simpara>
-
+     
     </simpara>
    </listitem>
   </varlistentry>
@@ -829,7 +1878,29 @@
    </term>
    <listitem>
     <simpara>
-
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-timecond-none">
+   <term>
+    <constant>CURL_TIMECOND_NONE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-tlsauth-srp">
+   <term>
+    <constant>CURL_TLSAUTH_SRP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of cURL 7.21.4.
     </simpara>
    </listitem>
   </varlistentry>
@@ -949,6 +2020,40 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curl-version-http2">
+   <term>
+    <constant>CURL_VERSION_HTTP2</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     HTTP2 support built-in.
+     Available as of cURL 7.33.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-http3">
+   <term>
+    <constant>CURL_VERSION_HTTP3</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0 and cURL 7.66.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-https-proxy">
+   <term>
+    <constant>CURL_VERSION_HTTPS_PROXY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 7.3.0 and cURL 7.52.0
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curl-version-idn">
    <term>
     <constant>CURL_VERSION_IDN</constant>
@@ -958,6 +2063,63 @@
     <simpara>
      Internationized Domain Names are supported.
      Available as of PHP 7.3.0 and cURL 7.12.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-ipv6">
+   <term>
+    <constant>CURL_VERSION_IPV6</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     IPv6-enabled.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-kerberos4">
+   <term>
+    <constant>CURL_VERSION_KERBEROS4</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Kerberos V4 auth is supported.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-kerberos5">
+   <term>
+    <constant>CURL_VERSION_KERBEROS5</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Kerberos V5 auth is supported.
+     Available as of PHP 7.0.7 and cURL 7.40.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-largefile">
+   <term>
+    <constant>CURL_VERSION_LARGEFILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Supports files larger than 2GB.
+     Available as of cURL 7.33.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curl-version-libz">
+   <term>
+    <constant>CURL_VERSION_LIBZ</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     libz features are present.
     </simpara>
    </listitem>
   </varlistentry>
@@ -996,75 +2158,6 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curl-version-ipv6">
-   <term>
-    <constant>CURL_VERSION_IPV6</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     IPv6-enabled.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-version-kerberos4">
-   <term>
-    <constant>CURL_VERSION_KERBEROS4</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Kerberos V4 auth is supported.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-version-kerberos5">
-   <term>
-    <constant>CURL_VERSION_KERBEROS5</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Kerberos V5 auth is supported.
-     Available as of PHP 7.0.7 and cURL 7.40.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-version-http2">
-   <term>
-    <constant>CURL_VERSION_HTTP2</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     HTTP2 support built-in.
-     Available as of cURL 7.33.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-version-http3">
-   <term>
-    <constant>CURL_VERSION_HTTP3</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 8.2.0 and cURL 7.66.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-version-largefile">
-   <term>
-    <constant>CURL_VERSION_LARGEFILE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Supports files larger than 2GB.
-     Available as of cURL 7.33.0
-    </simpara>
-   </listitem>
-  </varlistentry>
   <varlistentry xml:id="constant.curl-version-psl">
    <term>
     <constant>CURL_VERSION_PSL</constant>
@@ -1089,6 +2182,17 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curl-version-ssl">
+   <term>
+    <constant>CURL_VERSION_SSL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     SSL options are present.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curl-version-sspi">
    <term>
     <constant>CURL_VERSION_SSPI</constant>
@@ -1098,17 +2202,6 @@
     <simpara>
      Built against Windows SSPI.
      Available as of PHP 7.3.0 and cURL 7.13.2
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-version-ssl">
-   <term>
-    <constant>CURL_VERSION_SSL</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     SSL options are present.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1158,910 +2251,6 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.curl-version-libz">
-   <term>
-    <constant>CURL_VERSION_LIBZ</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     libz features are present.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlversion-now">
-   <term>
-    <constant>CURLVERSION_NOW</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlftpauth-default">
-   <term>
-    <constant>CURLFTPAUTH_DEFAULT</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlftpauth-ssl">
-   <term>
-    <constant>CURLFTPAUTH_SSL</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlftpauth-tls">
-   <term>
-    <constant>CURLFTPAUTH_TLS</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlproxy-http">
-   <term>
-    <constant>CURLPROXY_HTTP</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of cURL 7.10.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlproxy-http-1-0">
-   <term>
-    <constant>CURLPROXY_HTTP_1_0</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.0.7 and cURL 7.19.3
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlproxy-socks4">
-   <term>
-    <constant>CURLPROXY_SOCKS4</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of cURL 7.10.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlproxy-socks5">
-   <term>
-    <constant>CURLPROXY_SOCKS5</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of cURL 7.10.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-netrc-optional">
-   <term>
-    <constant>CURL_NETRC_OPTIONAL</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-netrc-ignored">
-   <term>
-    <constant>CURL_NETRC_IGNORED</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-netrc-required">
-   <term>
-    <constant>CURL_NETRC_REQUIRED</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-http-version-none">
-   <term>
-    <constant>CURL_HTTP_VERSION_NONE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-http-version-1-0">
-   <term>
-    <constant>CURL_HTTP_VERSION_1_0</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-http-version-1-1">
-   <term>
-    <constant>CURL_HTTP_VERSION_1_1</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-http-version-2">
-   <term>
-    <constant>CURL_HTTP_VERSION_2</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.0.7 and cURL 7.43.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-http-version-2-0">
-   <term>
-    <constant>CURL_HTTP_VERSION_2_0</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of cURL 7.33.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-http-version-2tls">
-   <term>
-    <constant>CURL_HTTP_VERSION_2TLS</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.0.7 and cURL 7.47.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-http-version-2-prior-knowledge">
-   <term>
-    <constant>CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.0.7 and cURL 7.49.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlmsg-done">
-   <term>
-    <constant>CURLMSG_DONE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-
-  <varlistentry xml:id="constant.curlsslopt-allow-beast">
-   <term>
-    <constant>CURLSSLOPT_ALLOW_BEAST</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of cURL 7.25.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlsslopt-no-revoke">
-   <term>
-    <constant>CURLSSLOPT_NO_REVOKE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.0.7 and cURL 7.44.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlsslopt-auto-client-cert">
-   <term>
-    <constant>CURLSSLOPT_AUTO_CLIENT_CERT</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 8.2.0 and cURL 7.77.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlsslopt-native-ca">
-   <term>
-    <constant>CURLSSLOPT_NATIVE_CA</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 8.2.0 and cURL 7.71.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlsslopt-no-partialchain">
-   <term>
-    <constant>CURLSSLOPT_NO_PARTIALCHAIN</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 8.2.0 and cURL 7.68.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlsslopt-revoke-best-effort">
-   <term>
-    <constant>CURLSSLOPT_REVOKE_BEST_EFFORT</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 8.2.0 and cURL 7.70.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-
-  <varlistentry xml:id="constant.curlssh-auth-agent">
-   <term>
-    <constant>CURLSSH_AUTH_AGENT</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.0.7 and cURL 7.28.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlssh-auth-any">
-   <term>
-    <constant>CURLSSH_AUTH_ANY</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlssh-auth-default">
-   <term>
-    <constant>CURLSSH_AUTH_DEFAULT</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlssh-auth-host">
-   <term>
-    <constant>CURLSSH_AUTH_HOST</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlssh-auth-keyboard">
-   <term>
-    <constant>CURLSSH_AUTH_KEYBOARD</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlssh-auth-none">
-   <term>
-    <constant>CURLSSH_AUTH_NONE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlssh-auth-password">
-   <term>
-    <constant>CURLSSH_AUTH_PASSWORD</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlssh-auth-publickey">
-   <term>
-    <constant>CURLSSH_AUTH_PUBLICKEY</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlpipe-nothing">
-   <term>
-    <constant>CURLPIPE_NOTHING</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of cURL 7.43.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlpipe-http1">
-   <term>
-    <constant>CURLPIPE_HTTP1</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of cURL 7.43.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlpipe-multiplex">
-   <term>
-    <constant>CURLPIPE_MULTIPLEX</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of cURL 7.43.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlproxy-socks4a">
-   <term>
-    <constant>CURLPROXY_SOCKS4A</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of cURL 7.18.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlproxy-socks5-hostname">
-   <term>
-    <constant>CURLPROXY_SOCKS5_HOSTNAME</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of cURL 7.18.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlheader-separate">
-   <term>
-    <constant>CURLHEADER_SEPARATE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.0.7 and cURL 7.37.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlheader-unified">
-   <term>
-    <constant>CURLHEADER_UNIFIED</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.0.7 and cURL 7.37.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-
-  <varlistentry xml:id="constant.curlauth-gssapi">
-   <term>
-    <constant>CURLAUTH_GSSAPI</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.3.0 and cURL 7.54.1
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-max-read-size">
-   <term>
-    <constant>CURL_MAX_READ_SIZE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.3.0 and cURL 7.53.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-
-  <varlistentry xml:id="constant.curlproxy-https">
-   <term>
-    <constant>CURLPROXY_HTTPS</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.3.0 and cURL 7.52.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-sslversion-max-default">
-   <term>
-    <constant>CURL_SSLVERSION_MAX_DEFAULT</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.3.0 and cURL 7.54.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-sslversion-max-none">
-   <term>
-    <constant>CURL_SSLVERSION_MAX_NONE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.3.0 and cURL 7.54.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-sslversion-max-tlsv1-0">
-   <term>
-    <constant>CURL_SSLVERSION_MAX_TLSv1_0</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.3.0 and cURL 7.54.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-sslversion-max-tlsv1-1">
-   <term>
-    <constant>CURL_SSLVERSION_MAX_TLSv1_1</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.3.0 and cURL 7.54.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-sslversion-max-tlsv1-2">
-   <term>
-    <constant>CURL_SSLVERSION_MAX_TLSv1_2</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.3.0 and cURL 7.54.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-sslversion-max-tlsv1-3">
-   <term>
-    <constant>CURL_SSLVERSION_MAX_TLSv1_3</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.3.0 and cURL 7.54.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-version-https-proxy">
-   <term>
-    <constant>CURL_VERSION_HTTPS_PROXY</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.3.0 and cURL 7.52.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlauth-bearer">
-   <term>
-    <constant>CURLAUTH_BEARER</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.3.0 and cURL 7.61.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-
-  <varlistentry xml:id="constant.curlssh-auth-gssapi">
-   <term>
-    <constant>CURLSSH_AUTH_GSSAPI</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 7.3.0 and cURL 7.58.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-
-  <varlistentry xml:id="constant.curlmimeopt-formescape">
-   <term>
-    <constant>CURLMIMEOPT_FORMESCAPE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 8.3.0 and cURL 7.81.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlws-raw-mode">
-   <term>
-    <constant>CURLWS_RAW_MODE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 8.3.0 and cURL 7.86.0
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlkhmatch-ok">
-   <term>
-    <constant>CURLKHMATCH_OK</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 8.3.0 and cURL 7.19.6
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlkhmatch-mismatch">
-   <term>
-    <constant>CURLKHMATCH_MISMATCH</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 8.3.0 and cURL 7.19.6
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlkhmatch-missing">
-   <term>
-    <constant>CURLKHMATCH_MISSING</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 8.3.0 and cURL 7.19.6
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlkhmatch-last">
-   <term>
-    <constant>CURLKHMATCH_LAST</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of PHP 8.3.0 and cURL 7.19.6
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-fnmatchfunc-fail">
-   <term>
-    <constant>CURL_FNMATCHFUNC_FAIL</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Returned by the wildcard match callback function if an error occured.
-     Available as of cURL 7.21.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-fnmatchfunc-match">
-   <term>
-    <constant>CURL_FNMATCHFUNC_MATCH</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Returned by the wildcard match callback function
-     if pattern matches the string.
-     Available as of cURL 7.21.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-fnmatchfunc-nomatch">
-   <term>
-    <constant>CURL_FNMATCHFUNC_NOMATCH</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Returned by the wildcard match callback function
-     if pattern does not match the string.
-     Available as of cURL 7.21.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-ipresolve-v4">
-   <term>
-    <constant>CURL_IPRESOLVE_V4</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Use only IPv4 addresses when establishing a connection
-     or choosing one from the connection pool.
-     Available as of cURL 7.10.8.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-ipresolve-v6">
-   <term>
-    <constant>CURL_IPRESOLVE_V6</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Use only IPv6 addresses when establishing a connection
-     or choosing one from the connection pool.
-     Available as of cURL 7.10.8.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-ipresolve-whatever">
-   <term>
-    <constant>CURL_IPRESOLVE_WHATEVER</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Use addresses of all IP versions allowed by the system.
-     Available as of cURL 7.10.8.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-readfunc-pause">
-   <term>
-    <constant>CURL_READFUNC_PAUSE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of cURL 7.18.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-rtspreq-announce">
-   <term>
-    <constant>CURL_RTSPREQ_ANNOUNCE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     When sent by a client, this method changes the description of the session.
-     <literal>ANNOUNCE</literal> acts like an HTTP PUT or POST
-     just like <constant>CURL_RTSPREQ_SET_PARAMETER</constant>.
-     Available as of cURL 7.20.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-rtspreq-describe">
-   <term>
-    <constant>CURL_RTSPREQ_DESCRIBE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Used to get the low level description of a stream.
-     The application should note what formats it understands
-     in the <literal>Accept:</literal> header. Unless set manually,
-     libcurl automatically adds in <literal>Accept: application/sdp</literal>.
-     Time-condition headers are added to DESCRIBE requests
-     if the <constant>CURLOPT_TIMECONDITION</constant> option is used.
-     Available as of cURL 7.20.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-rtspreq-get-parameter">
-   <term>
-    <constant>CURL_RTSPREQ_GET_PARAMETER</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Retrieve a parameter from the server.
-     By default, libcurl adds a <literal>Content-Type: text/parameters</literal>
-     header on all non-empty requests unless a custom one is set.
-     <literal>GET_PARAMETER</literal> acts just like an HTTP PUT or POST.
-     Applications wishing to send a heartbeat message
-     should use an empty <literal>GET_PARAMETER</literal> request.
-     Available as of cURL 7.20.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-rtspreq-options">
-   <term>
-    <constant>CURL_RTSPREQ_OPTIONS</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Used to retrieve the available methods of the server.
-     Available as of cURL 7.20.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-rtspreq-pause">
-   <term>
-    <constant>CURL_RTSPREQ_PAUSE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Send a <literal>PAUSE</literal> command to the server.
-     Use the <constant>CURLOPT_RANGE</constant> option with a single value
-     to indicate when the stream should be halted (e.g. npt=25).
-     Available as of cURL 7.20.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-rtspreq-play">
-   <term>
-    <constant>CURL_RTSPREQ_PLAY</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Send a <literal>PLAY</literal> command to the server.
-     Use the <constant>CURLOPT_RANGE</constant> option
-     to modify the playback time (e.g. npt=10-15).
-     Available as of cURL 7.20.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-rtspreq-receive">
-   <term>
-    <constant>CURL_RTSPREQ_RECEIVE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Set the RTSP request type to this value to receive interleaved RTP data.
-     Available as of cURL 7.20.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-rtspreq-record">
-   <term>
-    <constant>CURL_RTSPREQ_RECORD</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Used to tell the server to record a session.
-     Use the <constant>CURLOPT_RANGE</constant> option to modify the record time.
-     Available as of cURL 7.20.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-rtspreq-set-parameter">
-   <term>
-    <constant>CURL_RTSPREQ_SET_PARAMETER</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Set a parameter on the server.
-     Available as of cURL 7.20.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-rtspreq-setup">
-   <term>
-    <constant>CURL_RTSPREQ_SETUP</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Used to initialize the transport layer for the session.
-     Available as of cURL 7.20.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-rtspreq-teardown">
-   <term>
-    <constant>CURL_RTSPREQ_TEARDOWN</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Terminates an RTSP session.
-     Simply closing a connection does not terminate the RTSP session
-     since it is valid to control an RTSP session over different connections.
-     Available as of cURL 7.20.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curl-tlsauth-srp">
-   <term>
-    <constant>CURL_TLSAUTH_SRP</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of cURL 7.21.4.
-    </simpara>
-   </listitem>
-  </varlistentry>
   <varlistentry xml:id="constant.curl-writefunc-pause">
    <term>
     <constant>CURL_WRITEFUNC_PAUSE</constant>
@@ -2070,200 +2259,6 @@
    <listitem>
     <simpara>
      Available as of cURL 7.18.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlauth-digest-ie">
-   <term>
-    <constant>CURLAUTH_DIGEST_IE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Use HTTP Digest authentication with an IE flavor.
-     Available as of cURL 7.19.3.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlauth-none">
-   <term>
-    <constant>CURLAUTH_NONE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Available as of cURL 7.10.6.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlauth-only">
-   <term>
-    <constant>CURLAUTH_ONLY</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     This is a meta symbol. OR this value together
-     with a single specific auth value
-     to force libcurl to probe for unrestricted auth and if not,
-     only that single auth algorithm is acceptable.
-     Available as of cURL 7.21.3.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlftpmethod-multicwd">
-   <term>
-    <constant>CURLFTPMETHOD_MULTICWD</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Do a single <literal>CWD</literal> operation
-     for each path part in the given URL.
-     Available as of cURL 7.15.3.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlftpmethod-nocwd">
-   <term>
-    <constant>CURLFTPMETHOD_NOCWD</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     libcurl makes no <literal>CWD</literal> at all.
-     libcurl does <literal>SIZE</literal>, <literal>RETR</literal>,
-     <literal>STOR</literal> etc.
-     and gives a full path to the server for all these commands.
-     Available as of cURL 7.15.3.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlftpmethod-singlecwd">
-   <term>
-    <constant>CURLFTPMETHOD_SINGLECWD</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     libcurl does one <literal>CWD</literal> with the full target directory
-     and then operates on the file like in the multicwd case.
-     Available as of cURL 7.15.3.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlftpssl-ccc-active">
-   <term>
-    <constant>CURLFTPSSL_CCC_ACTIVE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Initiate the shutdown and wait for a reply.
-     Available as of cURL 7.16.2.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlftpssl-ccc-none">
-   <term>
-    <constant>CURLFTPSSL_CCC_NONE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Do not attempt to use CCC (Clear Command Channel).
-     Available as of cURL 7.16.2.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlftpssl-ccc-passive">
-   <term>
-    <constant>CURLFTPSSL_CCC_PASSIVE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Do not initiate the shutdown, but wait for the server to do it.
-     Do not send a reply.
-     Available as of cURL 7.16.1.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlgssapi-delegation-flag">
-   <term>
-    <constant>CURLGSSAPI_DELEGATION_FLAG</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Allow unconditional GSSAPI credential delegation.
-     Available as of cURL 7.22.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlgssapi-delegation-policy-flag">
-   <term>
-    <constant>CURLGSSAPI_DELEGATION_POLICY_FLAG</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Delegate only if the <literal>OK-AS-DELEGATE</literal> flag is set
-     in the service ticket if this feature is supported by the GSS-API implementation
-     and the definition of <literal>GSS_C_DELEG_POLICY_FLAG</literal>
-     was available at compile-time.
-     Available as of cURL 7.22.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlusessl-all">
-   <term>
-    <constant>CURLUSESSL_ALL</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Require SSL for all communication
-     or fail with <constant>CURLE_USE_SSL_FAILED</constant>.
-     Available as of cURL 7.17.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlusessl-control">
-   <term>
-    <constant>CURLUSESSL_CONTROL</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Require SSL for the control connection
-     or fail with <constant>CURLE_USE_SSL_FAILED</constant>.
-     Available as of cURL 7.17.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlusessl-none">
-   <term>
-    <constant>CURLUSESSL_NONE</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Do not attempt to use SSL.
-     Available as of cURL 7.17.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.curlusessl-try">
-   <term>
-    <constant>CURLUSESSL_TRY</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Try using SSL, proceed as normal otherwise.
-     Note that server may close the connection if the negotiation does not succeed.
-     Available as of cURL 7.17.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -98,21 +98,6 @@
     </simpara>
    </listitem>
   </varlistentry>
-
-<!-- intentionally leave out, currently does nothing
-  <varlistentry xml:id="constant.curlopt-readdata">
-   <term>
-    <constant>CURLOPT_READDATA</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
--->
-
   <varlistentry xml:id="constant.curlaltsvc-h1">
    <term>
     <constant>CURLALTSVC_H1</constant>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -60,7 +60,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -71,7 +71,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -93,7 +93,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -115,7 +115,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -149,7 +149,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -182,7 +182,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -219,7 +219,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -230,7 +230,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -241,7 +241,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -304,7 +304,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -352,7 +352,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -363,7 +363,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -374,7 +374,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -544,7 +544,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1050,7 +1050,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1061,7 +1061,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1083,7 +1083,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1094,7 +1094,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1105,7 +1105,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1116,7 +1116,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1127,7 +1127,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1255,7 +1255,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1315,7 +1315,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1326,7 +1326,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1381,7 +1381,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1441,7 +1441,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1452,7 +1452,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1463,7 +1463,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1702,7 +1702,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1779,7 +1779,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1790,7 +1790,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1801,7 +1801,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1812,7 +1812,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1823,7 +1823,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1834,7 +1834,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1856,7 +1856,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1867,7 +1867,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1878,7 +1878,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -1889,7 +1889,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
This PR adds the last few missing constants from https://github.com/php/doc-en/issues/2747. All constant descriptions and cURL version availability is based on the [cURL Symbols page](https://curl.se/libcurl/c/symbols-in-versions.html).

As the last commit sorts the constants which throws off the diff, this PR is definitely best reviewed commit by commit.

As a side note, I used [this script](https://gist.github.com/haszi/bca07054a7d4504d773d8d7fdfcffe2f) to sort the constants which may or may not be useful for doing the same in the translations.