### PR TITLE
Normalize version strings in changelog entries

### DIFF
--- a/language/context/zip.xml
+++ b/language/context/zip.xml
@@ -43,7 +43,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>PHP 7.2.0, PECL zip 1.14.0</entry>
+       <entry>7.2.0, PECL zip 1.14.0</entry>
        <entry>
         Added <parameter>password</parameter>.
        </entry>

--- a/reference/dbase/functions/dbase-add-record.xml
+++ b/reference/dbase/functions/dbase-add-record.xml
@@ -67,7 +67,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>dbase 7.0.0</entry>
+      <entry>PECL dbase 7.0.0</entry>
       <entry>
        <parameter>database</parameter> is now a <type>resource</type>
        instead of an <type>int</type>.

--- a/reference/dbase/functions/dbase-close.xml
+++ b/reference/dbase/functions/dbase-close.xml
@@ -50,7 +50,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>dbase 7.0.0</entry>
+      <entry>PECL dbase 7.0.0</entry>
       <entry>
        <parameter>database</parameter> is now a <type>resource</type>
        instead of an <type>int</type>.

--- a/reference/dbase/functions/dbase-create.xml
+++ b/reference/dbase/functions/dbase-create.xml
@@ -84,13 +84,13 @@
     </thead>
     <tbody>
      <row>
-      <entry>dbase 7.0.0</entry>
+      <entry>PECL dbase 7.0.0</entry>
       <entry>
        The <parameter>type</parameter> parameter has been added.
       </entry>
      </row>
      <row>
-      <entry>dbase 7.0.0</entry>
+      <entry>PECL dbase 7.0.0</entry>
       <entry>
        The return value is now a <type>resource</type> instead of an
        <type>int</type>.

--- a/reference/dbase/functions/dbase-delete-record.xml
+++ b/reference/dbase/functions/dbase-delete-record.xml
@@ -66,7 +66,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>dbase 7.0.0</entry>
+      <entry>PECL dbase 7.0.0</entry>
       <entry>
        <parameter>database</parameter> is now a <type>resource</type>
        instead of an <type>int</type>.

--- a/reference/dbase/functions/dbase-get-header-info.xml
+++ b/reference/dbase/functions/dbase-get-header-info.xml
@@ -111,7 +111,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>dbase 7.0.0</entry>
+      <entry>PECL dbase 7.0.0</entry>
       <entry>
        <parameter>database</parameter> is now a <type>resource</type>
        instead of an <type>int</type>.

--- a/reference/dbase/functions/dbase-get-record-with-names.xml
+++ b/reference/dbase/functions/dbase-get-record-with-names.xml
@@ -70,7 +70,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>dbase 7.0.0</entry>
+      <entry>PECL dbase 7.0.0</entry>
       <entry>
        <parameter>database</parameter> is now a <type>resource</type>
        instead of an <type>int</type>.

--- a/reference/dbase/functions/dbase-get-record.xml
+++ b/reference/dbase/functions/dbase-get-record.xml
@@ -68,7 +68,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>dbase 7.0.0</entry>
+      <entry>PECL dbase 7.0.0</entry>
       <entry>
        <parameter>database</parameter> is now a <type>resource</type>
        instead of an <type>int</type>.

--- a/reference/dbase/functions/dbase-numfields.xml
+++ b/reference/dbase/functions/dbase-numfields.xml
@@ -56,7 +56,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>dbase 7.0.0</entry>
+      <entry>PECL dbase 7.0.0</entry>
       <entry>
        <parameter>database</parameter> is now a <type>resource</type>
        instead of an <type>int</type>.

--- a/reference/dbase/functions/dbase-numrecords.xml
+++ b/reference/dbase/functions/dbase-numrecords.xml
@@ -61,7 +61,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>dbase 7.0.0</entry>
+      <entry>PECL dbase 7.0.0</entry>
       <entry>
        <parameter>database</parameter> is now a <type>resource</type>
        instead of an <type>int</type>.

--- a/reference/dbase/functions/dbase-open.xml
+++ b/reference/dbase/functions/dbase-open.xml
@@ -76,7 +76,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>dbase 7.0.0</entry>
+      <entry>PECL dbase 7.0.0</entry>
       <entry>
        The return value is now a <type>resource</type> instead of an
        <type>int</type>.

--- a/reference/dbase/functions/dbase-pack.xml
+++ b/reference/dbase/functions/dbase-pack.xml
@@ -53,7 +53,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>dbase 7.0.0</entry>
+      <entry>PECL dbase 7.0.0</entry>
       <entry>
        <parameter>database</parameter> is now a <type>resource</type>
        instead of an <type>int</type>.

--- a/reference/dbase/functions/dbase-replace-record.xml
+++ b/reference/dbase/functions/dbase-replace-record.xml
@@ -77,7 +77,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>dbase 7.0.0</entry>
+      <entry>PECL dbase 7.0.0</entry>
       <entry>
        <parameter>database</parameter> is now a <type>resource</type>
        instead of an <type>int</type>.

--- a/reference/gnupg/functions/gnupg-init.xml
+++ b/reference/gnupg/functions/gnupg-init.xml
@@ -81,7 +81,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>1.5.0</entry>
+      <entry>PECL gnupg 1.5.0</entry>
       <entry>The <parameter>options</parameter> parameter was added.</entry>
      </row>
     </tbody>

--- a/reference/ibm_db2/functions/db2-pconnect.xml
+++ b/reference/ibm_db2/functions/db2-pconnect.xml
@@ -511,27 +511,27 @@ db2set DB2COMM=TCPIP</literallayout>
      </thead>
      <tbody>
       <row>
-       <entry>ibm_db2 1.9.0</entry>
+       <entry>PECL ibm_db2 1.9.0</entry>
        <entry>
         Active transactions within a persistent connection will be rolled back
         at the end of each request.
        </entry>
       </row>
       <row>
-       <entry>ibm_db2 1.8.0</entry>
+       <entry>PECL ibm_db2 1.8.0</entry>
        <entry>
         The <parameter>i5_libl</parameter> option is available for i5/OS
         users.
        </entry>
       </row>
       <row>
-       <entry>ibm_db2 1.7.0</entry>
+       <entry>PECL ibm_db2 1.7.0</entry>
        <entry>
         The <parameter>trustedcontext</parameter> option is available.
        </entry>
       </row>
       <row>
-       <entry>ibm_db2 1.5.1</entry>
+       <entry>PECL ibm_db2 1.5.1</entry>
        <entry>
         The <parameter>i5_lib</parameter>, <parameter>i5_naming</parameter>,
         <parameter>i5_commit</parameter>,

--- a/reference/imagick/imagick/getimagealphachannel.xml
+++ b/reference/imagick/imagick/getimagealphachannel.xml
@@ -51,7 +51,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>imagick 3.6.0</entry>
+      <entry>PECL imagick 3.6.0</entry>
       <entry>
        Returns a &boolean; now; previously, an &integer; was returned.
       </entry>

--- a/reference/intl/dateformatter/format.xml
+++ b/reference/intl/dateformatter/format.xml
@@ -94,7 +94,7 @@
        </entry>
       </row>
       <row>
-       <entry>PECL 3.0.0</entry>
+       <entry>PECL intl 3.0.0</entry>
        <entry>
         Support for providing <classname>IntlCalendar</classname> objects to the
         <parameter>datetime</parameter> parameter was added.

--- a/reference/intl/dateformatter/set-calendar.xml
+++ b/reference/intl/dateformatter/set-calendar.xml
@@ -87,7 +87,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>5.5.0</entry>
+       <entry>PECL intl 3.0.0</entry>
        <entry>
         It became possible to pass an <classname>IntlCalendar</classname>
         object.

--- a/reference/intl/dateformatter/set-calendar.xml
+++ b/reference/intl/dateformatter/set-calendar.xml
@@ -87,7 +87,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>5.5.0/PECL 3.0.0</entry>
+       <entry>5.5.0</entry>
        <entry>
         It became possible to pass an <classname>IntlCalendar</classname>
         object.

--- a/reference/memcache/memcache/delete.xml
+++ b/reference/memcache/memcache/delete.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>Memcache::delete</methodname>
    <methodparam><type>string</type><parameter>key</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>timeout</parameter><initializer>0</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>exptime</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
 
   <para>
@@ -33,7 +33,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>timeout</parameter></term>
+     <term><parameter>exptime</parameter></term>
      <listitem>
       <para>
        This deprecated parameter is not supported, and defaults to <literal>0</literal> seconds.
@@ -64,13 +64,10 @@
     </thead>
     <tbody>
      <row>
-      <entry>Unknown</entry>
+      <entry>PECL memcache 3.0.5</entry>
       <entry>
-       <!-- @todo I don't understand this topic; it could be documented better -->
-       It's not recommended to use the <parameter>timeout</parameter> parameter. The
-       behavior differs between memcached versions, but setting to <literal>0</literal>
-       is safe. Other values for this deprecated feature may cause the memcache delete
-       to fail.
+       The <parameter>timeout</parameter> is deprecated, and should not be supplied.
+       Values other than <literal>0</literal> may cause unexpected errors.
       </entry>
      </row>
     </tbody>

--- a/reference/memcache/memcache/delete.xml
+++ b/reference/memcache/memcache/delete.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>Memcache::delete</methodname>
    <methodparam><type>string</type><parameter>key</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>exptime</parameter><initializer>0</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>timeout</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
 
   <para>
@@ -33,7 +33,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>exptime</parameter></term>
+     <term><parameter>timeout</parameter></term>
      <listitem>
       <para>
        This deprecated parameter is not supported, and defaults to <literal>0</literal> seconds.
@@ -64,10 +64,13 @@
     </thead>
     <tbody>
      <row>
-      <entry>PECL memcache 3.0.5</entry>
+      <entry>Unknown</entry>
       <entry>
-       The <parameter>timeout</parameter> is deprecated, and should not be supplied.
-       Values other than <literal>0</literal> may cause unexpected errors.
+       <!-- @todo I don't understand this topic; it could be documented better -->
+       It's not recommended to use the <parameter>timeout</parameter> parameter. The
+       behavior differs between memcached versions, but setting to <literal>0</literal>
+       is safe. Other values for this deprecated feature may cause the memcache delete
+       to fail.
       </entry>
      </row>
     </tbody>

--- a/reference/misc/functions/pack.xml
+++ b/reference/misc/functions/pack.xml
@@ -221,7 +221,7 @@
        </entry>
       </row>
       <row>
-       <entry>7.0.15,7.1.1</entry>
+       <entry>7.0.15, 7.1.1</entry>
        <entry>
         The "e", "E", "g" and "G" codes were added to enable byte order support for float and double.
        </entry>

--- a/reference/mongodb/bson.xml
+++ b/reference/mongodb/bson.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
  <book xml:id="book.bson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <?phpdoc extension-membership="pecl" ?>
   <title>MongoDB BSON Classes and Functions</title>
   <titleabbrev>MongoDB\BSON</titleabbrev>
 

--- a/reference/mongodb/mongodb.xml
+++ b/reference/mongodb/mongodb.xml
@@ -2,6 +2,7 @@
 <!-- $Revision$ -->
 
  <book xml:id="book.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <?phpdoc extension-membership="pecl" ?>
   <title>MongoDB Extension Classes</title>
   <titleabbrev>MongoDB\Driver</titleabbrev>
 

--- a/reference/pthreads/pool/collect.xml
+++ b/reference/pthreads/pool/collect.xml
@@ -55,7 +55,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>v3</entry>
+       <entry>PECL pthreads 3.0.0</entry>
        <entry>
         An integer is now returned, and the <parameter>collector</parameter>
         parameter is now optional.

--- a/reference/pthreads/worker/unstack.xml
+++ b/reference/pthreads/worker/unstack.xml
@@ -43,7 +43,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>v3</entry>
+       <entry>PECL pthreads 3.0.0</entry>
        <entry>
         The parameter to specify the task to unstack has been removed. Now, only the
         first task in the stack is removed.

--- a/reference/rpminfo/functions/rpmvercmp.xml
+++ b/reference/rpminfo/functions/rpmvercmp.xml
@@ -83,7 +83,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>0.7.0</entry>
+      <entry>PECL rpminfo 0.7.0</entry>
       <entry>
        Optional <parameter>operator</parameter> was added.
       </entry>

--- a/reference/solr/solrclient/commit.xml
+++ b/reference/solr/solrclient/commit.xml
@@ -88,7 +88,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>PECL solr 1.1.0, 2.0.0</entry>
+       <entry>PECL solr 1.1.0, PECL solr 2.0.0</entry>
        <entry>
         $maxSegments removed
        </entry>

--- a/reference/stomp/stomp/readframe.xml
+++ b/reference/stomp/stomp/readframe.xml
@@ -60,7 +60,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>Stomp 0.4.0</entry>
+       <entry>PECL stomp 0.4.0</entry>
        <entry>
         <parameter>class_name</parameter> parameter was added.
        </entry>

--- a/reference/uopz/functions/uopz-set-mock.xml
+++ b/reference/uopz/functions/uopz-set-mock.xml
@@ -70,7 +70,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>uopz 6.0.0</entry>
+      <entry>PECL uopz 6.0.0</entry>
       <entry>
        Mocking static members is no longer supported by this function.
        <function>uopz_redefine</function> and <function>uopz_set_return</function>,

--- a/reference/zip/ziparchive/addemptydir.xml
+++ b/reference/zip/ziparchive/addemptydir.xml
@@ -66,7 +66,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>8.0.0 / 1.18.0</entry>
+       <entry>8.0.0, PECL zip 1.18.0</entry>
        <entry>
         <parameter>flags</parameter> was added.
        </entry>

--- a/reference/zip/ziparchive/addfile.xml
+++ b/reference/zip/ziparchive/addfile.xml
@@ -98,19 +98,19 @@
      </thead>
      <tbody>
       <row>
-       <entry>8.0.0 / 1.18.0</entry>
+       <entry>8.0.0, PECL zip 1.18.0</entry>
        <entry>
         <parameter>flags</parameter> was added.
        </entry>
       </row>
       <row>
-       <entry>8.3.0 / 1.22.1</entry>
+       <entry>8.3.0, PECL zip 1.22.1</entry>
        <entry>
         <constant>ZipArchive::FL_OPEN_FILE_NOW</constant> was added.
        </entry>
       </row>
       <row>
-       <entry>8.3.0 / 1.22.2</entry>
+       <entry>8.3.0, PECL zip 1.22.2</entry>
        <entry>
         <constant>ZipArchive::LENGTH_TO_END</constant> and <constant>ZipArchive::LENGTH_UNCHECKED</constant> were added.
        </entry>

--- a/reference/zip/ziparchive/addfromstring.xml
+++ b/reference/zip/ziparchive/addfromstring.xml
@@ -76,7 +76,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>8.0.0 / 1.18.0</entry>
+       <entry>8.0.0, PECL zip 1.18.0</entry>
        <entry>
         <parameter>flags</parameter> was added.
        </entry>

--- a/reference/zip/ziparchive/addglob.xml
+++ b/reference/zip/ziparchive/addglob.xml
@@ -148,13 +148,13 @@
      </thead>
      <tbody>
       <row>
-       <entry>8.0.0 / 1.18.0</entry>
+       <entry>8.0.0, PECL zip 1.18.0</entry>
        <entry>
         <literal>"flags"</literal> in <parameter>options</parameter> was added.
        </entry>
       </row>
       <row>
-       <entry>8.0.0 / 1.18.1</entry>
+       <entry>8.0.0, PECL zip 1.18.1</entry>
        <entry>
         <literal>"comp_method"</literal>, <literal>"comp_flags"</literal>,
         <literal>"enc_method"</literal> and <literal>"enc_password"</literal> in
@@ -162,7 +162,7 @@
        </entry>
       </row>
       <row>
-       <entry>8.3.0 / 1.22.1</entry>
+       <entry>8.3.0, PECL zip 1.22.1</entry>
        <entry>
         <constant>ZipArchive::FL_OPEN_FILE_NOW</constant> was added.
        </entry>

--- a/reference/zip/ziparchive/getstatusstring.xml
+++ b/reference/zip/ziparchive/getstatusstring.xml
@@ -41,13 +41,13 @@
      </thead>
      <tbody>
       <row>
-       <entry>8.0.0 / 1.18.0</entry>
+       <entry>8.0.0, PECL zip 1.18.0</entry>
        <entry>
         This method can be called on closed archive.
        </entry>
       </row>
       <row>
-       <entry>8.0.0 / 1.18.0</entry>
+       <entry>8.0.0, PECL zip 1.18.0</entry>
        <entry>
         This method no longer returns &false; on failure.
        </entry>

--- a/reference/zip/ziparchive/replacefile.xml
+++ b/reference/zip/ziparchive/replacefile.xml
@@ -97,13 +97,13 @@
      </thead>
      <tbody>
       <row>
-       <entry>8.3.0 / 1.22.1</entry>
+       <entry>8.3.0, PECL zip 1.22.1</entry>
        <entry>
         <constant>ZipArchive::FL_OPEN_FILE_NOW</constant> was added.
        </entry>
       </row>
       <row>
-       <entry>8.3.0 / 1.22.2</entry>
+       <entry>8.3.0, PECL zip 1.22.2</entry>
        <entry>
         <constant>ZipArchive::LENGTH_TO_END</constant> and <constant>ZipArchive::LENGTH_UNCHECKED</constant> were added.
        </entry>


### PR DESCRIPTION
Now they're always `N.X.Y` for a PHP version, or `PECL extension N.X.Y` for PECL extensions.