### PR TITLE
Use Makefile instead of docker-compose.yml

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -13,5 +13,7 @@ RUN git clone --depth 1 https://github.com/php/phd.git &&  \
 
 RUN echo 'memory_limit = 512M' >> /usr/local/etc/php/conf.d/local.ini
 
+ENV FORMAT=xhtml
+
 CMD php doc-base/configure.php --disable-segfault-error && \
-    php phd/render.php --docbook doc-base/.manual.xml --output=/var/www/en/output --package PHP --format xhtml
+    php phd/render.php --docbook doc-base/.manual.xml --output=/var/www/en/output --package PHP --format ${FORMAT}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 entities.*.xml
 output
+.docker/built

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+.PHONY: *
+
+SHELL = /bin/sh
+
+CURRENT_UID := $(shell id -u)
+CURRENT_GID := $(shell id -g)
+
+#
+# If doc-base or phd exist as siblings to the current directory, add those as
+# volumes to our Docker runs.
+#
+
+PATHS := -v .:/var/www/en
+ifneq ($(wildcard ../doc-base/LICENSE),)
+	PATHS += -v ${PWD}/../doc-base:/var/www/doc-base
+endif
+ifneq ($(wildcard ../phd/LICENSE),)
+	PATHS += -v ${PWD}/../phd:/var/www/phd
+endif
+
+xhtml: .docker/built
+	docker run ${PATHS} -w /var/www -u ${CURRENT_UID}:${CURRENT_GID} php/doc-en
+
+php: .docker/built
+	docker run ${PATHS} -w /var/www -u ${CURRENT_UID}:${CURRENT_GID} \
+		-e FORMAT=php php/doc-en
+
+build: .docker/built
+
+.docker/built:
+	docker build .docker -t php/doc-en
+	touch .docker/built

--- a/README.md
+++ b/README.md
@@ -15,11 +15,21 @@ For information related to creating this setup,
 see the [contribution guidelines](https://github.com/php/doc-base/blob/master/CONTRIBUTING_DOCS.md)
 or [this page](http://doc.php.net/tutorial/local-setup.php) on our documentation website.
 
-## Running With Docker
+## Building With make and Docker
 
 - Install Docker (https://docs.docker.com/get-docker/)
-- Rebuild the documentation using `docker-compose up`
+- Rebuild the documentation using `make`
 - Open output/php-chunked-xhtml/ in your browser.
+
+If the `doc-base` or `phd` repositories are available in directories to the
+adjacent to this directory, those will be used for building.
+
+To force the Docker image used for building to itself be rebuilt, you can run
+`make -B build`, otherwise the `Makefile` will only build it if does not
+already exist.
+
+You can also build the `web` version of the documentation with `make php`
+and the output will be placed in output/php-web
 
 ## Translations
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,0 @@
-version: '3'
-
-services:
-  doc:
-    build: .docker
-    working_dir: /var/www
-    volumes:
-      - .:/var/www/en


### PR DESCRIPTION
This allows us to build different formats more easily, and use `phd` and `doc-base` from parallel checkouts, which is much easier for issues that span the repositories.