### PR TITLE
Fixed incomplete information in realpath() docs

### DIFF
--- a/reference/filesystem/functions/realpath.xml
+++ b/reference/filesystem/functions/realpath.xml
@@ -31,7 +31,7 @@
        The path being checked.
        <note>
         <para>
-         Whilst a path must be supplied, the value can be an empty string.
+         Whilst a path must be supplied, the value can be an empty string or <literal>false</literal>.
          In this case, the value is interpreted as the current directory.
         </para>
        </note>


### PR DESCRIPTION
Not only an empty string, but also the boolean value FALSE, when supplied as argument to `realpath()`, is interpreted as the current directory.

Feel free to rephrase.