### PR TITLE
Add information about Composer and example of using its autoloader

### DIFF
--- a/install/composer.xml
+++ b/install/composer.xml
@@ -30,12 +30,11 @@
    to the code. The <link xlink:href="&url.composer;/doc/01-basic-usage.md">Composer
    "Basic Usage" documentation</link> goes into this in more depth.
   </simpara>
-  <para>
-   <example>
-    <title>
-     <literal>composer.json</literal> that requires a single package
-    </title>
-    <programlisting role="javascript">
+  <example>
+   <title>
+    <literal>composer.json</literal> that requires a single package
+   </title>
+   <programlisting role="javascript">
 <![CDATA[
 {
     "require": {
@@ -43,9 +42,8 @@
     }
 }
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
 
  </sect1>
 </chapter>

--- a/install/composer.xml
+++ b/install/composer.xml
@@ -17,8 +17,9 @@
   </simpara>
   <simpara>
    For example, if you are writing a PHP application or website that needs
-   to work with <abbrev>UUID</abbrev> values, you might want to use Ben
-   Ramsey's <literal>ramsey/uuid</literal> package that implements the
+   to work with <abbrev>UUID</abbrev> values, you might want to use
+   <link xlink:href="&url.packagist.package;ramsey/uuid">Ben Ramsey's
+   <literal>ramsey/uuid</literal> package</link> that implements the
    widely known and used types of UUIDs that are defined by
    <link xlink:href="&url.rfc;4122">RFC 4122</link>.
   </simpara>

--- a/install/composer.xml
+++ b/install/composer.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<chapter xml:id="install.composer" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Installation of Composer and third-party packages</title>
+
+ <sect1 xml:id="install.composer.intro">
+  <title>Introduction to Composer</title>
+  <simpara>
+   &link.composer; is a dependency manager for PHP that makes it possible
+   to define third-party packages of code that your project uses that can
+   then be easily installed and updated. It leverages the the built-in
+   <link linkend="language.oop5.autoload">class autoloading features</link>
+   of PHP, repositories of PHP packages such as
+   <link xlink:href="&url.packagist;">Packagist</link>, and common project
+   layout and coding conventions.
+  </simpara>
+  <simpara>
+   For example, if you are writing a PHP application or website that needs
+   to work with <abbrev>UUID</abbrev> values, you might want to use Ben
+   Ramsey's <literal>ramsey/uuid</literal> package that implements the
+   widely known and used types of UUIDs that are defined by
+   <link xlink:href="&url.rfc;4122">RFC 4122</link>.
+  </simpara>
+  <simpara>
+   Briefly, you would do this by creating a <literal>composer.json</literal>
+   in your project, using Composer to install the latest version of the
+   package, and including Composer's autoload script to make it available
+   to your code. The <link xlink:href="&url.composer;/doc/01-basic-usage.md">Composer
+   "Basic Usage" documentation</link> goes into this in more depth.
+  </simpara>
+  <para>
+   <example>
+    <title>
+     <literal>composer.json</literal> that requires a single package
+    </title>
+    <programlisting role="javascript">
+<![CDATA[
+{
+    "require": {
+        "ramsey/uuid": "^4.7"
+    }
+}
+]]>
+    </programlisting>
+   </example>
+  </para>
+
+ </sect1>
+</chapter>

--- a/install/composer.xml
+++ b/install/composer.xml
@@ -8,8 +8,8 @@
   <title>Introduction to Composer</title>
   <simpara>
    &link.composer; is a dependency manager for PHP that makes it possible
-   to define third-party packages of code that a project uses that can
-   then be easily installed and updated. It leverages the the built-in
+   to define third-party code packages used by a project that can
+   then be easily installed and updated. It leverages the built-in
    <link linkend="language.oop5.autoload">class autoloading features</link>
    of PHP, repositories of PHP packages such as
    <link xlink:href="&url.packagist;">Packagist</link>, and common project

--- a/install/composer.xml
+++ b/install/composer.xml
@@ -8,7 +8,7 @@
   <title>Introduction to Composer</title>
   <simpara>
    &link.composer; is a dependency manager for PHP that makes it possible
-   to define third-party packages of code that your project uses that can
+   to define third-party packages of code that a project uses that can
    then be easily installed and updated. It leverages the the built-in
    <link linkend="language.oop5.autoload">class autoloading features</link>
    of PHP, repositories of PHP packages such as
@@ -16,18 +16,18 @@
    layout and coding conventions.
   </simpara>
   <simpara>
-   For example, if you are writing a PHP application or website that needs
-   to work with <abbrev>UUID</abbrev> values, you might want to use
+   For example, if a PHP application or website needs
+   to work with <abbrev>UUID</abbrev> values,
    <link xlink:href="&url.packagist.package;ramsey/uuid">Ben Ramsey's
    <literal>ramsey/uuid</literal> package</link> that implements the
    widely known and used types of UUIDs that are defined by
-   <link xlink:href="&url.rfc;4122">RFC 4122</link>.
+   <link xlink:href="&url.rfc;4122">RFC 4122</link> could be used.
   </simpara>
   <simpara>
-   Briefly, you would do this by creating a <literal>composer.json</literal>
-   in your project, using Composer to install the latest version of the
+   Briefly, this is done by creating a <literal>composer.json</literal>
+   in the project, using Composer to install the latest version of the
    package, and including Composer's autoload script to make it available
-   to your code. The <link xlink:href="&url.composer;/doc/01-basic-usage.md">Composer
+   to the code. The <link xlink:href="&url.composer;/doc/01-basic-usage.md">Composer
    "Basic Usage" documentation</link> goes into this in more depth.
   </simpara>
   <para>

--- a/language/oop5/autoload.xml
+++ b/language/oop5/autoload.xml
@@ -82,6 +82,26 @@ Fatal error: Interface 'ITest' not found in ...
 ]]>
     </programlisting>
    </example>
+   <example>
+    <title>Using Composer's autoloader</title>
+    <para>
+     &link.composer; generates a <literal>vendor/autoload.php</literal>
+     with is set up to automatically load packages that are being managed
+     by Composer. By including this file, you can use those packages without
+     any additional work.
+    </para>
+    <programlisting role="php">
+<![CDATA[
+<?php
+require __DIR__ . '/vendor/autoload.php';
+
+$uuid = new Ramsey\Uuid\Uuid::uuid7();
+
+echo "Generated new UUID -> ", $uuid->toString(), "\n";
+?>
+]]>
+    </programlisting>
+   </example>
   </para>
 
   <simplesect role="seealso">

--- a/language/oop5/autoload.xml
+++ b/language/oop5/autoload.xml
@@ -84,12 +84,12 @@ Fatal error: Interface 'ITest' not found in ...
    </example>
    <example>
     <title>Using Composer's autoloader</title>
-    <para>
+    <simpara>
      &link.composer; generates a <literal>vendor/autoload.php</literal>
-     with is set up to automatically load packages that are being managed
+     which is set up to automatically load packages that are being managed
      by Composer. By including this file, those packages can be used without
      any additional work.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/language/oop5/autoload.xml
+++ b/language/oop5/autoload.xml
@@ -87,7 +87,7 @@ Fatal error: Interface 'ITest' not found in ...
     <para>
      &link.composer; generates a <literal>vendor/autoload.php</literal>
      with is set up to automatically load packages that are being managed
-     by Composer. By including this file, you can use those packages without
+     by Composer. By including this file, those packages can be used without
      any additional work.
     </para>
     <programlisting role="php">


### PR DESCRIPTION
Long past time that we included information about Composer in the documentation. Related PR for `doc-base` incoming.