### PR TITLE
Update array_merge() documentation: clarify behavior with non-array arguments in PHP 7.4 and 8.x

### DIFF
--- a/reference/array/functions/array-diff.xml
+++ b/reference/array/functions/array-diff.xml
@@ -156,6 +156,10 @@ $result = array_diff($source, $filter);
     array. Of course you can check deeper dimensions by using
     <literal>array_diff($array1[0], $array2[0]);</literal>.
    </para>
+   <para>
+    As of PHP 7.4, passing non-array arguments (such as strings) to <function>array_merge()</function> will generate a <constant>E_WARNING</constant> and return <constant>null</constant>. 
+    In PHP 8.0 and later, this results in a <literal>Fatal error</literal>.
+   </para>
   </note>
  </refsect1>
 


### PR DESCRIPTION
This pull request updates the documentation for the array_merge() function to include details about how the function behaves when non-array arguments are passed. It clarifies that:
•	In PHP 7.4, passing non-array arguments triggers an E_WARNING and returns null.
•	In PHP 8.0 and later, passing non-array arguments results in a Fatal error.
