### PR TITLE
Clarify second param of Memcache::delete and how it was changed

### DIFF
--- a/reference/memcache/memcache/delete.xml
+++ b/reference/memcache/memcache/delete.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>Memcache::delete</methodname>
    <methodparam><type>string</type><parameter>key</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>timeout</parameter><initializer>0</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>exptime</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
 
   <para>
@@ -33,7 +33,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>timeout</parameter></term>
+     <term><parameter>exptime</parameter></term>
      <listitem>
       <para>
        This deprecated parameter is not supported, and defaults to <literal>0</literal> seconds.
@@ -64,13 +64,10 @@
     </thead>
     <tbody>
      <row>
-      <entry>Unknown</entry>
+      <entry>PECL memcache 3.0.5</entry>
       <entry>
-       <!-- @todo I don't understand this topic; it could be documented better -->
-       It's not recommended to use the <parameter>timeout</parameter> parameter. The
-       behavior differs between memcached versions, but setting to <literal>0</literal>
-       is safe. Other values for this deprecated feature may cause the memcache delete
-       to fail.
+       The <parameter>exptime</parameter> is deprecated, and should not be supplied.
+       Values other than <literal>0</literal> may cause unexpected errors.
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
It never should have been a parameter, basically, and was never a timeout. Just a wonky edge of the underlying interface.

Was originally noticed as part of #3672, split out to be reviewed/merged on its own.