### PR TITLE
Document DOMNamedNodeMap/DOMNodeList array access syntax

### DIFF
--- a/reference/dom/domnamednodemap.xml
+++ b/reference/dom/domnamednodemap.xml
@@ -115,7 +115,7 @@ Remove me once you perform substitutions
       Nodes in the map can be accessed by array syntax.
     </simpara>
    </note>
- </section>
+  </section>
 
 <!-- {{{ See also -->
 <!--

--- a/reference/dom/domnamednodemap.xml
+++ b/reference/dom/domnamednodemap.xml
@@ -108,6 +108,15 @@ Remove me once you perform substitutions
    </informaltable>
   </section>
 
+  <section role="notes">
+   &reftitle.notes;
+   <note>
+    <simpara>
+      Nodes in the map can be accessed by array syntax.
+    </simpara>
+   </note>
+ </section>
+
 <!-- {{{ See also -->
 <!--
   <section role="seealso">

--- a/reference/dom/domnamednodemap/getnameditem.xml
+++ b/reference/dom/domnamednodemap/getnameditem.xml
@@ -39,6 +39,38 @@
    &null; if no node is found.
   </para>
  </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+   <example>
+    <title>Getting an attribute on a node</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$doc = new DOMDocument;
+$doc->load('book.xml');
+
+$id = $doc->firstChild->attributes->getNamedItem('id');
+
+?>
+]]>
+    </programlisting>
+   </example>
+   <example>
+    <simpara>
+     Items can be also accessed with array syntax:
+    </simpara>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$id = $doc->firstChild->attributes['id'];
+
+?>
+]]>
+    </programlisting>
+   </example>
+ </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/dom/domnamednodemap/getnameditem.xml
+++ b/reference/dom/domnamednodemap/getnameditem.xml
@@ -41,9 +41,9 @@
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;
-   <example>
-    <title>Getting an attribute on a node</title>
-    <programlisting role="php">
+  <example>
+   <title>Getting an attribute on a node</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 
@@ -54,13 +54,13 @@ $id = $doc->firstChild->attributes->getNamedItem('id');
 
 ?>
 ]]>
-    </programlisting>
-   </example>
-   <example>
-    <simpara>
-     Items can be also accessed with array syntax:
-    </simpara>
-    <programlisting role="php">
+   </programlisting>
+  </example>
+  <example>
+   <simpara>
+    Items can be also accessed with array syntax:
+   </simpara>
+   <programlisting role="php">
 <![CDATA[
 <?php
 
@@ -68,8 +68,8 @@ $id = $doc->firstChild->attributes['id'];
 
 ?>
 ]]>
-    </programlisting>
-   </example>
+   </programlisting>
+  </example>
  </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/dom/domnodelist.xml
+++ b/reference/dom/domnodelist.xml
@@ -107,6 +107,15 @@ Remove me once you perform substitutions
    </para>
   </section><!-- }}} -->
 
+  <section role="notes">
+   &reftitle.notes;
+   <note>
+    <simpara>
+      Nodes in the list can be accessed by array syntax.
+    </simpara>
+   </note>
+ </section>
+
  <!-- {{{ See also -->
   <section role="seealso">
    &reftitle.seealso;

--- a/reference/dom/domnodelist.xml
+++ b/reference/dom/domnodelist.xml
@@ -114,7 +114,7 @@ Remove me once you perform substitutions
       Nodes in the list can be accessed by array syntax.
     </simpara>
    </note>
- </section>
+  </section>
 
  <!-- {{{ See also -->
   <section role="seealso">

--- a/reference/dom/domnodelist/item.xml
+++ b/reference/dom/domnodelist/item.xml
@@ -69,6 +69,24 @@ for ($i = 0; $i < $items->length; $i++) {
 ?>
 ]]>
     </programlisting>
+   </example>
+   <example>
+    <simpara>
+     Items can be also accessed with array syntax:
+    </simpara>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+for ($i = 0; $i < $items->length; $i++) {
+    echo $items[$i]->nodeValue . "\n";
+}
+
+?>
+]]>
+    </programlisting>
+   </example>
+   <example>
     <para>
      Alternatively, you can use &foreach;, which is a much more convenient way:
     </para>


### PR DESCRIPTION
As discussed in https://github.com/php/doc-en/issues/3691 there's a read-only array access functionality to `DOMNamedNodeMap` and `DOMNodeList` which isn't documented

This is my first phpdoc PR so please review. The phd build looked fine other than `<programlisting>` tags rendering without whitespace (But that includes the ones I didn't touch so I presume it's a phd issue)