### PR TITLE
format.xml: add both class method names or replcate to interface name

### DIFF
--- a/reference/datetime/datetimeinterface/format.xml
+++ b/reference/datetime/datetimeinterface/format.xml
@@ -256,8 +256,9 @@
            Microseconds. Note that
            <function>date</function> will always generate
            <literal>000000</literal> since it takes an <type>int</type>
-           parameter, whereas <methodname>DateTime::format</methodname> does
-           support microseconds if <classname>DateTime</classname> was
+           parameter, whereas <methodname>DateTime::format</methodname> and
+           <methodname>DateTimeImmutable::format</methodname> does
+           support microseconds if <classname>DateTime</classname> or <classname>DateTimeImmutable</classname> was
            created with microseconds.
           </entry>
           <entry>Example: <literal>654321</literal></entry>

--- a/reference/datetime/datetimeinterface/format.xml
+++ b/reference/datetime/datetimeinterface/format.xml
@@ -256,10 +256,9 @@
            Microseconds. Note that
            <function>date</function> will always generate
            <literal>000000</literal> since it takes an <type>int</type>
-           parameter, whereas <methodname>DateTime::format</methodname> and
-           <methodname>DateTimeImmutable::format</methodname> does
-           support microseconds if <classname>DateTime</classname> or <classname>DateTimeImmutable</classname> was
-           created with microseconds.
+           parameter, whereas <methodname>DateTimeInterface::format</methodname> does
+           support microseconds if an object of type
+           <classname>DateTimeInterface</classname> was created with microseconds.
           </entry>
           <entry>Example: <literal>654321</literal></entry>
          </row>

--- a/reference/datetime/datetimeinterface/format.xml
+++ b/reference/datetime/datetimeinterface/format.xml
@@ -258,7 +258,7 @@
            <literal>000000</literal> since it takes an <type>int</type>
            parameter, whereas <methodname>DateTimeInterface::format</methodname> does
            support microseconds if an object of type
-           <classname>DateTimeInterface</classname> was created with microseconds.
+           <interfacename>DateTimeInterface</interfacename> was created with microseconds.
           </entry>
           <entry>Example: <literal>654321</literal></entry>
          </row>


### PR DESCRIPTION
We must either add the names of the format methods of both classes — `DateTime::format` and `DateTimeImmutable::format` and names of the both class names — `DateTime` and `DateTimeImmutable`, or replace the name of the method of the `DateTime::format` class with the name of the interface method — `DateTimeInterface::format`, and the name of the `DateTime` class with the name of the interface common to these classes — `DateTimeInterface`.

Otherwise, the description of the `u` parameter behaves as if it does not concern the `DateTimeImmutable::format()` method (although it is assumed that every PHP programmer knows about this; but in reality not everyone knows).

Alternative:

```
Microseconds. Note that
<function>date</function> will always generate
<literal>000000</literal> since it takes an <type>int</type>
parameter, whereas <methodname>DateTimeInterface::format</methodname> does
support microseconds if [object implementing the] <interfacename>DateTimeInterface</interfacename> was
created with microseconds.
```