### PR TITLE
COM variant_fix() and variant_int(): differences are now clear in MSDN

### DIFF
--- a/reference/com/functions/variant-fix.xml
+++ b/reference/com/functions/variant-fix.xml
@@ -48,17 +48,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="notes">
-  &reftitle.notes;
-  <warning>
-   <simpara>
-    This documentation is based on the MSDN documentation; it appears
-    that this function is either the same as
-    <function>variant_int</function>, or that there is an error in the MSDN
-    documentation.
-   </simpara>
-  </warning>
- </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/com/functions/variant-int.xml
+++ b/reference/com/functions/variant-int.xml
@@ -35,7 +35,7 @@
   &reftitle.returnvalues;
   <para>
    If <parameter>value</parameter> is negative, then the first negative
-   integer greater than or equal to the variant is returned, otherwise
+   integer less than or equal to the variant is returned, otherwise
    returns the integer portion of the value of
    <parameter>value</parameter>.
   </para>


### PR DESCRIPTION
There is a difference between variant_fix() and variant_int() in MSDN docs.
See [VarInt function](https://learn.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-varint) and  [VarFix function](https://learn.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-varfix).
The note was removed from variant_fix() and the logic was fixed in variant_int().