### PR TITLE
cubrid-data-seek.xml: remove parameter tag

### DIFF
--- a/reference/cubrid/cubridmysql/cubrid-data-seek.xml
+++ b/reference/cubrid/cubridmysql/cubrid-data-seek.xml
@@ -19,7 +19,7 @@
    CUBRID result (associated with the specified result identifier) to point
    to a specific row number. There are functions, such as
    <function>cubrid_fetch_assoc</function>, which use the current stored
-   value of row number. 
+   value of row number.
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-data-seek.xml
+++ b/reference/cubrid/cubridmysql/cubrid-data-seek.xml
@@ -15,27 +15,27 @@
    <methodparam><type>int</type><parameter>row_number</parameter></methodparam>
   </methodsynopsis>
   <para>
-    This function performs the moving of the internal row pointer of the
-    CUBRID result (associated with the specified result identifier) to point
-    to a specific row number. There are functions, such as
-    <function>cubrid_fetch_assoc</function>, which use the current stored
-    value of <parameter>row number</parameter>. 
+   This function performs the moving of the internal row pointer of the
+   CUBRID result (associated with the specified result identifier) to point
+   to a specific row number. There are functions, such as
+   <function>cubrid_fetch_assoc</function>, which use the current stored
+   value of row number. 
   </para>
  </refsect1>
 
  <refsect1 role="parameters">
- &reftitle.parameters;
- <para>
-  <variablelist>
+  &reftitle.parameters;
+  <para>
+   <variablelist>
     <varlistentry>
-  <term><parameter>result</parameter></term>
-  <listitem><para>The result.</para></listitem>
-   </varlistentry>
-   <varlistentry>
-  <term><parameter>row_number</parameter></term>
-  <listitem><para>This is the desired row number of the new result pointer.</para></listitem>
-   </varlistentry>
-  </variablelist>
+     <term><parameter>result</parameter></term>
+     <listitem><para>The result.</para></listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>row_number</parameter></term>
+     <listitem><para>This is the desired row number of the new result pointer.</para></listitem>
+    </varlistentry>
+   </variablelist>
   </para>
  </refsect1>
 
@@ -74,8 +74,8 @@ cubrid_disconnect($conn);
 ?>
 ]]>
    </programlisting>
-       &example.outputs;
-    <screen>
+   &example.outputs;
+   <screen>
 <![CDATA[
 array(2) {
   [0]=>
@@ -96,12 +96,11 @@ array(2) {
   string(6) "Silver"
 }
 ]]>
-    </screen>
+   </screen>
   </example>
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
The "row number" in the sentence is not a direct reference to the function parameter row_number.

Also, adjustments in identation were necessary.