### PR TITLE
cubrid-data-seek.xml: remove parameter tag

### DIFF
--- a/reference/cubrid/cubridmysql/cubrid-data-seek.xml
+++ b/reference/cubrid/cubridmysql/cubrid-data-seek.xml
@@ -19,7 +19,7 @@
     CUBRID result (associated with the specified result identifier) to point
     to a specific row number. There are functions, such as
     <function>cubrid_fetch_assoc</function>, which use the currently stored
-    value of row number. 
+    value of row number.
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-data-seek.xml
+++ b/reference/cubrid/cubridmysql/cubrid-data-seek.xml
@@ -18,8 +18,8 @@
     This function performs the moving of the internal row pointer of the
     CUBRID result (associated with the specified result identifier) to point
     to a specific row number. There are functions, such as
-    <function>cubrid_fetch_assoc</function>, which use the current stored
-    value of <parameter>row number</parameter>. 
+    <function>cubrid_fetch_assoc</function>, which use the currently stored
+    value of row number. 
   </para>
  </refsect1>
 


### PR DESCRIPTION
The "row number" in the sentence is not a direct reference to the function parameter row_number.