### PR TITLE
Update get-debug-type.xml

### DIFF
--- a/reference/var/functions/get-debug-type.xml
+++ b/reference/var/functions/get-debug-type.xml
@@ -121,7 +121,7 @@
         <row>
          <entry>Objects from Anonymous Classes</entry>
          <entry>
-          <literal>"class@anonymous"</literal>
+          <literal>"class@anonymous"</literal> or parent class name/interface name if the class extends another class or implements an interface e.g. <literal>"Foo\Bar@anonymous"</literal>
          </entry>
          <entry>
           Anonymous classes are those created through the $x = new class { ... } syntax
@@ -157,6 +157,13 @@ echo get_debug_type($fp) . PHP_EOL;
 
 echo get_debug_type(new stdClass) . PHP_EOL;
 echo get_debug_type(new class {}) . PHP_EOL;
+
+namespace Foo;
+
+echo get_debug_type(new class implements A {}) . PHP_EOL;
+echo get_debug_type(new class implements A,B {}) . PHP_EOL;
+echo get_debug_type(new class extends C {}) . PHP_EOL;
+echo get_debug_type(new class extends C implements A {}) . PHP_EOL;
 ?>
 ]]>
     </programlisting>
@@ -173,6 +180,10 @@ resource (stream)
 resource (closed)
 stdClass
 class@anonymous
+Foo\A@anonymous
+Foo\A@anonymous
+Foo\C@anonymous
+Foo\C@anonymous
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
Closes: https://github.com/php/doc-en/issues/3702

Adds more examples to `get_debug_type` output in cases of anonymous classes that extend another class and/or implement an interface.