### PR TITLE
Fix typo on Win32Service constants name

### DIFF
--- a/reference/win32service/constants.xml
+++ b/reference/win32service/constants.xml
@@ -905,85 +905,85 @@
       </entry>
      </row>
      <row xml:id="constant.info-load-order">
-      <entry><constant>INFO_LOAD_ORDER</constant></entry>
+      <entry><constant>WIN32_INFO_LOAD_ORDER</constant></entry>
       <entry>"load_order"</entry>
       <entry>
       </entry>
      </row>
      <row xml:id="constant.info-svc-type">
-      <entry><constant>INFO_SVC_TYPE</constant></entry>
+      <entry><constant>WIN32_INFO_SVC_TYPE</constant></entry>
       <entry>"svc_type"</entry>
       <entry>
       </entry>
      </row>
      <row xml:id="constant.info-error-control">
-      <entry><constant>INFO_ERROR_CONTROL</constant></entry>
+      <entry><constant>WIN32_INFO_ERROR_CONTROL</constant></entry>
       <entry>"error_control"</entry>
       <entry>
       </entry>
      </row>
      <row xml:id="constant.info-delayed-start">
-      <entry><constant>INFO_DELAYED_START</constant></entry>
+      <entry><constant>WIN32_INFO_DELAYED_START</constant></entry>
       <entry>"delayed_start"</entry>
       <entry>
       </entry>
      </row>
      <row xml:id="constant.info-base-priority">
-      <entry><constant>INFO_BASE_PRIORITY</constant></entry>
+      <entry><constant>WIN32_INFO_BASE_PRIORITY</constant></entry>
       <entry>"base_priority"</entry>
       <entry>
       </entry>
      </row>
      <row xml:id="constant.info-dependencies">
-      <entry><constant>INFO_DEPENDENCIES</constant></entry>
+      <entry><constant>WIN32_INFO_DEPENDENCIES</constant></entry>
       <entry>"dependencies"</entry>
       <entry>
       </entry>
      </row>
      <row xml:id="constant.info-recovery-delay">
-      <entry><constant>INFO_RECOVERY_DELAY</constant></entry>
+      <entry><constant>WIN32_INFO_RECOVERY_DELAY</constant></entry>
       <entry>"recovery_delay"</entry>
       <entry>
       </entry>
      </row>
      <row xml:id="constant.info-recovery-action-1">
-      <entry><constant>INFO_RECOVERY_ACTION_1</constant></entry>
+      <entry><constant>WIN32_INFO_RECOVERY_ACTION_1</constant></entry>
       <entry>"recovery_action_1"</entry>
       <entry>
       </entry>
      </row>
      <row xml:id="constant.info-recovery-action-2">
-      <entry><constant>INFO_RECOVERY_ACTION_2</constant></entry>
+      <entry><constant>WIN32_INFO_RECOVERY_ACTION_2</constant></entry>
       <entry>"recovery_action_2"</entry>
       <entry>
       </entry>
      </row>
      <row xml:id="constant.info-recovery-action-3">
-      <entry><constant>INFO_RECOVERY_ACTION_3</constant></entry>
+      <entry><constant>WIN32_INFO_RECOVERY_ACTION_3</constant></entry>
       <entry>"recovery_action_3"</entry>
       <entry>
       </entry>
      </row>
      <row xml:id="constant.info-recovery-reset-period">
-      <entry><constant>INFO_RECOVERY_RESET_PERIOD</constant></entry>
+      <entry><constant>WIN32_INFO_RECOVERY_RESET_PERIOD</constant></entry>
       <entry>"recovery_reset_period"</entry>
       <entry>
       </entry>
      </row>
      <row xml:id="constant.info-recovery-enabled">
-      <entry><constant>INFO_RECOVERY_ENABLED</constant></entry>
+      <entry><constant>WIN32_INFO_RECOVERY_ENABLED</constant></entry>
       <entry>"recovery_enabled"</entry>
       <entry>
       </entry>
      </row>
      <row xml:id="constant.info-recovery-reboot-msg">
-      <entry><constant>INFO_RECOVERY_REBOOT_MSG</constant></entry>
+      <entry><constant>WIN32_INFO_RECOVERY_REBOOT_MSG</constant></entry>
       <entry>"recovery_reboot_msg"</entry>
       <entry>
       </entry>
      </row>
      <row xml:id="constant.info-recovery-command">
-      <entry><constant>INFO_RECOVERY_COMMAND</constant></entry>
+      <entry><constant>WIN32_INFO_RECOVERY_COMMAND</constant></entry>
       <entry>"recovery_command"</entry>
       <entry>
       </entry>


### PR DESCRIPTION
Add the `WIN32_` prefix for all constants.