### PR TITLE
Drop some irrelevant info

### DIFF
--- a/reference/gmp/book.xml
+++ b/reference/gmp/book.xml
@@ -26,7 +26,7 @@
   </note>
   <note>
    <para>
-    From PHP 5.6 onwards, the
+    The
     <link linkend="language.operators.arithmetic">arithmetic</link>,
     <link linkend="language.operators.bitwise">bitwise</link>, and
     <link linkend="language.operators.comparison">comparison</link> operators
@@ -40,11 +40,6 @@
     them to floats, resulting in a loss of precision.
    </simpara>
   </warning>
-  <note>
-   <simpara>
-    This extension is available on Windows platforms.
-   </simpara>
-  </note>
  </preface>
  <!-- }}} -->
  

--- a/reference/mysqlnd/config.xml
+++ b/reference/mysqlnd/config.xml
@@ -248,9 +248,7 @@ d:t:x:O,/tmp/mysqlnd.trace
 </programlisting>
      <note>
       <para>
-       This feature is only available with a debug build of PHP. Works
-       on Microsoft Windows if using a debug build of PHP and PHP was
-       built using Microsoft Visual C version 9 and above.
+       This feature is only available with a debug build of PHP.
       </para>
      </note>
      <para></para>


### PR DESCRIPTION
Neither PHP 5.6, nor Visual C 9 are relevant for the manual.  And the fact that GMP is available on Windows (as of PHP 5.1.0) is also irrelevant.