### PR TITLE
array-map.xml: add an explanation of the 'zip operation' term

### DIFF
--- a/reference/array/functions/array-map.xml
+++ b/reference/array/functions/array-map.xml
@@ -40,7 +40,8 @@
       </para>
       <para>
        &null; can be passed as a value to <parameter>callback</parameter>
-       to perform a zip operation on multiple arrays.
+       to perform a zip operation on multiple arrays and return an array
+       whose elements are each an array holding the elements of the input arrays of the same index.
        If only <parameter>array</parameter> is provided,
        <methodname>array_map</methodname> will return the input array.
       </para>

--- a/reference/array/functions/array-map.xml
+++ b/reference/array/functions/array-map.xml
@@ -41,7 +41,7 @@
       <para>
        &null; can be passed as a value to <parameter>callback</parameter>
        to perform a zip operation on multiple arrays and return an array
-       whose elements are each an array holding the elements of the input arrays of the same index.
+       whose elements are each an array holding the elements of the input arrays of the same index (see example below).
        If only <parameter>array</parameter> is provided,
        <methodname>array_map</methodname> will return the input array.
       </para>


### PR DESCRIPTION
Why not add a few words about what a 'zip operation' is? Yes, the `array_map` page contains a sample code, but it does not contain a formal explanation, as far as all other doc pages. I suppose this information will be useful :-)