### PR TITLE
Documentation updates for ext-mongodb 1.20

### DIFF
--- a/reference/mongodb/bson/dbpointer.xml
+++ b/reference/mongodb/bson/dbpointer.xml
@@ -3,7 +3,7 @@
 
 <reference xml:id="class.mongodb-bson-dbpointer" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>The MongoDB\BSON\DBPointer class (deprecated)</title>
+ <title>The MongoDB\BSON\DBPointer class</title>
  <titleabbrev>MongoDB\BSON\DBPointer</titleabbrev>
 
  <partintro>

--- a/reference/mongodb/bson/document/fromjson.xml
+++ b/reference/mongodb/bson/document/fromjson.xml
@@ -47,7 +47,6 @@
   <simplelist>
    <member><methodname>MongoDB\BSON\Document::fromPHP</methodname></member>
    <member><methodname>MongoDB\BSON\Document::fromBSON</methodname></member>
-   <member><function>MongoDB\BSON\fromJSON</function></member>
    <member><link xlink:href="&url.mongodb.docs.extendedjson;">MongoDB Extended JSON</link></member>
    <member><link xlink:href="&url.mongodb.docs.bson;">BSON Types</link></member>
   </simplelist>

--- a/reference/mongodb/bson/document/fromphp.xml
+++ b/reference/mongodb/bson/document/fromphp.xml
@@ -43,7 +43,6 @@
   <simplelist>
    <member><methodname>MongoDB\BSON\Document::fromBSON</methodname></member>
    <member><methodname>MongoDB\BSON\Document::fromJSON</methodname></member>
-   <member><function>MongoDB\BSON\fromPHP</function></member>
    <member><link xlink:href="&url.mongodb.docs.bson;">BSON Types</link></member>
   </simplelist>
  </refsect1>

--- a/reference/mongodb/bson/packedarray/fromphp.xml
+++ b/reference/mongodb/bson/packedarray/fromphp.xml
@@ -41,7 +41,6 @@
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><function>MongoDB\BSON\fromPHP</function></member>
    <member><link xlink:href="&url.mongodb.docs.bson;">BSON Types</link></member>
   </simplelist>
  </refsect1>

--- a/reference/mongodb/bson/serializable/bsonserialize.xml
+++ b/reference/mongodb/bson/serializable/bsonserialize.xml
@@ -21,8 +21,8 @@
   <para>
    Root documents (e.g. a
    <interfacename>MongoDB\BSON\Serializable</interfacename> passed to
-   <function>MongoDB\BSON\fromPHP</function>) will always be serialized as a
-   BSON document. For field values, associative arrays and
+   <methodname>MongoDB\BSON\Document::fromPHP</methodname>) will always be
+   serialized as a BSON document. For field values, associative arrays and
    <classname>stdClass</classname> instances will be serialized as a BSON
    document and sequential arrays (i.e. sequential, numeric indexes starting at
    <literal>0</literal>) will be serialized as a BSON array.
@@ -113,8 +113,7 @@ class MyDocument implements MongoDB\BSON\Serializable
     }
 }
 
-$bson = MongoDB\BSON\fromPHP(new MyDocument);
-echo MongoDB\BSON\toJSON($bson), "\n";
+echo MongoDB\BSON\Document::fromPHP(new MyDocument)->toRelaxedExtendedJSON(), "\n";
 
 ?>
 ]]>
@@ -141,8 +140,7 @@ class MyArray implements MongoDB\BSON\Serializable
     }
 }
 
-$bson = MongoDB\BSON\fromPHP(new MyArray);
-echo MongoDB\BSON\toJSON($bson), "\n";
+echo MongoDB\BSON\Document::fromPHP(new MyArray)->toRelaxedExtendedJSON(), "\n";
 
 ?>
 ]]>
@@ -170,8 +168,8 @@ class MyDocument implements MongoDB\BSON\Serializable
 }
 
 $value = ['document' => new MyDocument];
-$bson = MongoDB\BSON\fromPHP($value);
-echo MongoDB\BSON\toJSON($bson), "\n";
+
+echo MongoDB\BSON\Document::fromPHP($value)->toRelaxedExtendedJSON(), "\n";
 
 ?>
 ]]>
@@ -199,8 +197,8 @@ class MyArray implements MongoDB\BSON\Serializable
 }
 
 $value = ['array' => new MyArray];
-$bson = MongoDB\BSON\fromPHP($value);
-echo MongoDB\BSON\toJSON($bson), "\n";
+
+echo MongoDB\BSON\Document::fromPHP($value)->toRelaxedExtendedJSON(), "\n";
 
 ?>
 ]]>

--- a/reference/mongodb/bson/symbol.xml
+++ b/reference/mongodb/bson/symbol.xml
@@ -3,7 +3,7 @@
 
 <reference xml:id="class.mongodb-bson-symbol" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>The MongoDB\BSON\Symbol class (deprecated)</title>
+ <title>The MongoDB\BSON\Symbol class</title>
  <titleabbrev>MongoDB\BSON\Symbol</titleabbrev>
 
  <partintro>

--- a/reference/mongodb/bson/undefined.xml
+++ b/reference/mongodb/bson/undefined.xml
@@ -3,7 +3,7 @@
 
 <reference xml:id="class.mongodb-bson-undefined" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>The MongoDB\BSON\Undefined class (deprecated)</title>
+ <title>The MongoDB\BSON\Undefined class</title>
  <titleabbrev>MongoDB\BSON\Undefined</titleabbrev>
 
  <partintro>

--- a/reference/mongodb/bson/unserializable/bsonunserialize.xml
+++ b/reference/mongodb/bson/unserializable/bsonunserialize.xml
@@ -71,9 +71,9 @@ class MyDocument implements MongoDB\BSON\Unserializable
     }
 }
 
-$bson = MongoDB\BSON\fromJSON('{ "foo": "bar" }');
-$value = MongoDB\BSON\toPHP($bson, ['root' => 'MyDocument']);
-var_dump($value);
+$bson = MongoDB\BSON\Document::fromJSON('{ "foo": "bar" }');
+
+var_dump($bson->toPHP(['root' => 'MyDocument']));
 
 ?>
 ]]>

--- a/reference/mongodb/exceptions.xml
+++ b/reference/mongodb/exceptions.xml
@@ -54,7 +54,7 @@
         <listitem><simpara><classname>MongoDB\Driver\Exception\CommandException</classname></simpara></listitem>
         <listitem><simpara><classname>MongoDB\Driver\Exception\ExecutionTimeoutException</classname></simpara></listitem>
         <listitem>
-         <simpara><classname>MongoDB\Driver\Exception\WriteException</classname></simpara>
+         <simpara><classname>MongoDB\Driver\Exception\WriteException</classname> (deprecated)</simpara>
          <itemizedlist>
           <listitem><simpara><classname>MongoDB\Driver\Exception\BulkWriteException</classname></simpara></listitem>
          </itemizedlist>

--- a/reference/mongodb/functions/bson/fromjson.xml
+++ b/reference/mongodb/functions/bson/fromjson.xml
@@ -7,6 +7,16 @@
   <refpurpose>Returns the BSON representation of a JSON value</refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  <warning>
+   <para>
+    This function has been <emphasis>DEPRECATED</emphasis> as of extension
+    version 1.20.0 and will be removed in 2.0. Applications should use
+    <methodname>MongoDB\BSON\Document::fromJSON</methodname> instead.
+   </para>
+  </warning>
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>

--- a/reference/mongodb/functions/bson/fromphp.xml
+++ b/reference/mongodb/functions/bson/fromphp.xml
@@ -7,6 +7,16 @@
   <refpurpose>Returns the BSON representation of a PHP value</refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  <warning>
+   <para>
+    This function has been <emphasis>DEPRECATED</emphasis> as of extension
+    version 1.20.0 and will be removed in 2.0. Applications should use
+    <methodname>MongoDB\BSON\Document::fromPHP</methodname> instead.
+   </para>
+  </warning>
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>

--- a/reference/mongodb/functions/bson/tocanonicalextendedjson.xml
+++ b/reference/mongodb/functions/bson/tocanonicalextendedjson.xml
@@ -7,6 +7,17 @@
   <refpurpose>Returns the Canonical Extended JSON representation of a BSON value</refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  <warning>
+   <para>
+    This function has been <emphasis>DEPRECATED</emphasis> as of extension
+    version 1.20.0 and will be removed in 2.0. Applications should use
+    <methodname>MongoDB\BSON\Document::toCanonicalExtendedJSON</methodname>
+    instead.
+   </para>
+  </warning>
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>

--- a/reference/mongodb/functions/bson/tojson.xml
+++ b/reference/mongodb/functions/bson/tojson.xml
@@ -7,6 +7,18 @@
   <refpurpose>Returns the Legacy Extended JSON representation of a BSON value</refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  <warning>
+   <para>
+    This function has been <emphasis>DEPRECATED</emphasis> as of extension
+    version 1.20.0 and will be removed in 2.0. Applications should use
+    <methodname>MongoDB\BSON\Document::toCanonicalExtendedJSON</methodname> or
+    <methodname>MongoDB\BSON\Document::toRelaxedExtendedJSON</methodname>
+    instead.
+   </para>
+  </warning>
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>

--- a/reference/mongodb/functions/bson/tophp.xml
+++ b/reference/mongodb/functions/bson/tophp.xml
@@ -7,6 +7,16 @@
   <refpurpose>Returns the PHP representation of a BSON value</refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  <warning>
+   <para>
+    This function has been <emphasis>DEPRECATED</emphasis> as of extension
+    version 1.20.0 and will be removed in 2.0. Applications should use
+    <methodname>MongoDB\BSON\Document::toPHP</methodname> instead.
+   </para>
+  </warning>
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>

--- a/reference/mongodb/functions/bson/torelaxedextendedjson.xml
+++ b/reference/mongodb/functions/bson/torelaxedextendedjson.xml
@@ -7,6 +7,17 @@
   <refpurpose>Returns the Relaxed Extended JSON representation of a BSON value</refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  <warning>
+   <para>
+    This function has been <emphasis>DEPRECATED</emphasis> as of extension
+    version 1.20.0 and will be removed in 2.0. Applications should use
+    <methodname>MongoDB\BSON\Document::toRelaxedExtendedJSON</methodname>
+    instead.
+   </para>
+  </warning>
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>

--- a/reference/mongodb/mongodb/driver/exception/sslconnectionexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/sslconnectionexception.xml
@@ -3,17 +3,19 @@
 
 <reference xml:id="class.mongodb-driver-exception-sslconnectionexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>The MongoDB\Driver\Exception\SSLConnectionException class (deprecated)</title>
+ <title>The MongoDB\Driver\Exception\SSLConnectionException class</title>
  <titleabbrev>MongoDB\Driver\Exception\SSLConnectionException</titleabbrev>
 
  <partintro>
 
- <warning>
-  <simpara>
-   This exception class is deprecated and may be removed in a future major
-   version. The extension has never thrown this exception.
-  </simpara>
- </warning>
+  <warning>
+   <simpara>
+    This exception class is <emphasis>DEPRECATED</emphasis> as of extension
+    version 1.5.0 and will be removed in 2.0. This exception was never thrown
+    by the extension. Applications should use
+    <classname>MongoDB\Driver\Exception\ConnectionException</classname> instead.
+   </simpara>
+  </warning>
 
 <!-- {{{ MongoDB\Driver\Exception\SSLConnectionException intro -->
   <section xml:id="mongodb-driver-exception-sslconnectionexception.intro">

--- a/reference/mongodb/mongodb/driver/exception/writeexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/writeexception.xml
@@ -8,6 +8,15 @@
 
  <partintro>
 
+  <warning>
+   <simpara>
+    This exception class is <emphasis>DEPRECATED</emphasis> as of extension
+    version 1.20.0 and will be removed in 2.0. This exception was never directly
+    thrown by the extension. Applications should use
+    <classname>MongoDB\Driver\Exception\BulkWriteException</classname> instead.
+   </simpara>
+  </warning>
+
 <!-- {{{ MongoDB\Driver\Exception\WriteException intro -->
   <section xml:id="mongodb-driver-exception-writeexception.intro">
    &reftitle.intro;

--- a/reference/mongodb/mongodb/driver/query/construct.xml
+++ b/reference/mongodb/mongodb/driver/query/construct.xml
@@ -540,7 +540,7 @@ $options = [
 $query = new MongoDB\Driver\Query($filter, $options);
 
 $manager = new MongoDB\Driver\Manager('mongodb://localhost:27017');
-$readPreference = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
+$readPreference = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY);
 $cursor = $manager->executeQuery('databaseName.collectionName', $query, $readPreference);
 
 foreach($cursor as $document) {

--- a/reference/mongodb/mongodb/driver/readconcern/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/bsonserialize.xml
@@ -46,7 +46,7 @@
 $rc = new MongoDB\Driver\ReadConcern;
 var_dump($rc->bsonSerialize());
 
-echo "\n", MongoDB\BSON\toJSON(MongoDB\BSON\fromPHP($rc));
+echo "\n", MongoDB\BSON\Document::fromPHP($rc)->toRelaxedExtendedJSON();
 
 ?>
 ]]>
@@ -69,7 +69,7 @@ object(stdClass)#2 (0) {
 $rc = new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LOCAL);
 var_dump($rc->bsonSerialize());
 
-echo "\n", MongoDB\BSON\toJSON(MongoDB\BSON\fromPHP($rc));
+echo "\n", MongoDB\BSON\Document::fromPHP($rc)->toRelaxedExtendedJSON();
 
 ?>
 ]]>

--- a/reference/mongodb/mongodb/driver/readpreference.xml
+++ b/reference/mongodb/mongodb/driver/readpreference.xml
@@ -133,6 +133,13 @@
        All operations read from the current replica set primary. This is the
        default read preference for MongoDB.
       </para>
+      <warning>
+       <para>
+        This constant has been <emphasis>DEPRECATED</emphasis> as of extension
+        version 1.20.0 and will be removed in 2.0. Applications should use
+        <constant>MongoDB\Driver\ReadPreference::PRIMARY</constant> instead.
+       </para>
+      </warning>
      </listitem>
     </varlistentry>
 
@@ -143,6 +150,13 @@
        In most situations, operations read from the primary but if it is
        unavailable, operations read from secondary members.
       </para>
+      <warning>
+       <para>
+        This constant has been <emphasis>DEPRECATED</emphasis> as of extension
+        version 1.20.0 and will be removed in 2.0. Applications should use
+        <constant>MongoDB\Driver\ReadPreference::PRIMARY_PREFERRED</constant> instead.
+       </para>
+      </warning>
      </listitem>
     </varlistentry>
 
@@ -152,6 +166,13 @@
       <para>
        All operations read from the secondary members of the replica set.
       </para>
+      <warning>
+       <para>
+        This constant has been <emphasis>DEPRECATED</emphasis> as of extension
+        version 1.20.0 and will be removed in 2.0. Applications should use
+        <constant>MongoDB\Driver\ReadPreference::SECONDARY</constant> instead.
+       </para>
+      </warning>
      </listitem>
     </varlistentry>
 
@@ -162,6 +183,13 @@
        In most situations, operations read from secondary members but if no
        secondary members are available, operations read from the primary.
       </para>
+      <warning>
+       <para>
+        This constant has been <emphasis>DEPRECATED</emphasis> as of extension
+        version 1.20.0 and will be removed in 2.0. Applications should use
+        <constant>MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED</constant> instead.
+       </para>
+      </warning>
      </listitem>
     </varlistentry>
 
@@ -172,6 +200,13 @@
        Operations read from member of the replica set with the least network
        latency, irrespective of the member&apos;s type.
       </para>
+      <warning>
+       <para>
+        This constant has been <emphasis>DEPRECATED</emphasis> as of extension
+        version 1.20.0 and will be removed in 2.0. Applications should use
+        <constant>MongoDB\Driver\ReadPreference::NEAREST</constant> instead.
+       </para>
+      </warning>
      </listitem>
     </varlistentry>
 
@@ -267,6 +302,20 @@
       </thead>
       <tbody>
        <row>
+        <entry>PECL mongodb 1.20.0</entry>
+        <entry>
+         <para>
+          Deprecated the
+          <constant>MongoDB\Driver\ReadPreference::RP_PRIMARY</constant>,
+          <constant>MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED</constant>,
+          <constant>MongoDB\Driver\ReadPreference::RP_SECONDARY</constant>,
+          <constant>MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED</constant>,
+          and <constant>MongoDB\Driver\ReadPreference::RP_NEAREST</constant>
+          constants.
+         </para>
+        </entry>
+       </row>
+       <row>
         <entry>PECL mongodb 1.7.0</entry>
         <entry>
          <para>
@@ -275,7 +324,8 @@
           <constant>MongoDB\Driver\ReadPreference::PRIMARY_PREFERRED</constant>,
           <constant>MongoDB\Driver\ReadPreference::SECONDARY</constant>,
           <constant>MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED</constant>,
-          <constant>MongoDB\Driver\ReadPreference::NEAREST</constant> constants.
+          and <constant>MongoDB\Driver\ReadPreference::NEAREST</constant>
+          constants.
          </para>
          <para>
           Implements <interfacename>Serializable</interfacename>.

--- a/reference/mongodb/mongodb/driver/readpreference/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/bsonserialize.xml
@@ -43,7 +43,7 @@
 <![CDATA[
 <?php
 
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
+$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY);
 var_dump($rp->bsonSerialize());
 
 echo "\n", MongoDB\BSON\Document::fromPHP($rp)->toRelaxedExtendedJSON();
@@ -70,7 +70,7 @@ object(stdClass)#2 (1) {
 <?php
 
 $rp = new MongoDB\Driver\ReadPreference(
-    MongoDB\Driver\ReadPreference::RP_SECONDARY,
+    MongoDB\Driver\ReadPreference::SECONDARY,
     [
         ['dc' => 'ny'],
         ['dc' => 'sf', 'use' => 'reporting'],
@@ -121,7 +121,7 @@ object(stdClass)#2 (2) {
 <?php
 
 $rp = new MongoDB\Driver\ReadPreference(
-    MongoDB\Driver\ReadPreference::RP_SECONDARY,
+    MongoDB\Driver\ReadPreference::SECONDARY,
     null,
     ['maxStalenessSeconds' => 120]
 );

--- a/reference/mongodb/mongodb/driver/readpreference/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/bsonserialize.xml
@@ -46,7 +46,7 @@
 $rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
 var_dump($rp->bsonSerialize());
 
-echo "\n", MongoDB\BSON\toJSON(MongoDB\BSON\fromPHP($rp));
+echo "\n", MongoDB\BSON\Document::fromPHP($rp)->toRelaxedExtendedJSON();
 
 ?>
 ]]>
@@ -79,7 +79,7 @@ $rp = new MongoDB\Driver\ReadPreference(
 );
 var_dump($rp->bsonSerialize());
 
-echo "\n", MongoDB\BSON\toJSON(MongoDB\BSON\fromPHP($rp));
+echo "\n", MongoDB\BSON\Document::fromPHP($rp)->toRelaxedExtendedJSON();
 
 ?>
 ]]>
@@ -127,7 +127,7 @@ $rp = new MongoDB\Driver\ReadPreference(
 );
 var_dump($rp->bsonSerialize());
 
-echo "\n", MongoDB\BSON\toJSON(MongoDB\BSON\fromPHP($rp));
+echo "\n", MongoDB\BSON\Document::fromPHP($rp)->toRelaxedExtendedJSON();
 
 ?>
 ]]>

--- a/reference/mongodb/mongodb/driver/readpreference/construct.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/construct.xml
@@ -39,7 +39,7 @@
         </thead>
         <tbody>
          <row>
-          <entry><constant>MongoDB\Driver\ReadPreference::RP_PRIMARY</constant> or <literal>"primary"</literal></entry>
+          <entry><literal>"primary"</literal></entry>
           <entry>
            <para>
             All operations read from the current replica set primary. This is
@@ -48,7 +48,7 @@
           </entry>
          </row>
          <row>
-          <entry><constant>MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED</constant> or <literal>"primaryPreferred"</literal></entry>
+          <entry><literal>"primaryPreferred"</literal></entry>
           <entry>
            <para>
             In most situations, operations read from the primary but if it is
@@ -57,7 +57,7 @@
           </entry>
          </row>
          <row>
-          <entry><constant>MongoDB\Driver\ReadPreference::RP_SECONDARY</constant> or <literal>"secondary"</literal></entry>
+          <entry><literal>"secondary"</literal></entry>
           <entry>
            <para>
             All operations read from the secondary members of the replica set.
@@ -65,7 +65,7 @@
           </entry>
          </row>
          <row>
-          <entry><constant>MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED</constant> or <literal>"secondaryPreferred"</literal></entry>
+          <entry><literal>"secondaryPreferred"</literal></entry>
           <entry>
            <para>
             In most situations, operations read from secondary members but if no
@@ -74,7 +74,7 @@
           </entry>
          </row>
          <row>
-          <entry><constant>MongoDB\Driver\ReadPreference::RP_NEAREST</constant> or <literal>"nearest"</literal></entry>
+          <entry><literal>"nearest"</literal></entry>
           <entry>
            <para>
             Operations read from member of the replica set with the least
@@ -102,11 +102,9 @@
       fallback.
      </para>
      <para>
-      Tags are not compatible with the
-      <constant>MongoDB\Driver\ReadPreference::RP_PRIMARY</constant> mode and,
+      Tags are not compatible with the <literal>"primary"</literal> mode and,
       in general, only apply when selecting a secondary member of a set for a
-      read operation. However, the
-      <constant>MongoDB\Driver\ReadPreference::RP_NEAREST</constant> mode, when
+      read operation. However, the <literal>"nearest"</literal> mode, when
       combined with a tag set, selects the matching member with the lowest
       network latency. This member may be a primary or secondary.
      </para>
@@ -164,12 +162,11 @@
             when choosing where to direct a read operation.
            </para>
            <para>
-            This option is not compatible with the
-            <constant>MongoDB\Driver\ReadPreference::RP_PRIMARY</constant> mode.
-            Specifying a max staleness also requires all MongoDB instances in
-            the deployment to be using MongoDB 3.4+. An exception will be thrown
-            at execution time if any MongoDB instances in the deployment are of
-            an older server version.
+            This option is not compatible with the <literal>"primary"</literal>
+            mode. Specifying a max staleness also requires all MongoDB instances
+            in the deployment to be using MongoDB 3.4+. An exception will be
+            thrown at execution time if any MongoDB instances in the deployment
+            are of an older server version.
            </para>
           </entry>
          </row>
@@ -204,6 +201,13 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>PECL mongodb 1.20.0</entry>
+       <entry>
+        Passing an <type>int</type> for the <parameter>mode</parameter> argument
+        is <emphasis>DEPRECATED</emphasis>.
+       </entry>
+      </row>
       <row>
        <entry>PECL mongodb 1.8.0</entry>
        <entry>
@@ -244,16 +248,16 @@
 <?php
 
 /* Prefer a secondary node but fall back to a primary. */
-var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED));
 
 /* Prefer a node in the New York data center with lowest latency. */
-var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_NEAREST, [['dc' => 'ny']]));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::NEAREST, [['dc' => 'ny']]));
 
 /* Require a secondary node whose replication lag is within two minutes of the primary */
-var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['maxStalenessSeconds' => 120]));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 120]));
 
 /* Explicitly enable server hedged reads */
-var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, ['hedge' => ['enabled' => true]]));
+var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['hedge' => ['enabled' => true]]));
 
 ?>
 ]]>

--- a/reference/mongodb/mongodb/driver/readpreference/getmaxstalenessseconds.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/getmaxstalenessseconds.xml
@@ -46,20 +46,20 @@
 <![CDATA[
 <?php
 
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY);
+$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 var_dump($rp->getMaxStalenessSeconds());
 
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, [
+$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, [
     'maxStalenessSeconds' => MongoDB\Driver\ReadPreference::NO_MAX_STALENESS,
 ]);
 var_dump($rp->getMaxStalenessSeconds());
 
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, [
+$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, [
     'maxStalenessSeconds' => MongoDB\Driver\ReadPreference::SMALLEST_MAX_STALENESS_SECONDS,
 ]);
 var_dump($rp->getMaxStalenessSeconds());
 
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY, null, [
+$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, [
     'maxStalenessSeconds' => 1000,
 ]);
 var_dump($rp->getMaxStalenessSeconds());

--- a/reference/mongodb/mongodb/driver/readpreference/getmode.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/getmode.xml
@@ -7,6 +7,17 @@
   <refpurpose>Returns the ReadPreference&apos;s "mode" option</refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  <warning>
+   <para>
+    This function has been <emphasis>DEPRECATED</emphasis> as of extension
+    version 1.20.0 and will be removed in 2.0. Applications should use
+    <methodname>MongoDB\Driver\ReadPreference::getModeString</methodname>
+    instead.
+   </para>
+  </warning>
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -43,19 +54,19 @@
 <![CDATA[
 <?php
 
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
+$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY);
 var_dump($rp->getMode());
 
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED);
+$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY_PREFERRED);
 var_dump($rp->getMode());
 
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY);
+$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 var_dump($rp->getMode());
 
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED);
+$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED);
 var_dump($rp->getMode());
 
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_NEAREST);
+$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::NEAREST);
 var_dump($rp->getMode());
 
 ?>

--- a/reference/mongodb/mongodb/driver/readpreference/getmodestring.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/getmodestring.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="mongodb-driver-readpreference.getmodestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\Driver\ReadPreference::getModeString</refname>
-  <refpurpose>Returns the ReadPreference&apos;s "mode" option as a string</refpurpose>
+  <refpurpose>Returns the ReadPreference&apos;s "mode" option</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/mongodb/mongodb/driver/readpreference/gettagsets.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/gettagsets.xml
@@ -43,7 +43,7 @@
 <![CDATA[
 <?php
 
-$mode = MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED;
+$mode = MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED;
 
 /* Null and an empty array both denote no tag set preference. */
 $rp = new MongoDB\Driver\ReadPreference($mode, null);

--- a/reference/mongodb/mongodb/driver/server/gethost.xml
+++ b/reference/mongodb/mongodb/driver/server/gethost.xml
@@ -47,9 +47,7 @@
 <?php
 
 $manager = new MongoDB\Driver\Manager("mongodb://localhost:27017/");
-
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
-$server = $manager->selectServer($rp);
+$server = $manager->selectServer();
 
 var_dump($server->getHost());
 

--- a/reference/mongodb/mongodb/driver/server/getlatency.xml
+++ b/reference/mongodb/mongodb/driver/server/getlatency.xml
@@ -76,9 +76,7 @@
 <?php
 
 $manager = new MongoDB\Driver\Manager("mongodb://localhost:27017/");
-
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
-$server = $manager->selectServer($rp);
+$server = $manager->selectServer();
 
 var_dump($server->getLatency());
 

--- a/reference/mongodb/mongodb/driver/server/getport.xml
+++ b/reference/mongodb/mongodb/driver/server/getport.xml
@@ -47,9 +47,7 @@
 <?php
 
 $manager = new MongoDB\Driver\Manager("mongodb://localhost:27017/");
-
-$rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
-$server = $manager->selectServer($rp);
+$server = $manager->selectServer();
 
 var_dump($server->getPort());
 

--- a/reference/mongodb/mongodb/driver/writeconcern/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/bsonserialize.xml
@@ -46,7 +46,7 @@
 $wc = new MongoDB\Driver\WriteConcern(MongoDB\Driver\WriteConcern::MAJORITY);
 var_dump($wc->bsonSerialize());
 
-echo "\n", MongoDB\BSON\toJSON(MongoDB\BSON\fromPHP($wc));
+echo "\n", MongoDB\BSON\Document::fromPHP($wc)->toRelaxedExtendedJSON();
 
 ?>
 ]]>
@@ -71,7 +71,7 @@ object(stdClass)#2 (1) {
 $wc = new MongoDB\Driver\WriteConcern(2, 1000, true);
 var_dump($wc->bsonSerialize());
 
-echo "\n", MongoDB\BSON\toJSON(MongoDB\BSON\fromPHP($wc));
+echo "\n", MongoDB\BSON\Document::fromPHP($wc)->toRelaxedExtendedJSON();
 
 ?>
 ]]>

--- a/reference/mongodb/mongodb/driver/writeresult/getserver.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getserver.xml
@@ -51,7 +51,7 @@
 <?php
 
 $manager = new MongoDB\Driver\Manager;
-$server = $manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY));
+$server = $manager->selectServer();
 
 $bulk = new MongoDB\Driver\BulkWrite;
 $bulk->insert(['x' => 1]);

--- a/reference/mongodb/versions.xml
+++ b/reference/mongodb/versions.xml
@@ -215,9 +215,9 @@
  <function name='mongodb\driver\exception\runtimeexception' from='mongodb &gt;= 1.0.0'/>
  <function name='mongodb\driver\exception\runtimeexception::hasErrorLabel' from='mongodb &gt;= 1.6.0'/>
  <function name='mongodb\driver\exception\serverexception' from='mongodb &gt;= 1.5.0'/>
- <function name='mongodb\driver\exception\sslconnectionexception' from='mongodb &gt;= 1.0.0'/>
+ <function name='mongodb\driver\exception\sslconnectionexception' from='mongodb &gt;= 1.0.0' deprecated='mongodb 1.5.0'/>
  <function name='mongodb\driver\exception\unexpectedvalueexception' from='mongodb &gt;= 1.0.0'/>
- <function name='mongodb\driver\exception\writeexception' from='mongodb &gt;= 1.0.0'/>
+ <function name='mongodb\driver\exception\writeexception' from='mongodb &gt;= 1.0.0' deprecated='mongodb 1.20.0'/>
  <function name='mongodb\driver\exception\writeexception::getwriteresult' from='mongodb &gt;= 1.0.0'/>
 
  <!-- Monitoring interfaces -->

--- a/reference/mongodb/versions.xml
+++ b/reference/mongodb/versions.xml
@@ -6,12 +6,12 @@
 
 <versions>
  <!-- BSON functions -->
- <function name='mongodb\bson\fromjson' from='mongodb &gt;=1.0.0'/>
- <function name='mongodb\bson\fromphp' from='mongodb &gt;=1.0.0'/>
- <function name='mongodb\bson\tojson' from='mongodb &gt;=1.0.0'/>
- <function name='mongodb\bson\tocanonicalextendedjson' from='mongodb &gt;=1.3.0'/>
- <function name='mongodb\bson\torelaxedextendedjson' from='mongodb &gt;=1.3.0'/>
- <function name='mongodb\bson\tophp' from='mongodb &gt;=1.0.0'/>
+ <function name='mongodb\bson\fromjson' from='mongodb &gt;=1.0.0' deprecated='mongodb 1.20.0'/>
+ <function name='mongodb\bson\fromphp' from='mongodb &gt;=1.0.0' deprecated='mongodb 1.20.0'/>
+ <function name='mongodb\bson\tojson' from='mongodb &gt;=1.0.0' deprecated='mongodb 1.20.0'/>
+ <function name='mongodb\bson\tocanonicalextendedjson' from='mongodb &gt;=1.3.0' deprecated='mongodb 1.20.0'/>
+ <function name='mongodb\bson\torelaxedextendedjson' from='mongodb &gt;=1.3.0' deprecated='mongodb 1.20.0'/>
+ <function name='mongodb\bson\tophp' from='mongodb &gt;=1.0.0' deprecated='mongodb 1.20.0'/>
 
  <!-- Monitoring functions -->
  <function name='mongodb\driver\monitoring\addsubscriber' from='mongodb &gt;=1.3.0'/>

--- a/reference/mongodb/versions.xml
+++ b/reference/mongodb/versions.xml
@@ -489,7 +489,7 @@
  <function name='mongodb\bson\utcdatetime::serialize' from='mongodb &gt;=1.2.0'/>
  <function name='mongodb\bson\utcdatetime::unserialize' from='mongodb &gt;=1.2.0'/>
 
- <!-- deprecated BSON type classes -->
+ <!-- BSON type classes (for deprecated BSON types) -->
  <function name='mongodb\bson\dbpointer' from='mongodb &gt;=1.4.0'/>
  <function name='mongodb\bson\dbpointer::__construct' from='mongodb &gt;=1.4.0'/>
  <function name='mongodb\bson\dbpointer::__tostring' from='mongodb &gt;=1.4.0'/>

--- a/reference/mongodb/versions.xml
+++ b/reference/mongodb/versions.xml
@@ -97,7 +97,7 @@
  <function name='mongodb\driver\readpreference::bsonserialize' from='mongodb &gt;=1.2.0'/>
  <function name='mongodb\driver\readpreference::gethedge' from='mongodb &gt;=1.8.0'/>
  <function name='mongodb\driver\readpreference::getmaxstalenessseconds' from='mongodb &gt;=1.2.0'/>
- <function name='mongodb\driver\readpreference::getmode' from='mongodb &gt;=1.0.0'/>
+ <function name='mongodb\driver\readpreference::getmode' from='mongodb &gt;=1.0.0' deprecated='mongodb 1.20.0'/>
  <function name='mongodb\driver\readpreference::getmodestring' from='mongodb &gt;=1.7.0'/>
  <function name='mongodb\driver\readpreference::gettagsets' from='mongodb &gt;=1.0.0'/>
  <function name='mongodb\driver\readpreference::serialize' from='mongodb &gt;=1.7.0'/>


### PR DESCRIPTION
This PR will collect various changes for ext-mongodb 1.20 (see: [PHPC tickets with `documentation-needed` label](https://jira.mongodb.org/issues/?jql=project%20%3D%20PHPC%20AND%20labels%20%3D%20documentation-needed)).

 * [PHPC-1489](https://jira.mongodb.org/browse/PHPC-1489): Deprecate using ReadPreference integer constants
 * [PHPC-2347](https://jira.mongodb.org/browse/PHPC-2347): Deprecate BSON functions in favor of Document methods
 * [PHPC-2349](https://jira.mongodb.org/browse/PHPC-2349): Deprecate WriteException class
 * [PHPC-2411](https://jira.mongodb.org/browse/PHPC-2411): Deprecate SSLConnectionException class
