### PR TITLE
Add missing comma

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -6,7 +6,7 @@
    <?phpdoc print-version-for="enumerations"?>
 
    <para>
-    Enumerations, or "Enums" allow a developer to define a custom type that is limited to one
+    Enumerations, or "Enums", allow a developer to define a custom type that is limited to one
     of a discrete number of possible values.  That can be especially helpful when defining a
     domain model, as it enables "making invalid states unrepresentable."
    </para>


### PR DESCRIPTION
> Enumerations, or "Enums", allow a developer to define a custom type that is limited to one


`or "Enums"` is parenthetical. It should have a trailing comma before the main sentence kicks back in.