### PR TITLE
Deprecate CursorId, document Cursor::getId() returning Int64

### DIFF
--- a/reference/mongodb/mongodb/driver/cursor/getid.xml
+++ b/reference/mongodb/mongodb/driver/cursor/getid.xml
@@ -10,13 +10,22 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\CursorId</type><methodname>MongoDB\Driver\Cursor::getId</methodname>
-   <void />
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\Driver\CursorId</type><type>MongoDB\BSON\Int64</type></type><methodname>MongoDB\Driver\Cursor::getId</methodname>
+   <methodparam><type>bool</type><parameter>asInt64</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Returns the <classname>MongoDB\Driver\CursorId</classname> associated with
-   this cursor. A cursor ID uniquely identifies the cursor on the server.
+   Returns the ID for this cursor, which uniquely identifies the cursor on the
+   server.
   </para>
+  <warning>
+   <para>
+    Returning <classname>MongoDB\Driver\CursorId</classname> from this method
+    has been <emphasis>DEPRECATED</emphasis> as of extension version
+    1.20.0. In version 2.0, the <parameter>asInt64</parameter> argument will be
+    removed and this method will always return a
+    <classname>MongoDB\BSON\Int64</classname> object.
+   </para>
+  </warning>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,7 +36,11 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the <classname>MongoDB\Driver\CursorId</classname> for this cursor.
+   Returns the ID for this cursor. If <parameter>asInt64</parameter> is &true;,
+   the ID will be returned as a <classname>MongoDB\BSON\Int64</classname>
+   object; otherwise, it will be returned as a
+   <classname>MongoDB\Driver\CursorId</classname> object and a deprecation
+   notice will be emitted.
   </para>
  </refsect1>
 
@@ -38,6 +51,32 @@
   </simplelist>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.20.0</entry>
+       <entry>
+        Deprecated returning a <classname>MongoDB\Driver\CursorId</classname>.
+        Added the <parameter>asInt64</parameter> argument to ease migration for
+        future versions. If <parameter>asInt64</parameter> is &true;, the ID
+        will be returned as a <classname>MongoDB\BSON\Int64</classname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
@@ -60,7 +99,7 @@ $bulk->insert(['x' => 3]);
 $manager->executeBulkWrite('db.collection', $bulk);
 
 $cursor = $manager->executeQuery('db.collection', $query);
-var_dump($cursor->getId());
+var_dump($cursor->getId(true));
 
 ?>
 ]]>
@@ -68,9 +107,9 @@ var_dump($cursor->getId());
    &example.outputs.similar;
    <screen>
 <![CDATA[
-object(MongoDB\Driver\CursorId)#5 (1) {
-  ["id"]=>
-  int(94810124093)
+object(MongoDB\BSON\Int64)#5 (1) {
+  ["integer"]=>
+  string(11) "94810124093"
 }
 ]]>
    </screen>
@@ -82,7 +121,7 @@ object(MongoDB\Driver\CursorId)#5 (1) {
   &reftitle.seealso;
   <simplelist>
    <member><classname>MongoDB\Driver\CursorId</classname></member>
-   <member><function>MongoDB\Driver\CursorId::__toString</function></member>
+   <member><classname>MongoDB\BSON\Int64</classname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/cursorid.xml
+++ b/reference/mongodb/mongodb/driver/cursorid.xml
@@ -16,6 +16,14 @@
     that represents a cursor ID. Instances of this class are returned by
     <function>MongoDB\Driver\Cursor::getId</function>.
    </para>
+   <warning>
+    <para>
+     This class has been <emphasis>DEPRECATED</emphasis> as of extension
+     version 1.20.0 and will be removed in 2.0. Applications should update their
+     usage of <methodname>MongoDB\Driver\Cursor::getId</methodname> to return
+     <classname>MongoDB\BSON\Int64</classname> instead.
+    </para>
+   </warning>
   </section>
 <!-- }}} -->
 
@@ -62,6 +70,12 @@
        </row>
       </thead>
       <tbody>
+       <row>
+        <entry>PECL mongodb 1.20.0</entry>
+        <entry>
+         This class has been deprecated and will be removed in version 2.0.
+        </entry>
+       </row>
        <row>
         <entry>PECL mongodb 1.12.0</entry>
         <entry>

--- a/reference/mongodb/mongodb/driver/cursorinterface/getid.xml
+++ b/reference/mongodb/mongodb/driver/cursorinterface/getid.xml
@@ -10,12 +10,12 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type>MongoDB\Driver\CursorId</type><methodname>MongoDB\Driver\CursorInterface::getId</methodname>
+   <modifier>abstract</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\Driver\CursorId</type><type>MongoDB\BSON\Int64</type></type><methodname>MongoDB\Driver\CursorInterface::getId</methodname>
    <void />
   </methodsynopsis>
   <para>
-   Returns the <classname>MongoDB\Driver\CursorId</classname> associated with
-   this cursor. A cursor ID uniquely identifies the cursor on the server.
+   Returns the ID for this cursor, which uniquely identifies the cursor on the
+   server.
   </para>
  </refsect1>
 
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the <classname>MongoDB\Driver\CursorId</classname> for this cursor.
+   Returns the ID for this cursor.
   </para>
  </refsect1>
 
@@ -38,12 +38,38 @@
   </simplelist>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.20.0</entry>
+       <entry>
+        Added <classname>MongoDB\BSON\Int64</classname> to the tentative return
+        type for this method. <classname>MongoDB\Driver\CursorId</classname>
+        will be removed from the return type in version 2.0.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><methodname>MongoDB\Driver\Cursor::getId</methodname></member>
    <member><classname>MongoDB\Driver\CursorId</classname></member>
-   <member><function>MongoDB\Driver\CursorId::__toString</function></member>
+   <member><classname>MongoDB\BSON\Int64</classname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/mongodb/versions.xml
+++ b/reference/mongodb/versions.xml
@@ -56,11 +56,11 @@
  <function name='mongodb\driver\cursor::toarray' from='mongodb &gt;=1.0.0'/>
  <function name='mongodb\driver\cursor::valid' from='mongodb &gt;=1.9.0'/>
 
- <function name='mongodb\driver\cursorid' from='mongodb &gt;=1.0.0'/>
- <function name='mongodb\driver\cursorid::__construct' from='mongodb &gt;=1.0.0'/>
- <function name='mongodb\driver\cursorid::__tostring' from='mongodb &gt;=1.0.0'/>
- <function name='mongodb\driver\cursorid::serialize' from='mongodb &gt;=1.7.0'/>
- <function name='mongodb\driver\cursorid::unserialize' from='mongodb &gt;=1.7.0'/>
+ <function name='mongodb\driver\cursorid' from='mongodb &gt;=1.0.0' deprecated='mongodb 1.20.0'/>
+ <function name='mongodb\driver\cursorid::__construct' from='mongodb &gt;=1.0.0' deprecated='mongodb 1.20.0'/>
+ <function name='mongodb\driver\cursorid::__tostring' from='mongodb &gt;=1.0.0' deprecated='mongodb 1.20.0'/>
+ <function name='mongodb\driver\cursorid::serialize' from='mongodb &gt;=1.7.0' deprecated='mongodb 1.20.0'/>
+ <function name='mongodb\driver\cursorid::unserialize' from='mongodb &gt;=1.7.0' deprecated='mongodb 1.20.0'/>
 
  <function name='mongodb\driver\manager' from='mongodb &gt;=1.0.0'/>
  <function name='mongodb\driver\manager::__construct' from='mongodb &gt;=1.0.0'/>


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2412