### PR TITLE
Recommend obtaining libedit instead of GNU Readline

### DIFF
--- a/faq/obtaining.xml
+++ b/faq/obtaining.xml
@@ -160,7 +160,7 @@
        </listitem>
        <listitem>
         <simpara>
-         <link xlink:href="&url.readline;">readline</link>.
+         <link xlink:href="&url.libedit;">libedit</link>.
         </simpara>
        </listitem>
       </itemizedlist>


### PR DESCRIPTION
The GNU Readline library is GPL 3 licensed and incompatible with PHP license.