### PR TITLE
Remove GNU Readline in favor of libedit

### DIFF
--- a/reference/readline/book.xml
+++ b/reference/readline/book.xml
@@ -3,7 +3,7 @@
  
 <book xml:id="book.readline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="bundledexternal" ?>
- <title>GNU Readline</title>
+ <title>Readline</title>
  <titleabbrev>Readline</titleabbrev>
  
  <!-- {{{ preface -->
@@ -11,7 +11,7 @@
   &reftitle.intro;
   <para>
    The readline functions implement an interface
-   to the GNU Readline library. These are functions that provide
+   to the libedit library. These are functions that provide
    editable command lines. An example being the way Bash allows you
    to use the arrow keys to insert characters or scroll through
    command history. Because of the interactive nature of this

--- a/reference/readline/configure.xml
+++ b/reference/readline/configure.xml
@@ -5,13 +5,39 @@
  <para>
   To use these functions you must compile the CGI or CLI version of PHP
   with readline support. You need to configure PHP
-  <option role="configure">--with-readline[=DIR]</option>.
-  If you want to use the libedit readline replacement, configure PHP
-  <option role="configure">--with-libedit[=DIR]</option>.
+  <option role="configure">--with-readline</option>.
  </para>
  <para>
   On Windows this extension is available by default as of PHP 7.1.0.
  </para>
+ <simplesect role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Configure option <option role="configure">--with-libedit</option>
+        has been removed in favor of the
+        <option role="configure">--with-readline</option> which now doesn't
+        accept a DIR argument anymore in favor of the pkg-config and now links
+        to the libedit library, a non-GPL replacement for the GNU Readline
+        library.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </simplesect>
 </section>
 
 <!-- Keep this comment at the end of the file

--- a/reference/readline/configure.xml
+++ b/reference/readline/configure.xml
@@ -3,7 +3,7 @@
 <section xml:id="readline.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
  <para>
-  To use these functions you must compile the CGI or CLI version of PHP
+  To use these functions the CGI or CLI version of PHP must be compiled
   with readline support. You need to configure PHP
   <option role="configure">--with-readline</option>.
  </para>

--- a/reference/readline/constants.xml
+++ b/reference/readline/constants.xml
@@ -3,20 +3,31 @@
 <appendix xml:id="readline.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants;
- <variablelist>
-  <varlistentry xml:id="constant.readline-lib">
-   <term>
-    <constant>READLINE_LIB</constant>
-    (<type>string</type>)
-   </term>
-   <listitem>
-    <simpara>
-     The library which is used for readline support; currently either
-     <literal>readline</literal> or <literal>libedit</literal>.
-    </simpara>
-   </listitem>
-  </varlistentry>
- </variablelist>
+ <formalpara>
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        The <constant>READLINE_LIB</constant> has been removed. The library
+        which is used for readline support; either <literal>readline</literal>
+        or <literal>libedit</literal>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </formalpara>
 </appendix>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/readline/setup.xml
+++ b/reference/readline/setup.xml
@@ -8,14 +8,8 @@
  <section xml:id="readline.requirements">
   &reftitle.required;
   <para>
-   To use the readline functions, you need to install libreadline. You can
-   find libreadline on the home page of the GNU Readline project, at
-   <link xlink:href="&url.readline;">&url.readline;</link>.
-   It's maintained by Chet Ramey, who's also the author of Bash.
-  </para>
-  <para>
-   You can also use these functions with the libedit library, a non-GPL
-   replacement for the readline library. The libedit library is BSD
+   To use the readline functions, you need to install the libedit library, a
+   non-GPL replacement for the GNU Readline library. The libedit library is BSD
    licensed and available for download from
    <link xlink:href="&url.libedit;">&url.libedit;</link>.
   </para>

--- a/reference/readline/setup.xml
+++ b/reference/readline/setup.xml
@@ -8,9 +8,8 @@
  <section xml:id="readline.requirements">
   &reftitle.required;
   <para>
-   To use the readline functions, you need to install the libedit library, a
-   non-GPL replacement for the GNU Readline library. The libedit library is BSD
-   licensed and available for download from
+   To use the readline functions, the libedit library must be installed. The
+   libedit library is BSD-licensed and available for download from
    <link xlink:href="&url.libedit;">&url.libedit;</link>.
   </para>
  </section>


### PR DESCRIPTION
The libedit library is a non-GPL replacement for the GNU Readline library.