### PR TITLE
socket-bind.xml: Remove notes related to Windows 9x/Me

### DIFF
--- a/reference/sockets/functions/socket-bind.xml
+++ b/reference/sockets/functions/socket-bind.xml
@@ -121,7 +121,7 @@ socket_write($sock, $request);
 // Close
 socket_close($sock);
 
-?> 
+?>
 ]]>
     </programlisting>
    </example>
@@ -134,14 +134,6 @@ socket_close($sock);
    <para>
     This function must be used on the socket before
     <function>socket_connect</function>.
-   </para>
-  </note>
-  <note>
-   <para>
-    Windows 9x/ME compatibility note:
-    <function>socket_last_error</function> may return an invalid error code
-    if trying to bind the socket to a wrong address that does not belong to
-    your machine.
    </para>
   </note>
  </refsect1>


### PR DESCRIPTION
Remove notes related to Windows 9x/Me which is not supported by the PHP versions currently documented in the manual.