### PR TITLE
Improve _PHP: Hypertext Preprocessor_ presentation

### DIFF
--- a/chapters/intro.xml
+++ b/chapters/intro.xml
@@ -6,8 +6,8 @@
   <section xml:id="intro-whatis">
    <info><title>What is PHP?</title></info>
    <para>
-    <acronym>PHP</acronym> (recursive acronym for <literal>PHP: Hypertext
-    Preprocessor</literal>) is a widely-used open source general-purpose
+    <acronym>PHP</acronym> (recursive acronym for <emphasis>PHP: Hypertext
+    Preprocessor</emphasis>) is a widely-used open source general-purpose
     scripting language that is especially suited for web
     development and can be embedded into HTML.
    </para>

--- a/preface.xml
+++ b/preface.xml
@@ -5,8 +5,8 @@
  <info><title>Preface</title>
  <abstract>
   <simpara>
-   <acronym>PHP</acronym>, which stands for &quot;<literal>PHP: Hypertext
-   Preprocessor</literal>&quot; is a widely-used open source general-purpose
+   <acronym>PHP</acronym>, which stands for &quot;<emphasis>PHP: Hypertext
+   Preprocessor</emphasis>&quot; is a widely-used open source general-purpose
    scripting language that is especially suited for web
    development and can be embedded into HTML. Its syntax draws
    upon C, Java, and Perl, and is easy to learn. The main goal of

--- a/preface.xml
+++ b/preface.xml
@@ -6,7 +6,7 @@
  <abstract>
   <simpara>
    <acronym>PHP</acronym>, which stands for <emphasis>PHP: Hypertext
-   Preprocessor</emphasis> is a widely-used open source general-purpose
+   Preprocessor</emphasis>, is a widely-used open source general-purpose
    scripting language that is especially suited for web
    development and can be embedded into HTML. Its syntax draws
    upon C, Java, and Perl, and is easy to learn. The main goal of

--- a/preface.xml
+++ b/preface.xml
@@ -5,8 +5,8 @@
  <info><title>Preface</title>
  <abstract>
   <simpara>
-   <acronym>PHP</acronym>, which stands for &quot;<emphasis>PHP: Hypertext
-   Preprocessor</emphasis>&quot; is a widely-used open source general-purpose
+   <acronym>PHP</acronym>, which stands for <emphasis>PHP: Hypertext
+   Preprocessor</emphasis> is a widely-used open source general-purpose
    scripting language that is especially suited for web
    development and can be embedded into HTML. Its syntax draws
    upon C, Java, and Perl, and is easy to learn. The main goal of


### PR DESCRIPTION
As this text is prose and not computer output, I would argue that `literal` should not be used and, if anything, we should use `emphasis` for visual reasons.

We are also inconsistently quoting the initialism expansion, i.e., _PHP: Hypertext Preprocessor_. Removing the quotes makes sense to me because we will present the term in italics.

I've also added the missing closing comma for the _Preface_ parenthetical.

Discussion point: I don't love the _What is PHP?_ parenthetical. It feels clunky. I would propose that we duplicate the _Preface_ parenthetical.

> PHP ~~(recursive acronym for PHP: Hypertext Preprocessor)~~, which stands for PHP: Hypertext Preprocessor,   is a widely-used open source general-purpose scripting language that is especially suited for web development and can be embedded into HTML.

I didn't make this change in this PR as it felt more opinionated. Love to hear your thoughts.

### Before

<img width="854" alt="Screenshot 2024-09-17 at 10 32 52" src="https://github.com/user-attachments/assets/9de3d1aa-1d01-4bf5-a4b8-3d97bf54ec77">

<img width="840" alt="Screenshot 2024-09-17 at 10 33 11" src="https://github.com/user-attachments/assets/335d5164-f669-4de9-a66f-76bcf1b5a68a">

### After

<img width="850" alt="Screenshot 2024-09-17 at 10 36 00" src="https://github.com/user-attachments/assets/0cb78d1f-9370-41ff-8345-86f01f062571">

<img width="850" alt="Screenshot 2024-09-17 at 10 35 22" src="https://github.com/user-attachments/assets/c77ddcf7-1b60-40ad-9061-5620cf8af30e">
