### PR TITLE
Use output tags

### DIFF
--- a/chapters/intro.xml
+++ b/chapters/intro.xml
@@ -39,7 +39,7 @@
    <para>
     Instead of lots of commands to output HTML (as seen in C or Perl),
     PHP pages contain HTML with embedded code that does
-    "something" (in this case, output "Hi, I'm a PHP script!").
+    "something" (in this case, output <computeroutput>Hi, I'm a PHP script!</computeroutput>).
     The PHP code is enclosed in special <link
     linkend="language.basic-syntax.phpmode">start and end processing
     instructions <code>&lt;?php</code> and <code>?&gt;</code></link>


### PR DESCRIPTION
This is computer output.

From what I can see, we usually wrap computer output in `computeroutput` tags without quotes.

See `a is greater than b` on: https://www.php.net/manual/en/control-structures.else.php

I would say the docs site should probably style this tag in monospace font any highlight somehow.