### PR TITLE
Move/rewrite some of the macOS and Unix install instructions

### DIFF
--- a/install/macos/index.xml
+++ b/install/macos/index.xml
@@ -2,14 +2,14 @@
 <!-- $Revision$ -->
 <chapter xml:id="install.macosx" xmlns="http://docbook.org/ns/docbook">
  <title>Installation on macOS</title>
- <para>
-  This section contains notes and hints specific to installing PHP on macOS.
-  PHP is bundled with macOS since macOS X (10.0.0) prior to macOS Monterey (12.0.0).
-  Compiling is similar to the <link linkend="install.unix">Unix installation guide</link>.
- </para>
+ <simpara>
+  PHP was bundled with macOS in versions 10 and 11, but is not included in versions
+  since macOS 12 (Monterey). Installation on recent versions either requires using
+  packages from third-party sources, or compilation from source.
+ </simpara>
  &install.macos.packages;
- &install.macos.bundled;
  &install.macos.compile;
+ &install.macos.bundled;
 </chapter>
 
 <!-- Keep this comment at the end of the file

--- a/install/macos/packages.xml
+++ b/install/macos/packages.xml
@@ -16,38 +16,30 @@
    An easy way to install PHP on macOS is with the
    <link xlink:href="https://brew.sh/">Homebrew</link> packaging manager.
   </simpara>
-  <para>
-   <orderedlist>
-    <listitem>
-     <para>
-      Install Homebrew by following the instructions on the website.
-     </para>
-    </listitem>
-    <listitem>
-     <simpara>
-      <command>brew install php</command>
-     </simpara>
-    </listitem>
-   </orderedlist>
-  </para>
+  <orderedlist>
+   <listitem>
+    <para>
+     Install Homebrew by following the instructions on the website.
+    </para>
+   </listitem>
+   <listitem>
+    <simpara>
+     <command>brew install php</command>
+    </simpara>
+   </listitem>
+  </orderedlist>
   <simpara>
    The following alternative resources also offer easy to install packages and
    precompiled binaries for PHP on macOS:
   </simpara>
-  <para>
-   <itemizedlist>
-    <listitem>
-     <simpara>
-      <link xlink:href="&url.mac.macports;">MacPorts</link>
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      <link xlink:href="&url.mac.fink;">Fink</link>
-     </simpara>
-    </listitem>
-   </itemizedlist>
-  </para>
+  <simplelist>
+   <member>
+    <link xlink:href="&url.mac.macports;">MacPorts</link>
+   </member>
+   <member>
+    <link xlink:href="&url.mac.fink;">Fink</link>
+   </member>
+  </simplelist>
  </sect1>
 
 <!-- Keep this comment at the end of the file

--- a/install/macos/packages.xml
+++ b/install/macos/packages.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
  <sect1 xml:id="install.macosx.packages" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Using Packages</title>
+  <title>Installation on macOS using third-party packages</title>
   <simpara>
    There are a few pre-packaged and pre-compiled versions of PHP for
    macOS. This can help in setting up a standard
@@ -13,45 +13,37 @@
    version of PHP with the features you need.
   </simpara>
   <simpara>
-   The quickest way to install php on macOS is with homebrew:
+   An easy way to install PHP on macOS is with the
+   <link xlink:href="https://brew.sh/">Homebrew</link> packaging manager.
   </simpara>
   <para>
    <orderedlist>
     <listitem>
      <para>
-      install homebrew, by following the instructions at <link xlink:href="https://brew.sh/">brew.sh</link>
+      Install Homebrew by following the instructions on the website.
      </para>
     </listitem>
     <listitem>
      <simpara>
-      brew install php
+      <command>brew install php</command>
      </simpara>
     </listitem>
    </orderedlist>
   </para>
   <simpara>
    The following alternative resources also offer easy to install packages and
-   precompiled binaries for PHP on Mac OS:
+   precompiled binaries for PHP on macOS:
   </simpara>
   <para>
    <itemizedlist>
     <listitem>
      <simpara>
-      MacPorts: 
-      <link xlink:href="&url.mac.macports;">&url.mac.macports;</link>
+      <link xlink:href="&url.mac.macports;">MacPorts</link>
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      Liip: 
-      <link xlink:href="&url.mac.liip;">&url.mac.liip;</link>
-      (PHP 5.3 - PHP 7.3; deprecated)
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      Fink: 
-      <link xlink:href="&url.mac.fink;">&url.mac.fink;</link>
+      <link xlink:href="&url.mac.fink;">Fink</link>
      </simpara>
     </listitem>
    </itemizedlist>

--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -8,14 +8,7 @@
   This is also true for other distributions based on Debian, such as
   Ubuntu, Kali Linux, and Linux Mint.
  </para>
- <warning>
-  <para>
-   Unofficial builds from third-parties are not supported here. Any bugs
-   should be reported to the Debian team unless they can be reproduced using
-   the latest builds from our <link xlink:href="&url.php.downloads;">download
-   area</link>.
-  </para>
- </warning>
+ &warn.install.third-party-support;
  <para>
   The packages can be installed using either the <command>apt</command> or
   <command>aptitude</command> commands. This manual page uses these two

--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <sect1 xml:id="install.unix.debian" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Debian GNU/Linux installation notes</title>
+ <title>Installation on Debian GNU/Linux and related distributions</title>
  <para>
-  This section contains notes and hints specific to installing
-  PHP on <link xlink:href="&url.debian;">Debian GNU/Linux</link>.
+  While PHP can be installed from source, it is also available through
+  packages from <link xlink:href="&url.debian;">Debian GNU/Linux</link>.
+  This is also true for other distributions based on Debian, such as
+  Ubuntu, Kali Linux, and Linux Mint.
  </para>
  <warning>
   <para>
@@ -15,10 +17,9 @@
   </para>
  </warning>
  <para>
-  While the instructions for building PHP on Unix apply to Debian as well,
-  this manual page contains specific information for other options, such as
-  using either the <literal>apt</literal> or <literal>aptitude</literal>
-  commands. This manual page uses these two commands interchangeably.
+  The packages can be installed using either the <literal>apt</literal> or
+  <literal>aptitude</literal> commands. This manual page uses these two
+  commands interchangeably.
  </para>
  <sect2 xml:id="install.unix.debian.apt">
   <title>Using APT</title>

--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -17,8 +17,8 @@
   </para>
  </warning>
  <para>
-  The packages can be installed using either the <literal>apt</literal> or
-  <literal>aptitude</literal> commands. This manual page uses these two
+  The packages can be installed using either the <command>apt</command> or
+  <command>aptitude</command> commands. This manual page uses these two
   commands interchangeably.
  </para>
  <sect2 xml:id="install.unix.debian.apt">
@@ -64,7 +64,7 @@
     <link linkend="book.mysql">MySQL</link>,
     <link linkend="book.curl">cURL</link>,
     <link linkend="book.image">GD</link>,
-    etc. These may also be installed via the <literal>apt</literal> command.
+    etc. These may also be installed via the <command>apt</command> command.
    </simpara>
    <example xml:id="install.unix.debian.config.example">
     <title>Methods for listing additional PHP packages</title>
@@ -79,8 +79,8 @@
    <simpara>
     The examples will show a lot of packages including several PHP specific ones
     like php-cgi, php-cli and php-dev. Determine which are needed
-    and install them like any other with either <literal>apt</literal>
-    or <literal>aptitude</literal>. And because Debian performs
+    and install them like any other with either <command>apt</command>
+    or <command>aptitude</command>. And because Debian performs
     dependency checks, it'll prompt for those so for example to install
     MySQL and cURL:
    </simpara>
@@ -123,7 +123,7 @@
    <listitem>
     <simpara>
      There are two basic commands for installing packages on Debian (and other
-     linux variants): <literal>apt</literal> and <literal>aptitude</literal>.
+     linux variants): <command>apt</command> and <command>aptitude</command>.
      However, explaining the subtle differences between these commands goes
      beyond the scope of this manual.
     </simpara>

--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <sect1 xml:id="install.unix.debian" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Installation on Debian GNU/Linux and related distributions</title>
+ <title>Installing from packages on Debian GNU/Linux and related distributions</title>
  <para>
   While PHP can be installed from source, it is also available through
   packages from <link xlink:href="&url.debian;">Debian GNU/Linux</link>.

--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -70,12 +70,12 @@
     </programlisting>
    </example>
    <simpara>
-    The examples will show a lot of packages including several PHP specific ones
-    like php-cgi, php-cli and php-dev. Determine which are needed
-    and install them like any other with either <command>apt</command>
-    or <command>aptitude</command>. And because Debian performs
-    dependency checks, it'll prompt for those so for example to install
-    MySQL and cURL:
+    The list of packages will include a large number of packages that includes
+    basic PHP components, such as <literal>php-cgi</literal>,
+    <literal>php-cli</literal>, and <literal>php-dev</literal>, as well as
+    many PHP extensions. When extensions are installed, additional packages
+    will be automatically installed as necessary to satisfy the dependencies
+    of those packages.
    </simpara>
    <example xml:id="install.unix.debian.config.example2">
     <title>Install PHP with MySQL, cURL</title>
@@ -111,14 +111,6 @@
      If an extension was seemingly installed yet the functions are undefined,
      be sure that the appropriate ini file is being loaded and/or the web
      server was restarted after installation.
-    </simpara>
-   </listitem>
-   <listitem>
-    <simpara>
-     There are two basic commands for installing packages on Debian:
-     <command>apt</command> and <command>aptitude</command>.
-     However, explaining the subtle differences between these commands goes
-     beyond the scope of this manual.
     </simpara>
    </listitem>
   </itemizedlist>

--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -122,8 +122,8 @@
    </listitem>
    <listitem>
     <simpara>
-     There are two basic commands for installing packages on Debian (and other
-     linux variants): <command>apt</command> and <command>aptitude</command>.
+     There are two basic commands for installing packages on Debian:
+     <command>apt</command> and <command>aptitude</command>.
      However, explaining the subtle differences between these commands goes
      beyond the scope of this manual.
     </simpara>

--- a/install/unix/dnf.xml
+++ b/install/unix/dnf.xml
@@ -2,59 +2,63 @@
 <!-- $Revision$ -->
 <sect1 xml:id="install.unix.dnf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Installing from packages on GNU/Linux distributions that use DNF</title>
- <para>
+ <simpara>
   While PHP can be installed from source, it is also available through
   packages on systems that use DNF, such as Red Hat Enterprise Linux,
   OpenSUSE, Fedora, CentOS, Rocky Linux, and Oracle Enterprise Linux.
- </para>
+ </simpara>
  &warn.install.third-party-support;
- <para>
+ <simpara>
   The packages can be installed using the <command>dnf</command> command.
- </para>
+ </simpara>
  <sect2 xml:id="install.unix.dnf.packages">
   <title>Installing packages</title>
-   <simpara>
-    First, note that other related packages may be desired like
-    <literal>php-pear</literal> for PEAR, or <literal>php-mysqlnd</literal>
-    for the MySQL extension.
-   </simpara>
-   <simpara>
-    Second, before installing a package, it's wise to ensure the package list
-    is up to date. Typically, this is done by running the command
-    <command>dnf update</command>.
-   </simpara>
-   <example xml:id="install.unix.dnf.example">
-    <title>DNF Install Example</title>
-    <programlisting role="shell">
+  <simpara>
+   First, note that other related packages may be desired like
+   <literal>php-pear</literal> for <link xlink:href="&url.pear;">PEAR</link>,
+   or <literal>php-mysqlnd</literal> for the <link linkend="book.mysqlnd">MySQL
+   extension</link>.
+  </simpara>
+  <simpara>
+   Second, before installing a package, it's wise to ensure the package list
+   is up to date. Typically, this is done by running the command
+   <command>dnf update</command>.
+  </simpara>
+  <example xml:id="install.unix.dnf.example">
+   <title>DNF Install Example</title>
+   <programlisting role="shell">
 <![CDATA[
 # dnf install php php-common
 ]]>
-    </programlisting>
-   </example>
-   <simpara>
-    DNF will automatically install the configuration for PHP for the web server,
-    but it may need to be restarted in order for the changes to take effect.
-    For example:
-   </simpara>
-   <example xml:id="install.unix.dnf.example2">
-    <title>Restarting Apache once PHP is installed</title>
-    <programlisting role="shell">
+   </programlisting>
+  </example>
+  <simpara>
+   DNF will automatically install the configuration for PHP for the web server,
+   but it may need to be restarted in order for the changes to take effect.
+   For example:
+  </simpara>
+  <example xml:id="install.unix.dnf.example2">
+   <title>Restarting Apache once PHP is installed</title>
+   <programlisting role="shell">
 <![CDATA[
 # sudo systemctl restart httpd
 ]]>
-    </programlisting>
-   </example>
+   </programlisting>
+  </example>
  </sect2>
  <sect2 xml:id="install.unix.dnf.config">
   <title>Better control of configuration</title>
-  <simpara>
+  <para>
    In the last section, PHP was installed with only core modules. It's
    very likely that additional modules will be desired, such as
-   <link linkend="book.mysql">MySQL</link>,
-   <link linkend="book.curl">cURL</link>,
-   <link linkend="book.image">GD</link>,
-   etc. These may also be installed via the <command>dnf</command> command.
-  </simpara>
+   <simplelist type="inline">
+    <member><link linkend="book.mysql">MySQL</link></member>
+    <member><link linkend="book.curl">cURL</link></member>
+    <member><link linkend="book.image">GD</link></member>
+    <member>etc.</member>
+   </simplelist>
+   These may also be installed via the <command>dnf</command> command.
+  </para>
   <example xml:id="install.unix.dnf.config.example">
    <title>Methods for listing additional PHP packages</title>
    <programlisting role="shell">
@@ -80,14 +84,14 @@
    </programlisting>
   </example>
   <simpara>
-    DNF will automatically add the appropriate lines to the
-    different &php.ini; related files like
-    <filename>/etc/php/8.3/php.ini</filename>,
-    <filename>/etc/php/8.3/conf.d/*.ini</filename>, etc. and depending on
-    the extension will add entries similar to <literal>extension=foo.so</literal>.
-    However, restarting the web server (like Apache) is required before these
-    changes take affect.
-   </simpara>
+   DNF will automatically add the appropriate lines to the
+   different &php.ini; related files like
+   <filename>/etc/php/8.3/php.ini</filename>,
+   <filename>/etc/php/8.3/conf.d/*.ini</filename>, etc. and depending on
+   the extension will add entries similar to <literal>extension=foo.so</literal>.
+   However, restarting the web server (like Apache) is required before these
+   changes take affect.
+  </simpara>
  </sect2>
 </sect1>
 <!-- Keep this comment at the end of the file

--- a/install/unix/dnf.xml
+++ b/install/unix/dnf.xml
@@ -90,7 +90,6 @@
    </simpara>
  </sect2>
 </sect1>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/install/unix/dnf.xml
+++ b/install/unix/dnf.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<sect1 xml:id="install.unix.dnf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Installing from packages on GNU/Linux distributions that use DNF</title>
+ <para>
+  While PHP can be installed from source, it is also available through
+  packages on systems that use DNF, such as Red Hat Enterprise Linux,
+  OpenSUSE, Fedora, CentOS, Rocky Linux, and Oracle Enterprise Linux.
+ </para>
+ <warning>
+  <para>
+   Unofficial builds from third-parties are not supported here. Any bugs
+   should be reported to the upstream distribution unless they can be reproduced using
+   the latest builds from our <link xlink:href="&url.php.downloads;">download
+   area</link>.
+  </para>
+ </warning>
+ <para>
+  The packages can be installed using the <literal>dnf</literal> command.
+ </para>
+ <sect2 xml:id="install.unix.dnf.packages">
+  <title>Installing packages</title>
+   <simpara>
+    First, note that other related packages may be desired like
+    <literal>php-pear</literal> for PEAR, or <literal>php-mysqlnd</literal>
+    for the MySQL extension.
+   </simpara>
+   <simpara>
+    Second, before installing a package, it's wise to ensure the package list
+    is up to date. Typically, this is done by running the command
+    <command>dnf update</command>.
+   </simpara>
+   <example xml:id="install.unix.dnf.example">
+    <title>DNF Install Example</title>
+    <programlisting role="shell">
+<![CDATA[
+# dnf install php php-common
+]]>
+    </programlisting>
+   </example>
+   <simpara>
+    DNF will automatically install the configuration for PHP for the web server,
+    but it may need to be restarted in order for the changes to take effect.
+    For example:
+   </simpara>
+   <example xml:id="install.unix.dnf.example2">
+    <title>Restarting Apache once PHP is installed</title>
+    <programlisting role="shell">
+<![CDATA[
+# sudo systemctl restart httpd
+]]>
+    </programlisting>
+   </example>
+ </sect2>
+ <sect2 xml:id="install.unix.dnf.config">
+  <title>Better control of configuration</title>
+   <simpara>
+    In the last section, PHP was installed with only core modules. It's
+    very likely that additional modules will be desired, such as
+    <link linkend="book.mysql">MySQL</link>,
+    <link linkend="book.curl">cURL</link>,
+    <link linkend="book.image">GD</link>,
+    etc. These may also be installed via the <literal>dnf</literal> command.
+   </simpara>
+   <example xml:id="install.unix.dnf.config.example">
+    <title>Methods for listing additional PHP packages</title>
+    <programlisting role="shell">
+<![CDATA[
+# dnf search php
+]]>
+    </programlisting>
+   </example>
+   <simpara>
+    The examples will show a lot of packages including several PHP specific ones
+    like php-cgi, php-cli and php-dev. Determine which are needed
+    and install them like any other with <literal>dnf</literal>.
+    Because the package manager does
+    dependency checks, it'll prompt for those. For example, to install
+    MySQL and cURL:
+   </simpara>
+   <example xml:id="install.unix.dnf.config.example2">
+    <title>Install PHP with MySQL, cURL</title>
+    <programlisting role="shell">
+<![CDATA[
+# dnf install php-mysqlnd php-curl
+]]>
+    </programlisting>
+   </example>
+  <simpara>
+    DNF will automatically add the appropriate lines to the
+    different &php.ini; related files like 
+    <filename>/etc/php/8.3/php.ini</filename>,
+    <filename>/etc/php/8.3/conf.d/*.ini</filename>, etc. and depending on
+    the extension will add entries similar to <literal>extension=foo.so</literal>.
+    However, restarting the web server (like Apache) is required before these
+    changes take affect.
+   </simpara>
+ </sect2>
+</sect1>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/install/unix/dnf.xml
+++ b/install/unix/dnf.xml
@@ -47,38 +47,38 @@
  </sect2>
  <sect2 xml:id="install.unix.dnf.config">
   <title>Better control of configuration</title>
-   <simpara>
-    In the last section, PHP was installed with only core modules. It's
-    very likely that additional modules will be desired, such as
-    <link linkend="book.mysql">MySQL</link>,
-    <link linkend="book.curl">cURL</link>,
-    <link linkend="book.image">GD</link>,
-    etc. These may also be installed via the <command>dnf</command> command.
-   </simpara>
-   <example xml:id="install.unix.dnf.config.example">
-    <title>Methods for listing additional PHP packages</title>
-    <programlisting role="shell">
+  <simpara>
+   In the last section, PHP was installed with only core modules. It's
+   very likely that additional modules will be desired, such as
+   <link linkend="book.mysql">MySQL</link>,
+   <link linkend="book.curl">cURL</link>,
+   <link linkend="book.image">GD</link>,
+   etc. These may also be installed via the <command>dnf</command> command.
+  </simpara>
+  <example xml:id="install.unix.dnf.config.example">
+   <title>Methods for listing additional PHP packages</title>
+   <programlisting role="shell">
 <![CDATA[
 # dnf search php
 ]]>
-    </programlisting>
-   </example>
-   <simpara>
-    The examples will show a lot of packages including several PHP specific ones
-    like php-cgi, php-cli and php-dev. Determine which are needed
-    and install them like any other with <command>dnf</command>.
-    Because the package manager does
-    dependency checks, it'll prompt for those. For example, to install
-    MySQL and cURL:
-   </simpara>
-   <example xml:id="install.unix.dnf.config.example2">
-    <title>Install PHP with MySQL, cURL</title>
-    <programlisting role="shell">
+   </programlisting>
+  </example>
+  <simpara>
+   The examples will show a lot of packages including several PHP specific ones
+   like php-cgi, php-cli and php-dev. Determine which are needed
+   and install them like any other with <command>dnf</command>.
+   Because the package manager does
+   dependency checks, it'll prompt for those. For example, to install
+   MySQL and cURL:
+  </simpara>
+  <example xml:id="install.unix.dnf.config.example2">
+   <title>Install PHP with MySQL, cURL</title>
+   <programlisting role="shell">
 <![CDATA[
 # dnf install php-mysqlnd php-curl
 ]]>
-    </programlisting>
-   </example>
+   </programlisting>
+  </example>
   <simpara>
     DNF will automatically add the appropriate lines to the
     different &php.ini; related files like

--- a/install/unix/dnf.xml
+++ b/install/unix/dnf.xml
@@ -16,7 +16,7 @@
   </para>
  </warning>
  <para>
-  The packages can be installed using the <literal>dnf</literal> command.
+  The packages can be installed using the <command>dnf</command> command.
  </para>
  <sect2 xml:id="install.unix.dnf.packages">
   <title>Installing packages</title>
@@ -60,7 +60,7 @@
     <link linkend="book.mysql">MySQL</link>,
     <link linkend="book.curl">cURL</link>,
     <link linkend="book.image">GD</link>,
-    etc. These may also be installed via the <literal>dnf</literal> command.
+    etc. These may also be installed via the <command>dnf</command> command.
    </simpara>
    <example xml:id="install.unix.dnf.config.example">
     <title>Methods for listing additional PHP packages</title>
@@ -73,7 +73,7 @@
    <simpara>
     The examples will show a lot of packages including several PHP specific ones
     like php-cgi, php-cli and php-dev. Determine which are needed
-    and install them like any other with <literal>dnf</literal>.
+    and install them like any other with <command>dnf</command>.
     Because the package manager does
     dependency checks, it'll prompt for those. For example, to install
     MySQL and cURL:

--- a/install/unix/dnf.xml
+++ b/install/unix/dnf.xml
@@ -7,14 +7,7 @@
   packages on systems that use DNF, such as Red Hat Enterprise Linux,
   OpenSUSE, Fedora, CentOS, Rocky Linux, and Oracle Enterprise Linux.
  </para>
- <warning>
-  <para>
-   Unofficial builds from third-parties are not supported here. Any bugs
-   should be reported to the upstream distribution unless they can be reproduced using
-   the latest builds from our <link xlink:href="&url.php.downloads;">download
-   area</link>.
-  </para>
- </warning>
+ &warn.install.third-party-support;
  <para>
   The packages can be installed using the <command>dnf</command> command.
  </para>

--- a/install/unix/dnf.xml
+++ b/install/unix/dnf.xml
@@ -64,18 +64,18 @@
    </programlisting>
   </example>
   <simpara>
-   The examples will show a lot of packages including several PHP specific ones
-   like php-cgi, php-cli and php-dev. Determine which are needed
-   and install them like any other with <command>dnf</command>.
-   Because the package manager does
-   dependency checks, it'll prompt for those. For example, to install
-   MySQL and cURL:
+   The list of packages will include a large number of packages that includes
+   basic PHP components, such as <literal>php-cli</literal>,
+   <literal>php-fpm</literal>, and <literal>php-devel</literal>, as well as
+   many PHP extensions. When extensions are installed, additional packages
+   will be automatically installed as necessary to satisfy the dependencies
+   of those packages.
   </simpara>
   <example xml:id="install.unix.dnf.config.example2">
-   <title>Install PHP with MySQL, cURL</title>
+   <title>Install PHP with MySQL, GD</title>
    <programlisting role="shell">
 <![CDATA[
-# dnf install php-mysqlnd php-curl
+# dnf install php-mysqlnd php-gd
 ]]>
    </programlisting>
   </example>

--- a/install/unix/dnf.xml
+++ b/install/unix/dnf.xml
@@ -88,7 +88,7 @@
    </example>
   <simpara>
     DNF will automatically add the appropriate lines to the
-    different &php.ini; related files like 
+    different &php.ini; related files like
     <filename>/etc/php/8.3/php.ini</filename>,
     <filename>/etc/php/8.3/conf.d/*.ini</filename>, etc. and depending on
     the extension will add entries similar to <literal>extension=foo.so</literal>.

--- a/install/unix/index.xml
+++ b/install/unix/index.xml
@@ -27,7 +27,7 @@
    
    <!-- distribution specific nodes -->
    &install.unix.debian;
-   <!-- &install.unix.yum; -->
+   &install.unix.dnf;
    <!-- general from-source instructions -->
    &install.unix.source;
    <!-- web server specific nodes -->

--- a/install/unix/index.xml
+++ b/install/unix/index.xml
@@ -3,177 +3,42 @@
   <chapter xml:id="install.unix" xmlns="http://docbook.org/ns/docbook">
    <title>Installation on Unix systems</title>
    <para>
-    This section will guide you through the general configuration and
-    installation of PHP on Unix systems. Be sure to investigate any
-    sections specific to your platform or web server before you begin
-    the process.
+    Most Unix (and Linux) operating systems and distributions have a
+    packaged version of PHP and extensions available through their packaging
+    system. There are sections with basic information on installing
+    PHP using those systems.
    </para>
    <para>
-    As our manual outlines in the <link linkend="install.general">General
-    Installation Considerations</link> section, we are mainly dealing with
-    web centric setups of PHP in this section, although we will cover
-    setting up PHP for command line usage as well.
-   </para>
-   <para> 
-    There are several ways to install PHP for the Unix platform, either
-    with a compile and configure process, or through various
-    pre-packaged methods. This documentation is mainly focused around
-    the process of compiling and configuring PHP. Many Unix like systems
-    have some sort of package installation system. This can assist in
-    setting up a standard configuration, but if you need to have a
-    different set of features (such as a secure server, or a different
-    database driver), you may need to build PHP and/or your web server.
-    If you are unfamiliar with building and compiling your own software,
-    it is worth checking to see whether somebody has already built a
-    packaged version of PHP with the features you need.
+    For some distributions, there are also third-party repositories of
+    packages that generally include a wider variety of available versions and
+    extensions.
    </para>
    <para>
-    Prerequisite knowledge and software for compiling:
-    <itemizedlist>
-     <listitem>
-      <simpara>
-       Basic Unix skills (being able to operate "make" and a C
-       compiler)
-      </simpara>
-     </listitem> 
-     <listitem>
-      <simpara>
-       An ANSI C compiler
-      </simpara>
-     </listitem> 
-     <listitem>
-      <simpara>
-       A web server
-      </simpara>
-     </listitem>
-     <listitem>
-      <simpara>
-       Any module specific components (such as <acronym>GD</acronym>,
-       <acronym>PDF</acronym> libs, etc.)
-      </simpara>
-     </listitem>
-    </itemizedlist>
+    PHP can also be installed as a component of some third-party application
+    servers<!-- such as FrankenPHP and Open Swoole-->.
    </para>
-
    <para>
-    When building directly from Git sources or after custom modifications you
-    might also need:
-    <itemizedlist>
-     <listitem>
-      <simpara>
-       autoconf:
-      </simpara>
-      <itemizedlist>
-       <listitem>
-        <simpara>
-         PHP 7.3 and later: 2.68+
-        </simpara>
-       </listitem>
-       <listitem>
-        <simpara>
-         PHP 7.2: 2.64+
-        </simpara>
-       </listitem>
-       <listitem>
-        <simpara>
-         PHP 7.1 and earlier: 2.59+
-        </simpara>
-       </listitem>
-      </itemizedlist>
-     </listitem>
-     <listitem>
-      <simpara>
-       automake: 1.4+
-      </simpara>
-     </listitem>
-     <listitem>
-      <simpara>
-       libtool: 1.4.x+ (except 1.4.2)
-      </simpara>
-     </listitem>
-     <listitem>
-      <simpara>
-       re2c:
-      </simpara>
-      <itemizedlist>
-       <listitem>
-        <simpara>
-         PHP 8.3 and later: 1.0.3+
-        </simpara>
-       </listitem>
-       <listitem>
-        <simpara>
-         PHP 8.2 and earlier: 0.13.4+
-        </simpara>
-       </listitem>
-      </itemizedlist>
-     </listitem>
-     <listitem>
-      <simpara>
-       bison:
-      </simpara>
-      <itemizedlist>
-       <listitem>
-        <simpara>
-         PHP 7.4 and later: 3.0.0+
-        </simpara>
-       </listitem>
-       <listitem>
-        <simpara>
-         PHP 7.3 and earlier: 2.4+ (including Bison 3.x)
-        </simpara>
-       </listitem>
-      </itemizedlist>
-     </listitem>
-    </itemizedlist>
+    Finally, PHP can always be installed from the source distributions, which
+    allows the greatest flexibility in choosing what features, extensions, and
+    server APIs to enable. There are sections with information about
+    compiling and configuring PHP to use with different server APIs in
+    particular.
    </para>
    
-   <para>
-    The initial PHP setup and configuration process is controlled by the
-    use of the command line options of the <command>configure</command>
-    script. You could get a list of all available options along with short
-    explanations running <command>./configure --help</command>.
-    Our manual documents the different options separately. You will
-    find the <link linkend="configure.about">core options in the appendix</link>,
-    while the different extension specific options are described on the
-    reference pages.
-   </para>
-    
-   <para>
-    When PHP is configured, you are ready to build the module and/or
-    executables. The command <command>make</command> should
-    take care of this. If it fails and you can't figure out why, see
-    the <link linkend="install.problems">Problems section</link>.
-   </para>
-
-   <note>
-    <para>
-     Some Unix systems (such as OpenBSD and SELinux) may disallow mapping pages
-     both writable and executable for security reasons, what is called PaX
-     MPROTECT or W^X violation protection. This kind of memory mapping is,
-     however, necessary for PCRE's JIT support, so either PHP has to be built
-     <link linkend="pcre.installation">without PCRE's JIT support</link>, or the
-     binary has to be whitelisted by any means provided by the system.
-    </para>
-   </note>
-
-   <note>
-    <simpara>
-     Cross-compiling for ARM with the Android toolchain is currently not supported.
-    </simpara>
-   </note>
-
+   <!-- distribution specific nodes -->
+   &install.unix.debian;
+   <!-- &install.unix.yum; -->
+   <!-- general from-source instructions -->
+   &install.unix.source;
    <!-- web server specific nodes -->
+   &install.unix.commandline;
    &install.unix.apache2;
    &install.unix.nginx;
    &install.unix.lighttpd-14;
    &install.unix.litespeed;
-   &install.unix.commandline;
    <!-- operating system specific nodes -->
    &install.unix.openbsd;
    &install.unix.solaris;
-   <!-- distribution specific nodes -->
-   &install.unix.debian;
    
   </chapter>
 

--- a/install/unix/index.xml
+++ b/install/unix/index.xml
@@ -28,6 +28,7 @@
    <!-- distribution specific nodes -->
    &install.unix.debian;
    &install.unix.dnf;
+   &install.unix.openbsd;
    <!-- general from-source instructions -->
    &install.unix.source;
    <!-- web server specific nodes -->
@@ -37,7 +38,6 @@
    &install.unix.lighttpd-14;
    &install.unix.litespeed;
    <!-- operating system specific nodes -->
-   &install.unix.openbsd;
    &install.unix.solaris;
    
   </chapter>

--- a/install/unix/index.xml
+++ b/install/unix/index.xml
@@ -1,47 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-  <chapter xml:id="install.unix" xmlns="http://docbook.org/ns/docbook">
-   <title>Installation on Unix systems</title>
-   <para>
-    Most Unix (and Linux) operating systems and distributions have a
-    packaged version of PHP and extensions available through their packaging
-    system. There are sections with basic information on installing
-    PHP using those systems.
-   </para>
-   <para>
-    For some distributions, there are also third-party repositories of
-    packages that generally include a wider variety of available versions and
-    extensions.
-   </para>
-   <para>
-    PHP can also be installed as a component of some third-party application
-    servers<!-- such as FrankenPHP and Open Swoole-->.
-   </para>
-   <para>
-    Finally, PHP can always be installed from the source distributions, which
-    allows the greatest flexibility in choosing what features, extensions, and
-    server APIs to enable. There are sections with information about
-    compiling and configuring PHP to use with different server APIs in
-    particular.
-   </para>
-   
-   <!-- distribution specific nodes -->
-   &install.unix.debian;
-   &install.unix.dnf;
-   &install.unix.openbsd;
-   <!-- general from-source instructions -->
-   &install.unix.source;
-   <!-- web server specific nodes -->
-   &install.unix.commandline;
-   &install.unix.apache2;
-   &install.unix.nginx;
-   &install.unix.lighttpd-14;
-   &install.unix.litespeed;
-   <!-- operating system specific nodes -->
-   &install.unix.solaris;
-   
-  </chapter>
+<chapter xml:id="install.unix" xmlns="http://docbook.org/ns/docbook">
+ <title>Installation on Unix systems</title>
+ <simpara>
+  Most Unix (and Linux) operating systems and distributions have a packaged
+  version of PHP and extensions available through their packaging system.
+  There are sections with basic information on installing PHP using those
+  systems.
+ </simpara>
+ <simpara>
+  For some distributions, there are also third-party repositories of packages
+  that generally include a wider variety of available versions and extensions.
+ </simpara>
+ <simpara>
+  PHP can also be installed as a component of some third-party application
+  servers <!-- such as FrankenPHP and Open Swoole-->.
+ </simpara>
+ <simpara>
+  Finally, PHP can always be installed from the source distributions, which
+  allows the greatest flexibility in choosing what features, extensions, and
+  server APIs to enable.
+  There are sections with information about compiling and configuring PHP to
+  use with different server APIs in particular.
+ </simpara>
 
+ <!-- distribution specific nodes -->
+ &install.unix.debian;
+ &install.unix.dnf;
+ &install.unix.openbsd;
+ <!-- general from-source instructions -->
+ &install.unix.source;
+ <!-- web server specific nodes -->
+ &install.unix.commandline;
+ &install.unix.apache2;
+ &install.unix.nginx;
+ &install.unix.lighttpd-14;
+ &install.unix.litespeed;
+ <!-- operating system specific nodes -->
+ &install.unix.solaris;
+
+</chapter>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/install/unix/openbsd.xml
+++ b/install/unix/openbsd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <sect1 xml:id="install.unix.openbsd" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>OpenBSD installation notes</title>
+ <title>Installing from packages or ports on OpenBSD</title>
  <para>
  This section contains notes and hints specific to installing
  PHP on <link xlink:href="&url.openbsd;">OpenBSD</link>.

--- a/install/unix/source.xml
+++ b/install/unix/source.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<sect1 xml:id="install.unix.source" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Installing from source on Unix and macOS systems</title>
+
+   <para>
+    Prerequisite knowledge and software for compiling:
+    <itemizedlist>
+     <listitem>
+      <simpara>
+       Basic Unix skills (being able to operate "make" and a C
+       compiler)
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       An ANSI C compiler
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       A web server
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       Any module specific components (such as <acronym>GD</acronym>,
+       <acronym>PDF</acronym> libs, etc.)
+      </simpara>
+     </listitem>
+    </itemizedlist>
+   </para>
+
+   <para>
+    When building directly from Git sources or after custom modifications you
+    might also need:
+    <itemizedlist>
+     <listitem>
+      <simpara>
+       autoconf:
+      </simpara>
+      <itemizedlist>
+       <listitem>
+        <simpara>
+         PHP 7.3 and later: 2.68+
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         PHP 7.2: 2.64+
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         PHP 7.1 and earlier: 2.59+
+        </simpara>
+       </listitem>
+      </itemizedlist>
+     </listitem>
+     <listitem>
+      <simpara>
+       automake: 1.4+
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       libtool: 1.4.x+ (except 1.4.2)
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       re2c:
+      </simpara>
+      <itemizedlist>
+       <listitem>
+        <simpara>
+         PHP 8.3 and later: 1.0.3+
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         PHP 8.2 and earlier: 0.13.4+
+        </simpara>
+       </listitem>
+      </itemizedlist>
+     </listitem>
+     <listitem>
+      <simpara>
+       bison:
+      </simpara>
+      <itemizedlist>
+       <listitem>
+        <simpara>
+         PHP 7.4 and later: 3.0.0+
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         PHP 7.3 and earlier: 2.4+ (including Bison 3.x)
+        </simpara>
+       </listitem>
+      </itemizedlist>
+     </listitem>
+    </itemizedlist>
+   </para>
+
+   <para>
+    The initial PHP setup and configuration process is controlled by the
+    use of the command line options of the <command>configure</command>
+    script. You could get a list of all available options along with short
+    explanations running <command>./configure --help</command>.
+    Our manual documents the different options separately. You will
+    find the <link linkend="configure.about">core options in the appendix</link>,
+    while the different extension specific options are described on the
+    reference pages.
+   </para>
+
+   <para>
+    When PHP is configured, you are ready to build the module and/or
+    executables. The command <command>make</command> should
+    take care of this. If it fails and you can't figure out why, see
+    the <link linkend="install.problems">Problems section</link>.
+   </para>
+
+   <note>
+    <para>
+     Some Unix systems (such as OpenBSD and SELinux) may disallow mapping pages
+     both writable and executable for security reasons, what is called PaX
+     MPROTECT or W^X violation protection. This kind of memory mapping is,
+     however, necessary for PCRE's JIT support, so either PHP has to be built
+     <link linkend="pcre.installation">without PCRE's JIT support</link>, or the
+     binary has to be whitelisted by any means provided by the system.
+    </para>
+   </note>
+
+   <note>
+    <simpara>
+     Cross-compiling for ARM with the Android toolchain is currently not supported.
+    </simpara>
+   </note>
+</sect1>

--- a/install/unix/source.xml
+++ b/install/unix/source.xml
@@ -2,109 +2,111 @@
 <!-- $Revision$ -->
 <sect1 xml:id="install.unix.source" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Installing from source on Unix and macOS systems</title>
-  <para>
-   Prerequisite knowledge and software for compiling:
-   <simplelist>
-    <member>
-     Basic Unix skills (being able to operate <command>make</command> and a C
-     compiler)
-    </member>
-    <member>
-     A C compiler (as of PHP 8.0.0, C99 compatibility is assumed)
-    </member>
-    <member>
-     A web server
-    </member>
-    <member>
-     Any module specific components (such as <acronym>GD</acronym>,
-     <acronym>PDF</acronym> libs, etc.)
-    </member>
-   </simplelist>
-  </para>
+ <para>
+  Prerequisite knowledge and software for compiling:
+  <simplelist>
+   <member>
+    Basic Unix skills (being able to operate <command>make</command> and a C
+    compiler)
+   </member>
+   <member>
+    A C compiler (as of PHP 8.0.0, C99 compatibility is assumed)
+   </member>
+   <member>
+    A web server
+   </member>
+   <member>
+    Any module specific components (such as <acronym>GD</acronym>,
+    <acronym>PDF</acronym> libs, etc.)
+   </member>
+  </simplelist>
+ </para>
 
-  <para>
-   When building directly from Git sources or after custom modifications,
-   these additional tools may be necessary:
-   <itemizedlist>
-    <listitem>
-     <simpara>
-      autoconf:
-     </simpara>
-     <simplelist>
-      <member>
-       PHP 7.3 and later: 2.68+
-      </member>
-      <member>
-       PHP 7.2: 2.64+
-      </member>
-      <member>
-       PHP 7.1 and earlier: 2.59+
-      </member>
-     </simplelist>
-    </listitem>
-    <listitem>
-     <simpara>
-      re2c:
-     </simpara>
-     <simplelist>
-      <member>
-       PHP 8.3 and later: 1.0.3+
-      </member>
-      <member>
-       PHP 8.2 and earlier: 0.13.4+
-      </member>
-     </simplelist>
-    </listitem>
-    <listitem>
-     <simpara>
-      bison:
-     </simpara>
-     <simplelist>
-      <member>
-       PHP 7.4 and later: 3.0.0+
-      </member>
-      <member>
-       PHP 7.3 and earlier: 2.4+ (including Bison 3.x)
-      </member>
-     </simplelist>
-    </listitem>
-   </itemizedlist>
-  </para>
+ <para>
+  When building directly from Git sources or after custom modifications,
+  these additional tools may be necessary:
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     autoconf:
+    </simpara>
+    <simplelist>
+     <member>
+      PHP 7.3 and later: 2.68+
+     </member>
+     <member>
+      PHP 7.2: 2.64+
+     </member>
+     <member>
+      PHP 7.1 and earlier: 2.59+
+     </member>
+    </simplelist>
+   </listitem>
+   <listitem>
+    <simpara>
+     re2c:
+    </simpara>
+    <simplelist>
+     <member>
+      PHP 8.3 and later: 1.0.3+
+     </member>
+     <member>
+      PHP 8.2 and earlier: 0.13.4+
+     </member>
+    </simplelist>
+   </listitem>
+   <listitem>
+    <simpara>
+     bison:
+    </simpara>
+    <simplelist>
+     <member>
+      PHP 7.4 and later: 3.0.0+
+     </member>
+     <member>
+      PHP 7.3 and earlier: 2.4+ (including Bison 3.x)
+     </member>
+    </simplelist>
+   </listitem>
+  </itemizedlist>
+ </para>
 
-  <para>
-   The initial PHP setup and configuration process is controlled by the
-   use of the command line options of the <command>configure</command>
-   script. A list of available options along with short explanations can
-   be shown by running <command>./configure --help</command>.
-   Our manual documents the different options separately. You will
-   find the <link linkend="configure.about">core options in the appendix</link>,
-   while the different extension specific options are described on the
-   reference pages.
-  </para>
+ <simpara>
+  The initial PHP setup and configuration process is controlled by the
+  use of the command line options of the <command>configure</command>
+  script. A list of available options along with short explanations can
+  be shown by running <command>./configure --help</command>.
+  This manual documents the different options separately.
+  The <link linkend="configure.about">core options can be found in the
+  appendix</link>, while the different extension specific options are
+  described on the reference pages.
+ </simpara>
 
-  <para>
-   When PHP is configured, you are ready to build the module and/or
-   executables. The command <command>make</command> should
-   take care of this. If it fails and you can't figure out why, see
-   the <link linkend="install.problems">Problems section</link>.
-  </para>
+ <simpara>
+  After the configuration script was been run, PHP can be built using
+  the <command>make</command> command.
+  The <link linkend="install.problems">Problems section of this
+  manual</link> has further information about how to handle build
+  problems.
+ </simpara>
 
-  <note>
-   <para>
-    Some Unix systems (such as OpenBSD and SELinux) may disallow mapping pages
-    both writable and executable for security reasons, what is called
-    <link xlink:href="https://en.wikibooks.org/wiki/Grsecurity/Appendix/Grsecurity_and_PaX_Configuration_Options#Restrict_mprotect()">PaX
-    MPROTECT</link> or <link xlink:href="https://en.wikipedia.org/wiki/W%5EX">W^X
-    violation protection</link>. This kind of memory mapping is necessary for
-    PCRE's JIT support, so either PHP has to be built
-    <link linkend="pcre.installation">without PCRE's JIT support</link>, or the
-    binary has to be whitelisted by any means provided by the system.
-   </para>
-  </note>
+ <note>
+  <simpara>
+   Some Unix systems (such as OpenBSD and SELinux) may disallow mapping
+   pages both writable and executable for security reasons, what is called
+   <link xlink:href="&url.install.unix.pax-mprotect;">PaX MPROTECT</link>
+   or <link xlink:href="&url.install.unix.w-x-violation;">W^X violation
+   protection</link>.
+   This kind of memory mapping is necessary for PCRE's JIT support, so
+   either PHP has to be built <link linkend="pcre.installation">without
+   PCRE's JIT support</link>, or the binary has to be whitelisted by
+   any means provided by the system.
+  </simpara>
+ </note>
 
-  <note>
-   <simpara>
-    Cross-compiling for ARM with the Android toolchain is currently not supported.
-   </simpara>
-  </note>
+ <note>
+  <simpara>
+   Cross-compiling for ARM with the Android toolchain is currently not supported.
+  </simpara>
+ </note>
 </sect1>

--- a/install/unix/source.xml
+++ b/install/unix/source.xml
@@ -14,7 +14,7 @@
      </listitem>
      <listitem>
       <simpara>
-       An ANSI C compiler
+       An ANSI C compiler (as of PHP 8.0.0, C99 compatibility is assumed)
       </simpara>
      </listitem>
      <listitem>
@@ -56,16 +56,6 @@
         </simpara>
        </listitem>
       </itemizedlist>
-     </listitem>
-     <listitem>
-      <simpara>
-       automake: 1.4+
-      </simpara>
-     </listitem>
-     <listitem>
-      <simpara>
-       libtool: 1.4.x+ (except 1.4.2)
-      </simpara>
      </listitem>
      <listitem>
       <simpara>

--- a/install/unix/source.xml
+++ b/install/unix/source.xml
@@ -3,11 +3,10 @@
 <sect1 xml:id="install.unix.source" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Installing from source on Unix and macOS systems</title>
  <para>
-  Prerequisite knowledge and software for compiling:
+  Prerequisite software for compiling:
   <simplelist>
    <member>
-    Basic Unix skills (being able to operate <command>make</command> and a C
-    compiler)
+    <link xlink:href="&url.gnu.make;">GNU <command>make</command></link>
    </member>
    <member>
     A C compiler (as of PHP 8.0.0, C99 compatibility is assumed)
@@ -28,7 +27,7 @@
   <itemizedlist>
    <listitem>
     <simpara>
-     autoconf:
+     <link xlink:href="&url.gnu.autoconf;">autoconf</link>:
     </simpara>
     <simplelist>
      <member>
@@ -44,7 +43,7 @@
    </listitem>
    <listitem>
     <simpara>
-     re2c:
+     <link xlink:href="&url.re2c;">re2c</link>:
     </simpara>
     <simplelist>
      <member>
@@ -57,7 +56,7 @@
    </listitem>
    <listitem>
     <simpara>
-     bison:
+     <link xlink:href="&url.bison;">bison</link>:
     </simpara>
     <simplelist>
      <member>

--- a/install/unix/source.xml
+++ b/install/unix/source.xml
@@ -2,130 +2,109 @@
 <!-- $Revision$ -->
 <sect1 xml:id="install.unix.source" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Installing from source on Unix and macOS systems</title>
+  <para>
+   Prerequisite knowledge and software for compiling:
+   <simplelist>
+    <member>
+     Basic Unix skills (being able to operate <command>make</command> and a C
+     compiler)
+    </member>
+    <member>
+     A C compiler (as of PHP 8.0.0, C99 compatibility is assumed)
+    </member>
+    <member>
+     A web server
+    </member>
+    <member>
+     Any module specific components (such as <acronym>GD</acronym>,
+     <acronym>PDF</acronym> libs, etc.)
+    </member>
+   </simplelist>
+  </para>
 
+  <para>
+   When building directly from Git sources or after custom modifications,
+   these additional tools may be necessary:
+   <itemizedlist>
+    <listitem>
+     <simpara>
+      autoconf:
+     </simpara>
+     <simplelist>
+      <member>
+       PHP 7.3 and later: 2.68+
+      </member>
+      <member>
+       PHP 7.2: 2.64+
+      </member>
+      <member>
+       PHP 7.1 and earlier: 2.59+
+      </member>
+     </simplelist>
+    </listitem>
+    <listitem>
+     <simpara>
+      re2c:
+     </simpara>
+     <simplelist>
+      <member>
+       PHP 8.3 and later: 1.0.3+
+      </member>
+      <member>
+       PHP 8.2 and earlier: 0.13.4+
+      </member>
+     </simplelist>
+    </listitem>
+    <listitem>
+     <simpara>
+      bison:
+     </simpara>
+     <simplelist>
+      <member>
+       PHP 7.4 and later: 3.0.0+
+      </member>
+      <member>
+       PHP 7.3 and earlier: 2.4+ (including Bison 3.x)
+      </member>
+     </simplelist>
+    </listitem>
+   </itemizedlist>
+  </para>
+
+  <para>
+   The initial PHP setup and configuration process is controlled by the
+   use of the command line options of the <command>configure</command>
+   script. A list of available options along with short explanations can
+   be shown by running <command>./configure --help</command>.
+   Our manual documents the different options separately. You will
+   find the <link linkend="configure.about">core options in the appendix</link>,
+   while the different extension specific options are described on the
+   reference pages.
+  </para>
+
+  <para>
+   When PHP is configured, you are ready to build the module and/or
+   executables. The command <command>make</command> should
+   take care of this. If it fails and you can't figure out why, see
+   the <link linkend="install.problems">Problems section</link>.
+  </para>
+
+  <note>
    <para>
-    Prerequisite knowledge and software for compiling:
-    <itemizedlist>
-     <listitem>
-      <simpara>
-       Basic Unix skills (being able to operate "make" and a C
-       compiler)
-      </simpara>
-     </listitem>
-     <listitem>
-      <simpara>
-       An ANSI C compiler (as of PHP 8.0.0, C99 compatibility is assumed)
-      </simpara>
-     </listitem>
-     <listitem>
-      <simpara>
-       A web server
-      </simpara>
-     </listitem>
-     <listitem>
-      <simpara>
-       Any module specific components (such as <acronym>GD</acronym>,
-       <acronym>PDF</acronym> libs, etc.)
-      </simpara>
-     </listitem>
-    </itemizedlist>
+    Some Unix systems (such as OpenBSD and SELinux) may disallow mapping pages
+    both writable and executable for security reasons, what is called
+    <link xlink:href="https://en.wikibooks.org/wiki/Grsecurity/Appendix/Grsecurity_and_PaX_Configuration_Options#Restrict_mprotect()">PaX
+    MPROTECT</link> or <link xlink:href="https://en.wikipedia.org/wiki/W%5EX">W^X
+    violation protection</link>. This kind of memory mapping is necessary for
+    PCRE's JIT support, so either PHP has to be built
+    <link linkend="pcre.installation">without PCRE's JIT support</link>, or the
+    binary has to be whitelisted by any means provided by the system.
    </para>
+  </note>
 
-   <para>
-    When building directly from Git sources or after custom modifications you
-    might also need:
-    <itemizedlist>
-     <listitem>
-      <simpara>
-       autoconf:
-      </simpara>
-      <itemizedlist>
-       <listitem>
-        <simpara>
-         PHP 7.3 and later: 2.68+
-        </simpara>
-       </listitem>
-       <listitem>
-        <simpara>
-         PHP 7.2: 2.64+
-        </simpara>
-       </listitem>
-       <listitem>
-        <simpara>
-         PHP 7.1 and earlier: 2.59+
-        </simpara>
-       </listitem>
-      </itemizedlist>
-     </listitem>
-     <listitem>
-      <simpara>
-       re2c:
-      </simpara>
-      <itemizedlist>
-       <listitem>
-        <simpara>
-         PHP 8.3 and later: 1.0.3+
-        </simpara>
-       </listitem>
-       <listitem>
-        <simpara>
-         PHP 8.2 and earlier: 0.13.4+
-        </simpara>
-       </listitem>
-      </itemizedlist>
-     </listitem>
-     <listitem>
-      <simpara>
-       bison:
-      </simpara>
-      <itemizedlist>
-       <listitem>
-        <simpara>
-         PHP 7.4 and later: 3.0.0+
-        </simpara>
-       </listitem>
-       <listitem>
-        <simpara>
-         PHP 7.3 and earlier: 2.4+ (including Bison 3.x)
-        </simpara>
-       </listitem>
-      </itemizedlist>
-     </listitem>
-    </itemizedlist>
-   </para>
-
-   <para>
-    The initial PHP setup and configuration process is controlled by the
-    use of the command line options of the <command>configure</command>
-    script. You could get a list of all available options along with short
-    explanations running <command>./configure --help</command>.
-    Our manual documents the different options separately. You will
-    find the <link linkend="configure.about">core options in the appendix</link>,
-    while the different extension specific options are described on the
-    reference pages.
-   </para>
-
-   <para>
-    When PHP is configured, you are ready to build the module and/or
-    executables. The command <command>make</command> should
-    take care of this. If it fails and you can't figure out why, see
-    the <link linkend="install.problems">Problems section</link>.
-   </para>
-
-   <note>
-    <para>
-     Some Unix systems (such as OpenBSD and SELinux) may disallow mapping pages
-     both writable and executable for security reasons, what is called PaX
-     MPROTECT or W^X violation protection. This kind of memory mapping is,
-     however, necessary for PCRE's JIT support, so either PHP has to be built
-     <link linkend="pcre.installation">without PCRE's JIT support</link>, or the
-     binary has to be whitelisted by any means provided by the system.
-    </para>
-   </note>
-
-   <note>
-    <simpara>
-     Cross-compiling for ARM with the Android toolchain is currently not supported.
-    </simpara>
-   </note>
+  <note>
+   <simpara>
+    Cross-compiling for ARM with the Android toolchain is currently not supported.
+   </simpara>
+  </note>
 </sect1>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2411,6 +2411,15 @@ threaded MPM in production with Apache 2. Use the prefork MPM, which is
 the default MPM with Apache 2.0 and 2.2.
 For information on why, read the related FAQ entry on using
 <link linkend="faq.installation.apache2">Apache2 with a threaded MPM</link></para></warning>'>
+<!ENTITY warn.install.third-party-support '<warning xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <para>
+   Builds from third-parties are considered unofficial and not directly
+   supported by the PHP project. Any bugs encountered should be reported to the
+   provider of those unofficial builds unless they can be reproduced using the
+   builds from <link xlink:href="&url.php.downloads;">the official download
+   area</link>.
+  </para>
+ </warning>'>
 
 <!ENTITY note.apache.slashes '<note xmlns="http://docbook.org/ns/docbook"><simpara>Remember that when adding
 path values in the Apache configuration files on Windows, all backslashes

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2412,14 +2412,14 @@ the default MPM with Apache 2.0 and 2.2.
 For information on why, read the related FAQ entry on using
 <link linkend="faq.installation.apache2">Apache2 with a threaded MPM</link></para></warning>'>
 <!ENTITY warn.install.third-party-support '<warning xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <para>
-   Builds from third-parties are considered unofficial and not directly
-   supported by the PHP project. Any bugs encountered should be reported to the
-   provider of those unofficial builds unless they can be reproduced using the
-   builds from <link xlink:href="&url.php.downloads;">the official download
-   area</link>.
-  </para>
- </warning>'>
+ <para>
+  Builds from third-parties are considered unofficial and not directly
+  supported by the PHP project. Any bugs encountered should be reported to the
+  provider of those unofficial builds unless they can be reproduced using the
+  builds from <link xlink:href="&url.php.downloads;">the official download
+  area</link>.
+ </para>
+</warning>'>
 
 <!ENTITY note.apache.slashes '<note xmlns="http://docbook.org/ns/docbook"><simpara>Remember that when adding
 path values in the Apache configuration files on Windows, all backslashes


### PR DESCRIPTION
Trying to put more emphasis/information on how to install from packages (either from distributions or third parties) and for Unix, in particular, move the stuff about compiling from source down a level so new users don't get knocked in the face with it.