### PR TITLE
Add explicit warning about CSV function's escape parameter

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1062,12 +1062,12 @@ purposes.</simpara></warning>'>
 
 <!-- CSV -->
 <!ENTITY warning.csv.escape-parameter '<warning xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"><simpara>
-When the <parameter>escape</parameter> is set to anything other than an empty string
-(<literal>""</literal>) it can result in CSV that is not compliant with
-<link xlink:href="&url.rfc;4180">RFC 4180</link> or unable to survive a roundtrip
-through the PHP CSV functions. The default for <parameter>escape</parameter> is "\\"
-so it is recommended to set it to the empty string explicitly. The default value
-will change in a future version of PHP, no earlier than PHP 9.0.
+ When <parameter>escape</parameter> is set to anything other than an empty string
+ (<literal>""</literal>) it can result in CSV that is not compliant with
+ <link xlink:href="&url.rfc;4180">RFC 4180</link> or unable to survive a roundtrip
+ through the PHP CSV functions. The default for <parameter>escape</parameter> is
+ <literal>"\\"</literal> so it is recommended to set it to the empty string explicitly.
+ The default value will change in a future version of PHP, no earlier than PHP 9.0.
 </simpara></warning>'>
 
 <!-- DBM notes -->

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1060,6 +1060,16 @@ purposes.</simpara></warning>'>
  </entry>
 </row>'>
 
+<!-- CSV -->
+<!ENTITY warning.csv.escape-parameter '<warning xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"><simpara>
+When the <parameter>escape</parameter> is set to anything other than an empty string
+(<literal>""</literal>) it can result in CSV that is not compliant with
+<link xlink:href="&url.rfc;4180">RFC 4180</link> or unable to survive a roundtrip
+through the PHP CSV functions. The default for <parameter>escape</parameter> is "\\"
+so it is recommended to set it to the empty string explicitly. The default value
+will change in a future version of PHP, no earlier than PHP 9.0.
+</simpara></warning>'>
+
 <!-- DBM notes -->
 
 <!ENTITY dbm.dbm-identifier.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>

--- a/reference/filesystem/functions/fgetcsv.xml
+++ b/reference/filesystem/functions/fgetcsv.xml
@@ -100,6 +100,7 @@
     </varlistentry>
    </variablelist>
   </para>
+  &warning.csv.escape-parameter;
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/filesystem/functions/fputcsv.xml
+++ b/reference/filesystem/functions/fputcsv.xml
@@ -81,6 +81,7 @@
     </varlistentry>
    </variablelist>
   </para>
+  &warning.csv.escape-parameter;
   <note>
    <para>
     If an <parameter>enclosure</parameter> character is contained in a field,

--- a/reference/spl/splfileobject/fgetcsv.xml
+++ b/reference/spl/splfileobject/fgetcsv.xml
@@ -69,6 +69,7 @@
     </varlistentry>
    </variablelist>
   </para>
+  &warning.csv.escape-parameter;
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/spl/splfileobject/fputcsv.xml
+++ b/reference/spl/splfileobject/fputcsv.xml
@@ -70,6 +70,7 @@
     </listitem>
    </varlistentry>
   </variablelist>
+  &warning.csv.escape-parameter;
   <note>
    <para>
     If an <parameter>enclosure</parameter> character is contained in a field,

--- a/reference/spl/splfileobject/setcsvcontrol.xml
+++ b/reference/spl/splfileobject/setcsvcontrol.xml
@@ -50,6 +50,7 @@
     </varlistentry>
    </variablelist>
   </para>
+  &warning.csv.escape-parameter;
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/strings/functions/str-getcsv.xml
+++ b/reference/strings/functions/str-getcsv.xml
@@ -21,6 +21,7 @@
    Parses a string input for fields in <acronym>CSV</acronym> format
    and returns an array containing the fields read.
   </para>
+  &warning.csv.escape-parameter;
   <note>
    <para>
     The locale settings are taken into account by this function. If

--- a/reference/strings/functions/str-getcsv.xml
+++ b/reference/strings/functions/str-getcsv.xml
@@ -21,7 +21,6 @@
    Parses a string input for fields in <acronym>CSV</acronym> format
    and returns an array containing the fields read.
   </para>
-  &warning.csv.escape-parameter;
   <note>
    <para>
     The locale settings are taken into account by this function. If
@@ -83,6 +82,7 @@
     </varlistentry>
    </variablelist>
   </para>
+  &warning.csv.escape-parameter;
  </refsect1>
 
  <refsect1 role="returnvalues">


### PR DESCRIPTION
The escape parameter is kind of a mess and the default is changing, so this adds a warning about it with an explicit recommendation to set it to the empty string instead of relying on the default that is in the process of being changed/deprecated.