### PR TITLE
strncmp: Correct minor typo in example

### DIFF
--- a/reference/strings/functions/strncmp.xml
+++ b/reference/strings/functions/strncmp.xml
@@ -95,7 +95,7 @@
 $var1 = 'Hello John';
 $var2 = 'Hello Doe';
 if (strncmp($var1, $var2, 5) === 0) {
-    echo 'First 5 characters of $var1 and $var2 are equals in a case-sensitive string comparison';
+    echo 'First 5 characters of $var1 and $var2 are equal in a case-sensitive string comparison';
 }
 ?>
 ]]>


### PR DESCRIPTION
`are equals` vs `are equal`