### PR TITLE
reference/pcntl: Fix `pcntl_strerror($error_code)` parameter name

### DIFF
--- a/reference/pcntl/functions/pcntl-strerror.xml
+++ b/reference/pcntl/functions/pcntl-strerror.xml
@@ -10,12 +10,12 @@
   &reftitle.description;
   <methodsynopsis>
    <type>string</type><methodname>pcntl_strerror</methodname>
-   <methodparam><type>int</type><parameter>error_number</parameter></methodparam>
+   <methodparam><type>int</type><parameter>error_code</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Returns the system error message associated with the given <parameter>error_number</parameter>
+   Returns the system error message associated with the given <parameter>error_code</parameter>
    (<literal>errno</literal>) of the last pcntl function that failed.
-   The <parameter>error_number</parameter> parameter may be obtained by calling
+   The <parameter>error_code</parameter> parameter may be obtained by calling
    <function>pcntl_get_last_error</function>.
   </para>
 
@@ -25,7 +25,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>error_number</parameter></term>
+    <term><parameter>error_code</parameter></term>
     <listitem>
      <para>
       An error number (<literal>errno</literal>),


### PR DESCRIPTION
The doc uses `error_number` as the first parameter to the `pcntl_strerror` function. However, `php-src` name for this parameter is `error_code`[^1], and it has always been[^2] `error_code`

[^1]: https://github.com/php/php-src/blob/php-8.4.0beta5/ext/pcntl/pcntl.stub.php#L1075
[^2]: https://github.com/php/php-src/blob/PHP-8.0/ext/pcntl/pcntl.stub.php#L75