### PR TITLE
reference/pcntl: Fix `pcntl_waitid(,,$info)` parameter name

### DIFF
--- a/reference/pcntl/functions/pcntl-waitid.xml
+++ b/reference/pcntl/functions/pcntl-waitid.xml
@@ -12,7 +12,7 @@
    <type>bool</type><methodname>pcntl_waitid</methodname>
    <methodparam choice="opt"><type>int</type><parameter>idtype</parameter><initializer>P_ALL</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>id</parameter><initializer>null</initializer></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter role="reference">siginfo</parameter><initializer>[]</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">info</parameter><initializer>[]</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>WEXITED</initializer></methodparam>
   </methodsynopsis>
   <para>
@@ -167,14 +167,14 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>siginfo</parameter></term>
+    <term><parameter>info</parameter></term>
     <listitem>
      <para>
-      The <parameter>siginfo</parameter> parameter is set to an array
+      The <parameter>info</parameter> parameter is set to an array
       containing information about the signal.
      </para>
      <para>
-      <parameter>siginfo</parameter> array may contain the following keys:
+      <parameter>info</parameter> array may contain the following keys:
       <simplelist>
        <member><literal>signo</literal>: Signal number</member>
        <member><literal>errno</literal>: System error number</member>
@@ -224,7 +224,7 @@
           <entry><constant>WNOWAIT</constant></entry>
           <entry>
            Keep the process whose status is returned in
-           <parameter>siginfo</parameter> in a waitable state. This shall not
+           <parameter>info</parameter> in a waitable state. This shall not
            affect the state of the process; the process may be waited for again
            after this call completes.
           </entry>


### PR DESCRIPTION
The doc uses `siginfo` as the third parameter name to the `pcntl_waitid` function. However, `php-src` name for this parameter is `info`[^1].

[^1]: https://github.com/php/php-src/blob/php-8.4.0beta5/ext/pcntl/pcntl.stub.php#L1010