### PR TITLE
Add titleabbrev+title to preface and reformat info box

### DIFF
--- a/preface.xml
+++ b/preface.xml
@@ -2,20 +2,21 @@
 <!-- $Revision$ -->
 
 <preface xml:id="preface" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook">
- <info><title>Preface</title>
- <abstract>
-  <simpara>
-   <acronym>PHP</acronym>, which stands for <emphasis>PHP: Hypertext
-   Preprocessor</emphasis>, is a widely-used open source general-purpose
-   scripting language that is especially suited for web
-   development and can be embedded into HTML. Its syntax draws
-   upon C, Java, and Perl, and is easy to learn. The main goal of
-   the language is to allow web developers to write dynamically
-   generated web pages quickly, but you can do much more with PHP.
-  </simpara>
- </abstract>
-</info>
-
+ <info>
+  <titleabbrev>Preface</titleabbrev>
+  <title>About this manual</title>
+  <abstract>
+   <simpara>
+    <acronym>PHP</acronym>, which stands for <emphasis>PHP: Hypertext
+    Preprocessor</emphasis>, is a widely-used open source general-purpose
+    scripting language that is especially suited for web
+    development and can be embedded into HTML. Its syntax draws
+    upon C, Java, and Perl, and is easy to learn. The main goal of
+    the language is to allow web developers to write dynamically
+    generated web pages quickly, but you can do much more with PHP.
+   </simpara>
+  </abstract>
+ </info>
  <para>
   This manual consists primarily of a <link linkend="funcref">
   function reference</link>, but also contains a 


### PR DESCRIPTION
Kind of a proof of concept for using titleabbrev+title for more sections so the front page of the manual isn't quite so sparse.