### PR TITLE
Fix #3241

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1510,7 +1510,7 @@ var_export($fn(5)(10));
 <?php
 
 fn(array $x) => $x;
-static fn(): int => $x;
+static fn($x): int => $x;
 fn($x = 42) => $x;
 fn(&$x) => $x;
 fn&($x) => $x;


### PR DESCRIPTION
Update arrow function example to include missing parameter.

The example code would only be valid if `$x` were to be declared previously, but that doesn't happen in this example, nor is consistent with the other examples.