### PR TITLE
Update and fix docs for openssl_open and openssl_seal

### DIFF
--- a/reference/openssl/functions/openssl-open.xml
+++ b/reference/openssl/functions/openssl-open.xml
@@ -18,14 +18,13 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>iv</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>openssl_open</function> opens (decrypts)
-   <parameter>data</parameter> using the private key associated with
-   the key identifier <parameter>private_key</parameter> and the envelope key
-   <parameter>encrypted_key</parameter>, and fills
-   <parameter>output</parameter> with the decrypted data.
-   The envelope key is generated when the
-   data are sealed and can only be used by one specific private key. See
-   <function>openssl_seal</function> for more information.
+   <function>openssl_open</function> opens (decrypts) <parameter>data</parameter> using an envelope
+   key that is decrypted from <parameter>encrypted_key</parameter> using
+   <parameter>private_key</parameter>. The decryption is done using
+   <parameter>cipher_algo</parameter> and <parameter>iv</parameter>. The IV is required only if the
+   cipher method requires it. The function fills <parameter>output</parameter> with the decrypted
+   data. The envelope key is usually generated when the data are sealed using a public key that is
+   associated with the private key. See <function>openssl_seal</function> for more information.
   </para>
  </refsect1>
 
@@ -37,6 +36,7 @@
      <term><parameter>data</parameter></term>
      <listitem>
       <para>
+       The sealed data.
       </para>
      </listitem>
     </varlistentry>
@@ -44,8 +44,7 @@
      <term><parameter>output</parameter></term>
      <listitem>
       <para>
-       If the call is successful the opened data is returned in this
-       parameter.
+       If the call is successful the opened data is returned in this parameter.
       </para>
      </listitem>
     </varlistentry>
@@ -53,6 +52,7 @@
      <term><parameter>encrypted_key</parameter></term>
      <listitem>
       <para>
+       The encrypted symmetric key that can be decrypted using <parameter>private_key</parameter>.
       </para>
      </listitem>
     </varlistentry>
@@ -60,6 +60,7 @@
      <term><parameter>private_key</parameter></term>
      <listitem>
       <para>
+       The private key used for decrypting <parameter>encrypted_key</parameter>.
       </para>
      </listitem>
     </varlistentry>
@@ -67,11 +68,12 @@
      <term><parameter>cipher_algo</parameter></term>
      <listitem>
       <para>
-       The cipher method.
+       The cipher method used for decryption of <parameter>data</parameter>.
        <caution>
         <simpara>
-         The default value (<literal>'RC4'</literal>) is considered insecure.
-         It is strongly recommended to explicitly specify a secure cipher method.
+         The default value for PHP versions prior to 8.0 is (<literal>'RC4'</literal>) which is
+         considered insecure. It is strongly recommended to explicitly specify a secure cipher
+         method.
         </simpara>
        </caution>
       </para>
@@ -81,7 +83,9 @@
      <term><parameter>iv</parameter></term>
      <listitem>
       <para>
-       The initialization vector.
+       The initialization vector used for decryption of <parameter>data</parameter>. It is required
+       if the cipher method requires IV. This can be found out by calling
+       <function>openssl_cipher_iv_length</function> with <parameter>cipher_algo</parameter>.
       </para>
      </listitem>
     </varlistentry>
@@ -135,24 +139,18 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// $sealed and $env_key are assumed to contain the sealed data
-// and our envelope key, both given to us by the sealer.
+// $sealed, $env_key and $iv are assumed to contain the sealed data, our
+// envelope key and IV. All given to us by the sealer.
 
-// fetch private key from file and ready it
-$fp = fopen("/src/openssl-0.9.6/demos/sign/key.pem", "r");
-$priv_key = fread($fp, 8192);
-fclose($fp);
-$pkeyid = openssl_get_privatekey($priv_key);
+// fetch private key from file located in private_key.pem
+$pkey = openssl_get_privatekey("file://private_key.pem);
 
 // decrypt the data and store it in $open
-if (openssl_open($sealed, $open, $env_key, $pkeyid)) {
+if (openssl_open($sealed, $open, $env_key, $pkey, 'AES256', $iv)) {
     echo "here is the opened data: ", $open;
 } else {
     echo "failed to open data";
 }
-
-// free the private key from memory
-openssl_free_key($pkeyid);
 ?>
 ]]>
     </programlisting>

--- a/reference/openssl/functions/openssl-seal.xml
+++ b/reference/openssl/functions/openssl-seal.xml
@@ -18,15 +18,14 @@
    <methodparam choice="opt"><type>string</type><parameter role="reference">iv</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>openssl_seal</function> seals (encrypts)
-   <parameter>data</parameter> by using the given <parameter>cipher_algo</parameter> with a randomly generated
-   secret key. The key is encrypted with each of the public keys
-   associated with the identifiers in <parameter>public_key</parameter>
-   and each encrypted key is returned
-   in <parameter>encrypted_keys</parameter>. This means that one can send
-   sealed data to multiple recipients (provided one has obtained their
-   public keys). Each recipient must receive both the sealed data and
-   the envelope key that was encrypted with the recipient's public key.
+   <function>openssl_seal</function> seals (encrypts) <parameter>data</parameter> using the
+   specified <parameter>cipher_algo</parameter> with a randomly generated secret key. The key is
+   then encrypted with each of the public keys in <parameter>public_key</parameter> array,
+   and each encrypted envelope key is returned in <parameter>encrypted_keys</parameter>. This allows
+   sealed data to be sent to multiple recipients (provided their public keys are available). Each
+   recipient must receive both the sealed data and the envelope key that was encrypted with the
+   recipient's public key. The IV (Initialization Vector) is generated, and its value is returned in
+   <parameter>iv</parameter>.
   </para>
  </refsect1>
 
@@ -73,8 +72,9 @@
        The cipher method.
        <caution>
         <simpara>
-         The default value (<literal>'RC4'</literal>) is considered insecure.
-         It is strongly recommended to explicitly specify a secure cipher method.
+         The default value for PHP versions prior to 8.0 is (<literal>'RC4'</literal>) which is
+         considered insecure. It is strongly recommended to explicitly specify a secure cipher
+         method.
         </simpara>
        </caution>
       </para>
@@ -84,8 +84,16 @@
      <term><parameter>iv</parameter></term>
      <listitem>
       <para>
-       The initialization vector.
+       The initialization vector for decryption of <parameter>data</parameter>. It is required if
+       the cipher method requires IV. This can be found out by calling
+       <function>openssl_cipher_iv_length</function> with <parameter>cipher_algo</parameter>.
       </para>
+      <caution>
+       <simpara>
+        The IV cannot be set explicitly. Any value set in it is overwritten by randomly generated
+        value.
+       </simpara>
+      </caution>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -148,25 +156,18 @@
 <![CDATA[
 <?php
 // $data is assumed to contain the data to be sealed
+$data = "test";
 
-// fetch public keys for our recipients, and ready them
-$fp = fopen("/src/openssl-0.9.6/demos/maurice/cert.pem", "r");
-$cert = fread($fp, 8192);
-fclose($fp);
-$pk1 = openssl_get_publickey($cert);
-// Repeat for second recipient
-$fp = fopen("/src/openssl-0.9.6/demos/sign/cert.pem", "r");
-$cert = fread($fp, 8192);
-fclose($fp);
-$pk2 = openssl_get_publickey($cert);
+// fetch public keys
+$pk1 = openssl_get_publickey("file://cert1.pem");
+$pk2 = openssl_get_publickey("file://cert2.pem");
 
 // seal message, only owners of $pk1 and $pk2 can decrypt $sealed with keys
 // $ekeys[0] and $ekeys[1] respectively.
-openssl_seal($data, $sealed, $ekeys, array($pk1, $pk2));
-
-// free the keys from memory
-openssl_free_key($pk1);
-openssl_free_key($pk2);
+if (openssl_seal($data, $sealed, $ekeys, array($pk1, $pk2), 'AES256', $iv) > 0) {
+    // possibly store the $sealed and $iv values and use later in openssl_open
+    echo "success\n";
+}
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
The current docs for `openssl_seal` and `openssl_open` are outdated and incorrect in many places. This fixes the issues and makes them up to date with more info.