### PR TITLE
Add caution about using the same DH params in openssl_dh_compute_key

### DIFF
--- a/reference/openssl/functions/openssl-dh-compute-key.xml
+++ b/reference/openssl/functions/openssl-dh-compute-key.xml
@@ -18,6 +18,12 @@
    often used as an encryption key to secretly communicate with a remote party.
    This is known as the Diffie-Hellman key exchange.
   </para>
+  <caution>
+   <para>
+    It is important to use the same DH parameters for remote and local key pairs; otherwise, the
+    generated secret between the two parties will not match.
+   </para>
+  </caution>
   <note>
    <simpara>
     ECDH is only supported as of PHP 8.1.0 <emphasis>and</emphasis> OpenSSL 3.0.0.


### PR DESCRIPTION
Currently there is no warning that it requires using the same DH parameters.