### PR TITLE
Add caution about openssl_pkey_derive key_length parameter

### DIFF
--- a/reference/openssl/functions/openssl-pkey-derive.xml
+++ b/reference/openssl/functions/openssl-pkey-derive.xml
@@ -52,7 +52,7 @@
       <simpara>
        This parameter should not be used, as it does not work as expected. It never returns a secret
        longer than the size of the prime. If the desired length is smaller than the size of the
-       prime, it truncate the length only for ECDH keys but fails for DH keys.
+       prime, it truncates the length only for ECDH keys but fails for DH keys.
       </simpara>
      </caution>
     </listitem>

--- a/reference/openssl/functions/openssl-pkey-derive.xml
+++ b/reference/openssl/functions/openssl-pkey-derive.xml
@@ -46,8 +46,15 @@
     <term><parameter>key_length</parameter></term>
     <listitem>
      <para>
-      If not zero, will set the desired length of the derived secret.
+      If not zero, will attempt to set the desired length of the derived secret.
      </para>
+     <caution>
+      <simpara>
+       This parameter should not be used, as it does not work as expected. It never returns a secret
+       longer than the size of the prime. If the desired length is smaller than the size of the
+       prime, it truncate the length only for ECDH keys but fails for DH keys.
+      </simpara>
+     </caution>
     </listitem>
    </varlistentry>
   </variablelist>


### PR DESCRIPTION
We should probably deprecate that `key_length` in 8.5...