### PR TITLE
Update recommendations for openssl_pbkdf2

### DIFF
--- a/reference/openssl/functions/openssl-pbkdf2.xml
+++ b/reference/openssl/functions/openssl-pbkdf2.xml
@@ -38,7 +38,7 @@
     <term><parameter>salt</parameter></term>
     <listitem>
      <para>
-      PBKDF2 recommends a crytographic salt of at least 64 bits (8 bytes).
+      PBKDF2 recommends a crytographic salt of at least 128 bits (16 bytes).
      </para>
     </listitem>
    </varlistentry>
@@ -54,8 +54,10 @@
     <term><parameter>iterations</parameter></term>
     <listitem>
      <para>
-      The number of iterations desired. <link xlink:href="https://pages.nist.gov/800-63-3/sp800-63b.html#sec5">NIST
-      recommends at least 10,000</link>.
+      The number of iterations desired.
+      <link xlink:href="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-132.pdf">NIST
+       recommends at least 1,000</link>. As of 2023, OWASP recommends 600,000 iterations for
+      PBKDF2-HMAC-SHA256 and 210,000 for PBKDF2-HMAC-SHA512.
      </para>
     </listitem>
    </varlistentry>
@@ -63,7 +65,8 @@
     <term><parameter>digest_algo</parameter></term>
     <listitem>
      <para>
-      Optional hash or digest algorithm from <function>openssl_get_md_methods</function>.  Defaults to SHA-1.
+      Optional hash or digest algorithm from <function>openssl_get_md_methods</function>.  Defaults
+      to SHA-1. It is recommended to set it to SHA-256 or SHA-512.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
The current recommendation are out of date so this PR updates them.