### PR TITLE
Sync exif dependency on mbstring extension as optional

### DIFF
--- a/reference/exif/setup.xml
+++ b/reference/exif/setup.xml
@@ -13,11 +13,6 @@
    extension must be enabled by compiling PHP with <literal>--enable-mbstring</literal>.
    PHP does not require any additional library for the exif module.
   </para>
-  <para>
-   Windows only: The <link linkend="ref.mbstring">mbstring</link> extension must always
-   be enabled. Note that <link linkend="ref.mbstring">mbstring</link> extension must be
-   loaded prior to EXIF in <filename>php.ini</filename>.
-  </para>
  </section>
  <!-- }}} -->
 


### PR DESCRIPTION
The required dependency on mbstring extension in exif was removed via php/php-src@755c2cd0d85b65f35abb2d54204fa7d38b820268 which made the mbstring extension optional dependency.

Also the exif extension uses the `ZEND_MOD_OPTIONAL` to define the dependency on mbstring extension so it already loads the extensions in this case properly (meaning: there's no need to mention that mbstring must be loaded before the exif in php.ini).

Update for the PHP build system:
https://github.com/php/php-src/pull/16062