### PR TITLE
UTCDateTime supports Int64, deprecates string and float

### DIFF
--- a/reference/mongodb/bson/utcdatetime/construct.xml
+++ b/reference/mongodb/bson/utcdatetime/construct.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\BSON\UTCDateTime::__construct</methodname>
-   <methodparam choice="opt"><type class="union"><type>int</type><type>float</type><type>string</type><type>DateTimeInterface</type><type>null</type></type><parameter>milliseconds</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>float</type><type>string</type><type>MongoDB\BSON\Int64</type><type>DateTimeInterface</type><type>null</type></type><parameter>milliseconds</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
  </refsect1>
 
@@ -25,7 +25,7 @@
       Number of milliseconds since the Unix epoch (Jan 1, 1970). Negative values
       represent dates before 1970. This value may be provided as a 64-bit
       <type>int</type>. For compatibility on 32-bit systems, this parameter
-      may also be provided as a <type>float</type> or <type>string</type>.
+      may also be provided as a <classname>MongoDB\BSON\Int64</classname>.
      </para>
      <para>
       If the argument is a <classname>DateTimeInterface</classname>, the number
@@ -58,6 +58,17 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>PECL mongodb 1.20.0</entry>
+       <entry>
+        <para>
+         The <parameter>milliseconds</parameter> argument now accepts a
+         <classname>MongoDB\BSON\Int64</classname> object (for compatibility on
+         32-bit platforms). Specifying a <type>string</type> or
+         <type>float</type> is deprecated.
+        </para>
+       </entry>
+      </row>
       <row>
        <entry>PECL mongodb 1.2.0</entry>
        <entry>


### PR DESCRIPTION
Related tickets:

 * https://jira.mongodb.org/browse/PHPC-2443
 * https://jira.mongodb.org/browse/PHPC-2458

Related PRs:

 * https://github.com/mongodb/mongo-php-driver/pull/1643
 * https://github.com/mongodb/mongo-php-driver/pull/1695