### PR TITLE
FILTER_VALIDATE_BOOL: make it clearer than `null` is treated as an empty string

### DIFF
--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -43,6 +43,10 @@
           &null; is returned for all non-boolean values.
          </para>
          <para>
+          Note that, since values are <link linkend="language.types.string.casting">converted
+          to string</link> before processing, &null; is treated as "".
+         </para>
+         <para>
           String values are trimmed using <function>trim</function> before comparison.
          </para>
         </entry>


### PR DESCRIPTION
Ref php/doc-en#3801