### PR TITLE
add Zip::ER_TRUNCATED_ZIP

### DIFF
--- a/reference/zip/constants.xml
+++ b/reference/zip/constants.xml
@@ -944,6 +944,19 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="ziparchive.constants.er-truncated-zip">
+   <term>
+    <constant>ZipArchive::ER_TRUNCATED_ZIP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Possibly truncated or corrupted zip archive.
+     Available as of PHP 8.4.0 and PECL zip 1.22.4, respectively,
+     if built against libzip ≥ 1.11.1.
+    </simpara>
+   </listitem>
+  </varlistentry>
  </variablelist>
 
  <variablelist xml:id="ziparchive.constants.em">


### PR DESCRIPTION
Introduced in libzip 1.11
Available in zip extension version 1.22.4 (and php 8.4)
