### PR TITLE
Add missing version info for Document::toPHP and Iterator ctor

### DIFF
--- a/reference/mongodb/versions.xml
+++ b/reference/mongodb/versions.xml
@@ -406,7 +406,7 @@
  <function name='mongodb\bson\document::offsetunset' from='mongodb &gt;=1.17.0'/>
  <function name='mongodb\bson\document::serialize' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\document::tocanonicalextendedjson' from='mongodb &gt;=1.16.0'/>
- <function name='mongodb\bson\document::to' from='mongodb &gt;=1.16.0'/>
+ <function name='mongodb\bson\document::tophp' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\document::torelaxedextendedjson' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\document::unserialize' from='mongodb &gt;=1.16.0'/>
 
@@ -418,6 +418,7 @@
  <function name='mongodb\bson\int64::unserialize' from='mongodb &gt;=1.5.0'/>
 
  <function name='mongodb\bson\iterator' from='mongodb &gt;=1.16.0'/>
+ <function name='mongodb\bson\iterator::__construct' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\iterator::current' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\iterator::key' from='mongodb &gt;=1.16.0'/>
  <function name='mongodb\bson\iterator::next' from='mongodb &gt;=1.16.0'/>


### PR DESCRIPTION
Noticed both of the following pages were displaying "(No version information available, might only be in Git)":

 * https://www.php.net/manual/en/mongodb-bson-document.tophp.php
 * https://www.php.net/manual/en/mongodb-bson-iterator.construct.php