### PR TITLE
Range indexes are no longer experimental

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -3526,7 +3526,7 @@ local: {
                <row>
                 <entry>sparsity</entry>
                 <entry><type>int</type></entry>
-                <entry>Required. Positive 64-bit integer.</entry>
+                <entry>Optional. Positive 64-bit integer.</entry>
                </row>
                <row>
                 <entry>precision</entry>
@@ -3540,7 +3540,7 @@ local: {
                <row>
                 <entry>trimFactor</entry>
                 <entry><type>int</type></entry>
-                <entry>Required. Positive 32-bit integer.</entry>
+                <entry>Optional. Positive 32-bit integer.</entry>
                </row>
               </tbody>
              </tgroup>

--- a/reference/mongodb/mongodb/driver/clientencryption.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption.xml
@@ -149,7 +149,6 @@
        option must be &false;.
       </para>
       <note>
-       <para>The range algorithm is experimental only. It is not intended for public use.</para>
        <para>The extension does not yet support range queries for Decimal128 BSON field types.</para>
       </note>
      </listitem>

--- a/reference/mongodb/mongodb/driver/clientencryption/encrypt.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/encrypt.xml
@@ -64,6 +64,19 @@
      </thead>
      <tbody>
       <row>
+       <entry>PECL mongodb 1.20.0</entry>
+       <entry>
+        Added the <literal>"trimFactor"</literal> range option. The
+        <literal>"sparsity"</literal> range option is now optional.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.16.0</entry>
+       <entry>
+        Added the <literal>"rangeOpts"</literal> option.
+       </entry>
+      </row>
+      <row>
        <entry>PECL mongodb 1.14.0</entry>
        <entry>
         Added the <literal>"contentionFactor"</literal> and
@@ -80,6 +93,7 @@
   &reftitle.seealso;
   <simplelist>
    <member><function>MongoDB\Driver\ClientEncryption::decrypt</function></member>
+   <member><function>MongoDB\Driver\ClientEncryption::encryptExpression</function></member>
   </simplelist>
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/clientencryption/encryptexpression.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/encryptexpression.xml
@@ -19,7 +19,6 @@
   </para>
   <para>To query with a range encrypted payload, the <classname>MongoDB\Driver\Manager</classname> must be configured with the <literal>"autoEncryption"</literal> driver option. The <literal>"bypassQueryAnalysis"</literal> auto encryption option may be &true;. The <literal>"bypassAutoEncryption"</literal> auto encryption option must be &false;.</para>
   <note>
-   <para>The range algorithm is experimental only. It is not intended for public use.</para>
    <para>The extension does not yet support range queries for Decimal128 BSON field types.</para>
   </note>
  </refsect1>
@@ -85,10 +84,36 @@
   </simplelist>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.20.0</entry>
+       <entry>
+        Added the <literal>"trimFactor"</literal> range option. The
+        <literal>"sparsity"</literal> range option is now optional.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><function>MongoDB\Driver\Manager::__construct</function></member>
+   <member><function>MongoDB\Driver\ClientEncryption::encrypt</function></member>
   </simplelist>
  </refsect1>
 


### PR DESCRIPTION
The "sparsity" and "trimFactor" range options are optional. Also add missing changelog entry from introducing "rangeOpts" in 1.16.0.

https://jira.mongodb.org/browse/PHPC-2403
https://jira.mongodb.org/browse/PHPC-2462