### PR TITLE
Remove XIInclude 1.1 attribute from element

### DIFF
--- a/reference/filesystem/functions/glob.xml
+++ b/reference/filesystem/functions/glob.xml
@@ -67,7 +67,7 @@
       <para>
        Valid flags:
        <variablelist>
-        <xi:include set-xml-id="" xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('constant.glob-constant-variablelist')/*)"><xi:fallback/></xi:include>
+        <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('constant.glob-constant-variablelist')/*)"><xi:fallback/></xi:include>
        </variablelist>
       </para>
      </listitem>


### PR DESCRIPTION
libxml2 doesn't support XIInclude 1.1 so the `set-xml-id` attribute will not work. This attribute was added by me and I've just noticed it still being there as it showed up as an error during the builds of one of the language repos.