### PR TITLE
Update trigger-error.xml

### DIFF
--- a/reference/errorfunc/functions/trigger-error.xml
+++ b/reference/errorfunc/functions/trigger-error.xml
@@ -86,6 +86,10 @@
        The function now throws a <classname>ValueError</classname> if an invalid
        <parameter>error_level</parameter> is specified. Previously, it returned &false;.
       </entry>
+      <entry>8.4.0</entry>
+      <entry>
+       Using <parameter>error_level</parameter> E_USER_ERROR is depreccated in version 8.4. 
+      </entry>      
      </row>
     </tbody>
    </tgroup>


### PR DESCRIPTION
E_USER_ERROR is deprecated from 8.4 onwards

RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error