### PR TITLE
Update CURLOPT constant descriptions

### DIFF
--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -13,7 +13,7 @@
      as <constant>CURLOPT_UNIX_SOCKET_PATH</constant>. These two options
      share the same storage and therefore only one of them can be set
      per handle.
-     Available as of PHP 7.3.0 and cURL 7.53.0
+     Available as of PHP 7.3.0 and cURL 7.53.0.
     </para>
    </listitem>
   </varlistentry>
@@ -68,8 +68,10 @@
    </term>
    <listitem>
     <para>
-     Pass the filename for cURL to use as the Alt-Svc cache file to read existing cache contents from and
-     possibly also write it back to a after a transfer, unless <constant>CURLALTSVC_READONLYFILE</constant>
+     Pass a <type>string</type> with the filename for cURL to use
+     as the Alt-Svc cache file to read existing cache contents from
+     and possibly also write it back to a after a transfer,
+     unless <constant>CURLALTSVC_READONLYFILE</constant>
      is set via <constant>CURLOPT_ALTSVC_CTRL</constant>.
      Available as of PHP 8.2.0 and cURL 7.64.1.
     </para>
@@ -85,11 +87,10 @@
      Populate the bitmask with the correct set of features to instruct cURL how to handle Alt-Svc for the
      transfers using this handle. cURL only accepts Alt-Svc headers over HTTPS. It will also only complete
      a request to an alternative origin if that origin is properly hosted over HTTPS.
-     Setting any bit will enable the alt-svc engine. The options are:
-     <constant>CURLALTSVC_H1</constant>,
-     <constant>CURLALTSVC_H2</constant>,
-     <constant>CURLALTSVC_H3</constant>, and
-     <constant>CURLALTSVC_READONLYFILE</constant>.
+     Setting any bit will enable the alt-svc engine.
+     Set to any of the
+     <constant>CURLALTSVC_<replaceable>*</replaceable></constant> constants.
+     Defaults to Alt-Svc handling being disabled.
      Available as of PHP 8.2.0 and cURL 7.64.1.
     </para>
    </listitem>
@@ -117,6 +118,8 @@
     <para>
      &true; to automatically set the <literal>Referer:</literal> field in
      requests where it follows a <literal>Location:</literal> redirect.
+     Defaults to <literal>0</literal>.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -127,10 +130,10 @@
    </term>
    <listitem>
     <para>
-     Provides AWS V4 signature authentication on HTTP(S) header.
+     Provides AWS V4 signature authentication on HTTP(S) header as a <type>string</type>.
      This option overrides any other authentication types that have been set in
      <constant>CURLOPT_HTTPAUTH</constant>. This method cannot be combined with other authentication types.
-     Available as of PHP 8.2.0 and cURL 7.75.0
+     Available as of PHP 8.2.0 and cURL 7.75.0.
     </para>
    </listitem>
   </varlistentry>
@@ -141,7 +144,8 @@
    </term>
    <listitem>
     <para>
-
+     This constant is no longer used as of PHP 5.5.0.
+     Deprecated as of PHP 8.4.0.
     </para>
    </listitem>
   </varlistentry>
@@ -154,6 +158,8 @@
     <para>
      The size of the buffer to use for each read. There is no guarantee
      this request will be fulfilled, however.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Defaults to <constant>CURL_MAX_WRITE_SIZE</constant> (16kB).
      Available as of cURL 7.10.
     </para>
    </listitem>
@@ -165,9 +171,10 @@
    </term>
    <listitem>
     <para>
-     The name of a file holding one or more certificates to verify the
+     A <type>string</type> with the name of a file holding one or more certificates to verify the
      peer with. This only makes sense when used in combination with
      <constant>CURLOPT_SSL_VERIFYPEER</constant>. Might require an absolute path.
+     Available as of cURL 7.4.2.
     </para>
    </listitem>
   </varlistentry>
@@ -178,9 +185,9 @@
    </term>
    <listitem>
     <para>
-     The name of a PEM file holding one or more certificates to verify the
+     A <type>string</type> with the name of a PEM file holding one or more certificates to verify the
      peer with. This option overrides <constant>CURLOPT_CAINFO</constant>.
-     Available as of PHP 8.2.0 and cURL 7.77.0
+     Available as of PHP 8.2.0 and cURL 7.77.0.
     </para>
    </listitem>
   </varlistentry>
@@ -191,8 +198,9 @@
    </term>
    <listitem>
     <para>
-     A directory that holds multiple CA certificates. Use this option
-     alongside <constant>CURLOPT_SSL_VERIFYPEER</constant>.
+     A <type>string</type> with a directory that holds multiple CA certificates.
+     Use this option alongside <constant>CURLOPT_SSL_VERIFYPEER</constant>.
+     Available as of cURL 7.9.8.
     </para>
    </listitem>
   </varlistentry>
@@ -203,6 +211,10 @@
    </term>
    <listitem>
     <para>
+     Sets the maximum time in seconds any in memory cached CA certificate store
+     may be kept and reused for new connections.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Defaults to <literal>86400</literal> (24 hours).
      Available as of PHP 8.3.0 and cURL 7.87.0
     </para>
    </listitem>
@@ -215,8 +227,10 @@
    <listitem>
     <para>
      &true; to output SSL certification information to <constant>STDERR</constant>
-     on secure transfers. Added in cURL 7.19.1.
+     on secure transfers.
      Requires <constant>CURLOPT_VERBOSE</constant> to be on to have an effect.
+     Defaults to &false;.
+     Available as of cURL 7.19.1.
     </para>
    </listitem>
   </varlistentry>
@@ -229,6 +243,9 @@
     <para>
      The number of seconds to wait while trying to connect. Use 0 to
      wait indefinitely.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Defaults to <literal>300</literal>.
+     Available as of cURL 7.7.
     </para>
    </listitem>
   </varlistentry>
@@ -239,12 +256,14 @@
    </term>
    <listitem>
     <para>
-     The number of milliseconds to wait while trying to connect. Use 0 to
-     wait indefinitely.
-     <!-- http://curl.haxx.se/libcurl/c/curl_easy_setopt.html -->
-     If libcurl is built to use the standard system name resolver, that
+     The number of milliseconds to wait while trying to connect.
+     Use <literal>0</literal> to wait indefinitely.
+     If cURL is built to use the standard system name resolver, that
      portion of the connect will still use full-second resolution for
-     timeouts with a minimum timeout allowed of one second. Available as of cURL 7.16.2.
+     timeouts with a minimum timeout allowed of one second.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Defaults to <literal>300000</literal>.
+     Available as of cURL 7.16.2.
     </para>
    </listitem>
   </varlistentry>
@@ -258,6 +277,7 @@
      &true; tells the library to perform all the required proxy authentication
      and connection setup, but no data transfer. This option is implemented for
      HTTP, SMTP and POP3.
+     Defaults to &false;.
      Available as of cURL 7.15.2.
     </para>
    </listitem>
@@ -270,9 +290,9 @@
    <listitem>
     <para>
      Connect to a specific host and port instead of the URL's host and port.
-     Accepts an array of strings with the format
+     Accepts an <type>array</type> of <type>string</type>s with the format
      <literal>HOST:PORT:CONNECT-TO-HOST:CONNECT-TO-PORT</literal>.
-     Available as of PHP 7.0.7 and cURL 7.49.0
+     Available as of PHP 7.0.7 and cURL 7.49.0.
     </para>
    </listitem>
   </varlistentry>
@@ -283,10 +303,11 @@
    </term>
    <listitem>
     <para>
-     The contents of the <literal>"Cookie: "</literal> header to be
-     used in the HTTP request.
+     A <type>string</type> with the contents
+     of the <literal>Cookie: </literal> header to be used in the HTTP request.
      Note that multiple cookies are separated with a semicolon followed
-     by a space (e.g., "<literal>fruit=apple; colour=red</literal>")
+     by a space (e.g., <literal>fruit=apple; colour=red</literal>).
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -297,11 +318,12 @@
    </term>
    <listitem>
     <para>
-     The name of the file containing the cookie data. The cookie file can
-     be in Netscape format, or just plain HTTP-style headers dumped into
-     a file.
-     If the name is an empty string, no cookies are loaded, but cookie
+     A <type>string</type> with the name of the file containing the cookie data.
+     The cookie file can be in Netscape format,
+     or just plain HTTP-style headers dumped into a file.
+     If the name is an empty <type>string</type>, no cookies are loaded, but cookie
      handling is still enabled.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -312,8 +334,9 @@
    </term>
    <listitem>
     <para>
-     The name of a file to save all internal cookies to when the
-     handle's destructor is called.
+     A <type>string</type> with the name of a file to save all internal cookies to
+     when the handle's destructor is called.
+     Available as of cURL 7.9.0.
      <warning>
       <simpara>
        As of PHP 8.0.0, <function>curl_close</function> is a no-op
@@ -332,13 +355,27 @@
    </term>
    <listitem>
     <para>
-     A cookie string (i.e. a single line in Netscape/Mozilla format, or a regular
+     A cookie <type>string</type> (i.e. a single line in Netscape/Mozilla format, or a regular
      HTTP-style Set-Cookie header) adds that single cookie to the internal cookie store.
-     <literal>"ALL"</literal> erases all cookies held in memory.
-     <literal>"SESS"</literal> erases all session cookies held in memory.
-     <literal>"FLUSH"</literal> writes all known cookies to the file specified by <constant>CURLOPT_COOKIEJAR</constant>.
-     <literal>"RELOAD"</literal> loads all cookies from the files specified by <constant>CURLOPT_COOKIEFILE</constant>.
-     Available as of cURL 7.14.1
+     <simplelist type="inline">
+      <member>
+       <literal>ALL</literal>
+       erases all cookies held in memory
+      </member>
+      <member>
+       <literal>SESS</literal>
+       erases all session cookies held in memory
+      </member>
+      <member>
+       <literal>FLUSH</literal>
+       writes all known cookies to the file specified by <constant>CURLOPT_COOKIEJAR</constant>
+      </member>
+      <member>
+       <literal>RELOAD</literal>
+       loads all cookies from the files specified by <constant>CURLOPT_COOKIEFILE</constant>
+      </member>
+     </simplelist>
+     Available as of cURL 7.14.1.
     </para>
    </listitem>
   </varlistentry>
@@ -349,12 +386,13 @@
    </term>
    <listitem>
     <para>
-     &true; to mark this as a new cookie "session". It will force libcurl
+     &true; to mark this as a new cookie "session". It will force cURL
      to ignore all cookies it is about to load that are "session cookies"
-     from the previous session. By default, libcurl always stores and
+     from the previous session. By default, cURL always stores and
      loads all cookies, independent if they are session cookies or not.
      Session cookies are cookies without expiry date and they are meant
      to be alive and existing for this "session" only.
+     Available as of cURL 7.9.7.
     </para>
    </listitem>
   </varlistentry>
@@ -367,6 +405,7 @@
     <para>
      &true; to convert Unix newlines to CRLF newlines
      on transfers.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -378,7 +417,7 @@
    <listitem>
     <para>
      Pass a <type>string</type> naming a file with the concatenation of
-     CRL (Certificate Revocation List) (in PEM format)
+	 CRL (Certificate Revocation List) (in PEM format)
      to use in the certificate validation that occurs during the SSL exchange.
      When cURL is built to use GnuTLS,
      there is no way to influence the use of CRL passed
@@ -391,7 +430,7 @@
      Also note that <constant>CURLOPT_CRLFILE</constant> implies
      <constant>CURLSSLOPT_NO_PARTIALCHAIN</constant>
      as of cURL 7.71.0 due to an OpenSSL bug.
-     Available as of cURL 7.19.0
+     Available as of cURL 7.19.0.
     </para>
    </listitem>
   </varlistentry>
@@ -403,14 +442,16 @@
    <listitem>
     <para>
      A custom request method to use instead of
-     <literal>"GET"</literal> or <literal>"HEAD"</literal> when doing
+     <literal>GET</literal> or <literal>HEAD</literal> when doing
      a HTTP request. This is useful for doing
-     <literal>"DELETE"</literal> or other, more obscure HTTP requests.
-     Valid values are things like <literal>"GET"</literal>,
-     <literal>"POST"</literal>, <literal>"CONNECT"</literal> and so on;
+     <literal>DELETE</literal> or other, more obscure HTTP requests.
+     Valid values are things like <literal>GET</literal>,
+     <literal>POST</literal>, <literal>CONNECT</literal> and so on;
      i.e. Do not enter a whole HTTP request line here. For instance,
-     entering <literal>"GET /index.html HTTP/1.0\r\n\r\n"</literal>
+     entering <literal>GET /index.html HTTP/1.0\r\n\r\n</literal>
      would be incorrect.
+     This option accepts a <type>string</type> or &null;.
+     Available as of cURL 7.1.
      <note>
       <para>
        Don't do this without making sure the server supports the custom
@@ -427,8 +468,8 @@
    </term>
    <listitem>
     <para>
-     The default protocol to use if the URL is missing a scheme name.
-     Available as of PHP 7.0.7 and cURL 7.45.0
+     A <type>string</type> with the default protocol to use if the URL is missing a scheme name.
+     Available as of PHP 7.0.7 and cURL 7.45.0.
     </para>
    </listitem>
   </varlistentry>
@@ -459,8 +500,9 @@
    </term>
    <listitem>
     <para>
-     &true; to not allow URLs that include a username. Usernames are allowed by default (0).
-     Available as of PHP 7.3.0 and cURL 7.61.0
+     &true; to not allow URLs that include a username.
+     Usernames are allowed by default.
+     Available as of PHP 7.3.0 and cURL 7.61.0.
     </para>
    </listitem>
   </varlistentry>
@@ -472,7 +514,9 @@
    <listitem>
     <para>
      The number of seconds to keep DNS entries in memory. This
-     option is set to 120 (2 minutes) by default.
+     option is set to <literal>120</literal> (2 minutes) by default.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of cURL 7.9.3.
     </para>
    </listitem>
   </varlistentry>
@@ -485,6 +529,7 @@
     <para>
      Set the name of the network interface that the DNS resolver should bind to.
      This must be an interface name (not an address).
+     This option accepts a <type>string</type> or &null;.
      Available as of PHP 7.0.7 and cURL 7.33.0
     </para>
    </listitem>
@@ -497,8 +542,9 @@
    <listitem>
     <para>
      Set the local IPv4 address that the resolver should bind to. The argument
-     should contain a single numerical IPv4 address as a string.
-     Available as of PHP 7.0.7 and cURL 7.33.0
+     should contain a single numerical IPv4 address.
+     This option accepts a <type>string</type> or &null;.
+     Available as of PHP 7.0.7 and cURL 7.33.0.
     </para>
    </listitem>
   </varlistentry>
@@ -510,8 +556,9 @@
    <listitem>
     <para>
      Set the local IPv6 address that the resolver should bind to. The argument
-     should contain a single numerical IPv6 address as a string.
-     Available as of PHP 7.0.7 and cURL 7.33.0
+     should contain a single numerical IPv6 address.
+     This option accepts a <type>string</type> or &null;.
+     Available as of PHP 7.0.7 and cURL 7.33.0.
     </para>
    </listitem>
   </varlistentry>
@@ -525,7 +572,7 @@
      Pass a <type>string</type> with a comma-separated list of DNS servers to be used
      instead of the system default
      (e.g.: <literal>192.168.1.100,192.168.1.101:8080</literal>).
-     Available as of cURL 7.24.0
+     Available as of cURL 7.24.0.
     </para>
    </listitem>
   </varlistentry>
@@ -539,7 +586,7 @@
      &true; to shuffle the order of all returned addresses so that they will be used
      in a random order, when a name is resolved and more than one IP address is returned.
      This may cause IPv4 to be used before IPv6 or vice versa.
-     Available as of PHP 7.3.0 and cURL 7.60.0
+     Available as of PHP 7.3.0 and cURL 7.60.0.
     </para>
    </listitem>
   </varlistentry>
@@ -553,6 +600,7 @@
      &true; to use a global DNS cache. This option is not thread-safe.
      It is conditionally enabled by default if PHP is built for non-threaded use
      (CLI, FCGI, Apache2-Prefork, etc.).
+     Available as of cURL 7.9.3 and deprecated as of cURL 7.11.1.
     </para>
    </listitem>
   </varlistentry>
@@ -563,7 +611,8 @@
    </term>
    <listitem>
     <para>
-     Verify the DNS-over-HTTPS server's SSL certificate name fields against the host name.
+     Set to <literal>2</literal> to verify the DNS-over-HTTPS server's
+     SSL certificate name fields against the host name.
      Available as of PHP 8.2.0 and cURL 7.76.0.
     </para>
    </listitem>
@@ -575,7 +624,8 @@
    </term>
    <listitem>
     <para>
-     Verify the authenticity of the DNS-over-HTTPS server's SSL certificate.
+     Set to <literal>1</literal> to enable and <literal>0</literal> to disable
+     verification of the authenticity of the DNS-over-HTTPS server's SSL certificate.
      Available as of PHP 8.2.0 and cURL 7.76.0.
     </para>
    </listitem>
@@ -587,7 +637,8 @@
    </term>
    <listitem>
     <para>
-     Tell cURL to verify the status of the DNS-over-HTTPS server certificate
+     Set to <literal>1</literal> to enable and <literal>0</literal> to disable
+     the verification of the status of the DNS-over-HTTPS server certificate
      using the "Certificate Status Request" TLS extension (OCSP stapling).
      Available as of PHP 8.2.0 and cURL 7.76.0.
     </para>
@@ -601,6 +652,7 @@
    <listitem>
     <para>
      Provides the DNS-over-HTTPS URL.
+     This option accepts a <type>string</type> or &null;.
      Available as of PHP 8.1.0 and cURL 7.62.0.
     </para>
    </listitem>
@@ -614,6 +666,7 @@
     <para>
      Like <constant>CURLOPT_RANDOM_FILE</constant>, except a filename
      to an Entropy Gathering Daemon socket.
+     Available as of cURL 7.7 and deprecated as of cURL 7.84.0.
     </para>
    </listitem>
   </varlistentry>
@@ -624,12 +677,17 @@
    </term>
    <listitem>
     <para>
-     The contents of the <literal>"Accept-Encoding: "</literal> header.
-     This enables decoding of the response. Supported encodings are
-     <literal>"identity"</literal>, <literal>"deflate"</literal>, and
-     <literal>"gzip"</literal>. If an empty string, <literal>""</literal>,
-     is set, a header containing all supported encoding types is sent.
-     Available as of cURL 7.10.
+     The contents of the <literal>Accept-Encoding: </literal> header as a <type>string</type>.
+     This enables decoding of the response. Supported encodings are:
+     <simplelist type="inline">
+      <member><literal>identity</literal></member>
+      <member><literal>deflate</literal></member>
+      <member><literal>gzip</literal></member>
+     </simplelist>
+     .
+     If an empty <type>string</type> is set,
+     a header containing all supported encoding types is sent.
+     Available as of cURL 7.10 and deprecated as of cURL 7.21.6.
     </para>
    </listitem>
   </varlistentry>
@@ -641,8 +699,9 @@
    <listitem>
     <para>
      The timeout for <literal>Expect: 100-continue</literal> responses in milliseconds.
-     Defaults to 1000 milliseconds.
-     Available as of PHP 7.0.7 and cURL 7.36.0
+     Defaults to <literal>1000</literal> milliseconds.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of PHP 7.0.7 and cURL 7.36.0.
     </para>
    </listitem>
   </varlistentry>
@@ -654,8 +713,9 @@
    <listitem>
     <para>
      &true; to fail verbosely if the HTTP code returned
-     is greater than or equal to 400. The default behavior is to return
+     is greater than or equal to <literal>400</literal>. The default behavior is to return
      the page normally, ignoring the code.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -666,8 +726,10 @@
    </term>
    <listitem>
     <para>
-     The file that the transfer should be written to. The default
-     is <constant>STDOUT</constant> (the browser window).
+     Accepts a file handle <type>resource</type>
+     to the file that the transfer should be written to.
+     The default is <constant>STDOUT</constant> (the browser window).
+     Available as of cURL 7.1 and deprecated as of cURL 7.9.7.
     </para>
    </listitem>
   </varlistentry>
@@ -678,10 +740,11 @@
    </term>
    <listitem>
     <para>
-     &true; to attempt to retrieve the modification
+     Set to &true; to attempt to retrieve the modification
      date of the remote document. This value can be retrieved using
      the <constant>CURLINFO_FILETIME</constant> option with
      <function>curl_getinfo</function>.
+     Available as of cURL 7.5.
     </para>
    </listitem>
   </varlistentry>
@@ -741,12 +804,13 @@
    </term>
    <listitem>
     <para>
-     &true; to follow any
-     <literal>"Location: "</literal> header that the server sends as
+     Set to &true; to follow any
+     <literal>Location: </literal> header that the server sends as
      part of the HTTP header.
      See also <constant>CURLOPT_MAXREDIRS</constant>.
      This constant is not available when <link xmlns="http://docbook.org/ns/docbook" linkend="ini.open-basedir">open_basedir</link>
      is enabled.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -757,8 +821,9 @@
    </term>
    <listitem>
     <para>
-     &true; to force the connection to explicitly
+     Set to &true; to force the connection to explicitly
      close when it has finished processing, and not be pooled for reuse.
+     Available as of cURL 7.7.
     </para>
    </listitem>
   </varlistentry>
@@ -769,8 +834,9 @@
    </term>
    <listitem>
     <para>
-     &true; to force the use of a new connection
+     Set to &true; to force the use of a new connection
      instead of a cached one.
+     Available as of cURL 7.7.
     </para>
    </listitem>
   </varlistentry>
@@ -781,8 +847,9 @@
    </term>
    <listitem>
     <para>
-     &true; to append to the remote file instead of
+     Set to &true; to append to the remote file instead of
      overwriting it.
+     Available as of cURL 7.1 and deprecated as of cURL 7.16.4.
     </para>
    </listitem>
   </varlistentry>
@@ -795,6 +862,9 @@
     <para>
      An alias of
      <constant>CURLOPT_TRANSFERTEXT</constant>. Use that instead.
+     Available as of cURL 7.1, deprecated as of cURL 7.11.1
+     and last available in cURL 7.15.5.
+     Removed as of PHP 7.3.
     </para>
    </listitem>
   </varlistentry>
@@ -805,8 +875,8 @@
    </term>
    <listitem>
     <para>
-     &true; to only list the names of an FTP
-     directory.
+     Set to &true; to only list the names of an FTP directory.
+     Available as of cURL 7.1 and deprecated as of cURL 7.16.4.
     </para>
    </listitem>
   </varlistentry>
@@ -817,12 +887,15 @@
    </term>
    <listitem>
     <para>
-     The value which will be used to get the IP address to use
-     for the FTP "PORT" instruction. The "PORT" instruction tells
+     A <type>string</type> which will be used to get the IP address to use
+     for the FTP <literal>PORT</literal> instruction.
+     The <literal>PORT</literal> instruction tells
      the remote server to connect to our specified IP address.  The
-     string may be a plain IP address, a hostname, a network
-     interface name (under Unix), or just a plain '-' to use the
-     systems default IP address.
+     <type>string</type> may be a plain IP address, a hostname, a network
+     interface name (under Unix), or just a plain <literal>-</literal> to use the
+     system's default IP address.
+     This option accepts a <type>string</type> or &null;.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -833,10 +906,9 @@
    </term>
    <listitem>
     <para>
-     The FTP authentication method (when is activated):
-     <constant>CURLFTPAUTH_SSL</constant> (try SSL first),
-     <constant>CURLFTPAUTH_TLS</constant> (try TLS first), or
-     <constant>CURLFTPAUTH_DEFAULT</constant> (let cURL decide).
+     Set the FTP over SSL authentication method (if activated) to any of the
+     <constant>CURLFTPAUTH_<replaceable>*</replaceable></constant> constants.
+     Defaults to <constant>CURLFTPAUTH_DEFAULT</constant>.
      Available as of cURL 7.12.2.
     </para>
    </listitem>
@@ -877,8 +949,9 @@
    </term>
    <listitem>
     <para>
-     &true; to create missing directories when an FTP operation
+     Set to &true; to create missing directories when an FTP operation
      encounters a path that currently doesn't exist.
+     Available as of cURL 7.10.7.
     </para>
    </listitem>
   </varlistentry>
@@ -889,11 +962,10 @@
    </term>
    <listitem>
     <para>
-     Tell curl which method to use to reach a file on a FTP(S) server. Possible values are
-     <constant>CURLFTPMETHOD_DEFAULT</constant>,
-     <constant>CURLFTPMETHOD_MULTICWD</constant>,
-     <constant>CURLFTPMETHOD_NOCWD</constant>, and
-     <constant>CURLFTPMETHOD_SINGLECWD</constant>.
+     Tell cURL which method to use to reach a file on a FTP(S) server.
+     Possible values are any of the
+     <constant>CURLFTPMETHOD_<replaceable>*</replaceable></constant> constants.
+     Defaults to <constant>CURLFTPMETHOD_MULTICWD</constant>.
      Available as of cURL 7.15.1.
     </para>
    </listitem>
@@ -937,7 +1009,7 @@
    </term>
    <listitem>
     <para>
-
+     Available as of cURL 7.11.0 and deprecated as of cURL 7.16.4.
     </para>
    </listitem>
   </varlistentry>
@@ -964,9 +1036,11 @@
    </term>
    <listitem>
     <para>
-     &true; to use EPRT (and LPRT) when doing active
-     FTP downloads. Use &false; to disable EPRT and LPRT and use PORT
-     only.
+     Set to &true; to use <literal>EPRT</literal> (and <literal>LPRT</literal>)
+     when doing active FTP downloads.
+     Set to &false; to disable <literal>EPRT</literal>
+     and <literal>LPRT</literal> and use <literal>PORT</literal> only.
+     Available as of cURL 7.10.5.
     </para>
    </listitem>
   </varlistentry>
@@ -977,9 +1051,10 @@
    </term>
    <listitem>
     <para>
-     &true; to first try an EPSV command for FTP
-     transfers before reverting back to PASV. Set to &false;
-     to disable EPSV.
+     Set to &true; to first try an <literal>EPSV</literal> command for FTP
+     transfers before reverting back to <literal>PASV</literal>.
+     Set to &false; to disable <literal>EPSV</literal>.
+    Available as of cURL 7.9.2.
     </para>
    </listitem>
   </varlistentry>
@@ -1022,10 +1097,11 @@
    </term>
    <listitem>
     <para>
-     Head start for ipv6 for the happy eyeballs algorithm. Happy eyeballs attempts
+     Head start for IPv6 for the happy eyeballs algorithm. Happy eyeballs attempts
      to connect to both IPv4 and IPv6 addresses for dual-stack hosts,
      preferring IPv6 first for timeout milliseconds.
-     Defaults to CURL_HET_DEFAULT, which is currently 200 milliseconds.
+     Defaults to <constant>CURL_HET_DEFAULT</constant>, which is currently 200 milliseconds.
+     This option accepts any value that can be cast to a valid <type>int</type>.
      Available as of PHP 7.3.0 and cURL 7.59.0
     </para>
    </listitem>
@@ -1037,9 +1113,9 @@
    </term>
    <listitem>
     <para>
-     &true; to send an HAProxy PROXY protocol v1 header at the start of the connection.
+     &true; to send an HAProxy <literal>PROXY</literal> protocol v1 header at the start of the connection.
      The default action is not to send this header.
-     Available as of PHP 7.3.0 and cURL 7.60.0
+     Available as of PHP 7.3.0 and cURL 7.60.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1050,7 +1126,9 @@
    </term>
    <listitem>
     <para>
-     &true; to include the header in the output.
+     Set to &true; to include the headers in the output sent to the callback
+     defined by <constant>CURLOPT_WRITEFUNCTION</constant>.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -1061,11 +1139,12 @@
    </term>
    <listitem>
     <para>
-     A callback accepting two parameters.
-     The first is the cURL resource, the second is a
-     string with the header data to be written. The header data must
+     A <type>callable</type> accepting two parameters and returning an <type>int</type>.
+     The first paratmeter is the cURL resource, the second is a
+     <type>string</type> with the header data which must
      be written by this callback. Return the number of
      bytes written.
+     Available as of cURL 7.7.2.
     </para>
    </listitem>
   </varlistentry>
@@ -1076,10 +1155,12 @@
    </term>
    <listitem>
     <para>
-     Possible values are <constant>CURLHEADER_UNIFIED</constant> or <constant>CURLHEADER_SEPARATE</constant>.
+     Send HTTP headers to both proxy and host or separately.
+     Possible values are any of the
+     <constant>CURLHEADER_<replaceable>*</replaceable></constant> constants.
      Defaults to <constant>CURLHEADER_SEPARATE</constant> as of cURL
-     7.42.1, and <constant>CURLHEADER_UNIFIED</constant> before.
-     Available as of PHP 7.0.7 and cURL 7.37.0
+     7.42.1, and <constant>CURLHEADER_UNIFIED</constant> prior to that.
+     Available as of PHP 7.0.7 and cURL 7.37.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1090,8 +1171,10 @@
    </term>
    <listitem>
     <para>
-     HSTS (HTTP Strict Transport Security) cache file name.
-     Available as of PHP 8.2.0 and cURL 7.74.0
+     <type>string</type> with HSTS (HTTP Strict Transport Security) cache file name
+     or &null; to allow HSTS without reading from or writing to any file
+     and clear the list of files to read HSTS data from.
+     Available as of PHP 8.2.0 and cURL 7.74.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1102,11 +1185,9 @@
    </term>
    <listitem>
     <para>
-     Controls HSTS (HTTP Strict Transport Security) behavior. Populate the bitmask with the correct set of
-     features to instruct cURL how to handle HSTS for the transfers using this handle.
-     <constant>CURLHSTS_ENABLE</constant> enables the in-memory HSTS cache. If the HSTS cache file is defined,
-     set <constant>CURLHSTS_READONLYFILE</constant> to make the file read-only.
-     Available as of PHP 8.2.0 and cURL 7.74.0
+     Accepts a bitmask of HSTS (HTTP Strict Transport Security) features
+     defined by the <constant>CURLHSTS_<replaceable>*</replaceable></constant> constants.
+     Available as of PHP 8.2.0 and cURL 7.74.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1117,9 +1198,9 @@
    </term>
    <listitem>
     <para>
-     Whether to allow HTTP/0.9 responses. Defaults to &false; as of libcurl 7.66.0;
+     Whether to allow HTTP/0.9 responses. Defaults to &false; as of cURL 7.66.0;
      formerly it defaulted to &true;.
-     Available as of PHP 7.3.15 and 7.4.3, respectively, and cURL 7.64.0
+     Available as of PHP 7.3.15 and 7.4.3, respectively, and cURL 7.64.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1130,8 +1211,8 @@
    </term>
    <listitem>
     <para>
-     An array of HTTP 200 responses that will be treated as valid
-     responses and not as errors.
+     An <type>array</type> of HTTP <literal>200</literal> responses
+     that will be treated as valid responses and not as errors.
      Available as of cURL 7.10.3.
     </para>
    </listitem>
@@ -1143,21 +1224,24 @@
    </term>
    <listitem>
     <para>
-     The HTTP authentication method(s) to use. The options are:
-     <constant>CURLAUTH_BASIC</constant>,
-     <constant>CURLAUTH_DIGEST</constant>,
-     <constant>CURLAUTH_GSSNEGOTIATE</constant>,
-     <constant>CURLAUTH_NTLM</constant>,
-     <constant>CURLAUTH_AWS_SIGV4</constant>,
-     <constant>CURLAUTH_ANY</constant>, and
-     <constant>CURLAUTH_ANYSAFE</constant>.
-     The bitwise <literal>|</literal> (or) operator can be used to combine
-     more than one method. If this is done, cURL will poll the server to see
+     A bitmask of HTTP authentication method(s) to use. The options are:
+     <simplelist type="inline">
+      <member><constant>CURLAUTH_BASIC</constant></member>
+      <member><constant>CURLAUTH_DIGEST</constant></member>
+      <member><constant>CURLAUTH_GSSNEGOTIATE</constant></member>
+      <member><constant>CURLAUTH_NTLM</constant></member>
+      <member><constant>CURLAUTH_AWS_SIGV4</constant></member>
+      <member><constant>CURLAUTH_ANY</constant></member>
+      <member><constant>CURLAUTH_ANYSAFE</constant></member>
+     </simplelist>
+     .
+     If more than one method is used, cURL will poll the server to see
      what methods it supports and pick the best one.
      <constant>CURLAUTH_ANY</constant> sets all bits. cURL will automatically select
      the one it finds most secure.
      <constant>CURLAUTH_ANYSAFE</constant> sets all bits except <constant>CURLAUTH_BASIC</constant>.
      cURL will automatically select the one it finds most secure.
+     Available as of cURL 7.10.6.
     </para>
    </listitem>
   </varlistentry>
@@ -1168,9 +1252,10 @@
    </term>
    <listitem>
     <para>
-     &true; to reset the HTTP request method to GET.
-     Since GET is the default, this is only necessary if the request
+     &true; to reset the HTTP request method to <literal>GET</literal>.
+     Since <literal>GET</literal> is the default, this is only necessary if the request
      method has been changed.
+     Available as of cURL 7.8.1.
     </para>
    </listitem>
   </varlistentry>
@@ -1181,10 +1266,11 @@
    </term>
    <listitem>
     <para>
-     An array of HTTP header fields to set, in the format
+     An <type>array</type> of HTTP header fields to set, in the format
      <code>
       array('Content-type: text/plain', 'Content-length: 100')
      </code>
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -1196,6 +1282,7 @@
    <listitem>
     <para>
      &true; to tunnel through a given HTTP proxy.
+     Available as of cURL 7.3.
     </para>
    </listitem>
   </varlistentry>
@@ -1234,14 +1321,10 @@
    </term>
    <listitem>
     <para>
-     <constant>CURL_HTTP_VERSION_NONE</constant> (default, lets CURL
-     decide which version to use),
-     <constant>CURL_HTTP_VERSION_1_0</constant> (forces HTTP/1.0),
-     <constant>CURL_HTTP_VERSION_1_1</constant> (forces HTTP/1.1),
-     <constant>CURL_HTTP_VERSION_2_0</constant> (attempts HTTP 2),
-     <constant>CURL_HTTP_VERSION_2</constant> (alias of <constant>CURL_HTTP_VERSION_2_0</constant>),
-     <constant>CURL_HTTP_VERSION_2TLS</constant> (attempts HTTP 2 over TLS (HTTPS) only) or
-     <constant>CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE</constant> (issues non-TLS HTTP requests using HTTP/2 without HTTP/1.1 Upgrade).
+     Set to one of the
+     <constant>CURL_HTTP_VERSION_<replaceable>*</replaceable></constant> constants
+     for cURL to use the specified HTTP version.
+     Available as of cURL 7.9.1.
     </para>
    </listitem>
   </varlistentry>
@@ -1267,7 +1350,10 @@
    </term>
    <listitem>
     <para>
-     The file that the transfer should be read from when uploading.
+     Accepts a file handle <type>resource</type>
+     to the file that the transfer should be read from when uploading.
+     Available as of cURL 7.1 and deprecated as of cURL 7.9.7.
+     Use <constant>CURLOPT_READDATA</constant> instead.
     </para>
    </listitem>
   </varlistentry>
@@ -1279,9 +1365,11 @@
    <listitem>
     <para>
      The expected size, in bytes, of the file when uploading a file to
-     a remote site. Note that using this option will not stop libcurl
+     a remote site. Note that using this option will not stop cURL
      from sending more data, as exactly what is sent depends on
      <constant>CURLOPT_READFUNCTION</constant>.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -1292,8 +1380,9 @@
    </term>
    <listitem>
     <para>
-     The name of the outgoing network interface to use. This can be an
-     interface name, an IP address or a host name.
+     Set to a <type>string</type> with the name of the outgoing network interface to use.
+     This can be an interface name, an IP address or a host name.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -1306,11 +1395,10 @@
     <para>
      Allows an application to select what kind of IP addresses to use when
      resolving host names. This is only interesting when using host names that
-     resolve addresses using more than one version of IP, possible values are
-     <constant>CURL_IPRESOLVE_WHATEVER</constant>,
-     <constant>CURL_IPRESOLVE_V4</constant>,
-     <constant>CURL_IPRESOLVE_V6</constant>, by default
-     <constant>CURL_IPRESOLVE_WHATEVER</constant>.
+     resolve addresses using more than one version of IP.
+     Set to one of the
+     <constant>CURL_IPRESOLVE_<replaceable>*</replaceable></constant> constants.
+     Defaults to <constant>CURL_IPRESOLVE_WHATEVER</constant>.
      Available as of cURL 7.10.8.
     </para>
    </listitem>
@@ -1340,7 +1428,9 @@
    </term>
    <listitem>
     <para>
-     Issuer SSL certificate from memory blob.
+     Pass a <type>string</type> with binary data of a CA SSL certificate in PEM format.
+     If set, an additional check against the peer certificate is performed
+     to verify the issuer is the one associated with the certificate provided by the option.
      Available as of PHP 8.1.0 and cURL 7.71.0.
     </para>
    </listitem>
@@ -1352,11 +1442,11 @@
    </term>
    <listitem>
     <para>
-     &true; to keep sending the request body if the HTTP code returned is
-     equal to or larger than 300. The default action would be to stop sending
+     Set to &true; to keep sending the request body if the HTTP code returned is
+     equal to or larger than <literal>300</literal>. The default action would be to stop sending
      and close the stream or connection. Suitable for manual NTLM authentication.
      Most applications do not need this option.
-     Available as of PHP 7.3.0 and cURL 7.51.0
+     Available as of PHP 7.3.0 and cURL 7.51.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1367,9 +1457,10 @@
    </term>
    <listitem>
     <para>
-     The password required to use the <constant>CURLOPT_SSLKEY</constant>
+     Set to a <type>string</type> with the password required to use the <constant>CURLOPT_SSLKEY</constant>
      or <constant>CURLOPT_SSH_PRIVATE_KEYFILE</constant> private key.
-     Available as of cURL 7.16.1.
+     Setting this option to &null; disables using a password for these options.
+     Available as of cURL 7.17.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1380,16 +1471,20 @@
    </term>
    <listitem>
     <para>
-     The KRB4 (Kerberos 4) security level. Any of the following values
+     The KRB4 (Kerberos 4) security level. Any of the following <type>string</type> values
      (in order from least to most powerful) are valid:
-     <literal>"clear"</literal>,
-     <literal>"safe"</literal>,
-     <literal>"confidential"</literal>,
-     <literal>"private".</literal>.
-     If the string does not match one of these,
-     <literal>"private"</literal> is used. Setting this option to &null;
+     <simplelist type="inline">
+      <member><literal>clear</literal></member>
+      <member><literal>safe</literal></member>
+      <member><literal>confidential</literal></member>
+      <member><literal>private</literal></member>
+     </simplelist>
+     .
+     If the <type>string</type> does not match one of these,
+     <literal>private</literal> is used. Setting this option to &null;
      will disable KRB4 security. Currently KRB4 security only works
      with FTP transactions.
+     Available as of cURL 7.3 and deprecated as of cURL 7.17.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1454,10 +1549,10 @@
    <listitem>
     <para>
      Can be used to set protocol specific login options, such as the
-     preferred authentication mechanism via "AUTH=NTLM" or "AUTH=*",
-     and should be used in conjunction with the
+     preferred authentication mechanism via <literal>AUTH=NTLM</literal>
+     or <literal>AUTH=*</literal>, and should be used in conjunction with the
      <constant>CURLOPT_USERNAME</constant> option.
-     Available as of PHP 7.0.7 and cURL 7.34.0
+     Available as of PHP 7.0.7 and cURL 7.34.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1471,6 +1566,8 @@
      The transfer speed, in bytes per second, that the transfer should be
      below during the count of <constant>CURLOPT_LOW_SPEED_TIME</constant>
      seconds before PHP considers the transfer too slow and aborts.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -1484,6 +1581,8 @@
      The number of seconds the transfer speed should be below
      <constant>CURLOPT_LOW_SPEED_LIMIT</constant> before PHP considers
      the transfer too slow and aborts.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -1546,7 +1645,15 @@
    </term>
    <listitem>
     <para>
-     Available as of PHP 8.2.0 and cURL 7.69.0
+     Set to <literal>1</literal> to allow <literal>RCPT TO</literal> command
+     to fail for some recipients which makes cURL ignore errors
+     for individual recipients and proceed with the remaining accepted recipients.
+     If all recipients trigger failures and this flag is specified,
+     cURL aborts the SMTP conversation
+     and returns the error received from to the last <literal>RCPT TO</literal> command.
+     Replaced by <constant>CURLOPT_MAIL_RCPT_ALLOWFAILS</constant> as of cURL 8.2.0.
+     Available as of PHP 8.2.0 and cURL 7.69.0.
+     Deprecated as of cURL 8.2.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1559,7 +1666,8 @@
     <para>
      The maximum idle time allowed for an existing connection to be considered for reuse.
      Default maximum age is set to <literal>118</literal> seconds.
-     Available as of PHP 8.2.0 and cURL 7.65.0
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of PHP 8.2.0 and cURL 7.65.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1573,6 +1681,8 @@
      The maximum amount of persistent connections that are allowed.
      When the limit is reached, the oldest one in the cache is closed
      to prevent increasing the number of open connections.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of cURL 7.7.
     </para>
    </listitem>
   </varlistentry>
@@ -1609,11 +1719,15 @@
    </term>
    <listitem>
     <para>
-     The maximum file size in bytes allowed to download. If the file requested is found larger than this value,
-     the transfer will not start and <constant>CURLE_FILESIZE_EXCEEDED</constant> will be returned.
-     The file size is not always known prior to download, and for such files this option has no effect even if
+     The maximum file size in bytes allowed to download.
+     If the file requested is found larger than this value,
+     the transfer will not start
+     and <constant>CURLE_FILESIZE_EXCEEDED</constant> will be returned.
+     The file size is not always known prior to download,
+     and for such files this option has no effect even if
      the file transfer ends up being larger than this given limit.
-     Available as of PHP 8.2.0 and cURL 7.11.0
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of PHP 8.2.0 and cURL 7.11.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1624,11 +1738,14 @@
    </term>
    <listitem>
     <para>
-     The maximum time in seconds, since the creation of the connection, that is allowed for an existing
-     connection to have for it to be considered for reuse. If a connection is found in the cache that is older
-     than this value, it will instead be closed once any in-progress transfers are complete.
-     Default is 0 seconds, meaning the option is disabled and all connections are eligible for reuse.
-     Available as of PHP 8.2.0 and cURL 7.80.0
+     The maximum time in seconds, since the creation of the connection,
+     that is allowed for an existing connection to have for it to be considered for reuse.
+     If a connection is found in the cache that is older than this value,
+     it will instead be closed once any in-progress transfers are complete.
+     Default is <literal>0</literal> seconds,
+     meaning the option is disabled and all connections are eligible for reuse.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of PHP 8.2.0 and cURL 7.80.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1639,11 +1756,12 @@
    </term>
    <listitem>
     <para>
-     The maximum amount of HTTP redirections to follow. Use this option
-     alongside <constant>CURLOPT_FOLLOWLOCATION</constant>.
+     The maximum amount of HTTP redirections to follow.
+     Use this option alongside <constant>CURLOPT_FOLLOWLOCATION</constant>.
      Default value of <literal>20</literal> is set to prevent infinite redirects.
-     Setting to <literal>-1</literal> allows inifinite redirects, and <literal>0</literal>
-     refuses all redirects.
+     Setting to <literal>-1</literal> allows inifinite redirects,
+     and <literal>0</literal> refuses all redirects.
+     Available as of cURL 7.5.
     </para>
    </listitem>
   </varlistentry>
@@ -1658,7 +1776,8 @@
      cumulative average during the transfer, the transfer will pause to
      keep the average rate less than or equal to the parameter value.
      Defaults to unlimited speed.
-     Available as of cURL 7.15.5
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of cURL 7.15.5.
     </para>
    </listitem>
   </varlistentry>
@@ -1673,7 +1792,8 @@
      cumulative average during the transfer, the transfer will pause to
      keep the average rate less than or equal to the parameter value.
      Defaults to unlimited speed.
-     Available as of cURL 7.15.5
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of cURL 7.15.5.
     </para>
    </listitem>
   </varlistentry>
@@ -1684,7 +1804,10 @@
    </term>
    <listitem>
     <para>
-     Available as of PHP 8.3.0 and cURL 7.81.0
+     Set to a bitmask of <constant>CURLMIMEOPT_<replaceable>*</replaceable></constant>
+     constants. Currently there is only one available option:
+     <constant>CURLMIMEOPT_FORMESCAPE</constant>.
+     Available as of PHP 8.3.0 and cURL 7.81.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1695,9 +1818,11 @@
    </term>
    <listitem>
     <para>
-     &true; to be completely silent with regards to
-     the cURL functions.
-     Removed as of cURL 7.15.5; use <constant xmlns="http://docbook.org/ns/docbook">CURLOPT_RETURNTRANSFER</constant> instead.
+     Set to &true; to be completely silent with regards to the cURL functions.
+     Use <constant>CURLOPT_RETURNTRANSFER</constant> instead.
+     Available as of cURL 7.1, deprecated as of cURL 7.8
+     and last available in cURL 7.15.5.
+     Removed as of PHP 7.3.
     </para>
    </listitem>
   </varlistentry>
@@ -1708,9 +1833,10 @@
    </term>
    <listitem>
     <para>
-     &true; to scan the <filename>~/.netrc</filename>
+     Set to &true; to scan the <filename>~/.netrc</filename>
      file to find a username and password for the remote site that
      a connection is being established with.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -1768,9 +1894,11 @@
    </term>
    <listitem>
     <para>
-     &true; to exclude the body from the output.
-     Request method is then set to HEAD. Changing this to &false; does
-     not change it to GET.
+     Set to &true; to exclude the body from the output.
+     For HTTP(S), cURL makes a HEAD request. For most other protocols,
+     cURL is not asking for the body data at all.
+     Changing this to &false; will result in body data being included in the output.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -1781,13 +1909,14 @@
    </term>
    <listitem>
     <para>
-     &true; to disable the progress meter for cURL transfers.
+     Set to &true; to disable the progress meter for cURL transfers.
      <note>
       <para>
        PHP automatically sets this option to &true;, this should only be
        changed for debugging purposes.
       </para>
      </note>
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -1833,10 +1962,12 @@
    </term>
    <listitem>
     <para>
-     A callback accepting three parameters.
-     The first is the cURL resource, the second is a
-     string containing a password prompt, and the third is the maximum
-     password length. Return the string containing the password.
+     A <type>callable</type> accepting three parameters and returning a <type>string</type>.
+     The first parameter is the cURL resource, the second is a
+     <type>string</type> containing a password prompt, and the third is the maximum
+     password length. Return the <type>string</type> containing the password.
+     Available as of cURL 7.4.2, deprecated as of cURL 7.11.1
+     and last available in cURL 7.15.5.
      Removed as of PHP 7.3.0.
     </para>
    </listitem>
@@ -1848,7 +1979,7 @@
    </term>
    <listitem>
     <para>
-     The password to use in authentication.
+     Set to a <type>string</type> with the password to use in authentication.
      Available as of cURL 7.19.1.
     </para>
    </listitem>
@@ -1860,8 +1991,11 @@
    </term>
    <listitem>
     <para>
-     &true; to not handle dot dot sequences.
-     Available as of PHP 7.0.7 and cURL 7.42.0
+     Set to &true; for cURL not alter URL paths before passing them on to the server.
+     Defaults to &false;, which squashes sequences of <literal>/../</literal>
+     or <literal>/./</literal> that may exist in the URL's path part
+     which is supposed to be removed according to RFC 3986 section 5.2.4.
+     Available as of PHP 7.0.7 and cURL 7.42.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1872,12 +2006,12 @@
    </term>
    <listitem>
     <para>
-     Set the pinned public key.
-      The string can be the file name of your pinned public key. The file
-      format expected is "PEM" or "DER". The string can also be any
-      number of base64 encoded sha256 hashes preceded by "sha256//" and
-      separated by ";".
-     Available as of PHP 7.0.7 and cURL 7.39.0
+     Set a <type>string</type> with the pinned public key.
+     The <type>string</type> can be the file name of the pinned public key
+     in a PEM or DER file format.
+     The <type>string</type> can also be any number of base64 encoded sha256 hashes
+     preceded by <literal>sha256//</literal> and separated by <literal>;</literal>.
+     Available as of PHP 7.0.7 and cURL 7.39.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1888,8 +2022,10 @@
    </term>
    <listitem>
     <para>
-     &true; to wait for pipelining/multiplexing.
-     Available as of PHP 7.0.7 and cURL 7.43.0
+     Set to &true; to wait for an existing connection to confirm
+     whether it can do multiplexing and use it if it can
+     before creating and using a new connection.
+     Available as of PHP 7.0.7 and cURL 7.43.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1900,7 +2036,9 @@
    </term>
    <listitem>
     <para>
-     An alternative port number to connect to.
+     An <type>int</type> with an alternative port number to connect to
+     instead of the one specified in the URL or the default port for the used protocol.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -1911,9 +2049,10 @@
    </term>
    <listitem>
     <para>
-     &true; to do a regular HTTP POST. This POST is the
-     normal <literal>application/x-www-form-urlencoded</literal> kind,
-     most commonly used by HTML forms.
+     Set to &true; to do a HTTP <literal>POST</literal> request.
+     This request uses the <literal>application/x-www-form-urlencoded</literal> header.
+     Defaults to &false;.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -1924,15 +2063,17 @@
    </term>
    <listitem>
     <para>
-     The full data to post in a HTTP "POST" operation.
+     The full data to post in a HTTP <literal>POST</literal> operation.
      This parameter can either be
-     passed as a urlencoded string like '<literal>para1=val1&amp;para2=val2&amp;...</literal>'
-     or as an array with the field name as key and field data as value.
-     If <parameter>value</parameter> is an array, the
+     passed as a urlencoded <type>string</type> like
+     '<literal>para1=val1&amp;para2=val2&amp;...</literal>'
+     or as an <type>array</type> with the field name as key and field data as value.
+     If <parameter>value</parameter> is an <type>array</type>, the
      <literal>Content-Type</literal> header will be set to
      <literal>multipart/form-data</literal>.
      Files can be sent using <classname>CURLFile</classname> or <classname>CURLStringFile</classname>,
-     in which case <parameter>value</parameter> must be an array.
+     in which case <parameter>value</parameter> must be an <type>array</type>.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -1943,8 +2084,9 @@
    </term>
    <listitem>
     <para>
-     An array of FTP commands to execute on the server after the FTP
-     request has been performed.
+     An <type>array</type> of FTP command <type>string</type>s
+     to execute on the server after the FTP request has been performed.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -1955,8 +2097,9 @@
    </term>
    <listitem>
     <para>
-     A bitmask of 1 (301 Moved Permanently), 2 (302 Found)
-     and 4 (303 See Other) if the HTTP POST method should be maintained
+     Set to a bitmask of <constant>CURL_REDIR_POST_301</constant>,
+     <constant>CURL_REDIR_POST_302</constant> and <constant>CURL_REDIR_POST_303</constant>
+     if the HTTP <literal>POST</literal> method should be maintained
      when <constant>CURLOPT_FOLLOWLOCATION</constant> is set and a
      specific type of redirect occurs.
      Available as of cURL 7.19.1.
@@ -1971,18 +2114,18 @@
    <listitem>
     <para>
      Set a <type>string</type> holding the host name or dotted numerical
-     IP address to be used as the preproxy that curl connects to before
+     IP address to be used as the preproxy that cURL connects to before
      it connects to the HTTP(S) proxy specified in the
      <constant>CURLOPT_PROXY</constant> option for the upcoming request.
      The preproxy can only be a SOCKS proxy and it should be prefixed with
      <literal>[scheme]://</literal> to specify which kind of socks is used.
      A numerical IPv6 address must be written within [brackets].
-     Setting the preproxy to an empty string explicitly disables the use of a preproxy.
-     To specify port number in this string, append <literal>:[port]</literal>
+     Setting the preproxy to an empty <type>string</type> explicitly disables the use of a preproxy.
+     To specify port number in this <type>string</type>, append <literal>:[port]</literal>
      to the end of the host name. The proxy's port number may optionally be
      specified with the separate option <constant>CURLOPT_PROXYPORT</constant>.
      Defaults to using port 1080 for proxies if a port is not specified.
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2025,8 +2168,8 @@
    </term>
    <listitem>
     <para>
-     A callback accepting five parameters.
-     The first is the cURL resource, the second is the total number of
+     A <type>callable</type> accepting five parameters and returning an <type>int</type>.
+     The first parameter is the cURL resource, the second is the total number of
      bytes expected to be downloaded in this transfer, the third is
      the number of bytes downloaded so far, the fourth is the total
      number of bytes expected to be uploaded in this transfer, and the
@@ -2037,9 +2180,10 @@
        option is set to &false;.
       </para>
      </note>
-     Return a non-zero value to abort the transfer. In which case, the
-     transfer will set a <constant>CURLE_ABORTED_BY_CALLBACK</constant>
-     error.
+     Return an <type>int</type> with a non-zero value to abort the transfer
+     and set a <constant>CURLE_ABORTED_BY_CALLBACK</constant> error.
+     Available as of cURL 7.1 and deprecated as of cURL 7.32.0.
+     Use <constant>CURLOPT_XFERINFOFUNCTION</constant> instead.
     </para>
    </listitem>
   </varlistentry>
@@ -2050,28 +2194,11 @@
    </term>
    <listitem>
     <para>
-     Bitmask of <constant>CURLPROTO_*</constant> values. If used, this bitmask
-     limits what protocols libcurl may use in the transfer. This allows you to have
-     a libcurl built to support a wide range of protocols but still limit specific
-     transfers to only be allowed to use a subset of them. By default libcurl will
-     accept all protocols it supports.
+     Bitmask of <constant>CURLPROTO_<replaceable>*</replaceable></constant> values.
+     If used, this bitmask limits what protocols cURL may use in the transfer.
+     Defaults to <constant>CURLPROTO_ALL</constant>, ie. cURL will accept all protocols it supports.
      See also <constant>CURLOPT_REDIR_PROTOCOLS</constant>.
-     Valid protocol options are:
-     <constant>CURLPROTO_HTTP</constant>,
-     <constant>CURLPROTO_HTTPS</constant>,
-     <constant>CURLPROTO_FTP</constant>,
-     <constant>CURLPROTO_FTPS</constant>,
-     <constant>CURLPROTO_SCP</constant>,
-     <constant>CURLPROTO_SFTP</constant>,
-     <constant>CURLPROTO_TELNET</constant>,
-     <constant>CURLPROTO_LDAP</constant>,
-     <constant>CURLPROTO_LDAPS</constant>,
-     <constant>CURLPROTO_DICT</constant>,
-     <constant>CURLPROTO_FILE</constant>,
-     <constant>CURLPROTO_TFTP</constant>,
-     <constant>CURLPROTO_MQTT</constant>,
-     <constant>CURLPROTO_ALL</constant>
-     Available as of cURL 7.19.4.
+     Available as of cURL 7.19.4 and deprecated as of cURL 7.85.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2082,7 +2209,47 @@
    </term>
    <listitem>
     <para>
-     Available as of PHP 8.3.0 and cURL 7.85.0
+     Set to a <type>string</type> with a comma separated list
+     of case insensitive protocol names (URL schemes) to allow in the transfer.
+     Set to <literal>ALL</literal> to enable all protocols.
+     By default, cURL accepts all protocols it was built with support for.
+     Available protocols are:
+     <simplelist type="inline">
+      <member><literal>DICT</literal></member>
+      <member><literal>FILE</literal></member>
+      <member><literal>FTP</literal></member>
+      <member><literal>FTPS</literal></member>
+      <member><literal>GOPHER</literal></member>
+      <member><literal>GOPHERS</literal></member>
+      <member><literal>HTTP</literal></member>
+      <member><literal>HTTPS</literal></member>
+      <member><literal>IMAP</literal></member>
+      <member><literal>IMAPS</literal></member>
+      <member><literal>LDAP</literal></member>
+      <member><literal>LDAPS</literal></member>
+      <member><literal>MQTT</literal></member>
+      <member><literal>POP3</literal></member>
+      <member><literal>POP3S</literal></member>
+      <member><literal>RTMP</literal></member>
+      <member><literal>RTMPE</literal></member>
+      <member><literal>RTMPS</literal></member>
+      <member><literal>RTMPT</literal></member>
+      <member><literal>RTMPTE</literal></member>
+      <member><literal>RTMPTS</literal></member>
+      <member><literal>RTSP</literal></member>
+      <member><literal>SCP</literal></member>
+      <member><literal>SFTP</literal></member>
+      <member><literal>SMB</literal></member>
+      <member><literal>SMBS</literal></member>
+      <member><literal>SMTP</literal></member>
+      <member><literal>SMTPS</literal></member>
+      <member><literal>TELNET</literal></member>
+      <member><literal>TFTP</literal></member>
+      <member><literal>WS</literal></member>
+      <member><literal>WSS</literal></member>
+     </simplelist>
+     .
+     Available as of PHP 8.3.0 and cURL 7.85.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2093,7 +2260,10 @@
    </term>
    <listitem>
     <para>
-     The HTTP proxy to tunnel requests through.
+     A <type>string</type> with the HTTP proxy to tunnel requests through.
+     This should be the hostname, the dotted numerical IP address
+     or a numerical IPv6 address written within [brackets].
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -2104,11 +2274,12 @@
    </term>
    <listitem>
     <para>
-     The HTTP authentication method(s) to use for the proxy connection.
-     Use the same bitmasks as described in
-     <constant>CURLOPT_HTTPAUTH</constant>. For proxy authentication,
-     only <constant>CURLAUTH_BASIC</constant> and
+     A bitmask of the HTTP authentication method(s)
+     (<constant>CURLAUTH_<replaceable>*</replaceable></constant> constants)
+     to use for the proxy connection.
+     For proxy authentication, only <constant>CURLAUTH_BASIC</constant> and
      <constant>CURLAUTH_NTLM</constant> are currently supported.
+     Defaults to <constant>CURLAUTH_BASIC</constant>.
      Available as of cURL 7.10.7.
     </para>
    </listitem>
@@ -2120,8 +2291,8 @@
    </term>
    <listitem>
     <para>
-     An array of custom HTTP headers to pass to proxies.
-     Available as of PHP 7.0.7 and cURL 7.37.0
+     An <type>array</type> of custom HTTP header <type>string</type>s to pass to proxies.
+     Available as of PHP 7.0.7 and cURL 7.37.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2144,8 +2315,11 @@
    </term>
    <listitem>
     <para>
-     The port number of the proxy to connect to. This port number can
-     also be set in <constant>CURLOPT_PROXY</constant>.
+     An <type>int</type> with the port number of the proxy to connect to.
+     This port number can also be set in <constant>CURLOPT_PROXY</constant>.
+     Setting this to zero makes cURL use the default proxy port number
+     or the port number specified in the proxy URL <type>string</type>.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -2156,11 +2330,9 @@
    </term>
    <listitem>
     <para>
-     Either <constant>CURLPROXY_HTTP</constant> (default),
-     <constant>CURLPROXY_SOCKS4</constant>,
-     <constant>CURLPROXY_SOCKS5</constant>,
-     <constant>CURLPROXY_SOCKS4A</constant> or
-     <constant>CURLPROXY_SOCKS5_HOSTNAME</constant>.
+     Sets the type of the proxy to one of the
+     <constant>CURLPROXY_<replaceable>*</replaceable></constant> constants.
+     Defaults to <constant>CURLPROXY_HTTP</constant>.
      Available as of cURL 7.10.
     </para>
    </listitem>
@@ -2184,9 +2356,10 @@
    </term>
    <listitem>
     <para>
-     A username and password formatted as
-     <literal>"[username]:[password]"</literal> to use for the
+     A <type>string</type> with a username and password formatted as
+     <literal>[username]:[password]</literal> to use for the
      connection to the proxy.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -2201,9 +2374,9 @@
      <type>string</type> naming a file holding one or more certificates to
      verify the HTTPS proxy with.
      This option is for connecting to an HTTPS proxy, not an HTTPS server.
-     Defaults set to the system path where libcurl's cacert bundle is assumed
+     Defaults set to the system path where cURL's cacert bundle is assumed
      to be stored.
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2214,11 +2387,12 @@
    </term>
    <listitem>
     <para>
-     The name of a PEM file holding one or more certificates to verify the HTTPS proxy with.
+     A <type>string</type> with the name of a PEM file
+     holding one or more certificates to verify the HTTPS proxy with.
      This option is for connecting to an HTTPS proxy, not an HTTPS server.
-     Defaults set to the system path where libcurl's cacert bundle is assumed
+     Defaults set to the system path where cURL's cacert bundle is assumed
      to be stored.
-     Available as of PHP 8.2.0 and cURL 7.77.0
+     Available as of PHP 8.2.0 and cURL 7.77.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2229,8 +2403,9 @@
    </term>
    <listitem>
     <para>
-     The directory holding multiple CA certificates to verify the HTTPS proxy with.
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     A <type>string</type> with the directory holding multiple CA certificates
+     to verify the HTTPS proxy with.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2241,10 +2416,11 @@
    </term>
    <listitem>
     <para>
-     Set the file name with the concatenation of CRL (Certificate Revocation List)
+     Set to a <type>string</type> with the file name
+     with the concatenation of CRL (Certificate Revocation List)
      in PEM format to use in the certificate validation that occurs during
      the SSL exchange.
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2255,7 +2431,7 @@
    </term>
    <listitem>
     <para>
-     Proxy issuer SSL certificate filename.
+     Proxy issuer SSL certificate filename <type>string</type>.
      Available as of PHP 8.1.0 and cURL 7.71.0.
     </para>
    </listitem>
@@ -2267,7 +2443,7 @@
    </term>
    <listitem>
     <para>
-     Proxy issuer SSL certificate from memory blob.
+     A <type>string</type> with the proxy issuer SSL certificate.
      Available as of PHP 8.1.0 and cURL 7.71.0.
     </para>
    </listitem>
@@ -2279,11 +2455,12 @@
    </term>
    <listitem>
     <para>
-     Set the string be used as the password required to use the
-     <constant>CURLOPT_PROXY_SSLKEY</constant> private key. You never needed a
-     passphrase to load a certificate but you need one to load your private key.
+     Set the <type>string</type> be used as the password required to use the
+     <constant>CURLOPT_PROXY_SSLKEY</constant> private key.
+     A passphrase is not needed to load a certificate
+     but one is needed to load a private key.
      This option is for connecting to an HTTPS proxy, not an HTTPS server.
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2294,11 +2471,13 @@
    </term>
    <listitem>
     <para>
-     Set the pinned public key for HTTPS proxy. The string can be the file name
-     of your pinned public key. The file format expected is "PEM" or "DER".
-     The string can also be any number of base64 encoded sha256 hashes preceded by
-     "sha256//" and separated by ";".
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     Set the pinned public key for HTTPS proxy.
+     The <type>string</type> can be the file name of the pinned public key
+     which is expected to be in a <literal>PEM</literal>
+     or <literal>DER</literal> file format.
+     The <type>string</type> can also be any number of base64 encoded sha256 hashes
+     preceded by <literal>sha256//</literal> and separated by <literal>;</literal>.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2309,7 +2488,7 @@
    </term>
    <listitem>
     <para>
-     The proxy authentication service name.
+     A <type>string</type> with the proxy authentication service name.
      Available as of PHP 7.0.7, cURL 7.43.0 (for HTTP proxies) and cURL 7.49.0 (for SOCKS5 proxies).
     </para>
    </listitem>
@@ -2321,14 +2500,17 @@
    </term>
    <listitem>
     <para>
-     The file name of your client certificate used to connect to the HTTPS proxy.
-     The default format is "P12" on Secure Transport and "PEM" on other engines,
+     A <type>string</type> with the file name of the client certificate
+     used to connect to the HTTPS proxy.
+     The default format is <literal>P12</literal> on Secure Transport
+     and <literal>PEM</literal> on other engines,
      and can be changed with <constant>CURLOPT_PROXY_SSLCERTTYPE</constant>.
      With NSS or Secure Transport, this can also be the nickname of the certificate
-     you wish to authenticate with as it is named in the security database.
-     If you want to use a file from the current directory, please precede it with
-     "./" prefix, in order to avoid confusion with a nickname.
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     used for authentication as it is named in the security database.
+     If a file from the current directory is to be used,
+     it must be prefixed with <literal>./</literal>
+     in order to avoid confusion with a nickname.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2339,12 +2521,14 @@
    </term>
    <listitem>
     <para>
-     The format of your client certificate used when connecting to an HTTPS proxy.
-     Supported formats are "PEM" and "DER", except with Secure Transport.
+     A <type>string</type> with the format of the client certificate used
+     when connecting to an HTTPS proxy.
+     Supported formats are <literal>PEM</literal> and <literal>DER</literal>,
+     except with Secure Transport.
      OpenSSL (versions 0.9.3 and later) and Secure Transport
-     (on iOS 5 or later, or OS X 10.7 or later) also support "P12" for
-     PKCS#12-encoded files. Defaults to "PEM".
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     (on iOS 5 or later, or OS X 10.7 or later) also support <literal>P12</literal> for
+     PKCS#12-encoded files. Defaults to <literal>PEM</literal>.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2355,7 +2539,7 @@
    </term>
    <listitem>
     <para>
-     SSL proxy client certificate from memory blob.
+     A <type>string</type> with the SSL proxy client certificate.
      Available as of PHP 8.1.0 and cURL 7.71.0.
     </para>
    </listitem>
@@ -2367,11 +2551,13 @@
    </term>
    <listitem>
     <para>
-     The file name of your private key used for connecting to the HTTPS proxy.
-     The default format is "PEM" and can be changed with
+     A <type>string</type> with the file name of the private key
+     used for connecting to the HTTPS proxy.
+     The default format is <literal>PEM</literal> and can be changed with
      <constant>CURLOPT_PROXY_SSLKEYTYPE</constant>.
-     (iOS and Mac OS X only) This option is ignored if curl was built against Secure Transport. Available if built TLS enabled.
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     (iOS and Mac OS X only) This option is ignored if cURL was built against
+     Secure Transport. Available if built with TLS enabled.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2382,8 +2568,15 @@
    </term>
    <listitem>
     <para>
-     The format of your private key. Supported formats are "PEM", "DER" and "ENG".
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     A <type>string</type> with the format of the private key.
+     Supported formats are:
+     <simplelist type="inline">
+      <member><literal>PEM</literal></member>
+      <member><literal>DER</literal></member>
+      <member><literal>ENG</literal></member>
+     </simplelist>
+     .
+     Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2394,7 +2587,7 @@
    </term>
    <listitem>
     <para>
-     Private key for proxy cert from memory blob.
+     A <type>string</type> with the private key for connecting to the HTTPS proxy.
      Available as of PHP 8.1.0 and cURL 7.71.0.
     </para>
    </listitem>
@@ -2406,22 +2599,10 @@
    </term>
    <listitem>
     <para>
-     One of
-     <simplelist type="inline">
-      <member><constant>CURL_SSLVERSION_DEFAULT</constant></member>
-      <member><constant>CURL_SSLVERSION_TLSv1</constant></member>
-      <member><constant>CURL_SSLVERSION_TLSv1_0</constant></member>
-      <member><constant>CURL_SSLVERSION_TLSv1_1</constant></member>
-      <member><constant>CURL_SSLVERSION_TLSv1_2</constant></member>
-      <member><constant>CURL_SSLVERSION_TLSv1_3</constant></member>
-      <member><constant>CURL_SSLVERSION_MAX_DEFAULT</constant></member>
-      <member><constant>CURL_SSLVERSION_MAX_TLSv1_0</constant></member>
-      <member><constant>CURL_SSLVERSION_MAX_TLSv1_1</constant></member>
-      <member><constant>CURL_SSLVERSION_MAX_TLSv1_2</constant></member>
-      <member><constant>CURL_SSLVERSION_MAX_TLSv1_3</constant></member>
-      <member><constant>CURL_SSLVERSION_SSLv3</constant></member>
-     </simplelist>
-     .
+     Set the preferred HTTPS proxy TLS version to one of the
+     <constant>CURL_SSLVERSION_<replaceable>*</replaceable></constant>
+     constants.
+     Defaults to <constant>CURL_SSLVERSION_DEFAULT</constant>.
      <warning>
       <simpara>
        It is better to not set this option and leave the default
@@ -2429,7 +2610,7 @@
        which will attempt to figure out the remote SSL protocol version.
       </simpara>
      </warning>
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2440,11 +2621,12 @@
    </term>
    <listitem>
     <para>
-     The list of ciphers to use for the connection to the HTTPS proxy.
-     The list must be syntactically correct, it consists of one or more cipher
-     strings separated by colons. Commas or spaces are also acceptable separators
-     but colons are normally used, !, - and + can be used as operators.
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     A <type>string</type> with a colon-separated list of ciphers
+     to use for the connection to the HTTPS proxy.
+     When used with OpenSSL commas and spaces are also acceptable as separators,
+     and <literal>!</literal>, <literal>-</literal> and <literal>+</literal>
+     can be used as operators.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2455,13 +2637,9 @@
    </term>
    <listitem>
     <para>
-     Set proxy SSL behavior options, which is a bitmask of the following constants:
-     <simplelist type="inline">
-      <member><constant>CURLSSLOPT_ALLOW_BEAST</constant></member>
-      <member><constant>CURLSSLOPT_NO_REVOKE</constant></member>
-      <member><constant>CURLSSLOPT_NO_PARTIALCHAIN</constant></member>
-     </simplelist>
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     Set proxy SSL behavior options, which is a bitmask of the
+     <constant>CURLSSLOPT_<replaceable>*</replaceable></constant> constants.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2475,11 +2653,12 @@
      Set to <literal>2</literal> to verify in the HTTPS proxy's certificate name fields against the proxy name.
      When set to <literal>0</literal> the connection succeeds regardless of the names used in the certificate.
      Use that ability with caution!
-     <literal>1</literal> treated as a debug option in curl 7.28.0 and earlier.
-     From curl 7.28.1 to 7.65.3 <constant>CURLE_BAD_FUNCTION_ARGUMENT</constant> is returned.
-     From curl 7.66.0 onwards <literal>1</literal> and <literal>2</literal> is treated as the same value.
-     In production environments the value of this option should be kept at <literal>2</literal> (default value).
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     Set to <literal>1</literal> in cURL 7.28.0 and earlier as a debug option.
+     Set to <literal>1</literal> in  cURL 7.28.1 to 7.65.3 <constant>CURLE_BAD_FUNCTION_ARGUMENT</constant> is returned.
+     As of cURL 7.66.0 <literal>1</literal> and <literal>2</literal> is treated as the same value.
+     Defaults to <literal>2</literal>.
+     In production environments the value of this option should be kept at <literal>2</literal>.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2490,13 +2669,14 @@
    </term>
    <listitem>
     <para>
-     &false; to stop cURL from verifying the peer's certificate.
+     Set to &false; to stop cURL from verifying the peer's certificate.
      Alternate certificates to verify against can be
      specified with the <constant>CURLOPT_CAINFO</constant> option
      or a certificate directory can be specified with the
      <constant>CURLOPT_CAPATH</constant> option.
-     When set to false, the peer certificate verification succeeds regardless. &true; by default.
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     When set to &false;, the peer certificate verification succeeds regardless.
+     &true; by default.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2507,13 +2687,12 @@
    </term>
    <listitem>
     <para>
-     The list of cipher suites to use for the TLS 1.3 connection to a proxy.
-     The list must be syntactically correct, it consists of one or more
-     cipher suite strings separated by colons. This option is currently used
-     only when curl is built to use OpenSSL 1.1.1 or later.
-     If you are using a different SSL backend you can try setting
-     TLS 1.3 cipher suites by using the <constant>CURLOPT_PROXY_SSL_CIPHER_LIST</constant> option. Available when built with OpenSSL &gt;= 1.1.1.
-     Available as of PHP 7.3.0 and cURL 7.61.0
+     A <type>string</type> with a colon-separated list of ciphers
+     to use for the connection to the TLS 1.3 connection to a proxy.
+     This option is currently used only when cURL is built to use OpenSSL 1.1.1 or later.
+     When using a different SSL backend the TLS 1.3 cipher suites can be set
+     with the <constant>CURLOPT_PROXY_SSL_CIPHER_LIST</constant> option.
+     Available as of PHP 7.3.0 and cURL 7.61.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2524,10 +2703,11 @@
    </term>
    <listitem>
     <para>
-     The password to use for the TLS authentication method specified with the
+     A <type>string</type> with the password to use
+     for the TLS authentication method specified with the
      <constant>CURLOPT_PROXY_TLSAUTH_TYPE</constant> option. Requires that the
      <constant>CURLOPT_PROXY_TLSAUTH_USERNAME</constant> option to also be set.
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2539,16 +2719,16 @@
    <listitem>
     <para>
      The method of the TLS authentication used for the HTTPS connection.
-     Supported method is <literal>"SRP"</literal>.
+     Supported method is <literal>SRP</literal>.
      <note>
       <para>
        Secure Remote Password (SRP) authentication for TLS provides mutual authentication
-       if both sides have a shared secret. To use TLS-SRP, you must also set the
+       if both sides have a shared secret. To use TLS-SRP, the
        <constant>CURLOPT_PROXY_TLSAUTH_USERNAME</constant> and
-       <constant>CURLOPT_PROXY_TLSAUTH_PASSWORD</constant> options.
+       <constant>CURLOPT_PROXY_TLSAUTH_PASSWORD</constant> options must also be set.
       </para>
      </note>
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2562,7 +2742,7 @@
      The username to use for the HTTPS proxy TLS authentication method specified with the
      <constant>CURLOPT_PROXY_TLSAUTH_TYPE</constant> option. Requires that the
      <constant>CURLOPT_PROXY_TLSAUTH_PASSWORD</constant> option to also be set.
-     Available as of PHP 7.3.0 and cURL 7.52.0
+     Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2592,8 +2772,9 @@
    <listitem>
     <para>
      &true; to HTTP PUT a file. The file to PUT must
-     be set with <constant>CURLOPT_INFILE</constant> and
+     be set with <constant>CURLOPT_READDATA</constant> and
      <constant>CURLOPT_INFILESIZE</constant>.
+     Available as of cURL 7.1 and deprecated as of cURL 7.12.1.
     </para>
    </listitem>
   </varlistentry>
@@ -2604,7 +2785,11 @@
    </term>
    <listitem>
     <para>
-     Available as of PHP 8.3.0 and cURL 7.87.0
+     Set to &true; for cURL to skip cleanup of resources
+     when recovering from a timeout.
+     This allows for a swift termination of the cURL process
+     at the expense of a possible leak of associated resources.
+     Available as of PHP 8.3.0 and cURL 7.87.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2615,8 +2800,9 @@
    </term>
    <listitem>
     <para>
-     An array of FTP commands to execute on the server prior to the FTP
-     request.
+     An <type>array</type> of FTP command <type>string</type>s to execute
+     on the server prior to the FTP request.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -2627,7 +2813,9 @@
    </term>
    <listitem>
     <para>
-     A filename to be used to seed the random number generator for SSL.
+     A <type>string</type> with a filename to be used
+     to seed the random number generator for SSL.
+     Available as of cURL 7.7.0 and deprecated as of 7.84.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2638,10 +2826,12 @@
    </term>
    <listitem>
     <para>
-     Range(s) of data to retrieve in the format
-     <literal>"X-Y"</literal> where X or Y are optional. HTTP transfers
+     A <type>string</type> with the range(s) of data to retrieve in the format
+     <literal>X-Y</literal> where X or Y are optional. HTTP transfers
      also support several intervals, separated with commas in the format
-     <literal>"X-Y,N-M"</literal>.
+     <literal>X-Y,N-M</literal>.
+     Set to &null; to disable requesting a byte range.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -2665,14 +2855,15 @@
    </term>
    <listitem>
     <para>
-     A callback accepting three parameters.
-     The first is the cURL resource, the second is a
-     stream resource provided to cURL through the option
-     <constant>CURLOPT_INFILE</constant>, and the third is the maximum
-     amount of data to be read. The callback must return a string
+     A <type>callable</type> accepting three parameters and returning a <type>string</type>.
+     The first parameter is the cURL resource, the second is a
+     stream <type>resource</type> provided to cURL through the option
+     <constant>CURLOPT_READDATA</constant>, and the third is the maximum
+     amount of data to be read. The callback must return a <type>string</type>
      with a length equal or smaller than the amount of data requested,
-     typically by reading it from the passed stream resource. It should
-     return an empty string to signal <literal>EOF</literal>.
+     typically by reading it from the passed stream <type>resource</type>.
+     It should return an empty <type>string</type> to signal <literal>EOF</literal>.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -2683,15 +2874,16 @@
    </term>
    <listitem>
     <para>
-     Bitmask of <constant>CURLPROTO_*</constant> values. If used, this bitmask
-     limits what protocols libcurl may use in a transfer that it follows to in
+     Bitmask of <constant>CURLPROTO_<replaceable>*</replaceable></constant> values
+     which limit what protocols cURL may use in a transfer that it follows to in
      a redirect when <constant>CURLOPT_FOLLOWLOCATION</constant> is enabled.
-     This allows you to limit specific transfers to only be allowed to use a subset
-     of protocols in redirections. By default libcurl will allow all protocols
-     except for FILE and SCP. This is a difference compared to pre-7.19.4 versions
-     which unconditionally would follow to all protocols supported.
+     This allows limiting specific transfers to only be allowed to use a subset
+     of protocols in redirections.
+     As of cURL 7.19.4, by default cURL will allow all protocols
+     except for <literal>FILE</literal> and <literal>SCP</literal>.
+     Prior to cURL 7.19.4, cURL would unconditionally follow to all supported protocols.
      See also <constant>CURLOPT_PROTOCOLS</constant> for protocol constant values.
-     Available as of cURL 7.19.4.
+     Available as of cURL 7.19.4 and deprecated as of cURL 7.85.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2702,6 +2894,54 @@
    </term>
    <listitem>
     <para>
+     Set to a <type>string</type> with a comma separated list
+     of case insensitive protocol names (URL schemes)
+     to allow to follow to in a redirect when
+     <constant>CURLOPT_FOLLOWLOCATION</constant> is enabled.
+     Set to <literal>ALL</literal> to enable all protocols.
+     As of cURL 7.65.2 it defaults to <literal>FTP</literal>,
+     <literal>FTPS</literal>, <literal>HTTP</literal> and <literal>HTTPS</literal>.
+     From cURL 7.40.0 to 7.65.1, this defaults to all protocols except
+     <literal>FILE</literal>, <literal>SCP</literal>, <literal>SMB</literal> and
+     <literal>SMBS</literal>.
+     Prior to cURL 7.40.0, this defaults to all protocols except
+     <literal>FILE</literal> and <literal>SCP</literal>.
+     Available protocols are:
+     <simplelist type="inline">
+      <member><literal>DICT</literal></member>
+      <member><literal>FILE</literal></member>
+      <member><literal>FTP</literal></member>
+      <member><literal>FTPS</literal></member>
+      <member><literal>GOPHER</literal></member>
+      <member><literal>GOPHERS</literal></member>
+      <member><literal>HTTP</literal></member>
+      <member><literal>HTTPS</literal></member>
+      <member><literal>IMAP</literal></member>
+      <member><literal>IMAPS</literal></member>
+      <member><literal>LDAP</literal></member>
+      <member><literal>LDAPS</literal></member>
+      <member><literal>MQTT</literal></member>
+      <member><literal>POP3</literal></member>
+      <member><literal>POP3S</literal></member>
+      <member><literal>RTMP</literal></member>
+      <member><literal>RTMPE</literal></member>
+      <member><literal>RTMPS</literal></member>
+      <member><literal>RTMPT</literal></member>
+      <member><literal>RTMPTE</literal></member>
+      <member><literal>RTMPTS</literal></member>
+      <member><literal>RTSP</literal></member>
+      <member><literal>SCP</literal></member>
+      <member><literal>SFTP</literal></member>
+      <member><literal>SMB</literal></member>
+      <member><literal>SMBS</literal></member>
+      <member><literal>SMTP</literal></member>
+      <member><literal>SMTPS</literal></member>
+      <member><literal>TELNET</literal></member>
+      <member><literal>TFTP</literal></member>
+      <member><literal>WS</literal></member>
+      <member><literal>WSS</literal></member>
+     </simplelist>
+     .
      Available as of PHP 8.3.0 and cURL 7.85.0.
     </para>
    </listitem>
@@ -2713,8 +2953,9 @@
    </term>
    <listitem>
     <para>
-     The contents of the <literal>"Referer: "</literal> header to be used
-     in a HTTP request.
+     A <type>string</type> with the contents of the <literal>Referer: </literal>
+     header to be used in a HTTP request.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -2725,6 +2966,8 @@
    </term>
    <listitem>
     <para>
+     A <type>string</type> to use in the upcoming request
+     instead of the path as extracted from the URL.
      Available as of PHP 7.3.0 and cURL 7.55.0.
     </para>
    </listitem>
@@ -2736,11 +2979,13 @@
    </term>
    <listitem>
     <para>
-     Provide a custom address for a specific host and port pair. An array
-     of hostname, port, and IP address strings, each element separated by
-     a colon. In the format:
+     Provide an <type>array</type> of colon-separated <type>string</type>s
+     with custom addresses for specific host and port pairs in the following format:
      <code>
-      array("example.com:80:127.0.0.1")
+      array(
+        "example.com:80:127.0.0.1",
+        "example2.com:443:127.0.0.2",
+      )
      </code>
      Available as of cURL 7.21.3.
     </para>
@@ -2754,6 +2999,8 @@
    <listitem>
     <para>
      The offset, in bytes, to resume a transfer from.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -2764,7 +3011,7 @@
    </term>
    <listitem>
     <para>
-     &true; to return the transfer as a string of the
+     &true; to return the transfer as a <type>string</type> of the
      return value of <function>curl_exec</function> instead of outputting
      it directly.
     </para>
@@ -2884,11 +3131,13 @@
    </term>
    <listitem>
     <para>
-     The authorization identity (authzid) for the transfer. Only applicable to the PLAIN SASL
-     authentication mechanism where it is optional. When not specified, only the authentication identity
-     (authcid) as specified by the username will be sent to the server, along with the password.
-     The server will derive the authzid from the authcid when not provided, which it will then use internally.
-     Available as of PHP 8.2.0 and cURL 7.66.0
+     The authorization identity (authzid) <type>string</type> for the transfer.
+     Only applicable to the PLAIN SASL authentication mechanism where it is optional.
+     When not specified, only the authentication identity (authcid)
+     as specified by the username will be sent to the server, along with the password.
+     The server will derive the authzid from the authcid when not provided,
+     which it will then use internally.
+     Available as of PHP 8.2.0 and cURL 7.66.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2900,7 +3149,7 @@
    <listitem>
     <para>
      &true; to enable sending the initial response in the first packet.
-     Available as of PHP 7.0.7 and cURL 7.31.0
+     Available as of PHP 7.0.7 and cURL 7.31.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2911,8 +3160,8 @@
    </term>
    <listitem>
     <para>
-     The authentication service name.
-     Available as of PHP 7.0.7 and cURL 7.43.0
+     A <type>string</type> with the authentication service name.
+     Available as of PHP 7.0.7 and cURL 7.43.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2923,8 +3172,9 @@
    </term>
    <listitem>
     <para>
-     A result of <function>curl_share_init</function>. Makes the cURL
-     handle to use the data from the shared handle.
+     A result of <function>curl_share_init</function>.
+     Makes the cURL handle to use the data from the shared handle.
+     Available as of cURL 7.10.
     </para>
    </listitem>
   </varlistentry>
@@ -2936,18 +3186,17 @@
    <listitem>
     <para>
      The SOCKS5 authentication method(s) to use. The options are:
-     <constant>CURLAUTH_BASIC</constant>,
-     <constant>CURLAUTH_GSSAPI</constant>,
-     <constant>CURLAUTH_NONE</constant>.
-     The bitwise <literal>|</literal> (or) operator can be used to combine
-     more than one method. If this is done, cURL will poll the server to see
+     <simplelist type="inline">
+      <member><constant>CURLAUTH_BASIC</constant></member>
+      <member><constant>CURLAUTH_GSSAPI</constant></member>
+      <member><constant>CURLAUTH_NONE</constant></member>
+     </simplelist>
+     .
+     When more than one method is set, cURL will poll the server to see
      what methods it supports and pick the best one.
-     <constant>CURLAUTH_BASIC</constant> allows username/password authentication.
-     <constant>CURLAUTH_GSSAPI</constant> allows GSS-API authentication.
-     <constant>CURLAUTH_NONE</constant> allows no authentication.
      Defaults to <literal>CURLAUTH_BASIC|CURLAUTH_GSSAPI</literal>.
      Set the actual username and password with the <constant>CURLOPT_PROXYUSERPWD</constant> option.
-     Available as of PHP 7.3.0 and cURL 7.55.0
+     Available as of PHP 7.3.0 and cURL 7.55.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2986,12 +3235,16 @@
    </term>
    <listitem>
     <para>
-     A bitmask consisting of one or more of
-     <constant>CURLSSH_AUTH_PUBLICKEY</constant>,
-     <constant>CURLSSH_AUTH_PASSWORD</constant>,
-     <constant>CURLSSH_AUTH_HOST</constant>,
-     <constant>CURLSSH_AUTH_KEYBOARD</constant>. Set to
-     <constant>CURLSSH_AUTH_ANY</constant> to let libcurl pick one.
+     A bitmask consisting of one or more of the following constants:
+     <simplelist type="inline">
+      <member><constant>CURLSSH_AUTH_PUBLICKEY</constant></member>
+      <member><constant>CURLSSH_AUTH_PASSWORD</constant></member>
+      <member><constant>CURLSSH_AUTH_HOST</constant></member>
+      <member><constant>CURLSSH_AUTH_KEYBOARD</constant></member>
+      <member><constant>CURLSSH_AUTH_AGENT</constant></member>
+      <member><constant>CURLSSH_AUTH_ANY</constant></member>
+     </simplelist>
+     Defaults to <constant>CURLSSH_AUTH_ANY</constant>.
      Available as of cURL 7.16.1.
     </para>
    </listitem>
@@ -3003,9 +3256,10 @@
    </term>
    <listitem>
     <para>
-     &true; to enable built-in SSH compression. This is a request, not an order;
-     the server may or may not do it.
-     Available as of PHP 7.3.0 and cURL 7.56.0
+     &true; to enable, &false; to disable built-in SSH compression.
+     Note that the server can disregard this request.
+     Defaults to &false;.
+     Available as of PHP 7.3.0 and cURL 7.56.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3016,7 +3270,10 @@
    </term>
    <listitem>
     <para>
-     Available as of PHP 8.3.0 and cURL 7.84.0
+     Set to a <type>callable</type> that will be called
+     when SSH host key verification is needed. This callback overrides
+     <constant>CURLOPT_SSH_KNOWNHOSTS</constant>.
+     Available as of PHP 8.3.0 and cURL 7.84.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3027,8 +3284,8 @@
    </term>
    <listitem>
     <para>
-     A string containing 32 hexadecimal digits. The string should be the
-     MD5 checksum of the remote host's public key, and libcurl will reject
+     A <type>string</type> containing 32 hexadecimal digits which should contain the
+     MD5 checksum of the remote host's public key, and cURL will reject
      the connection to the host unless the md5sums match.
      This option is only for SCP and SFTP transfers.
      Available as of cURL 7.17.1.
@@ -3042,9 +3299,10 @@
    </term>
    <listitem>
     <para>
-     Base64-encoded SHA256 hash of the remote host's public key.
+     A <type>string</type> with the base64-encoded SHA256 hash
+     of the remote host's public key.
      The transfer will fail if the given hash does not match the hash the remote host provides.
-     Available as of PHP 8.2.0 and cURL 7.80.0
+     Available as of PHP 8.2.0 and cURL 7.80.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3068,9 +3326,9 @@
    </term>
    <listitem>
     <para>
-     The file name for your private key. If not used, libcurl defaults to
-     $HOME/.ssh/id_dsa if the HOME environment variable is set,
-     and just "id_dsa" in the current directory if HOME is not set.
+     The file name for a private key. If not used, cURL defaults to
+     <filename>$HOME/.ssh/id_dsa</filename> if the HOME environment variable is set,
+     and just <literal>id_dsa</literal> in the current directory if HOME is not set.
      If the file is password-protected, set the password with
      <constant>CURLOPT_KEYPASSWD</constant>.
      Available as of cURL 7.16.1.
@@ -3084,9 +3342,9 @@
    </term>
    <listitem>
     <para>
-     The file name for your public key. If not used, libcurl defaults to
-     $HOME/.ssh/id_dsa.pub if the HOME environment variable is set,
-     and just "id_dsa.pub" in the current directory if HOME is not set.
+     The file name for a public key. If not used, cURL defaults to
+     <filename>$HOME/.ssh/id_dsa.pub</filename> if the HOME environment variable is set,
+     and just <literal>id_dsa.pub</literal> in the current directory if HOME is not set.
      Available as of cURL 7.16.1.
     </para>
    </listitem>
@@ -3099,6 +3357,7 @@
    <listitem>
     <para>
      The name of a file containing a PEM formatted certificate.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -3111,6 +3370,7 @@
     <para>
      The password required to use the
      <constant>CURLOPT_SSLCERT</constant> certificate.
+     Available as of cURL 7.1 and deprecated as of cURL 7.17.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3121,11 +3381,16 @@
    </term>
    <listitem>
     <para>
-     The format of the certificate. Supported formats are
-     <literal>"PEM"</literal> (default), <literal>"DER"</literal>,
-     and <literal>"ENG"</literal>.
-     As of OpenSSL 0.9.3, <literal>"P12"</literal> (for PKCS#12-encoded files)
-     is also supported.
+     The format of the certificate. Supported formats are:
+     <simplelist type="inline">
+      <member><literal>PEM</literal></member>
+      <member><literal>DER</literal></member>
+      <member><literal>ENG</literal></member>
+      <member><literal>P12</literal></member>
+     </simplelist>
+     .
+     <literal>P12</literal> (for PKCS#12-encoded files) is available as of OpenSSL 0.9.3.
+     Defaults to <literal>PEM</literal>.
      Available as of cURL 7.9.3.
     </para>
    </listitem>
@@ -3137,7 +3402,7 @@
    </term>
    <listitem>
     <para>
-     SSL client certificate from memory blob.
+     A <type>string</type> with the SSL client certificate.
      Available as of PHP 8.1.0 and cURL 7.71.0.
     </para>
    </listitem>
@@ -3149,8 +3414,9 @@
    </term>
    <listitem>
     <para>
-     The identifier for the crypto engine of the private SSL key
+     The <type>string</type> identifier for the crypto engine of the private SSL key
      specified in <constant>CURLOPT_SSLKEY</constant>.
+     Available as of cURL 7.9.3.
     </para>
    </listitem>
   </varlistentry>
@@ -3161,8 +3427,9 @@
    </term>
    <listitem>
     <para>
-     The identifier for the crypto engine used for asymmetric crypto
+     The <type>string</type> identifier for the crypto engine used for asymmetric crypto
      operations.
+     Available as of cURL 7.9.3.
     </para>
    </listitem>
   </varlistentry>
@@ -3174,6 +3441,7 @@
    <listitem>
     <para>
      The name of a file containing a private SSL key.
+     Available as of cURL 7.9.3.
     </para>
    </listitem>
   </varlistentry>
@@ -3192,6 +3460,7 @@
        the PHP script it is contained within safe.
       </para>
      </note>
+     Available as of cURL 7.9.3 and deprecated as of cURL 7.17.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3203,9 +3472,16 @@
    <listitem>
     <para>
      The key type of the private SSL key specified in
-     <constant>CURLOPT_SSLKEY</constant>. Supported key types are
-     <literal>"PEM"</literal> (default), <literal>"DER"</literal>,
-     and <literal>"ENG"</literal>.
+     <constant>CURLOPT_SSLKEY</constant>.
+      Supported key types are:
+     <simplelist type="inline">
+      <member><literal>PEM</literal></member>
+      <member><literal>DER</literal></member>
+      <member><literal>ENG</literal></member>
+     </simplelist>
+     .
+     Defaults to <literal>PEM</literal>.
+     Available as of cURL 7.9.3.
     </para>
    </listitem>
   </varlistentry>
@@ -3216,7 +3492,7 @@
    </term>
    <listitem>
     <para>
-     Private key for client cert from memory blob.
+     A <type>string</type> private key for client cert.
      Available as of PHP 8.1.0 and cURL 7.71.0.
     </para>
    </listitem>
@@ -3228,34 +3504,8 @@
    </term>
    <listitem>
     <para>
-     One of
-     <simplelist type="inline">
-      <member><constant>CURL_SSLVERSION_DEFAULT</constant></member>
-      <member><constant>CURL_SSLVERSION_TLSv1</constant></member>
-      <member><constant>CURL_SSLVERSION_SSLv2</constant></member>
-      <member><constant>CURL_SSLVERSION_SSLv3</constant></member>
-      <member><constant>CURL_SSLVERSION_TLSv1_0</constant></member>
-      <member><constant>CURL_SSLVERSION_TLSv1_1</constant></member>
-      <member><constant>CURL_SSLVERSION_TLSv1_2</constant></member>
-      <member><constant>CURL_SSLVERSION_TLSv1_3</constant></member>
-     </simplelist>
-     .
-     The maximum TLS version can be set by using one of the
-     <constant>CURL_SSLVERSION_MAX_<replaceable>*</replaceable></constant>
-     constants.
-     It is also possible to bitwise OR one of the
-     <constant>CURL_SSLVERSION_<replaceable>*</replaceable></constant>
-     constants with one of the
-     <constant>CURL_SSLVERSION_MAX_<replaceable>*</replaceable></constant>.
-
-     <simplelist type="inline">
-      <member><constant>CURL_SSLVERSION_MAX_DEFAULT</constant> (the maximum version supported by the library)</member>
-      <member><constant>CURL_SSLVERSION_MAX_TLSv1_0</constant></member>
-      <member><constant>CURL_SSLVERSION_MAX_TLSv1_1</constant></member>
-      <member><constant>CURL_SSLVERSION_MAX_TLSv1_2</constant></member>
-      <member><constant>CURL_SSLVERSION_MAX_TLSv1_3</constant></member>
-     </simplelist>
-     .
+     One of the
+     <constant>CURL_SSLVERSION_<replaceable>*</replaceable></constant> constants.
      <warning>
       <simpara>
        It is better to not set this option and leave the defaults.
@@ -3267,6 +3517,8 @@
        vulnerabilities in SSLv2 and SSLv3.
       </simpara>
      </warning>
+     Defaults to <constant>CURL_SSLVERSION_DEFAULT</constant>.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -3277,9 +3529,9 @@
    </term>
    <listitem>
     <para>
-     A list of ciphers to use for SSL. For example,
-     <literal>RC4-SHA</literal> and <literal>TLSv1</literal> are valid
-     cipher lists.
+     A colon-separated <type>string</type> of ciphers to use
+     for the TLS 1.2 (1.1, 1.0) connection.
+     Available as of cURL 7.9.
     </para>
    </listitem>
   </varlistentry>
@@ -3294,7 +3546,7 @@
      <literal>X25519:P-521</literal> is a valid list of two elliptic curves.
      This option defines the client's key exchange algorithms in the SSL handshake,
      if the SSL backend cURL is built to use supports it.
-     Available as of PHP 8.2.0 and cURL 7.73.0
+     Available as of PHP 8.2.0 and cURL 7.73.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3306,9 +3558,9 @@
    <listitem>
     <para>
      &false; to disable ALPN in the SSL handshake (if the SSL backend
-     libcurl is built to use supports it), which can be used to
+     cURL is built to use supports it), which can be used to
      negotiate http2.
-     Available as of PHP 7.0.7 and cURL 7.36.0
+     Available as of PHP 7.0.7 and cURL 7.36.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3320,9 +3572,9 @@
    <listitem>
     <para>
      &false; to disable NPN in the SSL handshake (if the SSL backend
-     libcurl is built to use supports it), which can be used to
+     cURL is built to use supports it), which can be used to
      negotiate http2.
-     Available as of PHP 7.0.7 and cURL 7.36.0
+     Available as of PHP 7.0.7 and cURL 7.36.0, and deprecated as of cURL 7.86.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3333,8 +3585,10 @@
    </term>
    <listitem>
     <para>
-     &true; to enable TLS false start.
-     Available as of PHP 7.0.7 and cURL 7.42.0
+     &true; to enable and &false; to disable TLS false start
+     which is a mode where a TLS client starts sending application data
+     before verifying the server's <literal>Finished</literal> message.
+     Available as of PHP 7.0.7 and cURL 7.42.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3345,16 +3599,10 @@
    </term>
    <listitem>
     <para>
-     Set SSL behavior options, which is a bitmask of the following constants:
-     <simplelist type="inline">
-      <member><constant>CURLSSLOPT_ALLOW_BEAST</constant></member>
-      <member><constant>CURLSSLOPT_NO_REVOKE</constant></member>
-      <member><constant>CURLSSLOPT_AUTO_CLIENT_CERT</constant></member>
-      <member><constant>CURLSSLOPT_NATIVE_CA</constant></member>
-      <member><constant>CURLSSLOPT_NO_PARTIALCHAIN</constant></member>
-      <member><constant>CURLSSLOPT_REVOKE_BEST_EFFORT</constant></member>
-     </simplelist>
-     Available as of PHP 7.0.7. and cURL 7.25.0
+     Set SSL behavior options, which is a bitmask of the
+     <constant>CURLSSLOPT_<replaceable>*</replaceable></constant> constants.
+     Defaults to none of the bits being set.
+     Available as of PHP 7.0.7. and cURL 7.25.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3385,6 +3633,7 @@
      <literal>1</literal> should not be used.
      In production environments the value of this option
      should be kept at <literal>2</literal> (default value). Support for value <literal>1</literal> removed in cURL 7.28.1.
+     Available as of cURL 7.8.1.
     </para>
    </listitem>
   </varlistentry>
@@ -3399,8 +3648,10 @@
      certificate. Alternate certificates to verify against can be
      specified with the <constant>CURLOPT_CAINFO</constant> option
      or a certificate directory can be specified with the
-     <constant>CURLOPT_CAPATH</constant> option. &true; by default as of cURL 7.10. Default bundle installed as of
-     cURL 7.10.
+     <constant>CURLOPT_CAPATH</constant> option.
+     Defaults to &true; of cURL 7.10.
+     Default bundle of CA certificates installed as of cURL 7.10.
+     Available as of cURL 7.4.2.
     </para>
    </listitem>
   </varlistentry>
@@ -3411,8 +3662,8 @@
    </term>
    <listitem>
     <para>
-     &true; to verify the certificate's status.
-     Available as of PHP 7.0.7 and cURL 7.41.0
+     &true; to enable and &false; to disable verification of the certificate's status.
+     Available as of PHP 7.0.7 and cURL 7.41.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3423,8 +3674,10 @@
    </term>
    <listitem>
     <para>
-     An alternative location to output errors to instead of
+     Accepts a file handle <type>resource</type> pointing to
+     an alternative location to output errors to instead of
      <constant>STDERR</constant>.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -3435,8 +3688,9 @@
    </term>
    <listitem>
     <para>
-     Set the numerical stream weight (a number between 1 and 256).
-     Available as of PHP 7.0.7 and cURL 7.46.0
+     Set the numerical stream weight
+     (a number between <literal>1</literal> and <literal>256</literal>).
+     Available as of PHP 7.0.7 and cURL 7.46.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3450,7 +3704,8 @@
      &true; to suppress proxy CONNECT response headers from the user callback functions
      <constant>CURLOPT_HEADERFUNCTION</constant> and <constant>CURLOPT_WRITEFUNCTION</constant>,
      when <constant>CURLOPT_HTTPPROXYTUNNEL</constant> is used and a CONNECT request is made.
-     Available as of PHP 7.3.0 and cURL 7.54.0
+     Defaults to &false;.
+     Available as of PHP 7.3.0 and cURL 7.54.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3461,8 +3716,8 @@
    </term>
    <listitem>
     <para>
-     &true; to enable TCP Fast Open.
-     Available as of PHP 7.0.7 and cURL 7.49.0
+     &true; to enable and &false; to disable TCP Fast Open.
+     Available as of PHP 7.0.7 and cURL 7.49.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3477,7 +3732,7 @@
      frequency of these probes can be controlled by the <constant>CURLOPT_TCP_KEEPIDLE</constant>
      and <constant>CURLOPT_TCP_KEEPINTVL</constant> options, provided the operating system
      supports them. If set to <literal>0</literal> (default) keepalive probes are disabled.
-     Available as of cURL 7.25.0
+     Available as of cURL 7.25.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3492,7 +3747,7 @@
      idle before sending keepalive probes, if <constant>CURLOPT_TCP_KEEPALIVE</constant> is
      enabled. Not all operating systems support this option.
      The default is <literal>60</literal>.
-     Available as of cURL 7.25.0
+     Available as of cURL 7.25.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3507,7 +3762,7 @@
      keepalive probes, if <constant>CURLOPT_TCP_KEEPALIVE</constant> is enabled.
      Not all operating systems support this option.
      The default is <literal>60</literal>.
-     Available as of cURL 7.25.0
+     Available as of cURL 7.25.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3520,6 +3775,7 @@
     <para>
      &true; to disable TCP's Nagle algorithm, which tries to minimize
      the number of small packets on the network.
+     Defaults to &true;.
      Available as of cURL 7.11.2.
     </para>
    </listitem>
@@ -3565,7 +3821,8 @@
    <listitem>
     <para>
      &true; to not send TFTP options requests.
-     Available as of PHP 7.0.7 and cURL 7.48.0
+     Defaults to &false;.
+     Available as of PHP 7.0.7 and cURL 7.48.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3576,17 +3833,19 @@
    </term>
    <listitem>
     <para>
-     How <constant>CURLOPT_TIMEVALUE</constant> is treated.
+     Set how <constant>CURLOPT_TIMEVALUE</constant> is treated.
      Use <constant>CURL_TIMECOND_IFMODSINCE</constant> to return the
      page only if it has been modified since the time specified in
      <constant>CURLOPT_TIMEVALUE</constant>. If it hasn't been modified,
-     a <literal>"304 Not Modified"</literal> header will be returned
+     a <literal>304 Not Modified</literal> header will be returned
      assuming <constant>CURLOPT_HEADER</constant> is &true;.
      Use <constant>CURL_TIMECOND_IFUNMODSINCE</constant> for the reverse
      effect. Use <constant>CURL_TIMECOND_NONE</constant> to ignore
      <constant>CURLOPT_TIMEVALUE</constant> and always return the page.
-     <constant>CURL_TIMECOND_NONE</constant> is the default. Before cURL 7.46.0 the default was
+     <constant>CURL_TIMECOND_NONE</constant> is the default.
+     Prior to cURL 7.46.0 the default was
      <constant>CURL_TIMECOND_IFMODSINCE</constant>.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -3598,6 +3857,8 @@
    <listitem>
     <para>
      The maximum number of seconds to allow cURL functions to execute.
+     Defaults to <literal>0</literal>, meaning that functions never time out during transfer.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -3610,10 +3871,10 @@
     <para>
      The maximum number of milliseconds to allow cURL functions to
      execute.
-     <!-- http://curl.haxx.se/libcurl/c/curl_easy_setopt.html -->
-     If libcurl is built to use the standard system name resolver, that
+     If cURL is built to use the standard system name resolver, that
      portion of the connect will still use full-second resolution for
      timeouts with a minimum timeout allowed of one second.
+     Defaults to <literal>0</literal>, meaning that functions never time out during transfer.
      Available as of cURL 7.16.2.
     </para>
    </listitem>
@@ -3627,6 +3888,8 @@
     <para>
      The time in seconds since January 1st, 1970. The time will be used
      by <constant>CURLOPT_TIMECONDITION</constant>.
+     Defaults to <literal>0</literal>.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -3642,7 +3905,7 @@
      The difference between this option and <constant>CURLOPT_TIMEVALUE</constant>
      is the type of the argument. On systems where 'long' is only 32 bit wide,
      this option has to be used to set dates beyond the year 2038.
-     Available as of PHP 7.3.0 and cURL 7.59.0
+     Available as of PHP 7.3.0 and cURL 7.59.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3653,12 +3916,12 @@
    </term>
    <listitem>
     <para>
-     The list of cipher suites to use for the TLS 1.3 connection. The list must be
-     syntactically correct, it consists of one or more cipher suite strings separated by colons.
-     This option is currently used only when curl is built to use OpenSSL 1.1.1 or later.
-     If you are using a different SSL backend you can try setting
-     TLS 1.3 cipher suites by using the <constant>CURLOPT_SSL_CIPHER_LIST</constant> option. Available when built with OpenSSL &gt;= 1.1.1.
-     Available as of PHP 7.3.0 and cURL 7.61.0
+     A <type>string</type> with a colon-separated list of ciphers
+     to use for the connection to the TLS 1.3 connection.
+     This option is currently used only when cURL is built to use OpenSSL 1.1.1 or later.
+     When using a different SSL backend the TLS 1.3 cipher suites can be set
+     with the <constant>CURLOPT_SSL_CIPHER_LIST</constant> option.
+     Available as of PHP 7.3.0 and cURL 7.61.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3735,6 +3998,8 @@
      For LDAP, it retrieves data in plain text instead of HTML. On
      Windows systems, it will not set <constant>STDOUT</constant> to binary
      mode.
+     Defaults to &false;.
+     Available as of cURL 7.1.1.
     </para>
    </listitem>
   </varlistentry>
@@ -3747,7 +4012,9 @@
     <para>
      Enables the use of Unix domain sockets as connection endpoint and
      sets the path to the given <type>string</type>.
-     Available as of PHP 7.0.7 and cURL 7.40.0
+     Set to &null; to disable.
+     Defaults to &null;.
+     Available as of PHP 7.0.7 and cURL 7.40.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3762,6 +4029,8 @@
      when following locations (using
      <constant>CURLOPT_FOLLOWLOCATION</constant>), even when the
      hostname has changed.
+     Defaults to &false;.
+     Available as of cURL 7.10.4.
     </para>
    </listitem>
   </varlistentry>
@@ -3776,8 +4045,9 @@
      on existing connections in order to keep them alive. This option defines the connection upkeep interval.
      Currently, the only protocol with a connection upkeep mechanism is HTTP/2. When the connection upkeep
      interval is exceeded, an HTTP/2 PING frame is sent on the connection.
-     Default is <literal>60</literal> seconds.
-     Available as of PHP 8.2.0 and cURL 7.62.0
+     Defaults to <constant>CURL_UPKEEP_INTERVAL_DEFAULT</constant>
+     which is currently <literal>60</literal> seconds.
+     Available as of PHP 8.2.0 and cURL 7.62.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3788,7 +4058,9 @@
    </term>
    <listitem>
     <para>
-     &true; to prepare for an upload.
+     &true; to prepare for and perform an upload.
+     Defaults to &false;.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -3802,7 +4074,7 @@
      Preferred buffer size in bytes for the cURL upload buffer.
      The upload buffer size by default is 64 kilobytes. The maximum buffer size allowed to be set is 2 megabytes.
      The minimum buffer size allowed to be set is 16 kilobytes.
-     Available as of PHP 8.2.0 and cURL 7.62.0
+     Available as of PHP 8.2.0 and cURL 7.62.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3815,6 +4087,7 @@
     <para>
      The URL to fetch. This can also be set when initializing a
      session with <function>curl_init</function>.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -3829,11 +4102,8 @@
      when using FTP, SMTP, POP3, IMAP, etc.
      These are all protocols that start out plain text
      and get "upgraded" to SSL using the STARTTLS command.
-     Set to one of the following:
-     <constant>CURLUSESSL_NONE</constant>,
-     <constant>CURLUSESSL_TRY</constant>,
-     <constant>CURLUSESSL_CONTROL</constant> or
-     <constant>CURLUSESSL_ALL</constant>.
+     Set to one of the
+     <constant>CURLUSESSL_<replaceable>*</replaceable></constant> constants.
      Available as of cURL 7.17.0.
     </para>
    </listitem>
@@ -3845,8 +4115,9 @@
    </term>
    <listitem>
     <para>
-     The contents of the <literal>"User-Agent: "</literal> header to be
+     The contents of the <literal>User-Agent: </literal> header to be
      used in a HTTP request.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -3858,7 +4129,7 @@
    <listitem>
     <para>
      The user name to use in authentication.
-     Available as of cURL 7.19.1
+     Available as of cURL 7.19.1.
     </para>
    </listitem>
   </varlistentry>
@@ -3870,8 +4141,9 @@
    <listitem>
     <para>
      A username and password formatted as
-     <literal>"[username]:[password]"</literal> to use for the
+     <literal>[username]:[password]</literal> to use for the
      connection.
+     Available as cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -3885,6 +4157,8 @@
      &true; to output verbose information. Writes
      output to <constant>STDERR</constant>, or the file specified using
      <constant>CURLOPT_STDERR</constant>.
+     Defaults to &false;.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -3912,11 +4186,12 @@
    </term>
    <listitem>
     <para>
-     A callback accepting two parameters.
-     The first is the cURL resource, and the second is a
-     string with the data to be written. The data must be saved by
-     this callback. It must return the exact number of bytes written
+     A <type>callable</type> accepting two parameters and returning an <type>int</type>.
+     The first parameter is the cURL resource, and the second is a
+     <type>string</type> with the data to be written. The data must be saved by
+     this callback. The callback must return the exact number of bytes written
      or the transfer will be aborted with an error.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -3927,7 +4202,9 @@
    </term>
    <listitem>
     <para>
-     The file that the header part of the transfer is written to.
+     Accepts a file handle <type>resource</type> to the file
+     that the header part of the transfer is written to.
+     Available as of cURL 7.1.
     </para>
    </listitem>
   </varlistentry>
@@ -3938,7 +4215,10 @@
    </term>
    <listitem>
     <para>
-     Available as of PHP 8.3.0 and cURL 7.86.0
+     Accepts a bitmask setting WebSocket behavior options.
+     The only available option is <constant>CURLWS_RAW_MODE</constant>.
+     Defaults to <literal>0</literal>.
+     Available as of PHP 8.3.0 and cURL 7.86.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3949,9 +4229,14 @@
    </term>
    <listitem>
     <para>
-     A callback accepting two parameters.
-     Has a similar purpose as <constant>CURLOPT_PROGRESSFUNCTION</constant> but is more modern
-     and the preferred option from cURL.
+     A <type>callable</type> accepting five parameters and returning an <type>int</type>.
+     The first parameter is the cURL resource, the second is the total number of
+     bytes expected to be downloaded in this transfer, the third is
+     the number of bytes downloaded so far, the fourth is the total
+     number of bytes expected to be uploaded in this transfer, and the
+     fifth is the number of bytes uploaded so far.
+     Return <literal>1</literal> to abort the transfer
+     and set a <constant>CURLE_ABORTED_BY_CALLBACK</constant> error.
      Available as of PHP 8.2.0 and cURL 7.32.0.
     </para>
    </listitem>
@@ -3964,7 +4249,9 @@
    <listitem>
     <para>
      Specifies the OAuth 2.0 access token.
-     Available as of PHP 7.0.7 and cURL 7.33.0
+     Set to &null; to disable.
+     Defaults to &null;.
+     Available as of PHP 7.0.7 and cURL 7.33.0.
     </para>
    </listitem>
   </varlistentry>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -196,7 +196,8 @@
    </term>
    <listitem>
     <para>
-     A <type>string</type> with a directory that holds multiple CA certificates. Use this option alongside <constant>CURLOPT_SSL_VERIFYPEER</constant>.
+     A <type>string</type> with a directory that holds multiple CA certificates.
+     Use this option alongside <constant>CURLOPT_SSL_VERIFYPEER</constant>.
      Available as of cURL 7.9.8.
     </para>
    </listitem>
@@ -253,7 +254,8 @@
    </term>
    <listitem>
     <para>
-     The number of milliseconds to wait while trying to connect. Use <literal>0</literal> to wait indefinitely.
+     The number of milliseconds to wait while trying to connect.
+     Use <literal>0</literal> to wait indefinitely.
      If cURL is built to use the standard system name resolver, that
      portion of the connect will still use full-second resolution for
      timeouts with a minimum timeout allowed of one second.
@@ -313,7 +315,8 @@
    </term>
    <listitem>
     <para>
-     A <type>string</type> with the name of the file containing the cookie data. The cookie file can be in Netscape format, or just plain HTTP-style headers dumped into a file.
+     A <type>string</type> with the name of the file containing the cookie data.
+     The cookie file can be in Netscape format, or just plain HTTP-style headers dumped into a file.
      If the name is an empty <type>string</type>, no cookies are loaded, but cookie
      handling is still enabled.
      Available as of cURL 7.1.0.
@@ -327,7 +330,8 @@
    </term>
    <listitem>
     <para>
-     A <type>string</type> with the name of a file to save all internal cookies to when the handle's destructor is called.
+     A <type>string</type> with the name of a file to save all internal cookies to when
+     the handle's destructor is called.
      Available as of cURL 7.9.0.
      <warning>
       <simpara>
@@ -492,7 +496,8 @@
    </term>
    <listitem>
     <para>
-     &true; to not allow URLs that include a username. Usernames are allowed by default.
+     &true; to not allow URLs that include a username.
+     Usernames are allowed by default.
      Available as of PHP 7.3.0 and cURL 7.61.0.
     </para>
    </listitem>
@@ -532,7 +537,8 @@
    </term>
    <listitem>
     <para>
-     Set the local IPv4 address that the resolver should bind to. The argument should contain a single numerical IPv4 address.
+     Set the local IPv4 address that the resolver should bind to.
+     The argument should contain a single numerical IPv4 address.
      This option accepts a <type>string</type> or &null;.
      Available as of PHP 7.0.7 and cURL 7.33.0.
     </para>
@@ -545,7 +551,8 @@
    </term>
    <listitem>
     <para>
-     Set the local IPv6 address that the resolver should bind to. The argument should contain a single numerical IPv6 address.
+     Set the local IPv6 address that the resolver should bind to.
+     The argument should contain a single numerical IPv6 address.
      This option accepts a <type>string</type> or &null;.
      Available as of PHP 7.0.7 and cURL 7.33.0.
     </para>
@@ -714,7 +721,8 @@
    <listitem>
     <para>
      Accepts a file handle <type>resource</type>
-     to the file that the transfer should be written to. The default is <constant>STDOUT</constant> (the browser window).
+     to the file that the transfer should be written to.
+     The default is <constant>STDOUT</constant> (the browser window).
      Available as of cURL 7.1.0 and deprecated as of cURL 7.9.7.
     </para>
    </listitem>
@@ -874,7 +882,9 @@
     <para>
      A <type>string</type> which will be used to get the IP address to use for the FTP <literal>PORT</literal> instruction. The <literal>PORT</literal> instruction tells
      the remote server to connect to our specified IP address.  The
-     <type>string</type> may be a plain IP address, a hostname, a network interface name (under Unix), or just a plain <literal>-</literal> to use the system's default IP address.
+     <type>string</type> may be a plain IP address, a hostname,
+     a network interface name (under Unix),
+     or just a plain <literal>-</literal> to use the system's default IP address.
      This option accepts a <type>string</type> or &null;.
      Available as of cURL 7.1.0.
     </para>
@@ -1016,7 +1026,8 @@
    </term>
    <listitem>
     <para>
-     Set to &true; to use <literal>EPRT</literal> (and <literal>LPRT</literal>) when doing active FTP downloads. Set to &false; to disable <literal>EPRT</literal> and <literal>LPRT</literal> and use <literal>PORT</literal> only.
+     Set to &true; to use <literal>EPRT</literal> (and <literal>LPRT</literal>) when doing active FTP downloads.
+     Set to &false; to disable <literal>EPRT</literal> and <literal>LPRT</literal> and use <literal>PORT</literal> only.
      Available as of cURL 7.10.5.
     </para>
    </listitem>
@@ -1028,7 +1039,8 @@
    </term>
    <listitem>
     <para>
-     Set to &true; to first try an <literal>EPSV</literal> command for FTP transfers before reverting back to <literal>PASV</literal>. Set to &false; to disable <literal>EPSV</literal>.
+     Set to &true; to first try an <literal>EPSV</literal> command for FTP transfers before reverting back to <literal>PASV</literal>.
+     Set to &false; to disable <literal>EPSV</literal>.
      Available as of cURL 7.9.2.
     </para>
    </listitem>
@@ -1372,7 +1384,8 @@
    </term>
    <listitem>
     <para>
-     Set to a <type>string</type> with the name of the outgoing network interface to use. This can be an interface name, an IP address or a host name.
+     Set to a <type>string</type> with the name of the outgoing network interface to use.
+     This can be an interface name, an IP address or a host name.
      Available as of cURL 7.1.0.
     </para>
    </listitem>
@@ -1433,7 +1446,8 @@
    </term>
    <listitem>
     <para>
-     Set to &true; to keep sending the request body if the HTTP code returned is equal to or larger than <literal>300</literal>. The default action would be to stop sending
+     Set to &true; to keep sending the request body if the HTTP code returned is equal to or larger than <literal>300</literal>.
+     The default action would be to stop sending
      and close the stream or connection. Suitable for manual NTLM authentication.
      Most applications do not need this option.
      Available as of PHP 7.3.0 and cURL 7.51.0.
@@ -1801,7 +1815,7 @@
      Set to &true; to be completely silent with regards to
      the cURL functions.
      Use <constant>CURLOPT_RETURNTRANSFER</constant> instead.
-     Available as of cURL 7.1, deprecated as of cURL 7.8
+     Available as of cURL 7.1.0, deprecated as of cURL 7.8.0
      and last available in cURL 7.15.5.
      Removed as of PHP 7.3.0.
     </para>
@@ -3025,7 +3039,8 @@
    </term>
    <listitem>
     <para>
-     A <type>string</type> with the contents of the <literal>Referer: </literal> header to be used in a HTTP request.
+     A <type>string</type> with the contents of the <literal>Referer: </literal>
+     header to be used in a HTTP request.
      Available as of cURL 7.1.0.
     </para>
    </listitem>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -68,10 +68,8 @@
    </term>
    <listitem>
     <para>
-     Pass a <type>string</type> with the filename for cURL to use
-     as the Alt-Svc cache file to read existing cache contents from
-     and possibly also write it back to a after a transfer,
-     unless <constant>CURLALTSVC_READONLYFILE</constant>
+     Pass a <type>string</type> with the filename for cURL to use as the Alt-Svc cache file to read existing cache contents from and
+     possibly also write it back to a after a transfer, unless <constant>CURLALTSVC_READONLYFILE</constant>
      is set via <constant>CURLOPT_ALTSVC_CTRL</constant>.
      Available as of PHP 8.2.0 and cURL 7.64.1.
     </para>
@@ -119,7 +117,7 @@
      &true; to automatically set the <literal>Referer:</literal> field in
      requests where it follows a <literal>Location:</literal> redirect.
      Defaults to <literal>0</literal>.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -159,7 +157,7 @@
      The size of the buffer to use for each read. There is no guarantee
      this request will be fulfilled, however.
      This option accepts any value that can be cast to a valid <type>int</type>.
-     Defaults to <constant>CURL_MAX_WRITE_SIZE</constant> (16kB).
+     Defaults to <constant>CURL_MAX_WRITE_SIZE</constant> (currently, 16kB).
      Available as of cURL 7.10.
     </para>
    </listitem>
@@ -198,8 +196,7 @@
    </term>
    <listitem>
     <para>
-     A <type>string</type> with a directory that holds multiple CA certificates.
-     Use this option alongside <constant>CURLOPT_SSL_VERIFYPEER</constant>.
+     A <type>string</type> with a directory that holds multiple CA certificates. Use this option alongside <constant>CURLOPT_SSL_VERIFYPEER</constant>.
      Available as of cURL 7.9.8.
     </para>
    </listitem>
@@ -245,7 +242,7 @@
      wait indefinitely.
      This option accepts any value that can be cast to a valid <type>int</type>.
      Defaults to <literal>300</literal>.
-     Available as of cURL 7.7.
+     Available as of cURL 7.7.0.
     </para>
    </listitem>
   </varlistentry>
@@ -256,8 +253,7 @@
    </term>
    <listitem>
     <para>
-     The number of milliseconds to wait while trying to connect.
-     Use <literal>0</literal> to wait indefinitely.
+     The number of milliseconds to wait while trying to connect. Use <literal>0</literal> to wait indefinitely.
      If cURL is built to use the standard system name resolver, that
      portion of the connect will still use full-second resolution for
      timeouts with a minimum timeout allowed of one second.
@@ -303,11 +299,10 @@
    </term>
    <listitem>
     <para>
-     A <type>string</type> with the contents
-     of the <literal>Cookie: </literal> header to be used in the HTTP request.
+     A <type>string</type> with the contents of the <literal>Cookie: </literal> header to be used in the HTTP request.
      Note that multiple cookies are separated with a semicolon followed
      by a space (e.g., <literal>fruit=apple; colour=red</literal>).
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -318,12 +313,10 @@
    </term>
    <listitem>
     <para>
-     A <type>string</type> with the name of the file containing the cookie data.
-     The cookie file can be in Netscape format,
-     or just plain HTTP-style headers dumped into a file.
+     A <type>string</type> with the name of the file containing the cookie data. The cookie file can be in Netscape format, or just plain HTTP-style headers dumped into a file.
      If the name is an empty <type>string</type>, no cookies are loaded, but cookie
      handling is still enabled.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -334,8 +327,7 @@
    </term>
    <listitem>
     <para>
-     A <type>string</type> with the name of a file to save all internal cookies to
-     when the handle's destructor is called.
+     A <type>string</type> with the name of a file to save all internal cookies to when the handle's destructor is called.
      Available as of cURL 7.9.0.
      <warning>
       <simpara>
@@ -374,7 +366,7 @@
        <literal>RELOAD</literal>
        loads all cookies from the files specified by <constant>CURLOPT_COOKIEFILE</constant>
       </member>
-     </simplelist>
+     </simplelist>.
      Available as of cURL 7.14.1.
     </para>
    </listitem>
@@ -405,7 +397,7 @@
     <para>
      &true; to convert Unix newlines to CRLF newlines
      on transfers.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -417,7 +409,7 @@
    <listitem>
     <para>
      Pass a <type>string</type> naming a file with the concatenation of
-	 CRL (Certificate Revocation List) (in PEM format)
+     CRL (Certificate Revocation List) (in PEM format)
      to use in the certificate validation that occurs during the SSL exchange.
      When cURL is built to use GnuTLS,
      there is no way to influence the use of CRL passed
@@ -451,7 +443,7 @@
      entering <literal>GET /index.html HTTP/1.0\r\n\r\n</literal>
      would be incorrect.
      This option accepts a <type>string</type> or &null;.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
      <note>
       <para>
        Don't do this without making sure the server supports the custom
@@ -500,8 +492,7 @@
    </term>
    <listitem>
     <para>
-     &true; to not allow URLs that include a username.
-     Usernames are allowed by default.
+     &true; to not allow URLs that include a username. Usernames are allowed by default.
      Available as of PHP 7.3.0 and cURL 7.61.0.
     </para>
    </listitem>
@@ -541,8 +532,7 @@
    </term>
    <listitem>
     <para>
-     Set the local IPv4 address that the resolver should bind to. The argument
-     should contain a single numerical IPv4 address.
+     Set the local IPv4 address that the resolver should bind to. The argument should contain a single numerical IPv4 address.
      This option accepts a <type>string</type> or &null;.
      Available as of PHP 7.0.7 and cURL 7.33.0.
     </para>
@@ -555,8 +545,7 @@
    </term>
    <listitem>
     <para>
-     Set the local IPv6 address that the resolver should bind to. The argument
-     should contain a single numerical IPv6 address.
+     Set the local IPv6 address that the resolver should bind to. The argument should contain a single numerical IPv6 address.
      This option accepts a <type>string</type> or &null;.
      Available as of PHP 7.0.7 and cURL 7.33.0.
     </para>
@@ -611,8 +600,7 @@
    </term>
    <listitem>
     <para>
-     Set to <literal>2</literal> to verify the DNS-over-HTTPS server's
-     SSL certificate name fields against the host name.
+     Set to <literal>2</literal> to verify the DNS-over-HTTPS server's SSL certificate name fields against the host name.
      Available as of PHP 8.2.0 and cURL 7.76.0.
     </para>
    </listitem>
@@ -666,7 +654,7 @@
     <para>
      Like <constant>CURLOPT_RANDOM_FILE</constant>, except a filename
      to an Entropy Gathering Daemon socket.
-     Available as of cURL 7.7 and deprecated as of cURL 7.84.0.
+     Available as of cURL 7.7.0 and deprecated as of cURL 7.84.0.
     </para>
    </listitem>
   </varlistentry>
@@ -683,8 +671,7 @@
       <member><literal>identity</literal></member>
       <member><literal>deflate</literal></member>
       <member><literal>gzip</literal></member>
-     </simplelist>
-     .
+     </simplelist>.
      If an empty <type>string</type> is set,
      a header containing all supported encoding types is sent.
      Available as of cURL 7.10 and deprecated as of cURL 7.21.6.
@@ -715,7 +702,7 @@
      &true; to fail verbosely if the HTTP code returned
      is greater than or equal to <literal>400</literal>. The default behavior is to return
      the page normally, ignoring the code.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -727,9 +714,8 @@
    <listitem>
     <para>
      Accepts a file handle <type>resource</type>
-     to the file that the transfer should be written to.
-     The default is <constant>STDOUT</constant> (the browser window).
-     Available as of cURL 7.1 and deprecated as of cURL 7.9.7.
+     to the file that the transfer should be written to. The default is <constant>STDOUT</constant> (the browser window).
+     Available as of cURL 7.1.0 and deprecated as of cURL 7.9.7.
     </para>
    </listitem>
   </varlistentry>
@@ -744,7 +730,7 @@
      date of the remote document. This value can be retrieved using
      the <constant>CURLINFO_FILETIME</constant> option with
      <function>curl_getinfo</function>.
-     Available as of cURL 7.5.
+     Available as of cURL 7.5.0.
     </para>
    </listitem>
   </varlistentry>
@@ -804,13 +790,12 @@
    </term>
    <listitem>
     <para>
-     Set to &true; to follow any
-     <literal>Location: </literal> header that the server sends as
+     Set to &true; to follow any <literal>Location: </literal> header that the server sends as
      part of the HTTP header.
      See also <constant>CURLOPT_MAXREDIRS</constant>.
      This constant is not available when <link xmlns="http://docbook.org/ns/docbook" linkend="ini.open-basedir">open_basedir</link>
      is enabled.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -823,7 +808,7 @@
     <para>
      Set to &true; to force the connection to explicitly
      close when it has finished processing, and not be pooled for reuse.
-     Available as of cURL 7.7.
+     Available as of cURL 7.7.0.
     </para>
    </listitem>
   </varlistentry>
@@ -836,7 +821,7 @@
     <para>
      Set to &true; to force the use of a new connection
      instead of a cached one.
-     Available as of cURL 7.7.
+     Available as of cURL 7.7.0.
     </para>
    </listitem>
   </varlistentry>
@@ -849,7 +834,7 @@
     <para>
      Set to &true; to append to the remote file instead of
      overwriting it.
-     Available as of cURL 7.1 and deprecated as of cURL 7.16.4.
+     Available as of cURL 7.1.0 and deprecated as of cURL 7.16.4.
     </para>
    </listitem>
   </varlistentry>
@@ -864,7 +849,7 @@
      <constant>CURLOPT_TRANSFERTEXT</constant>. Use that instead.
      Available as of cURL 7.1, deprecated as of cURL 7.11.1
      and last available in cURL 7.15.5.
-     Removed as of PHP 7.3.
+     Removed as of PHP 7.3.0.
     </para>
    </listitem>
   </varlistentry>
@@ -876,7 +861,7 @@
    <listitem>
     <para>
      Set to &true; to only list the names of an FTP directory.
-     Available as of cURL 7.1 and deprecated as of cURL 7.16.4.
+     Available as of cURL 7.1.0 and deprecated as of cURL 7.16.4.
     </para>
    </listitem>
   </varlistentry>
@@ -887,15 +872,11 @@
    </term>
    <listitem>
     <para>
-     A <type>string</type> which will be used to get the IP address to use
-     for the FTP <literal>PORT</literal> instruction.
-     The <literal>PORT</literal> instruction tells
+     A <type>string</type> which will be used to get the IP address to use for the FTP <literal>PORT</literal> instruction. The <literal>PORT</literal> instruction tells
      the remote server to connect to our specified IP address.  The
-     <type>string</type> may be a plain IP address, a hostname, a network
-     interface name (under Unix), or just a plain <literal>-</literal> to use the
-     system's default IP address.
+     <type>string</type> may be a plain IP address, a hostname, a network interface name (under Unix), or just a plain <literal>-</literal> to use the system's default IP address.
      This option accepts a <type>string</type> or &null;.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -962,9 +943,8 @@
    </term>
    <listitem>
     <para>
-     Tell cURL which method to use to reach a file on a FTP(S) server.
-     Possible values are any of the
-     <constant>CURLFTPMETHOD_<replaceable>*</replaceable></constant> constants.
+     Tell cURL which method to use to reach a file on a FTP(S) server. Possible values are
+     any of the <constant>CURLFTPMETHOD_<replaceable>*</replaceable></constant> constants.
      Defaults to <constant>CURLFTPMETHOD_MULTICWD</constant>.
      Available as of cURL 7.15.1.
     </para>
@@ -1036,10 +1016,7 @@
    </term>
    <listitem>
     <para>
-     Set to &true; to use <literal>EPRT</literal> (and <literal>LPRT</literal>)
-     when doing active FTP downloads.
-     Set to &false; to disable <literal>EPRT</literal>
-     and <literal>LPRT</literal> and use <literal>PORT</literal> only.
+     Set to &true; to use <literal>EPRT</literal> (and <literal>LPRT</literal>) when doing active FTP downloads. Set to &false; to disable <literal>EPRT</literal> and <literal>LPRT</literal> and use <literal>PORT</literal> only.
      Available as of cURL 7.10.5.
     </para>
    </listitem>
@@ -1051,10 +1028,8 @@
    </term>
    <listitem>
     <para>
-     Set to &true; to first try an <literal>EPSV</literal> command for FTP
-     transfers before reverting back to <literal>PASV</literal>.
-     Set to &false; to disable <literal>EPSV</literal>.
-    Available as of cURL 7.9.2.
+     Set to &true; to first try an <literal>EPSV</literal> command for FTP transfers before reverting back to <literal>PASV</literal>. Set to &false; to disable <literal>EPSV</literal>.
+     Available as of cURL 7.9.2.
     </para>
    </listitem>
   </varlistentry>
@@ -1128,7 +1103,7 @@
     <para>
      Set to &true; to include the headers in the output sent to the callback
      defined by <constant>CURLOPT_WRITEFUNCTION</constant>.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1139,11 +1114,31 @@
    </term>
    <listitem>
     <para>
-     A <type>callable</type> accepting two parameters and returning an <type>int</type>.
-     The first paratmeter is the cURL resource, the second is a
-     <type>string</type> with the header data which must
-     be written by this callback. Return the number of
-     bytes written.
+     A <type>callable</type> with the following signature:
+     <methodsynopsis>
+      <type>int</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>resource</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>string</type><parameter>headerData</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         The cURL handle.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>headerData</parameter></term>
+       <listitem>
+        <simpara>
+         The header data which must be written by the callback.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     The callback should return the number of bytes written.
      Available as of cURL 7.7.2.
     </para>
    </listitem>
@@ -1211,8 +1206,7 @@
    </term>
    <listitem>
     <para>
-     An <type>array</type> of HTTP <literal>200</literal> responses
-     that will be treated as valid responses and not as errors.
+     An <type>array</type> of HTTP <literal>200</literal> responses that will be treated as valid responses and not as errors.
      Available as of cURL 7.10.3.
     </para>
    </listitem>
@@ -1233,8 +1227,7 @@
       <member><constant>CURLAUTH_AWS_SIGV4</constant></member>
       <member><constant>CURLAUTH_ANY</constant></member>
       <member><constant>CURLAUTH_ANYSAFE</constant></member>
-     </simplelist>
-     .
+     </simplelist>.
      If more than one method is used, cURL will poll the server to see
      what methods it supports and pick the best one.
      <constant>CURLAUTH_ANY</constant> sets all bits. cURL will automatically select
@@ -1252,8 +1245,7 @@
    </term>
    <listitem>
     <para>
-     &true; to reset the HTTP request method to <literal>GET</literal>.
-     Since <literal>GET</literal> is the default, this is only necessary if the request
+     Set to &true; to reset the HTTP request method to <literal>GET</literal>. Since <literal>GET</literal> is the default, this is only necessary if the request
      method has been changed.
      Available as of cURL 7.8.1.
     </para>
@@ -1270,7 +1262,7 @@
      <code>
       array('Content-type: text/plain', 'Content-length: 100')
      </code>
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1282,7 +1274,7 @@
    <listitem>
     <para>
      &true; to tunnel through a given HTTP proxy.
-     Available as of cURL 7.3.
+     Available as of cURL 7.3.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1352,7 +1344,7 @@
     <para>
      Accepts a file handle <type>resource</type>
      to the file that the transfer should be read from when uploading.
-     Available as of cURL 7.1 and deprecated as of cURL 7.9.7.
+     Available as of cURL 7.1.0 and deprecated as of cURL 7.9.7.
      Use <constant>CURLOPT_READDATA</constant> instead.
     </para>
    </listitem>
@@ -1369,7 +1361,7 @@
      from sending more data, as exactly what is sent depends on
      <constant>CURLOPT_READFUNCTION</constant>.
      This option accepts any value that can be cast to a valid <type>int</type>.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1380,9 +1372,8 @@
    </term>
    <listitem>
     <para>
-     Set to a <type>string</type> with the name of the outgoing network interface to use.
-     This can be an interface name, an IP address or a host name.
-     Available as of cURL 7.1.
+     Set to a <type>string</type> with the name of the outgoing network interface to use. This can be an interface name, an IP address or a host name.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1442,8 +1433,7 @@
    </term>
    <listitem>
     <para>
-     Set to &true; to keep sending the request body if the HTTP code returned is
-     equal to or larger than <literal>300</literal>. The default action would be to stop sending
+     Set to &true; to keep sending the request body if the HTTP code returned is equal to or larger than <literal>300</literal>. The default action would be to stop sending
      and close the stream or connection. Suitable for manual NTLM authentication.
      Most applications do not need this option.
      Available as of PHP 7.3.0 and cURL 7.51.0.
@@ -1478,13 +1468,12 @@
       <member><literal>safe</literal></member>
       <member><literal>confidential</literal></member>
       <member><literal>private</literal></member>
-     </simplelist>
-     .
+     </simplelist>.
      If the <type>string</type> does not match one of these,
      <literal>private</literal> is used. Setting this option to &null;
      will disable KRB4 security. Currently KRB4 security only works
      with FTP transactions.
-     Available as of cURL 7.3 and deprecated as of cURL 7.17.0.
+     Available as of cURL 7.3.0 and deprecated as of cURL 7.17.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1502,8 +1491,7 @@
       <member><literal>safe</literal></member>
       <member><literal>confidential</literal></member>
       <member><literal>private</literal></member>
-     </simplelist>
-     .
+     </simplelist>.
      If the <type>string</type> is set but does not match one of these,
      <literal>private</literal> is used.
      Setting this option to &null; will disable kerberos support for FTP.
@@ -1549,8 +1537,7 @@
    <listitem>
     <para>
      Can be used to set protocol specific login options, such as the
-     preferred authentication mechanism via <literal>AUTH=NTLM</literal>
-     or <literal>AUTH=*</literal>, and should be used in conjunction with the
+     preferred authentication mechanism via <literal>AUTH=NTLM</literal> or <literal>AUTH=*</literal>, and should be used in conjunction with the
      <constant>CURLOPT_USERNAME</constant> option.
      Available as of PHP 7.0.7 and cURL 7.34.0.
     </para>
@@ -1567,7 +1554,7 @@
      below during the count of <constant>CURLOPT_LOW_SPEED_TIME</constant>
      seconds before PHP considers the transfer too slow and aborts.
      This option accepts any value that can be cast to a valid <type>int</type>.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1582,7 +1569,7 @@
      <constant>CURLOPT_LOW_SPEED_LIMIT</constant> before PHP considers
      the transfer too slow and aborts.
      This option accepts any value that can be cast to a valid <type>int</type>.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1682,7 +1669,7 @@
      When the limit is reached, the oldest one in the cache is closed
      to prevent increasing the number of open connections.
      This option accepts any value that can be cast to a valid <type>int</type>.
-     Available as of cURL 7.7.
+     Available as of cURL 7.7.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1719,12 +1706,9 @@
    </term>
    <listitem>
     <para>
-     The maximum file size in bytes allowed to download.
-     If the file requested is found larger than this value,
-     the transfer will not start
-     and <constant>CURLE_FILESIZE_EXCEEDED</constant> will be returned.
-     The file size is not always known prior to download,
-     and for such files this option has no effect even if
+     The maximum file size in bytes allowed to download. If the file requested is found larger than this value,
+     the transfer will not start and <constant>CURLE_FILESIZE_EXCEEDED</constant> will be returned.
+     The file size is not always known prior to download, and for such files this option has no effect even if
      the file transfer ends up being larger than this given limit.
      This option accepts any value that can be cast to a valid <type>int</type>.
      Available as of PHP 8.2.0 and cURL 7.11.0.
@@ -1738,12 +1722,10 @@
    </term>
    <listitem>
     <para>
-     The maximum time in seconds, since the creation of the connection,
-     that is allowed for an existing connection to have for it to be considered for reuse.
-     If a connection is found in the cache that is older than this value,
-     it will instead be closed once any in-progress transfers are complete.
-     Default is <literal>0</literal> seconds,
-     meaning the option is disabled and all connections are eligible for reuse.
+     The maximum time in seconds, since the creation of the connection, that is allowed for an existing
+     connection to have for it to be considered for reuse. If a connection is found in the cache that is older
+     than this value, it will instead be closed once any in-progress transfers are complete.
+     Default is <literal>0</literal> seconds, meaning the option is disabled and all connections are eligible for reuse.
      This option accepts any value that can be cast to a valid <type>int</type>.
      Available as of PHP 8.2.0 and cURL 7.80.0.
     </para>
@@ -1756,12 +1738,10 @@
    </term>
    <listitem>
     <para>
-     The maximum amount of HTTP redirections to follow.
-     Use this option alongside <constant>CURLOPT_FOLLOWLOCATION</constant>.
+     The maximum amount of HTTP redirections to follow. Use this option alongside <constant>CURLOPT_FOLLOWLOCATION</constant>.
      Default value of <literal>20</literal> is set to prevent infinite redirects.
-     Setting to <literal>-1</literal> allows inifinite redirects,
-     and <literal>0</literal> refuses all redirects.
-     Available as of cURL 7.5.
+     Setting to <literal>-1</literal> allows inifinite redirects, and <literal>0</literal> refuses all redirects.
+     Available as of cURL 7.5.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1818,11 +1798,12 @@
    </term>
    <listitem>
     <para>
-     Set to &true; to be completely silent with regards to the cURL functions.
+     Set to &true; to be completely silent with regards to
+     the cURL functions.
      Use <constant>CURLOPT_RETURNTRANSFER</constant> instead.
      Available as of cURL 7.1, deprecated as of cURL 7.8
      and last available in cURL 7.15.5.
-     Removed as of PHP 7.3.
+     Removed as of PHP 7.3.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1836,7 +1817,7 @@
      Set to &true; to scan the <filename>~/.netrc</filename>
      file to find a username and password for the remote site that
      a connection is being established with.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1898,7 +1879,7 @@
      For HTTP(S), cURL makes a HEAD request. For most other protocols,
      cURL is not asking for the body data at all.
      Changing this to &false; will result in body data being included in the output.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1916,7 +1897,7 @@
        changed for debugging purposes.
       </para>
      </note>
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1962,10 +1943,40 @@
    </term>
    <listitem>
     <para>
-     A <type>callable</type> accepting three parameters and returning a <type>string</type>.
-     The first parameter is the cURL resource, the second is a
-     <type>string</type> containing a password prompt, and the third is the maximum
-     password length. Return the <type>string</type> containing the password.
+     A <type>callable</type> with the following signature:
+     <methodsynopsis>
+      <type>string</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>resource</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>string</type><parameter>passwordPrompt</parameter></methodparam>
+      <methodparam><type>int</type><parameter>maximumPasswordLength</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         The cURL handle.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>passwordPrompt</parameter></term>
+       <listitem>
+        <simpara>
+         A password prompt.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>maximumPasswordLength</parameter></term>
+       <listitem>
+        <simpara>
+         The maximum length of the password.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     The callback should return a <type>string</type> containing the password.
      Available as of cURL 7.4.2, deprecated as of cURL 7.11.1
      and last available in cURL 7.15.5.
      Removed as of PHP 7.3.0.
@@ -2008,9 +2019,9 @@
     <para>
      Set a <type>string</type> with the pinned public key.
      The <type>string</type> can be the file name of the pinned public key
-     in a PEM or DER file format.
-     The <type>string</type> can also be any number of base64 encoded sha256 hashes
-     preceded by <literal>sha256//</literal> and separated by <literal>;</literal>.
+     in a PEM or DER file format. The <type>string</type> can also be any
+     number of base64 encoded sha256 hashes preceded by <literal>sha256//</literal> and
+     separated by <literal>;</literal>.
      Available as of PHP 7.0.7 and cURL 7.39.0.
     </para>
    </listitem>
@@ -2038,7 +2049,7 @@
     <para>
      An <type>int</type> with an alternative port number to connect to
      instead of the one specified in the URL or the default port for the used protocol.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2052,7 +2063,7 @@
      Set to &true; to do a HTTP <literal>POST</literal> request.
      This request uses the <literal>application/x-www-form-urlencoded</literal> header.
      Defaults to &false;.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2065,15 +2076,14 @@
     <para>
      The full data to post in a HTTP <literal>POST</literal> operation.
      This parameter can either be
-     passed as a urlencoded <type>string</type> like
-     '<literal>para1=val1&amp;para2=val2&amp;...</literal>'
+     passed as a urlencoded <type>string</type> like '<literal>para1=val1&amp;para2=val2&amp;...</literal>'
      or as an <type>array</type> with the field name as key and field data as value.
      If <parameter>value</parameter> is an <type>array</type>, the
      <literal>Content-Type</literal> header will be set to
      <literal>multipart/form-data</literal>.
      Files can be sent using <classname>CURLFile</classname> or <classname>CURLStringFile</classname>,
      in which case <parameter>value</parameter> must be an <type>array</type>.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2086,7 +2096,7 @@
     <para>
      An <type>array</type> of FTP command <type>string</type>s
      to execute on the server after the FTP request has been performed.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2168,21 +2178,66 @@
    </term>
    <listitem>
     <para>
-     A <type>callable</type> accepting five parameters and returning an <type>int</type>.
-     The first parameter is the cURL resource, the second is the total number of
-     bytes expected to be downloaded in this transfer, the third is
-     the number of bytes downloaded so far, the fourth is the total
-     number of bytes expected to be uploaded in this transfer, and the
-     fifth is the number of bytes uploaded so far.
+     A <type>callable</type> with the following signature:
+     <methodsynopsis>
+      <type>int</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>resource</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>int</type><parameter>bytesToDownload</parameter></methodparam>
+      <methodparam><type>int</type><parameter>bytesDownloaded</parameter></methodparam>
+      <methodparam><type>int</type><parameter>bytesToUpload</parameter></methodparam>
+      <methodparam><type>int</type><parameter>bytesUploaded</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         The cURL handle.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>bytesToDownload</parameter></term>
+       <listitem>
+        <simpara>
+         The total number of bytes expected to be downloaded in this transfer.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>bytesDownloaded</parameter></term>
+       <listitem>
+        <simpara>
+         The number of bytes downloaded so far.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>bytesToUpload</parameter></term>
+       <listitem>
+        <simpara>
+         The total number of bytes expected to be uploaded in this transfer.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>bytesUploaded</parameter></term>
+       <listitem>
+        <simpara>
+         The number of bytes uploaded so far.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     The callback should return an <type>int</type> with a non-zero value to abort the transfer
+     and set a <constant>CURLE_ABORTED_BY_CALLBACK</constant> error.
      <note>
       <para>
        The callback is only called when the <constant>CURLOPT_NOPROGRESS</constant>
        option is set to &false;.
       </para>
      </note>
-     Return an <type>int</type> with a non-zero value to abort the transfer
-     and set a <constant>CURLE_ABORTED_BY_CALLBACK</constant> error.
-     Available as of cURL 7.1 and deprecated as of cURL 7.32.0.
+     Available as of cURL 7.1.0 and deprecated as of cURL 7.32.0.
      Use <constant>CURLOPT_XFERINFOFUNCTION</constant> instead.
     </para>
    </listitem>
@@ -2247,8 +2302,7 @@
       <member><literal>TFTP</literal></member>
       <member><literal>WS</literal></member>
       <member><literal>WSS</literal></member>
-     </simplelist>
-     .
+     </simplelist>.
      Available as of PHP 8.3.0 and cURL 7.85.0.
     </para>
    </listitem>
@@ -2263,7 +2317,7 @@
      A <type>string</type> with the HTTP proxy to tunnel requests through.
      This should be the hostname, the dotted numerical IP address
      or a numerical IPv6 address written within [brackets].
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2319,7 +2373,7 @@
      This port number can also be set in <constant>CURLOPT_PROXY</constant>.
      Setting this to zero makes cURL use the default proxy port number
      or the port number specified in the proxy URL <type>string</type>.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2359,7 +2413,7 @@
      A <type>string</type> with a username and password formatted as
      <literal>[username]:[password]</literal> to use for the
      connection to the proxy.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2387,8 +2441,7 @@
    </term>
    <listitem>
     <para>
-     A <type>string</type> with the name of a PEM file
-     holding one or more certificates to verify the HTTPS proxy with.
+     A <type>string</type> with the name of a PEM file holding one or more certificates to verify the HTTPS proxy with.
      This option is for connecting to an HTTPS proxy, not an HTTPS server.
      Defaults set to the system path where cURL's cacert bundle is assumed
      to be stored.
@@ -2500,10 +2553,8 @@
    </term>
    <listitem>
     <para>
-     A <type>string</type> with the file name of the client certificate
-     used to connect to the HTTPS proxy.
-     The default format is <literal>P12</literal> on Secure Transport
-     and <literal>PEM</literal> on other engines,
+     A <type>string</type> with the file name of the client certificate used to connect to the HTTPS proxy.
+     The default format is <literal>P12</literal> on Secure Transport and <literal>PEM</literal> on other engines,
      and can be changed with <constant>CURLOPT_PROXY_SSLCERTTYPE</constant>.
      With NSS or Secure Transport, this can also be the nickname of the certificate
      used for authentication as it is named in the security database.
@@ -2521,10 +2572,8 @@
    </term>
    <listitem>
     <para>
-     A <type>string</type> with the format of the client certificate used
-     when connecting to an HTTPS proxy.
-     Supported formats are <literal>PEM</literal> and <literal>DER</literal>,
-     except with Secure Transport.
+     A <type>string</type> with the format of the client certificate used when connecting to an HTTPS proxy.
+     Supported formats are <literal>PEM</literal> and <literal>DER</literal>, except with Secure Transport.
      OpenSSL (versions 0.9.3 and later) and Secure Transport
      (on iOS 5 or later, or OS X 10.7 or later) also support <literal>P12</literal> for
      PKCS#12-encoded files. Defaults to <literal>PEM</literal>.
@@ -2574,8 +2623,7 @@
       <member><literal>PEM</literal></member>
       <member><literal>DER</literal></member>
       <member><literal>ENG</literal></member>
-     </simplelist>
-     .
+     </simplelist>.
      Available as of PHP 7.3.0 and cURL 7.52.0.
     </para>
    </listitem>
@@ -2687,8 +2735,7 @@
    </term>
    <listitem>
     <para>
-     A <type>string</type> with a colon-separated list of ciphers
-     to use for the connection to the TLS 1.3 connection to a proxy.
+     A <type>string</type> with a colon-separated list of ciphers to use for the connection to the TLS 1.3 connection to a proxy.
      This option is currently used only when cURL is built to use OpenSSL 1.1.1 or later.
      When using a different SSL backend the TLS 1.3 cipher suites can be set
      with the <constant>CURLOPT_PROXY_SSL_CIPHER_LIST</constant> option.
@@ -2703,8 +2750,7 @@
    </term>
    <listitem>
     <para>
-     A <type>string</type> with the password to use
-     for the TLS authentication method specified with the
+     A <type>string</type> with the password to use for the TLS authentication method specified with the
      <constant>CURLOPT_PROXY_TLSAUTH_TYPE</constant> option. Requires that the
      <constant>CURLOPT_PROXY_TLSAUTH_USERNAME</constant> option to also be set.
      Available as of PHP 7.3.0 and cURL 7.52.0.
@@ -2774,7 +2820,7 @@
      &true; to HTTP PUT a file. The file to PUT must
      be set with <constant>CURLOPT_READDATA</constant> and
      <constant>CURLOPT_INFILESIZE</constant>.
-     Available as of cURL 7.1 and deprecated as of cURL 7.12.1.
+     Available as of cURL 7.1.0 and deprecated as of cURL 7.12.1.
     </para>
    </listitem>
   </varlistentry>
@@ -2800,9 +2846,8 @@
    </term>
    <listitem>
     <para>
-     An <type>array</type> of FTP command <type>string</type>s to execute
-     on the server prior to the FTP request.
-     Available as of cURL 7.1.
+     An <type>array</type> of FTP command <type>string</type>s to execute on the server prior to the FTP request.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2813,9 +2858,8 @@
    </term>
    <listitem>
     <para>
-     A <type>string</type> with a filename to be used
-     to seed the random number generator for SSL.
-     Available as of cURL 7.7.0 and deprecated as of 7.84.0.
+     A <type>string</type> with a filename to be used to seed the random number generator for SSL.
+     Available as of cURL 7.7.0 and deprecated as of cURL 7.84.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2826,12 +2870,11 @@
    </term>
    <listitem>
     <para>
-     A <type>string</type> with the range(s) of data to retrieve in the format
-     <literal>X-Y</literal> where X or Y are optional. HTTP transfers
+     A <type>string</type> with the range(s) of data to retrieve in the format <literal>X-Y</literal> where X or Y are optional. HTTP transfers
      also support several intervals, separated with commas in the format
      <literal>X-Y,N-M</literal>.
      Set to &null; to disable requesting a byte range.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2855,15 +2898,45 @@
    </term>
    <listitem>
     <para>
-     A <type>callable</type> accepting three parameters and returning a <type>string</type>.
-     The first parameter is the cURL resource, the second is a
-     stream <type>resource</type> provided to cURL through the option
-     <constant>CURLOPT_READDATA</constant>, and the third is the maximum
-     amount of data to be read. The callback must return a <type>string</type>
+     A <type>callable</type> with the following signature:
+     <methodsynopsis>
+      <type>string</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>resource</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>resource</type><parameter>streamResource</parameter></methodparam>
+      <methodparam><type>int</type><parameter>maxAmountOfDataToRead</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         The cURL handle.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>streamResource</parameter></term>
+       <listitem>
+        <simpara>
+         Stream <type>resource</type> provided to cURL through the option
+     <constant>CURLOPT_READDATA</constant>.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>maxAmountOfDataToRead</parameter></term>
+       <listitem>
+        <simpara>
+         The maximum amount of data to be read.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     The callback should return a <type>string</type>
      with a length equal or smaller than the amount of data requested,
-     typically by reading it from the passed stream <type>resource</type>.
-     It should return an empty <type>string</type> to signal <literal>EOF</literal>.
-     Available as of cURL 7.1.
+     typically by reading it from the passed stream <type>resource</type>. It should
+     return an empty <type>string</type> to signal <literal>EOF</literal>.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2940,8 +3013,7 @@
       <member><literal>TFTP</literal></member>
       <member><literal>WS</literal></member>
       <member><literal>WSS</literal></member>
-     </simplelist>
-     .
+     </simplelist>.
      Available as of PHP 8.3.0 and cURL 7.85.0.
     </para>
    </listitem>
@@ -2953,9 +3025,8 @@
    </term>
    <listitem>
     <para>
-     A <type>string</type> with the contents of the <literal>Referer: </literal>
-     header to be used in a HTTP request.
-     Available as of cURL 7.1.
+     A <type>string</type> with the contents of the <literal>Referer: </literal> header to be used in a HTTP request.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3000,7 +3071,7 @@
     <para>
      The offset, in bytes, to resume a transfer from.
      This option accepts any value that can be cast to a valid <type>int</type>.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3131,12 +3202,10 @@
    </term>
    <listitem>
     <para>
-     The authorization identity (authzid) <type>string</type> for the transfer.
-     Only applicable to the PLAIN SASL authentication mechanism where it is optional.
-     When not specified, only the authentication identity (authcid)
-     as specified by the username will be sent to the server, along with the password.
-     The server will derive the authzid from the authcid when not provided,
-     which it will then use internally.
+     The authorization identity (authzid) <type>string</type> for the transfer. Only applicable to the PLAIN SASL
+     authentication mechanism where it is optional. When not specified, only the authentication identity
+     (authcid) as specified by the username will be sent to the server, along with the password.
+     The server will derive the authzid from the authcid when not provided, which it will then use internally.
      Available as of PHP 8.2.0 and cURL 7.66.0.
     </para>
    </listitem>
@@ -3172,8 +3241,8 @@
    </term>
    <listitem>
     <para>
-     A result of <function>curl_share_init</function>.
-     Makes the cURL handle to use the data from the shared handle.
+     A result of <function>curl_share_init</function>. Makes the cURL
+     handle to use the data from the shared handle.
      Available as of cURL 7.10.
     </para>
    </listitem>
@@ -3190,8 +3259,7 @@
       <member><constant>CURLAUTH_BASIC</constant></member>
       <member><constant>CURLAUTH_GSSAPI</constant></member>
       <member><constant>CURLAUTH_NONE</constant></member>
-     </simplelist>
-     .
+     </simplelist>.
      When more than one method is set, cURL will poll the server to see
      what methods it supports and pick the best one.
      Defaults to <literal>CURLAUTH_BASIC|CURLAUTH_GSSAPI</literal>.
@@ -3243,7 +3311,7 @@
       <member><constant>CURLSSH_AUTH_KEYBOARD</constant></member>
       <member><constant>CURLSSH_AUTH_AGENT</constant></member>
       <member><constant>CURLSSH_AUTH_ANY</constant></member>
-     </simplelist>
+     </simplelist>.
      Defaults to <constant>CURLSSH_AUTH_ANY</constant>.
      Available as of cURL 7.16.1.
     </para>
@@ -3270,9 +3338,50 @@
    </term>
    <listitem>
     <para>
-     Set to a <type>callable</type> that will be called
-     when SSH host key verification is needed. This callback overrides
-     <constant>CURLOPT_SSH_KNOWNHOSTS</constant>.
+     A <type>callable</type> that will be called when SSH host key verification is needed.
+     The callback must have the following signature:
+     <methodsynopsis>
+      <type>int</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>resource</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>int</type><parameter>keyType</parameter></methodparam>
+      <methodparam><type>string</type><parameter>key</parameter></methodparam>
+      <methodparam><type>int</type><parameter>keyLength</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         The cURL handle.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>keyType</parameter></term>
+       <listitem>
+        <simpara>
+         One of the <constant>CURLKHTYPE_<replaceable>*</replaceable></constant> key types.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>key</parameter></term>
+       <listitem>
+        <simpara>
+         The key to check.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>keyLength</parameter></term>
+       <listitem>
+        <simpara>
+         The length of the key in bytes.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     This callback overrides <constant>CURLOPT_SSH_KNOWNHOSTS</constant>.
      Available as of PHP 8.3.0 and cURL 7.84.0.
     </para>
    </listitem>
@@ -3357,7 +3466,7 @@
    <listitem>
     <para>
      The name of a file containing a PEM formatted certificate.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3370,7 +3479,7 @@
     <para>
      The password required to use the
      <constant>CURLOPT_SSLCERT</constant> certificate.
-     Available as of cURL 7.1 and deprecated as of cURL 7.17.0.
+     Available as of cURL 7.1.0 and deprecated as of cURL 7.17.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3381,14 +3490,13 @@
    </term>
    <listitem>
     <para>
-     The format of the certificate. Supported formats are:
+     A <type>string</type> with the format of the certificate. Supported formats are:
      <simplelist type="inline">
       <member><literal>PEM</literal></member>
       <member><literal>DER</literal></member>
       <member><literal>ENG</literal></member>
       <member><literal>P12</literal></member>
-     </simplelist>
-     .
+     </simplelist>.
      <literal>P12</literal> (for PKCS#12-encoded files) is available as of OpenSSL 0.9.3.
      Defaults to <literal>PEM</literal>.
      Available as of cURL 7.9.3.
@@ -3472,14 +3580,12 @@
    <listitem>
     <para>
      The key type of the private SSL key specified in
-     <constant>CURLOPT_SSLKEY</constant>.
-      Supported key types are:
+     <constant>CURLOPT_SSLKEY</constant>. Supported key types are:
      <simplelist type="inline">
       <member><literal>PEM</literal></member>
       <member><literal>DER</literal></member>
       <member><literal>ENG</literal></member>
-     </simplelist>
-     .
+     </simplelist>.
      Defaults to <literal>PEM</literal>.
      Available as of cURL 7.9.3.
     </para>
@@ -3504,8 +3610,8 @@
    </term>
    <listitem>
     <para>
-     One of the
-     <constant>CURL_SSLVERSION_<replaceable>*</replaceable></constant> constants.
+     One of
+     the <constant>CURL_SSLVERSION_<replaceable>*</replaceable></constant> constants.
      <warning>
       <simpara>
        It is better to not set this option and leave the defaults.
@@ -3518,7 +3624,7 @@
       </simpara>
      </warning>
      Defaults to <constant>CURL_SSLVERSION_DEFAULT</constant>.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3649,7 +3755,7 @@
      specified with the <constant>CURLOPT_CAINFO</constant> option
      or a certificate directory can be specified with the
      <constant>CURLOPT_CAPATH</constant> option.
-     Defaults to &true; of cURL 7.10.
+     Defaults to &true; as of cURL 7.10.
      Default bundle of CA certificates installed as of cURL 7.10.
      Available as of cURL 7.4.2.
     </para>
@@ -3677,7 +3783,7 @@
      Accepts a file handle <type>resource</type> pointing to
      an alternative location to output errors to instead of
      <constant>STDERR</constant>.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3688,8 +3794,7 @@
    </term>
    <listitem>
     <para>
-     Set the numerical stream weight
-     (a number between <literal>1</literal> and <literal>256</literal>).
+     Set the numerical stream weight (a number between <literal>1</literal> and <literal>256</literal>).
      Available as of PHP 7.0.7 and cURL 7.46.0.
     </para>
    </listitem>
@@ -3791,7 +3896,7 @@
      The variables should be in the format <literal>&gt;option=value&lt;</literal>.
      cURL supports the options <literal>TTYPE</literal>,
      <literal>XDISPLOC</literal> and <literal>NEW_ENV</literal>.
-     Available as of cURL 7.7.
+     Available as of cURL 7.7.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3845,7 +3950,7 @@
      <constant>CURL_TIMECOND_NONE</constant> is the default.
      Prior to cURL 7.46.0 the default was
      <constant>CURL_TIMECOND_IFMODSINCE</constant>.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3858,7 +3963,7 @@
     <para>
      The maximum number of seconds to allow cURL functions to execute.
      Defaults to <literal>0</literal>, meaning that functions never time out during transfer.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -3889,7 +3994,7 @@
      The time in seconds since January 1st, 1970. The time will be used
      by <constant>CURLOPT_TIMECONDITION</constant>.
      Defaults to <literal>0</literal>.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -4060,7 +4165,7 @@
     <para>
      &true; to prepare for and perform an upload.
      Defaults to &false;.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -4087,7 +4192,7 @@
     <para>
      The URL to fetch. This can also be set when initializing a
      session with <function>curl_init</function>.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -4117,7 +4222,7 @@
     <para>
      The contents of the <literal>User-Agent: </literal> header to be
      used in a HTTP request.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -4143,7 +4248,7 @@
      A username and password formatted as
      <literal>[username]:[password]</literal> to use for the
      connection.
-     Available as cURL 7.1.
+     Available as cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -4158,7 +4263,7 @@
      output to <constant>STDERR</constant>, or the file specified using
      <constant>CURLOPT_STDERR</constant>.
      Defaults to &false;.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -4186,12 +4291,34 @@
    </term>
    <listitem>
     <para>
-     A <type>callable</type> accepting two parameters and returning an <type>int</type>.
-     The first parameter is the cURL resource, and the second is a
-     <type>string</type> with the data to be written. The data must be saved by
-     this callback. The callback must return the exact number of bytes written
+     A <type>callable</type> with the following signature:
+     <methodsynopsis>
+      <type>int</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>resource</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>string</type><parameter>data</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         The cURL handle.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>data</parameter></term>
+       <listitem>
+        <simpara>
+         The data to be written.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     The data must be saved by the callback
+     and the callback must return the exact number of bytes written
      or the transfer will be aborted with an error.
-     Available as of cURL 7.1.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -4202,9 +4329,8 @@
    </term>
    <listitem>
     <para>
-     Accepts a file handle <type>resource</type> to the file
-     that the header part of the transfer is written to.
-     Available as of cURL 7.1.
+     Accepts a file handle <type>resource</type> to the file that the header part of the transfer is written to.
+     Available as of cURL 7.1.0.
     </para>
    </listitem>
   </varlistentry>
@@ -4229,12 +4355,57 @@
    </term>
    <listitem>
     <para>
-     A <type>callable</type> accepting five parameters and returning an <type>int</type>.
-     The first parameter is the cURL resource, the second is the total number of
-     bytes expected to be downloaded in this transfer, the third is
-     the number of bytes downloaded so far, the fourth is the total
-     number of bytes expected to be uploaded in this transfer, and the
-     fifth is the number of bytes uploaded so far.
+     A <type>callable</type> with the following signature:
+     <methodsynopsis>
+      <type>int</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>resource</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>int</type><parameter>bytesToDownload</parameter></methodparam>
+      <methodparam><type>int</type><parameter>bytesDownloaded</parameter></methodparam>
+      <methodparam><type>int</type><parameter>bytesToUpload</parameter></methodparam>
+      <methodparam><type>int</type><parameter>bytesUploaded</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         The cURL handle.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>bytesToDownload</parameter></term>
+       <listitem>
+        <simpara>
+         The total number of bytes expected to be downloaded in this transfer.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>bytesDownloaded</parameter></term>
+       <listitem>
+        <simpara>
+         The number of bytes downloaded so far.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>bytesToUpload</parameter></term>
+       <listitem>
+        <simpara>
+         The total number of bytes expected to be uploaded in this transfer.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>bytesUploaded</parameter></term>
+       <listitem>
+        <simpara>
+         The number of bytes uploaded so far.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
      Return <literal>1</literal> to abort the transfer
      and set a <constant>CURLE_ABORTED_BY_CALLBACK</constant> error.
      Available as of PHP 8.2.0 and cURL 7.32.0.


### PR DESCRIPTION
Updated descriptions of `CURLOPT_*` constants with the following:

- added some missing descriptions
- added type information on the associated accepted values
- added default values
- added cURL version information on availability, deprecation, removal 
- added applicable DocBook tags
- replaced lists of accepted value constants with their generalized version (eg.  `CURLALTSVC_*` instead of listing all `CURLALTSVC_` constants individually)
- standardized minor style details (e.g. use cURL instead of curl, libcurl, CURL; sentences to end in a period; remove double quotes from within `<literal>` tags, etc.)

Unfortunately since `CURLOPT` constants are the biggest subset of all cURL constants, the diff is pretty big.