### PR TITLE
Updated paragraph on initialization of static variables

### DIFF
--- a/language/variables.xml
+++ b/language/variables.xml
@@ -469,8 +469,8 @@ function test()
    </para>
 
    <para>
-    Before PHP 8.3, you could only initialize a static variable using 
-    a constant expression. As of PHP 8.3, dynamic expressions
+    Prior to PHP 8.3.0, you could only initialize a static variable using
+    a constant expression. As of PHP 8.3.0, dynamic expressions
     (e.g., function calls) are also allowed:
    </para>
    <para>
@@ -482,7 +482,7 @@ function test()
 function foo(){
     static $int = 0;          // correct 
     static $int = 1+2;        // correct
-    static $int = sqrt(121);  // correct in PHP >= 8.3
+    static $int = sqrt(121);  // correct as of PHP 8.3.0
 
     $int++;
     echo $int;

--- a/language/variables.xml
+++ b/language/variables.xml
@@ -469,9 +469,9 @@ function test()
    </para>
 
    <para>
-    Static variables can be assigned values which are the
-    result of constant expressions, but dynamic expressions, such as function
-    calls, will cause a parse error.
+    Before PHP 8.3, you could only initialize a static variable using 
+    a constant expression. As of PHP 8.3, dynamic expressions
+    (e.g., function calls) are also allowed:
    </para>
    <para>
     <example>
@@ -482,7 +482,7 @@ function test()
 function foo(){
     static $int = 0;          // correct 
     static $int = 1+2;        // correct
-    static $int = sqrt(121);  // wrong  (as it is a function)
+    static $int = sqrt(121);  // correct in PHP >= 8.3
 
     $int++;
     echo $int;

--- a/language/variables.xml
+++ b/language/variables.xml
@@ -471,7 +471,7 @@ function test()
    <para>
     Prior to PHP 8.3.0, you could only initialize a static variable using
     a constant expression. As of PHP 8.3.0, dynamic expressions
-    (e.g., function calls) are also allowed:
+    (e.g. function calls) are also allowed:
    </para>
    <para>
     <example>

--- a/language/variables.xml
+++ b/language/variables.xml
@@ -520,12 +520,6 @@ var_dump(Bar::counter()); // int(4), prior to PHP 8.1.0 int(2)
 ]]>
     </programlisting>
    </example>
-
-   <note>
-    <para>
-     Static declarations are resolved in compile-time.
-    </para>
-   </note>
   </sect2>
 
   <sect2 xml:id="language.variables.scope.references">


### PR DESCRIPTION
Updated information about restrictions on initialization of static variables to comply with PHP 8.3