### PR TITLE
Add missing new classes to migration guides

### DIFF
--- a/appendices/migration80.xml
+++ b/appendices/migration80.xml
@@ -22,6 +22,7 @@
  </para>
 
  &appendices.migration80.new-features;
+ &appendices.migration80.new-classes;
  &appendices.migration80.incompatible;
  &appendices.migration80.deprecated;
  &appendices.migration80.other-changes;

--- a/appendices/migration80/new-classes.xml
+++ b/appendices/migration80/new-classes.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration80.new-classes" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>New Classes and Interfaces</title>
+
+ <sect2 xml:id="migration80.new-classes.curl">
+  <title>cURL</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>CurlHandle</classname>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <classname>CurlMultiHandle</classname>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <classname>CurlShareHandle</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration80.new-classes.enchant">
+  <title>Enchant</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>EnchantBroker</classname>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <classname>EnchantDictionary</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration80.new-classes.gd">
+  <title>GD</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>GdImage</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration80.new-classes.openssl">
+  <title>OpenSSL</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>OpenSSLAsymmetricKey</classname>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <classname>OpenSSLCertificate</classname>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <classname>OpenSSLCertificateSigningRequest</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration80.new-classes.shmop">
+  <title>Shmop</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>Shmop</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration80.new-classes.sockets">
+  <title>Sockets</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>AddressInfo</classname>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <classname>Socket</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration80.new-classes.sysv">
+  <title>Systen V</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>SysvMessageQueue</classname>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <classname>SysvSemaphore</classname>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <classname>SysvSharedMemory</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration80.new-classes.xmlparser">
+  <title>XML Parser</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>XMLParser</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration80.new-classes.xmlwriter">
+  <title>XMLWriter</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>XMLWriter</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration80.new-classes.zlib">
+  <title>Zlib</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>DeflateContext</classname>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <classname>InflateContext</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+</sect1>

--- a/appendices/migration81/new-classes.xml
+++ b/appendices/migration81/new-classes.xml
@@ -14,6 +14,42 @@
   </itemizedlist>
  </sect2>
 
+ <sect2 xml:id="migration81.new-classes.fileinfo">
+  <title>FileInfo</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>finfo</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-classes.ftp">
+  <title>FTP</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>FTP\Connection</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-classes.imap">
+  <title>IMAP</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>IMAP\Connection</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
  <sect2 xml:id="migration81.new-classes.intl">
   <title>Intl</title>
 
@@ -21,6 +57,67 @@
    <listitem>
     <simpara>
      <classname>IntlDatePatternGenerator</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-classes.ldap">
+  <title>LDAP</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>LDAP\Connection</classname>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <classname>LDAP\Result</classname>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <classname>LDAP\ResultEntry</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-classes.pgsql">
+  <title>PgSQL</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>PgSql\Connection</classname>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <classname>PgSql\Lob</classname>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <classname>PgSql\Result</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-classes.spell">
+  <title>PSpell</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>PSpell\Config</classname>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <classname>PSpell\Dictionary</classname>
     </simpara>
    </listitem>
   </itemizedlist>


### PR DESCRIPTION
While these are already documented in the incompatible changes section regarding the resource to object conversions, they should also be listed explicitly as new classes.

---

Note that I used to verbose `<itemizedlist>` markup for consistency, although a `<simplelist>` seems more appropriate.