### PR TITLE
Move the parse_url() caution up to description section

### DIFF
--- a/reference/url/functions/parse-url.xml
+++ b/reference/url/functions/parse-url.xml
@@ -24,6 +24,15 @@
    URLs are also accepted, <function>parse_url</function> tries its best to
    parse them correctly.
   </para>
+  <caution>
+   <para>
+    This function may not give correct results for relative or invalid URLs,
+    and the results may not even match common behavior of HTTP clients.
+    If URLs from untrusted input need to be parsed, extra validation is
+    required, e.g. by using <function>filter_var</function> with the
+    <constant>FILTER_VALIDATE_URL</constant> filter.
+   </para>
+  </caution>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -252,15 +261,6 @@ array(3) {
 
  <refsect1 role="notes">
   &reftitle.notes;
-  <caution>
-   <para>
-    This function may not give correct results for relative or invalid URLs,
-    and the results may not even match common behavior of HTTP clients.
-    If URLs from untrusted input need to be parsed, extra validation is
-    required, e.g. by using <function>filter_var</function> with the
-    <constant>FILTER_VALIDATE_URL</constant> filter.
-   </para>
-  </caution>
   <note>
    <para>
     This function is intended specifically for the purpose of parsing URLs


### PR DESCRIPTION
This information is apparently not widely known, so we put it in a more prominent place.

---

In my opinion, the notes section should not contain any notes, cautions, and warnings at all. These should be put where they make most sense; the notes section should only contain "normal" text.