### PR TITLE
PCRE S modifier has no effect since PHP 7.3.0

### DIFF
--- a/reference/pcre/pattern.modifiers.xml
+++ b/reference/pcre/pattern.modifiers.xml
@@ -112,6 +112,7 @@
         this extra analysis is performed. At present, studying a
         pattern is useful only for non-anchored patterns that do not
         have a single fixed starting character.
+        As of PHP 7.3.0 this flag has no effect.
        </simpara>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
> The 'S' modifier has no effect, patterns are studied automatically. No real impact.
> https://wiki.php.net/rfc/pcre2-migration#backward_incompatible_changes