### PR TITLE
Gmagick compositeimage.xml: set parameter name to lowercase

### DIFF
--- a/reference/gmagick/gmagick/compositeimage.xml
+++ b/reference/gmagick/gmagick/compositeimage.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>Gmagick</type><methodname>Gmagick::compositeimage</methodname>
    <methodparam><type>Gmagick</type><parameter>source</parameter></methodparam>
-   <methodparam><type>int</type><parameter>COMPOSE</parameter></methodparam>
+   <methodparam><type>int</type><parameter>compose</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
    <methodparam><type>int</type><parameter>y</parameter></methodparam>
   </methodsynopsis>

--- a/reference/gmagick/gmagick/compositeimage.xml
+++ b/reference/gmagick/gmagick/compositeimage.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>Gmagick</type><methodname>Gmagick::compositeimage</methodname>
    <methodparam><type>Gmagick</type><parameter>source</parameter></methodparam>
-   <methodparam><type>int</type><parameter>compose</parameter></methodparam>
+   <methodparam><type>int</type><parameter>COMPOSE</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
    <methodparam><type>int</type><parameter>y</parameter></methodparam>
   </methodsynopsis>
@@ -35,7 +35,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>compose</parameter></term>
+     <term><parameter>COMPOSE</parameter></term>
      <listitem>
       <para>
        Composite operator.


### PR DESCRIPTION
According to the standards (and to the source code), the parameter name should be in lowercase.