### PR TITLE
Discourage the use of ArrayObject

### DIFF
--- a/reference/spl/arrayobject.xml
+++ b/reference/spl/arrayobject.xml
@@ -12,6 +12,11 @@
    <para>
     This class allows objects to work as arrays.
    </para>
+   <note>
+    <simpara>
+     This class is conceptionally flawed, and therefore its usage is discouraged.
+    </simpara>
+   </note>
   </section>
 <!-- }}} -->
  


### PR DESCRIPTION
See <https://github.com/php/php-src/pull/15775#issuecomment-2334813587>. While a formal deprecation process is pending, it seems prudent to not advertise this class any longer.