### PR TITLE
Fix #1369 + #1370: adding GearmanClient::setXXXCallback documentation

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1518,6 +1518,13 @@ encoding value will be used.</para>'>
  </variablelist>
 </para>'>
 
+<!ENTITY gearman.note.callback '<note xmlns="http://docbook.org/ns/docbook">
+ <para>
+  The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
+  after calling this method.
+ </para>
+</note>'>
+
 <!-- Date and time entities -->
 <!ENTITY date.timezone.intro.title '<title xmlns="http://docbook.org/ns/docbook">List of Supported Timezones</title>'>
 

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1485,11 +1485,13 @@ encoding value will be used.</para>'>
    <listitem>
     <para>
      A function or method to call.
-     It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
-     or a valid <link linkend="gearman.constants">Gearman return value</link>.
+     It should return a valid <link linkend="gearman.constants">Gearman return value</link>.
+    </para>
+    <para>
+     If no return statement is present, it defaults to <constant>GEARMAN_SUCCESS</constant>.
     </para>
     <methodsynopsis>
-     <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
+     <type>int</type><methodname><replaceable>callback</replaceable></methodname>
      <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
      <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
     </methodsynopsis>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1478,45 +1478,41 @@ encoding value will be used.</para>'>
 
 <!ENTITY gearman.parameter.jobhandle 'The job handle assigned by the Gearman server'>
 
-<!ENTITY gearman.parameter.callback '<para xmlns="http://docbook.org/ns/docbook">
- <variablelist>
-  <varlistentry>
-   <term><parameter>callback</parameter></term>
-   <listitem>
-    <para>
-     A function or method to call.
-     It should return a valid <link linkend="gearman.constants">Gearman return value</link>.
-    </para>
-    <para>
-     If no return statement is present, it defaults to <constant>GEARMAN_SUCCESS</constant>.
-    </para>
-    <methodsynopsis>
-     <type>int</type><methodname><replaceable>callback</replaceable></methodname>
-     <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
-     <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
-    </methodsynopsis>
-    <variablelist>
-     <varlistentry>
-      <term><parameter>task</parameter></term>
-      <listitem>
-       <para>
-        The task this callback is called for.
-       </para>
-      </listitem>
-     </varlistentry>
-     <varlistentry>
-      <term><parameter>context</parameter></term>
-      <listitem>
-       <para>
-        Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
-       </para>
-      </listitem>
-     </varlistentry>
-    </variablelist>
-   </listitem>
-  </varlistentry>
- </variablelist>
-</para>'>
+<!ENTITY gearman.parameter.callback '<varlistentry xmlns="http://docbook.org/ns/docbook">
+ <term><parameter>callback</parameter></term>
+ <listitem>
+  <para>
+   A function or method to call.
+   It should return a valid <link linkend="gearman.constants">Gearman return value</link>.
+  </para>
+  <para>
+   If no return statement is present, it defaults to <constant>GEARMAN_SUCCESS</constant>.
+  </para>
+  <methodsynopsis>
+   <type>int</type><methodname><replaceable>callback</replaceable></methodname>
+   <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
+  </methodsynopsis>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>task</parameter></term>
+    <listitem>
+     <para>
+      The task this callback is called for.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>context</parameter></term>
+    <listitem>
+     <para>
+      Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </listitem>
+</varlistentry>'>
 
 <!ENTITY gearman.note.callback '<note xmlns="http://docbook.org/ns/docbook">
  <para>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1478,6 +1478,44 @@ encoding value will be used.</para>'>
 
 <!ENTITY gearman.parameter.jobhandle 'The job handle assigned by the Gearman server'>
 
+<!ENTITY gearman.parameter.callback '<para xmlns="http://docbook.org/ns/docbook">
+ <variablelist>
+  <varlistentry>
+   <term><parameter>callback</parameter></term>
+   <listitem>
+    <para>
+     A function or method to call.
+     It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
+     or a valid <link linkend="gearman.constants">Gearman return value</link>.
+    </para>
+    <methodsynopsis>
+     <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
+     <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+     <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
+    </methodsynopsis>
+    <variablelist>
+     <varlistentry>
+      <term><parameter>task</parameter></term>
+      <listitem>
+       <para>
+        The task this callback is called for.
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term><parameter>context</parameter></term>
+      <listitem>
+       <para>
+        Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
+       </para>
+      </listitem>
+     </varlistentry>
+    </variablelist>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+</para>'>
+
 <!-- Date and time entities -->
 <!ENTITY date.timezone.intro.title '<title xmlns="http://docbook.org/ns/docbook">List of Supported Timezones</title>'>
 

--- a/reference/gearman/gearmanclient/setclientcallback.xml
+++ b/reference/gearman/gearmanclient/setclientcallback.xml
@@ -32,43 +32,7 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>callback</parameter></term>
-     <listitem>
-      <para>
-       A function or method to call.
-       It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
-       or a valid <link linkend="gearman.constants">Gearman return value</link>.
-      </para>
-      <methodsynopsis>
-       <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
-       <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
-       <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
-      </methodsynopsis>
-      <variablelist>
-       <varlistentry>
-        <term><parameter>task</parameter></term>
-        <listitem>
-         <para>
-          The task this callback is called for.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><parameter>context</parameter></term>
-        <listitem>
-         <para>
-          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
-         </para>
-        </listitem>
-       </varlistentry>
-      </variablelist>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  &gearman.parameter.callback;
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/gearman/gearmanclient/setclientcallback.xml
+++ b/reference/gearman/gearmanclient/setclientcallback.xml
@@ -27,7 +27,11 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  &gearman.parameter.callback;
+  <para>
+   <variablelist>
+    &gearman.parameter.callback;
+   </variablelist>
+  </para>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/gearman/gearmanclient/setclientcallback.xml
+++ b/reference/gearman/gearmanclient/setclientcallback.xml
@@ -14,8 +14,7 @@
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Sets the callback function for accepting data packets for a task. The callback function should
-   take a single argument, a <classname>GearmanTask</classname> object.
+   Sets the callback function for accepting data packets for a task.
   </para>
   <note>
    <para>
@@ -35,6 +34,28 @@
       <para>
        A function or method to call
       </para>
+      <methodsynopsis>
+       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+      </methodsynopsis>
+      <variablelist>
+       <varlistentry>
+        <term><parameter>task</parameter></term>
+        <listitem>
+         <para>
+          The task this callback is called for.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><parameter>context</parameter></term>
+        <listitem>
+         <para>
+          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> as <parameter>context</parameter>.
+         </para>
+        </listitem>
+       </varlistentry>
+      </variablelist>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/gearman/gearmanclient/setclientcallback.xml
+++ b/reference/gearman/gearmanclient/setclientcallback.xml
@@ -22,12 +22,7 @@
     the 0.6.0 release of the Gearman extension.
    </para>
   </note>
-  <note>
-   <para>
-    The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
-    after calling this method.
-   </para>
-  </note>
+  &gearman.note.callback;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/gearman/gearmanclient/setclientcallback.xml
+++ b/reference/gearman/gearmanclient/setclientcallback.xml
@@ -22,6 +22,12 @@
     the 0.6.0 release of the Gearman extension.
    </para>
   </note>
+  <note>
+   <para>
+    The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
+    after calling this method.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,11 +38,14 @@
      <term><parameter>callback</parameter></term>
      <listitem>
       <para>
-       A function or method to call
+       A function or method to call.
+       It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
+       or a valid <link linkend="gearman.constants">Gearman return value</link>.
       </para>
       <methodsynopsis>
-       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
        <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
       </methodsynopsis>
       <variablelist>
        <varlistentry>
@@ -51,7 +60,7 @@
         <term><parameter>context</parameter></term>
         <listitem>
          <para>
-          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> as <parameter>context</parameter>.
+          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
          </para>
         </listitem>
        </varlistentry>

--- a/reference/gearman/gearmanclient/setcompletecallback.xml
+++ b/reference/gearman/gearmanclient/setcompletecallback.xml
@@ -31,43 +31,7 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>callback</parameter></term>
-     <listitem>
-      <para>
-       A function to be called.
-       It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
-       or a valid <link linkend="gearman.constants">Gearman return value</link>.
-      </para>
-      <methodsynopsis>
-       <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
-       <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
-       <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
-      </methodsynopsis>
-      <variablelist>
-       <varlistentry>
-        <term><parameter>task</parameter></term>
-        <listitem>
-         <para>
-          The task this callback is called for.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><parameter>context</parameter></term>
-        <listitem>
-         <para>
-          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
-         </para>
-        </listitem>
-       </varlistentry>
-      </variablelist>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  &gearman.parameter.callback;
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/gearman/gearmanclient/setcompletecallback.xml
+++ b/reference/gearman/gearmanclient/setcompletecallback.xml
@@ -26,7 +26,11 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  &gearman.parameter.callback;
+  <para>
+   <variablelist>
+    &gearman.parameter.callback;
+   </variablelist>
+  </para>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/gearman/gearmanclient/setcompletecallback.xml
+++ b/reference/gearman/gearmanclient/setcompletecallback.xml
@@ -10,17 +10,23 @@
   &reftitle.description;
   <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setCompleteCallback</methodname>
-   <methodparam><type>callable</type><parameter>function</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Use to set a function to be called when a <classname>GearmanTask</classname> is completed, or
+   Use to set a callback function to be called when a <classname>GearmanTask</classname> is completed, or
    when <methodname>GearmanJob::sendComplete</methodname> is invoked by a worker (whichever happens
    first).
   </para>
   <para>
    This callback executes only when executing a <classname>GearmanTask</classname> using
    <methodname>GearmanClient::runTasks</methodname>. It is not used for individual jobs.
-  </para>  
+  </para>
+  <note>
+   <para>
+    The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
+    after calling this method.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,13 +34,15 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>function</parameter></term>
+     <term><parameter>callback</parameter></term>
      <listitem>
       <para>
-       A function to be called
+       A function to be called.
+       It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
+       or a valid <link linkend="gearman.constants">Gearman return value</link>.
       </para>
       <methodsynopsis>
-       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
        <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
        <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
       </methodsynopsis>
@@ -51,7 +59,7 @@
         <term><parameter>context</parameter></term>
         <listitem>
          <para>
-          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> as <parameter>context</parameter>.
+          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
          </para>
         </listitem>
        </varlistentry>

--- a/reference/gearman/gearmanclient/setcompletecallback.xml
+++ b/reference/gearman/gearmanclient/setcompletecallback.xml
@@ -21,12 +21,7 @@
    This callback executes only when executing a <classname>GearmanTask</classname> using
    <methodname>GearmanClient::runTasks</methodname>. It is not used for individual jobs.
   </para>
-  <note>
-   <para>
-    The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
-    after calling this method.
-   </para>
-  </note>
+  &gearman.note.callback;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/gearman/gearmanclient/setcompletecallback.xml
+++ b/reference/gearman/gearmanclient/setcompletecallback.xml
@@ -33,6 +33,29 @@
       <para>
        A function to be called
       </para>
+      <methodsynopsis>
+       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
+      </methodsynopsis>
+      <variablelist>
+       <varlistentry>
+        <term><parameter>task</parameter></term>
+        <listitem>
+         <para>
+          The task this callback is called for.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><parameter>context</parameter></term>
+        <listitem>
+         <para>
+          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> as <parameter>context</parameter>.
+         </para>
+        </listitem>
+       </varlistentry>
+      </variablelist>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/gearman/gearmanclient/setcreatedcallback.xml
+++ b/reference/gearman/gearmanclient/setcreatedcallback.xml
@@ -25,43 +25,7 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>callback</parameter></term>
-     <listitem>
-      <para>
-       A function to call.
-       It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
-       or a valid <link linkend="gearman.constants">Gearman return value</link>.
-      </para>
-      <methodsynopsis>
-       <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
-       <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
-       <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
-      </methodsynopsis>
-      <variablelist>
-       <varlistentry>
-        <term><parameter>task</parameter></term>
-        <listitem>
-         <para>
-          The task this callback is called for.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><parameter>context</parameter></term>
-        <listitem>
-         <para>
-          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
-         </para>
-        </listitem>
-       </varlistentry>
-      </variablelist>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  &gearman.parameter.callback;
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/gearman/gearmanclient/setcreatedcallback.xml
+++ b/reference/gearman/gearmanclient/setcreatedcallback.xml
@@ -20,7 +20,11 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  &gearman.parameter.callback;
+  <para>
+   <variablelist>
+    &gearman.parameter.callback;
+   </variablelist>
+  </para>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/gearman/gearmanclient/setcreatedcallback.xml
+++ b/reference/gearman/gearmanclient/setcreatedcallback.xml
@@ -10,12 +10,17 @@
   &reftitle.description;
   <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setCreatedCallback</methodname>
-   <methodparam><type>callable</type><parameter>function</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Sets a function to be called when a task is received and queued by the Gearman job server.
-   The callback should accept a single argument, a <classname>GearmanTask</classname> object.
+   Sets a callback function to be called when a task is received and queued by the Gearman job server.
   </para>
+  <note>
+   <para>
+    The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
+    after calling this method.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -23,13 +28,15 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>function</parameter></term>
+     <term><parameter>callback</parameter></term>
      <listitem>
       <para>
-       A function to call
+       A function to call.
+       It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
+       or a valid <link linkend="gearman.constants">Gearman return value</link>.
       </para>
       <methodsynopsis>
-       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
        <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
        <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
       </methodsynopsis>
@@ -46,7 +53,7 @@
         <term><parameter>context</parameter></term>
         <listitem>
          <para>
-          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> as <parameter>context</parameter>.
+          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
          </para>
         </listitem>
        </varlistentry>

--- a/reference/gearman/gearmanclient/setcreatedcallback.xml
+++ b/reference/gearman/gearmanclient/setcreatedcallback.xml
@@ -15,12 +15,7 @@
   <para>
    Sets a callback function to be called when a task is received and queued by the Gearman job server.
   </para>
-  <note>
-   <para>
-    The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
-    after calling this method.
-   </para>
-  </note>
+  &gearman.note.callback;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/gearman/gearmanclient/setcreatedcallback.xml
+++ b/reference/gearman/gearmanclient/setcreatedcallback.xml
@@ -28,6 +28,29 @@
       <para>
        A function to call
       </para>
+      <methodsynopsis>
+       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
+      </methodsynopsis>
+      <variablelist>
+       <varlistentry>
+        <term><parameter>task</parameter></term>
+        <listitem>
+         <para>
+          The task this callback is called for.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><parameter>context</parameter></term>
+        <listitem>
+         <para>
+          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> as <parameter>context</parameter>.
+         </para>
+        </listitem>
+       </varlistentry>
+      </variablelist>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/gearman/gearmanclient/setdatacallback.xml
+++ b/reference/gearman/gearmanclient/setdatacallback.xml
@@ -15,12 +15,7 @@
   <para>
    Sets the callback function for accepting data packets for a task.
   </para>
-  <note>
-   <para>
-    The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
-    after calling this method.
-   </para>
-  </note>
+  &gearman.note.callback;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/gearman/gearmanclient/setdatacallback.xml
+++ b/reference/gearman/gearmanclient/setdatacallback.xml
@@ -20,7 +20,11 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  &gearman.parameter.callback;
+  <para>
+   <variablelist>
+    &gearman.parameter.callback;
+   </variablelist>
+  </para>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/gearman/gearmanclient/setdatacallback.xml
+++ b/reference/gearman/gearmanclient/setdatacallback.xml
@@ -25,43 +25,7 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>callback</parameter></term>
-     <listitem>
-      <para>
-       A function or method to call.
-       It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
-       or a valid <link linkend="gearman.constants">Gearman return value</link>.
-      </para>
-      <methodsynopsis>
-       <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
-       <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
-       <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
-      </methodsynopsis>
-      <variablelist>
-       <varlistentry>
-        <term><parameter>task</parameter></term>
-        <listitem>
-         <para>
-          The task this callback is called for.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><parameter>context</parameter></term>
-        <listitem>
-         <para>
-          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
-         </para>
-        </listitem>
-       </varlistentry>
-      </variablelist>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  &gearman.parameter.callback;
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/gearman/gearmanclient/setdatacallback.xml
+++ b/reference/gearman/gearmanclient/setdatacallback.xml
@@ -10,11 +10,17 @@
   &reftitle.description;
   <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setDataCallback</methodname>
-   <methodparam><type>callable</type><parameter>function</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <para>
    Sets the callback function for accepting data packets for a task.
   </para>
+  <note>
+   <para>
+    The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
+    after calling this method.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -22,14 +28,17 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>function</parameter></term>
+     <term><parameter>callback</parameter></term>
      <listitem>
       <para>
-       A function or method to call
+       A function or method to call.
+       It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
+       or a valid <link linkend="gearman.constants">Gearman return value</link>.
       </para>
       <methodsynopsis>
-       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
        <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
       </methodsynopsis>
       <variablelist>
        <varlistentry>
@@ -44,7 +53,7 @@
         <term><parameter>context</parameter></term>
         <listitem>
          <para>
-          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> as <parameter>context</parameter>.
+          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
          </para>
         </listitem>
        </varlistentry>

--- a/reference/gearman/gearmanclient/setdatacallback.xml
+++ b/reference/gearman/gearmanclient/setdatacallback.xml
@@ -13,8 +13,7 @@
    <methodparam><type>callable</type><parameter>function</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Sets the callback function for accepting data packets for a task. The callback function should
-   take a single argument, a <classname>GearmanTask</classname> object.
+   Sets the callback function for accepting data packets for a task.
   </para>
  </refsect1>
 
@@ -28,6 +27,28 @@
       <para>
        A function or method to call
       </para>
+      <methodsynopsis>
+       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+      </methodsynopsis>
+      <variablelist>
+       <varlistentry>
+        <term><parameter>task</parameter></term>
+        <listitem>
+         <para>
+          The task this callback is called for.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><parameter>context</parameter></term>
+        <listitem>
+         <para>
+          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> as <parameter>context</parameter>.
+         </para>
+        </listitem>
+       </varlistentry>
+      </variablelist>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/gearman/gearmanclient/setexceptioncallback.xml
+++ b/reference/gearman/gearmanclient/setexceptioncallback.xml
@@ -15,12 +15,7 @@
   <para>
    Specifies a callback function to call when a worker for a task sends an exception.
   </para>
-  <note>
-   <para>
-    The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
-    after calling this method.
-   </para>
-  </note>
+  &gearman.note.callback;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/gearman/gearmanclient/setexceptioncallback.xml
+++ b/reference/gearman/gearmanclient/setexceptioncallback.xml
@@ -20,7 +20,11 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  &gearman.parameter.callback;
+  <para>
+   <variablelist>
+    &gearman.parameter.callback;
+   </variablelist>
+  </para>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/gearman/gearmanclient/setexceptioncallback.xml
+++ b/reference/gearman/gearmanclient/setexceptioncallback.xml
@@ -27,6 +27,28 @@
       <para>
        Function to call when the worker throws an exception
       </para>
+      <methodsynopsis>
+       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+      </methodsynopsis>
+      <variablelist>
+       <varlistentry>
+        <term><parameter>task</parameter></term>
+        <listitem>
+         <para>
+          The task this callback is called for.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><parameter>context</parameter></term>
+        <listitem>
+         <para>
+          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> as <parameter>context</parameter>.
+         </para>
+        </listitem>
+       </varlistentry>
+      </variablelist>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/gearman/gearmanclient/setexceptioncallback.xml
+++ b/reference/gearman/gearmanclient/setexceptioncallback.xml
@@ -25,43 +25,7 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>callback</parameter></term>
-     <listitem>
-      <para>
-       Function to call when the worker throws an exception.
-       It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
-       or a valid <link linkend="gearman.constants">Gearman return value</link>.
-      </para>
-      <methodsynopsis>
-       <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
-       <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
-       <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
-      </methodsynopsis>
-      <variablelist>
-       <varlistentry>
-        <term><parameter>task</parameter></term>
-        <listitem>
-         <para>
-          The task this callback is called for.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><parameter>context</parameter></term>
-        <listitem>
-         <para>
-          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
-         </para>
-        </listitem>
-       </varlistentry>
-      </variablelist>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  &gearman.parameter.callback;
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/gearman/gearmanclient/setexceptioncallback.xml
+++ b/reference/gearman/gearmanclient/setexceptioncallback.xml
@@ -10,11 +10,17 @@
   &reftitle.description;
   <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setExceptionCallback</methodname>
-   <methodparam><type>callable</type><parameter>function</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Specifies a function to call when a worker for a task sends an exception.
+   Specifies a callback function to call when a worker for a task sends an exception.
   </para>
+  <note>
+   <para>
+    The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
+    after calling this method.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -22,14 +28,17 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>function</parameter></term>
+     <term><parameter>callback</parameter></term>
      <listitem>
       <para>
-       Function to call when the worker throws an exception
+       Function to call when the worker throws an exception.
+       It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
+       or a valid <link linkend="gearman.constants">Gearman return value</link>.
       </para>
       <methodsynopsis>
-       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
        <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
       </methodsynopsis>
       <variablelist>
        <varlistentry>
@@ -44,7 +53,7 @@
         <term><parameter>context</parameter></term>
         <listitem>
          <para>
-          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> as <parameter>context</parameter>.
+          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
          </para>
         </listitem>
        </varlistentry>

--- a/reference/gearman/gearmanclient/setfailcallback.xml
+++ b/reference/gearman/gearmanclient/setfailcallback.xml
@@ -25,43 +25,7 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>callback</parameter></term>
-     <listitem>
-      <para>
-       A function to call.
-       It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
-       or a valid <link linkend="gearman.constants">Gearman return value</link>.
-      </para>
-      <methodsynopsis>
-       <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
-       <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
-       <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
-      </methodsynopsis>
-      <variablelist>
-       <varlistentry>
-        <term><parameter>task</parameter></term>
-        <listitem>
-         <para>
-          The task this callback is called for.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><parameter>context</parameter></term>
-        <listitem>
-         <para>
-          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
-         </para>
-        </listitem>
-       </varlistentry>
-      </variablelist>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  &gearman.parameter.callback;
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/gearman/gearmanclient/setfailcallback.xml
+++ b/reference/gearman/gearmanclient/setfailcallback.xml
@@ -20,7 +20,11 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  &gearman.parameter.callback;
+  <para>
+   <variablelist>
+    &gearman.parameter.callback;
+   </variablelist>
+  </para>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/gearman/gearmanclient/setfailcallback.xml
+++ b/reference/gearman/gearmanclient/setfailcallback.xml
@@ -15,12 +15,7 @@
   <para>
    Sets the callback function to be used when a task does not complete successfully.
   </para>
-  <note>
-   <para>
-    The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
-    after calling this method.
-   </para>
-  </note>
+  &gearman.note.callback;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/gearman/gearmanclient/setfailcallback.xml
+++ b/reference/gearman/gearmanclient/setfailcallback.xml
@@ -13,8 +13,7 @@
    <methodparam><type>callable</type><parameter>function</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Sets the callback function to be used when a task does not complete successfully.  The function
-   should accept a single argument, a <classname>GearmanTask</classname> object.
+   Sets the callback function to be used when a task does not complete successfully.
   </para>
  </refsect1>
 
@@ -28,6 +27,28 @@
       <para>
        A function to call
       </para>
+      <methodsynopsis>
+       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+      </methodsynopsis>
+      <variablelist>
+       <varlistentry>
+        <term><parameter>task</parameter></term>
+        <listitem>
+         <para>
+          The task this callback is called for.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><parameter>context</parameter></term>
+        <listitem>
+         <para>
+          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> as <parameter>context</parameter>.
+         </para>
+        </listitem>
+       </varlistentry>
+      </variablelist>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/gearman/gearmanclient/setfailcallback.xml
+++ b/reference/gearman/gearmanclient/setfailcallback.xml
@@ -10,11 +10,17 @@
   &reftitle.description;
   <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setFailCallback</methodname>
-   <methodparam><type>callable</type><parameter>function</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <para>
    Sets the callback function to be used when a task does not complete successfully.
   </para>
+  <note>
+   <para>
+    The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
+    after calling this method.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -22,14 +28,17 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>function</parameter></term>
+     <term><parameter>callback</parameter></term>
      <listitem>
       <para>
-       A function to call
+       A function to call.
+       It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
+       or a valid <link linkend="gearman.constants">Gearman return value</link>.
       </para>
       <methodsynopsis>
-       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
        <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
       </methodsynopsis>
       <variablelist>
        <varlistentry>
@@ -44,7 +53,7 @@
         <term><parameter>context</parameter></term>
         <listitem>
          <para>
-          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> as <parameter>context</parameter>.
+          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
          </para>
         </listitem>
        </varlistentry>

--- a/reference/gearman/gearmanclient/setstatuscallback.xml
+++ b/reference/gearman/gearmanclient/setstatuscallback.xml
@@ -25,43 +25,7 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>callback</parameter></term>
-     <listitem>
-      <para>
-       A function to call.
-       It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
-       or a valid <link linkend="gearman.constants">Gearman return value</link>.
-      </para>
-      <methodsynopsis>
-       <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
-       <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
-       <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
-      </methodsynopsis>
-      <variablelist>
-       <varlistentry>
-        <term><parameter>task</parameter></term>
-        <listitem>
-         <para>
-          The task this callback is called for.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><parameter>context</parameter></term>
-        <listitem>
-         <para>
-          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
-         </para>
-        </listitem>
-       </varlistentry>
-      </variablelist>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  &gearman.parameter.callback;
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/gearman/gearmanclient/setstatuscallback.xml
+++ b/reference/gearman/gearmanclient/setstatuscallback.xml
@@ -20,7 +20,11 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  &gearman.parameter.callback;
+  <para>
+   <variablelist>
+    &gearman.parameter.callback;
+   </variablelist>
+  </para>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/gearman/gearmanclient/setstatuscallback.xml
+++ b/reference/gearman/gearmanclient/setstatuscallback.xml
@@ -15,12 +15,7 @@
   <para>
    Sets a callback function used for getting updated status information from a worker.
   </para>
-  <note>
-   <para>
-    The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
-    after calling this method.
-   </para>
-  </note>
+  &gearman.note.callback;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/gearman/gearmanclient/setstatuscallback.xml
+++ b/reference/gearman/gearmanclient/setstatuscallback.xml
@@ -13,8 +13,7 @@
    <methodparam><type>callable</type><parameter>function</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Sets a callback function used for getting updated status information from a worker.  The function
-   should accept a single argument, a <classname>GearmanTask</classname> object.
+   Sets a callback function used for getting updated status information from a worker.
   </para>
  </refsect1>
 
@@ -28,6 +27,28 @@
       <para>
        A function to call
       </para>
+      <methodsynopsis>
+       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+      </methodsynopsis>
+      <variablelist>
+       <varlistentry>
+        <term><parameter>task</parameter></term>
+        <listitem>
+         <para>
+          The task this callback is called for.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><parameter>context</parameter></term>
+        <listitem>
+         <para>
+          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> as <parameter>context</parameter>.
+         </para>
+        </listitem>
+       </varlistentry>
+      </variablelist>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/gearman/gearmanclient/setstatuscallback.xml
+++ b/reference/gearman/gearmanclient/setstatuscallback.xml
@@ -10,11 +10,17 @@
   &reftitle.description;
   <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setStatusCallback</methodname>
-   <methodparam><type>callable</type><parameter>function</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <para>
    Sets a callback function used for getting updated status information from a worker.
   </para>
+  <note>
+   <para>
+    The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
+    after calling this method.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -22,14 +28,17 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>function</parameter></term>
+     <term><parameter>callback</parameter></term>
      <listitem>
       <para>
-       A function to call
+       A function to call.
+       It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
+       or a valid <link linkend="gearman.constants">Gearman return value</link>.
       </para>
       <methodsynopsis>
-       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
        <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
       </methodsynopsis>
       <variablelist>
        <varlistentry>
@@ -44,7 +53,7 @@
         <term><parameter>context</parameter></term>
         <listitem>
          <para>
-          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> as <parameter>context</parameter>.
+          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
          </para>
         </listitem>
        </varlistentry>

--- a/reference/gearman/gearmanclient/setwarningcallback.xml
+++ b/reference/gearman/gearmanclient/setwarningcallback.xml
@@ -25,43 +25,7 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>callback</parameter></term>
-     <listitem>
-      <para>
-       A function to call.
-       It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
-       or a valid <link linkend="gearman.constants">Gearman return value</link>.
-      </para>
-      <methodsynopsis>
-       <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
-       <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
-       <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
-      </methodsynopsis>
-      <variablelist>
-       <varlistentry>
-        <term><parameter>task</parameter></term>
-        <listitem>
-         <para>
-          The task this callback is called for.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><parameter>context</parameter></term>
-        <listitem>
-         <para>
-          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
-         </para>
-        </listitem>
-       </varlistentry>
-      </variablelist>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  &gearman.parameter.callback;
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/gearman/gearmanclient/setwarningcallback.xml
+++ b/reference/gearman/gearmanclient/setwarningcallback.xml
@@ -20,7 +20,11 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  &gearman.parameter.callback;
+  <para>
+   <variablelist>
+    &gearman.parameter.callback;
+   </variablelist>
+  </para>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/gearman/gearmanclient/setwarningcallback.xml
+++ b/reference/gearman/gearmanclient/setwarningcallback.xml
@@ -13,8 +13,7 @@
    <methodparam><type>callable</type><parameter>function</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Sets a function to be called when a worker sends a warning.  The callback should accept
-   a single argument, a <classname>GearmanTask</classname> object.
+   Sets a function to be called when a worker sends a warning.
   </para>
  </refsect1>
 
@@ -28,6 +27,28 @@
       <para>
        A function to call
       </para>
+      <methodsynopsis>
+       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+      </methodsynopsis>
+      <variablelist>
+       <varlistentry>
+        <term><parameter>task</parameter></term>
+        <listitem>
+         <para>
+          The task this callback is called for.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><parameter>context</parameter></term>
+        <listitem>
+         <para>
+          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> as <parameter>context</parameter>.
+         </para>
+        </listitem>
+       </varlistentry>
+      </variablelist>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/gearman/gearmanclient/setwarningcallback.xml
+++ b/reference/gearman/gearmanclient/setwarningcallback.xml
@@ -15,12 +15,7 @@
   <para>
    Sets a callback function to be called when a worker sends a warning.
   </para>
-  <note>
-   <para>
-    The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
-    after calling this method.
-   </para>
-  </note>
+  &gearman.note.callback;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/gearman/gearmanclient/setwarningcallback.xml
+++ b/reference/gearman/gearmanclient/setwarningcallback.xml
@@ -10,11 +10,17 @@
   &reftitle.description;
   <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setWarningCallback</methodname>
-   <methodparam><type>callable</type><parameter>function</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Sets a function to be called when a worker sends a warning.
+   Sets a callback function to be called when a worker sends a warning.
   </para>
+  <note>
+   <para>
+    The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
+    after calling this method.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -22,14 +28,17 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>function</parameter></term>
+     <term><parameter>callback</parameter></term>
      <listitem>
       <para>
-       A function to call
+       A function to call.
+       It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
+       or a valid <link linkend="gearman.constants">Gearman return value</link>.
       </para>
       <methodsynopsis>
-       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
        <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
       </methodsynopsis>
       <variablelist>
        <varlistentry>
@@ -44,7 +53,7 @@
         <term><parameter>context</parameter></term>
         <listitem>
          <para>
-          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> as <parameter>context</parameter>.
+          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
          </para>
         </listitem>
        </varlistentry>

--- a/reference/gearman/gearmanclient/setworkloadcallback.xml
+++ b/reference/gearman/gearmanclient/setworkloadcallback.xml
@@ -15,8 +15,7 @@
   <para>
    Sets a function to be called when a worker needs to send back data prior to job completion.
    A worker can do this when it needs to send updates, send partial results, or flush data
-   during long running jobs.  The callback should accept a single argument, a 
-   <classname>GearmanTask</classname> object.
+   during long running jobs.
   </para>
  </refsect1>
 
@@ -30,6 +29,28 @@
       <para>
        A function to call
       </para>
+      <methodsynopsis>
+       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+      </methodsynopsis>
+      <variablelist>
+       <varlistentry>
+        <term><parameter>task</parameter></term>
+        <listitem>
+         <para>
+          The task this callback is called for.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><parameter>context</parameter></term>
+        <listitem>
+         <para>
+          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> as <parameter>context</parameter>.
+         </para>
+        </listitem>
+       </varlistentry>
+      </variablelist>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/gearman/gearmanclient/setworkloadcallback.xml
+++ b/reference/gearman/gearmanclient/setworkloadcallback.xml
@@ -10,13 +10,19 @@
   &reftitle.description;
   <methodsynopsis role="GearmanClient">
    <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setWorkloadCallback</methodname>
-   <methodparam><type>callable</type><parameter>function</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Sets a function to be called when a worker needs to send back data prior to job completion.
+   Sets a callback function to be called when a worker needs to send back data prior to job completion.
    A worker can do this when it needs to send updates, send partial results, or flush data
    during long running jobs.
   </para>
+  <note>
+   <para>
+    The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
+    after calling this method.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,14 +30,17 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>function</parameter></term>
+     <term><parameter>callback</parameter></term>
      <listitem>
       <para>
-       A function to call
+       A function to call.
+       It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
+       or a valid <link linkend="gearman.constants">Gearman return value</link>.
       </para>
       <methodsynopsis>
-       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
        <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
       </methodsynopsis>
       <variablelist>
        <varlistentry>
@@ -46,7 +55,7 @@
         <term><parameter>context</parameter></term>
         <listitem>
          <para>
-          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> as <parameter>context</parameter>.
+          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
          </para>
         </listitem>
        </varlistentry>

--- a/reference/gearman/gearmanclient/setworkloadcallback.xml
+++ b/reference/gearman/gearmanclient/setworkloadcallback.xml
@@ -17,12 +17,7 @@
    A worker can do this when it needs to send updates, send partial results, or flush data
    during long running jobs.
   </para>
-  <note>
-   <para>
-    The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
-    after calling this method.
-   </para>
-  </note>
+  &gearman.note.callback;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/gearman/gearmanclient/setworkloadcallback.xml
+++ b/reference/gearman/gearmanclient/setworkloadcallback.xml
@@ -22,7 +22,11 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  &gearman.parameter.callback;
+  <para>
+   <variablelist>
+    &gearman.parameter.callback;
+   </variablelist>
+  </para>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/gearman/gearmanclient/setworkloadcallback.xml
+++ b/reference/gearman/gearmanclient/setworkloadcallback.xml
@@ -27,43 +27,7 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>callback</parameter></term>
-     <listitem>
-      <para>
-       A function to call.
-       It must return either nothing (which defaults to <constant>GEARMAN_SUCCESS</constant>)
-       or a valid <link linkend="gearman.constants">Gearman return value</link>.
-      </para>
-      <methodsynopsis>
-       <type class="union"><type>int</type><type>void</type></type><methodname><replaceable>callback</replaceable></methodname>
-       <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
-       <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
-      </methodsynopsis>
-      <variablelist>
-       <varlistentry>
-        <term><parameter>task</parameter></term>
-        <listitem>
-         <para>
-          The task this callback is called for.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><parameter>context</parameter></term>
-        <listitem>
-         <para>
-          Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
-         </para>
-        </listitem>
-       </varlistentry>
-      </variablelist>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  &gearman.parameter.callback;
  </refsect1>
 
  <refsect1 role="returnvalues">


### PR DESCRIPTION
### This PR adds documentation for the `GearmanClient::setXXXCallback` methods.

This includes:
- specification of arguments and return type of each callback method (see #1370)
- a note that the `setXXXCallback` methods should be called before calling `addTaskXXX` (see #1369)
___

In the [PECL extension](https://github.com/php/pecl-networking-gearman) you can see, that all callback functions are called (equally) by this code snippet:

https://github.com/php/pecl-networking-gearman/blob/a52052cdd712a95091ce926be3bcdca41c730696/php_gearman_task.c#L32-L48

If you look closely, you might note, that `task->zdata` (which is called `$context` in PHP) will be provided if it has been set when `GearmanClient::addTaskXXX` was called. As I have tested, otherwise `null` is passed and no warning/error/exception is raised.

For some of the `GearmanClient::setXXXCallback` methods, there are already examples in this documentation mentioning, that those two arguments are provided. 