### PR TITLE
Restrict discouragement of ArrayObject to wrapping objects

### DIFF
--- a/reference/spl/arrayobject.xml
+++ b/reference/spl/arrayobject.xml
@@ -14,7 +14,7 @@
    </para>
    <note>
     <simpara>
-     This class is conceptionally flawed, and therefore its usage is discouraged.
+     Wrapping objects with this class is conceptionally flawed, and therefore its usage with objects is discouraged.
     </simpara>
    </note>
   </section>

--- a/reference/spl/arrayobject.xml
+++ b/reference/spl/arrayobject.xml
@@ -14,7 +14,7 @@
    </para>
    <note>
     <simpara>
-     Wrapping objects with this class is conceptionally flawed, and therefore its usage with objects is discouraged.
+     Wrapping objects with this class is fundamentally flawed, and therefore its usage with objects is discouraged.
     </simpara>
    </note>
   </section>


### PR DESCRIPTION
This is a follow-up to PR #3858, based on a comment by @arnaud-lb[1].

[1] <https://github.com/php/php-src/issues/16371#issuecomment-2410928030>