### PR TITLE
[PHP 8.4] Add new Sodium functions and constants

### DIFF
--- a/reference/sodium/constants.xml
+++ b/reference/sodium/constants.xml
@@ -76,6 +76,94 @@
      </simpara>
     </listitem>
    </varlistentry>
+   <varlistentry xml:id="constant.sodium-crypto-aead-aegis128l-keybytes">
+    <term>
+     <constant>SODIUM_CRYPTO_AEAD_AEGIS128L_KEYBYTES</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Available as of PHP 8.4.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.sodium-crypto-aead-aegis128l-nsecbytes">
+    <term>
+     <constant>SODIUM_CRYPTO_AEAD_AEGIS128L_NSECBYTES</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Available as of PHP 8.4.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.sodium-crypto-aead-aegis128l-npubbytes">
+    <term>
+     <constant>SODIUM_CRYPTO_AEAD_AEGIS128L_NPUBBYTES</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Available as of PHP 8.4.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.sodium-crypto-aead-aegis128l-abytes">
+    <term>
+     <constant>SODIUM_CRYPTO_AEAD_AEGIS128L_ABYTES</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Available as of PHP 8.4.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.sodium-crypto-aead-aegis256-keybytes">
+    <term>
+     <constant>SODIUM_CRYPTO_AEAD_AEGIS256_KEYBYTES</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Available as of PHP 8.4.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.sodium-crypto-aead-aegis256-nsecbytes">
+    <term>
+     <constant>SODIUM_CRYPTO_AEAD_AEGIS256_NSECBYTES</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Available as of PHP 8.4.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.sodium-crypto-aead-aegis256-npubbytes">
+    <term>
+     <constant>SODIUM_CRYPTO_AEAD_AEGIS256_NPUBBYTES</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Available as of PHP 8.4.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.sodium-crypto-aead-aegis256-abytes">
+    <term>
+     <constant>SODIUM_CRYPTO_AEAD_AEGIS256_ABYTES</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Available as of PHP 8.4.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="constant.sodium-crypto-aead-aes256gcm-keybytes">
     <term>
      <constant>SODIUM_CRYPTO_AEAD_AES256GCM_KEYBYTES</constant>

--- a/reference/sodium/functions/sodium-crypto-aead-aegis128l-decrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aegis128l-decrypt.xml
@@ -15,9 +15,9 @@
    <methodparam><type>string</type><parameter>nonce</parameter></methodparam>
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Verify then decrypt a message with AEGIS-128L.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,34 +26,34 @@
    <varlistentry>
     <term><parameter>ciphertext</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Must be in the format provided by <function>sodium_crypto_aead_aegis128l_encrypt</function>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>additional_data</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Additional, authenticated data. This is used in the verification of the authentication tag
       appended to the ciphertext, but it is not encrypted or stored in the ciphertext.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>nonce</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       A number that must be only used once, per message.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>key</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Encryption key (128-bit).
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -61,9 +61,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the plaintext on success, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/sodium/functions/sodium-crypto-aead-aegis128l-decrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aegis128l-decrypt.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.sodium-crypto-aead-aegis128l-decrypt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>sodium_crypto_aead_aegis128l_decrypt</refname>
+  <refpurpose>Verify then decrypt a message with AEGIS-128L</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>sodium_crypto_aead_aegis128l_decrypt</methodname>
+   <methodparam><type>string</type><parameter>ciphertext</parameter></methodparam>
+   <methodparam><type>string</type><parameter>additional_data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>nonce</parameter></methodparam>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Verify then decrypt a message with AEGIS-128L.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>ciphertext</parameter></term>
+    <listitem>
+     <para>
+      Must be in the format provided by <function>sodium_crypto_aead_aegis128l_encrypt</function>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>additional_data</parameter></term>
+    <listitem>
+     <para>
+      Additional, authenticated data. This is used in the verification of the authentication tag
+      appended to the ciphertext, but it is not encrypted or stored in the ciphertext.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>nonce</parameter></term>
+    <listitem>
+     <para>
+      A number that must be only used once, per message.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+      Encryption key (128-bit).
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the plaintext on success, &return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>sodium_crypto_aead_aegis128l_encrypt</function></member>
+   <member><function>sodium_crypto_aead_aegis128l_keygen</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sodium/functions/sodium-crypto-aead-aegis128l-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aegis128l-encrypt.xml
@@ -15,9 +15,9 @@
    <methodparam><type>string</type><parameter>nonce</parameter></methodparam>
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Encrypt then authenticate a message with AEGIS-128L.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,34 +26,34 @@
    <varlistentry>
     <term><parameter>message</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       The plaintext message to encrypt.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>additional_data</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Additional, authenticated data. This is used in the verification of the authentication tag
       appended to the ciphertext, but it is not encrypted or stored in the ciphertext.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>nonce</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       A number that must be only used once, per message.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>key</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Encryption key (128-bit).
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -61,9 +61,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the ciphertext and authentication tag as a string of raw binary bytes.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/sodium/functions/sodium-crypto-aead-aegis128l-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aegis128l-encrypt.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.sodium-crypto-aead-aegis128l-encrypt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>sodium_crypto_aead_aegis128l_encrypt</refname>
+  <refpurpose>Encrypt then authenticate a message with AEGIS-128L</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>sodium_crypto_aead_aegis128l_encrypt</methodname>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>message</parameter></methodparam>
+   <methodparam><type>string</type><parameter>additional_data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>nonce</parameter></methodparam>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Encrypt then authenticate a message with AEGIS-128L.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>message</parameter></term>
+    <listitem>
+     <para>
+      The plaintext message to encrypt.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>additional_data</parameter></term>
+    <listitem>
+     <para>
+      Additional, authenticated data. This is used in the verification of the authentication tag
+      appended to the ciphertext, but it is not encrypted or stored in the ciphertext.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>nonce</parameter></term>
+    <listitem>
+     <para>
+      A number that must be only used once, per message.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+      Encryption key (128-bit).
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the ciphertext and authentication tag as a string of raw binary bytes.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>sodium_crypto_aead_aegis128l_decrypt</function></member>
+   <member><function>sodium_crypto_aead_aegis128l_keygen</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sodium/functions/sodium-crypto-aead-aegis128l-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aegis128l-keygen.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.sodium-crypto-aead-aegis128l-keygen" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>sodium_crypto_aead_aegis128l_keygen</refname>
+  <refpurpose>Generate a random AEGIS-128L key</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>sodium_crypto_aead_aegis128l_keygen</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Generate a random key for use with <function>sodium_crypto_aead_aegis128l_encrypt</function> and
+   <function>sodium_crypto_aead_aegis128l_decrypt</function>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns a 128-bit random key.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>sodium_crypto_aead_aegis128l_decrypt</function></member>
+   <member><function>sodium_crypto_aead_aegis128l_encrypt</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sodium/functions/sodium-crypto-aead-aegis128l-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aegis128l-keygen.xml
@@ -10,12 +10,12 @@
   &reftitle.description;
   <methodsynopsis>
    <type>string</type><methodname>sodium_crypto_aead_aegis128l_keygen</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Generate a random key for use with <function>sodium_crypto_aead_aegis128l_encrypt</function> and
    <function>sodium_crypto_aead_aegis128l_decrypt</function>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns a 128-bit random key.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/sodium/functions/sodium-crypto-aead-aegis256-decrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aegis256-decrypt.xml
@@ -15,9 +15,9 @@
    <methodparam><type>string</type><parameter>nonce</parameter></methodparam>
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Verify then decrypt a message with AEGIS-256.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,34 +26,34 @@
    <varlistentry>
     <term><parameter>ciphertext</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Must be in the format provided by <function>sodium_crypto_aead_aegis256_encrypt</function>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>additional_data</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Additional, authenticated data. This is used in the verification of the authentication tag
       appended to the ciphertext, but it is not encrypted or stored in the ciphertext.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>nonce</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       A number that must be only used once, per message.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>key</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Encryption key (256-bit).
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -61,9 +61,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the plaintext on success, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/sodium/functions/sodium-crypto-aead-aegis256-decrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aegis256-decrypt.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.sodium-crypto-aead-aegis256-decrypt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>sodium_crypto_aead_aegis256_decrypt</refname>
+  <refpurpose>Verify then decrypt a message with AEGIS-256</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>sodium_crypto_aead_aegis256_decrypt</methodname>
+   <methodparam><type>string</type><parameter>ciphertext</parameter></methodparam>
+   <methodparam><type>string</type><parameter>additional_data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>nonce</parameter></methodparam>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Verify then decrypt a message with AEGIS-256.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>ciphertext</parameter></term>
+    <listitem>
+     <para>
+      Must be in the format provided by <function>sodium_crypto_aead_aegis256_encrypt</function>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>additional_data</parameter></term>
+    <listitem>
+     <para>
+      Additional, authenticated data. This is used in the verification of the authentication tag
+      appended to the ciphertext, but it is not encrypted or stored in the ciphertext.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>nonce</parameter></term>
+    <listitem>
+     <para>
+      A number that must be only used once, per message.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+      Encryption key (256-bit).
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the plaintext on success, &return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>sodium_crypto_aead_aegis256_encrypt</function></member>
+   <member><function>sodium_crypto_aead_aegis256_keygen</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sodium/functions/sodium-crypto-aead-aegis256-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aegis256-encrypt.xml
@@ -15,9 +15,9 @@
    <methodparam><type>string</type><parameter>nonce</parameter></methodparam>
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Encrypt then authenticate a message with AEGIS-256.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,34 +26,34 @@
    <varlistentry>
     <term><parameter>message</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       The plaintext message to encrypt.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>additional_data</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Additional, authenticated data. This is used in the verification of the authentication tag
       appended to the ciphertext, but it is not encrypted or stored in the ciphertext.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>nonce</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       A number that must be only used once, per message.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>key</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Encryption key (256-bit).
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -61,9 +61,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the ciphertext and authentication tag as a string of raw binary bytes.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/sodium/functions/sodium-crypto-aead-aegis256-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aegis256-encrypt.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.sodium-crypto-aead-aegis256-encrypt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>sodium_crypto_aead_aegis256_encrypt</refname>
+  <refpurpose>Encrypt then authenticate a message with AEGIS-256</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>sodium_crypto_aead_aegis256_encrypt</methodname>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>message</parameter></methodparam>
+   <methodparam><type>string</type><parameter>additional_data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>nonce</parameter></methodparam>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Encrypt then authenticate a message with AEGIS-256.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>message</parameter></term>
+    <listitem>
+     <para>
+      The plaintext message to encrypt.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>additional_data</parameter></term>
+    <listitem>
+     <para>
+      Additional, authenticated data. This is used in the verification of the authentication tag
+      appended to the ciphertext, but it is not encrypted or stored in the ciphertext.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>nonce</parameter></term>
+    <listitem>
+     <para>
+      A number that must be only used once, per message.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+      Encryption key (256-bit).
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the ciphertext and authentication tag as a string of raw binary bytes.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>sodium_crypto_aead_aegis256_decrypt</function></member>
+   <member><function>sodium_crypto_aead_aegis256_keygen</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sodium/functions/sodium-crypto-aead-aegis256-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aegis256-keygen.xml
@@ -10,12 +10,12 @@
   &reftitle.description;
   <methodsynopsis>
    <type>string</type><methodname>sodium_crypto_aead_aegis256_keygen</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Generate a random key for use with <function>sodium_crypto_aead_aegis256_encrypt</function> and
    <function>sodium_crypto_aead_aegis256_decrypt</function>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns a 256-bit random key.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/sodium/functions/sodium-crypto-aead-aegis256-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aegis256-keygen.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.sodium-crypto-aead-aegis256-keygen" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>sodium_crypto_aead_aegis256_keygen</refname>
+  <refpurpose>Generate a random AEGIS-256 key</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>sodium_crypto_aead_aegis256_keygen</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Generate a random key for use with <function>sodium_crypto_aead_aegis256_encrypt</function> and
+   <function>sodium_crypto_aead_aegis256_decrypt</function>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns a 256-bit random key.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>sodium_crypto_aead_aegis256_decrypt</function></member>
+   <member><function>sodium_crypto_aead_aegis256_encrypt</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sodium/versions.xml
+++ b/reference/sodium/versions.xml
@@ -8,6 +8,12 @@
  <!-- Functions -->
  <function name="sodium_base642bin" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
  <function name="sodium_bin2base64" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="sodium_crypto_aead_aegis128l_decrypt" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="sodium_crypto_aead_aegis128l_encrypt" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="sodium_crypto_aead_aegis128l_keygen" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="sodium_crypto_aead_aegis256_decrypt" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="sodium_crypto_aead_aegis256_encrypt" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="sodium_crypto_aead_aegis256_keygen" from="PHP 8 &gt;= 8.4.0"/>
  <function name="sodium_crypto_aead_aes256gcm_is_available" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
  <function name="sodium_crypto_aead_aes256gcm_decrypt" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
  <function name="sodium_crypto_aead_aes256gcm_encrypt" from="PHP 7 &gt;= 7.2.0, PHP 8"/>


### PR DESCRIPTION
- https://github.com/php/doc-en/issues/3872

Constants:
- `SODIUM_CRYPTO_AEAD_AEGIS128L_KEYBYTES`
- `SODIUM_CRYPTO_AEAD_AEGIS128L_NSECBYTES`
- `SODIUM_CRYPTO_AEAD_AEGIS128L_NPUBBYTES`
- `SODIUM_CRYPTO_AEAD_AEGIS128L_ABYTES`
- `SODIUM_CRYPTO_AEAD_AEGIS256_KEYBYTES`
- `SODIUM_CRYPTO_AEAD_AEGIS256_NSECBYTES`
- `SODIUM_CRYPTO_AEAD_AEGIS256_NPUBBYTES`
- `SODIUM_CRYPTO_AEAD_AEGIS256_ABYTES`

Functions:
- `sodium_crypto_aead_aegis128l_decrypt()`
- `sodium_crypto_aead_aegis128l_encrypt()`
- `sodium_crypto_aead_aegis128l_keygen()`
- `sodium_crypto_aead_aegis256_decrypt()`
- `sodium_crypto_aead_aegis256_encrypt()`
- `sodium_crypto_aead_aegis256_keygen()`
