### PR TITLE
getarchiveflag.xml: fix parameter name to flags

### DIFF
--- a/reference/zip/ziparchive/getarchiveflag.xml
+++ b/reference/zip/ziparchive/getarchiveflag.xml
@@ -55,7 +55,7 @@
      <term><parameter>flags</parameter></term>
      <listitem>
       <para>
-       If <parameter>flag</parameter>s is set to <constant>ZipArchive::FL_UNCHANGED</constant>,
+       If <parameter>flags</parameter> is set to <constant>ZipArchive::FL_UNCHANGED</constant>,
        the original unchanged flag is returned.
       </para>
      </listitem>


### PR DESCRIPTION
The "s" was outside of the parameter tag.