### PR TITLE
curl: Fix `curl_multi_close()` description

### DIFF
--- a/reference/curl/functions/curl-multi-close.xml
+++ b/reference/curl/functions/curl-multi-close.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.curl-multi-close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>curl_multi_close</refname>
-  <refpurpose>Close a set of cURL handles</refpurpose>
+  <refpurpose>Remove all cURL handles from a multi handle</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">
@@ -12,9 +12,12 @@
    <type>void</type><methodname>curl_multi_close</methodname>
    <methodparam><type>CurlMultiHandle</type><parameter>multi_handle</parameter></methodparam>
   </methodsynopsis>
-  &note.resource-migration-8.0-dead-function;
   <para>
-   Closes a set of cURL handles.
+   Removes all <classname>CurlHandle</classname>s attached to the <classname>CurlMultiHandle</classname>,
+   as if <function>curl_multi_remove_handle</function> was called for each of them.
+  </para>
+  <para>
+   Prior to PHP 8.0.0 this function also closed the cURL multi handle resource, making it unusable.
   </para>
  </refsect1>
 


### PR DESCRIPTION
This function is not actually a noop with PHP 8.x.