### PR TITLE
Clarify `strcspn()` example

### DIFF
--- a/reference/strings/functions/strcspn.xml
+++ b/reference/strings/functions/strcspn.xml
@@ -154,29 +154,26 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$a = strcspn('abcd',  'apple');
-$b = strcspn('abcd',  'banana');
-$c = strcspn('hello', 'l');
-$d = strcspn('hello', 'world');
-$e = strcspn('abcdhelloabcd', 'abcd', -9);
-$f = strcspn('abcdhelloabcd', 'abcd', -9, -5);
+$a = strcspn('banana', 'a');
+$b = strcspn('banana', 'abcd');
+$c = strcspn('banana', 'z');
+$d = strcspn('abcdhelloabcd', 'a', -9);
+$e = strcspn('abcdhelloabcd', 'a', -9, -5);
 
 var_dump($a);
 var_dump($b);
 var_dump($c);
 var_dump($d);
 var_dump($e);
-var_dump($f);
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
+int(1)
 int(0)
-int(0)
-int(2)
-int(2)
+int(6)
 int(5)
 int(4)
 ]]>


### PR DESCRIPTION
Using human readable words for the `$characters` parameter creates confusion, as each character is used separately in the function.

I propose to simplify the example by using one character when focusing on the standard behavior or the offset/length parameters. And modifying the example to use multiple consecutive characters instead of a real word (with duplicate characters).