### PR TITLE
Add attributes

### DIFF
--- a/language/predefined/attributes/allowdynamicproperties.xml
+++ b/language/predefined/attributes/allowdynamicproperties.xml
@@ -18,6 +18,7 @@
 
    <classsynopsis class="class">
     <ooclass>
+     <modifier role="attribute">#[Attribute(Attribute::TARGET_CLASS)]</modifier>
      <modifier>final</modifier>
      <classname>AllowDynamicProperties</classname>
     </ooclass>

--- a/language/predefined/attributes/attribute.xml
+++ b/language/predefined/attributes/attribute.xml
@@ -23,6 +23,7 @@
 
    <classsynopsis class="class">
     <ooclass>
+     <modifier role="attribute">#[Attribute(Attribute::TARGET_CLASS)]</modifier>
      <modifier>final</modifier>
      <classname>Attribute</classname>
     </ooclass>

--- a/language/predefined/attributes/deprecated.xml
+++ b/language/predefined/attributes/deprecated.xml
@@ -18,6 +18,7 @@
 
    <classsynopsis class="class">
     <ooclass>
+     <modifier role="attribute">#[Attribute(Attribute::TARGET_METHOD|Attribute::TARGET_FUNCTION|Attribute::TARGET_CLASS_CONSTANT)]</modifier>
      <modifier>final</modifier>
      <classname>Deprecated</classname>
     </ooclass>

--- a/language/predefined/attributes/override.xml
+++ b/language/predefined/attributes/override.xml
@@ -16,6 +16,7 @@
 
    <classsynopsis class="class">
     <ooclass>
+     <modifier role="attribute">#[Attribute(Attribute::TARGET_METHOD)]</modifier>
      <modifier>final</modifier>
      <classname>Override</classname>
     </ooclass>

--- a/language/predefined/attributes/returntypewillchange.xml
+++ b/language/predefined/attributes/returntypewillchange.xml
@@ -23,6 +23,7 @@
 
    <classsynopsis class="class">
     <ooclass>
+     <modifier role="attribute">#[Attribute(Attribute::TARGET_METHOD)]</modifier>
      <modifier>final</modifier>
      <classname>ReturnTypeWillChange</classname>
     </ooclass>

--- a/language/predefined/attributes/sensitiveparameter.xml
+++ b/language/predefined/attributes/sensitiveparameter.xml
@@ -19,6 +19,7 @@
 
    <classsynopsis class="class">
     <ooclass>
+     <modifier role="attribute">#[Attribute(Attribute::TARGET_PARAMETER)]</modifier>
      <modifier>final</modifier>
      <classname>SensitiveParameter</classname>
     </ooclass>

--- a/language/predefined/stdclass.xml
+++ b/language/predefined/stdclass.xml
@@ -42,6 +42,7 @@
 
    <classsynopsis class="class">
     <ooclass>
+     <modifier role="attribute">#[AllowDynamicProperties]</modifier>
      <classname>stdClass</classname>
     </ooclass>
    </classsynopsis>


### PR DESCRIPTION
I have grepped the stub files of master, and besides `Deprecated` attributes, which I've ignored for now, only found a couple of attributes.

So now we have:

![stdclass](https://github.com/user-attachments/assets/b21d0ad6-0957-4387-b4b0-a31ff84b32a6)

Great! Even linking works. However, two paragraphs above:

> Despite not implementing [__get()](http://localhost:8080/manual/en/language.oop5.overloading.php#object.get)/[__set()](http://localhost:8080/manual/en/language.oop5.overloading.php#object.set) magic methods, this class allows dynamic properties and does not require the #[\AllowDynamicProperties] attribute.

Hmm.

---

We also have:

![attribute](https://github.com/user-attachments/assets/21d6c13c-ea7e-4b7b-909f-dce1f28f347f)

No linking (yet), but okay for now. Should only `Attribute` be linked, or also `Attribute::TARGET_CLASS`?

---

And now:

![deprecated](https://github.com/user-attachments/assets/d56fc542-3062-4531-8dc8-25ce050d009a)

Okay, there is a scroll bar at the bottom of the classsynopsis, and the view width isn't up to modern standards (maybe), but this doesn't look great. What to do here?  Leave as is? More line breaks? Skip the `Attribute::` "prefix"? The latter would look like

![deprecated2](https://github.com/user-attachments/assets/46081c9f-0ffd-48c7-acd3-f1d9321634db)

And how to handle `Deprecated`. We already have prominent warnings about deprecations, and even versions.xml allows to specify that. Still *add* the attribute?

It seems to me that before even implementing documentation support for attributes in gen_stub.php, we need to figure out the details. Suggestions welcome!