### PR TITLE
Document DOMImplementation::createDocument() change for PHP  8.4

### DIFF
--- a/reference/dom/domimplementation/createdocument.xml
+++ b/reference/dom/domimplementation/createdocument.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DOMImplementation">
-   <modifier>public</modifier> <type class="union"><type>DOMDocument</type><type>false</type></type><methodname>DOMImplementation::createDocument</methodname>
+   <modifier>public</modifier> <type>DOMDocument</type><methodname>DOMImplementation::createDocument</methodname>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>namespace</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>qualifiedName</parameter><initializer>""</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>DOMDocumentType</type><type>null</type></type><parameter>doctype</parameter><initializer>&null;</initializer></methodparam>
@@ -54,10 +54,10 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   A new <classname>DOMDocument</classname> object or &false; on error. If
+   A new <classname>DOMDocument</classname> object. If
    <parameter>namespace</parameter>, <parameter>qualifiedName</parameter>,
    and <parameter>doctype</parameter> are null, the returned
-   <classname>DOMDocument</classname> is empty with no document element
+   <classname>DOMDocument</classname> is empty with no document element.
   </para>
  </refsect1>
 
@@ -98,6 +98,12 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        The function now has the tentative return type <type>DOMDocument</type>.
+       </entry>
+      </row>
       <row>
        <entry>8.0.3</entry>
        <entry>


### PR DESCRIPTION
Technically this can throw INVALID_STATE_ERR on allocation failure, just like other DOM node classes, but people shouldn't be handling that anyway as that happens when the system allocator is OOM...