### PR TITLE
Update docs for ftp_ssl_connect about missing verification

### DIFF
--- a/reference/ftp/functions/ftp-ssl-connect.xml
+++ b/reference/ftp/functions/ftp-ssl-connect.xml
@@ -17,10 +17,9 @@
    <function>ftp_ssl_connect</function> opens an <emphasis>explicit</emphasis> SSL-FTP connection to the
    specified <parameter>hostname</parameter>. That implies that
    <function>ftp_ssl_connect</function> will succeed even if the server is not
-   configured for SSL-FTP, or its certificate is invalid. Only when
-   <function>ftp_login</function> is called, the client will send the
-   appropriate AUTH FTP command, so <function>ftp_login</function> will fail in
-   the mentioned cases.
+   configured for SSL-FTP. Only when <function>ftp_login</function> is called, the client will send the
+   appropriate AUTH FTP command, so <function>ftp_login</function> will fail. 
+   The connection established by <function>ftp_ssl_connect</function> will NOT do peer-certificate verification.
   </para>
   <note>
    <title>Why this function may not exist</title>


### PR DESCRIPTION
The current wording implies ftp_login would fail if the certificate is invalid, which is not the case, it accepts every cert, without warning.

I will also create a feature request later for an optional parameter/mode that would do such verification. Changing this in-place would be a BC break.


[Historic discussion](https://github.com/php/php-src/security/advisories/GHSA-jvgv-xm8c-pjmp):
This has been tested by connecting to servers using connection-hostnames other than their SANs/CN include, or also selfsigned certs. The connection "just works".
I've found this discussion:
https://bugs.php.net/bug.php?id=72717
I don't follow the explanation here. It's true and fine that the TLS handshake is delayed until ftp_login is called, which then issues the login command after AUTH TLS.
However, in my testing and observation, there is no cert validation happening in [this](https://github.com/php/php-src/blob/23c60d6b726aca72afc906c12e41fe9126332930/ext/ftp/ftp.c#L265) step either.
This would allow for MITM tampering. Popular packages like league/flysystem FTP adapter also rely on this function.