### PR TITLE
Makefile: Automatically remove Docker containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ ifneq ($(wildcard ../phd/LICENSE),)
 endif
 
 xhtml: .docker/built
-	docker run ${PATHS} -w /var/www -u ${CURRENT_UID}:${CURRENT_GID} php/doc-en
+	docker run --rm ${PATHS} -w /var/www -u ${CURRENT_UID}:${CURRENT_GID} php/doc-en
 
 php: .docker/built
-	docker run ${PATHS} -w /var/www -u ${CURRENT_UID}:${CURRENT_GID} \
+	docker run --rm ${PATHS} -w /var/www -u ${CURRENT_UID}:${CURRENT_GID} \
 		-e FORMAT=php php/doc-en
 
 build: .docker/built


### PR DESCRIPTION
As a `docker run` will only perform a single build, the container is useless afterwards. Ensure it is automatically removed after the build.