### PR TITLE
Update mhash constants page

### DIFF
--- a/reference/mhash/constants.xml
+++ b/reference/mhash/constants.xml
@@ -152,15 +152,6 @@
      <simpara></simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.mhash-sha192">
-    <term>
-     <constant>MHASH_SHA192</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara></simpara>
-    </listitem>
-   </varlistentry>
    <varlistentry xml:id="constant.mhash-sha224">
     <term>
      <constant>MHASH_SHA224</constant>
@@ -191,15 +182,6 @@
    <varlistentry xml:id="constant.mhash-sha512">
     <term>
      <constant>MHASH_SHA512</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara></simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.mhash-snefru128">
-    <term>
-     <constant>MHASH_SNEFRU128</constant>
      (<type>int</type>)
     </term>
     <listitem>

--- a/reference/mhash/constants.xml
+++ b/reference/mhash/constants.xml
@@ -7,143 +7,251 @@
   Here is a list of hashes which are currently supported by mhash. If a
   hash is not listed here, but it is listed in the mhash documentation
   as supported, you can safely assume that this documentation is outdated.
-  <itemizedlist>
-   <listitem xml:id="constant.mhash-adler32">
-    <simpara>
+  <variablelist>
+   <varlistentry  xml:id="constant.mhash-adler32">
+    <term>
      <constant>MHASH_ADLER32</constant>
-    </simpara>
-   </listitem>
-   <listitem xml:id="constant.mhash-crc32">
-    <simpara>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry  xml:id="constant.mhash-crc32">
+    <term>
      <constant>MHASH_CRC32</constant>
-    </simpara>
-   </listitem>
-   <listitem xml:id="constant.mhash-crc32b">
-    <simpara>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-crc32b">
+    <term>
      <constant>MHASH_CRC32B</constant>
-    </simpara>
-   </listitem>
-   <listitem xml:id="constant.mhash-gost">
-    <simpara>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-gost">
+    <term>
      <constant>MHASH_GOST</constant>
-    </simpara>
-   </listitem>
-   <listitem xml:id="constant.mhash-haval128">
-    <simpara>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-haval128">
+    <term>
      <constant>MHASH_HAVAL128</constant>
-    </simpara>
-   </listitem>
-   <listitem xml:id="constant.mhash-haval160">
-    <simpara>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-haval160">
+    <term>
      <constant>MHASH_HAVAL160</constant>
-    </simpara>
-   </listitem>
-   <listitem xml:id="constant.mhash-haval192">
-     <simpara>
-      <constant>MHASH_HAVAL192</constant>
-     </simpara>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
     </listitem>
-   <listitem xml:id="constant.mhash-haval224">
-     <simpara>
-      <constant>MHASH_HAVAL224</constant>
-     </simpara>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-haval192">
+    <term>
+     <constant>MHASH_HAVAL192</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
     </listitem>
-   <listitem xml:id="constant.mhash-haval256">
-    <simpara>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-haval224">
+    <term>
+     <constant>MHASH_HAVAL224</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-haval256">
+    <term>
      <constant>MHASH_HAVAL256</constant>
-    </simpara>
-   </listitem>
-   <listitem xml:id="constant.mhash-md2">
-     <simpara>
-      <constant>MHASH_MD2</constant>
-     </simpara>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
     </listitem>
-   <listitem xml:id="constant.mhash-md4">
-     <simpara>
-      <constant>MHASH_MD4</constant>
-     </simpara>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-md2">
+    <term>
+     <constant>MHASH_MD2</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
     </listitem>
-   <listitem xml:id="constant.mhash-md5">
-    <simpara>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-md4">
+    <term>
+     <constant>MHASH_MD4</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-md5">
+    <term>
      <constant>MHASH_MD5</constant>
-    </simpara>
-   </listitem>
-   <listitem xml:id="constant.mhash-ripemd128">
-     <simpara>
-      <constant>MHASH_RIPEMD128</constant>
-     </simpara>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
     </listitem>
-   <listitem xml:id="constant.mhash-ripemd256">
-     <simpara>
-      <constant>MHASH_RIPEMD256</constant>
-     </simpara>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-ripemd128">
+    <term>
+     <constant>MHASH_RIPEMD128</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
     </listitem>
-   <listitem xml:id="constant.mhash-ripemd320">
-     <simpara>
-      <constant>MHASH_RIPEMD320</constant>
-     </simpara>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-ripemd256">
+    <term>
+     <constant>MHASH_RIPEMD256</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
     </listitem>
-   <listitem xml:id="constant.mhash-sha1">
-    <simpara>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-ripemd320">
+    <term>
+     <constant>MHASH_RIPEMD320</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-sha1">
+    <term>
      <constant>MHASH_SHA1</constant>
-    </simpara>
-   </listitem>
-   <listitem xml:id="constant.mhash-sha192">
-     <simpara>
-      <constant>MHASH_SHA192</constant>
-     </simpara>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
     </listitem>
-   <listitem xml:id="constant.mhash-sha224">
-     <simpara>
-      <constant>MHASH_SHA224</constant>
-     </simpara>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-sha192">
+    <term>
+     <constant>MHASH_SHA192</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
     </listitem>
-   <listitem xml:id="constant.mhash-sha256">
-     <simpara>
-      <constant>MHASH_SHA256</constant>
-     </simpara>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-sha224">
+    <term>
+     <constant>MHASH_SHA224</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
     </listitem>
-   <listitem xml:id="constant.mhash-sha384">
-     <simpara>
-      <constant>MHASH_SHA384</constant>
-     </simpara>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-sha256">
+    <term>
+     <constant>MHASH_SHA256</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
     </listitem>
-   <listitem xml:id="constant.mhash-sha512">
-     <simpara>
-      <constant>MHASH_SHA512</constant>
-     </simpara>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-sha384">
+    <term>
+     <constant>MHASH_SHA384</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
     </listitem>
-   <listitem xml:id="constant.mhash-snefru128">
-     <simpara>
-      <constant>MHASH_SNEFRU128</constant>
-     </simpara>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-sha512">
+    <term>
+     <constant>MHASH_SHA512</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
     </listitem>
-    <listitem xml:id="constant.mhash-snefru256">
-     <simpara>
-      <constant>MHASH_SNEFRU256</constant>
-     </simpara>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-snefru128">
+    <term>
+     <constant>MHASH_SNEFRU128</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
     </listitem>
-    <listitem xml:id="constant.mhash-tiger">
-    <simpara>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-snefru256">
+    <term>
+     <constant>MHASH_SNEFRU256</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-tiger">
+    <term>
      <constant>MHASH_TIGER</constant>
-    </simpara>
-   </listitem>
-   <listitem xml:id="constant.mhash-tiger128">
-    <simpara>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-tiger128">
+    <term>
      <constant>MHASH_TIGER128</constant>
-    </simpara>
-   </listitem>
-   <listitem xml:id="constant.mhash-tiger160">
-     <simpara>
-      <constant>MHASH_TIGER160</constant>
-     </simpara>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
     </listitem>
-   <listitem xml:id="constant.mhash-whirlpool">
-     <simpara>
-      <constant>MHASH_WHIRLPOOL</constant>
-     </simpara>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-tiger160">
+    <term>
+     <constant>MHASH_TIGER160</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
     </listitem>
-  </itemizedlist>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-whirlpool">
+    <term>
+     <constant>MHASH_WHIRLPOOL</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </para>
 </appendix>
 

--- a/reference/mhash/constants.xml
+++ b/reference/mhash/constants.xml
@@ -35,6 +35,53 @@
      <simpara></simpara>
     </listitem>
    </varlistentry>
+   <varlistentry xml:id="constant.mhash-crc32c">
+    <term>
+     <constant>MHASH_CRC32C</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Available as of PHP 7.4.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-fnv132">
+    <term>
+     <constant>MHASH_FNV132</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-fnv1a32">
+    <term>
+     <constant>MHASH_FNV1A32</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-fnv164">
+    <term>
+     <constant>MHASH_FNV164</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-fnv1a64">
+    <term>
+     <constant>MHASH_FNV1A64</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="constant.mhash-gost">
     <term>
      <constant>MHASH_GOST</constant>
@@ -89,6 +136,15 @@
      <simpara></simpara>
     </listitem>
    </varlistentry>
+   <varlistentry xml:id="constant.mhash-joaat">
+    <term>
+     <constant>MHASH_JOAAT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="constant.mhash-md2">
     <term>
      <constant>MHASH_MD2</constant>
@@ -116,9 +172,51 @@
      <simpara></simpara>
     </listitem>
    </varlistentry>
+   <varlistentry xml:id="constant.mhash-murmur3a">
+    <term>
+     <constant>MHASH_MURMUR3A</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Available as of PHP 8.1.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-murmur3c">
+    <term>
+     <constant>MHASH_MURMUR3C</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Available as of PHP 8.1.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-murmur3f">
+    <term>
+     <constant>MHASH_MURMUR3F</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Available as of PHP 8.1.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="constant.mhash-ripemd128">
     <term>
      <constant>MHASH_RIPEMD128</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-ripemd160">
+    <term>
+     <constant>MHASH_RIPEMD160</constant>
      (<type>int</type>)
     </term>
     <listitem>
@@ -227,6 +325,42 @@
    <varlistentry xml:id="constant.mhash-whirlpool">
     <term>
      <constant>MHASH_WHIRLPOOL</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-xxh32">
+    <term>
+     <constant>MHASH_XXH32</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-xxh64">
+    <term>
+     <constant>MHASH_XXH64</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-xxh3">
+    <term>
+     <constant>MHASH_XXH3</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara></simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.mhash-xxh128">
+    <term>
+     <constant>MHASH_XXH128</constant>
      (<type>int</type>)
     </term>
     <listitem>


### PR DESCRIPTION
We fix the uncommon markup, remove constants which are not available, and add constant which are available (including the PHP version they have been introduced). We do not, however, document the purpose of these legacy constants, which should be self-explaining anyway.

Closes GH-3902.

---

Might best be reviewed commit by commit.