### PR TITLE
Add Jing to the Dockerfile so it can be used for validation

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.2-cli
 
 RUN apt-get update && \
-    apt-get install -y git
+    apt-get install -y git jing
 
 WORKDIR /var/www
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,6 @@ php: .docker/built
 
 build: .docker/built
 
-.docker/built:
+.docker/built: .docker/Dockerfile
 	docker build .docker -t php/doc-en
 	touch .docker/built


### PR DESCRIPTION
Along with php/doc-base#170 this runs Jing when the initial RelaxNG validation fails to get more useful error messages.