### PR TITLE
Replace _XXX with _* in constants

### DIFF
--- a/reference/com/functions/variant-cast.xml
+++ b/reference/com/functions/variant-cast.xml
@@ -39,7 +39,7 @@
      <listitem>
       <para>
        <parameter>type</parameter> should be one of the
-       <constant>VT_XXX</constant> constants.
+       <constant>VT_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/com/functions/variant-get-type.xml
+++ b/reference/com/functions/variant-get-type.xml
@@ -37,7 +37,7 @@
    <parameter>variant</parameter>, which can be an instance of
    <xref linkend="class.com"/>, <xref linkend="class.dotnet"/> or
    <xref linkend="class.variant"/> classes.  The return value can be compared
-   to one of the <constant>VT_XXX</constant> constants.
+   to one of the <constant>VT_<replaceable>*</replaceable></constant> constants.
   </para>
   <para>
    The return value for COM and DOTNET objects will usually be

--- a/reference/com/variant/construct.xml
+++ b/reference/com/variant/construct.xml
@@ -35,7 +35,7 @@
     <listitem>
      <simpara>
       Specifies the content type of the variant object. Possible values are
-      one of the <constant>VT_XXX</constant> <xref
+      one of the <constant>VT_<replaceable>*</replaceable></constant> <xref
       linkend="com.constants"/>.
      </simpara>
      <simpara>

--- a/reference/curl/functions/curl-multi-add-handle.xml
+++ b/reference/curl/functions/curl-multi-add-handle.xml
@@ -32,7 +32,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns 0 on success, or one of the <constant>CURLM_XXX</constant> errors
+   Returns 0 on success, or one of the <constant>CURLM_<replaceable>*</replaceable></constant> errors
    code.
   </para>
  </refsect1>

--- a/reference/curl/functions/curl-multi-remove-handle.xml
+++ b/reference/curl/functions/curl-multi-remove-handle.xml
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns 0 on success, or one of the <constant>CURLM_XXX</constant> error
+   Returns 0 on success, or one of the <constant>CURLM_<replaceable>*</replaceable></constant> error
    codes.
   </para>
  </refsect1>

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -28,7 +28,7 @@
      <term><parameter>option</parameter></term>
      <listitem>
       <para>
-       The <literal>CURLOPT_XXX</literal> option to set.
+       The <constant>CURLOPT_<replaceable>*</replaceable></constant> option to set.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/curl/functions/curl-version.xml
+++ b/reference/curl/functions/curl-version.xml
@@ -65,7 +65,7 @@
       </row>
       <row>
        <entry>features</entry>
-       <entry>A bitmask of the <literal>CURL_VERSION_XXX</literal> constants</entry>
+       <entry>A bitmask of the <constant>CURL_VERSION_<replaceable>*</replaceable></constant> constants</entry>
       </row>
       <row>
        <entry>protocols</entry>

--- a/reference/dom/domnode.xml
+++ b/reference/dom/domnode.xml
@@ -164,7 +164,7 @@
     <varlistentry xml:id="domnode.props.nodetype">
      <term><varname>nodeType</varname></term>
      <listitem>
-      <para>Gets the type of the node. One of the predefined <link linkend="dom.constants">XML_xxx_NODE constants</link></para>
+      <para>Gets the type of the node. One of the predefined <constant>XML_<replaceable>*</replaceable>_NODE</constant> constants</para>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="domnode.props.parentnode">

--- a/reference/image/functions/getimagesize.xml
+++ b/reference/image/functions/getimagesize.xml
@@ -118,7 +118,7 @@
    </para>
   </note>
   <para>
-   Index 2 is one of the <link linkend="image.constants">IMAGETYPE_XXX constants</link> indicating 
+   Index 2 is one of the <constant>IMAGETYPE_<replaceable>*</replaceable></constant> constants indicating 
    the type of the image.
   </para>
   <para>

--- a/reference/image/functions/getimagesize.xml
+++ b/reference/image/functions/getimagesize.xml
@@ -118,7 +118,7 @@
    </para>
   </note>
   <para>
-   Index 2 is one of the <constant>IMAGETYPE_<replaceable>*</replaceable></constant> constants indicating 
+   Index 2 is one of the <constant>IMAGETYPE_<replaceable>*</replaceable></constant> constants indicating
    the type of the image.
   </para>
   <para>

--- a/reference/image/functions/image-type-to-extension.xml
+++ b/reference/image/functions/image-type-to-extension.xml
@@ -13,7 +13,7 @@
    <methodparam choice="opt"><type>bool</type><parameter>include_dot</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Returns the extension for the given <literal>IMAGETYPE_XXX</literal>
+   Returns the extension for the given <constant>IMAGETYPE_<replaceable>*</replaceable></constant>
    constant.
   </para>
  </refsect1>
@@ -25,7 +25,7 @@
      <term><parameter>image_type</parameter></term>
      <listitem>
       <para>
-       One of the <literal>IMAGETYPE_XXX</literal> constant.
+       One of the <constant>IMAGETYPE_<replaceable>*</replaceable></constant> constant.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/image-type-to-mime-type.xml
+++ b/reference/image/functions/image-type-to-mime-type.xml
@@ -25,7 +25,7 @@
      <term><parameter>image_type</parameter></term>
      <listitem>
       <para>
-       One of the <literal>IMAGETYPE_XXX</literal> constants.
+       One of the <constant>IMAGETYPE_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagepng.xml
+++ b/reference/image/functions/imagepng.xml
@@ -51,7 +51,7 @@
      <listitem>
       <para>
        Allows reducing the PNG file size. It is a bitmask field which may be
-       set to any combination of the <literal>PNG_FILTER_XXX</literal> 
+       set to any combination of the <constant>PNG_FILTER_<replaceable>*</replaceable></constant> 
        constants. <constant>PNG_NO_FILTER</constant> or 
        <constant>PNG_ALL_FILTERS</constant> may also be used to respectively
        disable or activate all filters.

--- a/reference/image/functions/imagepng.xml
+++ b/reference/image/functions/imagepng.xml
@@ -51,7 +51,7 @@
      <listitem>
       <para>
        Allows reducing the PNG file size. It is a bitmask field which may be
-       set to any combination of the <constant>PNG_FILTER_<replaceable>*</replaceable></constant> 
+       set to any combination of the <constant>PNG_FILTER_<replaceable>*</replaceable></constant>
        constants. <constant>PNG_NO_FILTER</constant> or 
        <constant>PNG_ALL_FILTERS</constant> may also be used to respectively
        disable or activate all filters.

--- a/reference/soap/soapserver/setpersistence.xml
+++ b/reference/soap/soapserver/setpersistence.xml
@@ -39,7 +39,7 @@
      <term><parameter>mode</parameter></term>
      <listitem>
       <para>
-       One of the <literal>SOAP_PERSISTENCE_XXX</literal> constants.
+       One of the <constant>SOAP_PERSISTENCE_<replaceable>*</replaceable></constant> constants.
       </para>
       <para>
        <constant>SOAP_PERSISTENCE_REQUEST</constant> - SoapServer data does not persist between

--- a/reference/tidy/constants.xml
+++ b/reference/tidy/constants.xml
@@ -4,7 +4,7 @@
  &reftitle.constants;
  &extension.constants;
  <para>
-  Each <literal>TIDY_TAG_XXX</literal> represents a HTML tag. For example,
+  Each <constant>TIDY_TAG_<replaceable>*</replaceable></constant> represents a HTML tag. For example,
   <constant>TIDY_TAG_A</constant> represents a
   <literal>"&lt;a href="XX"&gt;link&lt;/a&gt;"</literal> tag.
  </para>


### PR DESCRIPTION
Replace the replaceable parts of constants using `_XXX` with `_*` and add a `<replaceable>` tag. 

Also replaced some `<literal>` with `<constant>` tags and removed two `<link>`s as I'm planning on adding a feature to `PhD` that would link these `_*` constants to the first matching constant defined in the index.