### PR TITLE
curl-multi-remove-handle.xml Correct the inaccuracy of the description

### DIFF
--- a/reference/curl/functions/curl-multi-remove-handle.xml
+++ b/reference/curl/functions/curl-multi-remove-handle.xml
@@ -5,7 +5,7 @@
   <refname>curl_multi_remove_handle</refname>
   <refpurpose>Remove a handle from a set of cURL handles</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -15,8 +15,8 @@
   </methodsynopsis>
   <para>
    Removes a given <parameter>handle</parameter> from the given <parameter>multi_handle</parameter>.
-   When the <parameter>handle</parameter> has been removed, it is again perfectly 
-   legal to run <function>curl_exec</function> on this handle.  Removing the <parameter>handle</parameter> while being 
+   When the <parameter>handle</parameter> has been removed, it is again perfectly
+   legal to run <function>curl_exec</function> on this handle.  Removing the <parameter>handle</parameter> while being
    used, will effectively halt the transfer in progress involving that handle.
   </para>
  </refsect1>
@@ -30,7 +30,7 @@
    </variablelist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/curl/functions/curl-multi-remove-handle.xml
+++ b/reference/curl/functions/curl-multi-remove-handle.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.curl-multi-remove-handle" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>curl_multi_remove_handle</refname>
-  <refpurpose>Remove a multi handle from a set of cURL handles</refpurpose>
+  <refpurpose>Remove a handle from a set of cURL handles</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">
@@ -14,9 +14,9 @@
    <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Removes a given <parameter>handle</parameter> handle from the given <parameter>multi_handle</parameter>
-   handle. When the <parameter>handle</parameter> handle has been removed, it is again perfectly 
-   legal to run <function>curl_exec</function> on this handle.  Removing the <parameter>handle</parameter> handle while being 
+   Removes a given <parameter>handle</parameter> from the given <parameter>multi_handle</parameter>.
+   When the <parameter>handle</parameter> has been removed, it is again perfectly 
+   legal to run <function>curl_exec</function> on this handle.  Removing the <parameter>handle</parameter> while being 
    used, will effectively halt the transfer in progress involving that handle.
   </para>
  </refsect1>


### PR DESCRIPTION
The function removes a normal handle from the cURL multi handle, rather than multi handle