### PR TITLE
curl-multi-exec.xml Change the function purpose

### DIFF
--- a/reference/curl/functions/curl-multi-exec.xml
+++ b/reference/curl/functions/curl-multi-exec.xml
@@ -14,7 +14,7 @@
    <methodparam><type>int</type><parameter role="reference">still_running</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Processes each of the handles in the stack.  This method can be called whether or not a handle 
+   Processes each of the handles in the stack.  This method can be called whether or not a handle
    needs to read or write data.
   </para>
  </refsect1>

--- a/reference/curl/functions/curl-multi-exec.xml
+++ b/reference/curl/functions/curl-multi-exec.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.curl-multi-exec" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>curl_multi_exec</refname>
-  <refpurpose>Run the sub-connections of the current cURL handle</refpurpose>
+  <refpurpose>Run the connections of handles of a set of cURL handles</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">

--- a/reference/curl/functions/curl-multi-exec.xml
+++ b/reference/curl/functions/curl-multi-exec.xml
@@ -5,7 +5,7 @@
   <refname>curl_multi_exec</refname>
   <refpurpose>Run the connections of handles of a set of cURL handles</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter role="reference">still_running</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Processes each of the handles in the stack.  This method can be called whether or not a handle
+   Processes each of the handles in the stack.  This method can be called whether or not a handle 
    needs to read or write data.
-  </para> 
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -43,13 +43,13 @@
   </para>
   <note>
    <para>
-    This only returns errors regarding the whole multi stack. There might still have 
-    occurred problems on individual transfers even when this function returns 
+    This only returns errors regarding the whole multi stack. There might still have
+    occurred problems on individual transfers even when this function returns
     <constant>CURLM_OK</constant>.
    </para>
   </note>
  </refsect1>
- 
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -136,7 +136,7 @@ curl_multi_close($mh);
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -147,7 +147,7 @@ curl_multi_close($mh);
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/curl/functions/curl-multi-exec.xml
+++ b/reference/curl/functions/curl-multi-exec.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.curl-multi-exec" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>curl_multi_exec</refname>
-  <refpurpose>Run the connections of handles of a set of cURL handles</refpurpose>
+  <refpurpose>Processes each of the handles in the stack</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">


### PR DESCRIPTION
I'm not sure I'm offering a better description, perhaps a formulation like `Run the connections of handles contained in the given cURL multi handle [asynchronously]` would be better, or some similar. I was just a little confused by the words `sub-connections` (the explanation of which is not given, although it is clear that we are talking about the connections of descriptors contained in the multi-descriptor), and the `current` word... current in relation to what, and multiple `connections` for a `the current cURL handle` (it sounds like a normal handle contains a lot of connections).

And I also don't know if we should add a paragraph saying that the multi handle starts many connections at once, which can improve the performance of application