### PR TITLE
[PHP 8.4] Add deprecation warning to mysqli functions

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -363,6 +363,11 @@ xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
 <emphasis>DEPRECATED</emphasis> as of PHP 8.3.0. Relying on this function
 is highly discouraged.</simpara></warning>'>
 
+<!ENTITY warn.deprecated.function-8-4-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
+<emphasis>DEPRECATED</emphasis> as of PHP 8.4.0. Relying on this function
+is highly discouraged.</simpara></warning>'>
+
 <!ENTITY removed.php.future 'This deprecated feature <emphasis xmlns="http://docbook.org/ns/docbook">will</emphasis>
 certainly be <emphasis xmlns="http://docbook.org/ns/docbook">removed</emphasis> in the future.'>
 

--- a/reference/mysqli/mysqli/kill.xml
+++ b/reference/mysqli/mysqli/kill.xml
@@ -7,6 +7,10 @@
   <refpurpose>Asks the server to kill a MySQL thread</refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-4-0;
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>

--- a/reference/mysqli/mysqli/ping.xml
+++ b/reference/mysqli/mysqli/ping.xml
@@ -7,6 +7,10 @@
   <refpurpose>Pings a server connection, or tries to reconnect if the connection has gone down</refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-4-0;
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <para>&style.oop;</para>

--- a/reference/mysqli/mysqli/refresh.xml
+++ b/reference/mysqli/mysqli/refresh.xml
@@ -6,6 +6,10 @@
   <refname>mysqli_refresh</refname>
   <refpurpose>Refreshes</refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-4-0;
+ </refsynopsisdiv>
  
  <refsect1 role="description">
   &reftitle.description;


### PR DESCRIPTION
In addition to the row in the changelog,
shouldn't we also add this entry?

Refs: 

1afd3581fea176162adacef6dd692dfc114410f3
4d68e15db0907404cad6c78ac274fd8f8c31fba3
3bbf9e31d58a54743c8509cbce76567efd4de5d1