### PR TITLE
[PHP 8.4] Add deprecation warning to mysqli constants

### DIFF
--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -272,6 +272,7 @@
       the copy approach can reduce the overall memory usage
       because PHP variables holding results may be released earlier.
       Available with <literal>mysqlnd</literal> only.
+      Deprecated as of PHP 8.4.0.
      </simpara>
     </listitem>
    </varlistentry>
@@ -993,6 +994,7 @@
     <listitem>
      <para>
       Refreshes the grant tables.
+      Deprecated as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1005,6 +1007,7 @@
      <para>
       Flushes the logs, like executing the
       <literal>FLUSH LOGS</literal> <acronym>SQL</acronym> statement.
+      Deprecated as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1017,6 +1020,7 @@
      <para>
       Flushes the table cache, like executing the
       <literal>FLUSH TABLES</literal> <acronym>SQL</acronym> statement.
+      Deprecated as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1029,6 +1033,7 @@
      <para>
       Flushes the host cache, like executing the
       <literal>FLUSH HOSTS</literal> <acronym>SQL</acronym> statement.
+      Deprecated as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1040,7 +1045,7 @@
     <listitem>
      <para>
       Alias of <constant>MYSQLI_REFRESH_SLAVE</constant> constant.
-      Available as of PHP 8.1.0.
+      Available as of PHP 8.1.0. Deprecated as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1053,6 +1058,7 @@
      <para>
       Reset the status variables, like executing the
       <literal>FLUSH STATUS</literal> <acronym>SQL</acronym> statement.
+      Deprecated as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1064,6 +1070,7 @@
     <listitem>
      <para>
       Flushes the thread cache.
+      Deprecated as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1077,6 +1084,7 @@
       On a slave replication server: resets the master server information, and
       restarts the slave. Like executing the <literal>RESET SLAVE</literal>
       <acronym>SQL</acronym> statement.
+      Deprecated as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1090,6 +1098,7 @@
       On a master replication server: removes the binary log files listed in the
       binary log index, and truncates the index file. Like executing the
       <literal>RESET MASTER</literal> <acronym>SQL</acronym> statement.
+      Deprecated as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1101,6 +1110,7 @@
     <listitem>
      <simpara>
       Closes and reopens the backup log files.
+      Deprecated as of PHP 8.4.0.
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Deprecate `MYSQLI_REFRESH_* ` and `MYSQLI_STORE_RESULT_COPY_DATA`