### PR TITLE
[PHP 8.4] Add removal note to mysqli constants

### DIFF
--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -837,6 +837,7 @@
     </term>
     <listitem>
      <para>
+      Removed as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -867,6 +868,7 @@
     </term>
     <listitem>
      <para>
+      Removed as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -887,6 +889,7 @@
     </term>
     <listitem>
      <para>
+      Removed as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/mysqli/mysqli_stmt/attr-set.xml
+++ b/reference/mysqli/mysqli_stmt/attr-set.xml
@@ -67,6 +67,7 @@
             Number of rows to fetch from server at a time when using a cursor.
             <parameter>value</parameter> can be in the range from 1 to the maximum
             value of unsigned long. The default is 1.
+            Removed as of PHP 8.4.0.
            </entry>
           </row>
          </tbody>


### PR DESCRIPTION
Marked constants as removed.

For `MYSQLI_SET_CHARSET_DIR` I did not find a mention in the documentation,
for the others, I added a note.

Not sure about the function note `mysqli_stmt_attr_set`,
should I keep it there, or omit?