### PR TITLE
Use standard variablelist markup for Tidy constants

### DIFF
--- a/reference/tidy/constants.xml
+++ b/reference/tidy/constants.xml
@@ -8,684 +8,1667 @@
   <constant>TIDY_TAG_A</constant> represents a
   <literal>"&lt;a href="XX"&gt;link&lt;/a&gt;"</literal> tag.
  </para>
- <para>
-  The following constants are defined:
-  <table xml:id="tidy.constants.tag">
-   <title>tidy tag constants</title>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>Constant</entry>
-       <entry>Notes</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row xml:id="constant.tidy-tag-unknown">
-       <entry><constant>TIDY_TAG_UNKNOWN</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-a">
-       <entry><constant>TIDY_TAG_A</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-abbr">
-       <entry><constant>TIDY_TAG_ABBR</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-acronym">
-       <entry><constant>TIDY_TAG_ACRONYM</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-address">
-       <entry><constant>TIDY_TAG_ADDRESS</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-align">
-       <entry><constant>TIDY_TAG_ALIGN</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-applet">
-       <entry><constant>TIDY_TAG_APPLET</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-area">
-       <entry><constant>TIDY_TAG_AREA</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-article">
-       <entry><constant>TIDY_TAG_ARTICLE</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-aside">
-       <entry><constant>TIDY_TAG_ASIDE</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-audio">
-       <entry><constant>TIDY_TAG_AUDIO</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-b">
-       <entry><constant>TIDY_TAG_B</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-base">
-       <entry><constant>TIDY_TAG_BASE</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-basefont">
-       <entry><constant>TIDY_TAG_BASEFONT</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-bdi">
-       <entry><constant>TIDY_TAG_BDI</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-bdo">
-       <entry><constant>TIDY_TAG_BDO</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-bgsound">
-       <entry><constant>TIDY_TAG_BGSOUND</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-big">
-       <entry><constant>TIDY_TAG_BIG</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-blink">
-       <entry><constant>TIDY_TAG_BLINK</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-blockquote">
-       <entry><constant>TIDY_TAG_BLOCKQUOTE</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-body">
-       <entry><constant>TIDY_TAG_BODY</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-br">
-       <entry><constant>TIDY_TAG_BR</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-button">
-       <entry><constant>TIDY_TAG_BUTTON</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-canvas">
-       <entry><constant>TIDY_TAG_CANVAS</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-caption">
-       <entry><constant>TIDY_TAG_CAPTION</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-center">
-       <entry><constant>TIDY_TAG_CENTER</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-cite">
-       <entry><constant>TIDY_TAG_CITE</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-code">
-       <entry><constant>TIDY_TAG_CODE</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-col">
-       <entry><constant>TIDY_TAG_COL</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-colgroup">
-       <entry><constant>TIDY_TAG_COLGROUP</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-command">
-       <entry><constant>TIDY_TAG_COMMAND</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-comment">
-       <entry><constant>TIDY_TAG_COMMENT</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-datalist">
-       <entry><constant>TIDY_TAG_DATALIST</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-dd">
-       <entry><constant>TIDY_TAG_DD</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-del">
-       <entry><constant>TIDY_TAG_DEL</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-details">
-       <entry><constant>TIDY_TAG_DETAILS</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-dfn">
-       <entry><constant>TIDY_TAG_DFN</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-dialog">
-       <entry><constant>TIDY_TAG_DIALOG</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-dir">
-       <entry><constant>TIDY_TAG_DIR</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-div">
-       <entry><constant>TIDY_TAG_DIV</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-dl">
-       <entry><constant>TIDY_TAG_DL</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-dt">
-       <entry><constant>TIDY_TAG_DT</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-em">
-       <entry><constant>TIDY_TAG_EM</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-embed">
-       <entry><constant>TIDY_TAG_EMBED</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-fieldset">
-       <entry><constant>TIDY_TAG_FIELDSET</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-figcaption">
-       <entry><constant>TIDY_TAG_FIGCAPTION</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-figure">
-       <entry><constant>TIDY_TAG_FIGURE</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-font">
-       <entry><constant>TIDY_TAG_FONT</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-footer">
-       <entry><constant>TIDY_TAG_FOOTER</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-form">
-       <entry><constant>TIDY_TAG_FORM</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-frame">
-       <entry><constant>TIDY_TAG_FRAME</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-frameset">
-       <entry><constant>TIDY_TAG_FRAMESET</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-h1">
-       <entry><constant>TIDY_TAG_H1</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-h2">
-       <entry><constant>TIDY_TAG_H2</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-h3">
-       <entry><constant>TIDY_TAG_H3</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-h4">
-       <entry><constant>TIDY_TAG_H4</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-h5">
-       <entry><constant>TIDY_TAG_H5</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-h6">
-       <entry><constant>TIDY_TAG_H6</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-head">
-       <entry><constant>TIDY_TAG_HEAD</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-header">
-       <entry><constant>TIDY_TAG_HEADER</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-hgroup">
-       <entry><constant>TIDY_TAG_HGROUP</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-hr">
-       <entry><constant>TIDY_TAG_HR</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-html">
-       <entry><constant>TIDY_TAG_HTML</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-i">
-       <entry><constant>TIDY_TAG_I</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-iframe">
-       <entry><constant>TIDY_TAG_IFRAME</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-ilayer">
-       <entry><constant>TIDY_TAG_ILAYER</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-img">
-       <entry><constant>TIDY_TAG_IMG</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-input">
-       <entry><constant>TIDY_TAG_INPUT</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-ins">
-       <entry><constant>TIDY_TAG_INS</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-isindex">
-       <entry><constant>TIDY_TAG_ISINDEX</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-kbd">
-       <entry><constant>TIDY_TAG_KBD</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-keygen">
-       <entry><constant>TIDY_TAG_KEYGEN</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-label">
-       <entry><constant>TIDY_TAG_LABEL</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-layer">
-       <entry><constant>TIDY_TAG_LAYER</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-legend">
-       <entry><constant>TIDY_TAG_LEGEND</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-li">
-       <entry><constant>TIDY_TAG_LI</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-link">
-       <entry><constant>TIDY_TAG_LINK</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-listing">
-       <entry><constant>TIDY_TAG_LISTING</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-main">
-       <entry><constant>TIDY_TAG_MAIN</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-map">
-       <entry><constant>TIDY_TAG_MAP</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-mark">
-       <entry><constant>TIDY_TAG_MARK</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-marquee">
-       <entry><constant>TIDY_TAG_MARQUEE</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-menu">
-       <entry><constant>TIDY_TAG_MENU</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-menuitem">
-       <entry><constant>TIDY_TAG_MENUITEM</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-meta">
-       <entry><constant>TIDY_TAG_META</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-meter">
-       <entry><constant>TIDY_TAG_METER</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-multicol">
-       <entry><constant>TIDY_TAG_MULTICOL</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-nav">
-       <entry><constant>TIDY_TAG_NAV</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-nobr">
-       <entry><constant>TIDY_TAG_NOBR</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-noembed">
-       <entry><constant>TIDY_TAG_NOEMBED</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-noframes">
-       <entry><constant>TIDY_TAG_NOFRAMES</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-nolayer">
-       <entry><constant>TIDY_TAG_NOLAYER</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-nosave">
-       <entry><constant>TIDY_TAG_NOSAVE</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-noscript">
-       <entry><constant>TIDY_TAG_NOSCRIPT</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-object">
-       <entry><constant>TIDY_TAG_OBJECT</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-ol">
-       <entry><constant>TIDY_TAG_OL</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-optgroup">
-       <entry><constant>TIDY_TAG_OPTGROUP</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-option">
-       <entry><constant>TIDY_TAG_OPTION</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-output">
-       <entry><constant>TIDY_TAG_OUTPUT</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-p">
-       <entry><constant>TIDY_TAG_P</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-param">
-       <entry><constant>TIDY_TAG_PARAM</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-plaintext">
-       <entry><constant>TIDY_TAG_PLAINTEXT</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-pre">
-       <entry><constant>TIDY_TAG_PRE</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-progress">
-       <entry><constant>TIDY_TAG_PROGRESS</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-q">
-       <entry><constant>TIDY_TAG_Q</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-rb">
-       <entry><constant>TIDY_TAG_RB</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-rbc">
-       <entry><constant>TIDY_TAG_RBC</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-rp">
-       <entry><constant>TIDY_TAG_RP</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-rt">
-       <entry><constant>TIDY_TAG_RT</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-rtc">
-       <entry><constant>TIDY_TAG_RTC</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-ruby">
-       <entry><constant>TIDY_TAG_RUBY</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-s">
-       <entry><constant>TIDY_TAG_S</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-samp">
-       <entry><constant>TIDY_TAG_SAMP</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-script">
-       <entry><constant>TIDY_TAG_SCRIPT</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-section">
-       <entry><constant>TIDY_TAG_SECTION</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-select">
-       <entry><constant>TIDY_TAG_SELECT</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-server">
-       <entry><constant>TIDY_TAG_SERVER</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-servlet">
-       <entry><constant>TIDY_TAG_SERVLET</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-small">
-       <entry><constant>TIDY_TAG_SMALL</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-source">
-       <entry><constant>TIDY_TAG_SOURCE</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-spacer">
-       <entry><constant>TIDY_TAG_SPACER</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-span">
-       <entry><constant>TIDY_TAG_SPAN</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-strike">
-       <entry><constant>TIDY_TAG_STRIKE</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-strong">
-       <entry><constant>TIDY_TAG_STRONG</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-style">
-       <entry><constant>TIDY_TAG_STYLE</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-sub">
-       <entry><constant>TIDY_TAG_SUB</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-summary">
-       <entry><constant>TIDY_TAG_SUMMARY</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-sup">
-       <entry><constant>TIDY_TAG_SUP</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-table">
-       <entry><constant>TIDY_TAG_TABLE</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-tbody">
-       <entry><constant>TIDY_TAG_TBODY</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-td">
-       <entry><constant>TIDY_TAG_TD</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-template">
-       <entry><constant>TIDY_TAG_TEMPLATE</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-textarea">
-       <entry><constant>TIDY_TAG_TEXTAREA</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-tfoot">
-       <entry><constant>TIDY_TAG_TFOOT</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-th">
-       <entry><constant>TIDY_TAG_TH</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-thead">
-       <entry><constant>TIDY_TAG_THEAD</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-time">
-       <entry><constant>TIDY_TAG_TIME</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-title">
-       <entry><constant>TIDY_TAG_TITLE</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-tr">
-       <entry><constant>TIDY_TAG_TR</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-track">
-       <entry><constant>TIDY_TAG_TRACK</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-tt">
-       <entry><constant>TIDY_TAG_TT</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-u">
-       <entry><constant>TIDY_TAG_U</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-ul">
-       <entry><constant>TIDY_TAG_UL</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-var">
-       <entry><constant>TIDY_TAG_VAR</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-video">
-       <entry><constant>TIDY_TAG_VIDEO</constant></entry>
-       <entry>Added in libtidy 5.0.0. Available as of PHP 7.4.0.</entry>
-      </row>
-      <row xml:id="constant.tidy-tag-wbr">
-       <entry><constant>TIDY_TAG_WBR</constant></entry>
-       <entry></entry>
-      </row>
-      <row xml:id="constant.tidy-tag-xmp">
-       <entry><constant>TIDY_TAG_XMP</constant></entry>
-       <entry></entry>
-      </row>
-     </tbody>
-    </tgroup>
-  </table>
- </para>
 
- <para>
-  <table xml:id="tidy.constants.nodetype">
-   <title>tidy nodetype constants</title>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>constant</entry>
-      <entry>description</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row xml:id="constant.tidy-nodetype-root">
-      <entry><constant>TIDY_NODETYPE_ROOT</constant></entry>
-      <entry>root node</entry>
-     </row>
-     <row xml:id="constant.tidy-nodetype-doctype">
-      <entry><constant>TIDY_NODETYPE_DOCTYPE</constant></entry>
-      <entry>doctype</entry>
-     </row>
-     <row xml:id="constant.tidy-nodetype-comment">
-      <entry><constant>TIDY_NODETYPE_COMMENT</constant></entry>
-      <entry>HTML comment</entry>
-     </row>
-     <row xml:id="constant.tidy-nodetype-procins">
-      <entry><constant>TIDY_NODETYPE_PROCINS</constant></entry>
-      <entry>Processing Instruction</entry>
-     </row>
-     <row xml:id="constant.tidy-nodetype-text">
-      <entry><constant>TIDY_NODETYPE_TEXT</constant></entry>
-      <entry>Text</entry>
-     </row>
-     <row xml:id="constant.tidy-nodetype-start">
-      <entry><constant>TIDY_NODETYPE_START</constant></entry>
-      <entry>start tag</entry>
-     </row>
-     <row xml:id="constant.tidy-nodetype-end">
-      <entry><constant>TIDY_NODETYPE_END</constant></entry>
-      <entry>end tag</entry>
-     </row>
-     <row xml:id="constant.tidy-nodetype-startend">
-      <entry><constant>TIDY_NODETYPE_STARTEND</constant></entry>
-      <entry>empty tag</entry>
-     </row>
-     <row xml:id="constant.tidy-nodetype-cdata">
-      <entry><constant>TIDY_NODETYPE_CDATA</constant></entry>
-      <entry>CDATA</entry>
-     </row>
-     <row xml:id="constant.tidy-nodetype-section">
-      <entry><constant>TIDY_NODETYPE_SECTION</constant></entry>
-      <entry>XML section</entry>
-     </row>
-     <row xml:id="constant.tidy-nodetype-asp">
-      <entry><constant>TIDY_NODETYPE_ASP</constant></entry>
-      <entry>ASP code</entry>
-     </row>
-     <row xml:id="constant.tidy-nodetype-jste">
-      <entry><constant>TIDY_NODETYPE_JSTE</constant></entry>
-      <entry>JSTE code</entry>
-     </row>
-     <row xml:id="constant.tidy-nodetype-php">
-      <entry><constant>TIDY_NODETYPE_PHP</constant></entry>
-      <entry>PHP code</entry>
-     </row>
-     <row xml:id="constant.tidy-nodetype-xmldecl">
-      <entry><constant>TIDY_NODETYPE_XMLDECL</constant></entry>
-      <entry>XML declaration</entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </table>
- </para>
+ <variablelist xml:id="tidy.constants.tag">
+  <title>tidy nodetype constants</title>
+  <varlistentry xml:id="constant.tidy-tag-unknown">
+   <term>
+    <constant>TIDY_TAG_UNKNOWN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-a">
+   <term>
+    <constant>TIDY_TAG_A</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-abbr">
+   <term>
+    <constant>TIDY_TAG_ABBR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-acronym">
+   <term>
+    <constant>TIDY_TAG_ACRONYM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-address">
+   <term>
+    <constant>TIDY_TAG_ADDRESS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-align">
+   <term>
+    <constant>TIDY_TAG_ALIGN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-applet">
+   <term>
+    <constant>TIDY_TAG_APPLET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-area">
+   <term>
+    <constant>TIDY_TAG_AREA</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-article">
+   <term>
+    <constant>TIDY_TAG_ARTICLE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-aside">
+   <term>
+    <constant>TIDY_TAG_ASIDE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-audio">
+   <term>
+    <constant>TIDY_TAG_AUDIO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-b">
+   <term>
+    <constant>TIDY_TAG_B</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-base">
+   <term>
+    <constant>TIDY_TAG_BASE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-basefont">
+   <term>
+    <constant>TIDY_TAG_BASEFONT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-bdi">
+   <term>
+    <constant>TIDY_TAG_BDI</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-bdo">
+   <term>
+    <constant>TIDY_TAG_BDO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-bgsound">
+   <term>
+    <constant>TIDY_TAG_BGSOUND</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-big">
+   <term>
+    <constant>TIDY_TAG_BIG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-blink">
+   <term>
+    <constant>TIDY_TAG_BLINK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-blockquote">
+   <term>
+    <constant>TIDY_TAG_BLOCKQUOTE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-body">
+   <term>
+    <constant>TIDY_TAG_BODY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-br">
+   <term>
+    <constant>TIDY_TAG_BR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-button">
+   <term>
+    <constant>TIDY_TAG_BUTTON</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-canvas">
+   <term>
+    <constant>TIDY_TAG_CANVAS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-caption">
+   <term>
+    <constant>TIDY_TAG_CAPTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-center">
+   <term>
+    <constant>TIDY_TAG_CENTER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-cite">
+   <term>
+    <constant>TIDY_TAG_CITE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-code">
+   <term>
+    <constant>TIDY_TAG_CODE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-col">
+   <term>
+    <constant>TIDY_TAG_COL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-colgroup">
+   <term>
+    <constant>TIDY_TAG_COLGROUP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-command">
+   <term>
+    <constant>TIDY_TAG_COMMAND</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-comment">
+   <term>
+    <constant>TIDY_TAG_COMMENT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-datalist">
+   <term>
+    <constant>TIDY_TAG_DATALIST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-dd">
+   <term>
+    <constant>TIDY_TAG_DD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-del">
+   <term>
+    <constant>TIDY_TAG_DEL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-details">
+   <term>
+    <constant>TIDY_TAG_DETAILS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-dfn">
+   <term>
+    <constant>TIDY_TAG_DFN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-dialog">
+   <term>
+    <constant>TIDY_TAG_DIALOG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-dir">
+   <term>
+    <constant>TIDY_TAG_DIR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-div">
+   <term>
+    <constant>TIDY_TAG_DIV</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-dl">
+   <term>
+    <constant>TIDY_TAG_DL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-dt">
+   <term>
+    <constant>TIDY_TAG_DT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-em">
+   <term>
+    <constant>TIDY_TAG_EM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-embed">
+   <term>
+    <constant>TIDY_TAG_EMBED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-fieldset">
+   <term>
+    <constant>TIDY_TAG_FIELDSET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-figcaption">
+   <term>
+    <constant>TIDY_TAG_FIGCAPTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-figure">
+   <term>
+    <constant>TIDY_TAG_FIGURE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-font">
+   <term>
+    <constant>TIDY_TAG_FONT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-footer">
+   <term>
+    <constant>TIDY_TAG_FOOTER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-form">
+   <term>
+    <constant>TIDY_TAG_FORM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-frame">
+   <term>
+    <constant>TIDY_TAG_FRAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-frameset">
+   <term>
+    <constant>TIDY_TAG_FRAMESET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-h1">
+   <term>
+    <constant>TIDY_TAG_H1</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-h2">
+   <term>
+    <constant>TIDY_TAG_H2</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-h3">
+   <term>
+    <constant>TIDY_TAG_H3</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-h4">
+   <term>
+    <constant>TIDY_TAG_H4</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-h5">
+   <term>
+    <constant>TIDY_TAG_H5</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-h6">
+   <term>
+    <constant>TIDY_TAG_H6</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-head">
+   <term>
+    <constant>TIDY_TAG_HEAD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-header">
+   <term>
+    <constant>TIDY_TAG_HEADER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-hgroup">
+   <term>
+    <constant>TIDY_TAG_HGROUP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-hr">
+   <term>
+    <constant>TIDY_TAG_HR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-html">
+   <term>
+    <constant>TIDY_TAG_HTML</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-i">
+   <term>
+    <constant>TIDY_TAG_I</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-iframe">
+   <term>
+    <constant>TIDY_TAG_IFRAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-ilayer">
+   <term>
+    <constant>TIDY_TAG_ILAYER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-img">
+   <term>
+    <constant>TIDY_TAG_IMG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-input">
+   <term>
+    <constant>TIDY_TAG_INPUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-ins">
+   <term>
+    <constant>TIDY_TAG_INS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-isindex">
+   <term>
+    <constant>TIDY_TAG_ISINDEX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-kbd">
+   <term>
+    <constant>TIDY_TAG_KBD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-keygen">
+   <term>
+    <constant>TIDY_TAG_KEYGEN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-label">
+   <term>
+    <constant>TIDY_TAG_LABEL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-layer">
+   <term>
+    <constant>TIDY_TAG_LAYER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-legend">
+   <term>
+    <constant>TIDY_TAG_LEGEND</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-li">
+   <term>
+    <constant>TIDY_TAG_LI</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-link">
+   <term>
+    <constant>TIDY_TAG_LINK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-listing">
+   <term>
+    <constant>TIDY_TAG_LISTING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-main">
+   <term>
+    <constant>TIDY_TAG_MAIN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-map">
+   <term>
+    <constant>TIDY_TAG_MAP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-mark">
+   <term>
+    <constant>TIDY_TAG_MARK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-marquee">
+   <term>
+    <constant>TIDY_TAG_MARQUEE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-menu">
+   <term>
+    <constant>TIDY_TAG_MENU</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-menuitem">
+   <term>
+    <constant>TIDY_TAG_MENUITEM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-meta">
+   <term>
+    <constant>TIDY_TAG_META</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-meter">
+   <term>
+    <constant>TIDY_TAG_METER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-multicol">
+   <term>
+    <constant>TIDY_TAG_MULTICOL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-nav">
+   <term>
+    <constant>TIDY_TAG_NAV</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-nobr">
+   <term>
+    <constant>TIDY_TAG_NOBR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-noembed">
+   <term>
+    <constant>TIDY_TAG_NOEMBED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-noframes">
+   <term>
+    <constant>TIDY_TAG_NOFRAMES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-nolayer">
+   <term>
+    <constant>TIDY_TAG_NOLAYER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-nosave">
+   <term>
+    <constant>TIDY_TAG_NOSAVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-noscript">
+   <term>
+    <constant>TIDY_TAG_NOSCRIPT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-object">
+   <term>
+    <constant>TIDY_TAG_OBJECT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-ol">
+   <term>
+    <constant>TIDY_TAG_OL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-optgroup">
+   <term>
+    <constant>TIDY_TAG_OPTGROUP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-option">
+   <term>
+    <constant>TIDY_TAG_OPTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-output">
+   <term>
+    <constant>TIDY_TAG_OUTPUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-p">
+   <term>
+    <constant>TIDY_TAG_P</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-param">
+   <term>
+    <constant>TIDY_TAG_PARAM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-plaintext">
+   <term>
+    <constant>TIDY_TAG_PLAINTEXT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-pre">
+   <term>
+    <constant>TIDY_TAG_PRE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-progress">
+   <term>
+    <constant>TIDY_TAG_PROGRESS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-q">
+   <term>
+    <constant>TIDY_TAG_Q</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-rb">
+   <term>
+    <constant>TIDY_TAG_RB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-rbc">
+   <term>
+    <constant>TIDY_TAG_RBC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-rp">
+   <term>
+    <constant>TIDY_TAG_RP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-rt">
+   <term>
+    <constant>TIDY_TAG_RT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-rtc">
+   <term>
+    <constant>TIDY_TAG_RTC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-ruby">
+   <term>
+    <constant>TIDY_TAG_RUBY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-s">
+   <term>
+    <constant>TIDY_TAG_S</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-samp">
+   <term>
+    <constant>TIDY_TAG_SAMP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-script">
+   <term>
+    <constant>TIDY_TAG_SCRIPT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-section">
+   <term>
+    <constant>TIDY_TAG_SECTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-select">
+   <term>
+    <constant>TIDY_TAG_SELECT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-server">
+   <term>
+    <constant>TIDY_TAG_SERVER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-servlet">
+   <term>
+    <constant>TIDY_TAG_SERVLET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-small">
+   <term>
+    <constant>TIDY_TAG_SMALL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-source">
+   <term>
+    <constant>TIDY_TAG_SOURCE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-spacer">
+   <term>
+    <constant>TIDY_TAG_SPACER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-span">
+   <term>
+    <constant>TIDY_TAG_SPAN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-strike">
+   <term>
+    <constant>TIDY_TAG_STRIKE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-strong">
+   <term>
+    <constant>TIDY_TAG_STRONG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-style">
+   <term>
+    <constant>TIDY_TAG_STYLE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-sub">
+   <term>
+    <constant>TIDY_TAG_SUB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-summary">
+   <term>
+    <constant>TIDY_TAG_SUMMARY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-sup">
+   <term>
+    <constant>TIDY_TAG_SUP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-variablelist">
+   <term>
+    <constant>TIDY_TAG_variablelist</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-tbody">
+   <term>
+    <constant>TIDY_TAG_TBODY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-td">
+   <term>
+    <constant>TIDY_TAG_TD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-template">
+   <term>
+    <constant>TIDY_TAG_TEMPLATE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-textarea">
+   <term>
+    <constant>TIDY_TAG_TEXTAREA</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-tfoot">
+   <term>
+    <constant>TIDY_TAG_TFOOT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-th">
+   <term>
+    <constant>TIDY_TAG_TH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-thead">
+   <term>
+    <constant>TIDY_TAG_THEAD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-time">
+   <term>
+    <constant>TIDY_TAG_TIME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-title">
+   <term>
+    <constant>TIDY_TAG_TITLE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-tr">
+   <term>
+    <constant>TIDY_TAG_TR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-track">
+   <term>
+    <constant>TIDY_TAG_TRACK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-tt">
+   <term>
+    <constant>TIDY_TAG_TT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-u">
+   <term>
+    <constant>TIDY_TAG_U</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-ul">
+   <term>
+    <constant>TIDY_TAG_UL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-var">
+   <term>
+    <constant>TIDY_TAG_VAR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-video">
+   <term>
+    <constant>TIDY_TAG_VIDEO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Added in libtidy 5.0.0. Available as of PHP 7.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-wbr">
+   <term>
+    <constant>TIDY_TAG_WBR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-tag-xmp">
+   <term>
+    <constant>TIDY_TAG_XMP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+
+ <variablelist xml:id="tidy.constants.nodetype">
+  <title>tidy nodetype constants</title>
+  <varlistentry xml:id="constant.tidy-nodetype-root">
+   <term>
+    <constant>TIDY_NODETYPE_ROOT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     root node
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-nodetype-doctype">
+   <term>
+    <constant>TIDY_NODETYPE_DOCTYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     doctype
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-nodetype-comment">
+   <term>
+    <constant>TIDY_NODETYPE_COMMENT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     HTML comment
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-nodetype-procins">
+   <term>
+    <constant>TIDY_NODETYPE_PROCINS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Processing Instruction
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-nodetype-text">
+   <term>
+    <constant>TIDY_NODETYPE_TEXT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Text
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-nodetype-start">
+   <term>
+    <constant>TIDY_NODETYPE_START</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     start tag
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-nodetype-end">
+   <term>
+    <constant>TIDY_NODETYPE_END</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     end tag
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-nodetype-startend">
+   <term>
+    <constant>TIDY_NODETYPE_STARTEND</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     empty tag
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-nodetype-cdata">
+   <term>
+    <constant>TIDY_NODETYPE_CDATA</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     CDATA
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-nodetype-section">
+   <term>
+    <constant>TIDY_NODETYPE_SECTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     XML section
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-nodetype-asp">
+   <term>
+    <constant>TIDY_NODETYPE_ASP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     ASP code
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-nodetype-jste">
+   <term>
+    <constant>TIDY_NODETYPE_JSTE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     JSTE code
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-nodetype-php">
+   <term>
+    <constant>TIDY_NODETYPE_PHP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     PHP code
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tidy-nodetype-xmldecl">
+   <term>
+    <constant>TIDY_NODETYPE_XMLDECL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     XML declaration
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
 </appendix>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
This adds the type of the constants at the same time.