### PR TITLE
Update curl-exec.xml Mention the direct output

### DIFF
--- a/reference/curl/functions/curl-exec.xml
+++ b/reference/curl/functions/curl-exec.xml
@@ -34,7 +34,7 @@
   &reftitle.returnvalues;
   <para>
    On success, this function flushes the result directly to the
-   <literal>stdout</literal> (the browser window) and returns &true;, &false; on failure.
+   <literal>stdout</literal> and returns &true;, &return.falseforfailure;.
    However, if the <constant>CURLOPT_RETURNTRANSFER</constant>
    option is <link linkend="function.curl-setopt">set</link>, it will return
    the result on success, &false; on failure.

--- a/reference/curl/functions/curl-exec.xml
+++ b/reference/curl/functions/curl-exec.xml
@@ -33,7 +33,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success; However, if the <constant>CURLOPT_RETURNTRANSFER</constant>
+   On success, this function flushes the result directly to the
+   <literal>stdout</literal> (the browser window) and returns &true;, &false; on failure.
+   However, if the <constant>CURLOPT_RETURNTRANSFER</constant>
    option is <link linkend="function.curl-setopt">set</link>, it will return
    the result on success, &false; on failure.
   </para>


### PR DESCRIPTION
It seems to me an omission that in the description of the `curl_exec()` there is no mention of the transfer output to the browser (if https://www.php.net/manual/en/curl.constants.php#constant.curlopt-returntransfer option is not set)