### PR TITLE
refactor(ext/pgsql): Remove unnecessary error handling

### DIFF
--- a/reference/pgsql/functions/pg-fetch-result.xml
+++ b/reference/pgsql/functions/pg-fetch-result.xml
@@ -110,7 +110,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$db = pg_connect("dbname=users user=me") || die();
+$db = pg_connect("dbname=users user=me");
 
 $res = pg_query($db, "SELECT 1 UNION ALL SELECT 2");
 

--- a/reference/pgsql/functions/pg-free-result.xml
+++ b/reference/pgsql/functions/pg-free-result.xml
@@ -75,7 +75,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$db = pg_connect("dbname=users user=me") || die();
+$db = pg_connect("dbname=users user=me");
 
 $res = pg_query($db, "SELECT 1 UNION ALL SELECT 2");
 


### PR DESCRIPTION
This is a very small change.

It's a fairly old code example, and it has unnecessary error handling, similar to what was pointed out in https://github.com/php/doc-en/pull/3972#discussion_r1822605837, so I removed it.