### PR TITLE
Group math constants and use standard <variablelist> tag

### DIFF
--- a/reference/math/constants.xml
+++ b/reference/math/constants.xml
@@ -3,163 +3,297 @@
 <appendix xml:id="math.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &extension.constants.core;
- <para>
-  <table>
-   <title>Math constants</title>
-   <tgroup cols="4">
-    <thead>
-     <row>
-      <entry>Constant</entry>
-      <entry>Value</entry>
-      <entry>Description</entry>
-      <entry>Availability</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row xml:id="constant.m-pi">
-      <entry><constant>M_PI</constant></entry>
-      <entry>3.14159265358979323846</entry>
-      <entry>Pi</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.m-e">
-      <entry><constant>M_E</constant></entry>
-      <entry>2.7182818284590452354</entry>
-      <entry>e</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.m-log2e">
-      <entry><constant>M_LOG2E</constant></entry> 
-      <entry>1.4426950408889634074</entry>
-      <entry>log_2 e</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.m-log10e">
-      <entry><constant>M_LOG10E</constant></entry>
-      <entry>0.43429448190325182765</entry>
-      <entry>log_10 e</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.m-ln2">
-      <entry><constant>M_LN2</constant></entry>   
-      <entry>0.69314718055994530942</entry>
-      <entry>log_e 2</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.m-ln10">
-      <entry><constant>M_LN10</constant></entry>  
-      <entry>2.30258509299404568402</entry>
-      <entry>log_e 10</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.m-pi-2">
-      <entry><constant>M_PI_2</constant></entry>
-      <entry>1.57079632679489661923</entry>
-      <entry>pi/2</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.m-pi-4">
-      <entry><constant>M_PI_4</constant></entry>
-     <entry>0.78539816339744830962</entry>
-      <entry>pi/4</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.m-1-pi">
-      <entry><constant>M_1_PI</constant></entry>
-      <entry>0.31830988618379067154</entry>
-      <entry>1/pi</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.m-2-pi">
-      <entry><constant>M_2_PI</constant></entry>
-      <entry>0.63661977236758134308</entry>
-      <entry>2/pi</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.m-sqrtpi">
-      <entry><constant>M_SQRTPI</constant></entry>    
-      <entry>1.77245385090551602729</entry>
-      <entry>sqrt(pi)</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.m-2-sqrtpi">
-      <entry><constant>M_2_SQRTPI</constant></entry>  
-      <entry>1.12837916709551257390</entry>
-      <entry>2/sqrt(pi)</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.m-sqrt2">
-      <entry><constant>M_SQRT2</constant></entry> 
-      <entry>1.41421356237309504880</entry>
-      <entry>sqrt(2)</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.m-sqrt3">
-      <entry><constant>M_SQRT3</constant></entry> 
-      <entry>1.73205080756887729352</entry>
-      <entry>sqrt(3)</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.m-sqrt1-2">
-      <entry><constant>M_SQRT1_2</constant></entry>   
-      <entry>0.70710678118654752440</entry>
-      <entry>1/sqrt(2)</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.m-lnpi">
-      <entry><constant>M_LNPI</constant></entry>  
-      <entry>1.14472988584940017414</entry>
-      <entry>log_e(pi)</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.m-euler">
-      <entry><constant>M_EULER</constant></entry> 
-      <entry>0.57721566490153286061</entry>
-      <entry>Euler constant</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.php-round-half-up">
-      <entry><constant>PHP_ROUND_HALF_UP</constant></entry> 
-      <entry>1</entry>
-      <entry>Round halves up</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.php-round-half-down">
-      <entry><constant>PHP_ROUND_HALF_DOWN</constant></entry> 
-      <entry>2</entry>
-      <entry>Round halves down</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.php-round-half-even">
-      <entry><constant>PHP_ROUND_HALF_EVEN</constant></entry> 
-      <entry>3</entry>
-      <entry>Round halves to even numbers</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.php-round-half-odd">
-      <entry><constant>PHP_ROUND_HALF_ODD</constant></entry> 
-      <entry>4</entry>
-      <entry>Round halves to odd numbers</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.nan">
-      <entry><constant>NAN</constant></entry>
-      <entry>NAN (as a float)</entry>
-      <entry>Not A Number</entry>
-      <entry></entry>
-     </row>
-     <row xml:id="constant.inf">
-      <entry><constant>INF</constant></entry>
-      <entry>INF (as a float)</entry>
-      <entry>The infinite</entry>
-      <entry></entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </table>
- </para>
-</appendix>
+ <!-- TODO: Use MathML the moment PhD supports it -->
+ <variablelist>
+  <title>Mathematical Constants</title>
+  <varlistentry xml:id="constant.m-pi">
+   <term>
+    <constant>M_PI</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Approximation of the number π (pi).
+     (<literal>3.14159265358979323846</literal>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.m-e">
+   <term>
+    <constant>M_E</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Approximation of Euler's number <emphasis>e</emphasis>
+     (<literal>2.7182818284590452354</literal>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.m-log2e">
+   <term>
+    <constant>M_LOG2E</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Approximation of <literal>log_2(e)</literal>
+     (<literal>1.4426950408889634074</literal>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.m-log10e">
+   <term>
+    <constant>M_LOG10E</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Approximation of <literal>log_10(e)</literal>
+     (<literal>0.43429448190325182765</literal>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.m-ln2">
+   <term>
+    <constant>M_LN2</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Approximation of <literal>log_e(2)</literal>
+     (<literal>0.69314718055994530942</literal>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.m-ln10">
+   <term>
+    <constant>M_LN10</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Approximation of <literal>log_e(10)</literal>
+     (<literal>2.30258509299404568402</literal>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.m-pi-2">
+   <term>
+    <constant>M_PI_2</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Approximation of <literal>π/2</literal>
+     (<literal>1.57079632679489661923</literal>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.m-pi-4">
+   <term>
+    <constant>M_PI_4</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Approximation of <literal>π/4</literal>
+     (<literal>0.78539816339744830962</literal>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.m-1-pi">
+   <term>
+    <constant>M_1_PI</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Approximation of <literal>1/π</literal>
+     (<literal>0.31830988618379067154</literal>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.m-2-pi">
+   <term>
+    <constant>M_2_PI</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Approximation of <literal>2/π</literal>
+     (<literal>0.63661977236758134308</literal>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.m-sqrtpi">
+   <term>
+    <constant>M_SQRTPI</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Approximation of <literal>sqrt(π)</literal>
+     (<literal>1.77245385090551602729</literal>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.m-2-sqrtpi">
+   <term>
+    <constant>M_2_SQRTPI</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Approximation of <literal>2/sqrt(π)</literal>
+     (<literal>1.12837916709551257390</literal>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.m-sqrt2">
+   <term>
+    <constant>M_SQRT2</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Approximation of <literal>sqrt(2)</literal>
+     (<literal>1.41421356237309504880</literal>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.m-sqrt3">
+   <term>
+    <constant>M_SQRT3</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Approximation of <literal>sqrt(3)</literal>
+     (<literal>1.73205080756887729352</literal>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.m-sqrt1-2">
+   <term>
+    <constant>M_SQRT1_2</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Approximation of <literal>1/sqrt(2)</literal>
+     (<literal>0.70710678118654752440</literal>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.m-lnpi">
+   <term>
+    <constant>M_LNPI</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Approximation of <literal>log_e(π)</literal>
+     (<literal>1.14472988584940017414</literal>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.m-euler">
+   <term>
+    <constant>M_EULER</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Approximation of Euler's constant γ
+     (<literal>0.57721566490153286061</literal>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
 
+ <variablelist>
+  <title>IEEE 754 floating point constants</title>
+  <varlistentry xml:id="constant.nan">
+   <term>
+    <constant>NAN</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Not A Number
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.inf">
+   <term>
+    <constant>INF</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Infinity
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+
+ <variablelist>
+  <title>Rounding constants</title>
+  <note>
+   <simpara>
+    As of PHP 8.4.0, it is recommended to use the
+    <!-- <enumname>RoundingMode</enumname> -->
+    RoundingMode
+    enum instead.
+   </simpara>
+  </note>
+  <varlistentry xml:id="constant.php-round-half-up">
+   <term>
+    <constant>PHP_ROUND_HALF_UP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Rounding half away from zero.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-round-half-down">
+   <term>
+    <constant>PHP_ROUND_HALF_DOWN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Rounding half toward zero.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-round-half-even">
+   <term>
+    <constant>PHP_ROUND_HALF_EVEN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Round halves to even numbers
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-round-half-odd">
+   <term>
+    <constant>PHP_ROUND_HALF_ODD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Round halves to odd numbers
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+</appendix>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/math/constants.xml
+++ b/reference/math/constants.xml
@@ -25,7 +25,7 @@
    </term>
    <listitem>
     <simpara>
-     Approximation of Euler's number <emphasis>e</emphasis>
+     Approximation of Euler's number <literal>e</literal>
      (<literal>2.7182818284590452354</literal>).
     </simpara>
    </listitem>
@@ -37,7 +37,7 @@
    </term>
    <listitem>
     <simpara>
-     Approximation of <literal>log_2(e)</literal>
+     Approximation of <literal>log<subscript>2</subscript>(e)</literal>
      (<literal>1.4426950408889634074</literal>).
     </simpara>
    </listitem>
@@ -49,7 +49,7 @@
    </term>
    <listitem>
     <simpara>
-     Approximation of <literal>log_10(e)</literal>
+     Approximation of <literal>log<subscript>10</subscript>(e)</literal>
      (<literal>0.43429448190325182765</literal>).
     </simpara>
    </listitem>
@@ -61,7 +61,7 @@
    </term>
    <listitem>
     <simpara>
-     Approximation of <literal>log_e(2)</literal>
+     Approximation of <literal>ln(2)</literal>
      (<literal>0.69314718055994530942</literal>).
     </simpara>
    </listitem>
@@ -73,7 +73,7 @@
    </term>
    <listitem>
     <simpara>
-     Approximation of <literal>log_e(10)</literal>
+     Approximation of <literal>ln(10)</literal>
      (<literal>2.30258509299404568402</literal>).
     </simpara>
    </listitem>
@@ -193,7 +193,7 @@
    </term>
    <listitem>
     <simpara>
-     Approximation of <literal>log_e(π)</literal>
+     Approximation of <literal>ln(π)</literal>
      (<literal>1.14472988584940017414</literal>).
     </simpara>
    </listitem>


### PR DESCRIPTION
This also adds a note to recommend using the new RoundingMode enum.