### PR TITLE
PDO Drivers: remove the visual noice

### DIFF
--- a/reference/pdo_cubrid/reference.xml
+++ b/reference/pdo_cubrid/reference.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <reference xml:id="ref.pdo-cubrid" xmlns="http://docbook.org/ns/docbook"><?phpdoc extension-membership="pecl" ?>
  <title>CUBRID Functions (PDO_CUBRID)</title>
- <titleabbrev>CUBRID (PDO)</titleabbrev>
+ <titleabbrev>CUBRID</titleabbrev>
  <partintro>
 
   <section xml:id="pdo-cubrid.intro">&reftitle.intro;

--- a/reference/pdo_dblib/reference.xml
+++ b/reference/pdo_dblib/reference.xml
@@ -4,7 +4,7 @@
  <reference xml:id="ref.pdo-dblib" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="bundledexternal" ?>
   <title>Microsoft SQL Server and Sybase Functions (PDO_DBLIB)</title>
-  <titleabbrev>MS SQL Server (PDO)</titleabbrev>
+  <titleabbrev>MS SQL Server</titleabbrev>
   <partintro>
 
    <section xml:id="pdo-dblib.intro">

--- a/reference/pdo_firebird/reference.xml
+++ b/reference/pdo_firebird/reference.xml
@@ -10,8 +10,9 @@
    <section xml:id="pdo-firebird.intro">
    &reftitle.intro;
     <para>
-     PDO_FIREBIRD is a driver that implements the PHP Data Objects (PDO)
-     interface to enable access from PHP to Firebird database.
+     PDO_FIREBIRD is a driver that implements the <link linkend="intro.pdo">PHP
+     Data Objects (PDO) interface</link>
+     to enable access from PHP to Firebird database.
     </para>
    </section>
    &reference.pdo-firebird.configure;

--- a/reference/pdo_firebird/reference.xml
+++ b/reference/pdo_firebird/reference.xml
@@ -4,7 +4,7 @@
  <reference xml:id="ref.pdo-firebird" xmlns="http://docbook.org/ns/docbook">
   <?phpdoc extension-membership="bundledexternal" ?>
   <title>Firebird Functions (PDO_FIREBIRD)</title>
-  <titleabbrev>Firebird (PDO)</titleabbrev>
+  <titleabbrev>Firebird</titleabbrev>
   <partintro>
 
    <section xml:id="pdo-firebird.intro">

--- a/reference/pdo_ibm/reference.xml
+++ b/reference/pdo_ibm/reference.xml
@@ -2,7 +2,7 @@
 <reference xml:id="ref.pdo-ibm" xmlns="http://docbook.org/ns/docbook">
  <?phpdoc extension-membership="pecl" ?>
   <title>IBM Functions (PDO_IBM)</title>
-  <titleabbrev>IBM (PDO)</titleabbrev>
+  <titleabbrev>IBM</titleabbrev>
   <partintro>
 
    <section xml:id="pdo-ibm.intro">

--- a/reference/pdo_informix/reference.xml
+++ b/reference/pdo_informix/reference.xml
@@ -2,7 +2,7 @@
  <reference xml:id="ref.pdo-informix" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
   <title>Informix Functions (PDO_INFORMIX)</title>
-  <titleabbrev>Informix (PDO)</titleabbrev>
+  <titleabbrev>Informix</titleabbrev>
   <partintro>
 
    <section xml:id="pdo-informix.intro">

--- a/reference/pdo_mysql/reference.xml
+++ b/reference/pdo_mysql/reference.xml
@@ -4,7 +4,7 @@
  <reference xml:id="ref.pdo-mysql" xmlns="http://docbook.org/ns/docbook">
   <?phpdoc extension-membership="bundledexternal" ?>
   <title>MySQL Functions (PDO_MYSQL)</title>
-  <titleabbrev>MySQL (PDO)</titleabbrev>
+  <titleabbrev>MySQL</titleabbrev>
   <partintro>
 
    <section xml:id="pdo-mysql.intro">

--- a/reference/pdo_oci/reference.xml
+++ b/reference/pdo_oci/reference.xml
@@ -4,7 +4,7 @@
  <reference xml:id="ref.pdo-oci" xmlns="http://docbook.org/ns/docbook">
   <?phpdoc extension-membership="bundledexternal" ?>
   <title>Oracle Functions (PDO_OCI)</title>
-  <titleabbrev>Oracle (PDO)</titleabbrev>
+  <titleabbrev>Oracle</titleabbrev>
   <partintro>
    
    &reference.pdo-oci.configure;

--- a/reference/pdo_odbc/reference.xml
+++ b/reference/pdo_odbc/reference.xml
@@ -4,7 +4,7 @@
  <reference xml:id="ref.pdo-odbc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="bundledexternal" ?>
   <title>ODBC and DB2 Functions (PDO_ODBC)</title>
-  <titleabbrev>ODBC and DB2 (PDO)</titleabbrev>
+  <titleabbrev>ODBC and DB2</titleabbrev>
   <partintro>
 
    <section xml:id="pdo-odbc.intro">

--- a/reference/pdo_pgsql/reference.xml
+++ b/reference/pdo_pgsql/reference.xml
@@ -4,7 +4,7 @@
  <reference xml:id="ref.pdo-pgsql" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="bundledexternal" ?>
   <title>PostgreSQL Functions (PDO_PGSQL)</title>
-  <titleabbrev>PostgreSQL (PDO)</titleabbrev>
+  <titleabbrev>PostgreSQL</titleabbrev>
   <partintro>
 
    <section xml:id="pdo-pgsql.intro">

--- a/reference/pdo_sqlite/reference.xml
+++ b/reference/pdo_sqlite/reference.xml
@@ -4,7 +4,7 @@
  <reference xml:id="ref.pdo-sqlite" xmlns="http://docbook.org/ns/docbook">
   <?phpdoc extension-membership="bundledexternal" ?>
   <title>SQLite Functions (PDO_SQLITE)</title>
-  <titleabbrev>SQLite (PDO)</titleabbrev>
+  <titleabbrev>SQLite</titleabbrev>
   <partintro>
 
    <section xml:id="pdo-sqlite.intro">

--- a/reference/pdo_sqlsrv/reference.xml
+++ b/reference/pdo_sqlsrv/reference.xml
@@ -2,7 +2,7 @@
  <reference xml:id="ref.pdo-sqlsrv" xmlns="http://docbook.org/ns/docbook">
  <?phpdoc extension-membership="pecl" ?>
   <title>Microsoft SQL Server Functions (PDO_SQLSRV)</title>
-  <titleabbrev>MS SQL Server (PDO)</titleabbrev>
+  <titleabbrev>MS SQL Server</titleabbrev>
   <partintro>
 
    <section xml:id="pdo-sqlsrv.intro">


### PR DESCRIPTION
Take a look at these screenshots instead of a thousand words:

### Before

![visual_garbage](https://github.com/user-attachments/assets/6b8b7a6a-f466-4e21-9365-9b2cd5fb02df)

![menu_visual_garbage](https://github.com/user-attachments/assets/da56462c-a9a3-45fe-8119-624912032fd9)

### After

![clear_view](https://github.com/user-attachments/assets/48c128c9-3dbd-4c44-aac4-98b1cfe997a5)

![menu_clear_view](https://github.com/user-attachments/assets/f585da14-121f-48de-ae4f-51c0e742dfdb)

The names of the drivers in the list follow the general heading: **PDO Drivers,** so it is clear that each element of the list is a separate driver name, and the suffix ` (PDO)` only creates visual noise, so suffixes should be removed