### PR TITLE
Add IDs to GLOB constants

### DIFF
--- a/reference/filesystem/constants.xml
+++ b/reference/filesystem/constants.xml
@@ -82,8 +82,8 @@
    </listitem>
   </varlistentry>
  </variablelist>
- <variablelist xml:id="constant.glob-constant-variablelist">
-  <varlistentry>
+ <variablelist role="constant_list">
+  <varlistentry xml:id="constant.glob-brace">
    <term>
     <constant>GLOB_BRACE</constant>
      (<type>int</type>)
@@ -100,7 +100,7 @@
     </note>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.glob-err">
    <term>
     <constant>GLOB_ERR</constant>
      (<type>int</type>)
@@ -112,7 +112,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.glob-onlydir">
    <term>
     <constant>GLOB_ONLYDIR</constant>
      (<type>int</type>)
@@ -123,7 +123,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.glob-mark">
    <term>
     <constant>GLOB_MARK</constant>
      (<type>int</type>)
@@ -134,7 +134,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.glob-nosort">
    <term>
     <constant>GLOB_NOSORT</constant>
      (<type>int</type>)
@@ -146,7 +146,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.glob-nocheck">
    <term>
     <constant>GLOB_NOCHECK</constant>
      (<type>int</type>)
@@ -157,7 +157,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.glob-noescape">
    <term>
     <constant>GLOB_NOESCAPE</constant>
      (<type>int</type>)
@@ -168,7 +168,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.glob-available-flags">
    <term>
     <constant>GLOB_AVAILABLE_FLAGS</constant>
      (<type>int</type>)

--- a/reference/filesystem/constants.xml
+++ b/reference/filesystem/constants.xml
@@ -83,6 +83,21 @@
   </varlistentry>
  </variablelist>
  <variablelist role="constant_list">
+  <varlistentry xml:id="constant.glob-available-flags">
+   <term>
+    <constant>GLOB_AVAILABLE_FLAGS</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     All <constant>GLOB_<replaceable>*</replaceable></constant> flags combined.
+     Equivalent to <literal>0</literal> | <constant>GLOB_BRACE</constant> |
+     <constant>GLOB_MARK</constant> | <constant>GLOB_NOSORT</constant> |
+     <constant>GLOB_NOCHECK</constant> | <constant>GLOB_NOESCAPE</constant> |
+     <constant>GLOB_ERR</constant> | <constant>GLOB_ONLYDIR</constant>
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.glob-brace">
    <term>
     <constant>GLOB_BRACE</constant>
@@ -112,17 +127,6 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.glob-onlydir">
-   <term>
-    <constant>GLOB_ONLYDIR</constant>
-     (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Return only directory entries which match the pattern
-    </simpara>
-   </listitem>
-  </varlistentry>
   <varlistentry xml:id="constant.glob-mark">
    <term>
     <constant>GLOB_MARK</constant>
@@ -131,18 +135,6 @@
    <listitem>
     <simpara>
      Adds a slash (a backslash on Windows) to each directory returned
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.glob-nosort">
-   <term>
-    <constant>GLOB_NOSORT</constant>
-     (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Return files as they appear in the directory (no sorting).
-     When this flag is not used, the pathnames are sorted alphabetically
     </simpara>
    </listitem>
   </varlistentry>
@@ -168,18 +160,26 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.glob-available-flags">
+  <varlistentry xml:id="constant.glob-nosort">
    <term>
-    <constant>GLOB_AVAILABLE_FLAGS</constant>
+    <constant>GLOB_NOSORT</constant>
      (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     All <constant>GLOB_<replaceable>*</replaceable></constant> flags combined.
-     Equivalent to <literal>0</literal> | <constant>GLOB_BRACE</constant> |
-     <constant>GLOB_MARK</constant> | <constant>GLOB_NOSORT</constant> |
-     <constant>GLOB_NOCHECK</constant> | <constant>GLOB_NOESCAPE</constant> |
-     <constant>GLOB_ERR</constant> | <constant>GLOB_ONLYDIR</constant>
+     Return files as they appear in the directory (no sorting).
+     When this flag is not used, the pathnames are sorted alphabetically
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.glob-onlydir">
+   <term>
+    <constant>GLOB_ONLYDIR</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Return only directory entries which match the pattern
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/filesystem/functions/glob.xml
+++ b/reference/filesystem/functions/glob.xml
@@ -65,10 +65,7 @@
      <term><parameter>flags</parameter></term>
      <listitem>
       <para>
-       Valid flags:
-       <variablelist>
-        <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('constant.glob-constant-variablelist')/*)"><xi:fallback/></xi:include>
-       </variablelist>
+       Any of the <constant>GLOB_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
The second commit alphabetically sorts the constants so this PR is easier to review commit by commit.