### PR TITLE
fix(pdo_pgsql/constants): Correct use of `null` values

### DIFF
--- a/reference/pdo_pgsql/constants.xml
+++ b/reference/pdo_pgsql/constants.xml
@@ -29,7 +29,7 @@
     <para>
      Returns the amount of memory, in bytes, allocated to the specified query result
      <classname>PDOStatement</classname> instance,
-     or null if no results exist before the query is executed.
+     or &null; if no results exist before the query is executed.
      Available as of PHP 8.4.0.
     </para>
    </listitem>


### PR DESCRIPTION
fixes: https://github.com/php/doc-en/pull/3983#discussion_r1827141548