### PR TITLE
document potential Windows deadlock

### DIFF
--- a/reference/filesystem/functions/flock.xml
+++ b/reference/filesystem/functions/flock.xml
@@ -189,11 +189,26 @@ fclose($fp);
     <literal>FAT</literal> and its derivates and will therefore always
     return &false; under these environments.
    </para>
+   <para>
+    On Windows, if php tries to execute a LOCK_EX'ed php source code file, it will hang until the file is unlocked, meaning
+<![CDATA[
+<?php
+if($argv[1] ?? null === 'child') {die();}
+$fp = fopen(__FILE__, "rb");
+flock($fp,LOCK_EX);
+shell_exec("php " . escapeshellarg(__FILE__) . " child");
+?>
+]]>
+    will cause a deadlock.
+   </para>
   </warning>
   <note>
    <para>
     On Windows, if the locking process opens the file a second time, it cannot
     access the file through this second handle until it unlocks the file.
+   </para>
+   <para>
+    On Windows, if you try to require a LOCK_EX'ed file, it will fail with ErrorException: require(): Read of X bytes failed with errno=13 Permission denied
    </para>
   </note>
  </refsect1>

--- a/reference/filesystem/functions/flock.xml
+++ b/reference/filesystem/functions/flock.xml
@@ -190,16 +190,21 @@ fclose($fp);
     return &false; under these environments.
    </para>
    <para>
-    On Windows, if php tries to execute a LOCK_EX'ed php source code file, it will hang until the file is unlocked, meaning
+    On Windows, if PHP tries to execute a <constant>LOCK_EX</constant>'ed PHP source
+    code file, it will hang until the file is unlocked. The following example will
+    cause a deadlock:
+    <informalexample>
+     <programlisting role="php">
 <![CDATA[
 <?php
-if($argv[1] ?? null === 'child') {die();}
+if ($argv[1] ?? null === 'child') { die(); }
 $fp = fopen(__FILE__, "rb");
-flock($fp,LOCK_EX);
+flock($fp, LOCK_EX);
 shell_exec("php " . escapeshellarg(__FILE__) . " child");
 ?>
 ]]>
-    will cause a deadlock.
+     </programlisting>
+    </informalexample>
    </para>
   </warning>
   <note>

--- a/reference/filesystem/functions/flock.xml
+++ b/reference/filesystem/functions/flock.xml
@@ -207,9 +207,9 @@ shell_exec("php " . escapeshellarg(__FILE__) . " child");
     On Windows, if the locking process opens the file a second time, it cannot
     access the file through this second handle until it unlocks the file.
    </para>
-   <para>
+   <simpara>
     On Windows, if you try to require a LOCK_EX'ed file, it will fail with ErrorException: require(): Read of X bytes failed with errno=13 Permission denied
-   </para>
+   </simpara>
   </note>
  </refsect1>
  


### PR DESCRIPTION
on Windows php's require() and "php file.php" reacts differently to the LOCK_EX situation, require() will fail immediately (like a LOCK_NB) while cli "php file.php" will wait/hang until unlocked. Make that clear in the documentation.