### PR TITLE
SUNFUNCS_* constants are deprecated as of PHP 8.4.0

### DIFF
--- a/reference/datetime/constants.xml
+++ b/reference/datetime/constants.xml
@@ -3,17 +3,27 @@
 <appendix xml:id="datetime.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  <para>
-  The <link linkend="datetimeinterface.constants.types"><literal>DATE_*</literal>
-  constants</link> are defined and they offer standard
+  The <constant>DATE_<replaceable>*</replaceable></constant>
+  constants are defined and offer standard
   date representations, which can be used along with the date format functions
   (like <function>date</function>).
  </para>
- <para>
-  Following constants specify a format returned by
-  functions <function>date_sunrise</function> and
-  <function>date_sunset</function>.
- </para>
+
  <variablelist>
+  <title>
+   Available <parameter>returnFormat</parameter> for
+   <function>date_sunrise</function> and
+   <function>date_sunset</function>
+  </title>
+
+  <warning>
+   <simpara>
+    These constants are deprecated as of PHP 8.4.0.
+    The corresponding <function>date_sunrise</function> and
+    <function>date_sunset</function> functions are deprecated as of PHP 8.1.0.
+   </simpara>
+  </warning>
+
   <varlistentry xml:id="constant.sunfuncs-ret-timestamp">
    <term>
     <constant>SUNFUNCS_RET_TIMESTAMP</constant>


### PR DESCRIPTION
Improve grouping and add a warning for the whole group