### PR TITLE
Use full version for `utf8_(de|en)code` deprecation

### DIFF
--- a/reference/strings/versions.xml
+++ b/reference/strings/versions.xml
@@ -103,8 +103,8 @@
  <function name="trim" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="ucfirst" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="ucwords" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
- <function name="utf8_decode" from="PHP 4, PHP 5, PHP 7, PHP 8" deprecated="PHP 8.2"/>
- <function name="utf8_encode" from="PHP 4, PHP 5, PHP 7, PHP 8" deprecated="PHP 8.2"/>
+ <function name="utf8_decode" from="PHP 4, PHP 5, PHP 7, PHP 8" deprecated="PHP 8.2.0"/>
+ <function name="utf8_encode" from="PHP 4, PHP 5, PHP 7, PHP 8" deprecated="PHP 8.2.0"/>
  <function name="vfprintf" from="PHP 5, PHP 7, PHP 8"/>
  <function name="vprintf" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
  <function name="vsprintf" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>


### PR DESCRIPTION
see https://github.com/php/doc-en/pull/4010#discussion_r1830046625