### PR TITLE
functions.xml Make the comment clearer

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -466,9 +466,10 @@ Making a bowl of raspberry natural yogurt.
 function foo($a = [], $b) {}     // Default not used; deprecated as of PHP 8.0.0
 function foo($a, $b) {}          // Functionally equivalent, no deprecation notice
 
-function bar(A $a = null, $b) {} // As of PHP 8.1.0, $a is implicitly required (because it
-                                 // comes before the required one), but implicitly nullable (deprecated as of
-                                 // PHP 8.4.0), because the default parameter value is null
+function bar(A $a = null, $b) {} // As of PHP 8.1.0, $a is implicitly required
+                                 // (because it comes before the required one),
+                                 // but implicitly nullable (deprecated as of PHP 8.4.0),
+                                 // because the default parameter value is null
 function bar(?A $a, $b) {}       // Recommended
 
 ?>

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -461,14 +461,18 @@ Making a bowl of raspberry natural yogurt.
       <title>Declaring optional arguments after mandatory arguments</title>
       <programlisting role="php">
 <![CDATA[
- <?php
- function foo($a = [], $b) {} // Default not used; deprecated as of PHP 8.0.0
- function foo($a, $b) {}      // Functionally equivalent, no deprecation notice
+<?php
 
- function bar(A $a = null, $b) {} // Deprecated as of PHP 8.4.0; $a is required but nullable
- function bar(?A $a, $b) {}       // Recommended
- ?>
- ]]>
+function foo($a = [], $b) {}     // Default not used; deprecated as of PHP 8.0.0
+function foo($a, $b) {}          // Functionally equivalent, no deprecation notice
+
+function bar(A $a = null, $b) {} // As of PHP 8.1.0, $a is implicitly required (because it
+                                 // comes before the required one), but implicitly nullable (deprecated as of
+                                 // PHP 8.4.0), because the default parameter value is null
+function bar(?A $a, $b) {}       // Recommended
+
+?>
+]]>
       </programlisting>
      </example>
     </para>


### PR DESCRIPTION
`function bar(A $a = null, $b) {} // Deprecated (Deprecated what exactly? The positioning, implicity nullable type, other?) as of PHP 8.4.0; $a is required (Why? After all, the parameter has a default value) but nullable (Why?)`

My questions are in parentheses.

As a reader, I would like to get answers to these questions. (Especially if considering the example outside the context of the page.)
