### PR TITLE
Add a note about time zone changes in PHP 8.2

### DIFF
--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -125,10 +125,10 @@
     The properties of <classname>DatePeriod</classname> are now properly declared.
    </para>
 
-   <para>
-    Default timezones will fall back to UTC, rather than system timezone if 
+   <simpara>
+    Default timezones will fall back to UTC, rather than system timezone if
     none are defined in the <link linkend="ini.date.timezone">date.timezone</link> ini setting.
-   </para>
+   </simpara>
   </sect3>
 
   <sect3 xml:id="migration82.other-changes.extensions.intl">

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -126,8 +126,8 @@
    </para>
 
    <simpara>
-    Default timezones will fall back to UTC, rather than system timezone if
-    none are defined in the <link linkend="ini.date.timezone">date.timezone</link> ini setting.
+    Default timezone will fall back to UTC if the
+    <link linkend="ini.date.timezone">date.timezone</link> ini setting is not set.
    </simpara>
   </sect3>
 

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -124,6 +124,11 @@
    <para>
     The properties of <classname>DatePeriod</classname> are now properly declared.
    </para>
+
+   <para>
+    Default timezones will fall back to UTC, rather than system timezone if 
+    none are defined in the <link linkend="ini.date.timezone">date.timezone</link> ini setting.
+   </para>
   </sect3>
 
   <sect3 xml:id="migration82.other-changes.extensions.intl">


### PR DESCRIPTION
This MR documents the change made in: https://github.com/php/php-src/commit/6770158d474fa442ce55bba4ec32dd2703828b33

As mentioned in the issue: https://github.com/php/php-src/issues/11496

Since PHP 8.2, the fallback of the timezone is now UTC, rather than the timezone supplied by the system.