### PR TITLE
[PHP 8.4] fix(reflectionclass/newlazyghost): Confusion between proxy and ghost

### DIFF
--- a/reference/reflection/reflectionclass/newlazyghost.xml
+++ b/reference/reflection/reflectionclass/newlazyghost.xml
@@ -87,7 +87,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Returns a lazy proxy instance. If the object has no properties, or if all its
+   Returns a lazy ghost instance. If the object has no properties, or if all its
    properties are static or virtual, a normal (non-lazy) instance is returned.
    See also
    <link linkend="language.oop5.lazy-objects.lifecycle">Lifecycle of Lazy


### PR DESCRIPTION
It seems that the description of `newLazyGhost()` is the same as `newLazyProxy()`.