### PR TITLE
Add replaceable tags to constants

### DIFF
--- a/appendices/migration70/changed-functions.xml
+++ b/appendices/migration70/changed-functions.xml
@@ -46,7 +46,7 @@
    <listitem>
     <simpara>
      <function>setlocale</function> function no longer accepts <parameter>category</parameter>
-     passed as string. <constant>LC_*</constant> constants must be used instead.
+     passed as string. <constant>LC_<replaceable>*</replaceable></constant> constants must be used instead.
     </simpara>
    </listitem>
    <listitem>

--- a/appendices/migration70/incompatible/removed-functions.xml
+++ b/appendices/migration70/incompatible/removed-functions.xml
@@ -45,7 +45,7 @@
    <function>mcrypt_cbc</function>, <function>mcrypt_cfb</function> and
    <function>mcrypt_ofb</function> functions have been removed in favour of
    using <function>mcrypt_decrypt</function> with the appropriate
-   <constant>MCRYPT_MODE_*</constant> constant.
+   <constant>MCRYPT_MODE_<replaceable>*</replaceable></constant> constant.
   </para>
  </sect3>
 

--- a/appendices/migration80/other-changes.xml
+++ b/appendices/migration80/other-changes.xml
@@ -73,7 +73,7 @@
       <methodname>ZipArchive::addEmptyDir</methodname>, <methodname>ZipArchive::addFile</methodname>
       and <methodname>ZipArchive::addFromString</methodname>
       methods have a new <parameter>flags</parameter> argument. This allows managing name encoding
-      (<constant>ZipArchive::FL_ENC_*</constant>) and entry replacement
+      (<constant>ZipArchive::FL_ENC_<replaceable>*</replaceable></constant>) and entry replacement
       (<constant>ZipArchive::FL_OVERWRITE</constant>).
      </para>
     </listitem>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1416,7 +1416,7 @@ encoding value will be used.</para>'>
 <!ENTITY memcached.result.delete-multi '<para xmlns="http://docbook.org/ns/docbook">
    Returns an array indexed by <parameter>keys</parameter>. Each element
    is &true; if the corresponding key was deleted, or one of the
-   <constant>Memcached::RES_*</constant> constants if the corresponding deletion
+   <constant>Memcached::RES_<replaceable>*</replaceable></constant> constants if the corresponding deletion
    failed.
    </para>
   <para xmlns="http://docbook.org/ns/docbook">

--- a/reference/curl/functions/curl-multi-info-read.xml
+++ b/reference/curl/functions/curl-multi-info-read.xml
@@ -72,7 +72,7 @@
       </row>
       <row>
        <entry><literal>result</literal></entry>
-       <entry>One of the <constant>CURLE_*</constant> constants. If everything is
+       <entry>One of the <constant>CURLE_<replaceable>*</replaceable></constant> constants. If everything is
        OK, the <constant>CURLE_OK</constant> will be the result.</entry>
       </row>
       <row>

--- a/reference/curl/functions/curl-pause.xml
+++ b/reference/curl/functions/curl-pause.xml
@@ -29,7 +29,7 @@
     <term><parameter>flags</parameter></term>
     <listitem>
      <para>
-      One of <constant>CURLPAUSE_*</constant> constants.
+      One of <constant>CURLPAUSE_<replaceable>*</replaceable></constant> constants.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/image/functions/imageaffinematrixget.xml
+++ b/reference/image/functions/imageaffinematrixget.xml
@@ -25,7 +25,7 @@
     <term><parameter>type</parameter></term>
     <listitem>
      <para>
-      One of the <constant>IMG_AFFINE_*</constant> constants.
+      One of the <constant>IMG_AFFINE_<replaceable>*</replaceable></constant> constants.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/image/functions/imageflip.xml
+++ b/reference/image/functions/imageflip.xml
@@ -28,7 +28,7 @@
      <term><parameter>mode</parameter></term>
      <listitem>
       <para>
-       Flip mode, this can be one of the <constant>IMG_FLIP_*</constant> constants:
+       Flip mode, this can be one of the <constant>IMG_FLIP_<replaceable>*</replaceable></constant> constants:
       </para>
       <para>
        <informaltable>

--- a/reference/imagick/imagick/getimageinterpolatemethod.xml
+++ b/reference/imagick/imagick/getimageinterpolatemethod.xml
@@ -14,7 +14,7 @@
   </methodsynopsis>
   <para>
    Returns the interpolation method for the specified image. The method is one of 
-   the <constant>Imagick::INTERPOLATE_*</constant> constants.
+   the <constant>Imagick::INTERPOLATE_<replaceable>*</replaceable></constant> constants.
   </para>
  </refsect1>
 

--- a/reference/imagick/imagick/mergeimagelayers.xml
+++ b/reference/imagick/imagick/mergeimagelayers.xml
@@ -28,7 +28,7 @@
      <term><parameter>layer_method</parameter></term>
      <listitem>
       <para>
-       One of the <constant>Imagick::LAYERMETHOD_*</constant> constants
+       One of the <constant>Imagick::LAYERMETHOD_<replaceable>*</replaceable></constant> constants
       </para>
      </listitem>
     </varlistentry>

--- a/reference/imagick/imagick/setimagealphachannel.xml
+++ b/reference/imagick/imagick/setimagealphachannel.xml
@@ -14,7 +14,7 @@
   </methodsynopsis>
   <para>
    Activate or deactivate image alpha channel. The <parameter>mode</parameter> 
-   is one of the <constant>Imagick::ALPHACHANNEL_*</constant> constants.
+   is one of the <constant>Imagick::ALPHACHANNEL_<replaceable>*</replaceable></constant> constants.
    &imagick.method.available.0x638;
   </para>
  </refsect1>
@@ -27,7 +27,7 @@
      <term><parameter>mode</parameter></term>
      <listitem>
       <para>
-       One of the <constant>Imagick::ALPHACHANNEL_*</constant> constants
+       One of the <constant>Imagick::ALPHACHANNEL_<replaceable>*</replaceable></constant> constants
       </para>
      </listitem>
     </varlistentry>

--- a/reference/imagick/imagick/setimageinterpolatemethod.xml
+++ b/reference/imagick/imagick/setimageinterpolatemethod.xml
@@ -25,7 +25,7 @@
      <term><parameter>method</parameter></term>
      <listitem>
       <para>
-       The method is one of the <constant>Imagick::INTERPOLATE_*</constant> constants
+       The method is one of the <constant>Imagick::INTERPOLATE_<replaceable>*</replaceable></constant> constants
       </para>
      </listitem>
     </varlistentry>

--- a/reference/memcached/constants.xml
+++ b/reference/memcached/constants.xml
@@ -71,7 +71,7 @@
    <term><constant>Memcached::OPT_HASH</constant></term>
    <listitem>
     <para>Specifies the hashing algorithm used for the item keys. The valid
-     values are supplied via <constant>Memcached::HASH_*</constant> constants.
+     values are supplied via <constant>Memcached::HASH_<replaceable>*</replaceable></constant> constants.
      Each hash algorithm has its advantages and its disadvantages. Go with the
      default if you don't know or don't care.</para>
     <para>Type: &integer;, default: <constant>Memcached::HASH_DEFAULT</constant></para>

--- a/reference/memcached/memcached/getresultcode.xml
+++ b/reference/memcached/memcached/getresultcode.xml
@@ -14,7 +14,7 @@
   </methodsynopsis>
   <para>
    <function>Memcached::getResultCode</function> returns one of the
-   <constant>Memcached::RES_*</constant> constants that is the result of the
+   <constant>Memcached::RES_<replaceable>*</replaceable></constant> constants that is the result of the
    last executed Memcached method.
   </para>
  </refsect1>

--- a/reference/mysqli/mysqli/commit.xml
+++ b/reference/mysqli/mysqli/commit.xml
@@ -36,7 +36,7 @@
      <term><parameter>flags</parameter></term>
      <listitem>
       <para>
-       A bitmask of <constant>MYSQLI_TRANS_COR_*</constant> constants.
+       A bitmask of <constant>MYSQLI_TRANS_COR_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mysqli/mysqli/rollback.xml
+++ b/reference/mysqli/mysqli/rollback.xml
@@ -36,7 +36,7 @@
      <term><parameter>flags</parameter></term>
      <listitem>
       <para>
-       A bitmask of <constant>MYSQLI_TRANS_COR_*</constant> constants.
+       A bitmask of <constant>MYSQLI_TRANS_COR_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/oauth/oauth/fetch.xml
+++ b/reference/oauth/oauth/fetch.xml
@@ -45,8 +45,8 @@
      <term><parameter>http_method</parameter></term>
      <listitem>
       <para>
-       One of the <constant>OAUTH_HTTP_METHOD_*</constant>
-       <link linkend="oauth.constants">OAUTH constants</link>, which includes
+       One of the <constant>OAUTH_HTTP_METHOD_<replaceable>*</replaceable></constant>
+       OAUTH constants, which includes
        GET, POST, PUT, HEAD, or DELETE.
       </para>
       <para>

--- a/reference/oauth/oauthprovider/checkoauthrequest.xml
+++ b/reference/oauth/oauthprovider/checkoauthrequest.xml
@@ -37,8 +37,8 @@
     <term><parameter>method</parameter></term>
     <listitem>
      <para>
-      The <acronym>HTTP</acronym> method. Optionally pass in one of the 
-      <constant>OAUTH_HTTP_METHOD_*</constant> <link linkend="oauth.constants">OAuth constants</link>.
+      The <acronym>HTTP</acronym> method. Optionally pass in one of the
+      <constant>OAUTH_HTTP_METHOD_<replaceable>*</replaceable></constant> OAuth constants.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/pdo_pgsql/PDO/pgsqlGetNotify.xml
+++ b/reference/pdo_pgsql/PDO/pgsqlGetNotify.xml
@@ -26,7 +26,7 @@
      <listitem>
       <para>
        The format the result set should be returned as, represented as a
-       <link linkend="pdostatement.fetch"><constant>PDO::FETCH_*</constant></link>
+       <constant>PDO::FETCH_<replaceable>*</replaceable></constant>
        constant.
       </para>
      </listitem>

--- a/reference/phpdbg/functions/phpdbg-color.xml
+++ b/reference/phpdbg/functions/phpdbg-color.xml
@@ -26,7 +26,7 @@
     <term><parameter>element</parameter></term>
     <listitem>
      <para>
-      One of the <constant>PHPDBG_COLOR_*</constant> constants.
+      One of the <constant>PHPDBG_COLOR_<replaceable>*</replaceable></constant> constants.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/rnp/functions/rnp-dump-packets-to-json.xml
+++ b/reference/rnp/functions/rnp-dump-packets-to-json.xml
@@ -33,7 +33,7 @@
     <term><parameter>flags</parameter></term>
     <listitem>
      <para>
-      See <constant>RNP_JSON_DUMP_*</constant> predefined constants.
+      See <constant>RNP_JSON_DUMP_<replaceable>*</replaceable></constant> predefined constants.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/rnp/functions/rnp-dump-packets.xml
+++ b/reference/rnp/functions/rnp-dump-packets.xml
@@ -33,7 +33,7 @@
     <term><parameter>flags</parameter></term>
     <listitem>
      <para>
-      See <constant>RNP_DUMP_*</constant> predefined constants.
+      See <constant>RNP_DUMP_<replaceable>*</replaceable></constant> predefined constants.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/rnp/functions/rnp-import-keys.xml
+++ b/reference/rnp/functions/rnp-import-keys.xml
@@ -41,7 +41,7 @@
     <term><parameter>flags</parameter></term>
     <listitem>
      <para>
-      See <constant>RNP_LOAD_SAVE_*</constant> predefined constants.
+      See <constant>RNP_LOAD_SAVE_<replaceable>*</replaceable></constant> predefined constants.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/rnp/functions/rnp-key-export.xml
+++ b/reference/rnp/functions/rnp-key-export.xml
@@ -41,7 +41,7 @@
     <term><parameter>flags</parameter></term>
     <listitem>
      <para>
-      See <constant>RNP_KEY_EXPORT_*</constant> predefined constants
+      See <constant>RNP_KEY_EXPORT_<replaceable>*</replaceable></constant> predefined constants
       (except <constant>RNP_KEY_EXPORT_BASE64</constant>).
      </para>
     </listitem>

--- a/reference/rnp/functions/rnp-key-remove.xml
+++ b/reference/rnp/functions/rnp-key-remove.xml
@@ -42,7 +42,7 @@
     <term><parameter>flags</parameter></term>
     <listitem>
      <para>
-      See <constant>RNP_KEY_REMOVE_*</constant> constants. Flag <constant>RNP_KEY_REMOVE_SUBKEYS</constant> will work only for
+      See <constant>RNP_KEY_REMOVE_<replaceable>*</replaceable></constant> constants. Flag <constant>RNP_KEY_REMOVE_SUBKEYS</constant> will work only for
       the primary key and will remove all of its subkeys as well.
      </para>
     </listitem>

--- a/reference/runkit7/constants.xml
+++ b/reference/runkit7/constants.xml
@@ -79,7 +79,7 @@
     <listitem>
      <simpara>
      <function>runkit7_import</function> flag representing
-     a bitwise OR of the <constant>RUNKIT7_IMPORT_CLASS_*</constant>
+     a bitwise OR of the <constant>RUNKIT7_IMPORT_CLASS_<replaceable>*</replaceable></constant>
      constants.
      </simpara>
     </listitem>

--- a/reference/runkit7/functions/runkit7-constant-add.xml
+++ b/reference/runkit7/functions/runkit7-constant-add.xml
@@ -44,7 +44,7 @@
     <listitem>
      <para>
       Visibility of the constant, for class constants. Public by default.
-      One of the <constant>RUNKIT7_ACC_*</constant> constants.
+      One of the <constant>RUNKIT7_ACC_<replaceable>*</replaceable></constant> constants.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/runkit7/functions/runkit7-constant-redefine.xml
+++ b/reference/runkit7/functions/runkit7-constant-redefine.xml
@@ -46,7 +46,7 @@
      <para>
       The new visibility of the constant, for class constants.
       Unchanged by default.
-      One of the <constant>RUNKIT7_ACC_*</constant> constants.
+      One of the <constant>RUNKIT7_ACC_<replaceable>*</replaceable></constant> constants.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/snmp/snmp.xml
+++ b/reference/snmp/snmp.xml
@@ -251,7 +251,7 @@
      <listitem>
       <para>
        Controls which failures will raise SNMPException instead of
-       warning. Use bitwise OR'ed <constant>SNMP::ERRNO_*</constant> constants.
+       warning. Use bitwise OR'ed <constant>SNMP::ERRNO_<replaceable>*</replaceable></constant> constants.
        By default all SNMP exceptions are disabled.
       </para>
      </listitem>

--- a/reference/stream/functions/stream-notification-callback.xml
+++ b/reference/stream/functions/stream-notification-callback.xml
@@ -39,7 +39,7 @@
      <term><parameter>notification_code</parameter></term>
      <listitem>
       <para>
-       One of the <constant>STREAM_NOTIFY_*</constant> notification constants.
+       One of the <constant>STREAM_NOTIFY_<replaceable>*</replaceable></constant> notification constants.
       </para>
      </listitem>
     </varlistentry>
@@ -47,7 +47,7 @@
      <term><parameter>severity</parameter></term>
      <listitem>
       <para>
-       One of the <constant>STREAM_NOTIFY_SEVERITY_*</constant> notification constants.
+       One of the <constant>STREAM_NOTIFY_SEVERITY_<replaceable>*</replaceable></constant> notification constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zip/ziparchive/addglob.xml
+++ b/reference/zip/ziparchive/addglob.xml
@@ -92,8 +92,8 @@
          <literal>"comp_method"</literal>
         </para>
         <para>
-         Compression method, one of the <constant>ZipArchive::CM_*</constant>
-         constants, see <link linkend="zip.constants">ZIP constants</link> page.
+         Compression method, one of the <constant>ZipArchive::CM_<replaceable>*</replaceable></constant>
+         constants.
         </para>
        </listitem>
        <listitem>
@@ -109,8 +109,8 @@
          <literal>"enc_method"</literal>
         </para>
         <para>
-         Encryption method, one of the <constant>ZipArchive::EM_*</constant>
-         constants, see <link linkend="zip.constants">ZIP constants</link> page.
+         Encryption method, one of the <constant>ZipArchive::EM_<replaceable>*</replaceable></constant>
+         constants.
         </para>
        </listitem>
        <listitem>

--- a/reference/zip/ziparchive/iscompressionmethoddupported.xml
+++ b/reference/zip/ziparchive/iscompressionmethoddupported.xml
@@ -27,7 +27,7 @@
      <listitem>
       <para>
        The compression method, one of the
-       <constant>ZipArchive::CM_*</constant> constants.
+       <constant>ZipArchive::CM_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zip/ziparchive/isencryptionmethoddupported.xml
+++ b/reference/zip/ziparchive/isencryptionmethoddupported.xml
@@ -27,7 +27,7 @@
      <listitem>
       <para>
        The encryption method, one of the
-       <constant>ZipArchive::EM_*</constant> constants.
+       <constant>ZipArchive::EM_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zip/ziparchive/setcompressionindex.xml
+++ b/reference/zip/ziparchive/setcompressionindex.xml
@@ -34,7 +34,7 @@
      <listitem>
       <para>
        The compression method, one of the
-       <constant>ZipArchive::CM_*</constant> constants.
+       <constant>ZipArchive::CM_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zip/ziparchive/setcompressionname.xml
+++ b/reference/zip/ziparchive/setcompressionname.xml
@@ -34,7 +34,7 @@
      <listitem>
       <para>
        The compression method, one of the
-       <constant>ZipArchive::CM_*</constant> constants.
+       <constant>ZipArchive::CM_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zlib/functions/deflate_init.xml
+++ b/reference/zlib/functions/deflate_init.xml
@@ -39,7 +39,7 @@
     <term><parameter>encoding</parameter></term>
     <listitem>
      <para>
-      One of the <constant>ZLIB_ENCODING_*</constant> constants.
+      One of the <constant>ZLIB_ENCODING_<replaceable>*</replaceable></constant> constants.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/zlib/functions/gzcompress.xml
+++ b/reference/zlib/functions/gzcompress.xml
@@ -58,7 +58,7 @@
      <term><parameter>encoding</parameter></term>
      <listitem>
       <para>
-       One of <constant>ZLIB_ENCODING_*</constant> constants.
+       One of <constant>ZLIB_ENCODING_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zlib/functions/gzdeflate.xml
+++ b/reference/zlib/functions/gzdeflate.xml
@@ -49,7 +49,7 @@
      <term><parameter>encoding</parameter></term>
      <listitem>
       <para>
-       One of <constant>ZLIB_ENCODING_*</constant> constants.
+       One of <constant>ZLIB_ENCODING_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zlib/functions/inflate_init.xml
+++ b/reference/zlib/functions/inflate_init.xml
@@ -26,7 +26,7 @@
     <term><parameter>encoding</parameter></term>
     <listitem>
      <para>
-      One of the <constant>ZLIB_ENCODING_*</constant> constants.
+      One of the <constant>ZLIB_ENCODING_<replaceable>*</replaceable></constant> constants.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/zmq/zmqcontext/getopt.xml
+++ b/reference/zmq/zmqcontext/getopt.xml
@@ -27,7 +27,7 @@
      <listitem>
       <para>
        An integer representing the option.
-       See the <constant>ZMQ::CTXOPT_*</constant> constants.
+       See the <constant>ZMQ::CTXOPT_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zmq/zmqcontext/getsocket.xml
+++ b/reference/zmq/zmqcontext/getsocket.xml
@@ -30,7 +30,7 @@
      <term><parameter>type</parameter></term>
      <listitem>
       <para>
-       <constant>ZMQ::SOCKET_*</constant> constant to specify socket type.
+       <constant>ZMQ::SOCKET_<replaceable>*</replaceable></constant> constant to specify socket type.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zmq/zmqcontext/setopt.xml
+++ b/reference/zmq/zmqcontext/setopt.xml
@@ -28,7 +28,7 @@
      <term><parameter>key</parameter></term>
      <listitem>
       <para>
-       One of the <constant>ZMQ::CTXOPT_*</constant> constants.
+       One of the <constant>ZMQ::CTXOPT_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zmq/zmqsocket/construct.xml
+++ b/reference/zmq/zmqsocket/construct.xml
@@ -40,7 +40,7 @@
      <term><parameter>type</parameter></term>
      <listitem>
       <para>
-       The socket type. See <constant>ZMQ::SOCKET_*</constant> constants.
+       The socket type. See <constant>ZMQ::SOCKET_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zmq/zmqsocket/getsockettype.xml
+++ b/reference/zmq/zmqsocket/getsockettype.xml
@@ -27,7 +27,7 @@
   &reftitle.returnvalues;
   <para>
    Returns an integer representing the socket type. The integer can be compared against
-   <constant>ZMQ::SOCKET_*</constant> constants.
+   <constant>ZMQ::SOCKET_<replaceable>*</replaceable></constant> constants.
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqsocket/getsockopt.xml
+++ b/reference/zmq/zmqsocket/getsockopt.xml
@@ -27,7 +27,7 @@
      <listitem>
       <para>
        An integer representing the option.
-       See the <constant>ZMQ::SOCKOPT_*</constant> constants.
+       See the <constant>ZMQ::SOCKOPT_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zmq/zmqsocket/recv.xml
+++ b/reference/zmq/zmqsocket/recv.xml
@@ -30,7 +30,7 @@
      <listitem>
       <para>
        Pass mode flags to receive multipart messages or non-blocking operation. 
-       See <constant>ZMQ::MODE_*</constant> constants.
+       See <constant>ZMQ::MODE_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zmq/zmqsocket/recvmulti.xml
+++ b/reference/zmq/zmqsocket/recvmulti.xml
@@ -28,7 +28,7 @@
      <listitem>
       <para>
        Pass mode flags to receive multipart messages or non-blocking operation. 
-       See <constant>ZMQ::MODE_*</constant> constants.
+       See <constant>ZMQ::MODE_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zmq/zmqsocket/send.xml
+++ b/reference/zmq/zmqsocket/send.xml
@@ -36,7 +36,7 @@
      <listitem>
       <para>
        Pass mode flags to receive multipart messages or non-blocking operation. 
-       See <constant>ZMQ::MODE_*</constant> constants.
+       See <constant>ZMQ::MODE_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zmq/zmqsocket/sendmulti.xml
+++ b/reference/zmq/zmqsocket/sendmulti.xml
@@ -36,7 +36,7 @@
      <listitem>
       <para>
        Pass mode flags to receive multipart messages or non-blocking operation. 
-       See <constant>ZMQ::MODE_*</constant> constants.
+       See <constant>ZMQ::MODE_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zmq/zmqsocket/setsockopt.xml
+++ b/reference/zmq/zmqsocket/setsockopt.xml
@@ -28,7 +28,7 @@
      <term><parameter>key</parameter></term>
      <listitem>
       <para>
-       One of the <constant>ZMQ::SOCKOPT_*</constant> constants.
+       One of the <constant>ZMQ::SOCKOPT_<replaceable>*</replaceable></constant> constants.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
This PR adds `<replaceable>` tags to constants that are already using a `<constant>` tag and an `*` to mark the replaceable part of the constant.