### PR TITLE
Add cURL version availability info to CURLSHOPT constants

### DIFF
--- a/reference/curl/constants_curl_share_setopt.xml
+++ b/reference/curl/constants_curl_share_setopt.xml
@@ -9,7 +9,7 @@
   <listitem>
    <simpara>
     Shares/unshares the connection cache.
-    Available as of PHP 7.3.0 and cURL 7.10.0
+    Available as of PHP 7.3.0 and cURL 7.10.3.
    </simpara>
   </listitem>
  </varlistentry>
@@ -21,6 +21,7 @@
   <listitem>
    <simpara>
     Shares/unshares cookie data.
+    Available as of cURL 7.10.3.
    </simpara>
   </listitem>
  </varlistentry>
@@ -34,6 +35,7 @@
     Shares/unshares DNS cache.
     Note that when you use cURL multi handles,
     all handles added to the same multi handle will share DNS cache by default.
+    Available as of cURL 7.10.3.
    </simpara>
   </listitem>
  </varlistentry>
@@ -45,7 +47,7 @@
   <listitem>
    <simpara>
     Shares/unshares the Public Suffix List.
-    Available as of PHP 7.3.0 and cURL 7.61.0
+    Available as of PHP 7.3.0 and cURL 7.61.0.
    </simpara>
   </listitem>
  </varlistentry>
@@ -59,6 +61,7 @@
     Shares/unshares SSL session IDs, reducing the time spent
     on the SSL handshake when reconnecting to the same server.
     Note that SSL session IDs are reused within the same handle by default.
+    Available as of cURL 7.10.3.
    </simpara>
   </listitem>
  </varlistentry>
@@ -69,7 +72,7 @@
   </term>
   <listitem>
    <simpara>
-
+    Available as of cURL 7.10.3.
    </simpara>
   </listitem>
  </varlistentry>
@@ -81,6 +84,7 @@
   <listitem>
    <simpara>
     Specifies a type of data that should be shared.
+    Available as of cURL 7.10.3.
    </simpara>
   </listitem>
  </varlistentry>
@@ -92,6 +96,7 @@
   <listitem>
    <simpara>
     Specifies a type of data that will be no longer shared.
+    Available as of cURL 7.10.3.
    </simpara>
   </listitem>
  </varlistentry>


### PR DESCRIPTION
Please note that `CURLSHOPT_NONE` is one of those constants that don't actually do anything but are the first element in a `c` enum in `cURL`. There are also a few `_LAST` and `_LASTONE` constants in `doc-en` that also don't do anything but are the last element of such enums. 