### PR TITLE
Update migration84/new-features.xml: readfile -> readline

### DIFF
--- a/appendices/migration84/new-features.xml
+++ b/appendices/migration84/new-features.xml
@@ -455,8 +455,8 @@ $object = $reflector->newLazyGhost($initializer);
   </simpara>
  </sect2>
 
- <sect2 xml:id="migration84.new-features.readfile">
-  <title>Readfile</title>
+ <sect2 xml:id="migration84.new-features.readline">
+  <title>Readline</title>
 
   <simpara>
    Added ability to change the <literal>.php_history</literal> path through


### PR DESCRIPTION
The headline of this change is "Readfile", but it should be "Readline".

> Added ability to change the `.php_history` path through   the `PHP_HISTFILE` environment variable.

The change is related to REPL (read-eval-print loop) mode, which requires readline extension.