### PR TITLE
Simplify pm.start_servers default

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -421,8 +421,7 @@
        <para>
         The number of child processes created on startup.
         Used only when <literal>pm</literal> is set to <literal>dynamic</literal>.
-        Default Value: min_spare_servers + (max_spare_servers -
-        min_spare_servers) / 2.
+        Default Value: (min_spare_servers + max_spare_servers) / 2.
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
This mirrors the simplification that has already been done [here](https://github.com/php/php-src/commit/482784284a2e3869b500b25b41ff729143d61c79#diff-9b8e23037e5096da2b8c638e594d879bd09d61bb4acca3c80d4dc68469130ed0R117).