### PR TITLE
Fix #4054 - Missing backwards-incompatible change in PHP 8

### DIFF
--- a/reference/exec/functions/proc-open.xml
+++ b/reference/exec/functions/proc-open.xml
@@ -200,6 +200,15 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.0.0</entry>
+       <entry>
+        On Windows, program execution functions like <function>proc_open</function>, <function>exec</function>, and <function>popen</function>
+        that use the shell now consistently execute <literal>%comspec% /s /c "$commandline"</literal>, 
+        which has the same effect as executing <literal>$commandline</literal> without additional quotes.
+        This change can affect scripts that relied on the previous behavior.
+       </entry>
+      </row>
+      <row>
        <entry>7.4.4</entry>
        <entry>
         Added the <literal>create_new_console</literal> option to the


### PR DESCRIPTION
Updated changelog in docs for `proc_open()` to document the change in behavior for Windows systems in PHP 8.0 - program execution functions (`proc_open()`, `exec()`, `popen()`, etc.) now use `%comspec% /s /c "$commandline"`