### PR TITLE
PHP 8.4: trigger_error() updates

### DIFF
--- a/reference/errorfunc/functions/trigger-error.xml
+++ b/reference/errorfunc/functions/trigger-error.xml
@@ -46,6 +46,12 @@
        The designated error type for this error. It only works with the <constant>E_USER_<replaceable>*</replaceable></constant>
        family of constants, and will default to <constant>E_USER_NOTICE</constant>.
       </para>
+      <warning>
+       Passing <constant>E_USER_ERROR</constant> as the
+       <parameter>error_level</parameter> is now deprecated.
+       Throw an <exceptionname>Exception</exceptionname> or
+       call <function>exit</function> instead.
+      </warning>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -81,6 +87,22 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Passing <constant>E_USER_ERROR</constant> as the
+       <parameter>error_level</parameter> is now deprecated.
+       Throw an <exceptionname>Exception</exceptionname> or
+       call <function>exit</function> instead.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       The function now has a return type of <type>true</type>
+       instead of <type>bool</type>.
+      </entry>
+     </row>
+     <row>
       <entry>8.0.0</entry>
       <entry>
        The function now throws a <classname>ValueError</classname> if an invalid
@@ -103,8 +125,8 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-if ($divisor == 0) {
-    trigger_error("Cannot divide by zero", E_USER_ERROR);
+if (is_nan($divisor)) {
+    trigger_error("Cannot divide by NAN", E_USER_WARNING);
 }
 ?>
 ]]>
@@ -132,6 +154,7 @@ if ($divisor == 0) {
     <member><function>set_error_handler</function></member>
     <member><function>restore_error_handler</function></member>
     <member>The <link linkend="errorfunc.constants">error level constants</link></member>
+    <member>The <classname>Deprecated</classname> attribute</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/errorfunc/functions/trigger-error.xml
+++ b/reference/errorfunc/functions/trigger-error.xml
@@ -125,9 +125,11 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-if (is_nan($divisor)) {
-    trigger_error("Cannot divide by NAN", E_USER_WARNING);
+$password = $_POST['password'] ?? '';
+if ($password === '') {
+  trigger_error("Using an empty password is unsafe", E_USER_WARNING);
 }
+$hash = password_hash($password, PASSWORD_DEFAULT);
 ?>
 ]]>
     </programlisting>

--- a/reference/errorfunc/functions/trigger-error.xml
+++ b/reference/errorfunc/functions/trigger-error.xml
@@ -47,10 +47,12 @@
        family of constants, and will default to <constant>E_USER_NOTICE</constant>.
       </para>
       <warning>
-       Passing <constant>E_USER_ERROR</constant> as the
-       <parameter>error_level</parameter> is now deprecated.
-       Throw an <exceptionname>Exception</exceptionname> or
-       call <function>exit</function> instead.
+       <simpara>
+        Passing <constant>E_USER_ERROR</constant> as the
+        <parameter>error_level</parameter> is now deprecated.
+        Throw an <exceptionname>Exception</exceptionname> or
+        call <function>exit</function> instead.
+       </simpara>
       </warning>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Turns out the return type is already correct.

I have no idea for a "good" example, I was going to go for something to use `E_USER_DEPRECATED` but realised the new `Deprecated` attribute is better suited for this.

Maybe @TimWolla has opinions on how to format it for a See Also section?