### PR TITLE
Fix Apache functions return types to reflect the stubs

### DIFF
--- a/reference/apache/functions/apache-request-headers.xml
+++ b/reference/apache/functions/apache-request-headers.xml
@@ -27,8 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An associative array of all the HTTP headers in the current request, or
-   &false; on failure.
+   An associative array of all the HTTP headers in the current request.
   </para>
  </refsect1>
 

--- a/reference/apache/functions/apache-response-headers.xml
+++ b/reference/apache/functions/apache-response-headers.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type class="union"><type>array</type><type>false</type></type><methodname>apache_response_headers</methodname>
+   <type>array</type><methodname>apache_response_headers</methodname>
    <void/>
   </methodsynopsis>
   <para>
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An array of all Apache response headers on success&return.falseforfailure;.
+   An array of all Apache response headers on success.
   </para>
  </refsect1>
  

--- a/reference/apache/functions/getallheaders.xml
+++ b/reference/apache/functions/getallheaders.xml
@@ -31,8 +31,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An associative array of all the HTTP headers in the current request, or
-   &false; on failure.
+   An associative array of all the HTTP headers in the current request.
   </para>
  </refsect1>
 


### PR DESCRIPTION
The stubs for Apache functions `apache_request_headers`, `getallheaders` and `apache_response_headers` are as follows:

```php
<?php

// https://github.com/php/php-src/blob/PHP-8.3.12/sapi/apache2handler/php_functions.stub.php
// https://github.com/php/php-src/blob/PHP-8.3.12/sapi/cgi/cgi_main.stub.php

function apache_request_headers(): array {}

/** @alias apache_request_headers */
function getallheaders(): array {}

function apache_response_headers(): array {}
```

However, the return types in the docs wrongly include `false` as a return type for those functions.  
There even are some discrepancies within the same page between the **Description** content and the **Return Values** section.

This PR aims to fix these inconsistencies.
