### PR TITLE
Group E_* constants in appendix

### DIFF
--- a/appendices/reserved.constants.core.xml
+++ b/appendices/reserved.constants.core.xml
@@ -496,174 +496,69 @@
     <constant>E_ERROR</constant>
     (<type>int</type>)
    </term>
-   <listitem>
-    <simpara>
-     <link linkend="errorfunc.constants">Error reporting constant</link>
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
    <term>
     <constant>E_WARNING</constant>
     (<type>int</type>)
    </term>
-   <listitem>
-    <simpara>
-     <link linkend="errorfunc.constants">Error reporting constant</link>
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
    <term>
     <constant>E_PARSE</constant>
     (<type>int</type>)
    </term>
-   <listitem>
-    <simpara>
-     <link linkend="errorfunc.constants">Error reporting constant</link>
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
    <term>
     <constant>E_NOTICE</constant>
     (<type>int</type>)
    </term>
-   <listitem>
-    <simpara>
-     <link linkend="errorfunc.constants">Error reporting constant</link>
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
    <term>
     <constant>E_CORE_ERROR</constant>
     (<type>int</type>)
    </term>
-   <listitem>
-    <simpara>
-     <link linkend="errorfunc.constants">Error reporting constant</link>
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
    <term>
     <constant>E_CORE_WARNING</constant>
     (<type>int</type>)
    </term>
-   <listitem>
-    <simpara>
-     <link linkend="errorfunc.constants">Error reporting constant</link>
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
    <term>
     <constant>E_COMPILE_ERROR</constant>
     (<type>int</type>)
    </term>
-   <listitem>
-    <simpara>
-     <link linkend="errorfunc.constants">Error reporting constant</link>
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
    <term>
     <constant>E_COMPILE_WARNING</constant>
     (<type>int</type>)
    </term>
-   <listitem>
-    <simpara>
-     <link linkend="errorfunc.constants">Error reporting constant</link>
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
    <term>
     <constant>E_USER_ERROR</constant>
     (<type>int</type>)
    </term>
-   <listitem>
-    <simpara>
-     <link linkend="errorfunc.constants">Error reporting constant</link>
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
    <term>
     <constant>E_USER_WARNING</constant>
     (<type>int</type>)
    </term>
-   <listitem>
-    <simpara>
-     <link linkend="errorfunc.constants">Error reporting constant</link>
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
    <term>
     <constant>E_USER_NOTICE</constant>
     (<type>int</type>)
    </term>
-   <listitem>
-    <simpara>
-     <link linkend="errorfunc.constants">Error reporting constant</link>
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
    <term>
     <constant>E_RECOVERABLE_ERROR</constant>
     (<type>int</type>)
    </term>
-   <listitem>
-    <simpara>
-     <link linkend="errorfunc.constants">Error reporting constant</link>.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
    <term>
     <constant>E_DEPRECATED</constant>
     (<type>int</type>)
    </term>
-   <listitem>
-    <simpara>
-     <link linkend="errorfunc.constants">Error reporting constant</link>.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
    <term>
     <constant>E_USER_DEPRECATED</constant>
     (<type>int</type>)
    </term>
-   <listitem>
-    <simpara>
-     <link linkend="errorfunc.constants">Error reporting constant</link>.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
    <term>
     <constant>E_ALL</constant>
     (<type>int</type>)
    </term>
-   <listitem>
-    <simpara>
-     <link linkend="errorfunc.constants">Error reporting constant</link>
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
    <term>
     <constant>E_STRICT</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     <link linkend="errorfunc.constants">Error reporting constant</link>
+     <link linkend="errorfunc.constants">Error reporting constants</link>
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
Listing all `E_*` constants in the appendix appears to be reasonable, but having a dedicated `varlistentry` for each seems to be overkill.

---

![e-consts](https://github.com/user-attachments/assets/354354fd-d480-496a-add7-83a07b882d84)
