### PR TITLE
POSIX: Fix typo in constant

### DIFF
--- a/reference/posix/constants.xml
+++ b/reference/posix/constants.xml
@@ -573,9 +573,9 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.posix-sc-clk-tk">
+   <varlistentry xml:id="constant.posix-sc-clk-tck">
     <term>
-     <constant>POSIX_SC_CLK_TK</constant>
+     <constant>POSIX_SC_CLK_TCK</constant>
      (<type>int</type>)
     </term>
     <listitem>


### PR DESCRIPTION
Seems like a typo?

Also, the `POSIX_PC_SYMLINK_MAX` from PHP 8.3 seems to be undocumented, and the `POSIX_SC_OPEN_MAX` which has existed since I don't know when is also not documented. Could you document those @devnexen?