### PR TITLE
PHP 8.4: Document type widening of mode param of round()

### DIFF
--- a/reference/math/functions/max.xml
+++ b/reference/math/functions/max.xml
@@ -61,7 +61,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>value_array</parameter></term>
+     <term><parameter>value</parameter></term>
      <listitem>
       <para>
        An array containing the values.

--- a/reference/math/functions/min.xml
+++ b/reference/math/functions/min.xml
@@ -61,7 +61,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>value_array</parameter></term>
+     <term><parameter>value</parameter></term>
      <listitem>
       <para>
        An array containing the values.

--- a/reference/math/functions/round.xml
+++ b/reference/math/functions/round.xml
@@ -11,7 +11,7 @@
    <type>float</type><methodname>round</methodname>
    <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>num</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>precision</parameter><initializer>0</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>PHP_ROUND_HALF_UP</constant></initializer></methodparam>
+    <methodparam choice="opt"><type class="union"><type>int</type><type>RoundingMode</type></type><parameter>mode</parameter><initializer><constant>RoundingMode::HalfAwayFromZero</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
    Returns the rounded value of <parameter>num</parameter> to
@@ -136,6 +136,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <parameter>mode</parameter> now accepts values from the
+       <enumname>RoundingMode</enumname> enum.
+       The default value is now <enumidentifier>RoundingMode::HalfAwayFromZero</enumidentifier>.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>


### PR DESCRIPTION
@haszi not sure if I should use a `<constant>` tag here for linking, but `<enumidentifier>` is not allowed... I could use `<code>`, however.