### PR TITLE
property-hooks.xml Replace 'all' with 'non-static', as not all + typos

### DIFF
--- a/language/oop5/property-hooks.xml
+++ b/language/oop5/property-hooks.xml
@@ -25,8 +25,9 @@
   </listitem>
  </orderedlist>
  <simpara>
-  There are two hooks available on typed or untyped non-static properties: <literal>get</literal> and <literal>set</literal>.
+  There are two hooks available on non-static properties: <literal>get</literal> and <literal>set</literal>.
   They allow overriding the read and write behavior of a property, respectively.
+  Hooks are available for both typed and untyped properties.
  </simpara>
  <simpara>
   A property may be "backed" or "virtual".

--- a/language/oop5/property-hooks.xml
+++ b/language/oop5/property-hooks.xml
@@ -228,7 +228,7 @@ class Example
   </example>
   <simpara>
    For virtual properties, if a hook is omitted then that operation does
-   not exist and trying to use it wil produce an error.
+   not exist and trying to use it will produce an error.
    Virtual properties take up no memory space in an object.
    Virtual properties are suited for "derived" properties,
    such as those that are the combination of two other properties.

--- a/language/oop5/property-hooks.xml
+++ b/language/oop5/property-hooks.xml
@@ -25,7 +25,7 @@
   </listitem>
  </orderedlist>
  <simpara>
-  There are two hooks available on all properties: <literal>get</literal> and <literal>set</literal>.
+  There are two hooks available on typed or untyped non-static properties: <literal>get</literal> and <literal>set</literal>.
   They allow overriding the read and write behavior of a property, respectively.
  </simpara>
  <simpara>

--- a/language/oop5/property-hooks.xml
+++ b/language/oop5/property-hooks.xml
@@ -95,7 +95,7 @@ print $example->foo;
   </simpara>
   <simpara>
    At least one of the hooks references <code>$this->foo</code>, the property itself.
-   That means the property wll be "backed".
+   That means the property wll be "backed."
    When calling <code>$example->foo = 'changed'</code>,
    the provided string will be first cast to lowercase, then saved to the backing value.
    When reading from the property, the previously saved value may conditionally be appended

--- a/language/oop5/property-hooks.xml
+++ b/language/oop5/property-hooks.xml
@@ -95,7 +95,7 @@ print $example->foo;
   </simpara>
   <simpara>
    At least one of the hooks references <code>$this->foo</code>, the property itself.
-   That means the property wll be "backed."
+   That means the property wll be "backed".
    When calling <code>$example->foo = 'changed'</code>,
    the provided string will be first cast to lowercase, then saved to the backing value.
    When reading from the property, the previously saved value may conditionally be appended

--- a/language/oop5/property-hooks.xml
+++ b/language/oop5/property-hooks.xml
@@ -500,16 +500,16 @@ class CaseFoldingStrings extends Strings
    just like any other normal read/write action.
   </simpara>
   <simplelist>
-   <member><function>var_dump()</function>: Use raw value</member>
-   <member><function>serialize()</function>: Use raw value</member>
-   <member><function>unserialize()</function>: Use raw value</member>
+   <member><function>var_dump</function>: Use raw value</member>
+   <member><function>serialize</function>: Use raw value</member>
+   <member><function>unserialize</function>: Use raw value</member>
    <member><code>__serialize()</code>/<code>__unserialize()</code>: Custom logic, uses get/set hook</member>
    <member>Array casting: Use raw value</member>
-   <member><function>var_export()</function>: Use get hook</member>
-   <member><function>json_encode()</function>: Use get hook</member>
+   <member><function>var_export</function>: Use get hook</member>
+   <member><function>json_encode</function>: Use get hook</member>
    <member>JsonSerializable: Custom logic, uses get hook</member>
-   <member><function>get_object_vars()</function>: Use get hook</member>
-   <member><function>get_mangled_object_vars()</function>: Use raw value</member>
+   <member><function>get_object_vars</function>: Use get hook</member>
+   <member><function>get_mangled_object_vars</function>: Use raw value</member>
   </simplelist>
  </sect2>
 </sect1>


### PR DESCRIPTION
The word `all` seems to deceive the reader a little :)

How about adding some specifics about which properties are allowed to declare hooks for?