### PR TITLE
Update changelog for DOMNode

### DIFF
--- a/reference/dom/domnode.xml
+++ b/reference/dom/domnode.xml
@@ -405,6 +405,33 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Method <methodname>DOMNode::compareDocumentPosition</methodname> has
+        been added.
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Constants <constant>DOMNode::DOCUMENT_POSITION_DISCONNECTED</constant>,
+        <constant>DOMNode::DOCUMENT_POSITION_PRECEDING</constant>,
+        <constant>DOMNode::DOCUMENT_POSITION_FOLLOWING</constant>,
+        <constant>DOMNode::DOCUMENT_POSITION_CONTAINS</constant>,
+        <constant>DOMNode::DOCUMENT_POSITION_CONTAINED_BY</constant>,
+         and
+        <constant>DOMNode::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC</constant>
+        have been added.
+       </entry>
+      </row>
+      <row>
+       <entry>8.3.0</entry>
+       <entry>
+        Methods <methodname>DOMNode::contains</methodname>, and
+        <methodname>DOMNode::isEqualNode</methodname> have been added.
+       </entry>
+      </row>
+      <row>
        <entry>8.3.0</entry>
        <entry>
         Properties <property>DOMNode::$parentElement</property>, and


### PR DESCRIPTION
Includes missing 8.3 and 8.4 changes.

Closes & replaces GH-2893.