### PR TITLE
[skip-revcheck] Fill xi:fallback to avoid 'variablelist incomplete' in some translations

### DIFF
--- a/reference/spl/splfileobject/setcsvcontrol.xml
+++ b/reference/spl/splfileobject/setcsvcontrol.xml
@@ -24,7 +24,7 @@
   &reftitle.parameters;
   <variablelist>
    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
-    <xi:fallback/>
+    <xi:fallback><varlistentry><term>></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
    </xi:include>
    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)">
     <xi:fallback/>


### PR DESCRIPTION
Fix `tr` build. Also remove an error on `it`.