### PR TITLE
ext/bcmath - Fixed because the behavior change when dividing by 0 from PHP 8.0 was not reflected.

### DIFF
--- a/reference/bc/functions/bcdiv.xml
+++ b/reference/bc/functions/bcdiv.xml
@@ -55,16 +55,16 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   This function throws a <classname>ValueError</classname> in the following cases:
+   This function throws a <exceptionname>ValueError</exceptionname> in the following cases:
    <simplelist>
     <member><parameter>num1</parameter> or <parameter>num2</parameter> is not a well-formed BCMath numeric string</member>
     <member><parameter>scale</parameter> is outside the valid range</member>
    </simplelist>
   </para>
-  <para>
-   This function throws a <classname>DivisionByZeroError</classname> exception if <parameter>num2</parameter>
+  <simpara>
+   This function throws a <exceptionname>DivisionByZeroError</exceptionname> exception if <parameter>num2</parameter>
    is <literal>0</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -87,7 +87,7 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       Dividing by 0 now throws a <classname>DivisionByZeroError</classname> exception instead of returning null.
+       Dividing by 0 now throws a <exceptionname>DivisionByZeroError</exceptionname> exception instead of returning null.
       </entry>
      </row>
     </tbody>

--- a/reference/bc/functions/bcdiv.xml
+++ b/reference/bc/functions/bcdiv.xml
@@ -48,11 +48,25 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the result of the division as a string, or &null; if 
-   <parameter>num2</parameter> is <literal>0</literal>.
+   Returns the result of the division as a string.
   </para>
  </refsect1>
- 
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   This function throws a <classname>ValueError</classname> in the following cases:
+   <simplelist>
+    <member><parameter>num1</parameter> or <parameter>num2</parameter> is not a well-formed BCMath numeric string</member>
+    <member><parameter>scale</parameter> is outside the valid range</member>
+   </simplelist>
+  </para>
+  <para>
+   This function throws a <classname>DivisionByZeroError</classname> exception if <parameter>num2</parameter>
+   is <literal>0</literal>.
+  </para>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -68,6 +82,12 @@
       <entry>8.0.0</entry>
       <entry>
        <parameter>scale</parameter> is now nullable.
+      </entry>
+     </row>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       Dividing by 0 now throws a <classname>DivisionByZeroError</classname> exception instead of returning null.
       </entry>
      </row>
     </tbody>

--- a/reference/bc/functions/bcmod.xml
+++ b/reference/bc/functions/bcmod.xml
@@ -57,16 +57,16 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   This function throws a <classname>ValueError</classname> in the following cases:
+   This function throws a <exceptionname>ValueError</exceptionname> in the following cases:
    <simplelist>
     <member><parameter>num1</parameter> or <parameter>num2</parameter> is not a well-formed BCMath numeric string</member>
     <member><parameter>scale</parameter> is outside the valid range</member>
    </simplelist>
   </para>
-  <para>
-   This function throws a <classname>DivisionByZeroError</classname> exception if <parameter>num2</parameter>
+  <simpara>
+   This function throws a <exceptionname>DivisionByZeroError</exceptionname> exception if <parameter>num2</parameter>
    is <literal>0</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog"><!-- {{{ -->
@@ -89,7 +89,7 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       Dividing by 0 now throws a <classname>DivisionByZeroError</classname> exception instead of returning null.
+       Dividing by 0 now throws a <exceptionname>DivisionByZeroError</exceptionname> exception instead of returning null.
       </entry>
      </row>
      <row>

--- a/reference/bc/functions/bcmod.xml
+++ b/reference/bc/functions/bcmod.xml
@@ -42,6 +42,7 @@
       </para>
      </listitem>
     </varlistentry>
+    &bc.scale.description;
    </variablelist>
   </para>
  </refsect1>
@@ -49,11 +50,25 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the modulus as a string, or &null; if 
-   <parameter>num2</parameter> is <literal>0</literal>.
+   Returns the modulus as a string.
   </para>
  </refsect1>
- 
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   This function throws a <classname>ValueError</classname> in the following cases:
+   <simplelist>
+    <member><parameter>num1</parameter> or <parameter>num2</parameter> is not a well-formed BCMath numeric string</member>
+    <member><parameter>scale</parameter> is outside the valid range</member>
+   </simplelist>
+  </para>
+  <para>
+   This function throws a <classname>DivisionByZeroError</classname> exception if <parameter>num2</parameter>
+   is <literal>0</literal>.
+  </para>
+ </refsect1>
+
  <refsect1 role="changelog"><!-- {{{ -->
   &reftitle.changelog;
   <informaltable>
@@ -69,6 +84,12 @@
       <entry>8.0.0</entry>
       <entry>
        <parameter>scale</parameter> is now nullable.
+      </entry>
+     </row>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       Dividing by 0 now throws a <classname>DivisionByZeroError</classname> exception instead of returning null.
       </entry>
      </row>
      <row>


### PR DESCRIPTION
about `bcdiv` and `bcmod`.

Also, since `bcmod` was missing the explanation of the scale parameter, I added it in passing.

It seems like some of the error/exception items can be shared, but other functions are also involved, so I'll do it all together later.