### PR TITLE
ext/bcmath - `bcpow`: Reflected the behavior change when division by 0 occurs.

### DIFF
--- a/reference/bc/functions/bcpow.xml
+++ b/reference/bc/functions/bcpow.xml
@@ -57,17 +57,17 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   This function throws a <classname>ValueError</classname> in the following cases:
+   This function throws a <exceptionname>ValueError</exceptionname> in the following cases:
    <simplelist>
     <member><parameter>num</parameter> or <parameter>exponent</parameter> is not a well-formed BCMath numeric string</member>
     <member><parameter>scale</parameter> is outside the valid range</member>
     <member><parameter>exponent</parameter> has a fractional part</member>
    </simplelist>
   </para>
-  <para>
-   This function throws a <classname>DivisionByZeroError</classname> exception if <parameter>num</parameter>
+  <simpara>
+   This function throws a <exceptionname>DivisionByZeroError</exceptionname> exception if <parameter>num</parameter>
    is <literal>0</literal> and <parameter>exponent</parameter> is a negative value.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog"><!-- {{{ -->
@@ -84,14 +84,14 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Negative powers of 0 previously returned 0, but now throw a <classname>DivisionByZeroError</classname>
+       Negative powers of 0 previously returned 0, but now throw a <exceptionname>DivisionByZeroError</exceptionname>
        exception.
       </entry>
      </row>
      <row>
       <entry>8.0.0</entry>
       <entry>
-       When <parameter>exponent</parameter> has a fractional part, it now throws a <classname>ValueError</classname>
+       When <parameter>exponent</parameter> has a fractional part, it now throws a <exceptionname>ValueError</exceptionname>
        instead of truncating.
       </entry>
      </row>

--- a/reference/bc/functions/bcpow.xml
+++ b/reference/bc/functions/bcpow.xml
@@ -36,7 +36,7 @@
      <term><parameter>exponent</parameter></term>
      <listitem>
       <para>
-       The exponent, as a string. If the exponent is non-integral, it is truncated.
+       The exponent, as a string. Must be a value with no fractional part.
        The valid range of the exponent is platform specific, but is at least
        <literal>-2147483648</literal> to <literal>2147483647</literal>.
       </para>
@@ -53,7 +53,23 @@
    Returns the result as a string.
   </para>
  </refsect1>
- 
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   This function throws a <classname>ValueError</classname> in the following cases:
+   <simplelist>
+    <member><parameter>num</parameter> or <parameter>exponent</parameter> is not a well-formed BCMath numeric string</member>
+    <member><parameter>scale</parameter> is outside the valid range</member>
+    <member><parameter>exponent</parameter> has a fractional part</member>
+   </simplelist>
+  </para>
+  <para>
+   This function throws a <classname>DivisionByZeroError</classname> exception if <parameter>num</parameter>
+   is <literal>0</literal> and <parameter>exponent</parameter> is a negative value.
+  </para>
+ </refsect1>
+
  <refsect1 role="changelog"><!-- {{{ -->
   &reftitle.changelog;
   <informaltable>
@@ -65,6 +81,20 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Negative powers of 0 previously returned 0, but now throw a <classname>DivisionByZeroError</classname>
+       exception.
+      </entry>
+     </row>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       When <parameter>exponent</parameter> has a fractional part, it now throws a <classname>ValueError</classname>
+       instead of truncating.
+      </entry>
+     </row>
      <row>
       <entry>7.3.0</entry>
       <entry>


### PR DESCRIPTION
Also, the explanation of the behavior when the second argument `exponent` has a fractional part was incorrect, so I fixed it.