### PR TITLE
PHP 8.4: Add changelog entry for typed constants in XMLReader

### DIFF
--- a/reference/xmlreader/xmlreader.xml
+++ b/reference/xmlreader/xmlreader.xml
@@ -521,6 +521,29 @@
     </variablelist>
    </section>
   </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        The class constants are now typed.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
 <!-- }}} -->
  </partintro>
  


### PR DESCRIPTION
Their definitions were already typed, so this just adds the changelog entry.