### PR TITLE
abstract.xml Fix the error in the last example and CS

### DIFF
--- a/language/oop5/abstract.xml
+++ b/language/oop5/abstract.xml
@@ -106,13 +106,13 @@ FOO_ConcreteClass2
 
 abstract class AbstractClass
 {
-    // Our abstract method only needs to define the required arguments
+    // An abstract method only needs to define the required arguments
     abstract protected function prefixName($name);
 }
 
 class ConcreteClass extends AbstractClass
 {
-    // Our child class may define optional parameters which are not present in the parent's signature
+    // A child class may define optional parameters which are not present in the parent's signature
     public function prefixName($name, $separator = ".")
     {
         if ($name == "Pacman") {

--- a/language/oop5/abstract.xml
+++ b/language/oop5/abstract.xml
@@ -112,7 +112,7 @@ abstract class AbstractClass
 
 class ConcreteClass extends AbstractClass
 {
-    // Our child class may define optional parameters not in the parent's signature
+    // Our child class may define optional parameters which are not present in the parent's signature
     public function prefixName($name, $separator = ".")
     {
         if ($name == "Pacman") {

--- a/language/oop5/abstract.xml
+++ b/language/oop5/abstract.xml
@@ -36,47 +36,54 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+
 abstract class AbstractClass
 {
-    // Force Extending class to define this method
+    // Force extending class to define this method
     abstract protected function getValue();
     abstract protected function prefixValue($prefix);
 
     // Common method
-    public function printOut() {
+    public function printOut()
+    {
         print $this->getValue() . "\n";
     }
 }
 
 class ConcreteClass1 extends AbstractClass
 {
-    protected function getValue() {
+    protected function getValue()
+    {
         return "ConcreteClass1";
     }
 
-    public function prefixValue($prefix) {
+    public function prefixValue($prefix)
+    {
         return "{$prefix}ConcreteClass1";
     }
 }
 
 class ConcreteClass2 extends AbstractClass
 {
-    public function getValue() {
+    public function getValue()
+    {
         return "ConcreteClass2";
     }
 
-    public function prefixValue($prefix) {
+    public function prefixValue($prefix)
+    {
         return "{$prefix}ConcreteClass2";
     }
 }
 
-$class1 = new ConcreteClass1;
+$class1 = new ConcreteClass1();
 $class1->printOut();
-echo $class1->prefixValue('FOO_') ."\n";
+echo $class1->prefixValue('FOO_'), "\n";
 
-$class2 = new ConcreteClass2;
+$class2 = new ConcreteClass2();
 $class2->printOut();
-echo $class2->prefixValue('FOO_') ."\n";
+echo $class2->prefixValue('FOO_'), "\n";
+
 ?>
 ]]>
    </programlisting>
@@ -96,18 +103,18 @@ FOO_ConcreteClass2
     <programlisting role="php">
 <![CDATA[
 <?php
+
 abstract class AbstractClass
 {
     // Our abstract method only needs to define the required arguments
     abstract protected function prefixName($name);
-
 }
 
 class ConcreteClass extends AbstractClass
 {
-
-    // Our child class may define optional arguments not in the parent's signature
-    public function prefixName($name, $separator = ".") {
+    // Our child class may define optional parameters not in the parent's signature
+    public function prefixName($name, $separator = ".")
+    {
         if ($name == "Pacman") {
             $prefix = "Mr";
         } elseif ($name == "Pacwoman") {
@@ -115,13 +122,15 @@ class ConcreteClass extends AbstractClass
         } else {
             $prefix = "";
         }
+
         return "{$prefix}{$separator} {$name}";
     }
 }
 
-$class = new ConcreteClass;
+$class = new ConcreteClass();
 echo $class->prefixName("Pacman"), "\n";
 echo $class->prefixName("Pacwoman"), "\n";
+
 ?>
 ]]>
    </programlisting>
@@ -138,35 +147,44 @@ Mrs. Pacwoman
     <programlisting role="php">
 <![CDATA[
 <?php
+
 abstract class A
 {
-    // Extending classes must have a publicly-gettable property.
-    abstract public string $readable { get; }
+    // Extending classes must have a publicly-gettable property
+    abstract public string $readable {
+        get;
+    }
 
-    // Extending classes must have a protected- or public-writeable property.
-    abstract protected string $writeable { set; }
+    // Extending classes must have a protected- or public-writeable property
+    abstract protected string $writeable {
+        set;
+    }
 
-    // Extending classes must have a protected or public symmetric property.
-    abstract protected string $both { get; set; }
+    // Extending classes must have a protected or public symmetric property
+    abstract protected string $both {
+        get;
+        set;
+    }
 }
 
 class C extends A
 {
-    // This satisfies the requirement and also makes it settable, which is valid.
+    // This satisfies the requirement and also makes it settable, which is valid
     public string $readable;
 
-    // This would NOT satisfy the requirement, as it is not publicly readable.
+    // This would NOT satisfy the requirement, as it is not publicly readable
     protected string $readable;
 
     // This satisfies the requirement exactly, so is sufficient.
-    // It may only be written to, and only from protected scope.
+    // It may only be written to, and only from protected scope
     protected string $writeable {
         set => $value;
     }
 
-    // This expands the visibility from protected to public, which is fine.
+    // This expands the visibility from protected to public, which is fine
     public string $both;
 }
+
 ?>
 ]]>
    </programlisting>
@@ -180,15 +198,20 @@ class C extends A
    <programlisting role="php">
 <![CDATA[
 <?php
+
 abstract class A
 {
     // This provides a default (but overridable) set implementation,
-    // and requires child classes to provide a get implementation.
+    // and requires child classes to provide a get implementation
     abstract public string $foo {
         get;
-        set { $this->foo = $value };
+
+        set {
+            $this->foo = $value;
+        }
     }
 }
+
 ?>
  ]]>
    </programlisting>


### PR DESCRIPTION
The only thing I'm not sure about is whether one empty line is required between the hooks that contain the implementation. With an empty string, readability seems to be better.

If we imagine that hooks are the same as methods, then, perhaps, it is better to leave one empty string between the "methods" :)

In this case, it might be better to add one empty line between hooks without implementation