### PR TITLE
Fix typo in example code.

### DIFF
--- a/language/oop5/interfaces.xml
+++ b/language/oop5/interfaces.xml
@@ -164,7 +164,9 @@ class C2 implements I
     // the default behavior.
     public string $both {
         get => $this->all;
-        set => strtoupper($value);
+        set {
+            $this->all = strtoupper($value);
+        }
     }
 }
 ?>


### PR DESCRIPTION
I've also made the same correction in the original RFC, where this was copied from.