### PR TITLE
On Regexp manual page, revise wording, "described below" -> "described in this section"

### DIFF
--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -9,7 +9,7 @@
   <title>Introduction</title>
   <para>
    The syntax and semantics of the regular expressions
-   supported by PCRE are described below. Regular expressions are
+   supported by PCRE are described in this section. Regular expressions are
    also described in the Perl documentation and in a number of
    other books, some of which have copious examples. Jeffrey
    Friedl's "Mastering Regular Expressions", published by


### PR DESCRIPTION
https://www.php.net/manual/en/regexp.introduction.php

When viewing the page from php.net, "described below" is awkward phrasing when there is no content below from which is described.

I haven't proposed changes in a while to the manual, which is why I'm making this a PR instead of pushing directly.