### PR TITLE
Fix #4140: Return type for function gmp_setbit() and gmp_clrbit() are…

### DIFF
--- a/reference/gmp/functions/gmp-clrbit.xml
+++ b/reference/gmp/functions/gmp-clrbit.xml
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &gmp.return;
+   &return.void;
   </para>
  </refsect1>
 

--- a/reference/gmp/functions/gmp-setbit.xml
+++ b/reference/gmp/functions/gmp-setbit.xml
@@ -54,7 +54,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &gmp.return;
+   &return.void;
   </para>
  </refsect1>
 


### PR DESCRIPTION
… incorrectly documented as GMP