### PR TITLE
ext/bcmath: The `scale` parameter was made into a common component.

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2155,6 +2155,10 @@ of digits after the decimal place in the result. If omitted, it will default to 
 globally with the <function>bcscale</function> function, or fallback to <literal>0</literal> if
 this has not been set.</para></listitem></varlistentry>'>
 
+<!ENTITY bc.scale.parameter '<methodparam  xmlns="http://docbook.org/ns/docbook" choice="opt">
+<type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter>
+<initializer>&null;</initializer></methodparam>'>
+
 <!-- CTYPE Notes -->
 <!ENTITY note.ctype.parameter.integer '<note xmlns="http://docbook.org/ns/docbook"><para>
 If an <type>int</type> between -128 and 255 inclusive is provided, it is interpreted as

--- a/reference/bc/functions/bcadd.xml
+++ b/reference/bc/functions/bcadd.xml
@@ -12,7 +12,7 @@
    <type>string</type><methodname>bcadd</methodname>
    <methodparam><type>string</type><parameter>num1</parameter></methodparam>
    <methodparam><type>string</type><parameter>num2</parameter></methodparam>
-   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+   &bc.scale.parameter;
   </methodsynopsis>
   <para>
    Sums <parameter>num1</parameter> and

--- a/reference/bc/functions/bccomp.xml
+++ b/reference/bc/functions/bccomp.xml
@@ -12,7 +12,7 @@
    <type>int</type><methodname>bccomp</methodname>
    <methodparam><type>string</type><parameter>num1</parameter></methodparam>
    <methodparam><type>string</type><parameter>num2</parameter></methodparam>
-   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+   &bc.scale.parameter;
   </methodsynopsis>
   <para>
    Compares the <parameter>num1</parameter> to the

--- a/reference/bc/functions/bcdiv.xml
+++ b/reference/bc/functions/bcdiv.xml
@@ -12,7 +12,7 @@
    <type>string</type><methodname>bcdiv</methodname>
    <methodparam><type>string</type><parameter>num1</parameter></methodparam>
    <methodparam><type>string</type><parameter>num2</parameter></methodparam>
-   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+   &bc.scale.parameter;
   </methodsynopsis>
   <para>
    Divides the <parameter>num1</parameter> by the

--- a/reference/bc/functions/bcdivmod.xml
+++ b/reference/bc/functions/bcdivmod.xml
@@ -12,7 +12,7 @@
    <type>string</type><methodname>bcdivmod</methodname>
    <methodparam><type>string</type><parameter>num1</parameter></methodparam>
    <methodparam><type>string</type><parameter>num2</parameter></methodparam>
-   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+   &bc.scale.parameter;
   </methodsynopsis>
   <simpara>
    Get the quotient and remainder of dividing <parameter>num1</parameter> by

--- a/reference/bc/functions/bcmod.xml
+++ b/reference/bc/functions/bcmod.xml
@@ -12,7 +12,7 @@
    <type>string</type><methodname>bcmod</methodname>
    <methodparam><type>string</type><parameter>num1</parameter></methodparam>
    <methodparam><type>string</type><parameter>num2</parameter></methodparam>
-   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+   &bc.scale.parameter;
   </methodsynopsis>
   <para>
    Get the remainder of dividing <parameter>num1</parameter> by

--- a/reference/bc/functions/bcmul.xml
+++ b/reference/bc/functions/bcmul.xml
@@ -12,7 +12,7 @@
    <type>string</type><methodname>bcmul</methodname>
    <methodparam><type>string</type><parameter>num1</parameter></methodparam>
    <methodparam><type>string</type><parameter>num2</parameter></methodparam>
-   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+   &bc.scale.parameter;
   </methodsynopsis>
   <para>
    Multiply the <parameter>num1</parameter> by the

--- a/reference/bc/functions/bcpow.xml
+++ b/reference/bc/functions/bcpow.xml
@@ -12,7 +12,7 @@
    <type>string</type><methodname>bcpow</methodname>
    <methodparam><type>string</type><parameter>num</parameter></methodparam>
    <methodparam><type>string</type><parameter>exponent</parameter></methodparam>
-   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+   &bc.scale.parameter;
   </methodsynopsis>
   <para>
    Raise <parameter>num</parameter> to the power 

--- a/reference/bc/functions/bcpowmod.xml
+++ b/reference/bc/functions/bcpowmod.xml
@@ -13,7 +13,7 @@
    <methodparam><type>string</type><parameter>num</parameter></methodparam>
    <methodparam><type>string</type><parameter>exponent</parameter></methodparam>
    <methodparam><type>string</type><parameter>modulus</parameter></methodparam>
-   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+   &bc.scale.parameter;
   </methodsynopsis>
   <para>
    Use the fast-exponentiation method to raise 

--- a/reference/bc/functions/bcsqrt.xml
+++ b/reference/bc/functions/bcsqrt.xml
@@ -11,7 +11,7 @@
   <methodsynopsis>
    <type>string</type><methodname>bcsqrt</methodname>
    <methodparam><type>string</type><parameter>num</parameter></methodparam>
-   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+   &bc.scale.parameter;
   </methodsynopsis>
   <para>
    Return the square root of the <parameter>num</parameter>.

--- a/reference/bc/functions/bcsub.xml
+++ b/reference/bc/functions/bcsub.xml
@@ -12,7 +12,7 @@
    <type>string</type><methodname>bcsub</methodname>
    <methodparam><type>string</type><parameter>num1</parameter></methodparam>
    <methodparam><type>string</type><parameter>num2</parameter></methodparam>
-   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+   &bc.scale.parameter;
   </methodsynopsis>
   <para>
    Subtracts the <parameter>num2</parameter> from the


### PR DESCRIPTION
Since will also use it for `BcMath\Number`, will make it common.