### PR TITLE
Fix typo in iconv-strlen.xml

### DIFF
--- a/reference/iconv/functions/iconv-strlen.xml
+++ b/reference/iconv/functions/iconv-strlen.xml
@@ -18,7 +18,7 @@
    <function>iconv_strlen</function> counts the occurrences of characters
    in the given byte sequence <parameter>string</parameter> on the basis of
    the specified character set, the result of which is not necessarily
-   identical to the length of the string in byte.
+   identical to the length of the string in bytes.
   </para>
  </refsect1>
 


### PR DESCRIPTION
"length in byte" should read "length in bytes."