### PR TITLE
[PHP 8.3] Emphasize arbitrary expressions in static initializer

### DIFF
--- a/language/variables.xml
+++ b/language/variables.xml
@@ -533,10 +533,10 @@ function foo(){
     This means that static variables in methods now behave the same way as static properties.
    </para>
 
-   <para>
+   <simpara>
     As of PHP 8.3.0, static variables can be initialized with arbitrary expressions.
     This means that method calls, for example, can be used to initialize static variables.
-   </para>
+   </simpara>
 
    <example>
     <title>Usage of static Variables in Inherited Methods</title>

--- a/language/variables.xml
+++ b/language/variables.xml
@@ -533,6 +533,11 @@ function foo(){
     This means that static variables in methods now behave the same way as static properties.
    </para>
 
+   <para>
+    As of PHP 8.3.0, static variables can be initialized with arbitrary expressions.
+    This means that method calls, for example, can be used to initialize static variables.
+   </para>
+
    <example>
     <title>Usage of static Variables in Inherited Methods</title>
     <programlisting role="php">


### PR DESCRIPTION
Part of #2796

Already present, but I think this could be emphasized a bit rather than just having a code snippet that says it's correct without further explanation in example 9 of https://www.php.net/manual/en/language.variables.scope.php.