### PR TITLE
[PHP 8.3] Mention readonly props reset in `__clone()`

### DIFF
--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -336,7 +336,7 @@ $test->obj = new stdClass;
     <example>
      <title>Readonly properties and cloning</title>
      <programlisting role="php">
-      <![CDATA[
+<![CDATA[
 <?php
 class Test1 {
     public readonly ?string $prop;

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -330,6 +330,36 @@ $test->obj = new stdClass;
      </programlisting>
     </informalexample>
    </para>
+   <para>
+    As of PHP 8.3.0, readonly properties can be reinitialized when cloning an object
+    using the <link linkend="object.clone">__clone()</link> method.
+    <example>
+     <title>Readonly properties and cloning</title>
+     <programlisting role="php">
+      <![CDATA[
+<?php
+class Test1 {
+    public readonly ?string $prop;
+
+    public function __clone() {
+        $this->prop = null;
+    }
+
+    public function setProp(string $prop): void {
+        $this->prop = $prop;
+    }
+}
+
+$test1 = new Test1;
+$test1->setProp('foobar');
+
+$test2 = clone $test1;
+var_dump($test2->prop); // NULL
+?>
+]]>
+     </programlisting>
+    </example>
+   </para>
   </sect2>
 
   <sect2 xml:id="language.oop5.properties.dynamic-properties">


### PR DESCRIPTION
Part of #2796