### PR TITLE
[PHP 8.3] Mention `E_WARNING` on unconsumed input data

### DIFF
--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -161,6 +161,12 @@
       <row>
        <entry>8.3.0</entry>
        <entry>
+        Now emits <constant>E_WARNING</constant> when the input string has unconsumed data.
+       </entry>
+      </row>
+      <row>
+       <entry>8.3.0</entry>
+       <entry>
         Now emits <constant>E_WARNING</constant> when the passed string is not unserializeable;
         previously <constant>E_NOTICE</constant> was emitted.
        </entry>


### PR DESCRIPTION
Part of #2796