### PR TITLE
Update traits.xml Mention the hierarchy of classes

### DIFF
--- a/language/oop5/traits.xml
+++ b/language/oop5/traits.xml
@@ -425,23 +425,27 @@ Example::doSomething();
     <title>Static Properties</title>
     <caution>
      <simpara>
-      Prior to PHP 8.3.0, static properties were shared across all classes
-      using the trait. As of PHP 8.3.0, each class using the trait has its
+      Prior to PHP 8.3.0, static properties were shared across a single hierarchy of classes
+      which using the trait. As of PHP 8.3.0, each class using the trait has its
       own copy of the static property.
      </simpara>
     </caution>
     <programlisting role="php">
      <![CDATA[
 <?php
-trait StaticExample {
+
+trait StaticExample
+{
     public static $static = 'foo';
 }
 
-class Example {
+class Example
+{
     use StaticExample;
 }
 
 echo Example::$static;
+
 ?>
 ]]>
     </programlisting>
@@ -458,16 +462,20 @@ echo Example::$static;
     <programlisting role="php">
 <![CDATA[
 <?php
-trait PropertiesTrait {
+
+trait PropertiesTrait
+{
     public $x = 1;
 }
 
-class PropertiesExample {
+class PropertiesExample
+{
     use PropertiesTrait;
 }
 
-$example = new PropertiesExample;
+$example = new PropertiesExample();
 $example->x;
+
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
Static properties defined in the trait are shared only between classes of the same hierarchy. Maybe we should mention this?