### PR TITLE
Improve csv functions by mentioning that enclosure character will be ignore

### DIFF
--- a/reference/filesystem/functions/fgetcsv.xml
+++ b/reference/filesystem/functions/fgetcsv.xml
@@ -77,6 +77,7 @@
       <para>
        The <parameter>enclosure</parameter> parameter sets the field enclosure character.
        It must be a single byte character.
+       If the CSV does not use an enclosure character, the parameter will be ignored.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
See https://github.com/php/doc-en/issues/4175
