### PR TITLE
Document change in how C void returns are handled (closes #4202)

### DIFF
--- a/reference/ffi/ffi/cdef.xml
+++ b/reference/ffi/ffi/cdef.xml
@@ -75,6 +75,13 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.3.0</entry>
+      <entry>
+       C functions returning <literal>void</literal> return a PHP <type>null</type>
+       instead of <varname>FFI\CType::TYPE_VOID</varname>.
+      </entry>
+     </row>
+     <row>
       <entry>8.0.0</entry>
       <entry>
        <parameter>lib</parameter> is nullable now.


### PR DESCRIPTION
FFI is pretty sparsely documented as it is, so just a changelog entry here seems appropriate.