### PR TITLE
8.4: Document all new DOM classes and methods - part 1

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1648,6 +1648,12 @@ it is inserted with (e.g.) <function xmlns="http://docbook.org/ns/docbook">DOMNo
 
 <!ENTITY dom.malformederror '<para xmlns="http://docbook.org/ns/docbook">While malformed HTML should load successfully, this function may generate <constant>E_WARNING</constant> errors when it encounters bad markup. <link linkend="function.libxml-use-internal-errors">libxml&apos;s error handling functions</link> may be used to handle these errors.</para>'>
 <!ENTITY dom.note.utf8 '<note xmlns="http://docbook.org/ns/docbook"><para>The DOM extension uses UTF-8 encoding. Use <function>mb_convert_encoding</function>, <methodname>UConverter::transcode</methodname>, or <function>iconv</function> to handle other encodings.</para></note>'>
+<!ENTITY dom.note.modern.utf8 '<note xmlns="http://docbook.org/ns/docbook">
+ <simpara>
+  The DOM extension uses UTF-8 encoding when working with methods or properties.
+  The parser methods auto-detect the encoding or allow the caller to specify an encoding.
+ </simpara>
+</note>'>
 <!ENTITY dom.note.json '<note xmlns="http://docbook.org/ns/docbook"><para>When using <function>json_encode</function> on a <classname>DOMDocument</classname> object the result will be that of encoding an empty object.</para></note>'>
 <!ENTITY dom.domdocument.html5 '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1650,28 +1650,32 @@ it is inserted with (e.g.) <function xmlns="http://docbook.org/ns/docbook">DOMNo
 <!ENTITY dom.note.utf8 '<note xmlns="http://docbook.org/ns/docbook"><para>The DOM extension uses UTF-8 encoding. Use <function>mb_convert_encoding</function>, <methodname>UConverter::transcode</methodname>, or <function>iconv</function> to handle other encodings.</para></note>'>
 <!ENTITY dom.note.json '<note xmlns="http://docbook.org/ns/docbook"><para>When using <function>json_encode</function> on a <classname>DOMDocument</classname> object the result will be that of encoding an empty object.</para></note>'>
 <!ENTITY dom.domdocument.html5 '<warning xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
+  Use <classname>Dom\HTMLDocument</classname> to parse and process modern HTML
+  instead of <classname>DOMDocument</classname>.
+ </simpara>
+ <simpara>
   This function parses the input using an HTML 4 parser. The parsing rules
   of HTML 5, which is what modern web browsers use, are different. Depending
   on the input this might result in a different DOM structure. Therefore
   this function cannot be safely used for sanitizing HTML.
- </para>
- <para>
+ </simpara>
+ <simpara>
   The behavior when parsing HTML can depend on the version of
   <literal>libxml</literal> that is being used, particularly with regards to
   edge conditions and error handling.
   For parsing that conforms to the HTML5 specification,
   use <methodname>Dom\HTMLDocument::createFromString</methodname> or
   <methodname>Dom\HTMLDocument::createFromFile</methodname>, added in PHP 8.4.
- </para>
- <para>
+ </simpara>
+ <simpara>
   As an example, some HTML elements will implicitly close a parent element
   when encountered. The rules for automatically closing parent elements
   differ between HTML 4 and HTML 5 and thus the resulting DOM structure that
   <classname>DOMDocument</classname> sees might be different from the DOM
   structure a web browser sees, possibly allowing an attacker to break the
   resulting HTML.
- </para>
+ </simpara>
 </warning>'>
 
 

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -53,6 +53,7 @@
  &reference.dom.dom.dom-entity;
  &reference.dom.dom.dom-entityreference;
  &reference.dom.dom.dom-implementation;
+ &reference.dom.dom.dom-processinginstruction;
  &reference.dom.dom.dom-namespaceinfo;
  &reference.dom.dom.dom-node;
  &reference.dom.dom.dom-notation;

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -46,6 +46,7 @@
  &reference.dom.dom.dom-attr;
  &reference.dom.dom.dom-documenttype;
  &reference.dom.dom.dom-implementation;
+ &reference.dom.dom.dom-namespaceinfo;
  &reference.dom.dom.dom-node;
 
  <!-- FIXME:

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -48,6 +48,7 @@
  &reference.dom.dom.dom-characterdata;
  &reference.dom.dom.dom-childnode;
  &reference.dom.dom.dom-comment;
+ &reference.dom.dom.dom-document;
  &reference.dom.dom.dom-documentfragment;
  &reference.dom.dom.dom-documenttype;
  &reference.dom.dom.dom-entity;

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -41,7 +41,9 @@
  &reference.dom.domprocessinginstruction;
  &reference.dom.domtext;
  &reference.dom.domxpath;
+
  &reference.dom.dom.dom-adjacentposition;
+ &reference.dom.dom.dom-node;
 
  <!-- FIXME:
  <section xml:id="dom.class.domnamelist">

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -51,6 +51,7 @@
  &reference.dom.dom.dom-document;
  &reference.dom.dom.dom-documentfragment;
  &reference.dom.dom.dom-documenttype;
+ &reference.dom.dom.dom-dtdnamednodemap;
  &reference.dom.dom.dom-entity;
  &reference.dom.dom.dom-entityreference;
  &reference.dom.dom.dom-implementation;

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -44,6 +44,7 @@
 
  &reference.dom.dom.dom-adjacentposition;
  &reference.dom.dom.dom-attr;
+ &reference.dom.dom.dom-cdatasection;
  &reference.dom.dom.dom-documenttype;
  &reference.dom.dom.dom-entity;
  &reference.dom.dom.dom-implementation;

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -67,6 +67,7 @@
  &reference.dom.dom.dom-parentnode;
  &reference.dom.dom.dom-processinginstruction;
  &reference.dom.dom.dom-text;
+ &reference.dom.dom.dom-tokenlist;
  &reference.dom.dom.dom-xmldocument;
 
  <!-- FIXME:

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -43,6 +43,7 @@
  &reference.dom.domxpath;
 
  &reference.dom.dom.dom-adjacentposition;
+ &reference.dom.dom.dom-attr;
  &reference.dom.dom.dom-implementation;
  &reference.dom.dom.dom-node;
 

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -69,6 +69,7 @@
  &reference.dom.dom.dom-text;
  &reference.dom.dom.dom-tokenlist;
  &reference.dom.dom.dom-xmldocument;
+ &reference.dom.dom.dom-xpath;
 
  <!-- FIXME:
  <section xml:id="dom.class.domnamelist">

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -57,10 +57,11 @@
  &reference.dom.dom.dom-entityreference;
  &reference.dom.dom.dom-htmlcollection;
  &reference.dom.dom.dom-implementation;
- &reference.dom.dom.dom-processinginstruction;
+ &reference.dom.dom.dom-namednodemap;
  &reference.dom.dom.dom-namespaceinfo;
  &reference.dom.dom.dom-node;
  &reference.dom.dom.dom-notation;
+ &reference.dom.dom.dom-processinginstruction;
  &reference.dom.dom.dom-text;
 
  <!-- FIXME:

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -47,6 +47,7 @@
  &reference.dom.dom.dom-cdatasection;
  &reference.dom.dom.dom-characterdata;
  &reference.dom.dom.dom-childnode;
+ &reference.dom.dom.dom-comment;
  &reference.dom.dom.dom-documenttype;
  &reference.dom.dom.dom-entity;
  &reference.dom.dom.dom-implementation;

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -55,6 +55,7 @@
  &reference.dom.dom.dom-element;
  &reference.dom.dom.dom-entity;
  &reference.dom.dom.dom-entityreference;
+ &reference.dom.dom.dom-htmlcollection;
  &reference.dom.dom.dom-implementation;
  &reference.dom.dom.dom-processinginstruction;
  &reference.dom.dom.dom-namespaceinfo;

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -41,6 +41,7 @@
  &reference.dom.domprocessinginstruction;
  &reference.dom.domtext;
  &reference.dom.domxpath;
+ &reference.dom.dom.dom-adjacentposition;
 
  <!-- FIXME:
  <section xml:id="dom.class.domnamelist">

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -45,6 +45,7 @@
  &reference.dom.dom.dom-adjacentposition;
  &reference.dom.dom.dom-attr;
  &reference.dom.dom.dom-documenttype;
+ &reference.dom.dom.dom-entity;
  &reference.dom.dom.dom-implementation;
  &reference.dom.dom.dom-namespaceinfo;
  &reference.dom.dom.dom-node;

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -45,6 +45,7 @@
  &reference.dom.dom.dom-adjacentposition;
  &reference.dom.dom.dom-attr;
  &reference.dom.dom.dom-cdatasection;
+ &reference.dom.dom.dom-characterdata;
  &reference.dom.dom.dom-documenttype;
  &reference.dom.dom.dom-entity;
  &reference.dom.dom.dom-implementation;

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -62,6 +62,7 @@
  &reference.dom.dom.dom-namednodemap;
  &reference.dom.dom.dom-namespaceinfo;
  &reference.dom.dom.dom-node;
+ &reference.dom.dom.dom-nodelist;
  &reference.dom.dom.dom-notation;
  &reference.dom.dom.dom-processinginstruction;
  &reference.dom.dom.dom-text;

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -52,6 +52,7 @@
  &reference.dom.dom.dom-documentfragment;
  &reference.dom.dom.dom-documenttype;
  &reference.dom.dom.dom-dtdnamednodemap;
+ &reference.dom.dom.dom-element;
  &reference.dom.dom.dom-entity;
  &reference.dom.dom.dom-entityreference;
  &reference.dom.dom.dom-implementation;

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -64,6 +64,7 @@
  &reference.dom.dom.dom-node;
  &reference.dom.dom.dom-nodelist;
  &reference.dom.dom.dom-notation;
+ &reference.dom.dom.dom-parentnode;
  &reference.dom.dom.dom-processinginstruction;
  &reference.dom.dom.dom-text;
 

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -54,6 +54,7 @@
  &reference.dom.dom.dom-namespaceinfo;
  &reference.dom.dom.dom-node;
  &reference.dom.dom.dom-notation;
+ &reference.dom.dom.dom-text;
 
  <!-- FIXME:
  <section xml:id="dom.class.domnamelist">

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -44,6 +44,7 @@
 
  &reference.dom.dom.dom-adjacentposition;
  &reference.dom.dom.dom-attr;
+ &reference.dom.dom.dom-documenttype;
  &reference.dom.dom.dom-implementation;
  &reference.dom.dom.dom-node;
 

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -67,6 +67,7 @@
  &reference.dom.dom.dom-parentnode;
  &reference.dom.dom.dom-processinginstruction;
  &reference.dom.dom.dom-text;
+ &reference.dom.dom.dom-xmldocument;
 
  <!-- FIXME:
  <section xml:id="dom.class.domnamelist">

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -46,6 +46,7 @@
  &reference.dom.dom.dom-attr;
  &reference.dom.dom.dom-cdatasection;
  &reference.dom.dom.dom-characterdata;
+ &reference.dom.dom.dom-childnode;
  &reference.dom.dom.dom-documenttype;
  &reference.dom.dom.dom-entity;
  &reference.dom.dom.dom-implementation;

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -49,6 +49,7 @@
  &reference.dom.dom.dom-implementation;
  &reference.dom.dom.dom-namespaceinfo;
  &reference.dom.dom.dom-node;
+ &reference.dom.dom.dom-notation;
 
  <!-- FIXME:
  <section xml:id="dom.class.domnamelist">

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -51,6 +51,7 @@
  &reference.dom.dom.dom-documentfragment;
  &reference.dom.dom.dom-documenttype;
  &reference.dom.dom.dom-entity;
+ &reference.dom.dom.dom-entityreference;
  &reference.dom.dom.dom-implementation;
  &reference.dom.dom.dom-namespaceinfo;
  &reference.dom.dom.dom-node;

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -56,6 +56,7 @@
  &reference.dom.dom.dom-entity;
  &reference.dom.dom.dom-entityreference;
  &reference.dom.dom.dom-htmlcollection;
+ &reference.dom.dom.dom-htmldocument;
  &reference.dom.dom.dom-implementation;
  &reference.dom.dom.dom-namednodemap;
  &reference.dom.dom.dom-namespaceinfo;

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -57,6 +57,7 @@
  &reference.dom.dom.dom-entityreference;
  &reference.dom.dom.dom-htmlcollection;
  &reference.dom.dom.dom-htmldocument;
+ &reference.dom.dom.dom-htmlelement;
  &reference.dom.dom.dom-implementation;
  &reference.dom.dom.dom-namednodemap;
  &reference.dom.dom.dom-namespaceinfo;

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -48,6 +48,7 @@
  &reference.dom.dom.dom-characterdata;
  &reference.dom.dom.dom-childnode;
  &reference.dom.dom.dom-comment;
+ &reference.dom.dom.dom-documentfragment;
  &reference.dom.dom.dom-documenttype;
  &reference.dom.dom.dom-entity;
  &reference.dom.dom.dom-implementation;

--- a/reference/dom/book.xml
+++ b/reference/dom/book.xml
@@ -43,6 +43,7 @@
  &reference.dom.domxpath;
 
  &reference.dom.dom.dom-adjacentposition;
+ &reference.dom.dom.dom-implementation;
  &reference.dom.dom.dom-node;
 
  <!-- FIXME:

--- a/reference/dom/constants.xml
+++ b/reference/dom/constants.xml
@@ -283,7 +283,7 @@
       <entry>2</entry>
       <entry>
        If the specified range of text does not fit into a
-       <classname>DOMString</classname>.
+       <type>string</type>.
       </entry>
      </row>
      <row xml:id="constant.dom-hierarchy-request-err">

--- a/reference/dom/constants.xml
+++ b/reference/dom/constants.xml
@@ -8,9 +8,9 @@
    <tgroup cols="3">
     <thead>
      <row>
-      <entry>Constant</entry>
+      <entry>&Constants;</entry>
       <entry>Value</entry>
-      <entry>Description</entry>
+      <entry>&Description;</entry>
      </row>
     </thead>
     <tbody>
@@ -20,7 +20,7 @@
        (<type>int</type>)
       </entry>
       <entry>1</entry>
-      <entry>Node is a <classname>DOMElement</classname></entry>
+      <entry>Node is a <classname>DOMElement</classname> / <classname>Dom\Element</classname></entry>
      </row>
      <row xml:id="constant.xml-attribute-node">
       <entry>
@@ -28,7 +28,7 @@
        (<type>int</type>)
       </entry>
       <entry>2</entry>
-      <entry>Node is a <classname>DOMAttr</classname></entry>
+      <entry>Node is a <classname>DOMAttr</classname> / <classname>Dom\Attr</classname></entry>
      </row>
      <row xml:id="constant.xml-text-node">
       <entry>
@@ -36,7 +36,7 @@
        (<type>int</type>)
       </entry>
       <entry>3</entry>
-      <entry>Node is a <classname>DOMText</classname></entry>
+      <entry>Node is a <classname>DOMText</classname> / <classname>Dom\Text</classname></entry>
      </row>
      <row xml:id="constant.xml-cdata-section-node">
       <entry>
@@ -44,7 +44,7 @@
        (<type>int</type>)
       </entry>
       <entry>4</entry>
-      <entry>Node is a <classname>DOMCharacterData</classname></entry>
+      <entry>Node is a <classname>DOMCharacterData</classname> / <classname>Dom\CharacterData</classname></entry>
      </row>
      <row xml:id="constant.xml-entity-ref-node">
       <entry>
@@ -52,7 +52,7 @@
        (<type>int</type>)
       </entry>
       <entry>5</entry>
-      <entry>Node is a <classname>DOMEntityReference</classname></entry>
+      <entry>Node is a <classname>DOMEntityReference</classname> / <classname>Dom\EntityReference</classname></entry>
      </row>
      <row xml:id="constant.xml-entity-node">
       <entry>
@@ -60,7 +60,7 @@
        (<type>int</type>)
       </entry>
       <entry>6</entry>
-      <entry>Node is a <classname>DOMEntity</classname></entry>
+      <entry>Node is a <classname>DOMEntity</classname> / <classname>Dom\Entity</classname></entry>
      </row>
      <row xml:id="constant.xml-pi-node">
       <entry>
@@ -68,7 +68,7 @@
        (<type>int</type>)
       </entry>
       <entry>7</entry>
-      <entry>Node is a <classname>DOMProcessingInstruction</classname></entry>
+      <entry>Node is a <classname>DOMProcessingInstruction</classname> / <classname>Dom\ProcessingInstruction</classname></entry>
      </row>
      <row xml:id="constant.xml-comment-node">
       <entry>
@@ -76,7 +76,7 @@
        (<type>int</type>)
       </entry>
       <entry>8</entry>
-      <entry>Node is a <classname>DOMComment</classname></entry>
+      <entry>Node is a <classname>DOMComment</classname> / <classname>Dom\Comment</classname></entry>
      </row>
      <row xml:id="constant.xml-document-node">
       <entry>
@@ -84,7 +84,7 @@
        (<type>int</type>)
       </entry>
       <entry>9</entry>
-      <entry>Node is a <classname>DOMDocument</classname></entry>
+      <entry>Node is a <classname>DOMDocument</classname> / <classname>Dom\Document</classname></entry>
      </row>
      <row xml:id="constant.xml-document-type-node">
       <entry>
@@ -92,7 +92,7 @@
        (<type>int</type>)
       </entry>
       <entry>10</entry>
-      <entry>Node is a <classname>DOMDocumentType</classname></entry>
+      <entry>Node is a <classname>DOMDocumentType</classname> / <classname>Dom\DocumentType</classname></entry>
      </row>
      <row xml:id="constant.xml-document-frag-node">
       <entry>
@@ -100,7 +100,7 @@
        (<type>int</type>)
       </entry>
       <entry>11</entry>
-      <entry>Node is a <classname>DOMDocumentFragment</classname></entry>
+      <entry>Node is a <classname>DOMDocumentFragment</classname> / <classname>Dom\DocumentFragment</classname></entry>
      </row>
      <row xml:id="constant.xml-notation-node">
       <entry>
@@ -108,7 +108,7 @@
        (<type>int</type>)
       </entry>
       <entry>12</entry>
-      <entry>Node is a <classname>DOMNotation</classname></entry>
+      <entry>Node is a <classname>DOMNotation</classname> / <classname>Dom\Notation</classname></entry>
      </row>
      <row xml:id="constant.xml-html-document-node">
       <entry>
@@ -242,13 +242,48 @@
    </tgroup>
   </table>
   <table>
-   <title>DOMException constants</title>
+   <title>HTML constants</title>
    <tgroup cols="3">
     <thead>
      <row>
-      <entry>Constant</entry>
+      <entry>&Constants;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row xml:id="constant.dom-no-default-ns">
+      <entry>
+       <constant>Dom\NO_DEFAULT_NS</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>
+       <simpara>
+        This disables setting the namespace of elements during parsing when
+        using <classname>Dom\HTMLDocument</classname>.
+        This exists for backwards compatibility with
+        <classname>DOMDocument</classname>.
+       </simpara>
+       <caution>
+        <simpara>
+         Some DOM methods depend on the <acronym>HTML</acronym> namespace
+         being set.
+         By using this parser option, the behaviour of those methods can be
+         influenced.
+        </simpara>
+       </caution>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+  <table>
+   <title><classname>DOMException</classname> / <classname>Dom\Exception</classname> constants</title>
+   <tgroup cols="3">
+    <thead>
+     <row>
+      <entry>&Constants;</entry>
       <entry>Value</entry>
-      <entry>Description</entry>
+      <entry>&Description;</entry>
      </row>
     </thead>
     <tbody>
@@ -267,7 +302,7 @@
      </row>
      <row xml:id="constant.dom-index-size-err">
       <entry>
-       <constant>DOM_INDEX_SIZE_ERR</constant>
+       <constant>DOM_INDEX_SIZE_ERR</constant> / <constant>Dom\INDEX_SIZE_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>1</entry>
@@ -277,7 +312,7 @@
      </row>
      <row xml:id="constant.domstring-size-err">
       <entry>
-       <constant>DOMSTRING_SIZE_ERR</constant>
+       <constant>DOMSTRING_SIZE_ERR</constant> / <constant>Dom\STRING_SIZE_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>2</entry>
@@ -288,7 +323,7 @@
      </row>
      <row xml:id="constant.dom-hierarchy-request-err">
       <entry>
-       <constant>DOM_HIERARCHY_REQUEST_ERR</constant>
+       <constant>DOM_HIERARCHY_REQUEST_ERR</constant> / <constant>Dom\HIERARCHY_REQUEST_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>3</entry>
@@ -296,7 +331,7 @@
      </row>
      <row xml:id="constant.dom-wrong-document-err">
       <entry>
-       <constant>DOM_WRONG_DOCUMENT_ERR</constant>
+       <constant>DOM_WRONG_DOCUMENT_ERR</constant> / <constant>Dom\WRONG_DOCUMENT_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>4</entry>
@@ -306,7 +341,7 @@
      </row>
      <row xml:id="constant.dom-invalid-character-err">
       <entry>
-       <constant>DOM_INVALID_CHARACTER_ERR</constant>
+       <constant>DOM_INVALID_CHARACTER_ERR</constant> / <constant>Dom\INVALID_CHARACTER_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>5</entry>
@@ -316,7 +351,7 @@
      </row>
      <row xml:id="constant.dom-no-data-allowed-err">
       <entry>
-       <constant>DOM_NO_DATA_ALLOWED_ERR</constant>
+       <constant>DOM_NO_DATA_ALLOWED_ERR</constant> / <constant>Dom\NO_DATA_ALLOWED_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>6</entry>
@@ -326,7 +361,7 @@
      </row>
      <row xml:id="constant.dom-no-modification-allowed-err">
       <entry>
-       <constant>DOM_NO_MODIFICATION_ALLOWED_ERR</constant>
+       <constant>DOM_NO_MODIFICATION_ALLOWED_ERR</constant> / <constant>Dom\NO_MODIFICATION_ALLOWED_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>7</entry>
@@ -336,7 +371,7 @@
      </row>
      <row xml:id="constant.dom-not-found-err">
       <entry>
-       <constant>DOM_NOT_FOUND_ERR</constant>
+       <constant>DOM_NOT_FOUND_ERR</constant> / <constant>Dom\NOT_FOUND_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>8</entry>
@@ -346,7 +381,7 @@
      </row>
      <row xml:id="constant.dom-not-supported-err">
       <entry>
-       <constant>DOM_NOT_SUPPORTED_ERR</constant>
+       <constant>DOM_NOT_SUPPORTED_ERR</constant> / <constant>Dom\NOT_SUPPORTED_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>9</entry>
@@ -356,7 +391,7 @@
      </row>
      <row xml:id="constant.dom-inuse-attribute-err">
       <entry>
-       <constant>DOM_INUSE_ATTRIBUTE_ERR</constant>
+       <constant>DOM_INUSE_ATTRIBUTE_ERR</constant> / <constant>Dom\INUSE_ATTRIBUTE_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>10</entry>
@@ -366,7 +401,7 @@
      </row>
      <row xml:id="constant.dom-invalid-state-err">
       <entry>
-       <constant>DOM_INVALID_STATE_ERR</constant>
+       <constant>DOM_INVALID_STATE_ERR</constant> / <constant>Dom\INVALID_STATE_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>11</entry>
@@ -376,7 +411,7 @@
      </row>
      <row xml:id="constant.dom-syntax-err">
       <entry>
-       <constant>DOM_SYNTAX_ERR</constant>
+       <constant>DOM_SYNTAX_ERR</constant> / <constant>Dom\SYNTAX_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>12</entry>
@@ -384,7 +419,7 @@
      </row>
      <row xml:id="constant.dom-invalid-modification-err">
       <entry>
-       <constant>DOM_INVALID_MODIFICATION_ERR</constant>
+       <constant>DOM_INVALID_MODIFICATION_ERR</constant> / <constant>Dom\INVALID_MODIFICATION_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>13</entry>
@@ -392,7 +427,7 @@
      </row>
      <row xml:id="constant.dom-namespace-err">
       <entry>
-       <constant>DOM_NAMESPACE_ERR</constant>
+       <constant>DOM_NAMESPACE_ERR</constant> / <constant>Dom\NAMESPACE_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>14</entry>
@@ -403,7 +438,7 @@
      </row>
      <row xml:id="constant.dom-invalid-access-err">
       <entry>
-       <constant>DOM_INVALID_ACCESS_ERR</constant>
+       <constant>DOM_INVALID_ACCESS_ERR</constant> / <constant>Dom\INVALID_ACCESS_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>15</entry>
@@ -413,7 +448,7 @@
      </row>
      <row xml:id="constant.dom-validation-err">
       <entry>
-       <constant>DOM_VALIDATION_ERR</constant>
+       <constant>DOM_VALIDATION_ERR</constant> / <constant>Dom\VALIDATION_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>16</entry>

--- a/reference/dom/dom/attr/isid.xml
+++ b/reference/dom/dom/attr/isid.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="dom-attr.isid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>Dom\Attr::isId</refname>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domattr.isid')/db:refnamediv/db:refpurpose)"/>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Dom\\Attr">
+   <modifier>public</modifier> <type>bool</type><methodname>Dom\Attr::isId</methodname>
+   <void/>
+  </methodsynopsis>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domattr.isid')/db:refsect1[@role='description']/db:para[1])"/>
+  <simpara>
+   According to the DOM standard this requires a DTD which defines the
+   attribute ID to be of type ID. To utilise this method the document
+   must be validated at parse time by passing
+   <constant>LIBXML_DTDVALID</constant> as an option.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domattr.isid')/db:refsect1[@role='returnvalues']/*)">
+   <xi:fallback/>
+  </xi:include>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Dom\Attr::isId() Example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+// We need to validate our document before referring to the id
+$doc = Dom\XMLDocument::createFromFile('book.xml', LIBXML_DTDVALID);
+
+// We retrieve the attribute named id of the chapter element
+$attr = $doc->getElementsByTagName('chapter')->item(0)->getAttributeNode('id');
+
+var_dump($attr->isId()); // bool(true)
+
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/dom/attr/rename.xml
+++ b/reference/dom/dom/attr/rename.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="dom-attr.rename" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Dom\Attr::rename</refname>
+  <refpurpose>Changes the qualified name or namespace of an attribute</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Dom\\Attr">
+   <modifier>public</modifier> <type>void</type><methodname>Dom\Attr::rename</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>namespaceURI</parameter></methodparam>
+   <methodparam><type>string</type><parameter>qualifiedName</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   This method changes the qualified name or namespace of an attribute.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>namespaceURI</parameter></term>
+    <listitem>
+     <simpara>
+      The new namespace <acronym>URI</acronym> of the attribute.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>qualifiedName</parameter></term>
+    <listitem>
+     <simpara>
+      The new qualified name of the attribute.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <variablelist>
+   <varlistentry>
+    <term><classname>DOMException</classname> with code <constant>Dom\NAMESPACE_ERR</constant></term>
+    <listitem>
+     <simpara>
+      Raised if there is an error with the namespace, as determined by
+      <parameter>qualifiedName</parameter>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><classname>DOMException</classname> with code <constant>Dom\INVALID_MODIFICATION_ERR</constant></term>
+    <listitem>
+     <simpara>
+      Raised if there already exists an attribute in the element with the same
+      qualified name.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="dom-attr.rename.example.basic">
+   <title><methodname>Dom\Attr::rename</methodname> example to change both the namespace and qualified name</title>
+   <simpara>
+    This changes the qualified name of <literal>my-attr</literal> to
+    <literal>my-new-attr</literal> and also changes its namespace to
+    <literal>urn:my-ns</literal>.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$doc = Dom\XMLDocument::createFromString('<root my-attr="value"/>');
+
+$root = $doc->documentElement;
+$attribute = $root->attributes['my-attr'];
+$attribute->rename('urn:my-ns', 'my-new-attr');
+
+echo $doc->saveXml();
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<?xml version="1.0" encoding="UTF-8"?>
+<root xmlns:ns1="urn:my-ns" ns1:my-new-attr="value"/>
+]]>
+   </screen>
+  </example>
+  <example xml:id="dom-attr.rename.example.only-name">
+   <title><methodname>Dom\Attr::rename</methodname> example to change only the qualified name</title>
+   <simpara>
+    This only changes the qualified name of <literal>my-attr</literal>
+    and keeps the namespace <acronym>URI</acronym> the same.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$doc = Dom\XMLDocument::createFromString('<root my-attr="value"/>');
+
+$root = $doc->documentElement;
+$attribute = $root->attributes['my-attr'];
+$attribute->rename($attribute->namespaceURI, 'my-new-attr');
+
+echo $doc->saveXml();
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<?xml version="1.0" encoding="UTF-8"?>
+<root my-new-attr="value"/>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <simpara>
+    It is sometimes necessary to change the qualified name and namespace
+    <acronym>URI</acronym> together in one step to not break any
+    namespace rules.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Dom\Element::rename</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/dom/characterdata/after.xml
+++ b/reference/dom/dom/characterdata/after.xml
@@ -1,38 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-<refentry xml:id="domcharacterdata.after" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<refentry xml:id="dom-characterdata.after" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
-  <refname>DOMCharacterData::after</refname>
-  <refpurpose>Adds nodes after the character data</refpurpose>
+  <refname>Dom\CharacterData::after</refname>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.after')/db:refnamediv/db:refpurpose)"/>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="DOMCharacterData">
-   <modifier>public</modifier> <type>void</type><methodname>DOMCharacterData::after</methodname>
-   <methodparam rep="repeat"><type class="union"><type>DOMNode</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  <methodsynopsis role="Dom\\CharacterData">
+   <modifier>public</modifier> <type>void</type><methodname>Dom\CharacterData::after</methodname>
+   <methodparam rep="repeat"><type class="union"><type>Dom\Node</type><type>string</type></type><parameter>nodes</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Adds the passed <parameter>nodes</parameter> after the character data.
-  </para>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.after')/db:refsect1[@role='description']/db:para[1])"/>
  </refsect1>
 
  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.after')/db:refsect1[@role='parameters'])" />
  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.after')/db:refsect1[@role='returnvalues'])" />
  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.after')/db:refsect1[@role='errors'])" />
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.after')/db:refsect1[@role='changelog'])" />
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <example xml:id="domcharacterdata.after.example.basic">
-   <title><methodname>DOMCharacterData::after</methodname> example</title>
-   <para>
+  <example xml:id="dom-characterdata.after.example.basic">
+   <title><methodname>Dom\CharacterData::after</methodname> example</title>
+   <simpara>
     Adds nodes after the character data.
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
-$doc = new DOMDocument;
-$doc->loadXML("<container><![CDATA[hello]]]]><![CDATA[></container>");
+$doc = Dom\XMLDocument::createFromString("<container><![CDATA[hello]]]]><![CDATA[></container>");
 $cdata = $doc->documentElement->firstChild;
 
 $cdata->after("beautiful", $doc->createElement("world"));
@@ -44,7 +40,7 @@ echo $doc->saveXML();
    &example.outputs;
    <screen>
 <![CDATA[
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <container><![CDATA[hello]]]]><![CDATA[>beautiful<world/></container>
 ]]>
    </screen>
@@ -54,8 +50,8 @@ echo $doc->saveXML();
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><methodname>DOMChildNode::after</methodname></member>
-   <member><methodname>DOMCharacterData::before</methodname></member>
+   <member><methodname>Dom\ChildNode::after</methodname></member>
+   <member><methodname>Dom\CharacterData::before</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/dom/dom/characterdata/appenddata.xml
+++ b/reference/dom/dom/characterdata/appenddata.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="dom-characterdata.appenddata" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>Dom\CharacterData::appendData</refname>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.appenddata')/db:refnamediv/db:refpurpose)"/>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Dom\\CharacterData">
+   <modifier>public</modifier> <type>void</type><methodname>Dom\CharacterData::appendData</methodname>
+   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+  </methodsynopsis>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.appenddata')/db:refsect1[@role='description']/db:para[1])"/>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.appenddata')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.appenddata')/db:refsect1[@role='returnvalues'])" />
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Dom\CharacterData::deleteData</methodname></member>
+   <member><methodname>Dom\CharacterData::insertData</methodname></member>
+   <member><methodname>Dom\CharacterData::replaceData</methodname></member>
+   <member><methodname>Dom\CharacterData::substringData</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/dom/characterdata/before.xml
+++ b/reference/dom/dom/characterdata/before.xml
@@ -1,38 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-<refentry xml:id="domcharacterdata.before" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<refentry xml:id="dom-characterdata.before" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
-  <refname>DOMCharacterData::before</refname>
-  <refpurpose>Adds nodes before the character data</refpurpose>
+  <refname>Dom\CharacterData::before</refname>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.before')/db:refnamediv/db:refpurpose)"/>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="DOMCharacterData">
-   <modifier>public</modifier> <type>void</type><methodname>DOMCharacterData::before</methodname>
-   <methodparam rep="repeat"><type class="union"><type>DOMNode</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  <methodsynopsis role="Dom\\CharacterData">
+   <modifier>public</modifier> <type>void</type><methodname>Dom\CharacterData::before</methodname>
+   <methodparam rep="repeat"><type class="union"><type>Dom\Node</type><type>string</type></type><parameter>nodes</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Adds the passed <parameter>nodes</parameter> before the character data.
-  </para>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.before')/db:refsect1[@role='description']/db:para[1])"/>
  </refsect1>
 
  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.before')/db:refsect1[@role='parameters'])" />
  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.before')/db:refsect1[@role='returnvalues'])" />
  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.before')/db:refsect1[@role='errors'])" />
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.before')/db:refsect1[@role='changelog'])" />
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <example xml:id="domcharacterdata.before.example.basic">
-   <title><methodname>DOMCharacterData::before</methodname> example</title>
-   <para>
+  <example xml:id="dom-characterdata.before.example.basic">
+   <title><methodname>Dom\CharacterData::before</methodname> example</title>
+   <simpara>
     Adds nodes before the character data.
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
-$doc = new DOMDocument;
-$doc->loadXML("<container><![CDATA[world]]]]><![CDATA[></container>");
+$doc = Dom\XMLDocument::createFromString("<container><![CDATA[world]]]]><![CDATA[></container>");
 $cdata = $doc->documentElement->firstChild;
 
 $cdata->before("hello", $doc->createElement("beautiful"));
@@ -54,8 +50,8 @@ echo $doc->saveXML();
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><methodname>DOMChildNode::before</methodname></member>
-   <member><methodname>DOMCharacterData::after</methodname></member>
+   <member><methodname>Dom\ChildNode::before</methodname></member>
+   <member><methodname>Dom\CharacterData::after</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/dom/dom/characterdata/deletedata.xml
+++ b/reference/dom/dom/characterdata/deletedata.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="dom-characterdata.deletedata" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>Dom\CharacterData::deleteData</refname>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.deletedata')/db:refnamediv/db:refpurpose)"/>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Dom\\CharacterData">
+   <modifier>public</modifier> <type>void</type><methodname>Dom\CharacterData::deleteData</methodname>
+   <methodparam><type>int</type><parameter>offset</parameter></methodparam>
+   <methodparam><type>int</type><parameter>count</parameter></methodparam>
+  </methodsynopsis>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.deletedata')/db:refsect1[@role='description']/db:para[1])"/>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.deletedata')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.deletedata')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.deletedata')/db:refsect1[@role='errors'])" />
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Dom\CharacterData::appendData</methodname></member>
+   <member><methodname>Dom\CharacterData::insertData</methodname></member>
+   <member><methodname>Dom\CharacterData::replaceData</methodname></member>
+   <member><methodname>Dom\CharacterData::substringData</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/dom/characterdata/insertdata.xml
+++ b/reference/dom/dom/characterdata/insertdata.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="dom-characterdata.insertdata" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>Dom\CharacterData::insertData</refname>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.insertdata')/db:refnamediv/db:refpurpose)"/>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Dom\\CharacterData">
+   <modifier>public</modifier> <type>void</type><methodname>Dom\CharacterData::insertData</methodname>
+   <methodparam><type>int</type><parameter>offset</parameter></methodparam>
+   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+  </methodsynopsis>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.insertdata')/db:refsect1[@role='description']/db:para[1])"/>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.insertdata')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.insertdata')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.insertdata')/db:refsect1[@role='errors'])" />
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Dom\CharacterData::appendData</methodname></member>
+   <member><methodname>Dom\CharacterData::deleteData</methodname></member>
+   <member><methodname>Dom\CharacterData::replaceData</methodname></member>
+   <member><methodname>Dom\CharacterData::substringData</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/dom/characterdata/remove.xml
+++ b/reference/dom/dom/characterdata/remove.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<refentry xml:id="domcharacterdata.remove" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<refentry xml:id="dom-characterdata.remove" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
-  <refname>DOMCharacterData::remove</refname>
-  <refpurpose>Removes the character data node</refpurpose>
+  <refname>Dom\CharacterData::remove</refname>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.remove')/db:refnamediv/db:refpurpose)"/>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis role="DOMCharacterData">
-   <modifier>public</modifier> <type>void</type><methodname>DOMCharacterData::remove</methodname>
+  <methodsynopsis role="Dom\\CharacterData">
+   <modifier>public</modifier> <type>void</type><methodname>Dom\CharacterData::remove</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-   Removes the character data node.
-  </para>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.remove')/db:refsect1[@role='description']/db:para[1])"/>
  </refsect1>
 
  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.remove')/db:refsect1[@role='parameters'])" />
@@ -21,16 +19,15 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <example xml:id="domcharacterdata.remove.example.basic">
-   <title><methodname>DOMCharacterData::remove</methodname> example</title>
-   <para>
+  <example xml:id="dom-characterdata.remove.example.basic">
+   <title><methodname>Dom\CharacterData::remove</methodname> example</title>
+   <simpara>
     Removes the character data.
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
-$doc = new DOMDocument;
-$doc->loadXML("<container><![CDATA[hello]]]]><![CDATA[><world/></container>");
+$doc = Dom\XMLDocument::createFromString("<container><![CDATA[hello]]]]><![CDATA[><world/></container>");
 $cdata = $doc->documentElement->firstChild;
 
 $cdata->remove();
@@ -52,11 +49,11 @@ echo $doc->saveXML();
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><methodname>DOMChildNode::remove</methodname></member>
-   <member><methodname>DOMCharacterData::after</methodname></member>
-   <member><methodname>DOMCharacterData::before</methodname></member>
-   <member><methodname>DOMCharacterData::replaceWith</methodname></member>
-   <member><methodname>DOMNode::removeChild</methodname></member>
+   <member><methodname>Dom\ChildNode::remove</methodname></member>
+   <member><methodname>Dom\CharacterData::after</methodname></member>
+   <member><methodname>Dom\CharacterData::before</methodname></member>
+   <member><methodname>Dom\CharacterData::replaceWith</methodname></member>
+   <member><methodname>Dom\Node::removeChild</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/dom/dom/characterdata/replacedata.xml
+++ b/reference/dom/dom/characterdata/replacedata.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="dom-characterdata.replacedata" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>Dom\CharacterData::replaceData</refname>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.replacedata')/db:refnamediv/db:refpurpose)"/>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Dom\\CharacterData">
+   <modifier>public</modifier> <type>void</type><methodname>Dom\CharacterData::replaceData</methodname>
+   <methodparam><type>int</type><parameter>offset</parameter></methodparam>
+   <methodparam><type>int</type><parameter>count</parameter></methodparam>
+   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+  </methodsynopsis>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.replacedata')/db:refsect1[@role='description']/db:para[1])"/>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.replacedata')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.replacedata')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.replacedata')/db:refsect1[@role='errors'])" />
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Dom\CharacterData::appendData</methodname></member>
+   <member><methodname>Dom\CharacterData::deleteData</methodname></member>
+   <member><methodname>Dom\CharacterData::insertData</methodname></member>
+   <member><methodname>Dom\CharacterData::substringData</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/dom/characterdata/replacewith.xml
+++ b/reference/dom/dom/characterdata/replacewith.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="dom-characterdata.replacewith" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>Dom\CharacterData::replaceWith</refname>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.replacewith')/db:refnamediv/db:refpurpose)"/>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Dom\\CharacterData">
+   <modifier>public</modifier> <type>void</type><methodname>Dom\CharacterData::replaceWith</methodname>
+   <methodparam rep="repeat"><type class="union"><type>Dom\Node</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.replacewith')/db:refsect1[@role='description']/db:para[1])"/>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.replacewith')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.replacewith')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.replacewith')/db:refsect1[@role='errors'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="dom-characterdata.replacewith.example.basic">
+   <title><methodname>Dom\CharacterData::replaceWith</methodname> example</title>
+   <simpara>
+    Replaces the character data with new nodes.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$doc = Dom\XMLDocument::createFromString("<container><![CDATA[hello]]]]><![CDATA[></container>");
+$cdata = $doc->documentElement->firstChild;
+
+$cdata->replaceWith("beautiful", $doc->createElement("world"));
+
+echo $doc->saveXML();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<?xml version="1.0"?>
+<container>beautiful<world/></container>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Dom\ChildNode::replaceWith</methodname></member>
+   <member><methodname>Dom\CharacterData::after</methodname></member>
+   <member><methodname>Dom\CharacterData::before</methodname></member>
+   <member><methodname>Dom\CharacterData::remove</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/dom/characterdata/substringdata.xml
+++ b/reference/dom/dom/characterdata/substringdata.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="dom-characterdata.substringdata" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>Dom\CharacterData::substringData</refname>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.substringdata')/db:refnamediv/db:refpurpose)"/>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Dom\\CharacterData">
+   <modifier>public</modifier> <type>string</type><methodname>Dom\CharacterData::substringData</methodname>
+   <methodparam><type>int</type><parameter>offset</parameter></methodparam>
+   <methodparam><type>int</type><parameter>count</parameter></methodparam>
+  </methodsynopsis>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.substringdata')/db:refsect1[@role='description']/db:para[1])"/>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.substringdata')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.substringdata')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.substringdata')/db:refsect1[@role='errors'])" />
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Dom\CharacterData::appendData</methodname></member>
+   <member><methodname>Dom\CharacterData::deleteData</methodname></member>
+   <member><methodname>Dom\CharacterData::insertData</methodname></member>
+   <member><methodname>Dom\CharacterData::replaceData</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/dom/childnode/after.xml
+++ b/reference/dom/dom/childnode/after.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="dom-childnode.after" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>Dom\ChildNode::after</refname>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.after')/db:refnamediv/db:refpurpose)"/>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Dom\\ChildNode">
+   <modifier>public</modifier> <type>void</type><methodname>Dom\ChildNode::after</methodname>
+   <methodparam rep="repeat"><type class="union"><type>Dom\Node</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.after')/db:refsect1[@role='description']/db:para[1])"/>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.after')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.after')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.after')/db:refsect1[@role='errors'])" />
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Dom\ChildNode::before</methodname></member>
+   <member><methodname>Dom\ChildNode::remove</methodname></member>
+   <member><methodname>Dom\ChildNode::replaceWith</methodname></member>
+   <member><methodname>Dom\Node::appendChild</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/dom/childnode/before.xml
+++ b/reference/dom/dom/childnode/before.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="dom-childnode.before" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>Dom\ChildNode::before</refname>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.before')/db:refnamediv/db:refpurpose)"/>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Dom\\ChildNode">
+   <modifier>public</modifier> <type>void</type><methodname>Dom\ChildNode::before</methodname>
+   <methodparam rep="repeat"><type class="union"><type>Dom\Node</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.before')/db:refsect1[@role='description']/db:para[1])"/>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.before')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.before')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.before')/db:refsect1[@role='errors'])" />
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Dom\ChildNode::after</methodname></member>
+   <member><methodname>Dom\ChildNode::remove</methodname></member>
+   <member><methodname>Dom\ChildNode::replaceWith</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/dom/childnode/remove.xml
+++ b/reference/dom/dom/childnode/remove.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="dom-childnode.remove" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>Dom\ChildNode::remove</refname>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.remove')/db:refnamediv/db:refpurpose)"/>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Dom\\ChildNode">
+   <modifier>public</modifier> <type>void</type><methodname>Dom\ChildNode::remove</methodname>
+   <void/>
+  </methodsynopsis>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.remove')/db:refsect1[@role='description']/db:para[1])"/>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.remove')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.remove')/db:refsect1[@role='returnvalues'])" />
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Dom\ChildNode::after</methodname></member>
+   <member><methodname>Dom\ChildNode::before</methodname></member>
+   <member><methodname>Dom\ChildNode::replaceWith</methodname></member>
+   <member><methodname>Dom\Node::removeChild</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/dom/childnode/replacewith.xml
+++ b/reference/dom/dom/childnode/replacewith.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="dom-childnode.replacewith" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>Dom\ChildNode::replaceWith</refname>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.replacewith')/db:refnamediv/db:refpurpose)"/>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Dom\\ChildNode">
+   <modifier>public</modifier> <type>void</type><methodname>Dom\ChildNode::replaceWith</methodname>
+   <methodparam rep="repeat"><type class="union"><type>Dom\Node</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.replacewith')/db:refsect1[@role='description']/db:para[1])"/>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.replacewith')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.replacewith')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.replacewith')/db:refsect1[@role='errors'])" />
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Dom\ChildNode::after</methodname></member>
+   <member><methodname>Dom\ChildNode::before</methodname></member>
+   <member><methodname>Dom\ChildNode::remove</methodname></member>
+   <member><methodname>Dom\Node::replaceChild</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/dom/dom-adjacentposition.xml
+++ b/reference/dom/dom/dom-adjacentposition.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<reference xml:id="enum.dom.adjacentposition" role="enum" xmlns="http://docbook.org/ns/docbook">
+ <title>The Dom\AdjacentPosition Enum</title>
+ <titleabbrev>Dom\AdjacentPosition</titleabbrev>
+
+ <partintro>
+  <section xml:id="enum.dom.adjacentposition.intro">
+   &reftitle.intro;
+   <simpara>
+    The <enumname>AdjacentPosition</enumname> enum is used to specify
+    where, relative to the context element, insertion should be performed
+    using <methodname>Dom\Element::insertAdjacentElement</methodname>
+    or <methodname>Dom\Element::insertAdjacentText</methodname>.
+   </simpara>
+  </section>
+
+  <section xml:id="enum.dom.adjacentposition.synopsis">
+   &reftitle.enumsynopsis;
+
+   <enumsynopsis>
+    <enumname>AdjacentPosition</enumname>
+
+    <enumitem>
+     <enumidentifier>BeforeBegin</enumidentifier>
+     <enumitemdescription>
+      Insert before the context element.
+      This is only possible if the element is in a document and has a parent.
+     </enumitemdescription>
+    </enumitem>
+
+    <enumitem>
+     <enumidentifier>AfterBegin</enumidentifier>
+     <enumitemdescription>
+      Insert before the first child of the context element.
+     </enumitemdescription>
+    </enumitem>
+
+    <enumitem>
+     <enumidentifier>BeforeEnd</enumidentifier>
+     <enumitemdescription>
+      Insert after the last child of the context element.
+     </enumitemdescription>
+    </enumitem>
+
+    <enumitem>
+     <enumidentifier>AfterEnd</enumidentifier>
+     <enumitemdescription>
+      Insert after the context element.
+      This is only possible if the element is in a document and has a parent.
+     </enumitemdescription>
+    </enumitem>
+
+   </enumsynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/dom/dom-attr.xml
+++ b/reference/dom/dom/dom-attr.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-attr" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The <classname>Dom\Attr</classname> class</title>
+ <titleabbrev>Dom\Attr</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-attr.intro">
+   &reftitle.intro;
+   <simpara>
+    <classname>Dom\Attr</classname> represents an attribute in the
+    <classname>Dom\Element</classname> object.
+   </simpara>
+   <simpara>
+    This is the modern, spec-compliant equivalent of
+    <classname>DOMAttr</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-attr.synopsis">
+   &reftitle.classsynopsis;
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\Attr</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Dom\Node</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="dom-attr.props.namespaceuri">namespaceURI</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="dom-attr.props.prefix">prefix</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="dom-attr.props.localname">localName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="dom-attr.props.name">name</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="dom-attr.props.value">value</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Element</type><type>null</type></type>
+     <varname linkend="dom-attr.props.ownerelement">ownerElement</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>bool</type>
+     <varname linkend="dom-attr.props.specified">specified</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-attr')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Attr'])">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="dom-attr.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-attr.props.namespaceuri">
+     <term><varname>namespaceURI</varname></term>
+     <listitem>
+      <simpara>The namespace <acronym>URI</acronym> of the attribute.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-attr.props.prefix">
+     <term><varname>prefix</varname></term>
+     <listitem>
+      <simpara>The namespace prefix of the attribute.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-attr.props.localname">
+     <term><varname>localName</varname></term>
+     <listitem>
+      <simpara>The local name of the attribute.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-attr.props.name">
+     <term><varname>name</varname></term>
+     <listitem>
+      <simpara>The qualified name of the attribute.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-attr.props.value">
+     <term><varname>value</varname></term>
+     <listitem>
+      <simpara>The value of the attribute.</simpara>
+      <note>
+       <simpara>
+        Unlike the equivalent property in <classname>DOMAttr</classname>,
+        this does not substitute entities.
+       </simpara>
+      </note>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-attr.props.ownerelement">
+     <term><varname>ownerElement</varname></term>
+     <listitem>
+      <simpara>The element that contains the attribute or &null;.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-attr.props.specified">
+     <term><varname>specified</varname></term>
+     <listitem>
+      <simpara>Legacy option, always is &true;.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+  <section role="seealso">
+   &reftitle.seealso;
+   <simplelist>
+    <member><link xlink:href="&url.spec.dom.living.attr;">WHATWG specification of Attr</link></member>
+   </simplelist>
+  </section>
+
+ </partintro>
+
+<!-- &reference.dom.dom.entities.attr; -->
+
+</reference>

--- a/reference/dom/dom/dom-attr.xml
+++ b/reference/dom/dom/dom-attr.xml
@@ -158,6 +158,6 @@
 
  </partintro>
 
-<!-- &reference.dom.dom.entities.attr; -->
+ &reference.dom.dom.entities.attr;
 
 </reference>

--- a/reference/dom/dom/dom-attr.xml
+++ b/reference/dom/dom/dom-attr.xml
@@ -89,9 +89,10 @@
     </xi:include>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-cdatasection.xml
+++ b/reference/dom/dom/dom-cdatasection.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-cdatasection" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>The Dom\CDATASection class</title>
+ <titleabbrev>Dom\CDATASection</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-cdatasection.intro">
+   &reftitle.intro;
+   <simpara>
+    The <classname>Dom\CDATASection</classname> class inherits from
+    <classname>Dom\Text</classname> for textual representation
+    of CData constructs.
+   </simpara>
+   <simpara>
+    This is the modern, spec-compliant equivalent of
+    <classname>DOMCdataSection</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-cdatasection.synopsis">
+   &reftitle.classsynopsis;
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\CDATASection</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Dom\Text</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-text')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-text')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Text'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+
+  </section>
+ </partintro>
+
+</reference>

--- a/reference/dom/dom/dom-cdatasection.xml
+++ b/reference/dom/dom/dom-cdatasection.xml
@@ -55,9 +55,10 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
      <xi:fallback/>
     </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
 
   </section>

--- a/reference/dom/dom/dom-characterdata.xml
+++ b/reference/dom/dom/dom-characterdata.xml
@@ -6,8 +6,7 @@
 
  <partintro>
   <section xml:id="dom-characterdata.intro">
-   &reftitle.intro;
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.intro')/db:para)">
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.intro')/*)">
     <xi:fallback/>
    </xi:include>
    <simpara>
@@ -115,6 +114,6 @@
 
  </partintro>
 
-<!-- &reference.dom.dom.entities.characterdata; -->
+ &reference.dom.dom.entities.characterdata;
 
 </reference>

--- a/reference/dom/dom/dom-characterdata.xml
+++ b/reference/dom/dom/dom-characterdata.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-characterdata" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\CharacterData class</title>
+ <titleabbrev>Dom\CharacterData</titleabbrev>
+
+ <partintro>
+  <section xml:id="dom-characterdata.intro">
+   &reftitle.intro;
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.intro')/db:para)">
+    <xi:fallback/>
+   </xi:include>
+   <simpara>
+    This is the modern, spec-compliant equivalent of
+    <classname>DOMCharacterData</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-characterdata.synopsis">
+   &reftitle.classsynopsis;
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\CharacterData</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Dom\Node</classname>
+    </ooclass>
+
+    <oointerface>
+     <modifier>implements</modifier>
+     <interfacename>Dom\ChildNode</interfacename>
+    </oointerface>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Element</type><type>null</type></type>
+     <varname linkend="dom-characterdata.props.previouselementsibling">previousElementSibling</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Element</type><type>null</type></type>
+     <varname linkend="dom-characterdata.props.nextelementsibling">nextElementSibling</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="dom-characterdata.props.data">data</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="dom-characterdata.props.length">length</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="dom-characterdata.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-characterdata.props.previouselementsibling">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.previouselementsibling')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-characterdata.props.nextelementsibling">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.nextelementsibling')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-characterdata.props.data">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.data')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-characterdata.props.length">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.length')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+  <section role="seealso">
+   &reftitle.seealso;
+   <simplelist>
+    <member><link xlink:href="&url.spec.dom.living.characterdata;">WHATWG specification of CharacterData</link></member>
+   </simplelist>
+  </section>
+
+ </partintro>
+
+<!-- &reference.dom.dom.entities.characterdata; -->
+
+</reference>

--- a/reference/dom/dom/dom-characterdata.xml
+++ b/reference/dom/dom/dom-characterdata.xml
@@ -73,9 +73,10 @@
     </xi:include>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-childnode.xml
+++ b/reference/dom/dom/dom-childnode.xml
@@ -30,6 +30,6 @@
 
  </partintro>
 
-<!-- &reference.dom.dom.entities.childnode; -->
+ &reference.dom.dom.entities.childnode;
 
 </reference>

--- a/reference/dom/dom/dom-childnode.xml
+++ b/reference/dom/dom/dom-childnode.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<reference xml:id="class.dom-childnode" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\ChildNode interface</title>
+ <titleabbrev>Dom\ChildNode</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-childnode.intro">
+   &reftitle.intro;
+   <simpara>
+    This is the modern, spec-compliant equivalent of
+    <classname>DOMChildNode</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-childnode.synopsis">
+   &reftitle.interfacesynopsis;
+
+   <classsynopsis class="interface">
+    <oointerface>
+     <interfacename>Dom\ChildNode</interfacename>
+    </oointerface>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-childnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\ChildNode'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+ </partintro>
+
+<!-- &reference.dom.dom.entities.childnode; -->
+
+</reference>

--- a/reference/dom/dom/dom-comment.xml
+++ b/reference/dom/dom/dom-comment.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-comment" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\Comment class</title>
+ <titleabbrev>Dom\Comment</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-comment.intro">
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcomment.intro')/*)">
+    <xi:fallback/>
+   </xi:include>
+   <simpara>
+    This is the modern, spec-compliant equivalent of
+    <classname>DOMComment</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-comment.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\Comment</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Dom\CharacterData</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section role="seealso">
+   &reftitle.seealso;
+   <simplelist>
+    <member><link xlink:href="&url.spec.dom.living.comment;">WHATWG specification of Comment</link></member>
+   </simplelist>
+  </section>
+
+ </partintro>
+
+</reference>

--- a/reference/dom/dom/dom-comment.xml
+++ b/reference/dom/dom/dom-comment.xml
@@ -46,9 +46,10 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
      <xi:fallback/>
     </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-document.xml
+++ b/reference/dom/dom/dom-document.xml
@@ -1,0 +1,250 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-document" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\Document class</title>
+ <titleabbrev>Dom\Document</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-document.intro">
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.intro')/*)">
+    <xi:fallback/>
+   </xi:include>
+   <simpara>
+    This is the modern, spec-compliant equivalent of
+    <classname>DOMDocument</classname>.
+    It is the base class for <classname>Dom\XMLDocument</classname>
+    and <classname>Dom\HTMLDocument</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-document.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier>abstract</modifier>
+     <classname>Dom\Document</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Dom\Node</classname>
+    </ooclass>
+
+    <oointerface>
+     <modifier>implements</modifier>
+     <interfacename>Dom\ParentNode</interfacename>
+    </oointerface>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\Implementation</type>
+     <varname linkend="dom-document.props.implementation">implementation</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="dom-document.props.url">URL</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="dom-document.props.documenturi">documentURI</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="dom-document.props.characterset">characterSet</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="dom-document.props.charset">charset</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="dom-document.props.inputencoding">inputEncoding</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\DocumentType</type><type>null</type></type>
+     <varname linkend="dom-document.props.doctype">doctype</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Element</type><type>null</type></type>
+     <varname linkend="dom-document.props.documentelement">documentElement</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Element</type><type>null</type></type>
+     <varname linkend="dom-document.props.firstelementchild">firstElementChild</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Element</type><type>null</type></type>
+     <varname linkend="dom-document.props.lastelementchild">lastElementChild</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="dom-document.props.childelementcount">childElementCount</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type class="union"><type>Dom\HTMLElement</type><type>null</type></type>
+     <varname linkend="dom-document.props.body">body</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\HTMLElement</type><type>null</type></type>
+     <varname linkend="dom-document.props.head">head</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="dom-document.props.title">title</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="dom-document.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-document.props.implementation">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.implementation')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-document.props.doctype">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.doctype')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-document.props.url">
+     <term><varname>URL</varname></term>
+     <listitem>
+      <simpara>Equivalent to <varname>documentURI</varname>.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-document.props.characterset">
+     <term><varname>characterSet</varname></term>
+     <listitem>
+      <simpara>
+       The encoding of the document used for serialization.
+       Upon parsing a document, this is set to the input encoding of that
+       document.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-document.props.inputencoding">
+     <term><varname>inputEncoding</varname></term>
+     <listitem>
+      <simpara>Legacy alias for <varname>characterSet</varname>.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-document.props.charset">
+     <term><varname>charset</varname></term>
+     <listitem>
+      <simpara>Legacy alias for <varname>characterSet</varname>.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-document.props.documenturi">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.documenturi')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-document.props.documentelement">
+     <term><varname>documentElement</varname></term>
+     <listitem>
+      <simpara>
+       The <classname>Dom\Element</classname> that is the document element.
+       This evaluates to &null; for document without elements.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-document.props.firstelementchild">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.firstelementchild')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-document.props.lastelementchild">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.lastelementchild')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-document.props.childelementcount">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.childelementcount')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-document.props.body">
+     <term><varname>body</varname></term>
+     <listitem>
+      <simpara>
+       The first child of the <literal>html</literal> element that is either a
+       <literal>body</literal> tag or a <literal>frameset</literal> tag.
+       These need to be in the HTML namespace.
+       If no element matches, this evaluates to &null;.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-document.props.head">
+     <term><varname>head</varname></term>
+     <listitem>
+      <simpara>
+       The first <literal>head</literal> element that is a child of the
+       <literal>html</literal> element.
+       These need to be in the HTML namespace.
+       If no element matches, this evaluates to &null;.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-document.props.title">
+     <term><varname>title</varname></term>
+     <listitem>
+      <simpara>
+       The title of the document as set by the <literal>title</literal>
+       element for HTML or the SVG <literal>title</literal> element for SVG.
+       If there is no title, this evaluates to the empty string.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+ </partintro>
+
+<!-- &reference.dom.dom.entities.document; -->
+
+</reference>

--- a/reference/dom/dom/dom-document.xml
+++ b/reference/dom/dom/dom-document.xml
@@ -127,14 +127,16 @@
     </xi:include>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-documentfragment.xml
+++ b/reference/dom/dom/dom-documentfragment.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-documentfragment" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\DocumentFragment class</title>
+ <titleabbrev>Dom\DocumentFragment</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-documentfragment.intro">
+   &reftitle.intro;
+   <simpara>
+    This represents a document fragment, which can be used as a container for
+    other nodes.
+   </simpara>
+   <simpara>
+    This is the modern, spec-compliant equivalent of
+    <classname>DOMDocumentFragment</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-documentfragment.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\DocumentFragment</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Dom\Node</classname>
+    </ooclass>
+
+    <oointerface>
+     <modifier>implements</modifier>
+     <interfacename>Dom\ParentNode</interfacename>
+    </oointerface>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Element</type><type>null</type></type>
+     <varname linkend="dom-documentfragment.props.firstelementchild">firstElementChild</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Element</type><type>null</type></type>
+     <varname linkend="dom-documentfragment.props.lastelementchild">lastElementChild</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="dom-documentfragment.props.childelementcount">childElementCount</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-documentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DocumentFragment'])">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="dom-documentfragment.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-documentfragment.props.firstelementchild">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.firstelementchild')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-documentfragment.props.lastelementchild">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.lastelementchild')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-documentfragment.props.childelementcount">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.childelementcount')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+ </partintro>
+
+<!-- &reference.dom.dom.entities.documentfragment; -->
+
+</reference>

--- a/reference/dom/dom/dom-documentfragment.xml
+++ b/reference/dom/dom/dom-documentfragment.xml
@@ -67,14 +67,16 @@
     </xi:include>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-documentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DocumentFragment'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-documentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DocumentFragment'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-documenttype.xml
+++ b/reference/dom/dom/dom-documenttype.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-documenttype" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\DocumentType class</title>
+ <titleabbrev>Dom\DocumentType</titleabbrev>
+
+ <partintro>
+  <section xml:id="dom-documenttype.intro">
+   &reftitle.intro;
+   <simpara>
+    Each <classname>Dom\Document</classname> has a <literal>doctype</literal>
+    attribute whose value is either &null; or a <classname>Dom\DocumentType</classname> object.
+   </simpara>
+   <simpara>
+    This is the modern, spec-compliant equivalent of
+    <classname>DOMImplementation</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-documenttype.synopsis">
+   &reftitle.classsynopsis;
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\DocumentType</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Dom\Node</classname>
+    </ooclass>
+
+    <oointerface>
+     <modifier>implements</modifier>
+     <interfacename>Dom\ChildNode</interfacename>
+    </oointerface>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="dom-documenttype.props.name">name</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\DtdNamedNodeMap</type>
+     <varname linkend="dom-documenttype.props.entities">entities</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\DtdNamedNodeMap</type>
+     <varname linkend="dom-documenttype.props.notations">notations</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="dom-documenttype.props.publicid">publicId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="dom-documenttype.props.systemid">systemId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="dom-documenttype.props.internalsubset">internalSubset</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-documenttype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DocumentType'])">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="dom-documenttype.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-documenttype.props.publicid">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.publicid')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-documenttype.props.systemid">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.systemid')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-documenttype.props.name">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.name')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-documenttype.props.entities">
+     <term><varname>entities</varname></term>
+     <listitem>
+      <simpara>
+       A <classname>Dom\DtdNamedNodeMap</classname> containing the general
+       entities, both external and internal, declared in the <abbrev>DTD</abbrev>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-documenttype.props.notations">
+     <term><varname>notations</varname></term>
+     <listitem>
+      <simpara>
+       A <classname>Dom\DtdNamedNodeMap</classname> containing the notations
+       declared in the <abbrev>DTD</abbrev>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-documenttype.props.internalsubset">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.internalsubset')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+   </variablelist>
+  </section>
+ </partintro>
+
+</reference>

--- a/reference/dom/dom/dom-documenttype.xml
+++ b/reference/dom/dom/dom-documenttype.xml
@@ -83,14 +83,16 @@
     </xi:include>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-documenttype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DocumentType'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-documenttype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DocumentType'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-dtdnamednodemap.xml
+++ b/reference/dom/dom/dom-dtdnamednodemap.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-dtdnamednodemap" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\DtdNamedNodeMap class</title>
+ <titleabbrev>Dom\DtdNamedNodeMap</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-dtdnamednodemap.intro">
+   &reftitle.intro;
+   <simpara>
+    Represents a named node map for entities and notation nodes of the
+    <acronym>DTD</acronym>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-dtdnamednodemap.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\DtdNamedNodeMap</classname>
+    </ooclass>
+
+    <oointerface>
+     <modifier>implements</modifier>
+     <interfacename>IteratorAggregate</interfacename>
+    </oointerface>
+
+    <oointerface>
+     <interfacename>Countable</interfacename>
+    </oointerface>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="dom-dtdnamednodemap.props.length">length</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-dtdnamednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DtdNamedNodeMap'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="dom-dtdnamednodemap.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-dtdnamednodemap.props.length">
+     <term><varname>length</varname></term>
+     <listitem>
+      <simpara>
+       The total number of entities and notation nodes.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+ </partintro>
+
+<!-- &reference.dom.dom.entities.dtdnamednodemap; -->
+
+</reference>

--- a/reference/dom/dom/dom-dtdnamednodemap.xml
+++ b/reference/dom/dom/dom-dtdnamednodemap.xml
@@ -40,9 +40,10 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-dtdnamednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DtdNamedNodeMap'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-dtdnamednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DtdNamedNodeMap'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-element.xml
+++ b/reference/dom/dom/dom-element.xml
@@ -138,14 +138,16 @@
     </xi:include>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Element'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Element'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-element.xml
+++ b/reference/dom/dom/dom-element.xml
@@ -248,7 +248,7 @@
 
   <section role="notes">
    &reftitle.notes;
-   &dom.note.utf8;
+   &dom.note.modern.utf8;
   </section>
 
  </partintro>

--- a/reference/dom/dom/dom-element.xml
+++ b/reference/dom/dom/dom-element.xml
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-element" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\Element class</title>
+ <titleabbrev>Dom\Element</titleabbrev>
+ 
+ <partintro>
+
+  <section xml:id="dom-element.intro">
+   &reftitle.intro;
+   <simpara>
+    Represents an element.
+   </simpara>
+   <simpara>
+    This is the modern, spec-compliant equivalent of
+    <classname>DOMElement</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-element.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\Element</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Dom\Node</classname>
+    </ooclass>
+
+    <oointerface>
+     <modifier>implements</modifier>
+     <interfacename>Dom\ParentNode</interfacename>
+    </oointerface>
+
+    <oointerface>
+     <interfacename>Dom\ChildNode</interfacename>
+    </oointerface>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="dom-element.props.namespaceuri">namespaceURI</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="dom-element.props.prefix">prefix</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="dom-element.props.localname">localName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="dom-element.props.tagname">tagName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="dom-element.props.id">id</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="dom-element.props.classname">className</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\TokenList</type>
+     <varname linkend="dom-element.props.classlist">classList</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\NamedNodeMap</type>
+     <varname linkend="dom-element.props.attributes">attributes</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Element</type><type>null</type></type>
+     <varname linkend="dom-element.props.firstelementchild">firstElementChild</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Element</type><type>null</type></type>
+     <varname linkend="dom-element.props.lastelementchild">lastElementChild</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="dom-element.props.childelementcount">childElementCount</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Element</type><type>null</type></type>
+     <varname linkend="dom-element.props.previouselementsibling">previousElementSibling</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Element</type><type>null</type></type>
+     <varname linkend="dom-element.props.nextelementsibling">nextElementSibling</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="dom-element.props.innerhtml">innerHTML</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="dom-element.props.substitutednodevalue">substitutedNodeValue</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Element'])">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="dom-element.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-element.props.namespaceuri">
+     <term><varname>namespaceURI</varname></term>
+     <listitem>
+      <simpara>The namespace <abbrev>URI</abbrev> of the element.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.prefix">
+     <term><varname>prefix</varname></term>
+     <listitem>
+      <simpara>The namespace prefix of the element.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.localname">
+     <term><varname>localName</varname></term>
+     <listitem>
+      <simpara>The local name of the element.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.tagname">
+     <term><varname>tagName</varname></term>
+     <listitem>
+      <simpara>The HTML-uppercased qualified name of the element.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.classname">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.classname')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.classlist">
+     <term><varname>classList</varname></term>
+     <listitem>
+      <simpara>
+       Returns an instance of <classname>Dom\TokenList</classname> to
+       easily manage the classes on this element.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.attributes">
+     <term><varname>attributes</varname></term>
+     <listitem>
+      <simpara>
+       Returns an instance of <classname>Dom\NamedNodeMap</classname> that
+       represents the attributes of this element.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.id">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.id')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.firstelementchild">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.firstelementchild')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.lastelementchild">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.lastelementchild')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.childelementcount">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.childelementcount')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.previouselementsibling">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.previouselementsibling')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.nextelementsibling">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.nextelementsibling')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.innerhtml">
+     <term><varname>innerHTML</varname></term>
+     <listitem>
+      <simpara>The inner HTML (or XML for XML documents) of the element.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.substitutednodevalue">
+     <term><varname>substitutedNodeValue</varname></term>
+     <listitem>
+      <simpara>The node value with entity substitution enabled.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+  <section role="notes">
+   &reftitle.notes;
+   &dom.note.utf8;
+  </section>
+
+ </partintro>
+
+<!-- &reference.dom.dom.entities.element; -->
+
+</reference>

--- a/reference/dom/dom/dom-element.xml
+++ b/reference/dom/dom/dom-element.xml
@@ -3,7 +3,7 @@
 <reference xml:id="class.dom-element" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>The Dom\Element class</title>
  <titleabbrev>Dom\Element</titleabbrev>
- 
+
  <partintro>
 
   <section xml:id="dom-element.intro">

--- a/reference/dom/dom/dom-entity.xml
+++ b/reference/dom/dom/dom-entity.xml
@@ -58,9 +58,10 @@
     </xi:include>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-entity.xml
+++ b/reference/dom/dom/dom-entity.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-entity" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\Entity class</title>
+ <titleabbrev>Dom\Entity</titleabbrev>
+
+ <partintro>
+  <section xml:id="dom-entity.intro">
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.intro')/*)">
+    <xi:fallback/>
+   </xi:include>
+   <simpara>
+    This is the modern, spec-compliant equivalent of
+    <classname>DOMEntity</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-entity.synopsis">
+   &reftitle.classsynopsis;
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\Entity</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Dom\Node</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="dom-entity.props.publicid">publicId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="dom-entity.props.systemid">systemId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="dom-entity.props.notationname">notationName</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="dom-entity.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-entity.props.publicid">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.props.publicid')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-entity.props.systemid">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.props.systemid')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-entity.props.notationname">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.props.notationname')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+   </variablelist>
+  </section>
+ </partintro>
+
+</reference>

--- a/reference/dom/dom/dom-entityreference.xml
+++ b/reference/dom/dom/dom-entityreference.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-entityreference" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\EntityReference class</title>
+ <titleabbrev>Dom\EntityReference</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-entityreference.intro">
+   &reftitle.intro;
+   <simpara>
+    This is the modern, spec-compliant equivalent of
+    <classname>DOMEntityReference</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-entityreference.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\EntityReference</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Dom\Node</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+ </partintro>
+
+</reference>

--- a/reference/dom/dom/dom-entityreference.xml
+++ b/reference/dom/dom/dom-entityreference.xml
@@ -38,9 +38,10 @@
     </xi:include>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-htmlcollection.xml
+++ b/reference/dom/dom/dom-htmlcollection.xml
@@ -60,7 +60,7 @@
 
   <section role="notes">
    &reftitle.notes;
-   &dom.note.utf8;
+   &dom.note.modern.utf8;
   </section>
 
  </partintro>

--- a/reference/dom/dom/dom-htmlcollection.xml
+++ b/reference/dom/dom/dom-htmlcollection.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-htmlcollection" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\HTMLCollection class</title>
+ <titleabbrev>Dom\HTMLCollection</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-htmlcollection.intro">
+   &reftitle.intro;
+   <simpara>
+    Represents a static set of elements.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-htmlcollection.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\HTMLCollection</classname>
+    </ooclass>
+
+    <oointerface>
+     <modifier>implements</modifier>
+     <interfacename>IteratorAggregate</interfacename>
+    </oointerface>
+
+    <oointerface>
+     <interfacename>Countable</interfacename>
+    </oointerface>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="dom-htmlcollection.props.length">length</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-htmlcollection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\HTMLCollection'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="dom-htmlcollection.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-htmlcollection.props.length">
+     <term><varname>length</varname></term>
+     <listitem>
+      <simpara>The number of elements.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+  <section role="notes">
+   &reftitle.notes;
+   &dom.note.utf8;
+  </section>
+
+ </partintro>
+
+<!-- &reference.dom.dom.entities.htmlcollection; -->
+
+</reference>

--- a/reference/dom/dom/dom-htmlcollection.xml
+++ b/reference/dom/dom/dom-htmlcollection.xml
@@ -39,9 +39,10 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-htmlcollection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\HTMLCollection'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-htmlcollection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\HTMLCollection'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-htmldocument.xml
+++ b/reference/dom/dom/dom-htmldocument.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-htmldocument" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\HTMLDocument class</title>
+ <titleabbrev>Dom\HTMLDocument</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-htmldocument.intro">
+   &reftitle.intro;
+   <simpara>
+    Represents an <acronym>HTML</acronym> document.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-htmldocument.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier>final</modifier>
+     <classname>Dom\HTMLDocument</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Dom\Document</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-htmldocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\HTMLDocument'])">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section role="notes">
+   &reftitle.notes;
+   &dom.note.utf8;
+  </section>
+
+ </partintro>
+
+<!-- &reference.dom.dom.entities.htmldocument; -->
+
+</reference>

--- a/reference/dom/dom/dom-htmldocument.xml
+++ b/reference/dom/dom/dom-htmldocument.xml
@@ -59,7 +59,7 @@
 
   <section role="notes">
    &reftitle.notes;
-   &dom.note.utf8;
+   &dom.note.modern.utf8;
   </section>
 
  </partintro>

--- a/reference/dom/dom/dom-htmldocument.xml
+++ b/reference/dom/dom/dom-htmldocument.xml
@@ -41,17 +41,19 @@
     </xi:include>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-htmldocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\HTMLDocument'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-htmldocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\HTMLDocument'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
      <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-htmlelement.xml
+++ b/reference/dom/dom/dom-htmlelement.xml
@@ -52,7 +52,7 @@
 
   <section role="notes">
    &reftitle.notes;
-   &dom.note.utf8;
+   &dom.note.modern.utf8;
   </section>
 
  </partintro>

--- a/reference/dom/dom/dom-htmlelement.xml
+++ b/reference/dom/dom/dom-htmlelement.xml
@@ -40,12 +40,13 @@
     </xi:include>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Element'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Element'])">
      <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-htmlelement.xml
+++ b/reference/dom/dom/dom-htmlelement.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-htmlelement" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\HTMLElement class</title>
+ <titleabbrev>Dom\HTMLElement</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-htmlelement.intro">
+   &reftitle.intro;
+   <simpara>
+    Represents an element in the <acronym>HTML</acronym> namespace.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-htmlelement.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\HTMLElement</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Dom\Element</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Element'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section role="notes">
+   &reftitle.notes;
+   &dom.note.utf8;
+  </section>
+
+ </partintro>
+
+</reference>

--- a/reference/dom/dom/dom-implementation.xml
+++ b/reference/dom/dom/dom-implementation.xml
@@ -27,9 +27,10 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-implementation')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Implementation'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-implementation')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Implementation'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
 
   </section>

--- a/reference/dom/dom/dom-implementation.xml
+++ b/reference/dom/dom/dom-implementation.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-implementation" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\Implementation class</title>
+ <titleabbrev>Dom\Implementation</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-implementation.intro">
+   &reftitle.intro;
+   <simpara>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domimplementation.intro.brief')/text())">
+     <xi:fallback/>
+    </xi:include>
+   </simpara>
+   <simpara>
+    This is the modern, spec-compliant equivalent of
+    <classname>DOMImplementation</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-implementation.synopsis">
+   &reftitle.classsynopsis;
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\Implementation</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-implementation')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Implementation'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+
+  </section>
+
+ </partintro>
+
+<!-- &reference.dom.dom.entities.implementation; -->
+
+</reference>

--- a/reference/dom/dom/dom-namednodemap.xml
+++ b/reference/dom/dom/dom-namednodemap.xml
@@ -39,9 +39,10 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-namednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\NamedNodeMap'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-namednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\NamedNodeMap'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-namednodemap.xml
+++ b/reference/dom/dom/dom-namednodemap.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-namednodemap" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\NamedNodeMap class</title>
+ <titleabbrev>Dom\NamedNodeMap</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-namednodemap.intro">
+   &reftitle.intro;
+   <simpara>
+    Represents the set of attributes on an element.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-namednodemap.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\NamedNodeMap</classname>
+    </ooclass>
+
+    <oointerface>
+     <modifier>implements</modifier>
+     <interfacename>IteratorAggregate</interfacename>
+    </oointerface>
+
+    <oointerface>
+     <interfacename>Countable</interfacename>
+    </oointerface>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="dom-namednodemap.props.length">length</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-namednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\NamedNodeMap'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="dom-namednodemap.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-namednodemap.props.length">
+     <term><varname>length</varname></term>
+     <listitem>
+      <simpara>The number of attributes.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+  <section role="notes">
+   &reftitle.notes;
+   &dom.note.utf8;
+  </section>
+
+ </partintro>
+
+<!-- &reference.dom.dom.entities.namednodemap; -->
+
+</reference>

--- a/reference/dom/dom/dom-namednodemap.xml
+++ b/reference/dom/dom/dom-namednodemap.xml
@@ -60,7 +60,7 @@
 
   <section role="notes">
    &reftitle.notes;
-   &dom.note.utf8;
+   &dom.note.modern.utf8;
   </section>
 
  </partintro>

--- a/reference/dom/dom/dom-namespaceinfo.xml
+++ b/reference/dom/dom/dom-namespaceinfo.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-namespaceinfo" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\NamespaceInfo class</title>
+ <titleabbrev>Dom\NamespaceInfo</titleabbrev>
+
+ <partintro>
+  <section xml:id="dom-namespaceinfo.intro">
+   &reftitle.intro;
+   <simpara>
+    This represents immutable information about namespaces of an element.
+    This decouples namespaces from attributes, which was incorrectly intertwined for the old DOM classes.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-namespaceinfo.synopsis">
+   &reftitle.classsynopsis;
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier>final</modifier>
+     <modifier>readonly</modifier>
+     <classname>Dom\NamespaceInfo</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="dom-namespaceinfo.props.prefix">prefix</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="dom-namespaceinfo.props.namespaceuri">namespaceURI</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>Dom\Element</type>
+     <varname linkend="dom-namespaceinfo.props.element">element</varname>
+    </fieldsynopsis>
+
+    <!--<classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-namespaceinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Dom\\NamespaceInfo'])">
+     <xi:fallback/>
+    </xi:include>-->
+   </classsynopsis>
+  </section>
+
+  <section xml:id="dom-namespaceinfo.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-namespaceinfo.props.prefix">
+     <term><varname>prefix</varname></term>
+     <listitem>
+      <simpara>The namespace prefix of the attribute.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-namespaceinfo.props.namespaceuri">
+     <term><varname>namespaceURI</varname></term>
+     <listitem>
+      <simpara>The namespace <abbrev>URI</abbrev> of the attribute.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-namespaceinfo.props.element">
+     <term><varname>element</varname></term>
+     <listitem>
+      <simpara>The element that this namespace information is about.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+ </partintro>
+
+</reference>

--- a/reference/dom/dom/dom-node.xml
+++ b/reference/dom/dom/dom-node.xml
@@ -291,7 +291,7 @@
 
   <section role="notes">
    &reftitle.notes;
-   &dom.note.utf8;
+   &dom.note.modern.utf8;
   </section>
 
   <section role="seealso">

--- a/reference/dom/dom/dom-node.xml
+++ b/reference/dom/dom/dom-node.xml
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-node" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\Node class</title>
+ <titleabbrev>Dom\Node</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-node.intro">
+   &reftitle.intro;
+   <simpara>
+    This is the modern, spec-compliant equivalent of
+    <classname>DOMNode</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-node.synopsis">
+   &reftitle.classsynopsis;
+    <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\Node</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="dom-node.constants.document-position-disconnected">Dom\Node::DOCUMENT_POSITION_DISCONNECTED</varname>
+     <initializer>0x1</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="dom-node.constants.document-position-preceding">Dom\Node::DOCUMENT_POSITION_PRECEDING</varname>
+     <initializer>0x2</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="dom-node.constants.document-position-following">Dom\Node::DOCUMENT_POSITION_FOLLOWING</varname>
+     <initializer>0x4</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="dom-node.constants.document-position-contains">Dom\Node::DOCUMENT_POSITION_CONTAINS</varname>
+     <initializer>0x8</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="dom-node.constants.document-position-contained-by">Dom\Node::DOCUMENT_POSITION_CONTAINED_BY</varname>
+     <initializer>0x10</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="dom-node.constants.document-position-implementation-specific">Dom\Node::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC</varname>
+     <initializer>0x20</initializer>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="dom-node.props.nodetype">nodeType</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="dom-node.props.nodename">nodeName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="dom-node.props.baseuri">baseURI</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>bool</type>
+     <varname linkend="dom-node.props.isconnected">isConnected</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Document</type><type>null</type></type>
+     <varname linkend="dom-node.props.ownerdocument">ownerDocument</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Node</type><type>null</type></type>
+     <varname linkend="dom-node.props.parentnode">parentNode</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Element</type><type>null</type></type>
+     <varname linkend="dom-node.props.parentelement">parentElement</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\NodeList</type>
+     <varname linkend="dom-node.props.childnodes">childNodes</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Node</type><type>null</type></type>
+     <varname linkend="dom-node.props.firstchild">firstChild</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Node</type><type>null</type></type>
+     <varname linkend="dom-node.props.lastchild">lastChild</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Node</type><type>null</type></type>
+     <varname linkend="dom-node.props.previoussibling">previousSibling</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>Dom\Node</type><type>null</type></type>
+     <varname linkend="dom-node.props.nextsibling">nextSibling</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="dom-node.props.nodevalue">nodeValue</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="dom-node.props.textcontent">textContent</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Dom\\Node'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+
+  </section>
+
+  <section xml:id="dom-node.constants">
+   &reftitle.constants;
+   <variablelist>
+    <varlistentry xml:id="dom-node.constants.document-position-disconnected">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-disconnected')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-node.constants.document-position-preceding">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-preceding')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-node.constants.document-position-following">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-following')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-node.constants.document-position-contains">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-contains')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-node.constants.document-position-contained-by">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-contained-by')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-node.constants.document-position-implementation-specific">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-implementation-specific')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+  <section xml:id="dom-node.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-node.props.nodetype">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.nodetype')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-node.props.nodename">
+     <term><varname>nodeName</varname></term>
+     <listitem>
+      <simpara>Returns the most accurate name for the current node type.</simpara>
+      <itemizedlist>
+       <listitem><simpara>For elements, this is the HTML-uppercased qualified name.</simpara></listitem>
+       <listitem><simpara>For attributes, this is the qualified name.</simpara></listitem>
+       <listitem><simpara>For processing instructions, this is the target.</simpara></listitem>
+       <listitem><simpara>For document type nodes, this is the name.</simpara></listitem>
+      </itemizedlist>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-node.props.baseuri">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.baseuri')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-node.props.isconnected">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.isconnected')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-node.props.ownerdocument">
+     <term><varname>ownerDocument</varname></term>
+     <listitem>
+      <simpara>
+       The <classname>Dom\Document</classname> object associated with
+       this node, or &null; if this node is a document.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-node.props.parentnode">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.parentnode')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-node.props.parentelement">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.parentelement')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-node.props.childnodes">
+     <term><varname>childNodes</varname></term>
+     <listitem>
+      <simpara>
+       A <classname>Dom\NodeList</classname> that contains all
+       children of this node. If there are no children, this is an empty
+       <classname>Dom\NodeList</classname>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-node.props.firstchild">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.firstchild')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-node.props.lastchild">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.lastchild')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-node.props.previoussibling">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.previoussibling')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-node.props.nextsibling">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.nextsibling')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-node.props.nodevalue">
+     <term><varname>nodeValue</varname></term>
+     <listitem>
+      <simpara>
+       The value of this node, depending on its type.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-node.props.textcontent">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.textcontent')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+  <section role="notes">
+   &reftitle.notes;
+   &dom.note.utf8;
+  </section>
+
+  <section role="seealso">
+   &reftitle.seealso;
+   <simplelist>
+    <member><link xlink:href="&url.spec.dom.living.node;">WHATWG specification of Node</link></member>
+   </simplelist>
+  </section>
+
+ </partintro>
+
+<!-- &reference.dom.dom.entities.node; -->
+
+</reference>

--- a/reference/dom/dom/dom-node.xml
+++ b/reference/dom/dom/dom-node.xml
@@ -150,12 +150,10 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Dom\\Node'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
      <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
 
   </section>

--- a/reference/dom/dom/dom-nodelist.xml
+++ b/reference/dom/dom/dom-nodelist.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-nodelist" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The <classname>Dom\NodeList</classname> class</title>
+ <titleabbrev>Dom\NodeList</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-nodelist.intro">
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnodelist.intro')/*)">
+    <xi:fallback/>
+   </xi:include>
+   <simpara>
+    This is the modern, spec-compliant equivalent of
+    <classname>DOMNodeList</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-nodelist.synopsis">
+   &reftitle.classsynopsis;
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\NodeList</classname>
+    </ooclass>
+
+    <oointerface>
+     <modifier>implements</modifier>
+     <interfacename>IteratorAggregate</interfacename>
+    </oointerface>
+
+    <oointerface>
+     <interfacename>Countable</interfacename>
+    </oointerface>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="dom-nodelist.props.length">length</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-nodelist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\NodeList'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="dom-nodelist.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-nodelist.props.length">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnodelist.props.length')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+   </variablelist>
+  </section>
+ </partintro>
+
+<!-- &reference.dom.dom.entities.nodelist; -->
+
+</reference>

--- a/reference/dom/dom/dom-nodelist.xml
+++ b/reference/dom/dom/dom-nodelist.xml
@@ -41,9 +41,10 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-nodelist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\NodeList'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-nodelist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\NodeList'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-notation.xml
+++ b/reference/dom/dom/dom-notation.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-notation" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\Notation class</title>
+ <titleabbrev>Dom\Notation</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-notation.synopsis">
+   &reftitle.classsynopsis;
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\Notation</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Dom\Node</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="dom-notation.props.publicid">publicId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="dom-notation.props.systemid">systemId</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="dom-notation.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-notation.props.publicid">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnotation.props.publicid')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-notation.props.systemid">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnotation.props.systemid')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+ </partintro>
+
+</reference>

--- a/reference/dom/dom/dom-notation.xml
+++ b/reference/dom/dom/dom-notation.xml
@@ -43,9 +43,10 @@
     </xi:include>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-parentnode.xml
+++ b/reference/dom/dom/dom-parentnode.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<reference xml:id="class.dom-parentnode" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\ParentNode interface</title>
+ <titleabbrev>Dom\ParentNode</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-parentnode.intro">
+   &reftitle.intro;
+   <simpara>
+    This is the modern, spec-compliant equivalent of
+    <classname>DOMParentNode</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-parentnode.synopsis">
+   &reftitle.interfacesynopsis;
+
+   <classsynopsis class="interface">
+    <oointerface>
+     <interfacename>Dom\ParentNode</interfacename>
+    </oointerface>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-parentnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\ParentNode'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+
+  </section>
+
+ </partintro>
+
+<!-- &reference.dom.dom.entities.parentnode; -->
+
+</reference>

--- a/reference/dom/dom/dom-parentnode.xml
+++ b/reference/dom/dom/dom-parentnode.xml
@@ -31,6 +31,6 @@
 
  </partintro>
 
-<!-- &reference.dom.dom.entities.parentnode; -->
+ &reference.dom.dom.entities.parentnode;
 
 </reference>

--- a/reference/dom/dom/dom-processinginstruction.xml
+++ b/reference/dom/dom/dom-processinginstruction.xml
@@ -54,9 +54,10 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
      <xi:fallback/>
     </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-processinginstruction.xml
+++ b/reference/dom/dom/dom-processinginstruction.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-processinginstruction" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\ProcessingInstruction class</title>
+ <titleabbrev>Dom\ProcessingInstruction</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-processinginstruction.intro">
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domprocessinginstruction.intro')/*)">
+    <xi:fallback/>
+   </xi:include>
+   <simpara>
+    This is the modern, spec-compliant equivalent of
+    <classname>DOMProcessingInstruction</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-processinginstruction.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\ProcessingInstruction</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Dom\CharacterData</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="dom-processinginstruction.props.target">target</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="dom-processinginstruction.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-processinginstruction.props.target">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domprocessinginstruction.props.target')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+ </partintro>
+
+</reference>

--- a/reference/dom/dom/dom-text.xml
+++ b/reference/dom/dom/dom-text.xml
@@ -8,10 +8,10 @@
 
   <section xml:id="dom-text.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     The <classname>Dom\Text</classname> class inherits from
     <classname>Dom\CharacterData</classname> and represents a text node.
-   </para>
+   </simpara>
    <simpara>
     This is the modern, spec-compliant equivalent of
     <classname>DOMText</classname>.
@@ -79,5 +79,7 @@
   </section>
 
  </partintro>
+
+ &reference.dom.dom.entities.text;
 
 </reference>

--- a/reference/dom/dom/dom-text.xml
+++ b/reference/dom/dom/dom-text.xml
@@ -61,9 +61,10 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
      <xi:fallback/>
     </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-text.xml
+++ b/reference/dom/dom/dom-text.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-text" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\Text class</title>
+ <titleabbrev>Dom\Text</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-text.intro">
+   &reftitle.intro;
+   <para>
+    The <classname>Dom\Text</classname> class inherits from
+    <classname>Dom\CharacterData</classname> and represents a text node.
+   </para>
+   <simpara>
+    This is the modern, spec-compliant equivalent of
+    <classname>DOMText</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-text.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Dom\Text</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Dom\CharacterData</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="dom-text.props.wholetext">wholeText</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-text')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Text'])">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="dom-text.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-text.props.wholetext">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domtext.props.wholetext')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+ </partintro>
+
+</reference>

--- a/reference/dom/dom/dom-tokenlist.xml
+++ b/reference/dom/dom/dom-tokenlist.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-tokenlist" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\TokenList class</title>
+ <titleabbrev>Dom\TokenList</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-tokenlist.intro">
+   &reftitle.intro;
+   <simpara>
+    Represents a set of tokens in an attribute (e.g. class names).
+   </simpara>
+  </section>
+
+  <section xml:id="dom-tokenlist.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier>final</modifier>
+     <classname>Dom\TokenList</classname>
+    </ooclass>
+
+    <oointerface>
+     <modifier>implements</modifier>
+     <interfacename>IteratorAggregate</interfacename>
+    </oointerface>
+
+    <oointerface>
+     <interfacename>Countable</interfacename>
+    </oointerface>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="dom-tokenlist.props.length">length</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="dom-tokenlist.props.value">value</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-tokenlist')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Dom\\TokenList'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-tokenlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\TokenList'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="dom-tokenlist.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-tokenlist.props.length">
+     <term><varname>length</varname></term>
+     <listitem>
+      <simpara>The number of tokens.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-tokenlist.props.value">
+     <term><varname>value</varname></term>
+     <listitem>
+      <simpara>The value of the attribute linked to this object.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+  <section role="notes">
+   &reftitle.notes;
+   &dom.note.utf8;
+  </section>
+
+ </partintro>
+
+<!-- &reference.dom.dom.entities.tokenlist; -->
+
+</reference>

--- a/reference/dom/dom/dom-tokenlist.xml
+++ b/reference/dom/dom/dom-tokenlist.xml
@@ -75,7 +75,7 @@
 
   <section role="notes">
    &reftitle.notes;
-   &dom.note.utf8;
+   &dom.note.modern.utf8;
   </section>
 
  </partintro>

--- a/reference/dom/dom/dom-tokenlist.xml
+++ b/reference/dom/dom/dom-tokenlist.xml
@@ -45,12 +45,13 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-tokenlist')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Dom\\TokenList'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-tokenlist')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Dom\\TokenList'])">
      <xi:fallback/>
     </xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-tokenlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\TokenList'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-xmldocument.xml
+++ b/reference/dom/dom/dom-xmldocument.xml
@@ -82,6 +82,14 @@
 
   <section xml:id="dom-xmldocument.props">
    &reftitle.properties;
+   <note>
+    <simpara>
+     While the <classname>DOMDocument</classname> class allows setting certain
+     properties to influence parser behaviour, this class only uses the
+     <constant>LIBXML_<replaceable>*</replaceable></constant> constants to
+     configure the parser.
+    </simpara>
+   </note>
    <variablelist>
     <varlistentry xml:id="dom-xmldocument.props.xmlencoding">
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.xmlencoding')/*)">

--- a/reference/dom/dom/dom-xmldocument.xml
+++ b/reference/dom/dom/dom-xmldocument.xml
@@ -109,7 +109,7 @@
 
   <section role="notes">
    &reftitle.notes;
-   &dom.note.utf8;
+   &dom.note.modern.utf8;
   </section>
 
  </partintro>

--- a/reference/dom/dom/dom-xmldocument.xml
+++ b/reference/dom/dom/dom-xmldocument.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-xmldocument" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\XMLDocument class</title>
+ <titleabbrev>Dom\XMLDocument</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-xmldocument.intro">
+   &reftitle.intro;
+   <simpara>
+    Represents an <acronym>XML</acronym> document.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-xmldocument.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier>final</modifier>
+     <classname>Dom\XMLDocument</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Dom\Document</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="dom-xmldocument.props.xmlencoding">xmlEncoding</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>bool</type>
+     <varname linkend="dom-xmldocument.props.xmlstandalone">xmlStandalone</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="dom-xmldocument.props.xmlversion">xmlVersion</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>bool</type>
+     <varname linkend="dom-xmldocument.props.formatoutput">formatOutput</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xmldocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\XMLDocument'])">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="dom-xmldocument.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-xmldocument.props.xmlencoding">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.xmlencoding')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-xmldocument.props.xmlstandalone">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.xmlstandalone')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-xmldocument.props.xmlversion">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.xmlversion')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-xmldocument.props.formatoutput">
+     <term><varname>formatOutput</varname></term>
+     <listitem>
+      <simpara>Nicely formats output with indentation and extra space.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+  <section role="notes">
+   &reftitle.notes;
+   &dom.note.utf8;
+  </section>
+
+ </partintro>
+
+<!-- &reference.dom.dom.entities.xmldocument; -->
+
+</reference>

--- a/reference/dom/dom/dom-xmldocument.xml
+++ b/reference/dom/dom/dom-xmldocument.xml
@@ -64,17 +64,19 @@
     </xi:include>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xmldocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\XMLDocument'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xmldocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\XMLDocument'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
      <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
+    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-xpath.xml
+++ b/reference/dom/dom/dom-xpath.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<reference xml:id="class.dom-xpath" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Dom\XPath class</title>
+ <titleabbrev>Dom\XPath</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="dom-xpath.intro">
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domxpath.intro')/*)">
+    <xi:fallback/>
+   </xi:include>
+   <simpara>
+    This is the modern, spec-compliant equivalent of
+    <classname>DOMXPath</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="dom-xpath.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier>final</modifier>
+     <classname>Dom\XPath</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\Document</type>
+     <varname linkend="dom-xpath.props.document">document</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>bool</type>
+     <varname linkend="dom-xpath.props.registernodenamespaces">registerNodeNamespaces</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xpath')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Dom\\XPath'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xpath')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\XPath'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="dom-xpath.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-xpath.props.document">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domxpath.props.document')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-xpath.props.registernodenamespaces">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domxpath.props.registernodenamespaces')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+ </partintro>
+
+<!-- &reference.dom.dom.entities.xpath; -->
+
+</reference>

--- a/reference/dom/dom/dom-xpath.xml
+++ b/reference/dom/dom/dom-xpath.xml
@@ -39,12 +39,13 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xpath')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Dom\\XPath'])">
+    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xpath')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Dom\\XPath'])">
      <xi:fallback/>
     </xi:include>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xpath')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\XPath'])">
      <xi:fallback/>
-    </xi:include>
+    </xi:include>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/parentnode/append.xml
+++ b/reference/dom/dom/parentnode/append.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="dom-parentnode.append" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>Dom\ParentNode::append</refname>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.append')/db:refnamediv/db:refpurpose)"/>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Dom\\ParentNode">
+   <modifier>public</modifier> <type>void</type><methodname>Dom\ParentNode::append</methodname>
+   <methodparam rep="repeat"><type class="union"><type>Dom\Node</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.append')/db:refsect1[@role='description']/db:para[1])"/>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.append')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.append')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.append')/db:refsect1[@role='errors'])" />
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Dom\ParentNode::prepend</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/dom/parentnode/prepend.xml
+++ b/reference/dom/dom/parentnode/prepend.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="dom-parentnode.prepend" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>Dom\ParentNode::prepend</refname>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.prepend')/db:refnamediv/db:refpurpose)"/>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Dom\\ParentNode">
+   <modifier>public</modifier> <type>void</type><methodname>Dom\ParentNode::prepend</methodname>
+   <methodparam rep="repeat"><type class="union"><type>Dom\Node</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.prepend')/db:refsect1[@role='description']/db:para[1])"/>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.prepend')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.prepend')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.prepend')/db:refsect1[@role='errors'])" />
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Dom\ParentNode::append</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/dom/parentnode/queryselector.xml
+++ b/reference/dom/dom/parentnode/queryselector.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="dom-parentnode.queryselector" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>Dom\ParentNode::querySelector</refname>
+  <refpurpose>Returns the first element that matches the CSS selectors</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Dom\\ParentNode">
+   <modifier>public</modifier> <type class="union"><type>Dom\Element</type><type>null</type></type><methodname>Dom\ParentNode::querySelector</methodname>
+   <methodparam><type>string</type><parameter>selectors</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Returns the first element that matches the CSS selectors specified
+   in <parameter>selectors</parameter>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>selectors</parameter></term>
+    <listitem>
+     <simpara>
+      A string containing one or more CSS selectors.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns the first <classname>Dom\Element</classname> that matches
+   <parameter>selectors</parameter>. Returns &null; if no element matches.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Throws a <exceptionname>DOMException</exceptionname> with code
+   <constant>Dom\SYNTAX_ERR</constant> when <parameter>selectors</parameter>
+   is not a valid CSS selector string.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Dom\ParentNode::querySelectorAll</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/dom/parentnode/queryselectorall.xml
+++ b/reference/dom/dom/parentnode/queryselectorall.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="dom-parentnode.queryselectorall" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>Dom\ParentNode::querySelectorAll</refname>
+  <refpurpose>Returns a collection of elements that match the CSS selectors</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Dom\\ParentNode">
+   <modifier>public</modifier> <type>Dom\NodeList</type><methodname>Dom\ParentNode::querySelectorAll</methodname>
+   <methodparam><type>string</type><parameter>selectors</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Returns a collection of elements that match the CSS selectors specified
+   in <parameter>selectors</parameter>.
+  </simpara>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.queryselector')/db:refsect1[@role='parameters'])" />
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns a static collection of elements that match the CSS selectors
+   specified in <parameter>selectors</parameter>.
+  </simpara>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.queryselector')/db:refsect1[@role='errors'])" />
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Dom\ParentNode::querySelector</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/dom/parentnode/replacechildren.xml
+++ b/reference/dom/dom/parentnode/replacechildren.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="dom-parentnode.replacechildren" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>Dom\ParentNode::replaceChildren</refname>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.replacechildren')/db:refnamediv/db:refpurpose)"/>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Dom\\ParentNode">
+   <modifier>public</modifier> <type>void</type><methodname>Dom\ParentNode::replaceChildren</methodname>
+   <methodparam rep="repeat"><type class="union"><type>Dom\Node</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.replacechildren')/db:refsect1[@role='description']/db:para[1])"/>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.replacechildren')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.replacechildren')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.replacechildren')/db:refsect1[@role='errors'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Dom\ParentNode::replaceChildren</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$dom = Dom\HTMLDocument::createFromString('<!DOCTYPE HTML><html><p>hi</p> test <p>hi2</p></html>');
+
+$dom->documentElement->replaceChildren('foo', $dom->createElement('p'), 'bar');
+echo $dom->saveHtml();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<!DOCTYPE html><html>foo<p></p>bar</html>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/dom/text/splittext.xml
+++ b/reference/dom/dom/text/splittext.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="dom-text.splittext" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>Dom\Text::splitText</refname>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domtext.splittext')/db:refnamediv/db:refpurpose)"/>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Dom\\Text">
+   <modifier>public</modifier> <type>Dom\Text</type><methodname>Dom\Text::splitText</methodname>
+   <methodparam><type>int</type><parameter>offset</parameter></methodparam>
+  </methodsynopsis>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domtext.splittext')/db:refsect1[@role='description']/db:para[1])"/>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domtext.splittext')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domtext.splittext')/db:refsect1[@role='returnvalues'])" />
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domattr/isid.xml
+++ b/reference/dom/domattr/isid.xml
@@ -31,9 +31,9 @@
  
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   &return.success;
-  </para>
+  <simpara>
+   Returns &true; if this attribute is a defined ID, &false; otherwise.
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;
@@ -44,11 +44,11 @@
 <![CDATA[
 <?php
 
-$doc = new DomDocument;
+$doc = new DOMDocument;
 
 // We need to validate our document before referring to the id
 $doc->validateOnParse = true;
-$doc->Load('book.xml');
+$doc->load('book.xml');
 
 // We retrieve the attribute named id of the chapter element
 $attr = $doc->getElementsByTagName('chapter')->item(0)->getAttributeNode('id');

--- a/reference/dom/domcdatasection.xml
+++ b/reference/dom/domcdatasection.xml
@@ -11,7 +11,7 @@
   <section xml:id="domcdatasection.intro">
    &reftitle.intro;
    <para>
-    The <classname>DOMCdataSection</classname> inherits from 
+    The <classname>DOMCdataSection</classname> class inherits from
     <classname>DOMText</classname> for textual representation
     of CData constructs.
    </para>

--- a/reference/dom/domcharacterdata/deletedata.xml
+++ b/reference/dom/domcharacterdata/deletedata.xml
@@ -59,7 +59,7 @@
      <listitem>
       <para>
        Raised if <parameter>offset</parameter> is negative or greater than the
-       number of 16-bit units in data, or if <parameter>count</parameter> is
+       number of UTF-8 codepoints in data, or if <parameter>count</parameter> is
        negative.
       </para>
      </listitem>

--- a/reference/dom/domcharacterdata/deletedata.xml
+++ b/reference/dom/domcharacterdata/deletedata.xml
@@ -4,7 +4,7 @@
  <refnamediv>
   <refname>DOMCharacterData::deleteData</refname>
   <refpurpose>
-   Remove a range of characters from the node
+   Remove a range of characters from the character data
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">

--- a/reference/dom/domcharacterdata/insertdata.xml
+++ b/reference/dom/domcharacterdata/insertdata.xml
@@ -4,7 +4,7 @@
  <refnamediv>
   <refname>DOMCharacterData::insertData</refname>
   <refpurpose>
-   Insert a string at the specified 16-bit unit offset
+   Insert a string at the specified UTF-8 codepoint offset
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -56,7 +56,7 @@
      <listitem>
       <para>
        Raised if <parameter>offset</parameter> is negative or greater than the
-       number of 16-bit units in data.
+       number of UTF-8 codepoints in data.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dom/domcharacterdata/replacedata.xml
+++ b/reference/dom/domcharacterdata/replacedata.xml
@@ -68,7 +68,7 @@
      <listitem>
       <para>
        Raised if <parameter>offset</parameter> is negative or greater than the
-       number of 16-bit units in data, or if <parameter>count</parameter> is
+       number of UTF-8 codepoints in data, or if <parameter>count</parameter> is
        negative.
       </para>
      </listitem>

--- a/reference/dom/domcharacterdata/replacedata.xml
+++ b/reference/dom/domcharacterdata/replacedata.xml
@@ -4,7 +4,7 @@
  <refnamediv>
   <refname>DOMCharacterData::replaceData</refname>
   <refpurpose>
-   Replace a substring within the DOMCharacterData node
+   Replace a substring within the character data
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">

--- a/reference/dom/domcharacterdata/substringdata.xml
+++ b/reference/dom/domcharacterdata/substringdata.xml
@@ -45,7 +45,7 @@
   &reftitle.returnvalues;
   <para>
    The specified substring. If the sum of <parameter>offset</parameter> 
-   and <parameter>count</parameter> exceeds the length, then all 16-bit units 
+   and <parameter>count</parameter> exceeds the length, then all UTF-8 codepoints
    to the end of the data are returned.
   </para>
  </refsect1>
@@ -58,7 +58,7 @@
      <listitem>
       <para>
        Raised if <parameter>offset</parameter> is negative or greater than the
-       number of 16-bit units in data, or if <parameter>count</parameter> is 
+       number of UTF-8 codepoints in data, or if <parameter>count</parameter> is
        negative.
       </para>
      </listitem>

--- a/reference/dom/domcharacterdata/substringdata.xml
+++ b/reference/dom/domcharacterdata/substringdata.xml
@@ -4,7 +4,7 @@
  <refnamediv>
   <refname>DOMCharacterData::substringData</refname>
   <refpurpose>
-   Extracts a range of data from the node
+   Extracts a range of data from the character data
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">

--- a/reference/dom/domdocumenttype.xml
+++ b/reference/dom/domdocumenttype.xml
@@ -102,7 +102,7 @@
      <listitem>
       <para>
        The system identifier of the external subset. This may be an
-       absolute URI or not.
+       absolute <acronym>URI</acronym> or not.
       </para>
      </listitem>
     </varlistentry>
@@ -110,7 +110,7 @@
      <term><varname>name</varname></term>
      <listitem>
       <para>
-       The name of DTD; i.e., the name immediately following the
+       The name of <acronym>DTD</acronym>; i.e., the name immediately following the
        <literal>DOCTYPE</literal> keyword.
       </para>
      </listitem>
@@ -120,7 +120,7 @@
      <listitem>
       <para>
        A <classname>DOMNamedNodeMap</classname> containing the general 
-       entities, both external and internal, declared in the DTD.
+       entities, both external and internal, declared in the <acronym>DTD</acronym>.
       </para>
      </listitem>
     </varlistentry>
@@ -129,7 +129,7 @@
      <listitem>
       <para>
        A <classname>DOMNamedNodeMap</classname> containing the notations
-       declared in the DTD.
+       declared in the <acronym>DTD</acronym>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dom/domelement.xml
+++ b/reference/dom/domelement.xml
@@ -170,13 +170,13 @@
     <varlistentry xml:id="domelement.props.classname">
      <term><varname>className</varname></term>
      <listitem>
-      <para>A string representing the classes of the element separated by spaces</para>
+      <para>A string representing the classes of the element separated by spaces.</para>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="domelement.props.id">
      <term><varname>id</varname></term>
      <listitem>
-      <para>The element ID</para>
+      <para>Reflects the element ID through the <literal>"id"</literal> attribute.</para>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/dom/domexception.xml
+++ b/reference/dom/domexception.xml
@@ -9,7 +9,7 @@ FIXME: Remove me once you perform substitutions
     dom
 -->
 <reference xml:id="class.domexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
- <title>The DOMException class</title>
+ <title>The DOMException / Dom\Exception class</title>
  <titleabbrev>DOMException</titleabbrev>
  
  <partintro>
@@ -17,10 +17,14 @@ FIXME: Remove me once you perform substitutions
 <!-- {{{ DOMException intro -->
   <section xml:id="domexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     DOM operations raise exceptions under particular circumstances, i.e.,
     when an operation is impossible to perform for logical reasons.
-   </para>
+   </simpara>
+   <simpara>
+    This class is aliased as <classname>Dom\Exception</classname> in the
+    Dom namespace.
+   </simpara>
    <para>
     See also <xref linkend="language.exceptions"/>.
    </para>

--- a/reference/dom/domimplementation.xml
+++ b/reference/dom/domimplementation.xml
@@ -15,11 +15,11 @@ Remove me once you perform substitutions
 <!-- {{{ DOMImplementation intro -->
   <section xml:id="domimplementation.intro">
    &reftitle.intro;
-   <para>
-    The <classname>DOMImplementation</classname> class provides a number
+   <simpara xml:id="domimplementation.intro.brief">
+    This class provides a number
     of methods for performing operations that are independent of any 
     particular instance of the document object model.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
  

--- a/reference/dom/domnodelist.xml
+++ b/reference/dom/domnodelist.xml
@@ -12,16 +12,12 @@ Remove me once you perform substitutions
  
  <partintro>
  
-<!-- {{{ DOMNodeList intro -->
-<!-- FIXME: 
   <section xml:id="domnodelist.intro">
    &reftitle.intro;
-   <para>
-    
-   </para>
+   <simpara>
+    Represents a live list of nodes.
+   </simpara>
   </section>
--->
-<!-- }}} -->
  
   <section xml:id="domnodelist.synopsis">
    &reftitle.classsynopsis;

--- a/reference/dom/domnotation.xml
+++ b/reference/dom/domnotation.xml
@@ -74,21 +74,20 @@ Remove me once you perform substitutions
   </section>
  
 <!-- {{{ DOMNotation properties -->
-<!-- FIXME: Add descriptions -->
   <section xml:id="domnotation.props">
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="domnotation.props.publicid">
      <term><varname>publicId</varname></term>
      <listitem>
-      <para/>
+      <simpara>The public identifier associated with the notation.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="domnotation.props.systemid">
      <term><varname>systemId</varname></term>
      <listitem>
-      <para/>
+      <simpara>The system identifier associated with the notation.</simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/dom/domprocessinginstruction.xml
+++ b/reference/dom/domprocessinginstruction.xml
@@ -6,16 +6,13 @@
  
  <partintro>
  
-<!-- {{{ DOMProcessingInstruction intro -->
-<!-- FIXME:
   <section xml:id="domprocessinginstruction.intro">
    &reftitle.intro;
-   <para>
-    
-   </para>
+   <simpara>
+    This represents a processing instruction (PI) node.
+    These are meant to indicate data areas meant for processing by specific applications.
+   </simpara>
   </section>
--->
-<!-- }}} -->
  
   <section xml:id="domprocessinginstruction.synopsis">
    &reftitle.classsynopsis;
@@ -69,21 +66,20 @@
   </section>
  
 <!-- {{{ DOMProcessingInstruction properties -->
-<!-- FIXME: Add descrtiptions -->
   <section xml:id="domprocessinginstruction.props">
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="domprocessinginstruction.props.target">
      <term><varname>target</varname></term>
      <listitem>
-      <para/>
+      <simpara>A string representing to what application the data is intended for.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="domprocessinginstruction.props.data">
      <term><varname>data</varname></term>
      <listitem>
-      <para/>
+      <simpara>Application-specific data.</simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/dom/domxpath.xml
+++ b/reference/dom/domxpath.xml
@@ -15,9 +15,9 @@ Remove me once you perform substitutions
 <!-- {{{ DOMXPath intro -->
   <section xml:id="domxpath.intro">
    &reftitle.intro;
-   <para>
-    Supports XPath 1.0
-   </para>
+   <simpara>
+    Allows to use XPath 1.0 queries on HTML or XML documents.
+   </simpara>
   </section>
 <!-- }}} -->
  
@@ -56,20 +56,19 @@ Remove me once you perform substitutions
   </section>
  
 <!-- {{{ DOMXPath properties -->
-<!-- FIXME: Add description -->
   <section xml:id="domxpath.props">
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="domxpath.props.document">
      <term><varname>document</varname></term>
      <listitem>
-      <para/>
+      <simpara>The document that is linked to this object.</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="domxpath.props.registernodenamespaces">
      <term><varname>registerNodeNamespaces</varname></term>
      <listitem>
-      <para>When set to &true;, namespaces in the node are registered.</para>
+      <simpara>When set to &true;, namespaces in the node are registered.</simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/dom/functions/dom-import-simplexml.xml
+++ b/reference/dom/functions/dom-import-simplexml.xml
@@ -4,7 +4,7 @@
  <refnamediv>
   <refname>dom_import_simplexml</refname>
   <refpurpose>
-   Gets a <classname>DOMElement</classname> object from a
+   Gets a <classname>DOMAttr</classname> or <classname>DOMElement</classname> object from a
    <classname>SimpleXMLElement</classname> object
   </refpurpose>
  </refnamediv>

--- a/reference/dom/functions/dom-ns-import-simplexml.xml
+++ b/reference/dom/functions/dom-ns-import-simplexml.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.dom-ns-import-simplexml" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>Dom\import_simplexml</refname>
+  <refpurpose>
+   Gets a <classname>Dom\Attr</classname> or <classname>Dom\Element</classname> object from a
+   <classname>SimpleXMLElement</classname> object
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>Dom\Attr</type><type>Dom\Element</type></type><methodname>Dom\import_simplexml</methodname>
+   <methodparam><type>object</type><parameter>node</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   This function takes the given attribute or element <parameter>node</parameter> (a
+   <classname>SimpleXMLElement</classname> instance) and creates a
+   <classname>Dom\Attr</classname> or <classname>Dom\Element</classname> node, repectively.
+   The new <classname>Dom\Node</classname> refers to the same underlying XML node
+   as the <classname>SimpleXMLElement</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.dom-import-simplexml')/db:refsect1[@role='parameters']/*)">
+   <xi:fallback/>
+  </xi:include>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   The <classname>Dom\Attr</classname> or <classname>Dom\Element</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Import SimpleXML into DOM and modify SimpleXML through DOM</title>
+   <simpara>
+    Error handling omitted for brevity.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$sxe = simplexml_load_string('<books><book><title>blah</title></book></books>');
+$elt = Dom\import_simplexml($sxe);
+$elt->setAttribute("foo", "bar");
+echo $sxe->asXML();
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<?xml version="1.0"?>
+<books foo="bar"><book><title>blah</title></book></books>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>simplexml_import_dom</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -203,6 +203,7 @@
  <function name="dom\import_simplexml" from="PHP 8 &gt;= 8.4.0"/>
 
  <function name="dom\node" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\implementation" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -220,6 +220,7 @@
  <function name="dom\namednodemap" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\namespaceinfo" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\node" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\nodelist" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\notation" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\implementation" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\processinginstruction" from="PHP 8 &gt;= 8.4.0"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -204,6 +204,7 @@
 
  <function name="dom\attr" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\cdatasection" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\characterdata" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\documenttype" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\entity" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\namespaceinfo" from="PHP 8 &gt;= 8.4.0"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -210,6 +210,7 @@
  <function name="dom\document" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\documentfragment" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\documenttype" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\dtdnamednodemap" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\entity" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\entityreference" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\namespaceinfo" from="PHP 8 &gt;= 8.4.0"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -215,6 +215,7 @@
  <function name="dom\entity" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\entityreference" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\htmlcollection" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\htmldocument" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\namednodemap" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\namespaceinfo" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\node" from="PHP 8 &gt;= 8.4.0"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -204,6 +204,7 @@
 
  <function name="dom\attr" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\documenttype" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\namespaceinfo" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\node" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\implementation" from="PHP 8 &gt;= 8.4.0"/>
 </versions>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -233,6 +233,16 @@
  <function name="dom\attr::isid" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\attr::rename" from="PHP 8 &gt;= 8.4.0"/>
 
+ <function name="dom\characterdata::after" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\characterdata::appenddata" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\characterdata::before" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\characterdata::deletedata" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\characterdata::insertdata" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\characterdata::remove" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\characterdata::replacedata" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\characterdata::replacewith" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\characterdata::substringdata" from="PHP 8 &gt;= 8.4.0"/>
+
  <function name="dom\childnode::after" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\childnode::before" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\childnode::remove" from="PHP 8 &gt;= 8.4.0"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -232,6 +232,11 @@
 
  <function name="dom\attr::isid" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\attr::rename" from="PHP 8 &gt;= 8.4.0"/>
+
+ <function name="dom\childnode::after" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\childnode::before" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\childnode::remove" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\childnode::replacewith" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -203,6 +203,7 @@
  <function name="dom\import_simplexml" from="PHP 8 &gt;= 8.4.0"/>
 
  <function name="dom\attr" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\documenttype" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\node" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\implementation" from="PHP 8 &gt;= 8.4.0"/>
 </versions>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -207,6 +207,7 @@
  <function name="dom\characterdata" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\childnode" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\comment" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\documentfragment" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\documenttype" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\entity" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\namespaceinfo" from="PHP 8 &gt;= 8.4.0"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -206,6 +206,7 @@
  <function name="dom\cdatasection" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\characterdata" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\childnode" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\comment" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\documenttype" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\entity" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\namespaceinfo" from="PHP 8 &gt;= 8.4.0"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -226,6 +226,7 @@
  <function name="dom\parentnode" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\processinginstruction" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\text" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\tokenlist" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\xmldocument" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
 <!-- Keep this comment at the end of the file

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -207,6 +207,7 @@
  <function name="dom\characterdata" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\childnode" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\comment" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\document" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\documentfragment" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\documenttype" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\entity" from="PHP 8 &gt;= 8.4.0"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -229,6 +229,9 @@
  <function name="dom\tokenlist" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\xmldocument" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\xpath" from="PHP 8 &gt;= 8.4.0"/>
+
+ <function name="dom\attr::isid" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\attr::rename" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -205,6 +205,7 @@
  <function name="dom\attr" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\cdatasection" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\characterdata" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\childnode" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\documenttype" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\entity" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\namespaceinfo" from="PHP 8 &gt;= 8.4.0"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -228,6 +228,7 @@
  <function name="dom\text" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\tokenlist" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\xmldocument" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\xpath" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -226,6 +226,7 @@
  <function name="dom\parentnode" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\processinginstruction" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\text" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\xmldocument" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -201,6 +201,8 @@
 
  <function name="dom_import_simplexml" from="PHP 5, PHP 7, PHP 8"/>
  <function name="dom\import_simplexml" from="PHP 8 &gt;= 8.4.0"/>
+
+ <function name="dom\node" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -200,6 +200,7 @@
  <function name="domxpath::quote" from="PHP 8 &gt;= 8.4.0"/>
 
  <function name="dom_import_simplexml" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="dom\import_simplexml" from="PHP 8 &gt;= 8.4.0"/>
 
  <!-- Unsure -->
  <function name="dom_domconfigurationcansetparameter" from="PHP 5, PHP 7"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -211,6 +211,7 @@
  <function name="dom\documentfragment" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\documenttype" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\dtdnamednodemap" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\element" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\entity" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\entityreference" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\namespaceinfo" from="PHP 8 &gt;= 8.4.0"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -247,6 +247,8 @@
  <function name="dom\childnode::before" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\childnode::remove" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\childnode::replacewith" from="PHP 8 &gt;= 8.4.0"/>
+
+ <function name="dom\text::splittext" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -215,6 +215,7 @@
  <function name="dom\node" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\notation" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\implementation" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\processinginstruction" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\text" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
 <!-- Keep this comment at the end of the file

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -203,6 +203,7 @@
  <function name="dom\import_simplexml" from="PHP 8 &gt;= 8.4.0"/>
 
  <function name="dom\attr" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\cdatasection" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\documenttype" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\entity" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\namespaceinfo" from="PHP 8 &gt;= 8.4.0"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -215,6 +215,7 @@
  <function name="dom\entity" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\entityreference" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\htmlcollection" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\namednodemap" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\namespaceinfo" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\node" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\notation" from="PHP 8 &gt;= 8.4.0"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -223,6 +223,7 @@
  <function name="dom\nodelist" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\notation" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\implementation" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\parentnode" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\processinginstruction" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\text" from="PHP 8 &gt;= 8.4.0"/>
 </versions>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -214,6 +214,7 @@
  <function name="dom\element" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\entity" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\entityreference" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\htmlcollection" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\namespaceinfo" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\node" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\notation" from="PHP 8 &gt;= 8.4.0"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -202,6 +202,7 @@
  <function name="dom_import_simplexml" from="PHP 5, PHP 7, PHP 8"/>
  <function name="dom\import_simplexml" from="PHP 8 &gt;= 8.4.0"/>
 
+ <function name="dom\attr" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\node" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\implementation" from="PHP 8 &gt;= 8.4.0"/>
 </versions>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -207,6 +207,7 @@
  <function name="dom\entity" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\namespaceinfo" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\node" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\notation" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\implementation" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
 <!-- Keep this comment at the end of the file

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -213,6 +213,7 @@
  <function name="dom\node" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\notation" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\implementation" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\text" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -201,18 +201,6 @@
 
  <function name="dom_import_simplexml" from="PHP 5, PHP 7, PHP 8"/>
  <function name="dom\import_simplexml" from="PHP 8 &gt;= 8.4.0"/>
-
- <!-- Unsure -->
- <function name="dom_domconfigurationcansetparameter" from="PHP 5, PHP 7"/>
- <function name="dom_domconfigurationgetparameter" from="PHP 5, PHP 7"/>
- <function name="dom_domconfigurationsetparameter" from="PHP 5, PHP 7"/>
- <function name="dom_domerrorhandlerhandleerror" from="PHP 5, PHP 7"/>
- <function name="dom_domstringlistitem" from="PHP 5, PHP 7"/>
- <function name="dom_namelistgetname" from="PHP 5, PHP 7"/>
- <function name="dom_namelistgetnamespaceuri" from="PHP 5, PHP 7"/>
- <function name="dom_string_extend_find_offset16" from="PHP 5, PHP 7"/>
- <function name="dom_string_extend_find_offset32" from="PHP 5, PHP 7"/>
- <function name="dom_userdatahandler_handle" from="PHP 5, PHP 7"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -204,6 +204,7 @@
 
  <function name="dom\attr" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\documenttype" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\entity" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\namespaceinfo" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\node" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\implementation" from="PHP 8 &gt;= 8.4.0"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -210,6 +210,7 @@
  <function name="dom\documentfragment" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\documenttype" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\entity" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\entityreference" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\namespaceinfo" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\node" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\notation" from="PHP 8 &gt;= 8.4.0"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -216,6 +216,7 @@
  <function name="dom\entityreference" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\htmlcollection" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\htmldocument" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\htmlelement" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\namednodemap" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\namespaceinfo" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\node" from="PHP 8 &gt;= 8.4.0"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -248,6 +248,12 @@
  <function name="dom\childnode::remove" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\childnode::replacewith" from="PHP 8 &gt;= 8.4.0"/>
 
+ <function name="dom\parentnode::append" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\parentnode::prepend" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\parentnode::queryselector" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\parentnode::queryselectorall" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="dom\parentnode::replacechildren" from="PHP 8 &gt;= 8.4.0"/>
+
  <function name="dom\text::splittext" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
 <!-- Keep this comment at the end of the file

--- a/reference/simplexml/functions/simplexml-import-dom.xml
+++ b/reference/simplexml/functions/simplexml-import-dom.xml
@@ -75,6 +75,12 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
+       Added support for <classname>Dom\Document</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
        This function now throws a <classname>TypeError</classname> instead of
        a <classname>ValueError</classname> when passed a
        non-XML or non-HTML <parameter>node</parameter>.
@@ -89,7 +95,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Importing DOM</title>
+    <title>Importing a <classname>DOMDocument</classname></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -99,6 +105,26 @@ if (!$dom) {
     echo 'Error while parsing the document';
     exit;
 }
+
+$s = simplexml_import_dom($dom);
+
+echo $s->book[0]->title;
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+blah
+]]>
+    </screen>
+   </example>
+   <example>
+    <title>Importing a <classname>Dom\Document</classname></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$dom = Dom\XMLDocument::createFromString('<books><book><title>blah</title></book></books>');
 
 $s = simplexml_import_dom($dom);
 

--- a/reference/xsl/xsltprocessor/importstylesheet.xml
+++ b/reference/xsl/xsltprocessor/importstylesheet.xml
@@ -24,7 +24,8 @@
      <term><parameter>stylesheet</parameter></term>
      <listitem>
       <para>
-       The imported style sheet as a <classname>DOMDocument</classname> or
+       The imported style sheet as a <classname>Dom\Document</classname>,
+       <classname>DOMDocument</classname> or
        <classname>SimpleXMLElement</classname> object.
       </para>
      </listitem>
@@ -58,6 +59,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Added support for <classname>Dom\Document</classname>.
+      </entry>
+     </row>
      <row>
       <entry>8.4.0</entry>
       <entry>

--- a/reference/xsl/xsltprocessor/transformtodoc.xml
+++ b/reference/xsl/xsltprocessor/transformtodoc.xml
@@ -26,7 +26,7 @@
      <term><parameter>document</parameter></term>
      <listitem>
       <para>
-       The <classname>DOMDocument</classname> or <classname>SimpleXMLElement</classname> or libxml-compatible
+       The <classname>Dom\Document</classname>, <classname>DOMDocument</classname>, <classname>SimpleXMLElement</classname> or libxml-compatible
        object to be transformed.
       </para>
      </listitem>
@@ -51,11 +51,34 @@
    The resulting document or &false; on error.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Added support for <classname>Dom\Document</classname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
    <example>
-    <title>Transforming to a DOMDocument</title>
+    <title>Transforming to a <classname>DOMDocument</classname></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -83,8 +106,34 @@ Hey! Welcome to Nicolas Eliaszewicz's sweet CD collection!
 ]]>
     </screen>
    </example>
+   <example>
+    <title>Transforming to a <classname>Dom\Document</classname></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$xml = Dom\XMLDocument::createFromFile('collection.xml');
+$xsl = Dom\XMLDocument::createFromFile('collection.xsl');
+
+// Configure the transformer
+$proc = new XSLTProcessor;
+$proc->importStyleSheet($xsl); // attach the xsl rules
+
+echo trim($proc->transformToDoc($xml)->firstChild->wholeText);
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Hey! Welcome to Nicolas Eliaszewicz's sweet CD collection!
+]]>
+    </screen>
+   </example>
   </para>
  </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/xsl/xsltprocessor/transformtouri.xml
+++ b/reference/xsl/xsltprocessor/transformtouri.xml
@@ -25,8 +25,8 @@
      <term><parameter>document</parameter></term>
      <listitem>
       <para>
-       The <classname>DOMDocument</classname> or <classname>SimpleXMLElement</classname> object to
-       be transformed.
+       The <classname>Dom\Document</classname>, <classname>DOMDocument</classname>, <classname>SimpleXMLElement</classname> or libxml-compatible
+       object to be transformed.
       </para>
      </listitem>
     </varlistentry>
@@ -41,12 +41,36 @@
    </variablelist>
   </para>
  </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    Returns the number of bytes written or &false; if an error occurred.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Added support for <classname>Dom\Document</classname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -73,8 +97,28 @@ $proc->transformToURI($xml, 'file:///tmp/out.html');
 ]]>
     </programlisting>
    </example>
+   <example>
+    <title>Transforming to a HTML file using <classname>Dom\Document</classname></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$xml = Dom\XMLDocument::createFromFile('collection.xml');
+$xsl = Dom\XMLDocument::createFromFile('collection.xsl');
+
+// Configure the transformer
+$proc = new XSLTProcessor;
+$proc->importStyleSheet($xsl); // attach the xsl rules
+
+$proc->transformToURI($xml, 'file:///tmp/out.html');
+
+?>
+]]>
+    </programlisting>
+   </example>
   </para>
  </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/xsl/xsltprocessor/transformtoxml.xml
+++ b/reference/xsl/xsltprocessor/transformtoxml.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="xsltprocessor.transformtoxml" xmlns="http://docbook.org/ns/docbook">
+<refentry xml:id="xsltprocessor.transformtoxml" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>XSLTProcessor::transformToXml</refname>
   <refpurpose>Transform to XML</refpurpose>
@@ -17,20 +17,9 @@
   </para>
  </refsect1>
  <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>document</parameter></term>
-     <listitem>
-      <para>
-       The <classname>DOMDocument</classname> or <classname>SimpleXMLElement</classname> object to
-       be transformed.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('xsltprocessor.transformtodoc')/db:refsect1[@role='parameters']/*)">
+   <xi:fallback/>
+  </xi:include>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
@@ -38,6 +27,29 @@
    The result of the transformation as a string or &false; on error.
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Added support for <classname>Dom\Document</classname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -73,8 +85,37 @@ Hey! Welcome to Nicolas Eliaszewicz's sweet CD collection!
 ]]>
     </screen>
    </example>
+   <example>
+    <title>Transforming to a string using <classname>Dom\Document</classname></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$xml = Dom\XMLDocument::createFromFile('collection.xml');
+$xsl = Dom\XMLDocument::createFromFile('collection.xsl');
+
+// Configure the transformer
+$proc = new XSLTProcessor;
+$proc->importStyleSheet($xsl); // attach the xsl rules
+
+echo $proc->transformToXML($xml);
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Hey! Welcome to Nicolas Eliaszewicz's sweet CD collection!
+
+<h1>Fight for your mind</h1><h2>by Ben Harper - 1995</h2><hr>
+<h1>Electric Ladyland</h1><h2>by Jimi Hendrix - 1997</h2><hr>
+]]>
+    </screen>
+   </example>
   </para>
  </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>


### PR DESCRIPTION
Very WIP, not ready for review yet.

TODO:
- [x] Update other extensions that link into DOM
- [x] Update constants
- [x] Finish class skeletons (class page, properties, ...)
- [x] Document the NO_DEFAULT_NS constant (with caution)
- [ ] Document methods (NOTE: splitting PR because this is huge already)
- [x] Update note about encoding
- [ ] ~~Create examples of array indexing in NamedNodeMap ?~~ Let's do this separately
- [ ] ~~Add a note on top of the dom book to guide users to the new classes?~~ Do this later once the docs are completed
- [ ] ~~Explain xpath subtleties~~ Separate PR
- [x] Add note to XMLDocument properties that you should rely on the LIBXML_ flags now