### PR TITLE
is-callable.xml Add a link to the `__invoke` magic method

### DIFF
--- a/reference/var/functions/is-callable.xml
+++ b/reference/var/functions/is-callable.xml
@@ -41,8 +41,9 @@
       <para>
        If set to &true; the function only verifies that
        <parameter>value</parameter> might be a function or method. It will
-       reject any values that are neither <link linkend="object.invoke">invokable</link> objects,
-       strings nor arrays with a valid structure to be used as a callback. A valid callable array
+       reject any values that are not <link linkend="object.invoke">invokable</link> objects,
+       <classname>Closure</classname>, &string;s, or &array;s that do not have
+       a valid structure to be used as a callback. A valid callable array
        has 2 entries, the first of which is an object
        or a string, and the second a string.
       </para>

--- a/reference/var/functions/is-callable.xml
+++ b/reference/var/functions/is-callable.xml
@@ -41,8 +41,8 @@
       <para>
        If set to &true; the function only verifies that
        <parameter>value</parameter> might be a function or method. It will
-       reject any values that are neither callable objects, strings nor arrays
-       with a valid structure to be used as a callback. A valid callable array
+       reject any values that are neither <link linkend="object.invoke">invokable</link> objects,
+       strings nor arrays with a valid structure to be used as a callback. A valid callable array
        has 2 entries, the first of which is an object
        or a string, and the second a string.
       </para>


### PR DESCRIPTION
If by "callable object" means an object in whose class the magic method `__invoke` was implemented, maybe we should replace the word `callable` with the word `invokeable' and add a link to the magic method?