### PR TITLE
[PHP 8.3] `opcache.preload_user` is not required when run as root

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -962,6 +962,8 @@
       startup as root before switching to an unprivileged system user. Preloading as root is not
       allowed by default for security reasons, unless this directive is explicitly set to
       <literal>root</literal>.
+      As of PHP 8.3.0, this directive does not need to be set in order to allow preloading while
+      running as root when using the &cli.sapi; or <link linkend="book.phpdbg">phpdbg SAPI</link>.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Part of #2796