### PR TITLE
[PHP 8.3] `FFI::load` in preload scripts

### DIFF
--- a/reference/ffi/ffi/load.xml
+++ b/reference/ffi/ffi/load.xml
@@ -56,6 +56,31 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       <methodname>FFI::load</methodname> is now allowed in
+       <link linkend="opcache.preloading">preload scripts</link> when the
+       current system user is the same as the one defined in the
+       <literal>opcache.preload_user</literal> configuration directive.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>


### PR DESCRIPTION
Part of #2796 