### PR TITLE
Clarify that it represents midnight in the local timezone, not UTC.

### DIFF
--- a/reference/calendar/functions/easter-date.xml
+++ b/reference/calendar/functions/easter-date.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.easter-date" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>easter_date</refname>
-  <refpurpose>Get Unix timestamp for midnight on Easter of a given year</refpurpose>
+  <refpurpose>Get Unix timestamp for local midnight on Easter of a given year</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">


### PR DESCRIPTION
Explicitly specify "local midnight" to avoid confusion. Unix timestamps represent seconds since 1970-01-01 00:00:00 UTC, and without this clarification, users might assume the timestamp corresponds to UTC midnight. In fact, the timestamp (UTC) corresponds to 00:00:00 when converted to the local timezone.