### PR TITLE
[PHP 8.3] Parent dir with `open_basedir` and `ini_set` at runtime

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -1265,7 +1265,7 @@ include_path = ".:${USER}/pear/php"
         The default is to allow all files to be opened.
        </para>
        <note>
-        <para>
+        <simpara>
          open_basedir can be tightened at run-time. This means
          that if open_basedir is set to <literal>/www/</literal> in &php.ini;
          a script can tighten the configuration to
@@ -1273,7 +1273,12 @@ include_path = ".:${USER}/pear/php"
          <function>ini_set</function>. When listing several directories, you
          can use the <constant>PATH_SEPARATOR</constant> constant as a separator
          regardless of the operating system.
-        </para>
+        </simpara>
+        <simpara>
+         As of PHP 8.3.0, <option>open_basedir</option> no longer accepts a
+         paths containing the parent directory (<literal>..</literal>) when
+         set at runtime using <function>ini_set</function>.
+        </simpara>
        </note>
        <note>
         <para>


### PR DESCRIPTION
Part of #2796 