### PR TITLE
[PHP 8.3] `ValueError`'s previous exception is now set in `password_hash()`

### DIFF
--- a/reference/password/functions/password-hash.xml
+++ b/reference/password/functions/password-hash.xml
@@ -188,6 +188,16 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.3.0</entry>
+       <entry>
+        <function>password_hash</function> now sets the underlying
+        <exceptionname>Random\RandomException</exceptionname> as the
+        <property>Exception::$previous</property> exception when a
+        <exceptionname>ValueError</exceptionname> is thrown due to a failure
+        in the salt generation.
+       </entry>
+      </row>
+      <row>
        <entry>8.0.0</entry>
        <entry>
         <function>password_hash</function> no longer returns &false; on failure, instead a


### PR DESCRIPTION
Part of #2796