### PR TITLE
[PHP 8.4] Mention class constant types in `PDO` changelog

### DIFF
--- a/reference/pdo/pdo.xml
+++ b/reference/pdo/pdo.xml
@@ -485,6 +485,28 @@
    </classsynopsis>
   </section>
 
+  <section role="changelog" xml:id="pdo.changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        The class constants are now typed.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
  
  &reference.pdo.entities.pdo;


### PR DESCRIPTION
Part of #3872. Class constants are already typed elsewhere for this extension. 