### PR TITLE
Remove see also from getWarningCount()

### DIFF
--- a/reference/pdo_mysql/pdo/mysql/getwarningcount.xml
+++ b/reference/pdo_mysql/pdo/mysql/getwarningcount.xml
@@ -63,14 +63,6 @@ Warning (1365): Division by 0
   </example>
  </refsect1>
 
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <simplelist>
-   <member><function>mysqli_warning_count</function></member>
-   <member><property>mysqli::$warning_count</property></member>
-  </simplelist>
- </refsect1>
-
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
The property is not a link and mysqli links in PDO are irrelevant anyway. 