### PR TITLE
[PHP 8.4] `round()` can throw a `ValueError`

### DIFF
--- a/reference/math/functions/round.xml
+++ b/reference/math/functions/round.xml
@@ -125,6 +125,15 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   The function throws a <exceptionname>ValueError</exceptionname> if <parameter>mode</parameter> is
+   invalid.
+   Prior to PHP 8.4.0, an invalid mode would silently default to <constant>PHP_ROUND_HALF_UP</constant>.
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -136,6 +145,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       New throws a <exceptionname>ValueError</exceptionname> if
+       <parameter>mode</parameter> is invalid.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/math/functions/round.xml
+++ b/reference/math/functions/round.xml
@@ -148,7 +148,7 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       New throws a <exceptionname>ValueError</exceptionname> if
+       Now throws a <exceptionname>ValueError</exceptionname> if
        <parameter>mode</parameter> is invalid.
       </entry>
      </row>


### PR DESCRIPTION
Part of #3872 