### PR TITLE
[PHP 8.4] `unserialize()` can throw a `ValueError` and `TypeError`

### DIFF
--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -141,9 +141,15 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Objects may throw <classname>Throwable</classname>s in their unserialization handlers.
-  </para>
+  </simpara>
+  <simpara>
+   As of PHP 8.4.0, if the <literal>allowed_classes</literal> element of
+   <parameter>options</parameter> is not an <type>array</type> of class names,
+   <function>unserialize</function> throws <exceptionname>TypeError</exceptionname>s
+   and <exceptionname>ValueError</exceptionname>s.
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -152,6 +158,14 @@
    <informaltable>
     <tgroup cols="2">
      <thead>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Now throws <exceptionname>TypeError</exceptionname>s and
+        <exceptionname>ValueError</exceptionname>s if the <literal>allowed_classes</literal>
+        element of <parameter>options</parameter> is not an <type>array</type> of class names.
+       </entry>
+      </row>
       <row>
        <entry>&Version;</entry>
        <entry>&Description;</entry>


### PR DESCRIPTION
Part of #3872 