### PR TITLE
APCu: update apc.gc_ttl description

### DIFF
--- a/reference/apcu/ini.xml
+++ b/reference/apcu/ini.xml
@@ -229,13 +229,12 @@
     <listitem>
      <para>
       The number of seconds that a cache entry may
-      remain on the garbage-collection list after being
-      removed or invalidated. Entries are eligible for
-      removal if their reference count is zero or they
-      exceed this time limit. If set to <literal>0</literal>,
-      time-based cleanup is disabled, and entries are
-      only removed when their reference count drops to
-      zero.
+
+      remain on the garbage-collection list after being removed or invalidated.
+      Entries are eligible for removal if their reference count is zero,
+      or they exceed this time limit.
+      If set to <literal>0</literal>, time-based cleanup is disabled,
+      and entries are only removed when their reference count drops to zero.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/apcu/ini.xml
+++ b/reference/apcu/ini.xml
@@ -229,13 +229,13 @@
     <listitem>
      <para>
       The number of seconds that a cache entry may
-      remain on the garbage-collection list. This value
-      provides a fail-safe in the event that a server
-      process dies while executing a cached source file;
-      if that source file is modified, the memory
-      allocated for the old version will not be
-      reclaimed until this TTL reached. Set to zero to
-      disable this feature.
+      remain on the garbage-collection list after being
+      removed or invalidated. Entries are eligible for
+      removal if their reference count is zero or they
+      exceed this time limit. If set to <literal>0</literal>,
+      time-based cleanup is disabled, and entries are
+      only removed when their reference count drops to
+      zero.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/apcu/ini.xml
+++ b/reference/apcu/ini.xml
@@ -229,7 +229,6 @@
     <listitem>
      <para>
       The number of seconds that a cache entry may
-
       remain on the garbage-collection list after being removed or invalidated.
       Entries are eligible for removal if their reference count is zero,
       or they exceed this time limit.


### PR DESCRIPTION
This updates the documentation for `apc.gc_ttl` to reflect its current behavior in APCu. The existing description appears outdated, maybe written for the older APC extension when it also handled opcode caching.

Current implementation is https://github.com/krakjoe/apcu/blob/635899cfe32496323d03e051e15be220f8b53d68/apc_cache.c#L191