### PR TITLE
Fix missing version information for SimpleXML iterator methods

### DIFF
--- a/reference/simplexml/versions.xml
+++ b/reference/simplexml/versions.xml
@@ -24,15 +24,15 @@
  <function name="simplexmlelement::savexml" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="simplexmlelement::xpath" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="simplexmliterator" from="PHP 5 &gt;= 5.1.3, PHP 7, PHP 8"/>
- <function name="simplexmliterator::count" from="PHP 5, PHP 7, PHP 8"/>
- <function name="simplexmliterator::current" from="PHP 5, PHP 7, PHP 8"/>
- <function name="simplexmliterator::getchildren" from="PHP 5, PHP 7, PHP 8"/>
- <function name="simplexmliterator::haschildren" from="PHP 5, PHP 7, PHP 8"/>
- <function name="simplexmliterator::key" from="PHP 5, PHP 7, PHP 8"/>
- <function name="simplexmliterator::next" from="PHP 5, PHP 7, PHP 8"/>
- <function name="simplexmliterator::rewind" from="PHP 5, PHP 7, PHP 8"/>
- <function name="simplexmliterator::valid" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="simplexmlelement" from="PHP 8"/>
+ <function name="simplexmlelement::count" from="PHP 8"/>
+ <function name="simplexmlelement::current" from="PHP 8"/>
+ <function name="simplexmlelement::getchildren" from="PHP 8"/>
+ <function name="simplexmlelement::haschildren" from="PHP 8"/>
+ <function name="simplexmlelement::key" from="PHP 8"/>
+ <function name="simplexmlelement::next" from="PHP 8"/>
+ <function name="simplexmlelement::rewind" from="PHP 8"/>
+ <function name="simplexmlelement::valid" from="PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Prior to PHP 8, these were actually living in SimpleXMLIterator, but since then they live in SimpleXMLElement. The version file never changed the SimpleXMLIterator entries to SimpleXMLElement. We change the names here and because they are only available since PHP 8 on SimpleXMLElement also change the version data.