### PR TITLE
Fix inaccurate caution note on pack()

### DIFF
--- a/reference/misc/functions/pack.xml
+++ b/reference/misc/functions/pack.xml
@@ -256,7 +256,7 @@ $binarydata = pack("nvc*", 0x1234, 0x5678, 65, 66);
   &reftitle.notes;
   <caution>
    <para>Note that PHP internally stores <type>int</type> values as
-    signed values of a machine-dependent size.   
+    signed values of a machine-dependent size.
     Integer literals and operations that yield numbers outside the bounds of the  
     <type>int</type> type will be stored as <type>float</type>.
     When packing these floats as integers, they are first cast into the integer   

--- a/reference/misc/functions/pack.xml
+++ b/reference/misc/functions/pack.xml
@@ -256,7 +256,7 @@ $binarydata = pack("nvc*", 0x1234, 0x5678, 65, 66);
   &reftitle.notes;
   <caution>
    <para>Note that PHP internally stores <type>int</type> values as
-    signed values of a machine-dependent size (C type <literal>long</literal>).   
+    signed values of a machine-dependent size.   
     Integer literals and operations that yield numbers outside the bounds of the  
     <type>int</type> type will be stored as <type>float</type>.
     When packing these floats as integers, they are first cast into the integer   


### PR DESCRIPTION
Removed wrong caution From https://www.php.net/manual/en/function.pack.php

Fixes #4266 