### PR TITLE
The constant classes cannot be available before the introduction of the class

### DIFF
--- a/reference/pdo_mysql/constants.xml
+++ b/reference/pdo_mysql/constants.xml
@@ -207,6 +207,7 @@
    <listitem>
     <simpara>
      &Alias; <constant>Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT</constant>
+     Available as of PHP 7.0.18 and PHP 7.1.4.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/pdo_mysql/pdo-mysql.xml
+++ b/reference/pdo_mysql/pdo-mysql.xml
@@ -238,7 +238,6 @@ foreach ($unbufferedResult as $row) {
       <simpara>
        Allows restricting LOCAL DATA loading to files located in this
        designated directory.
-       Available as of PHP 8.1.0.
       </simpara>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
        <xi:fallback/>
@@ -429,7 +428,6 @@ foreach ($unbufferedResult as $row) {
      <listitem>
       <simpara>
        Provides a way to disable verification of the server <acronym>SSL</acronym> certificate.
-       Available as of PHP 7.0.18 and PHP 7.1.4.
       </simpara>
       <note>
        <simpara>


### PR DESCRIPTION
Found while reviewing doc-fr PRs