### PR TITLE
Document pkey gen params and addition of Curve25519 + Curve448

### DIFF
--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -138,52 +138,100 @@
 
   <section xml:id="openssl.key-types">
    <title>Key types</title>
- <variablelist>
-  <varlistentry xml:id="constant.openssl-keytype-rsa">
-   <term>
-    <constant>OPENSSL_KEYTYPE_RSA</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
+   <variablelist>
+    <varlistentry xml:id="constant.openssl-keytype-rsa">
+     <term>
+      <constant>OPENSSL_KEYTYPE_RSA</constant>
+      (<type>int</type>)
+     </term>
+     <listitem>
     <simpara>
-
+     RSA key type.
     </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.openssl-keytype-dsa">
-   <term>
-    <constant>OPENSSL_KEYTYPE_DSA</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="constant.openssl-keytype-dsa">
+     <term>
+      <constant>OPENSSL_KEYTYPE_DSA</constant>
+      (<type>int</type>)
+     </term>
+     <listitem>
+      <simpara>
+       DSA key type.
     </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.openssl-keytype-dh">
-   <term>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="constant.openssl-keytype-dh">
+     <term>
     <constant>OPENSSL_KEYTYPE_DH</constant>
     (<type>int</type>)
-   </term>
+     </term>
    <listitem>
     <simpara>
-
+     DH (Diffie-Hellman) key type.
     </simpara>
    </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.openssl-keytype-ec">
-   <term>
-    <constant>OPENSSL_KEYTYPE_EC</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     This constant is only available when PHP is compiled with OpenSSL 0.9.8+.
-    </simpara>
-   </listitem>
-  </varlistentry>
- </variablelist>
+    </varlistentry>
+    <varlistentry xml:id="constant.openssl-keytype-ec">
+     <term>
+      <constant>OPENSSL_KEYTYPE_EC</constant>
+      (<type>int</type>)
+     </term>
+     <listitem>
+      <simpara>
+       Elliptic curve key type.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="constant.openssl-keytype-x25519">
+     <term>
+      <constant>OPENSSL_KEYTYPE_X25519</constant>
+      (<type>int</type>)
+     </term>
+     <listitem>
+      <simpara>
+       X25519 curve key type.
+       This constant is only available when PHP is compiled with OpenSSL 3.0+.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="constant.openssl-keytype-ed25519">
+     <term>
+      <constant>OPENSSL_KEYTYPE_ED25519</constant>
+      (<type>int</type>)
+     </term>
+     <listitem>
+      <simpara>
+       Ed25519 curve key type.
+       This constant is only available when PHP is compiled with OpenSSL 3.0+.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="constant.openssl-keytype-x448">
+     <term>
+      <constant>OPENSSL_KEYTYPE_X448</constant>
+      (<type>int</type>)
+     </term>
+     <listitem>
+      <simpara>
+       X448 curve key type.
+       This constant is only available when PHP is compiled with OpenSSL 3.0+.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="constant.openssl-keytype-ed448">
+     <term>
+      <constant>OPENSSL_KEYTYPE_ED448</constant>
+      (<type>int</type>)
+     </term>
+     <listitem>
+      <simpara>
+       Ed448 curve key type.
+       This constant is only available when PHP is compiled with OpenSSL 3.0+.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
   </section>
 
   <section xml:id="openssl.pkcs7.flags">

--- a/reference/openssl/functions/openssl-pkey-get-details.xml
+++ b/reference/openssl/functions/openssl-pkey-get-details.xml
@@ -43,7 +43,12 @@
    <constant>OPENSSL_KEYTYPE_RSA</constant>,
    <constant>OPENSSL_KEYTYPE_DSA</constant>,
    <constant>OPENSSL_KEYTYPE_DH</constant>,
-   <constant>OPENSSL_KEYTYPE_EC</constant> or -1 meaning unknown).
+   <constant>OPENSSL_KEYTYPE_EC</constant>,
+   <constant>OPENSSL_KEYTYPE_X25519</constant>,
+   <constant>OPENSSL_KEYTYPE_ED25519</constant>,
+   <constant>OPENSSL_KEYTYPE_X448</constant>,
+   <constant>OPENSSL_KEYTYPE_ED448</constant>,
+   or <literal>-1</literal> meaning unknown).
   </para>
   <para>
    Depending on the key type used, additional details may be returned. Note that 
@@ -174,8 +179,16 @@
    </listitem>
    <listitem>
     <simpara>
-     <constant>OPENSSL_KEYTYPE_EC</constant>, an additional array key named <literal>"ec"</literal>, 
-     containing the key data is returned.
+     <constant>OPENSSL_KEYTYPE_X25519</constant>,
+     <constant>OPENSSL_KEYTYPE_ED25519</constant>,
+     <constant>OPENSSL_KEYTYPE_X448</constant>,
+     or <constant>OPENSSL_KEYTYPE_ED448</constant>
+     an additional array key named
+     <literal>"x25519"</literal>,
+     <literal>"ed25519"</literal>,
+     <literal>"x448"</literal>,
+     or <literal>"ed448"</literal> respectively,
+     is returned, containing the key data.
     </simpara>
      <informaltable>
       <tgroup cols="2">
@@ -187,24 +200,12 @@
        </thead>
        <tbody>
         <row>
-         <entry><literal>"curve_name"</literal></entry>
-         <entry>name of curve, see <function>openssl_get_curve_names</function></entry>
-        </row>
-        <row>
-         <entry><literal>"curve_oid"</literal></entry>
-         <entry>ASN1 Object identifier (OID) for EC curve.</entry>
-        </row>
-        <row>
-         <entry><literal>"x"</literal></entry>
-         <entry>x coordinate (public)</entry>
-        </row>
-        <row>
-         <entry><literal>"y"</literal></entry>
-         <entry>y coordinate (public)</entry>
-        </row>
-        <row>
-         <entry><literal>"d"</literal></entry>
+         <entry><literal>"priv_key"</literal></entry>
          <entry>private key</entry>
+        </row>
+        <row>
+         <entry><literal>"pub_key"</literal></entry>
+         <entry>public key</entry>
         </row>
        </tbody>
       </tgroup>
@@ -224,6 +225,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Added support for Curve25519 and Curve448 based keys.
+       Specifically the <literal>x25519</literal>, <literal>ed25519</literal>,
+       <literal>x448</literal> and <literal>ed448</literal> fields have been introduced.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/openssl/functions/openssl-pkey-new.xml
+++ b/reference/openssl/functions/openssl-pkey-new.xml
@@ -28,10 +28,344 @@
      <term><parameter>options</parameter></term>
      <listitem>
       <para>
-       You can finetune the key generation (such as specifying the number of
-       bits) using <parameter>options</parameter>.  See
-       <function>openssl_csr_new</function> for more information about
-       <parameter>options</parameter>.
+       It is possible to fine-tune the key generation (e.g. specifying the number of
+       bits or parameters) using the <parameter>options</parameter> parameter.
+       These options can either be algorithm-specific parameters used for key generation,
+       or generic options used also in <acronym>CSR</acronym>generation if not specified.
+       See <function>openssl_csr_new</function> for more information
+       about how to use <parameter>options</parameter> for a <acronym>CSR</acronym>.
+       Among those options only <literal>private_key_bits</literal>,
+       <literal>private_key_type</literal>, <literal>curve_name</literal>,
+       and <literal>config</literal> are used for key generation.
+       Algorithm-specific options are used if the associative array includes one of the specific keys.
+       <itemizedlist>
+        <listitem>
+         <simpara>
+          <literal>"rsa"</literal> key for setting RSA parameters.
+         </simpara>
+         <informaltable>
+          <tgroup cols="2">
+           <thead>
+            <row>
+             <entry>options</entry>
+             <entry>type</entry>
+             <entry>format</entry>
+             <entry>required</entry>
+             <entry>description</entry>
+            </row>
+           </thead>
+           <tbody>
+            <row>
+             <entry><literal>"n"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>yes</entry>
+             <entry>modulus</entry>
+            </row>
+            <row>
+             <entry><literal>"e"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>public exponent</entry>
+            </row>
+            <row>
+             <entry><literal>"d"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>yes</entry>
+             <entry>private exponent</entry>
+            </row>
+            <row>
+             <entry><literal>"p"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>prime 1</entry>
+            </row>
+            <row>
+             <entry><literal>"q"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>prime 2</entry>
+            </row>
+            <row>
+             <entry><literal>"dmp1"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>exponent1, d mod (p-1)</entry>
+            </row>
+            <row>
+             <entry><literal>"dmq1"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>exponent2, d mod (q-1)</entry>
+            </row>
+            <row>
+             <entry><literal>"iqmp"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>coefficient, (inverse of q) mod p</entry>
+            </row>
+           </tbody>
+          </tgroup>
+         </informaltable>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>"dsa"</literal> key for setting DSA parameters.
+         </simpara>
+         <informaltable>
+          <tgroup cols="2">
+           <thead>
+            <row>
+             <entry>options</entry>
+             <entry>type</entry>
+             <entry>format</entry>
+             <entry>required</entry>
+             <entry>description</entry>
+            </row>
+           </thead>
+           <tbody>
+            <row>
+             <entry><literal>"p"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>prime number (public)</entry>
+            </row>
+            <row>
+             <entry><literal>"q"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>160-bit subprime, q | p-1 (public)</entry>
+            </row>
+            <row>
+             <entry><literal>"g"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>generator of subgroup (public)</entry>
+            </row>
+            <row>
+             <entry><literal>"priv_key"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>PEM key</entry>
+             <entry>no</entry>
+             <entry>private key x</entry>
+            </row>
+            <row>
+             <entry><literal>"pub_key"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>PEM key</entry>
+             <entry>no</entry>
+             <entry>public key y = g^x</entry>
+            </row>
+           </tbody>
+          </tgroup>
+         </informaltable>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>"dh"</literal> key for DH (Diffie–Hellman key exchange) parameters.
+         </simpara>
+         <informaltable>
+          <tgroup cols="2">
+           <thead>
+            <row>
+             <entry>Options</entry>
+             <entry>&Type;</entry>
+             <entry>Format</entry>
+             <entry>Required</entry>
+             <entry>&Description;</entry>
+            </row>
+           </thead>
+           <tbody>
+            <row>
+             <entry><literal>"p"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>prime number (shared)</entry>
+            </row>
+            <row>
+             <entry><literal>"g"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>generator of Z_p (shared)</entry>
+            </row>
+            <row>
+             <entry><literal>"priv_key"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>PEM key</entry>
+             <entry>no</entry>
+             <entry>private DH value x</entry>
+            </row>
+            <row>
+             <entry><literal>"pub_key"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>PEM key</entry>
+             <entry>no</entry>
+             <entry>public DH value g^x</entry>
+            </row>
+           </tbody>
+          </tgroup>
+         </informaltable>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>"ec"</literal> key for Elliptic curve parameters
+         </simpara>
+         <informaltable>
+          <tgroup cols="2">
+           <thead>
+            <row>
+             <entry>Options</entry>
+             <entry>&Type;</entry>
+             <entry>Format</entry>
+             <entry>Required</entry>
+             <entry>&Description;</entry>
+            </row>
+           </thead>
+           <tbody>
+            <row>
+             <entry><literal>"curve_name"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>name</entry>
+             <entry>no</entry>
+             <entry>name of curve, see <function>openssl_get_curve_names</function></entry>
+            </row>
+            <row>
+             <entry><literal>"p"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>prime of the field for curve over Fp</entry>
+            </row>
+            <row>
+             <entry><literal>"a"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>coofecient a of the curve for Fp: y^2 mod p = x^3 + ax + b mod p</entry>
+            </row>
+            <row>
+             <entry><literal>"b"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>coofecient b of the curve for Fp: y^2 mod p = x^3 + ax + b mod p</entry>
+            </row>
+            <row>
+             <entry><literal>"seed"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>optional random number seed used to generate coefficient b</entry>
+            </row>
+            <row>
+             <entry><literal>"generator"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary encoded point</entry>
+             <entry>no</entry>
+             <entry>curve generator point</entry>
+            </row>
+            <row>
+             <entry><literal>"g_x"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>curver generator point x coordinat</entry>
+            </row>
+            <row>
+             <entry><literal>"g_y"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>curver generator point y coordinat</entry>
+            </row>
+            <row>
+             <entry><literal>"cofactor"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>curve cofactor</entry>
+            </row>
+            <row>
+             <entry><literal>"order"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>curve order</entry>
+            </row>
+            <row>
+             <entry><literal>"x"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>x coordinate (public)</entry>
+            </row>
+            <row>
+             <entry><literal>"y"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>y coordinate (public)</entry>
+            </row>
+            <row>
+             <entry><literal>"d"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>binary number</entry>
+             <entry>no</entry>
+             <entry>private key</entry>
+            </row>
+           </tbody>
+          </tgroup>
+         </informaltable>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>"x25519"</literal>, <literal>"x448"</literal>,
+          <literal>"ed25519"</literal>, <literal>"ed448"</literal> keys for
+          Curve25519 and Curve448 parameters.
+         </simpara>
+         <informaltable>
+          <tgroup cols="2">
+           <thead>
+            <row>
+             <entry>Options</entry>
+             <entry>&Type;</entry>
+             <entry>Format</entry>
+             <entry>Required</entry>
+             <entry>&Description;</entry>
+            </row>
+           </thead>
+           <tbody>
+             <row>
+             <entry><literal>"priv_key"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>PEM key</entry>
+             <entry>no</entry>
+             <entry>private key</entry>
+            </row>
+            <row>
+             <entry><literal>"pub_key"</literal></entry>
+             <entry><type>string</type></entry>
+             <entry>PEM key</entry>
+             <entry>no</entry>
+             <entry>public key</entry>
+            </row>
+           </tbody>
+          </tgroup>
+         </informaltable>
+        </listitem>
+       </itemizedlist>
       </para>
      </listitem>
     </varlistentry>
@@ -58,6 +392,24 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Added support for Curve25519 and Curve448 based keys with the introduction of the
+       <literal>x25519</literal>, <literal>ed25519</literal>, <literal>x448</literal>,
+       and <literal>ed448</literal> fields.
+      </entry>
+     </row>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       Added support for generation EC keys with custom EC parameters.
+       Specifically with the introduction of the EC options:
+       <literal>p</literal>, <literal>a</literal>, <literal>b</literal>, <literal>seed</literal>,
+       <literal>generator</literal>, <literal>g_x</literal>, <literal>g_y</literal>,
+       <literal>cofactor</literal>, and <literal>order</literal>.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>
@@ -127,6 +479,54 @@ object(OpenSSLAsymmetricKey)#2 (0) {
 }
 ]]>
    </screen>
+  </example>
+
+  <example xml:id="function.openssl-pkey-new.example.rsa-key">
+   <title>Generating RSA key from parameters</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$nhex = "BBF82F090682CE9C2338AC2B9DA871F7368D07EED41043A440D6B6F07454F51F" .
+        "B8DFBAAF035C02AB61EA48CEEB6FCD4876ED520D60E1EC4619719D8A5B8B807F" .
+        "AFB8E0A3DFC737723EE6B4B7D93A2584EE6A649D060953748834B2454598394E" .
+        "E0AAB12D7B61A51F527A9A41F6C1687FE2537298CA2A8F5946F8E5FD091DBDCB";
+
+$ehex = "11";
+$dhex = "A5DAFC5341FAF289C4B988DB30C1CDF83F31251E0668B42784813801579641B2" .
+        "9410B3C7998D6BC465745E5C392669D6870DA2C082A939E37FDCB82EC93EDAC9" .
+        "7FF3AD5950ACCFBC111C76F1A9529444E56AAF68C56C092CD38DC3BEF5D20A93" .
+        "9926ED4F74A13EDDFBE1A1CECC4894AF9428C2B7B8883FE4463A4BC85B1CB3C1";
+
+$phex = "EECFAE81B1B9B3C908810B10A1B5600199EB9F44AEF4FDA493B81A9E3D84F632" .
+        "124EF0236E5D1E3B7E28FAE7AA040A2D5B252176459D1F397541BA2A58FB6599";
+
+$qhex = "C97FB1F027F453F6341233EAAAD1D9353F6C42D08866B1D05A0F2035028B9D86" .
+        "9840B41666B42E92EA0DA3B43204B5CFCE3352524D0416A5A441E700AF461503";
+
+$dphex = "11";
+$dqhex = "11";
+$qinvhex = "b06c4fdabb6301198d265bdbae9423b380f271f73453885093077fcd39e2119f" .
+           "c98632154f5883b167a967bf402b4e9e2e0f9656e698ea3666edfb25798039f7";
+
+$rsa= openssl_pkey_new([
+    'rsa' => [
+        'n' => hex2bin($nhex),
+        'e' => hex2bin($ehex),
+        'd' => hex2bin($dhex),
+        'p' => hex2bin($phex),
+        'q' => hex2bin($qhex),
+        'dmp1' => hex2bin($dphex),
+        'dmq1' => hex2bin($dqhex),
+        'iqmp' => hex2bin($qinvhex),
+    ],
+]);
+$details = openssl_pkey_get_details($rsa);
+var_dump($details);
+
+?>
+]]>
+   </programlisting>
   </example>
  </refsect1>
 


### PR DESCRIPTION
This significantly extend docs for openssl_pkey_new and adds 8.4 changes for Curve25519 + Curve448