### PR TITLE
Remove function tags from titles in Yaf examples

### DIFF
--- a/reference/yaf/yaf_route_map/construct.xml
+++ b/reference/yaf/yaf_route_map/construct.xml
@@ -51,7 +51,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Yaf_Route_Map example</title>
+   <title><classname>Yaf_Route_Map</classname> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -76,7 +76,7 @@ array(
    </screen>
   </example>
   <example>
-   <title>Yaf_Route_Map example</title>
+   <title><classname>Yaf_Route_Map</classname> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -108,7 +108,7 @@ array(
    </screen>
   </example>
   <example>
-   <title>Yaf_Route_Map example</title>
+   <title><classname>Yaf_Route_Map</classname> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/yaf/yaf_route_map/construct.xml
+++ b/reference/yaf/yaf_route_map/construct.xml
@@ -51,7 +51,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>Yaf_Route_Map</function>example</title>
+   <title>Yaf_Route_Map example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -76,7 +76,7 @@ array(
    </screen>
   </example>
   <example>
-   <title><function>Yaf_Route_Map</function>example</title>
+   <title>Yaf_Route_Map example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -108,7 +108,7 @@ array(
    </screen>
   </example>
   <example>
-   <title><function>Yaf_Route_Map</function>example</title>
+   <title>Yaf_Route_Map example</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/yaf/yaf_route_regex/construct.xml
+++ b/reference/yaf/yaf_route_regex/construct.xml
@@ -92,7 +92,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Yaf_Route_Regex example</title>
+   <title><classname>Yaf_Route_Regex</classname> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -116,7 +116,7 @@
    </programlisting>
   </example>
   <example>
-   <title>Yaf_Route_Regex (as of 2.3.0) example</title>
+   <title><classname>Yaf_Route_Regex</classname> (as of 2.3.0) example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -140,7 +140,7 @@
    </programlisting>
   </example>
   <example>
-   <title>Yaf_Route_Regex and named capture ground (as of 2.3.0) example</title>
+   <title><classname>Yaf_Route_Regex</classname> and named capture group (as of 2.3.0) example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -164,7 +164,7 @@
    </programlisting>
   </example>
   <example>
-   <title>Yaf_Route_Regex example</title>
+   <title><classname>Yaf_Route_Regex</classname> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/yaf/yaf_route_regex/construct.xml
+++ b/reference/yaf/yaf_route_regex/construct.xml
@@ -92,7 +92,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>Yaf_Route_Regex</function>example</title>
+   <title>Yaf_Route_Regex example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -116,7 +116,7 @@
    </programlisting>
   </example>
   <example>
-   <title><function>Yaf_Route_Regex(as of 2.3.0)</function>example</title>
+   <title>Yaf_Route_Regex (as of 2.3.0) example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -140,7 +140,7 @@
    </programlisting>
   </example>
   <example>
-   <title><function>Yaf_Route_Regex and named capture ground(as of 2.3.0)</function>example</title>
+   <title>Yaf_Route_Regex and named capture ground (as of 2.3.0) example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -164,7 +164,7 @@
    </programlisting>
   </example>
   <example>
-   <title><function>Yaf_Route_Regex</function>example</title>
+   <title>Yaf_Route_Regex example</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/yaf/yaf_route_rewrite/construct.xml
+++ b/reference/yaf/yaf_route_rewrite/construct.xml
@@ -72,7 +72,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>Yaf_Route_Rewrite</function>example</title>
+   <title>Yaf_Route_Rewrite example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -114,7 +114,7 @@ array(
    </screen>
   </example>
   <example>
-   <title><function>Yaf_Route_Rewrite</function>example</title>
+   <title>Yaf_Route_Rewrite example</title>
    <programlisting role="php">
 <![CDATA[
     <?php
@@ -158,7 +158,7 @@ array(
    </screen>
   </example>
   <example>
-   <title><function>Yaf_Route_Rewrite(as of 2.3.0)</function>example</title>
+   <title>Yaf_Route_Rewrite (as of 2.3.0) example</title>
    <programlisting role="php">
 <![CDATA[
     <?php

--- a/reference/yaf/yaf_route_rewrite/construct.xml
+++ b/reference/yaf/yaf_route_rewrite/construct.xml
@@ -72,7 +72,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Yaf_Route_Rewrite example</title>
+   <title><classname>Yaf_Route_Rewrite</classname> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -114,7 +114,7 @@ array(
    </screen>
   </example>
   <example>
-   <title>Yaf_Route_Rewrite example</title>
+   <title><classname>Yaf_Route_Rewrite</classname> example</title>
    <programlisting role="php">
 <![CDATA[
     <?php
@@ -158,7 +158,7 @@ array(
    </screen>
   </example>
   <example>
-   <title>Yaf_Route_Rewrite (as of 2.3.0) example</title>
+   <title><classname>Yaf_Route_Rewrite</classname> (as of 2.3.0) example</title>
    <programlisting role="php">
 <![CDATA[
     <?php

--- a/reference/yaf/yaf_route_supervar/construct.xml
+++ b/reference/yaf/yaf_route_supervar/construct.xml
@@ -44,7 +44,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>Yaf_Route_Supervar</function>example</title>
+   <title>Yaf_Route_Supervar example</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/yaf/yaf_route_supervar/construct.xml
+++ b/reference/yaf/yaf_route_supervar/construct.xml
@@ -44,7 +44,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Yaf_Route_Supervar example</title>
+   <title><classname>Yaf_Route_Supervar</classname> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/yaf/yaf_view_simple/construct.xml
+++ b/reference/yaf/yaf_view_simple/construct.xml
@@ -61,7 +61,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>Yaf_View_Simple::__constructor</function>example</title>
+   <title><function>Yaf_View_Simple::__construct</function>example</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/yaf/yaf_view_simple/construct.xml
+++ b/reference/yaf/yaf_view_simple/construct.xml
@@ -61,7 +61,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>Yaf_View_Simple::__construct</function>example</title>
+   <title><methodname>Yaf_View_Simple::__construct</methodname> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php


### PR DESCRIPTION
Replace `function` tags from example titles where the class name is being referenced.
Fixes constructor method name `__construct`.
Fixes typo.