### PR TITLE
Fix ext/dom constant aliases

### DIFF
--- a/reference/dom/constants.xml
+++ b/reference/dom/constants.xml
@@ -302,7 +302,7 @@
      </row>
      <row xml:id="constant.dom-index-size-err">
       <entry>
-       <constant>DOM_INDEX_SIZE_ERR</constant> / <constant>Dom\INDEX_SIZE_ERR</constant>
+       <constant>DOM_INDEX_SIZE_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>1</entry>
@@ -310,9 +310,17 @@
        If index or size is negative, or greater than the allowed value.
       </entry>
      </row>
+     <row xml:id="constant.dom-dom-index-size-err">
+      <entry>
+       <constant>Dom\INDEX_SIZE_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>1</entry>
+      <entry>&Alias; <constant>DOM_INDEX_SIZE_ERR</constant>.</entry>
+     </row>
      <row xml:id="constant.domstring-size-err">
       <entry>
-       <constant>DOMSTRING_SIZE_ERR</constant> / <constant>Dom\STRING_SIZE_ERR</constant>
+       <constant>DOMSTRING_SIZE_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>2</entry>
@@ -321,17 +329,33 @@
        <type>string</type>.
       </entry>
      </row>
+     <row xml:id="constant.dom-string-size-err">
+      <entry>
+       <constant>Dom\STRING_SIZE_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>2</entry>
+      <entry>&Alias; <constant>DOMSTRING_SIZE_ERR</constant>.</entry>
+     </row>
      <row xml:id="constant.dom-hierarchy-request-err">
       <entry>
-       <constant>DOM_HIERARCHY_REQUEST_ERR</constant> / <constant>Dom\HIERARCHY_REQUEST_ERR</constant>
+       <constant>DOM_HIERARCHY_REQUEST_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>3</entry>
       <entry>If any node is inserted somewhere it doesn't belong</entry>
      </row>
+     <row xml:id="constant.dom-dom-hierarchy-request-err">
+      <entry>
+       <constant>Dom\HIERARCHY_REQUEST_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>3</entry>
+      <entry>&Alias; <constant>DOM_HIERARCHY_REQUEST_ERR</constant>.</entry>
+     </row>
      <row xml:id="constant.dom-wrong-document-err">
       <entry>
-       <constant>DOM_WRONG_DOCUMENT_ERR</constant> / <constant>Dom\WRONG_DOCUMENT_ERR</constant>
+       <constant>DOM_WRONG_DOCUMENT_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>4</entry>
@@ -339,9 +363,17 @@
        If a node is used in a different document than the one that created it.
       </entry>
      </row>
+     <row xml:id="constant.dom-dom-wrong-document-err">
+      <entry>
+       <constant>Dom\WRONG_DOCUMENT_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>4</entry>
+      <entry>&Alias; <constant>DOM_WRONG_DOCUMENT_ERR</constant>.</entry>
+     </row>
      <row xml:id="constant.dom-invalid-character-err">
       <entry>
-       <constant>DOM_INVALID_CHARACTER_ERR</constant> / <constant>Dom\INVALID_CHARACTER_ERR</constant>
+       <constant>DOM_INVALID_CHARACTER_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>5</entry>
@@ -349,9 +381,19 @@
        If an invalid or illegal character is specified, such as in a name.
       </entry>
      </row>
+     <row xml:id="constant.dom-dom-invalid-character-err">
+      <entry>
+       <constant>Dom\INVALID_CHARACTER_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>5</entry>
+      <entry>
+       &Alias; <constant>DOM_INVALID_CHARACTER_ERR</constant>.
+      </entry>
+     </row>
      <row xml:id="constant.dom-no-data-allowed-err">
       <entry>
-       <constant>DOM_NO_DATA_ALLOWED_ERR</constant> / <constant>Dom\NO_DATA_ALLOWED_ERR</constant>
+       <constant>DOM_NO_DATA_ALLOWED_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>6</entry>
@@ -359,9 +401,19 @@
        If data is specified for a node which does not support data.
       </entry>
      </row>
+     <row xml:id="constant.dom-dom-no-data-allowed-err">
+      <entry>
+       <constant>Dom\NO_DATA_ALLOWED_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>6</entry>
+      <entry>
+       &Alias; <constant>DOM_NO_DATA_ALLOWED_ERR</constant>.
+      </entry>
+     </row>
      <row xml:id="constant.dom-no-modification-allowed-err">
       <entry>
-       <constant>DOM_NO_MODIFICATION_ALLOWED_ERR</constant> / <constant>Dom\NO_MODIFICATION_ALLOWED_ERR</constant>
+       <constant>DOM_NO_MODIFICATION_ALLOWED_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>7</entry>
@@ -369,9 +421,19 @@
        If an attempt is made to modify an object where modifications are not allowed.
       </entry>
      </row>
+     <row xml:id="constant.dom-dom-no-modification-allowed-err">
+      <entry>
+       <constant>Dom\NO_MODIFICATION_ALLOWED_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>7</entry>
+      <entry>
+       &Alias; <constant>DOM_NO_MODIFICATION_ALLOWED_ERR</constant>.
+      </entry>
+     </row>
      <row xml:id="constant.dom-not-found-err">
       <entry>
-       <constant>DOM_NOT_FOUND_ERR</constant> / <constant>Dom\NOT_FOUND_ERR</constant>
+       <constant>DOM_NOT_FOUND_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>8</entry>
@@ -379,9 +441,19 @@
        If an attempt is made to reference a node in a context where it does not exist.
       </entry>
      </row>
+     <row xml:id="constant.dom-dom-not-found-err">
+      <entry>
+       <constant>Dom\NOT_FOUND_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>8</entry>
+      <entry>
+       &Alias; <constant>DOM_NOT_FOUND_ERR</constant>.
+      </entry>
+     </row>
      <row xml:id="constant.dom-not-supported-err">
       <entry>
-       <constant>DOM_NOT_SUPPORTED_ERR</constant> / <constant>Dom\NOT_SUPPORTED_ERR</constant>
+       <constant>DOM_NOT_SUPPORTED_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>9</entry>
@@ -389,9 +461,19 @@
        If the implementation does not support the requested type of object or operation.
       </entry>
      </row>
+     <row xml:id="constant.dom-dom-not-supported-err">
+      <entry>
+       <constant>Dom\NOT_SUPPORTED_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>9</entry>
+      <entry>
+       &Alias; <constant>DOM_NOT_SUPPORTED_ERR</constant>.
+      </entry>
+     </row>
      <row xml:id="constant.dom-inuse-attribute-err">
       <entry>
-       <constant>DOM_INUSE_ATTRIBUTE_ERR</constant> / <constant>Dom\INUSE_ATTRIBUTE_ERR</constant>
+       <constant>DOM_INUSE_ATTRIBUTE_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>10</entry>
@@ -399,9 +481,17 @@
        If an attempt is made to add an attribute that is already in use elsewhere.
       </entry>
      </row>
+     <row xml:id="constant.dom-dom-inuse-attribute-err">
+      <entry>
+       <constant>Dom\INUSE_ATTRIBUTE_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>10</entry>
+      <entry>&Alias; <constant>DOM_INUSE_ATTRIBUTE_ERR</constant>.</entry>
+     </row>
      <row xml:id="constant.dom-invalid-state-err">
       <entry>
-       <constant>DOM_INVALID_STATE_ERR</constant> / <constant>Dom\INVALID_STATE_ERR</constant>
+       <constant>DOM_INVALID_STATE_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>11</entry>
@@ -409,25 +499,51 @@
        If an attempt is made to use an object that is not, or is no longer, usable.
       </entry>
      </row>
+     <row xml:id="constant.dom-dom-invalid-state-err">
+      <entry>
+       <constant>Dom\INVALID_STATE_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>11</entry>
+      <entry>
+       &Alias; <constant>DOM_INVALID_STATE_ERR</constant>.
+      </entry>
+     </row>
      <row xml:id="constant.dom-syntax-err">
       <entry>
-       <constant>DOM_SYNTAX_ERR</constant> / <constant>Dom\SYNTAX_ERR</constant>
+       <constant>DOM_SYNTAX_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>12</entry>
       <entry>If an invalid or illegal string is specified.</entry>
      </row>
+     <row xml:id="constant.dom-dom-syntax-err">
+      <entry>
+       <constant>Dom\SYNTAX_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>12</entry>
+      <entry>&Alias; <constant>DOM_SYNTAX_ERR</constant>.</entry>
+     </row>
      <row xml:id="constant.dom-invalid-modification-err">
       <entry>
-       <constant>DOM_INVALID_MODIFICATION_ERR</constant> / <constant>Dom\INVALID_MODIFICATION_ERR</constant>
+       <constant>DOM_INVALID_MODIFICATION_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>13</entry>
       <entry>If an attempt is made to modify the type of the underlying object.</entry>
      </row>
+     <row xml:id="constant.dom-dom-invalid-modification-err">
+      <entry>
+       <constant>Dom\INVALID_MODIFICATION_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>13</entry>
+      <entry>&Alias; <constant>DOM_INVALID_MODIFICATION_ERR</constant>.</entry>
+     </row>
      <row xml:id="constant.dom-namespace-err">
       <entry>
-       <constant>DOM_NAMESPACE_ERR</constant> / <constant>Dom\NAMESPACE_ERR</constant>
+       <constant>DOM_NAMESPACE_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>14</entry>
@@ -436,9 +552,17 @@
        incorrect with regard to namespaces.
       </entry>
      </row>
+     <row xml:id="constant.dom-dom-namespace-err">
+      <entry>
+       <constant>Dom\NAMESPACE_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>14</entry>
+      <entry>&Alias; <constant>DOM_NAMESPACE_ERR</constant>.</entry>
+     </row>
      <row xml:id="constant.dom-invalid-access-err">
       <entry>
-       <constant>DOM_INVALID_ACCESS_ERR</constant> / <constant>Dom\INVALID_ACCESS_ERR</constant>
+       <constant>DOM_INVALID_ACCESS_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>15</entry>
@@ -446,9 +570,17 @@
        If a parameter or an operation is not supported by the underlying object.
       </entry>
      </row>
+     <row xml:id="constant.dom-dom-invalid-access-err">
+      <entry>
+       <constant>Dom\INVALID_ACCESS_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>15</entry>
+      <entry>&Alias; <constant>DOM_INVALID_ACCESS_ERR</constant>.</entry>
+     </row>
      <row xml:id="constant.dom-validation-err">
       <entry>
-       <constant>DOM_VALIDATION_ERR</constant> / <constant>Dom\VALIDATION_ERR</constant>
+       <constant>DOM_VALIDATION_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>16</entry>
@@ -457,6 +589,14 @@
        invalid with respect to "partial validity", this exception would be raised and
        the operation would not be done.
       </entry>
+     </row>
+     <row xml:id="constant.dom-dom-validation-err">
+      <entry>
+       <constant>Dom\VALIDATION_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>16</entry>
+      <entry>&Alias; <constant>DOM_VALIDATION_ERR</constant>.</entry>
      </row>
     </tbody>
    </tgroup>

--- a/reference/dom/constants.xml
+++ b/reference/dom/constants.xml
@@ -310,7 +310,7 @@
        If index or size is negative, or greater than the allowed value.
       </entry>
      </row>
-     <row xml:id="constant.dom-dom-index-size-err">
+     <row xml:id="dom.constants.index-size-err">
       <entry>
        <constant>Dom\INDEX_SIZE_ERR</constant>
        (<type>int</type>)
@@ -329,7 +329,7 @@
        <type>string</type>.
       </entry>
      </row>
-     <row xml:id="constant.dom-string-size-err">
+     <row xml:id="dom.constants.string-size-err">
       <entry>
        <constant>Dom\STRING_SIZE_ERR</constant>
        (<type>int</type>)
@@ -345,7 +345,7 @@
       <entry>3</entry>
       <entry>If any node is inserted somewhere it doesn't belong</entry>
      </row>
-     <row xml:id="constant.dom-dom-hierarchy-request-err">
+     <row xml:id="dom.constants.hierarchy-request-err">
       <entry>
        <constant>Dom\HIERARCHY_REQUEST_ERR</constant>
        (<type>int</type>)
@@ -363,7 +363,7 @@
        If a node is used in a different document than the one that created it.
       </entry>
      </row>
-     <row xml:id="constant.dom-dom-wrong-document-err">
+     <row xml:id="dom.constants.wrong-document-err">
       <entry>
        <constant>Dom\WRONG_DOCUMENT_ERR</constant>
        (<type>int</type>)
@@ -381,7 +381,7 @@
        If an invalid or illegal character is specified, such as in a name.
       </entry>
      </row>
-     <row xml:id="constant.dom-dom-invalid-character-err">
+     <row xml:id="dom.constants.invalid-character-err">
       <entry>
        <constant>Dom\INVALID_CHARACTER_ERR</constant>
        (<type>int</type>)
@@ -401,7 +401,7 @@
        If data is specified for a node which does not support data.
       </entry>
      </row>
-     <row xml:id="constant.dom-dom-no-data-allowed-err">
+     <row xml:id="dom.constants.no-data-allowed-err">
       <entry>
        <constant>Dom\NO_DATA_ALLOWED_ERR</constant>
        (<type>int</type>)
@@ -421,7 +421,7 @@
        If an attempt is made to modify an object where modifications are not allowed.
       </entry>
      </row>
-     <row xml:id="constant.dom-dom-no-modification-allowed-err">
+     <row xml:id="dom.constants.no-modification-allowed-err">
       <entry>
        <constant>Dom\NO_MODIFICATION_ALLOWED_ERR</constant>
        (<type>int</type>)
@@ -441,7 +441,7 @@
        If an attempt is made to reference a node in a context where it does not exist.
       </entry>
      </row>
-     <row xml:id="constant.dom-dom-not-found-err">
+     <row xml:id="dom.constants.not-found-err">
       <entry>
        <constant>Dom\NOT_FOUND_ERR</constant>
        (<type>int</type>)
@@ -461,7 +461,7 @@
        If the implementation does not support the requested type of object or operation.
       </entry>
      </row>
-     <row xml:id="constant.dom-dom-not-supported-err">
+     <row xml:id="dom.constants.not-supported-err">
       <entry>
        <constant>Dom\NOT_SUPPORTED_ERR</constant>
        (<type>int</type>)
@@ -481,7 +481,7 @@
        If an attempt is made to add an attribute that is already in use elsewhere.
       </entry>
      </row>
-     <row xml:id="constant.dom-dom-inuse-attribute-err">
+     <row xml:id="dom.constants.inuse-attribute-err">
       <entry>
        <constant>Dom\INUSE_ATTRIBUTE_ERR</constant>
        (<type>int</type>)
@@ -499,7 +499,7 @@
        If an attempt is made to use an object that is not, or is no longer, usable.
       </entry>
      </row>
-     <row xml:id="constant.dom-dom-invalid-state-err">
+     <row xml:id="dom.constants.invalid-state-err">
       <entry>
        <constant>Dom\INVALID_STATE_ERR</constant>
        (<type>int</type>)
@@ -517,7 +517,7 @@
       <entry>12</entry>
       <entry>If an invalid or illegal string is specified.</entry>
      </row>
-     <row xml:id="constant.dom-dom-syntax-err">
+     <row xml:id="dom.constants.syntax-err">
       <entry>
        <constant>Dom\SYNTAX_ERR</constant>
        (<type>int</type>)
@@ -533,7 +533,7 @@
       <entry>13</entry>
       <entry>If an attempt is made to modify the type of the underlying object.</entry>
      </row>
-     <row xml:id="constant.dom-dom-invalid-modification-err">
+     <row xml:id="dom.constants.invalid-modification-err">
       <entry>
        <constant>Dom\INVALID_MODIFICATION_ERR</constant>
        (<type>int</type>)
@@ -552,7 +552,7 @@
        incorrect with regard to namespaces.
       </entry>
      </row>
-     <row xml:id="constant.dom-dom-namespace-err">
+     <row xml:id="dom.constants.namespace-err">
       <entry>
        <constant>Dom\NAMESPACE_ERR</constant>
        (<type>int</type>)
@@ -570,7 +570,7 @@
        If a parameter or an operation is not supported by the underlying object.
       </entry>
      </row>
-     <row xml:id="constant.dom-dom-invalid-access-err">
+     <row xml:id="dom.constants.invalid-access-err">
       <entry>
        <constant>Dom\INVALID_ACCESS_ERR</constant>
        (<type>int</type>)
@@ -590,7 +590,7 @@
        the operation would not be done.
       </entry>
      </row>
-     <row xml:id="constant.dom-dom-validation-err">
+     <row xml:id="dom.constants.validation-err">
       <entry>
        <constant>Dom\VALIDATION_ERR</constant>
        (<type>int</type>)


### PR DESCRIPTION
I noticed failures when I tried to run `./build/gen_stub.php --verify-manual ./ ../doc-en/`, and it turned out that the newly added ext/dom constant aliases cause this. I found no way to add support for the `DOM_INDEX_SIZE_ERR / Dom\INDEX_SIZE_ERR ` format in gen_stub.php (gen_stub.php can only replace/fix constants one-by-one), so I had to duplicate the constant definitions in the manual.

Since the constant IDs would clash in most of the cases, I had to add an extra `dom-` prefix to them. It may be possible to fix these via phd and use `.` as separator instead of `-` in case of namespaces (?).