### PR TITLE
`Pdo\Pgsql::lobOpen`: Remove errors section from skeleton

### DIFF
--- a/reference/pdo_pgsql/pdo/pgsql/lobopen.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/lobopen.xml
@@ -54,14 +54,6 @@
   </simpara>
  </refsect1>
 
- <refsect1 role="errors">
-  &reftitle.errors;
-  <simpara>
-   When does this function issue <constant>E_*</constant> level errors,
-   and/or throw <exceptionname>Exception</exceptionname>s.
-  </simpara>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="pdo-pgsql.lobopen.example.basic">


### PR DESCRIPTION
There was no errors section in `PDO::pgsqlLOBOpen` document.
https://github.com/php/doc-en/blob/b95d28e6ec86e4a71e012737d36ebdc1cf009180/reference/pdo_pgsql/PDO/pgsqlLOBOpen.xml