### PR TITLE
Remove paragraph about contacting doc-license@ about licensing

### DIFF
--- a/bookinfo.xml
+++ b/bookinfo.xml
@@ -17,13 +17,6 @@
     The latest version is presently available at
    <link xlink:href="&url.cc.by;">&url.cc.by;</link>.
    </simpara>
-   <simpara>
-    If you are interested in redistribution or republishing of this document
-    in whole or in part, either modified or unmodified, and you have questions,
-    please contact the Copyright holders at
-    <link xlink:href="mailto:&email.php.doc.license;">&email.php.doc.license;</link>.
-    Note that this address is mapped to a publicly archived mailing list.
-   </simpara>
   </legalnotice>
 
  </info>


### PR DESCRIPTION
The license is clear on its own, there's not really anyone who can give permission to do anything else.

Fixes #4130.