### PR TITLE
Fix incorrect description of output

### DIFF
--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -974,11 +974,11 @@ echo "This works: {$obj->values[3]->name}";
 
 echo "This works: {$obj->$staticProp}";
 
-// Won't work, outputs: C:\folder\{fantastic}.txt
-echo "C:\folder\{$great}.txt";
+// Won't work, outputs: C:\directory\{fantastic}.txt
+echo "C:\directory\{$great}.txt";
 
-// Works, outputs: C:\folder\fantastic.txt
-echo "C:\\folder\\{$great}.txt";
+// Works, outputs: C:\directory\fantastic.txt
+echo "C:\\directory\\{$great}.txt";
 ?>
 ]]>
      </programlisting>


### PR DESCRIPTION
The `\f` within double quotes actually represents a form feed, so `"outputs: C:\folder\{fantastic}.txt"` is incorrect. Representing a form feed in a comment can be a bit tricky, and since it is not the focus of the example, I have changed `folder` in the strings to `directory`.