### PR TITLE
Document 8.4 changes in openssl_csr_new

### DIFF
--- a/reference/openssl/functions/openssl-csr-new.xml
+++ b/reference/openssl/functions/openssl-csr-new.xml
@@ -30,7 +30,11 @@
      <term><parameter>distinguished_names</parameter></term>
      <listitem>
       <para>
-       The Distinguished Name or subject fields to be used in the certificate.
+       The Distinguished Name or subject fields to be included in the
+       certificate. The <parameter>distinguished_names</parameter> is an
+       associative array where the keys represent the attribute names of
+       Distinguished Names and the values can either be strings (for single
+       value) or arrays (if multiple values need to be set).
       </para>
      </listitem>
     </varlistentry>
@@ -151,10 +155,9 @@
      <listitem>
       <para>
        <parameter>extra_attributes</parameter> is used to specify additional
-       configuration options for the <acronym>CSR</acronym>.  Both
-       <parameter>distinguished_names</parameter> and
-       <parameter>extra_attributes</parameter> are associative arrays, whose keys
-       are converted to OIDs and applied to the relevant part of the request.
+       attributes for the <acronym>CSR</acronym>. It is an associative arrays
+       where the keys are converted to OIDs and applied as
+       <acronym>CSR</acronym> attributes.
       </para>
      </listitem>
     </varlistentry>
@@ -165,8 +168,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the <acronym>CSR</acronym> on success, &true; if CSR creation is
-   successful but signing fails&return.falseforfailure;.
+   Returns the <acronym>CSR</acronym> on success, &true; if
+   <acronym>CSR</acronym> creation is successful but signing
+   fails&return.falseforfailure;.
   </para>
  </refsect1>
 
@@ -181,6 +185,20 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       The <parameter>distinguished_names</parameter> associative array now supports arrays as values,
+       allowing multiple values to be specified for a single attribute.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       The <parameter>extra_attributes</parameter> parameter now correctly sets the CSR attributes,
+       rather than modifying the subject's Distinguished Name as it previously did incorrectly.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>


### PR DESCRIPTION
This clarifies `distinguished_names` and `extra_attributes` params as well.