### PR TITLE
Move some PDO file  entities at sibling positions, wkhtmltox fragment dir

### DIFF
--- a/reference/pdo/drivers.xml
+++ b/reference/pdo/drivers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
- 
+
 <part xml:id="pdo.drivers" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>PDO Drivers</title>
 
@@ -68,15 +68,21 @@
 
  &reference.pdo-cubrid.reference;
  &reference.pdo-dblib.reference;
+ &reference.pdo-dblib.pdo-dblib;
  &reference.pdo-firebird.reference;
+ &reference.pdo-firebird.pdo-firebird;
  &reference.pdo-ibm.reference;
  &reference.pdo-informix.reference;
  &reference.pdo-mysql.reference;
+ &reference.pdo-mysql.pdo-mysql;
  &reference.pdo-sqlsrv.reference;
  &reference.pdo-oci.reference;
  &reference.pdo-odbc.reference;
+ &reference.pdo-odbc.pdo-odbc;
  &reference.pdo-pgsql.reference;
+ &reference.pdo-pgsql.pdo-pgsql;
  &reference.pdo-sqlite.reference;
+ &reference.pdo-sqlite.pdo-sqlite;
 </part>
 
 <!-- Keep this comment at the end of the file
@@ -99,4 +105,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/pdo_dblib/reference.xml
+++ b/reference/pdo_dblib/reference.xml
@@ -18,14 +18,14 @@
      This extension is not available anymore on Windows.
     </para>
     <para>
-     On Windows, you should use SqlSrv, an alternative driver for MS SQL is 
+     On Windows, you should use SqlSrv, an alternative driver for MS SQL is
      available from Microsoft: <link xlink:href="&url.sqlsrv;">&url.sqlsrv;
      </link>.
     </para>
     <para>
-     If it is not possible to use SqlSrv, you can use the 
-     <link linkend="ref.pdo-odbc">PDO_ODBC</link> driver to connect to 
-     Microsoft SQL Server and Sybase databases, as the native Windows DB-LIB 
+     If it is not possible to use SqlSrv, you can use the
+     <link linkend="ref.pdo-odbc">PDO_ODBC</link> driver to connect to
+     Microsoft SQL Server and Sybase databases, as the native Windows DB-LIB
      is ancient, thread un-safe and no longer supported by Microsoft.
     </para>
    </section>
@@ -120,7 +120,7 @@ dblib:host=localhost;dbname=testdb
   </refentry>
 
  </reference>
- &reference.pdo-dblib.pdo-dblib;
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/pdo_firebird/reference.xml
+++ b/reference/pdo_firebird/reference.xml
@@ -128,7 +128,6 @@ firebird:dbname=localhost:/var/lib/firebird/2.5/data/test.fdb;charset=utf-8;dial
   </refentry>
 
  </reference>
- &reference.pdo-firebird.pdo-firebird;
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/pdo_mysql/reference.xml
+++ b/reference/pdo_mysql/reference.xml
@@ -23,7 +23,7 @@
     </para>
 
     <para>
-     When running a PHP version before 7.1.16, or PHP 7.2 before 7.2.4, set 
+     When running a PHP version before 7.1.16, or PHP 7.2 before 7.2.4, set
      MySQL 8 Server's default password plugin to <emphasis>mysql_native_password</emphasis>
      or else you will see errors similar to
      <emphasis>The server requested authentication method unknown to the client [caching_sha2_password]</emphasis>
@@ -156,9 +156,9 @@ mysql:unix_socket=/tmp/mysql.sock;dbname=testdb
     <note>
      <title>Unix only:</title>
      <para>
-      When the host name is set to <literal>"localhost"</literal>, then the connection to the 
-      server is made through a domain socket. If PDO_MYSQL is compiled against libmysqlclient then the 
-      location of the socket file is at libmysqlclient's compiled in location. If PDO_MYSQL is compiled 
+      When the host name is set to <literal>"localhost"</literal>, then the connection to the
+      server is made through a domain socket. If PDO_MYSQL is compiled against libmysqlclient then the
+      location of the socket file is at libmysqlclient's compiled in location. If PDO_MYSQL is compiled
       against mysqlnd a default socket can be set through the <link linkend="ini.pdo-mysql.default-socket">
       pdo_mysql.default_socket</link> setting.
      </para>
@@ -167,7 +167,7 @@ mysql:unix_socket=/tmp/mysql.sock;dbname=testdb
   </refentry>
 
  </reference>
- &reference.pdo-mysql.pdo-mysql;
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/pdo_odbc/reference.xml
+++ b/reference/pdo_odbc/reference.xml
@@ -30,7 +30,7 @@
        <listitem>
         <para>
          Supports access to database servers through the unixODBC driver
-         manager and the database's own ODBC drivers. 
+         manager and the database's own ODBC drivers.
         </para>
        </listitem>
       </varlistentry>
@@ -154,13 +154,13 @@ odbc:Driver={Microsoft Access Driver (*.mdb)};Dbq=C:\\db.mdb;Uid=Admin
 ]]>
       </programlisting>
      </example>
-     
+
     </para>
    </refsect1>
   </refentry>
 
  </reference>
- &reference.pdo-odbc.pdo-odbc;
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/pdo_pgsql/reference.xml
+++ b/reference/pdo_pgsql/reference.xml
@@ -153,7 +153,7 @@ pgsql:host=/tmp;port=5432;dbname=testdb;user=bruce;password=mypass
   &reference.pdo-pgsql.entities.pdo-overloaded;
 
  </reference>
- &reference.pdo-pgsql.pdo-pgsql;
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/pdo_sqlite/reference.xml
+++ b/reference/pdo_sqlite/reference.xml
@@ -91,7 +91,7 @@ sqlite:
  &reference.pdo-sqlite.entities.pdo-overloaded;
 
  </reference>
- &reference.pdo-sqlite.pdo-sqlite;
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
While creating a new tool for detecting problematic XML files (from libxml perspective), I got reports of two invalid XML files in wkhtmltox, that are really XML fragment files, and various files in PDO hierarchy.

The "error" was about "Extra content at the end of the document", caused by entities used outside elements. To avoid losing that test, this PR changes the position of these entities of <reference>`s at sibling positions of other <reference>`s, maintaining the structure of XML, and to better reflect how the manual is rendered at the end.

But... are these files intended to be positioned in sibling positions? It is rendered nowadays as:

![image](https://github.com/user-attachments/assets/08800c1e-7896-4772-9a46-b5f8a8ad0280)

It's is possible to have `<reference>`s inside `<reference>`s, so an alternative is to move these class documentation *inside* their defining PDO drivers files.

Also, I suggest to reaming the titleabrev to something that is more easy to search and render more naturally in image above. `MySQL PDO Driver" instead of ``MySQL (PDO)`, and so on.