### PR TITLE
Modernize RPM docs

### DIFF
--- a/reference/rpminfo/book.xml
+++ b/reference/rpminfo/book.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <book xml:id="book.rpminfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
  <title>RpmInfo</title>
@@ -8,14 +7,14 @@
 
  <preface xml:id="intro.rpminfo">
   &reftitle.intro;
-  <para>
+  <simpara>
    This extension enables you to retrieve information from RPM files
    or from the installed RPMs database.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    It also provides a <literal>rpm</literal> stream wrapper to retrieve RPM content
    (since version 1.0.0 with librpm  &gt;=  4.13).
-  </para>
+  </simpara>
  </preface>
 
  &reference.rpminfo.setup;
@@ -23,7 +22,6 @@
  &reference.rpminfo.reference;
 
 </book>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/rpminfo/constants.xml
+++ b/reference/rpminfo/constants.xml
@@ -3,2898 +3,2915 @@
 <appendix xml:id="rpminfo.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants;
- <para>
-  <variablelist>
-   <varlistentry xml:id="constant.rpmversion">
-    <term>
-     <constant>RPMVERSION</constant>
-     (<type>string</type>)
-    </term>
-    <listitem>
-     <simpara>
+
+ <variablelist>
+  <title>Miscellaneous constants</title>
+  <varlistentry xml:id="constant.rpmversion">
+   <term>
+    <constant>RPMVERSION</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
      System librpm version.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-any">
-    <term>
-     <constant>RPMSENSE_ANY</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-less">
-    <term>
-     <constant>RPMSENSE_LESS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-greater">
-    <term>
-     <constant>RPMSENSE_GREATER</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-equal">
-    <term>
-     <constant>RPMSENSE_EQUAL</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-posttrans">
-    <term>
-     <constant>RPMSENSE_POSTTRANS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-prereq">
-    <term>
-     <constant>RPMSENSE_PREREQ</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-pretrans">
-    <term>
-     <constant>RPMSENSE_PRETRANS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-interp">
-    <term>
-     <constant>RPMSENSE_INTERP</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-script-pre">
-    <term>
-     <constant>RPMSENSE_SCRIPT_PRE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-script-post">
-    <term>
-     <constant>RPMSENSE_SCRIPT_POST</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-script-preun">
-    <term>
-     <constant>RPMSENSE_SCRIPT_PREUN</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-script-postun">
-    <term>
-     <constant>RPMSENSE_SCRIPT_POSTUN</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-script-verify">
-    <term>
-     <constant>RPMSENSE_SCRIPT_VERIFY</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-find-requires">
-    <term>
-     <constant>RPMSENSE_FIND_REQUIRES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-find-provides">
-    <term>
-     <constant>RPMSENSE_FIND_PROVIDES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-triggerin">
-    <term>
-     <constant>RPMSENSE_TRIGGERIN</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-triggerun">
-    <term>
-     <constant>RPMSENSE_TRIGGERUN</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-triggerpostun">
-    <term>
-     <constant>RPMSENSE_TRIGGERPOSTUN</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-missingok">
-    <term>
-     <constant>RPMSENSE_MISSINGOK</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-rpmlib">
-    <term>
-     <constant>RPMSENSE_RPMLIB</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-triggerprein">
-    <term>
-     <constant>RPMSENSE_TRIGGERPREIN</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-keyring">
-    <term>
-     <constant>RPMSENSE_KEYRING</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmsense-config">
-    <term>
-     <constant>RPMSENSE_CONFIG</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmmire-default">
-    <term>
-     <constant>RPMMIRE_DEFAULT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Search pattern is a regular expression with \., .* and ^...$ added.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmmire-strcmp">
-    <term>
-     <constant>RPMMIRE_STRCMP</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Search pattern is a <type>string</type>, using strcmp(3).
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmmire-regex">
-    <term>
-     <constant>RPMMIRE_REGEX</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Search pattern is a regular expression, using regcomp(3).
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmmire-glob">
-    <term>
-     <constant>RPMMIRE_GLOB</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Search pattern is a glob expression, using fnmatch(3).
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-arch">
-    <term>
-     <constant>RPMTAG_ARCH</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-archsuffix">
-    <term>
-     <constant>RPMTAG_ARCHSUFFIX</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Requires librpm &gt;= 4.18
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-archivesize">
-    <term>
-     <constant>RPMTAG_ARCHIVESIZE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-basenames">
-    <term>
-     <constant>RPMTAG_BASENAMES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Name (not path) of files, with database index.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-bugurl">
-    <term>
-     <constant>RPMTAG_BUGURL</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-buildarchs">
-    <term>
-     <constant>RPMTAG_BUILDARCHS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-buildhost">
-    <term>
-     <constant>RPMTAG_BUILDHOST</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-buildtime">
-    <term>
-     <constant>RPMTAG_BUILDTIME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-c">
-    <term>
-     <constant>RPMTAG_C</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-changelogname">
-    <term>
-     <constant>RPMTAG_CHANGELOGNAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-changelogtext">
-    <term>
-     <constant>RPMTAG_CHANGELOGTEXT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-changelogtime">
-    <term>
-     <constant>RPMTAG_CHANGELOGTIME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-classdict">
-    <term>
-     <constant>RPMTAG_CLASSDICT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-conflictflags">
-    <term>
-     <constant>RPMTAG_CONFLICTFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-conflictname">
-    <term>
-     <constant>RPMTAG_CONFLICTNAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Conflicting dependencies, with database index.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-conflictnevrs">
-    <term>
-     <constant>RPMTAG_CONFLICTNEVRS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-conflicts">
-    <term>
-     <constant>RPMTAG_CONFLICTS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-conflictversion">
-    <term>
-     <constant>RPMTAG_CONFLICTVERSION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-cookie">
-    <term>
-     <constant>RPMTAG_COOKIE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-dbinstance">
-    <term>
-     <constant>RPMTAG_DBINSTANCE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-dependsdict">
-    <term>
-     <constant>RPMTAG_DEPENDSDICT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-description">
-    <term>
-     <constant>RPMTAG_DESCRIPTION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-dirindexes">
-    <term>
-     <constant>RPMTAG_DIRINDEXES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-dirnames">
-    <term>
-     <constant>RPMTAG_DIRNAMES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Directory of files, with database index.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-distribution">
-    <term>
-     <constant>RPMTAG_DISTRIBUTION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-disttag">
-    <term>
-     <constant>RPMTAG_DISTTAG</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-disturl">
-    <term>
-     <constant>RPMTAG_DISTURL</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-dsaheader">
-    <term>
-     <constant>RPMTAG_DSAHEADER</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-e">
-    <term>
-     <constant>RPMTAG_E</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-encoding">
-    <term>
-     <constant>RPMTAG_ENCODING</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-enhanceflags">
-    <term>
-     <constant>RPMTAG_ENHANCEFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-enhancename">
-    <term>
-     <constant>RPMTAG_ENHANCENAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Weak dependencies, with database index, requires librpm &gt;= 4.13.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-enhancenevrs">
-    <term>
-     <constant>RPMTAG_ENHANCENEVRS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-enhances">
-    <term>
-     <constant>RPMTAG_ENHANCES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-enhanceversion">
-    <term>
-     <constant>RPMTAG_ENHANCEVERSION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-epoch">
-    <term>
-     <constant>RPMTAG_EPOCH</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-epochnum">
-    <term>
-     <constant>RPMTAG_EPOCHNUM</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-evr">
-    <term>
-     <constant>RPMTAG_EVR</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-excludearch">
-    <term>
-     <constant>RPMTAG_EXCLUDEARCH</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-excludeos">
-    <term>
-     <constant>RPMTAG_EXCLUDEOS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-exclusivearch">
-    <term>
-     <constant>RPMTAG_EXCLUSIVEARCH</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-exclusiveos">
-    <term>
-     <constant>RPMTAG_EXCLUSIVEOS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filecaps">
-    <term>
-     <constant>RPMTAG_FILECAPS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-fileclass">
-    <term>
-     <constant>RPMTAG_FILECLASS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filecolors">
-    <term>
-     <constant>RPMTAG_FILECOLORS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filecontexts">
-    <term>
-     <constant>RPMTAG_FILECONTEXTS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filedependsn">
-    <term>
-     <constant>RPMTAG_FILEDEPENDSN</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filedependsx">
-    <term>
-     <constant>RPMTAG_FILEDEPENDSX</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filedevices">
-    <term>
-     <constant>RPMTAG_FILEDEVICES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filedigestalgo">
-    <term>
-     <constant>RPMTAG_FILEDIGESTALGO</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filedigests">
-    <term>
-     <constant>RPMTAG_FILEDIGESTS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-fileflags">
-    <term>
-     <constant>RPMTAG_FILEFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filegroupname">
-    <term>
-     <constant>RPMTAG_FILEGROUPNAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-fileinodes">
-    <term>
-     <constant>RPMTAG_FILEINODES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filelangs">
-    <term>
-     <constant>RPMTAG_FILELANGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filelinktos">
-    <term>
-     <constant>RPMTAG_FILELINKTOS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filemd5s">
-    <term>
-     <constant>RPMTAG_FILEMD5S</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filemodes">
-    <term>
-     <constant>RPMTAG_FILEMODES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filemtimes">
-    <term>
-     <constant>RPMTAG_FILEMTIMES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filenames">
-    <term>
-     <constant>RPMTAG_FILENAMES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filenlinks">
-    <term>
-     <constant>RPMTAG_FILENLINKS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-fileprovide">
-    <term>
-     <constant>RPMTAG_FILEPROVIDE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filerdevs">
-    <term>
-     <constant>RPMTAG_FILERDEVS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filerequire">
-    <term>
-     <constant>RPMTAG_FILEREQUIRE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filesignaturelength">
-    <term>
-     <constant>RPMTAG_FILESIGNATURELENGTH</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filesignatures">
-    <term>
-     <constant>RPMTAG_FILESIGNATURES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filesizes">
-    <term>
-     <constant>RPMTAG_FILESIZES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filestates">
-    <term>
-     <constant>RPMTAG_FILESTATES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filetriggerconds">
-    <term>
-     <constant>RPMTAG_FILETRIGGERCONDS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filetriggerflags">
-    <term>
-     <constant>RPMTAG_FILETRIGGERFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filetriggerindex">
-    <term>
-     <constant>RPMTAG_FILETRIGGERINDEX</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filetriggername">
-    <term>
-     <constant>RPMTAG_FILETRIGGERNAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      File trigger name, with database index, requires librpm &gt;= 4.13.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filetriggerpriorities">
-    <term>
-     <constant>RPMTAG_FILETRIGGERPRIORITIES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filetriggerscriptflags">
-    <term>
-     <constant>RPMTAG_FILETRIGGERSCRIPTFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filetriggerscriptprog">
-    <term>
-     <constant>RPMTAG_FILETRIGGERSCRIPTPROG</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filetriggerscripts">
-    <term>
-     <constant>RPMTAG_FILETRIGGERSCRIPTS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filetriggertype">
-    <term>
-     <constant>RPMTAG_FILETRIGGERTYPE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-filetriggerversion">
-    <term>
-     <constant>RPMTAG_FILETRIGGERVERSION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-fileusername">
-    <term>
-     <constant>RPMTAG_FILEUSERNAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-fileverifyflags">
-    <term>
-     <constant>RPMTAG_FILEVERIFYFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-fscontexts">
-    <term>
-     <constant>RPMTAG_FSCONTEXTS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-gif">
-    <term>
-     <constant>RPMTAG_GIF</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-group">
-    <term>
-     <constant>RPMTAG_GROUP</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Group of the package, with database index.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-hdrid">
-    <term>
-     <constant>RPMTAG_HDRID</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-headercolor">
-    <term>
-     <constant>RPMTAG_HEADERCOLOR</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-headeri18ntable">
-    <term>
-     <constant>RPMTAG_HEADERI18NTABLE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-headerimage">
-    <term>
-     <constant>RPMTAG_HEADERIMAGE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-headerimmutable">
-    <term>
-     <constant>RPMTAG_HEADERIMMUTABLE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-headerregions">
-    <term>
-     <constant>RPMTAG_HEADERREGIONS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-headersignatures">
-    <term>
-     <constant>RPMTAG_HEADERSIGNATURES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-icon">
-    <term>
-     <constant>RPMTAG_ICON</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-installcolor">
-    <term>
-     <constant>RPMTAG_INSTALLCOLOR</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-installtid">
-    <term>
-     <constant>RPMTAG_INSTALLTID</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Installation transaction ID, with database index.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-installtime">
-    <term>
-     <constant>RPMTAG_INSTALLTIME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-instfilenames">
-    <term>
-     <constant>RPMTAG_INSTFILENAMES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Path of files, with database index.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-instprefixes">
-    <term>
-     <constant>RPMTAG_INSTPREFIXES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-license">
-    <term>
-     <constant>RPMTAG_LICENSE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-longarchivesize">
-    <term>
-     <constant>RPMTAG_LONGARCHIVESIZE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-longfilesizes">
-    <term>
-     <constant>RPMTAG_LONGFILESIZES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-longsigsize">
-    <term>
-     <constant>RPMTAG_LONGSIGSIZE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-longsize">
-    <term>
-     <constant>RPMTAG_LONGSIZE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-modularitylabel">
-    <term>
-     <constant>RPMTAG_MODULARITYLABEL</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-n">
-    <term>
-     <constant>RPMTAG_N</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-name">
-    <term>
-     <constant>RPMTAG_NAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Package name, with database index.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-nevr">
-    <term>
-     <constant>RPMTAG_NEVR</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-nevra">
-    <term>
-     <constant>RPMTAG_NEVRA</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-nopatch">
-    <term>
-     <constant>RPMTAG_NOPATCH</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-nosource">
-    <term>
-     <constant>RPMTAG_NOSOURCE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-nvr">
-    <term>
-     <constant>RPMTAG_NVR</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-nvra">
-    <term>
-     <constant>RPMTAG_NVRA</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-o">
-    <term>
-     <constant>RPMTAG_O</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-obsoleteflags">
-    <term>
-     <constant>RPMTAG_OBSOLETEFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-obsoletename">
-    <term>
-     <constant>RPMTAG_OBSOLETENAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Obsoleted packages, with database index.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-obsoletenevrs">
-    <term>
-     <constant>RPMTAG_OBSOLETENEVRS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-obsoletes">
-    <term>
-     <constant>RPMTAG_OBSOLETES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-obsoleteversion">
-    <term>
-     <constant>RPMTAG_OBSOLETEVERSION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-oldenhances">
-    <term>
-     <constant>RPMTAG_OLDENHANCES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-oldenhancesflags">
-    <term>
-     <constant>RPMTAG_OLDENHANCESFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-oldenhancesname">
-    <term>
-     <constant>RPMTAG_OLDENHANCESNAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-oldenhancesversion">
-    <term>
-     <constant>RPMTAG_OLDENHANCESVERSION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-oldfilenames">
-    <term>
-     <constant>RPMTAG_OLDFILENAMES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-oldsuggests">
-    <term>
-     <constant>RPMTAG_OLDSUGGESTS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-oldsuggestsflags">
-    <term>
-     <constant>RPMTAG_OLDSUGGESTSFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-oldsuggestsname">
-    <term>
-     <constant>RPMTAG_OLDSUGGESTSNAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-oldsuggestsversion">
-    <term>
-     <constant>RPMTAG_OLDSUGGESTSVERSION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-optflags">
-    <term>
-     <constant>RPMTAG_OPTFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-orderflags">
-    <term>
-     <constant>RPMTAG_ORDERFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-ordername">
-    <term>
-     <constant>RPMTAG_ORDERNAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-orderversion">
-    <term>
-     <constant>RPMTAG_ORDERVERSION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-origbasenames">
-    <term>
-     <constant>RPMTAG_ORIGBASENAMES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-origdirindexes">
-    <term>
-     <constant>RPMTAG_ORIGDIRINDEXES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-origdirnames">
-    <term>
-     <constant>RPMTAG_ORIGDIRNAMES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-origfilenames">
-    <term>
-     <constant>RPMTAG_ORIGFILENAMES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-os">
-    <term>
-     <constant>RPMTAG_OS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-p">
-    <term>
-     <constant>RPMTAG_P</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-packager">
-    <term>
-     <constant>RPMTAG_PACKAGER</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-patch">
-    <term>
-     <constant>RPMTAG_PATCH</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-patchesflags">
-    <term>
-     <constant>RPMTAG_PATCHESFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-patchesname">
-    <term>
-     <constant>RPMTAG_PATCHESNAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-patchesversion">
-    <term>
-     <constant>RPMTAG_PATCHESVERSION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-payloadcompressor">
-    <term>
-     <constant>RPMTAG_PAYLOADCOMPRESSOR</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-payloaddigest">
-    <term>
-     <constant>RPMTAG_PAYLOADDIGEST</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-payloaddigestalt">
-    <term>
-     <constant>RPMTAG_PAYLOADDIGESTALT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      With librpm &gt;= 4.16.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-payloaddigestalgo">
-    <term>
-     <constant>RPMTAG_PAYLOADDIGESTALGO</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-payloadflags">
-    <term>
-     <constant>RPMTAG_PAYLOADFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-payloadformat">
-    <term>
-     <constant>RPMTAG_PAYLOADFORMAT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-pkgid">
-    <term>
-     <constant>RPMTAG_PKGID</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-platform">
-    <term>
-     <constant>RPMTAG_PLATFORM</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-policies">
-    <term>
-     <constant>RPMTAG_POLICIES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-policyflags">
-    <term>
-     <constant>RPMTAG_POLICYFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-policynames">
-    <term>
-     <constant>RPMTAG_POLICYNAMES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-policytypes">
-    <term>
-     <constant>RPMTAG_POLICYTYPES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-policytypesindexes">
-    <term>
-     <constant>RPMTAG_POLICYTYPESINDEXES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-postin">
-    <term>
-     <constant>RPMTAG_POSTIN</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-postinflags">
-    <term>
-     <constant>RPMTAG_POSTINFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-postinprog">
-    <term>
-     <constant>RPMTAG_POSTINPROG</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-posttrans">
-    <term>
-     <constant>RPMTAG_POSTTRANS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-posttransflags">
-    <term>
-     <constant>RPMTAG_POSTTRANSFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-posttransprog">
-    <term>
-     <constant>RPMTAG_POSTTRANSPROG</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-postun">
-    <term>
-     <constant>RPMTAG_POSTUN</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-postunflags">
-    <term>
-     <constant>RPMTAG_POSTUNFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-postunprog">
-    <term>
-     <constant>RPMTAG_POSTUNPROG</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-postuntrans">
-    <term>
-     <constant>RPMTAG_POSTUNTRANS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Requires librpm &gt;= 4.19
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-postuntransflags">
-    <term>
-     <constant>RPMTAG_POSTUNTRANSFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Requires librpm &gt;= 4.19
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-postuntransprog">
-    <term>
-     <constant>RPMTAG_POSTUNTRANSPROG</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Requires librpm &gt;= 4.19
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-prefixes">
-    <term>
-     <constant>RPMTAG_PREFIXES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-prein">
-    <term>
-     <constant>RPMTAG_PREIN</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-preinflags">
-    <term>
-     <constant>RPMTAG_PREINFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-preinprog">
-    <term>
-     <constant>RPMTAG_PREINPROG</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-pretrans">
-    <term>
-     <constant>RPMTAG_PRETRANS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-pretransflags">
-    <term>
-     <constant>RPMTAG_PRETRANSFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-pretransprog">
-    <term>
-     <constant>RPMTAG_PRETRANSPROG</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-preun">
-    <term>
-     <constant>RPMTAG_PREUN</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-preunflags">
-    <term>
-     <constant>RPMTAG_PREUNFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-preunprog">
-    <term>
-     <constant>RPMTAG_PREUNPROG</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-preuntrans">
-    <term>
-     <constant>RPMTAG_PREUNTRANS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Requires librpm &gt;= 4.19
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-preuntransflags">
-    <term>
-     <constant>RPMTAG_PREUNTRANSFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Requires librpm &gt;= 4.19
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-preuntransprog">
-    <term>
-     <constant>RPMTAG_PREUNTRANSPROG</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Requires librpm &gt;= 4.19
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-provideflags">
-    <term>
-     <constant>RPMTAG_PROVIDEFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-providename">
-    <term>
-     <constant>RPMTAG_PROVIDENAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Provided dependencies, with database index.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-providenevrs">
-    <term>
-     <constant>RPMTAG_PROVIDENEVRS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-provides">
-    <term>
-     <constant>RPMTAG_PROVIDES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-provideversion">
-    <term>
-     <constant>RPMTAG_PROVIDEVERSION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-pubkeys">
-    <term>
-     <constant>RPMTAG_PUBKEYS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-r">
-    <term>
-     <constant>RPMTAG_R</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-recommendflags">
-    <term>
-     <constant>RPMTAG_RECOMMENDFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-recommendname">
-    <term>
-     <constant>RPMTAG_RECOMMENDNAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Recommended weak dependencies, with database index, requires librpm &gt;= 4.13.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-recommendnevrs">
-    <term>
-     <constant>RPMTAG_RECOMMENDNEVRS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-recommends">
-    <term>
-     <constant>RPMTAG_RECOMMENDS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-recommendversion">
-    <term>
-     <constant>RPMTAG_RECOMMENDVERSION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-recontexts">
-    <term>
-     <constant>RPMTAG_RECONTEXTS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-release">
-    <term>
-     <constant>RPMTAG_RELEASE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-removetid">
-    <term>
-     <constant>RPMTAG_REMOVETID</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-requireflags">
-    <term>
-     <constant>RPMTAG_REQUIREFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-requirename">
-    <term>
-     <constant>RPMTAG_REQUIRENAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Required dependencies, with database index.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-requirenevrs">
-    <term>
-     <constant>RPMTAG_REQUIRENEVRS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-requires">
-    <term>
-     <constant>RPMTAG_REQUIRES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-requireversion">
-    <term>
-     <constant>RPMTAG_REQUIREVERSION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-rpmversion">
-    <term>
-     <constant>RPMTAG_RPMVERSION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-rsaheader">
-    <term>
-     <constant>RPMTAG_RSAHEADER</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-sha1header">
-    <term>
-     <constant>RPMTAG_SHA1HEADER</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      SHA1 signature, with database index.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-sha256header">
-    <term>
-     <constant>RPMTAG_SHA256HEADER</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-siggpg">
-    <term>
-     <constant>RPMTAG_SIGGPG</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-sigmd5">
-    <term>
-     <constant>RPMTAG_SIGMD5</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      MD5 signature, with database index.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-sigpgp">
-    <term>
-     <constant>RPMTAG_SIGPGP</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-sigsize">
-    <term>
-     <constant>RPMTAG_SIGSIZE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-size">
-    <term>
-     <constant>RPMTAG_SIZE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-source">
-    <term>
-     <constant>RPMTAG_SOURCE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-sourcepackage">
-    <term>
-     <constant>RPMTAG_SOURCEPACKAGE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-sourcepkgid">
-    <term>
-     <constant>RPMTAG_SOURCEPKGID</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-sourcerpm">
-    <term>
-     <constant>RPMTAG_SOURCERPM</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-spec">
-    <term>
-     <constant>RPMTAG_SPEC</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Requires librpm &gt;= 4.18
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-suggestflags">
-    <term>
-     <constant>RPMTAG_SUGGESTFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-suggestname">
-    <term>
-     <constant>RPMTAG_SUGGESTNAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Suggested weak dependencies, with database index, requires librpm &gt;= 4.13.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-suggestnevrs">
-    <term>
-     <constant>RPMTAG_SUGGESTNEVRS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-suggests">
-    <term>
-     <constant>RPMTAG_SUGGESTS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-suggestversion">
-    <term>
-     <constant>RPMTAG_SUGGESTVERSION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-summary">
-    <term>
-     <constant>RPMTAG_SUMMARY</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-supplementflags">
-    <term>
-     <constant>RPMTAG_SUPPLEMENTFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-supplementname">
-    <term>
-     <constant>RPMTAG_SUPPLEMENTNAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Weak dependencies, with database index, requires librpm &gt;= 4.13.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-supplementnevrs">
-    <term>
-     <constant>RPMTAG_SUPPLEMENTNEVRS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-supplements">
-    <term>
-     <constant>RPMTAG_SUPPLEMENTS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-supplementversion">
-    <term>
-     <constant>RPMTAG_SUPPLEMENTVERSION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-sysusers">
-    <term>
-     <constant>RPMTAG_SYSUSERS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Requires librpm &gt;= 4.19
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-transfiletriggerconds">
-    <term>
-     <constant>RPMTAG_TRANSFILETRIGGERCONDS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-transfiletriggerflags">
-    <term>
-     <constant>RPMTAG_TRANSFILETRIGGERFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-transfiletriggerindex">
-    <term>
-     <constant>RPMTAG_TRANSFILETRIGGERINDEX</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-transfiletriggername">
-    <term>
-     <constant>RPMTAG_TRANSFILETRIGGERNAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Transaction file trigger name, with database index, requires librpm &gt;= 4.13.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-transfiletriggerpriorities">
-    <term>
-     <constant>RPMTAG_TRANSFILETRIGGERPRIORITIES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-transfiletriggerscriptflags">
-    <term>
-     <constant>RPMTAG_TRANSFILETRIGGERSCRIPTFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-transfiletriggerscriptprog">
-    <term>
-     <constant>RPMTAG_TRANSFILETRIGGERSCRIPTPROG</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-transfiletriggerscripts">
-    <term>
-     <constant>RPMTAG_TRANSFILETRIGGERSCRIPTS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-transfiletriggertype">
-    <term>
-     <constant>RPMTAG_TRANSFILETRIGGERTYPE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-transfiletriggerversion">
-    <term>
-     <constant>RPMTAG_TRANSFILETRIGGERVERSION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-translationurl">
-    <term>
-     <constant>RPMTAG_TRANSLATIONURL</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Requires librpm &gt;= 4.18
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-triggerconds">
-    <term>
-     <constant>RPMTAG_TRIGGERCONDS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-triggerflags">
-    <term>
-     <constant>RPMTAG_TRIGGERFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-triggerindex">
-    <term>
-     <constant>RPMTAG_TRIGGERINDEX</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-triggername">
-    <term>
-     <constant>RPMTAG_TRIGGERNAME</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Trigger name, with database index.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-triggerscriptflags">
-    <term>
-     <constant>RPMTAG_TRIGGERSCRIPTFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-triggerscriptprog">
-    <term>
-     <constant>RPMTAG_TRIGGERSCRIPTPROG</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-triggerscripts">
-    <term>
-     <constant>RPMTAG_TRIGGERSCRIPTS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-triggertype">
-    <term>
-     <constant>RPMTAG_TRIGGERTYPE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-triggerversion">
-    <term>
-     <constant>RPMTAG_TRIGGERVERSION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-upstreamreleases">
-    <term>
-     <constant>RPMTAG_UPSTREAMRELEASES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Requires librpm &gt;= 4.18
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-url">
-    <term>
-     <constant>RPMTAG_URL</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-v">
-    <term>
-     <constant>RPMTAG_V</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-vcs">
-    <term>
-     <constant>RPMTAG_VCS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-vendor">
-    <term>
-     <constant>RPMTAG_VENDOR</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-verbose">
-    <term>
-     <constant>RPMTAG_VERBOSE</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-verifyscript">
-    <term>
-     <constant>RPMTAG_VERIFYSCRIPT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-verifyscriptflags">
-    <term>
-     <constant>RPMTAG_VERIFYSCRIPTFLAGS</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-verifyscriptprog">
-    <term>
-     <constant>RPMTAG_VERIFYSCRIPTPROG</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-veritysignaturealgo">
-    <term>
-     <constant>RPMTAG_VERITYSIGNATUREALGO</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      With librpm &gt;= 4.17.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-veritysignatures">
-    <term>
-     <constant>RPMTAG_VERITYSIGNATURES</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-      With librpm &gt;= 4.17.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-version">
-    <term>
-     <constant>RPMTAG_VERSION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.rpmtag-xpm">
-    <term>
-     <constant>RPMTAG_XPM</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-  </variablelist>
- </para>
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+
+ <variablelist>
+  <title>RPM Senses</title>
+  <varlistentry xml:id="constant.rpmsense-any">
+   <term>
+    <constant>RPMSENSE_ANY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-less">
+   <term>
+    <constant>RPMSENSE_LESS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-greater">
+   <term>
+    <constant>RPMSENSE_GREATER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-equal">
+   <term>
+    <constant>RPMSENSE_EQUAL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-posttrans">
+   <term>
+    <constant>RPMSENSE_POSTTRANS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-prereq">
+   <term>
+    <constant>RPMSENSE_PREREQ</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-pretrans">
+   <term>
+    <constant>RPMSENSE_PRETRANS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-interp">
+   <term>
+    <constant>RPMSENSE_INTERP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-script-pre">
+   <term>
+    <constant>RPMSENSE_SCRIPT_PRE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-script-post">
+   <term>
+    <constant>RPMSENSE_SCRIPT_POST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-script-preun">
+   <term>
+    <constant>RPMSENSE_SCRIPT_PREUN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-script-postun">
+   <term>
+    <constant>RPMSENSE_SCRIPT_POSTUN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-script-verify">
+   <term>
+    <constant>RPMSENSE_SCRIPT_VERIFY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-find-requires">
+   <term>
+    <constant>RPMSENSE_FIND_REQUIRES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-find-provides">
+   <term>
+    <constant>RPMSENSE_FIND_PROVIDES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-triggerin">
+   <term>
+    <constant>RPMSENSE_TRIGGERIN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-triggerun">
+   <term>
+    <constant>RPMSENSE_TRIGGERUN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-triggerpostun">
+   <term>
+    <constant>RPMSENSE_TRIGGERPOSTUN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-missingok">
+   <term>
+    <constant>RPMSENSE_MISSINGOK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-rpmlib">
+   <term>
+    <constant>RPMSENSE_RPMLIB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-triggerprein">
+   <term>
+    <constant>RPMSENSE_TRIGGERPREIN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-keyring">
+   <term>
+    <constant>RPMSENSE_KEYRING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmsense-config">
+   <term>
+    <constant>RPMSENSE_CONFIG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+
+ <variablelist>
+  <title>RPM Mire</title>
+  <varlistentry xml:id="constant.rpmmire-default">
+   <term>
+    <constant>RPMMIRE_DEFAULT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Search pattern is a regular expression with
+     <literal>\.</literal>, <literal>.*</literal>,
+     and <literal>^...$</literal> added.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmmire-strcmp">
+   <term>
+    <constant>RPMMIRE_STRCMP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Search pattern is a <type>string</type>,
+     using <code>strcmp(3)</code>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmmire-regex">
+   <term>
+    <constant>RPMMIRE_REGEX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Search pattern is a regular expression,
+     using <code>regcomp(3)</code>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmmire-glob">
+   <term>
+    <constant>RPMMIRE_GLOB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Search pattern is a glob expression,
+     using <code>fnmatch(3)</code>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+
+ <variablelist>
+  <title>RPM tags</title>
+  <varlistentry xml:id="constant.rpmtag-arch">
+   <term>
+    <constant>RPMTAG_ARCH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-archsuffix">
+   <term>
+    <constant>RPMTAG_ARCHSUFFIX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Requires librpm &gt;= 4.18
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-archivesize">
+   <term>
+    <constant>RPMTAG_ARCHIVESIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-basenames">
+   <term>
+    <constant>RPMTAG_BASENAMES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Name (not path) of files, with database index.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-bugurl">
+   <term>
+    <constant>RPMTAG_BUGURL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-buildarchs">
+   <term>
+    <constant>RPMTAG_BUILDARCHS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-buildhost">
+   <term>
+    <constant>RPMTAG_BUILDHOST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-buildtime">
+   <term>
+    <constant>RPMTAG_BUILDTIME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-c">
+   <term>
+    <constant>RPMTAG_C</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-changelogname">
+   <term>
+    <constant>RPMTAG_CHANGELOGNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-changelogtext">
+   <term>
+    <constant>RPMTAG_CHANGELOGTEXT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-changelogtime">
+   <term>
+    <constant>RPMTAG_CHANGELOGTIME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-classdict">
+   <term>
+    <constant>RPMTAG_CLASSDICT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-conflictflags">
+   <term>
+    <constant>RPMTAG_CONFLICTFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-conflictname">
+   <term>
+    <constant>RPMTAG_CONFLICTNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Conflicting dependencies, with database index.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-conflictnevrs">
+   <term>
+    <constant>RPMTAG_CONFLICTNEVRS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-conflicts">
+   <term>
+    <constant>RPMTAG_CONFLICTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-conflictversion">
+   <term>
+    <constant>RPMTAG_CONFLICTVERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-cookie">
+   <term>
+    <constant>RPMTAG_COOKIE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-dbinstance">
+   <term>
+    <constant>RPMTAG_DBINSTANCE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-dependsdict">
+   <term>
+    <constant>RPMTAG_DEPENDSDICT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-description">
+   <term>
+    <constant>RPMTAG_DESCRIPTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-dirindexes">
+   <term>
+    <constant>RPMTAG_DIRINDEXES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-dirnames">
+   <term>
+    <constant>RPMTAG_DIRNAMES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Directory of files, with database index.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-distribution">
+   <term>
+    <constant>RPMTAG_DISTRIBUTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-disttag">
+   <term>
+    <constant>RPMTAG_DISTTAG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-disturl">
+   <term>
+    <constant>RPMTAG_DISTURL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-dsaheader">
+   <term>
+    <constant>RPMTAG_DSAHEADER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-e">
+   <term>
+    <constant>RPMTAG_E</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-encoding">
+   <term>
+    <constant>RPMTAG_ENCODING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-enhanceflags">
+   <term>
+    <constant>RPMTAG_ENHANCEFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-enhancename">
+   <term>
+    <constant>RPMTAG_ENHANCENAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Weak dependencies, with database index, requires librpm &gt;= 4.13.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-enhancenevrs">
+   <term>
+    <constant>RPMTAG_ENHANCENEVRS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-enhances">
+   <term>
+    <constant>RPMTAG_ENHANCES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-enhanceversion">
+   <term>
+    <constant>RPMTAG_ENHANCEVERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-epoch">
+   <term>
+    <constant>RPMTAG_EPOCH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-epochnum">
+   <term>
+    <constant>RPMTAG_EPOCHNUM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-evr">
+   <term>
+    <constant>RPMTAG_EVR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-excludearch">
+   <term>
+    <constant>RPMTAG_EXCLUDEARCH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-excludeos">
+   <term>
+    <constant>RPMTAG_EXCLUDEOS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-exclusivearch">
+   <term>
+    <constant>RPMTAG_EXCLUSIVEARCH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-exclusiveos">
+   <term>
+    <constant>RPMTAG_EXCLUSIVEOS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filecaps">
+   <term>
+    <constant>RPMTAG_FILECAPS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-fileclass">
+   <term>
+    <constant>RPMTAG_FILECLASS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filecolors">
+   <term>
+    <constant>RPMTAG_FILECOLORS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filecontexts">
+   <term>
+    <constant>RPMTAG_FILECONTEXTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filedependsn">
+   <term>
+    <constant>RPMTAG_FILEDEPENDSN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filedependsx">
+   <term>
+    <constant>RPMTAG_FILEDEPENDSX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filedevices">
+   <term>
+    <constant>RPMTAG_FILEDEVICES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filedigestalgo">
+   <term>
+    <constant>RPMTAG_FILEDIGESTALGO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filedigests">
+   <term>
+    <constant>RPMTAG_FILEDIGESTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-fileflags">
+   <term>
+    <constant>RPMTAG_FILEFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filegroupname">
+   <term>
+    <constant>RPMTAG_FILEGROUPNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-fileinodes">
+   <term>
+    <constant>RPMTAG_FILEINODES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filelangs">
+   <term>
+    <constant>RPMTAG_FILELANGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filelinktos">
+   <term>
+    <constant>RPMTAG_FILELINKTOS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filemd5s">
+   <term>
+    <constant>RPMTAG_FILEMD5S</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filemodes">
+   <term>
+    <constant>RPMTAG_FILEMODES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filemtimes">
+   <term>
+    <constant>RPMTAG_FILEMTIMES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filenames">
+   <term>
+    <constant>RPMTAG_FILENAMES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filenlinks">
+   <term>
+    <constant>RPMTAG_FILENLINKS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-fileprovide">
+   <term>
+    <constant>RPMTAG_FILEPROVIDE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filerdevs">
+   <term>
+    <constant>RPMTAG_FILERDEVS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filerequire">
+   <term>
+    <constant>RPMTAG_FILEREQUIRE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filesignaturelength">
+   <term>
+    <constant>RPMTAG_FILESIGNATURELENGTH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filesignatures">
+   <term>
+    <constant>RPMTAG_FILESIGNATURES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filesizes">
+   <term>
+    <constant>RPMTAG_FILESIZES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filestates">
+   <term>
+    <constant>RPMTAG_FILESTATES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filetriggerconds">
+   <term>
+    <constant>RPMTAG_FILETRIGGERCONDS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filetriggerflags">
+   <term>
+    <constant>RPMTAG_FILETRIGGERFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filetriggerindex">
+   <term>
+    <constant>RPMTAG_FILETRIGGERINDEX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filetriggername">
+   <term>
+    <constant>RPMTAG_FILETRIGGERNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     File trigger name, with database index, requires librpm &gt;= 4.13.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filetriggerpriorities">
+   <term>
+    <constant>RPMTAG_FILETRIGGERPRIORITIES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filetriggerscriptflags">
+   <term>
+    <constant>RPMTAG_FILETRIGGERSCRIPTFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filetriggerscriptprog">
+   <term>
+    <constant>RPMTAG_FILETRIGGERSCRIPTPROG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filetriggerscripts">
+   <term>
+    <constant>RPMTAG_FILETRIGGERSCRIPTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filetriggertype">
+   <term>
+    <constant>RPMTAG_FILETRIGGERTYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-filetriggerversion">
+   <term>
+    <constant>RPMTAG_FILETRIGGERVERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-fileusername">
+   <term>
+    <constant>RPMTAG_FILEUSERNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-fileverifyflags">
+   <term>
+    <constant>RPMTAG_FILEVERIFYFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-fscontexts">
+   <term>
+    <constant>RPMTAG_FSCONTEXTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-gif">
+   <term>
+    <constant>RPMTAG_GIF</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-group">
+   <term>
+    <constant>RPMTAG_GROUP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Group of the package, with database index.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-hdrid">
+   <term>
+    <constant>RPMTAG_HDRID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-headercolor">
+   <term>
+    <constant>RPMTAG_HEADERCOLOR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-headeri18ntable">
+   <term>
+    <constant>RPMTAG_HEADERI18NTABLE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-headerimage">
+   <term>
+    <constant>RPMTAG_HEADERIMAGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-headerimmutable">
+   <term>
+    <constant>RPMTAG_HEADERIMMUTABLE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-headerregions">
+   <term>
+    <constant>RPMTAG_HEADERREGIONS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-headersignatures">
+   <term>
+    <constant>RPMTAG_HEADERSIGNATURES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-icon">
+   <term>
+    <constant>RPMTAG_ICON</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-installcolor">
+   <term>
+    <constant>RPMTAG_INSTALLCOLOR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-installtid">
+   <term>
+    <constant>RPMTAG_INSTALLTID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Installation transaction ID, with database index.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-installtime">
+   <term>
+    <constant>RPMTAG_INSTALLTIME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-instfilenames">
+   <term>
+    <constant>RPMTAG_INSTFILENAMES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Path of files, with database index.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-instprefixes">
+   <term>
+    <constant>RPMTAG_INSTPREFIXES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-license">
+   <term>
+    <constant>RPMTAG_LICENSE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-longarchivesize">
+   <term>
+    <constant>RPMTAG_LONGARCHIVESIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-longfilesizes">
+   <term>
+    <constant>RPMTAG_LONGFILESIZES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-longsigsize">
+   <term>
+    <constant>RPMTAG_LONGSIGSIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-longsize">
+   <term>
+    <constant>RPMTAG_LONGSIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-modularitylabel">
+   <term>
+    <constant>RPMTAG_MODULARITYLABEL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-n">
+   <term>
+    <constant>RPMTAG_N</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-name">
+   <term>
+    <constant>RPMTAG_NAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Package name, with database index.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-nevr">
+   <term>
+    <constant>RPMTAG_NEVR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-nevra">
+   <term>
+    <constant>RPMTAG_NEVRA</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-nopatch">
+   <term>
+    <constant>RPMTAG_NOPATCH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-nosource">
+   <term>
+    <constant>RPMTAG_NOSOURCE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-nvr">
+   <term>
+    <constant>RPMTAG_NVR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-nvra">
+   <term>
+    <constant>RPMTAG_NVRA</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-o">
+   <term>
+    <constant>RPMTAG_O</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-obsoleteflags">
+   <term>
+    <constant>RPMTAG_OBSOLETEFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-obsoletename">
+   <term>
+    <constant>RPMTAG_OBSOLETENAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Obsoleted packages, with database index.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-obsoletenevrs">
+   <term>
+    <constant>RPMTAG_OBSOLETENEVRS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-obsoletes">
+   <term>
+    <constant>RPMTAG_OBSOLETES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-obsoleteversion">
+   <term>
+    <constant>RPMTAG_OBSOLETEVERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-oldenhances">
+   <term>
+    <constant>RPMTAG_OLDENHANCES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-oldenhancesflags">
+   <term>
+    <constant>RPMTAG_OLDENHANCESFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-oldenhancesname">
+   <term>
+    <constant>RPMTAG_OLDENHANCESNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-oldenhancesversion">
+   <term>
+    <constant>RPMTAG_OLDENHANCESVERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-oldfilenames">
+   <term>
+    <constant>RPMTAG_OLDFILENAMES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-oldsuggests">
+   <term>
+    <constant>RPMTAG_OLDSUGGESTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-oldsuggestsflags">
+   <term>
+    <constant>RPMTAG_OLDSUGGESTSFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-oldsuggestsname">
+   <term>
+    <constant>RPMTAG_OLDSUGGESTSNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-oldsuggestsversion">
+   <term>
+    <constant>RPMTAG_OLDSUGGESTSVERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-optflags">
+   <term>
+    <constant>RPMTAG_OPTFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-orderflags">
+   <term>
+    <constant>RPMTAG_ORDERFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-ordername">
+   <term>
+    <constant>RPMTAG_ORDERNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-orderversion">
+   <term>
+    <constant>RPMTAG_ORDERVERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-origbasenames">
+   <term>
+    <constant>RPMTAG_ORIGBASENAMES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-origdirindexes">
+   <term>
+    <constant>RPMTAG_ORIGDIRINDEXES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-origdirnames">
+   <term>
+    <constant>RPMTAG_ORIGDIRNAMES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-origfilenames">
+   <term>
+    <constant>RPMTAG_ORIGFILENAMES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-os">
+   <term>
+    <constant>RPMTAG_OS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-p">
+   <term>
+    <constant>RPMTAG_P</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-packager">
+   <term>
+    <constant>RPMTAG_PACKAGER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-patch">
+   <term>
+    <constant>RPMTAG_PATCH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-patchesflags">
+   <term>
+    <constant>RPMTAG_PATCHESFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-patchesname">
+   <term>
+    <constant>RPMTAG_PATCHESNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-patchesversion">
+   <term>
+    <constant>RPMTAG_PATCHESVERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-payloadcompressor">
+   <term>
+    <constant>RPMTAG_PAYLOADCOMPRESSOR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-payloaddigest">
+   <term>
+    <constant>RPMTAG_PAYLOADDIGEST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-payloaddigestalt">
+   <term>
+    <constant>RPMTAG_PAYLOADDIGESTALT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     With librpm &gt;= 4.16.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-payloaddigestalgo">
+   <term>
+    <constant>RPMTAG_PAYLOADDIGESTALGO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-payloadflags">
+   <term>
+    <constant>RPMTAG_PAYLOADFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-payloadformat">
+   <term>
+    <constant>RPMTAG_PAYLOADFORMAT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-pkgid">
+   <term>
+    <constant>RPMTAG_PKGID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-platform">
+   <term>
+    <constant>RPMTAG_PLATFORM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-policies">
+   <term>
+    <constant>RPMTAG_POLICIES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-policyflags">
+   <term>
+    <constant>RPMTAG_POLICYFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-policynames">
+   <term>
+    <constant>RPMTAG_POLICYNAMES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-policytypes">
+   <term>
+    <constant>RPMTAG_POLICYTYPES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-policytypesindexes">
+   <term>
+    <constant>RPMTAG_POLICYTYPESINDEXES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-postin">
+   <term>
+    <constant>RPMTAG_POSTIN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-postinflags">
+   <term>
+    <constant>RPMTAG_POSTINFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-postinprog">
+   <term>
+    <constant>RPMTAG_POSTINPROG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-posttrans">
+   <term>
+    <constant>RPMTAG_POSTTRANS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-posttransflags">
+   <term>
+    <constant>RPMTAG_POSTTRANSFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-posttransprog">
+   <term>
+    <constant>RPMTAG_POSTTRANSPROG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-postun">
+   <term>
+    <constant>RPMTAG_POSTUN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-postunflags">
+   <term>
+    <constant>RPMTAG_POSTUNFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-postunprog">
+   <term>
+    <constant>RPMTAG_POSTUNPROG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-postuntrans">
+   <term>
+    <constant>RPMTAG_POSTUNTRANS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Requires librpm &gt;= 4.19
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-postuntransflags">
+   <term>
+    <constant>RPMTAG_POSTUNTRANSFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Requires librpm &gt;= 4.19
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-postuntransprog">
+   <term>
+    <constant>RPMTAG_POSTUNTRANSPROG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Requires librpm &gt;= 4.19
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-prefixes">
+   <term>
+    <constant>RPMTAG_PREFIXES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-prein">
+   <term>
+    <constant>RPMTAG_PREIN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-preinflags">
+   <term>
+    <constant>RPMTAG_PREINFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-preinprog">
+   <term>
+    <constant>RPMTAG_PREINPROG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-pretrans">
+   <term>
+    <constant>RPMTAG_PRETRANS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-pretransflags">
+   <term>
+    <constant>RPMTAG_PRETRANSFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-pretransprog">
+   <term>
+    <constant>RPMTAG_PRETRANSPROG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-preun">
+   <term>
+    <constant>RPMTAG_PREUN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-preunflags">
+   <term>
+    <constant>RPMTAG_PREUNFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-preunprog">
+   <term>
+    <constant>RPMTAG_PREUNPROG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-preuntrans">
+   <term>
+    <constant>RPMTAG_PREUNTRANS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Requires librpm &gt;= 4.19
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-preuntransflags">
+   <term>
+    <constant>RPMTAG_PREUNTRANSFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Requires librpm &gt;= 4.19
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-preuntransprog">
+   <term>
+    <constant>RPMTAG_PREUNTRANSPROG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Requires librpm &gt;= 4.19
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-provideflags">
+   <term>
+    <constant>RPMTAG_PROVIDEFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-providename">
+   <term>
+    <constant>RPMTAG_PROVIDENAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Provided dependencies, with database index.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-providenevrs">
+   <term>
+    <constant>RPMTAG_PROVIDENEVRS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-provides">
+   <term>
+    <constant>RPMTAG_PROVIDES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-provideversion">
+   <term>
+    <constant>RPMTAG_PROVIDEVERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-pubkeys">
+   <term>
+    <constant>RPMTAG_PUBKEYS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-r">
+   <term>
+    <constant>RPMTAG_R</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-recommendflags">
+   <term>
+    <constant>RPMTAG_RECOMMENDFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-recommendname">
+   <term>
+    <constant>RPMTAG_RECOMMENDNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Recommended weak dependencies, with database index, requires librpm &gt;= 4.13.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-recommendnevrs">
+   <term>
+    <constant>RPMTAG_RECOMMENDNEVRS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-recommends">
+   <term>
+    <constant>RPMTAG_RECOMMENDS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-recommendversion">
+   <term>
+    <constant>RPMTAG_RECOMMENDVERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-recontexts">
+   <term>
+    <constant>RPMTAG_RECONTEXTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-release">
+   <term>
+    <constant>RPMTAG_RELEASE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-removetid">
+   <term>
+    <constant>RPMTAG_REMOVETID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-requireflags">
+   <term>
+    <constant>RPMTAG_REQUIREFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-requirename">
+   <term>
+    <constant>RPMTAG_REQUIRENAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Required dependencies, with database index.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-requirenevrs">
+   <term>
+    <constant>RPMTAG_REQUIRENEVRS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-requires">
+   <term>
+    <constant>RPMTAG_REQUIRES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-requireversion">
+   <term>
+    <constant>RPMTAG_REQUIREVERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-rpmversion">
+   <term>
+    <constant>RPMTAG_RPMVERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-rsaheader">
+   <term>
+    <constant>RPMTAG_RSAHEADER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-sha1header">
+   <term>
+    <constant>RPMTAG_SHA1HEADER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     SHA1 signature, with database index.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-sha256header">
+   <term>
+    <constant>RPMTAG_SHA256HEADER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-siggpg">
+   <term>
+    <constant>RPMTAG_SIGGPG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-sigmd5">
+   <term>
+    <constant>RPMTAG_SIGMD5</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     MD5 signature, with database index.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-sigpgp">
+   <term>
+    <constant>RPMTAG_SIGPGP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-sigsize">
+   <term>
+    <constant>RPMTAG_SIGSIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-size">
+   <term>
+    <constant>RPMTAG_SIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-source">
+   <term>
+    <constant>RPMTAG_SOURCE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-sourcepackage">
+   <term>
+    <constant>RPMTAG_SOURCEPACKAGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-sourcepkgid">
+   <term>
+    <constant>RPMTAG_SOURCEPKGID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-sourcerpm">
+   <term>
+    <constant>RPMTAG_SOURCERPM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-spec">
+   <term>
+    <constant>RPMTAG_SPEC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Requires librpm &gt;= 4.18
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-suggestflags">
+   <term>
+    <constant>RPMTAG_SUGGESTFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-suggestname">
+   <term>
+    <constant>RPMTAG_SUGGESTNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Suggested weak dependencies, with database index, requires librpm &gt;= 4.13.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-suggestnevrs">
+   <term>
+    <constant>RPMTAG_SUGGESTNEVRS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-suggests">
+   <term>
+    <constant>RPMTAG_SUGGESTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-suggestversion">
+   <term>
+    <constant>RPMTAG_SUGGESTVERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-summary">
+   <term>
+    <constant>RPMTAG_SUMMARY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-supplementflags">
+   <term>
+    <constant>RPMTAG_SUPPLEMENTFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-supplementname">
+   <term>
+    <constant>RPMTAG_SUPPLEMENTNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Weak dependencies, with database index, requires librpm &gt;= 4.13.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-supplementnevrs">
+   <term>
+    <constant>RPMTAG_SUPPLEMENTNEVRS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-supplements">
+   <term>
+    <constant>RPMTAG_SUPPLEMENTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-supplementversion">
+   <term>
+    <constant>RPMTAG_SUPPLEMENTVERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-sysusers">
+   <term>
+    <constant>RPMTAG_SYSUSERS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Requires librpm &gt;= 4.19
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-transfiletriggerconds">
+   <term>
+    <constant>RPMTAG_TRANSFILETRIGGERCONDS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-transfiletriggerflags">
+   <term>
+    <constant>RPMTAG_TRANSFILETRIGGERFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-transfiletriggerindex">
+   <term>
+    <constant>RPMTAG_TRANSFILETRIGGERINDEX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-transfiletriggername">
+   <term>
+    <constant>RPMTAG_TRANSFILETRIGGERNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Transaction file trigger name, with database index, requires librpm &gt;= 4.13.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-transfiletriggerpriorities">
+   <term>
+    <constant>RPMTAG_TRANSFILETRIGGERPRIORITIES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-transfiletriggerscriptflags">
+   <term>
+    <constant>RPMTAG_TRANSFILETRIGGERSCRIPTFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-transfiletriggerscriptprog">
+   <term>
+    <constant>RPMTAG_TRANSFILETRIGGERSCRIPTPROG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-transfiletriggerscripts">
+   <term>
+    <constant>RPMTAG_TRANSFILETRIGGERSCRIPTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-transfiletriggertype">
+   <term>
+    <constant>RPMTAG_TRANSFILETRIGGERTYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-transfiletriggerversion">
+   <term>
+    <constant>RPMTAG_TRANSFILETRIGGERVERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-translationurl">
+   <term>
+    <constant>RPMTAG_TRANSLATIONURL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Requires librpm &gt;= 4.18
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-triggerconds">
+   <term>
+    <constant>RPMTAG_TRIGGERCONDS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-triggerflags">
+   <term>
+    <constant>RPMTAG_TRIGGERFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-triggerindex">
+   <term>
+    <constant>RPMTAG_TRIGGERINDEX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-triggername">
+   <term>
+    <constant>RPMTAG_TRIGGERNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Trigger name, with database index.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-triggerscriptflags">
+   <term>
+    <constant>RPMTAG_TRIGGERSCRIPTFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-triggerscriptprog">
+   <term>
+    <constant>RPMTAG_TRIGGERSCRIPTPROG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-triggerscripts">
+   <term>
+    <constant>RPMTAG_TRIGGERSCRIPTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-triggertype">
+   <term>
+    <constant>RPMTAG_TRIGGERTYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-triggerversion">
+   <term>
+    <constant>RPMTAG_TRIGGERVERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-upstreamreleases">
+   <term>
+    <constant>RPMTAG_UPSTREAMRELEASES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Requires librpm &gt;= 4.18
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-url">
+   <term>
+    <constant>RPMTAG_URL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-v">
+   <term>
+    <constant>RPMTAG_V</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-vcs">
+   <term>
+    <constant>RPMTAG_VCS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-vendor">
+   <term>
+    <constant>RPMTAG_VENDOR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-verbose">
+   <term>
+    <constant>RPMTAG_VERBOSE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-verifyscript">
+   <term>
+    <constant>RPMTAG_VERIFYSCRIPT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-verifyscriptflags">
+   <term>
+    <constant>RPMTAG_VERIFYSCRIPTFLAGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-verifyscriptprog">
+   <term>
+    <constant>RPMTAG_VERIFYSCRIPTPROG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-veritysignaturealgo">
+   <term>
+    <constant>RPMTAG_VERITYSIGNATUREALGO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     With librpm &gt;= 4.17.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-veritysignatures">
+   <term>
+    <constant>RPMTAG_VERITYSIGNATURES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     With librpm &gt;= 4.17.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-version">
+   <term>
+    <constant>RPMTAG_VERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.rpmtag-xpm">
+   <term>
+    <constant>RPMTAG_XPM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
 </appendix>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/rpminfo/constants.xml
+++ b/reference/rpminfo/constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <appendix xml:id="rpminfo.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants;
@@ -2897,7 +2896,6 @@
   </variablelist>
  </para>
 </appendix>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/rpminfo/functions/rpmaddtag.xml
+++ b/reference/rpminfo/functions/rpmaddtag.xml
@@ -41,9 +41,9 @@
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><function>rpminfo</function></member> 
-   <member><function>rpmdbinfo</function></member> 
-   <member><function>rpmdbsearch</function></member> 
+   <member><function>rpminfo</function></member>
+   <member><function>rpmdbinfo</function></member>
+   <member><function>rpmdbsearch</function></member>
   </simplelist>
  </refsect1>
 

--- a/reference/rpminfo/functions/rpmaddtag.xml
+++ b/reference/rpminfo/functions/rpmaddtag.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
-<refentry xml:id="function.rpmaddtag" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="function.rpmaddtag" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>rpmaddtag</refname>
   <refpurpose>Add tag retrieved in query</refpurpose>
@@ -13,9 +12,9 @@
    <type>bool</type><methodname>rpmaddtag</methodname>
    <methodparam><type>int</type><parameter>tag</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Add an additional retrieved tag in subsequent queries.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +23,9 @@
    <varlistentry>
     <term><parameter>tag</parameter></term>
     <listitem>
-     <para>
-      One of RPMTAG_* constant, see the <link linkend="rpminfo.constants">rpminfo constants</link> page.
-     </para>
+     <simpara>
+      One of <constant>RPMTAG_<replaceable>*</replaceable></constant> constant.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -34,24 +33,21 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>rpminfo</function></member> 
-    <member><function>rpmdbinfo</function></member> 
-    <member><function>rpmdbsearch</function></member> 
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>rpminfo</function></member> 
+   <member><function>rpmdbinfo</function></member> 
+   <member><function>rpmdbsearch</function></member> 
+  </simplelist>
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/rpminfo/functions/rpmdbinfo.xml
+++ b/reference/rpminfo/functions/rpmdbinfo.xml
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   An <type>array</type> of <type>array</type> of information, or &null; on error.   
+   An <type>array</type> of <type>array</type> of information, or &null; on error.
   </simpara>
  </refsect1>
 

--- a/reference/rpminfo/functions/rpmdbinfo.xml
+++ b/reference/rpminfo/functions/rpmdbinfo.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
-<refentry xml:id="function.rpmdbinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="function.rpmdbinfo" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>rpmdbinfo</refname>
   <refpurpose>Get information from installed RPM</refpurpose>
@@ -14,10 +13,9 @@
    <methodparam><type>string</type><parameter>nevr</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>full</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retrieve information about an installed package, from the system RPM database.
-  </para>
-
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,17 +24,17 @@
    <varlistentry>
     <term><parameter>nevr</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Name with optional epoch, version and release.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>full</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       If &true; all information headers for the file are retrieved, else only a minimal set.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -44,17 +42,16 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   An <type>array</type> of <type>array</type> of information or NULL on error.   
-  </para>
+  <simpara>
+   An <type>array</type> of <type>array</type> of information, or &null; on error.   
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>rpmdbinfo</function> example</title>
-    <programlisting role="php">
+  <example>
+   <title>A <function>rpmdbinfo</function> example</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 rpmaddtag(RPMTAG_INSTALLTIME);
@@ -62,9 +59,9 @@ $info = rpmdbinfo("php-pecl-rpminfo");
 print_r($info);
 ?>
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 Array
 (
@@ -79,22 +76,18 @@ Array
         )
 )
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>rpmaddtag</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>rpmaddtag</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/rpminfo/functions/rpmdbsearch.xml
+++ b/reference/rpminfo/functions/rpmdbsearch.xml
@@ -64,7 +64,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   An <type>array</type> of <type>array</type> of information, or &null; on error.   
+   An <type>array</type> of <type>array</type> of information, or &null; on error.
   </simpara>
  </refsect1>
 

--- a/reference/rpminfo/functions/rpmdbsearch.xml
+++ b/reference/rpminfo/functions/rpmdbsearch.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.rpmdbsearch" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>rpmdbsearch</refname>
@@ -16,9 +15,9 @@
    <methodparam choice="opt"><type>int</type><parameter>rpmmire</parameter><initializer>-1</initializer></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>full</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Search packages in the system RPM database.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,34 +26,36 @@
    <varlistentry>
     <term><parameter>pattern</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Value to search for.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>rpmtag</parameter></term>
     <listitem>
-     <para>
-      Search criterion, one of RPMTAG_* constant, see the <link linkend="rpminfo.constants">rpminfo constants</link> page.
-     </para>
+     <simpara>
+      Search criterion, which is one of the
+      <constant>RPMTAG_<replaceable>*</replaceable></constant> constants.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>rpmmire</parameter></term>
     <listitem>
-     <para>
-      Pattern type, one of RPMMIRE_* constant, see the <link linkend="rpminfo.constants">rpminfo constants</link> page.
-      When &lt; 0 the criterion must equals the value, and database index is used if possible.
-     </para>
+     <simpara>
+      Pattern type, which is one of the
+      <constant>RPMMIRE_<replaceable>*</replaceable></constant> constants.
+      When &lt; 0 the criterion must equal the value, and database index is used if possible.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>full</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       If &true; all information headers for the file are retrieved, else only a minimal set.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -62,26 +63,25 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   An <type>array</type> of <type>array</type> of information or NULL on error.   
-  </para>
+  <simpara>
+   An <type>array</type> of <type>array</type> of information, or &null; on error.   
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Searching for the package owning a file</title>
-    <programlisting role="php">
+  <example>
+   <title>Searching for the package owning a file</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $info = rpmdbsearch("/usr/bin/php", RPMTAG_INSTFILENAMES);
 print_r($info);
 ?>
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 Array
 (
@@ -96,22 +96,18 @@ Array
 
 )
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>rpmaddtag</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>rpmaddtag</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/rpminfo/functions/rpmdefine.xml
+++ b/reference/rpminfo/functions/rpmdefine.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
-<refentry xml:id="function.rpmdefine" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="function.rpmdefine" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>rpmdefine</refname>
   <refpurpose>Define or change a RPM macro value</refpurpose>
@@ -13,14 +12,13 @@
    <type>bool</type><methodname>rpmdefine</methodname>
    <methodparam><type>string</type><parameter>text</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Define or change a RPM macro value.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    This can be used to select the database path and backend to use
    instead of system default one.
-  </para>
-
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,9 +27,9 @@
    <varlistentry>
     <term><parameter>text</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Macro name, options, body.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -39,17 +37,16 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>rpmdefine</function> example</title>
-    <programlisting role="php">
+  <example>
+   <title>A <function>rpmdefine</function> example</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 // use an old database (bdb) from an EL-8 chroot
@@ -63,30 +60,26 @@ rpmdefine("_db_backend sqlite");
 print_r(rpmdbinfo("fedora-release")[0]["Summary"]);
 ?>
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 AlmaLinux release file
 Fedora release files
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>rpmexpand</function></member>
-    <member><function>rpmdbinfo</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>rpmexpand</function></member>
+   <member><function>rpmdbinfo</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/rpminfo/functions/rpmexpand.xml
+++ b/reference/rpminfo/functions/rpmexpand.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
-<refentry xml:id="function.rpmexpand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="function.rpmexpand" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>rpmexpand</refname>
   <refpurpose>Retrieve expanded value of a RPM macro</refpurpose>
@@ -13,10 +12,9 @@
    <type>string</type><methodname>rpmexpand</methodname>
    <methodparam><type>string</type><parameter>text</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retrieve expanded value of a RPM macro.
-  </para>
-
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +23,9 @@
    <varlistentry>
     <term><parameter>text</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Text with RPM macros to expand.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,45 +33,40 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   A <type>string</type> with concatenated macro expansion(s).
-  </para>
+  <simpara>
+   A <type>string</type> with concatenated macro expansions.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>rpmexpand</function> example</title>
-    <programlisting role="php">
+  <example>
+   <title>A <function>rpmexpand</function> example</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $distro = rpmexpand("%{?fedora:Fedora %{fedora}}%{?rhel:Enterprise Linux %{rhel}}");
 print_r($distro);
 ?>
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 Fedora 41
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>rpmexpandnumeric</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>rpmexpandnumeric</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/rpminfo/functions/rpmexpandnumeric.xml
+++ b/reference/rpminfo/functions/rpmexpandnumeric.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.rpmexpandnumeric" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>rpmexpandnumeric</refname>
@@ -13,10 +12,9 @@
    <type>int</type><methodname>rpmexpandnumeric</methodname>
    <methodparam><type>string</type><parameter>text</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retrieve numerical value of a RPM macro.
-  </para>
-
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +23,9 @@
    <varlistentry>
     <term><parameter>text</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Text with RPM macros to expand.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,48 +33,44 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Macro expansion as a <type>int</type>.
    Boolean values (<literal>Y</literal> or <literal>y</literal> returns 1,
    <literal>N</literal> or <literal>n</literal> returns <literal>0</literal>)
-   are permitted as well. An undefined macro returns <literal>0</literal>.
-  </para>
+   are permitted as well.
+   An undefined macro returns <literal>0</literal>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>rpmexpandnumeric</function> example</title>
-    <programlisting role="php">
+  <example>
+   <title>A <function>rpmexpandnumeric</function> example</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $bits = rpmexpandnumeric("%__isa_bits");
 print_r($bits);
 ?>
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 64
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>rpmexpand</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>rpmexpand</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/rpminfo/functions/rpmgetsymlink.xml
+++ b/reference/rpminfo/functions/rpmgetsymlink.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.rpmgetsymlink" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>rpmgetsymlink</refname>
@@ -14,10 +13,9 @@
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Get target of a symlink.
-  </para>
-
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,17 +24,17 @@
    <varlistentry>
     <term><parameter>path</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Path of the RPM file.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>name</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Name of the symlink file.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -44,13 +42,13 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   A <type>string</type> with target of the symlink, NULL on error, or an empty string if not a symlink.
-  </para>
+  <simpara>
+   A <type>string</type> with target of the symlink,
+   &null; on error, or an empty string if not a symlink.
+  </simpara>
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/rpminfo/functions/rpminfo.xml
+++ b/reference/rpminfo/functions/rpminfo.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.rpminfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>rpminfo</refname>
@@ -15,10 +14,9 @@
    <methodparam choice="opt"><type>bool</type><parameter>full</parameter><initializer>&false;</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter role="reference">error</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retrieve information about a local file, a RPM package.
-  </para>
-
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,25 +25,27 @@
    <varlistentry>
     <term><parameter>path</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Path of the RPM file.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>full</parameter></term>
     <listitem>
-     <para>
-      If &true; all information headers for the file are retrieved, else only a minimal set.
-     </para>
+     <simpara>
+      If &true; all information headers for the file are retrieved,
+      else only a minimal set.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>error</parameter></term>
     <listitem>
-     <para>
-      If provided, will receive the possible error message, and will avoid a runtime warning.
-     </para>
+     <simpara>
+      If provided, will receive the possible error message,
+      and will avoid a runtime warning.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -53,17 +53,16 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   An <type>array</type> of information or NULL on error.
-  </para>
+  <simpara>
+   An <type>array</type> of information, or &null; on error.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>rpminfo</function> example</title>
-    <programlisting role="php">
+  <example>
+   <title>A <function>rpminfo</function> example</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 rpmaddtag(RPMTAG_BUILDTIME);
@@ -71,9 +70,9 @@ $info = rpminfo("./php-pecl-rpminfo-0.4.2-1.el8.remi.7.4.x86_64.rpm");
 print_r($info);
 ?>
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 Array
 (
@@ -85,22 +84,18 @@ Array
     [Arch] => x86_64
 )
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>rpmaddtag</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>rpmaddtag</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/rpminfo/functions/rpmvercmp.xml
+++ b/reference/rpminfo/functions/rpmvercmp.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <refentry xml:id="function.rpmvercmp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>rpmvercmp</refname>
@@ -15,9 +14,9 @@
    <methodparam><type>string</type><parameter>evr2</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>operator</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Compare two RPM package versions.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,34 +25,45 @@
    <varlistentry>
     <term><parameter>evr1</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       First <literal>epoch:version-release</literal> string.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>evr2</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Second <literal>epoch:version-release</literal> string.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>operator</parameter></term>
     <listitem>
      <para>
-      An optional operator. The possible operators
-      are: <literal>&lt;</literal> or <literal>lt</literal>;
-      <literal>&lt;=</literal> or <literal>le</literal>;
-      <literal>&gt;</literal> or <literal>gt</literal>;
-      <literal>&gt;=</literal> or <literal>ge</literal>;
-      <literal>==</literal>, <literal>=</literal> or <literal>eq</literal>;
-      <literal>!=</literal>, <literal>&lt;&gt;</literal> or <literal>ne</literal>.
+      An optional operator.
+      The possible operators are:
+      <simplelist type="inline">
+       <member><literal>&lt;</literal></member>
+       <member><literal>lt</literal></member>
+       <member><literal>&lt;=</literal></member>
+       <member><literal>le</literal></member>
+       <member><literal>&gt;</literal></member>
+       <member><literal>gt</literal></member>
+       <member><literal>&gt;=</literal></member>
+       <member><literal>ge</literal></member>
+       <member><literal>==</literal></member>
+       <member><literal>=</literal></member>
+       <member><literal>eq</literal></member>
+       <member><literal>!=</literal></member>
+       <member><literal>&lt;&gt;</literal></member>
+       <member><literal>ne</literal></member>
+      </simplelist>.
      </para>
-     <para>
+     <simpara>
       This parameter is case-sensitive, values should be lowercase.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -61,16 +71,16 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns <literal>-1</literal> if <parameter>evr1</parameter> is less than
    <parameter>evr2</parameter>, <literal>1</literal> if <parameter>evr1</parameter> is
    greater than <parameter>evr2</parameter>, and <literal>0</literal> if they are equal.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    When using the optional <parameter>operator</parameter> argument, the
    function will return &true; if the relationship is the one specified
    by the operator, &false; otherwise.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -96,7 +106,6 @@
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/rpminfo/reference.xml
+++ b/reference/rpminfo/reference.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <reference xml:id="ref.rpminfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>RpmInfo &Functions;</title>
 
  &reference.rpminfo.entities.functions;
 
 </reference>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/rpminfo/setup.xml
+++ b/reference/rpminfo/setup.xml
@@ -1,26 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <chapter xml:id="rpminfo.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
 
  <section xml:id="rpminfo.requirements">
   &reftitle.required;
-  <para>
+  <simpara>
    This extension requires <link xlink:href="https://rpm.org/">librpm</link> version 4.11.3 or higher.
-  </para>
+  </simpara>
  </section>
 
  <section xml:id="rpminfo.installation">
   <title>Installation via PECL</title>
-  <para>
+  <simpara>
    &pecl.info;
    <link xlink:href="&url.pecl.package;rpminfo">&url.pecl.package;rpminfo</link>.
-  </para>
+  </simpara>
  </section>
 
 </chapter>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
Use more appropriate DocBook tags, add constant tags which will handle automatic linking, use entities and literal tags, fix indentation, group related constants together.