### PR TITLE
Fix FPM event mechanism poll typo and improve it

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -210,8 +210,8 @@
       <listitem>
        <para>
         Specify the event mechanism FPM will use.
-        The following is available: select, pool, epoll, kqueue (*BSD), port (Solaris).
-        Default value: not set (auto detection).
+        The following is available: epoll, kqueue (*BSD), port (Solaris), poll, select.
+        Default value: not set (auto detection preferring epoll and kqueue).
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
This improves event.mechanism docs and fixes poll type (it was documented as pool).

The idea was to also document removal of `/dev/poll` but it was not documented and considering that it's just for unsupported Solaris platform and likely no one was using for ages, there is not much point to mention its removal in 8.4.