### PR TITLE
Add warnings to use `php_sapi_name()` to test when running as CLI

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -182,6 +182,16 @@
            also be found in the <varname>$_SERVER</varname> array, for example:
            <varname>$_SERVER['argv']</varname>.
           </para>
+          <warning>
+           <simpara>
+            If a PHP script can be run via the command line or through another SAPI,
+            <function>php_sapi_name</function> should be used to check whether the
+            script is being run from the command line and <varname>$argv</varname>
+            is safe to use, otherwise arbitrary arguments may be passed to the
+            script via other SAPIs depending on how
+            <link linkend="ini.register-argc-argv">register_argc_argv</link> is set.
+           </simpara>
+          </warning>
           </entry>
          </row>
          <row>

--- a/language/predefined/variables/argv.xml
+++ b/language/predefined/variables/argv.xml
@@ -25,6 +25,14 @@
     is disabled.
    </simpara>
   </note>
+  <warning>
+   <simpara>
+    To test if a script is being run from the command
+    line, <function>php_sapi_name</function> should be used
+    instead of checking whether <varname>$argv</varname> or
+    <varname>$_SERVER['argv']</varname> is set.
+   </simpara>
+  </warning>
  </refsect1>
  
  <refsect1 role="examples">


### PR DESCRIPTION
This has been a recurring security problem encountered by packages, most recently Craft CMS, so it's probably worth some warnings in the documentation.