### PR TITLE
Fix typo in pattern.modifiers.xml

### DIFF
--- a/reference/pcre/pattern.modifiers.xml
+++ b/reference/pcre/pattern.modifiers.xml
@@ -196,7 +196,7 @@
        </simpara>
        <simpara>
         For example, <code>preg_match('/\x{212A}/iu', "K")</code> matches the Kelvin sign <literal>K</literal> (U+212A).
-        When <emphasis>u</emphasis> is used (<code>preg_match('/\x{212A}/iur', "K")</code>), it does not match.
+        When <emphasis>r</emphasis> is used (<code>preg_match('/\x{212A}/iur', "K")</code>), it does not match.
        </simpara>
        <simpara>
         Available as of PHP 8.4.0.


### PR DESCRIPTION
This section compares cases where the `r` flag is not used and where it is used. While the `u` flag is also in effect, it seems likely that "u" is a mistake and should be "r".