### PR TITLE
Rename PDO driver titleabrevs

### DIFF
--- a/reference/pdo_cubrid/reference.xml
+++ b/reference/pdo_cubrid/reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <reference xml:id="ref.pdo-cubrid" xmlns="http://docbook.org/ns/docbook"><?phpdoc extension-membership="pecl" ?>
- <title>CUBRID Functions (PDO_CUBRID)</title>
+ <title>CUBRID PDO Driver (PDO_CUBRID)</title>
  <titleabbrev>CUBRID PDO Driver</titleabbrev>
  <partintro>
 

--- a/reference/pdo_cubrid/reference.xml
+++ b/reference/pdo_cubrid/reference.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <reference xml:id="ref.pdo-cubrid" xmlns="http://docbook.org/ns/docbook"><?phpdoc extension-membership="pecl" ?>
  <title>CUBRID Functions (PDO_CUBRID)</title>
- <titleabbrev>CUBRID (PDO)</titleabbrev>
+ <titleabbrev>CUBRID PDO Driver</titleabbrev>
  <partintro>
 
   <section xml:id="pdo-cubrid.intro">&reftitle.intro;
@@ -64,7 +64,7 @@
 
    <section>
     <title>Multiple SQL Statements</title>
-    
+
     <simpara>
      PDO_CUBRID supports Multiple SQL statements.
      Multiple SQL statements are separated by semicolons (<literal>;</literal>).
@@ -168,9 +168,9 @@ fpassthru($result[0]);
 $conn_str ="cubrid:dbname=demodb;host=localhost;port=33000";
 $cubrid_pdo = new PDO($conn_str, 'dba', '');
 
-$cubrid_pdo->exec("DROP TABLE if exists test_tbl"); 
+$cubrid_pdo->exec("DROP TABLE if exists test_tbl");
 $cubrid_pdo->exec("CREATE TABLE test_tbl (col_1 SET(VARCHAR))");
- 
+
 $sql_stmt_insert = "INSERT INTO test_tbl VALUES (?);";
 $stmt = $cubrid_pdo->prepare($sql_stmt_insert);
 $data = array("abc","def","ghi");
@@ -190,9 +190,9 @@ var_Dump($ret);
 $conn_str ="cubrid:dbname=demodb;host=localhost;port=33000";
 $cubrid_pdo = new PDO($conn_str, 'dba', '');
 
-$cubrid_pdo->exec("DROP TABLE if exists test_tbl"); 
+$cubrid_pdo->exec("DROP TABLE if exists test_tbl");
 $cubrid_pdo->exec("CREATE TABLE test_tbl (col_1 SET(int))");
- 
+
 $sql_stmt_insert = "INSERT INTO test_tbl VALUES (?);";
 $stmt = $cubrid_pdo->prepare($sql_stmt_insert);
 $data = array(1,2,3,4);

--- a/reference/pdo_dblib/reference.xml
+++ b/reference/pdo_dblib/reference.xml
@@ -4,7 +4,7 @@
  <reference xml:id="ref.pdo-dblib" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="bundledexternal" ?>
   <title>Microsoft SQL Server and Sybase Functions (PDO_DBLIB)</title>
-  <titleabbrev>MS SQL Server (PDO)</titleabbrev>
+  <titleabbrev>MS SQL Server PDO Driver)</titleabbrev>
   <partintro>
 
    <section xml:id="ref.pdo-dblib.intro">

--- a/reference/pdo_dblib/reference.xml
+++ b/reference/pdo_dblib/reference.xml
@@ -4,7 +4,7 @@
  <reference xml:id="ref.pdo-dblib" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="bundledexternal" ?>
   <title>Microsoft SQL Server and Sybase Functions (PDO_DBLIB)</title>
-  <titleabbrev>MS SQL Server PDO Driver)</titleabbrev>
+  <titleabbrev>MS SQL Server PDO Driver</titleabbrev>
   <partintro>
 
    <section xml:id="ref.pdo-dblib.intro">

--- a/reference/pdo_dblib/reference.xml
+++ b/reference/pdo_dblib/reference.xml
@@ -3,7 +3,7 @@
 
  <reference xml:id="ref.pdo-dblib" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="bundledexternal" ?>
-  <title>Microsoft SQL Server and Sybase Functions (PDO_DBLIB)</title>
+  <title>Microsoft SQL Server and Sybase PDO Driver (PDO_DBLIB)</title>
   <titleabbrev>MS SQL Server PDO Driver</titleabbrev>
   <partintro>
 

--- a/reference/pdo_firebird/reference.xml
+++ b/reference/pdo_firebird/reference.xml
@@ -4,7 +4,7 @@
  <reference xml:id="ref.pdo-firebird" xmlns="http://docbook.org/ns/docbook">
   <?phpdoc extension-membership="bundledexternal" ?>
   <title>Firebird Functions (PDO_FIREBIRD)</title>
-  <titleabbrev>Firebird (PDO)</titleabbrev>
+  <titleabbrev>Firebird PDO Driver</titleabbrev>
   <partintro>
 
    <section xml:id="ref.pdo-firebird.intro">

--- a/reference/pdo_firebird/reference.xml
+++ b/reference/pdo_firebird/reference.xml
@@ -3,7 +3,7 @@
 
  <reference xml:id="ref.pdo-firebird" xmlns="http://docbook.org/ns/docbook">
   <?phpdoc extension-membership="bundledexternal" ?>
-  <title>Firebird Functions (PDO_FIREBIRD)</title>
+  <title>Firebird PDO Driver (PDO_FIREBIRD)</title>
   <titleabbrev>Firebird PDO Driver</titleabbrev>
   <partintro>
 

--- a/reference/pdo_ibm/reference.xml
+++ b/reference/pdo_ibm/reference.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <reference xml:id="ref.pdo-ibm" xmlns="http://docbook.org/ns/docbook">
  <?phpdoc extension-membership="pecl" ?>
-  <title>IBM Functions (PDO_IBM)</title>
+  <title>IBM PDO Driver (PDO_IBM)</title>
   <titleabbrev>IBM PDO Driver</titleabbrev>
   <partintro>
 

--- a/reference/pdo_ibm/reference.xml
+++ b/reference/pdo_ibm/reference.xml
@@ -2,7 +2,7 @@
 <reference xml:id="ref.pdo-ibm" xmlns="http://docbook.org/ns/docbook">
  <?phpdoc extension-membership="pecl" ?>
   <title>IBM Functions (PDO_IBM)</title>
-  <titleabbrev>IBM (PDO)</titleabbrev>
+  <titleabbrev>IBM PDO Driver</titleabbrev>
   <partintro>
 
    <section xml:id="pdo-ibm.intro">
@@ -29,8 +29,8 @@
    <refsect1 role="description">
     &reftitle.description;
     <para>
-     The PDO_IBM Data Source Name (DSN) is based on the IBM CLI DSN. The major 
-     components of the PDO_IBM DSN are: 
+     The PDO_IBM Data Source Name (DSN) is based on the IBM CLI DSN. The major
+     components of the PDO_IBM DSN are:
      <variablelist>
       <varlistentry>
        <term>DSN prefix</term>
@@ -48,20 +48,20 @@
          <itemizedlist>
           <listitem>
            <para>
-            a) Data source setup using <filename>db2cli.ini</filename> 
+            a) Data source setup using <filename>db2cli.ini</filename>
             or <filename>odbc.ini</filename>
            </para>
           </listitem>
           <listitem>
            <para>
-            b) Catalogued database name i.e. database alias in the DB2 client 
+            b) Catalogued database name i.e. database alias in the DB2 client
             catalog
            </para>
           </listitem>
           <listitem>
            <para>
-             c) Complete connection string in the following format: 
-             <code>DRIVER={IBM DB2 ODBC DRIVER};DATABASE=<parameter>database</parameter>;HOSTNAME=<parameter>hostname</parameter>;PORT=<parameter>port</parameter>;PROTOCOL=TCPIP;UID=<parameter>username</parameter>;PWD=<parameter>password</parameter>;</code> 
+             c) Complete connection string in the following format:
+             <code>DRIVER={IBM DB2 ODBC DRIVER};DATABASE=<parameter>database</parameter>;HOSTNAME=<parameter>hostname</parameter>;PORT=<parameter>port</parameter>;PROTOCOL=TCPIP;UID=<parameter>username</parameter>;PWD=<parameter>password</parameter>;</code>
              where the parameters represent the following values:
              <variablelist>
               <varlistentry>
@@ -122,7 +122,7 @@
      <example>
       <title>PDO_IBM DSN example using <filename>db2cli.ini</filename></title>
       <para>
-       The following example shows a PDO_IBM DSN for connecting to an DB2 
+       The following example shows a PDO_IBM DSN for connecting to an DB2
        database cataloged as DB2_9 in <filename>db2cli.ini</filename>:
        <programlisting><![CDATA[
 $db = new PDO("ibm:DSN=DB2_9", "", "");
@@ -138,9 +138,9 @@ Servicename=56789
      <example>
       <title>PDO_IBM DSN example using a connection string</title>
       <para>
-       The following example shows a PDO_IBM DSN for connecting to an DB2 
-       database named <userinput>testdb</userinput> using the DB2 CLI 
-       connection string syntax. 
+       The following example shows a PDO_IBM DSN for connecting to an DB2
+       database named <userinput>testdb</userinput> using the DB2 CLI
+       connection string syntax.
        <programlisting><![CDATA[
 $db = new PDO("ibm:DRIVER={IBM DB2 ODBC DRIVER};DATABASE=testdb;" .
   "HOSTNAME=11.22.33.444;PORT=56789;PROTOCOL=TCPIP;", "testuser", "tespass");
@@ -148,7 +148,7 @@ $db = new PDO("ibm:DRIVER={IBM DB2 ODBC DRIVER};DATABASE=testdb;" .
        </programlisting>
       </para>
      </example>
-    
+
     </para>
    </refsect1>
   </refentry>

--- a/reference/pdo_informix/reference.xml
+++ b/reference/pdo_informix/reference.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
  <reference xml:id="ref.pdo-informix" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
-  <title>Informix Functions (PDO_INFORMIX)</title>
+  <title>Informix PDO Driver (PDO_INFORMIX)</title>
   <titleabbrev>Informix PDO Driver</titleabbrev>
   <partintro>
 

--- a/reference/pdo_informix/reference.xml
+++ b/reference/pdo_informix/reference.xml
@@ -2,7 +2,7 @@
  <reference xml:id="ref.pdo-informix" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
   <title>Informix Functions (PDO_INFORMIX)</title>
-  <titleabbrev>Informix (PDO)</titleabbrev>
+  <titleabbrev>Informix PDO Driver</titleabbrev>
   <partintro>
 
    <section xml:id="pdo-informix.intro">
@@ -108,7 +108,7 @@ $db = new PDO("informix:host=host.domain.com; service=9800;
        </programlisting>
       </para>
      </example>
-    
+
     </para>
    </refsect1>
   </refentry>

--- a/reference/pdo_mysql/reference.xml
+++ b/reference/pdo_mysql/reference.xml
@@ -3,7 +3,7 @@
 
  <reference xml:id="ref.pdo-mysql" xmlns="http://docbook.org/ns/docbook">
   <?phpdoc extension-membership="bundledexternal" ?>
-  <title>MySQL Functions (PDO_MYSQL)</title>
+  <title>MySQL PDO Driver (PDO_MYSQL)</title>
   <titleabbrev>MySQL PDO Driver</titleabbrev>
   <partintro>
 

--- a/reference/pdo_mysql/reference.xml
+++ b/reference/pdo_mysql/reference.xml
@@ -4,7 +4,7 @@
  <reference xml:id="ref.pdo-mysql" xmlns="http://docbook.org/ns/docbook">
   <?phpdoc extension-membership="bundledexternal" ?>
   <title>MySQL Functions (PDO_MYSQL)</title>
-  <titleabbrev>MySQL (PDO)</titleabbrev>
+  <titleabbrev>MySQL PDO Driver</titleabbrev>
   <partintro>
 
    <section xml:id="ref.pdo-mysql.intro">

--- a/reference/pdo_oci/reference.xml
+++ b/reference/pdo_oci/reference.xml
@@ -3,7 +3,7 @@
 
  <reference xml:id="ref.pdo-oci" xmlns="http://docbook.org/ns/docbook">
   <?phpdoc extension-membership="pecl" ?>
-  <title>Oracle Functions (PDO_OCI)</title>
+  <title>Oracle PDO Driver (PDO_OCI)</title>
   <titleabbrev>Oracle PDO Driver</titleabbrev>
   <partintro>
 

--- a/reference/pdo_oci/reference.xml
+++ b/reference/pdo_oci/reference.xml
@@ -4,9 +4,9 @@
  <reference xml:id="ref.pdo-oci" xmlns="http://docbook.org/ns/docbook">
   <?phpdoc extension-membership="pecl" ?>
   <title>Oracle Functions (PDO_OCI)</title>
-  <titleabbrev>Oracle (PDO)</titleabbrev>
+  <titleabbrev>Oracle PDO Driver</titleabbrev>
   <partintro>
-   
+
    &reference.pdo-oci.configure;
    &reference.pdo-oci.constants;
 

--- a/reference/pdo_odbc/reference.xml
+++ b/reference/pdo_odbc/reference.xml
@@ -4,7 +4,7 @@
  <reference xml:id="ref.pdo-odbc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="bundledexternal" ?>
   <title>ODBC and DB2 Functions (PDO_ODBC)</title>
-  <titleabbrev>ODBC and DB2 (PDO)</titleabbrev>
+  <titleabbrev>ODBC and DB2 PDO Driver</titleabbrev>
   <partintro>
 
    <section xml:id="ref.pdo-odbc.intro">

--- a/reference/pdo_odbc/reference.xml
+++ b/reference/pdo_odbc/reference.xml
@@ -3,7 +3,7 @@
 
  <reference xml:id="ref.pdo-odbc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="bundledexternal" ?>
-  <title>ODBC and DB2 Functions (PDO_ODBC)</title>
+  <title>ODBC and DB2 PDO Driver (PDO_ODBC)</title>
   <titleabbrev>ODBC and DB2 PDO Driver</titleabbrev>
   <partintro>
 

--- a/reference/pdo_pgsql/reference.xml
+++ b/reference/pdo_pgsql/reference.xml
@@ -4,7 +4,7 @@
  <reference xml:id="ref.pdo-pgsql" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="bundledexternal" ?>
   <title>PostgreSQL Functions (PDO_PGSQL)</title>
-  <titleabbrev>PostgreSQL (PDO)</titleabbrev>
+  <titleabbrev>PostgreSQL PDO Driver</titleabbrev>
   <partintro>
 
    <section xml:id="ref.pdo-pgsql.intro">

--- a/reference/pdo_pgsql/reference.xml
+++ b/reference/pdo_pgsql/reference.xml
@@ -3,7 +3,7 @@
 
  <reference xml:id="ref.pdo-pgsql" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="bundledexternal" ?>
-  <title>PostgreSQL Functions (PDO_PGSQL)</title>
+  <title>PostgreSQL PDO Driver (PDO_PGSQL)</title>
   <titleabbrev>PostgreSQL PDO Driver</titleabbrev>
   <partintro>
 

--- a/reference/pdo_sqlite/reference.xml
+++ b/reference/pdo_sqlite/reference.xml
@@ -3,7 +3,7 @@
 
  <reference xml:id="ref.pdo-sqlite" xmlns="http://docbook.org/ns/docbook">
   <?phpdoc extension-membership="bundledexternal" ?>
-  <title>SQLite Functions (PDO_SQLITE)</title>
+  <title>SQLite PDO Driver (PDO_SQLITE)</title>
   <titleabbrev>SQLite PDO Driver</titleabbrev>
   <partintro>
 

--- a/reference/pdo_sqlite/reference.xml
+++ b/reference/pdo_sqlite/reference.xml
@@ -4,7 +4,7 @@
  <reference xml:id="ref.pdo-sqlite" xmlns="http://docbook.org/ns/docbook">
   <?phpdoc extension-membership="bundledexternal" ?>
   <title>SQLite Functions (PDO_SQLITE)</title>
-  <titleabbrev>SQLite (PDO)</titleabbrev>
+  <titleabbrev>SQLite PDO Driver</titleabbrev>
   <partintro>
 
    <section xml:id="ref.pdo-sqlite.intro">

--- a/reference/pdo_sqlsrv/reference.xml
+++ b/reference/pdo_sqlsrv/reference.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
  <reference xml:id="ref.pdo-sqlsrv" xmlns="http://docbook.org/ns/docbook">
  <?phpdoc extension-membership="pecl" ?>
-  <title>Microsoft SQL Server Functions (PDO_SQLSRV)</title>
+  <title>Microsoft SQL Server PDO Driver (PDO_SQLSRV)</title>
   <titleabbrev>MS SQL Server PDO Driver</titleabbrev>
   <partintro>
 

--- a/reference/pdo_sqlsrv/reference.xml
+++ b/reference/pdo_sqlsrv/reference.xml
@@ -2,7 +2,7 @@
  <reference xml:id="ref.pdo-sqlsrv" xmlns="http://docbook.org/ns/docbook">
  <?phpdoc extension-membership="pecl" ?>
   <title>Microsoft SQL Server Functions (PDO_SQLSRV)</title>
-  <titleabbrev>MS SQL Server (PDO)</titleabbrev>
+  <titleabbrev>MS SQL Server PDO Driver</titleabbrev>
   <partintro>
 
    <section xml:id="pdo-sqlsrv.intro">
@@ -10,7 +10,7 @@
     <para>
      PDO_SQLSRV is a driver that implements the <link linkend="intro.pdo">PHP
      Data Objects (PDO) interface</link>
-     to enable access from PHP to MS SQL Server (starting with SQL Server 2005) 
+     to enable access from PHP to MS SQL Server (starting with SQL Server 2005)
      and SQL Azure databases.
     </para>
    </section>
@@ -49,7 +49,7 @@
        <term><literal>ConnectionPooling</literal></term>
        <listitem>
         <para>
-         Specifies whether the connection is assigned from a connection pool 
+         Specifies whether the connection is assigned from a connection pool
          (1 or &true;) or not (0 or &false;).
         </para>
        </listitem>
@@ -66,7 +66,7 @@
        <term><literal>Encrypt</literal></term>
        <listitem>
         <para>
-         Specifies whether the communication with SQL Server is encrypted 
+         Specifies whether the communication with SQL Server is encrypted
          (1 or &true;) or unencrypted (0 or &false;).
         </para>
        </listitem>
@@ -75,7 +75,7 @@
        <term><literal>Failover_Partner</literal></term>
        <listitem>
         <para>
-         Specifies the server and instance of the database's mirror (if enabled 
+         Specifies the server and instance of the database's mirror (if enabled
          and configured) to use when the primary server is unavailable.
         </para>
        </listitem>
@@ -100,7 +100,7 @@
        <term><literal>QuotedId</literal></term>
        <listitem>
         <para>
-         Specifies whether to use SQL-92 rules for quoted identifiers (1 or &true;) 
+         Specifies whether to use SQL-92 rules for quoted identifiers (1 or &true;)
          or to use legacy Transact-SQL rules (0 or &false;).
         </para>
        </listitem>
@@ -125,7 +125,7 @@
        <term><literal>TraceOn</literal></term>
        <listitem>
         <para>
-         Specifies whether ODBC tracing is enabled (1 or &true;) or disabled 
+         Specifies whether ODBC tracing is enabled (1 or &true;) or disabled
          (0 or &false;) for the connection being established.
         </para>
        </listitem>
@@ -134,9 +134,9 @@
        <term><literal>TransactionIsolation</literal></term>
        <listitem>
         <para>
-         Specifies the transaction isolation level. The accepted values for this 
-         option are PDO::SQLSRV_TXN_READ_UNCOMMITTED, PDO::SQLSRV_TXN_READ_COMMITTED, 
-         PDO::SQLSRV_TXN_REPEATABLE_READ, PDO::SQLSRV_TXN_SNAPSHOT, and 
+         Specifies the transaction isolation level. The accepted values for this
+         option are PDO::SQLSRV_TXN_READ_UNCOMMITTED, PDO::SQLSRV_TXN_READ_COMMITTED,
+         PDO::SQLSRV_TXN_REPEATABLE_READ, PDO::SQLSRV_TXN_SNAPSHOT, and
          PDO::SQLSRV_TXN_SERIALIZABLE.
         </para>
        </listitem>
@@ -145,7 +145,7 @@
        <term><literal>TrustServerCertificate</literal></term>
        <listitem>
         <para>
-         Specifies whether the client should trust (1 or &true;) or reject 
+         Specifies whether the client should trust (1 or &true;) or reject
          (0 or &false;) a self-signed server certificate.
         </para>
        </listitem>
@@ -176,7 +176,7 @@ $c = new PDO("sqlsrv:Server=localhost;Database=testdb", "UserName", "Password");
        </programlisting>
        </para>
        <para>
-       The following example shows how to connect to a MS SQL Server database on 
+       The following example shows how to connect to a MS SQL Server database on
        a specified port:
        <programlisting>
 <![CDATA[
@@ -185,8 +185,8 @@ $c = new PDO("sqlsrv:Server=localhost,1521;Database=testdb", "UserName", "Passwo
        </programlisting>
       </para>
       <para>
-       The following example shows how to connecto to a SQL Azure database with 
-       server ID 12345abcde. Note that when you connect to SQL Azure with PDO, 
+       The following example shows how to connecto to a SQL Azure database with
+       server ID 12345abcde. Note that when you connect to SQL Azure with PDO,
        your username will be UserName@12345abcde (UserName@ServerId).
        <programlisting>
 <![CDATA[


### PR DESCRIPTION
Rename PDO driver titleabrevs to something less crypt, as indicated on https://github.com/php/doc-en/pull/4330 .

The other line changes are trailing spaces, that does not shows on online diffs.