### PR TITLE
PDO: improve PDO::ATTR_STRINGIFY_FETCHES description

### DIFF
--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -580,7 +580,9 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
    </term>
    <listitem>
     <simpara>
-     Forces all values fetched to be treated as strings.
+     Forces all fetched values (except &null;) to be treated as strings.
+     &null; values remain unchanged unless <constant>PDO::ATTR_ORACLE_NULLS</constant>
+     is set to <constant>PDO::NULL_TO_STRING</constant>.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/pdo/pdo/setattribute.xml
+++ b/reference/pdo/pdo/setattribute.xml
@@ -136,9 +136,11 @@
      <term><constant>PDO::ATTR_STRINGIFY_FETCHES</constant></term>
      <listitem>
       <para>
-       Whether to convert numeric values to strings when fetching.
-       Takes a value of type <type>bool</type>: &true; to enable and
-       &false; to disable. <!-- By default, ??? TODO. -->
+       Controls whether fetched values (except &null;) are converted to strings.
+       Takes a value of type <type>bool</type>: &true; to enable and &false; to
+       disable (default).
+       &null; values remain unchanged unless <constant>PDO::ATTR_ORACLE_NULLS</constant>
+       is set to <constant>PDO::NULL_TO_STRING</constant>.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
1. Standardizes definition in both `constants` and `setattribute` pages. I'm not sure this duplication is ideal, but that is how the PDO documentation is currently structured.
2. Update text to reflect that it's not the numeric values that get converted, it's all non-null values. (E.g. boolean values get converted too.). I imagine the behavior could theoretically be different depending on the PDO driver, and that the behavior may have been different in the past too, but that seems to be the case nowadays in all core drivers, and so I think it's useful to state it.
3. Specify the default. Again, this may be driver-specific (an extension may override it), but at least that seems to be the case in all existing supported drivers.
4. Mention `ATTR_ORACLE_NULLS`. As a developer, it can be useful to enforce all types to be string, and that could be wrongly assumed to be done by this constant (named `ATTR_STRINGIFY_FETCHES`).