### PR TITLE
PDO(FETCH_CLASS): private and read-only properties are populated too

### DIFF
--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -251,7 +251,7 @@
       called, allowing the population of properties regardless of their
       visibility or whether they are marked as <literal>readonly</literal>. If
       a property does not exist in the class, the magic
-      <link linkend="language.oop5.overloading.members"><methodname>__set</methodname></link>
+      <link linkend="object.set">__set()</link>
       method will be invoked if it exists; otherwise, a dynamic public property
       will be created. However, when <constant>PDO::FETCH_PROPS_LATE</constant>
       is also given, the constructor is called <emphasis>before</emphasis> the

--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -253,7 +253,9 @@
       a property does not exist in the class, the magic
       <link linkend="language.oop5.overloading.members"><methodname>__set</methodname></link>
       method will be invoked if it exists; otherwise, a dynamic public property
-      will be created.
+      will be created. However, when <constant>PDO::FETCH_PROPS_LATE</constant>
+      is also given, the constructor is called <emphasis>before</emphasis> the
+      properties are populated.
      </simpara>
     </note>
    </listitem>

--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -243,6 +243,7 @@
     <simpara>
      Specifies that the fetch method shall return a new instance of the
      requested class, mapping the columns to named properties in the class.
+     Private and read-only properties will also be populated.
     </simpara>
     <note>
      <simpara>

--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -242,14 +242,18 @@
    <listitem>
     <simpara>
      Specifies that the fetch method shall return a new instance of the
-     requested class, mapping the columns to named properties in the class.
-     Private and read-only properties will also be populated.
+     requested class.
     </simpara>
     <note>
      <simpara>
-      The magic
+      The object is initialized by mapping the columns from the result set to
+      properties in the class. This process occurs before the constructor is
+      called, allowing the population of properties regardless of their
+      visibility or whether they are marked as <literal>readonly</literal>. If
+      a property does not exist in the class, the magic
       <link linkend="language.oop5.overloading.members"><methodname>__set</methodname></link>
-      method is called if the property doesn't exist in the requested class
+      method will be invoked if it exists; otherwise, a dynamic public property
+      will be created.
      </simpara>
     </note>
    </listitem>

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -271,11 +271,11 @@ Reading backwards:
 
    <example><title>Construction order</title>
     <simpara>
-     When objects are fetched via <literal>PDO::FETCH_CLASS</literal> the object
+     When objects are fetched via <class>PDO::FETCH_CLASS</class>, the object
      properties are assigned first, and then the constructor of the class is
-     invoked. If <literal>PDO::FETCH_PROPS_LATE</literal> is also given, this
-     order is reversed, i.e. first the constructor is called, and afterwards the
-     properties are assigned.
+     invoked. However, when <class>PDO::FETCH_PROPS_LATE</class> is also given,
+     this order is reversed, i.e. first the constructor is called, and
+     afterwards the properties are assigned.
     </simpara>
     <programlisting role="php">
 <![CDATA[

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -273,7 +273,7 @@ Reading backwards:
     <simpara>
      When objects are fetched via <class>PDO::FETCH_CLASS</class>, the object
      properties are assigned first, and then the constructor of the class is
-     invoked. However, when <class>PDO::FETCH_PROPS_LATE</class> is also given,
+     invoked. However, when <constant>PDO::FETCH_PROPS_LATE</constant> is also given,
      this order is reversed, i.e. first the constructor is called, and
      afterwards the properties are assigned.
     </simpara>

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -59,7 +59,7 @@
          of their visibility or whether they are marked as <literal>readonly</literal>.
          If a property does not exist in the class, the magic <methodname>__set</methodname>
          method will be invoked if it exists; otherwise, a dynamic public
-         property will be created. If <constant>PDO::FETCH_PROPS_LATE</constant>
+         property will be created. However, when <constant>PDO::FETCH_PROPS_LATE</constant>
          is also given, the constructor is called <emphasis>before</emphasis>
          the properties are populated. If <parameter>mode</parameter> includes
          <constant>PDO::FETCH_CLASSTYPE</constant> (e.g.

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -62,7 +62,7 @@
          property will be created. If <literal>PDO::FETCH_PROPS_LATE</literal>
          is also given, the constructor is called <emphasis>before</emphasis>
          the properties are populated. If <parameter>mode</parameter> includes
-         <literal>PDO::FETCH_CLASSTYPE</literal> (e.g.,
+         <literal>PDO::FETCH_CLASSTYPE</literal> (e.g.
          <literal>PDO::FETCH_CLASS | PDO::FETCH_CLASSTYPE</literal>), the name
          of the class is determined from the value of the first column.
         </para></listitem>

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -57,7 +57,7 @@
          the result set to properties in the class. This occurs before the
          constructor is called, allowing properties to be populated regardless
          of their visibility or whether they are marked as <literal>readonly</literal>.
-         If a property does not exist in the class, the magic <methodname>__set</methodname>
+         If a property does not exist in the class, the magic <link linkend="object.set">__set()</link>
          method will be invoked if it exists; otherwise, a dynamic public
          property will be created. However, when <constant>PDO::FETCH_PROPS_LATE</constant>
          is also given, the constructor is called <emphasis>before</emphasis>

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -60,6 +60,7 @@
          includes PDO::FETCH_CLASSTYPE (e.g. <literal>PDO::FETCH_CLASS |
          PDO::FETCH_CLASSTYPE</literal>) then the name of the class is
          determined from a value of the first column.
+         Private and read-only properties are also populated.
         </para></listitem>
         <listitem><para>
          <literal>PDO::FETCH_INTO</literal>: updates an existing instance

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -59,10 +59,10 @@
          of their visibility or whether they are marked as <literal>readonly</literal>.
          If a property does not exist in the class, the magic <methodname>__set</methodname>
          method will be invoked if it exists; otherwise, a dynamic public
-         property will be created. If <literal>PDO::FETCH_PROPS_LATE</literal>
+         property will be created. If <constant>PDO::FETCH_PROPS_LATE</constant>
          is also given, the constructor is called <emphasis>before</emphasis>
          the properties are populated. If <parameter>mode</parameter> includes
-         <literal>PDO::FETCH_CLASSTYPE</literal> (e.g.
+         <constant>PDO::FETCH_CLASSTYPE</constant> (e.g.
          <literal>PDO::FETCH_CLASS | PDO::FETCH_CLASSTYPE</literal>), the name
          of the class is determined from the value of the first column.
         </para></listitem>

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -53,14 +53,18 @@
         </para></listitem>
         <listitem><para>
          <literal>PDO::FETCH_CLASS</literal>: returns a new instance of the
-         requested class, mapping the columns of the result set to named
-         properties in the class, and calling the constructor afterwards, unless
-         <literal>PDO::FETCH_PROPS_LATE</literal> is also given.
-         If <parameter>mode</parameter>
-         includes PDO::FETCH_CLASSTYPE (e.g. <literal>PDO::FETCH_CLASS |
-         PDO::FETCH_CLASSTYPE</literal>) then the name of the class is
-         determined from a value of the first column.
-         Private and read-only properties are also populated.
+         requested class. The object is initialized by mapping the columns of
+         the result set to properties in the class. This occurs before the
+         constructor is called, allowing properties to be populated regardless
+         of their visibility or whether they are marked as <literal>readonly</literal>.
+         If a property does not exist in the class, the magic <methodname>__set</methodname>
+         method will be invoked if it exists; otherwise, a dynamic public
+         property will be created. If <literal>PDO::FETCH_PROPS_LATE</literal>
+         is also given, the constructor is called <emphasis>before</emphasis>
+         the properties are populated. If <parameter>mode</parameter> includes
+         <literal>PDO::FETCH_CLASSTYPE</literal> (e.g.,
+         <literal>PDO::FETCH_CLASS | PDO::FETCH_CLASSTYPE</literal>), the name
+         of the class is determined from the value of the first column.
         </para></listitem>
         <listitem><para>
          <literal>PDO::FETCH_INTO</literal>: updates an existing instance

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -271,7 +271,7 @@ Reading backwards:
 
    <example><title>Construction order</title>
     <simpara>
-     When objects are fetched via <class>PDO::FETCH_CLASS</class>, the object
+     When objects are fetched via <constant>PDO::FETCH_CLASS</constant>, the object
      properties are assigned first, and then the constructor of the class is
      invoked. However, when <constant>PDO::FETCH_PROPS_LATE</constant> is also given,
      this order is reversed, i.e. first the constructor is called, and


### PR DESCRIPTION
I'm not sure if this behavior is intentional, but it's something I rely on.