### PR TITLE
Copy setup code into second example to enable "run code"

### DIFF
--- a/reference/classobj/functions/is-a.xml
+++ b/reference/classobj/functions/is-a.xml
@@ -88,6 +88,15 @@ if (is_a($WF, 'WidgetFactory')) {
     <programlisting role="php">
 <![CDATA[
 <?php
+// define a class
+class WidgetFactory
+{
+  var $oink = 'moo';
+}
+
+// create a new object
+$WF = new WidgetFactory();
+
 if ($WF instanceof WidgetFactory) {
     echo 'Yes, $WF is a WidgetFactory';
 }


### PR DESCRIPTION
While browsing the docs, I tried to "run [the] code" examples of [`is_a`](https://www.php.net/manual/en/function.is-a.php).

The firs worked but the second failed with `Warning: Undefined variable $WF in php-wasm run script on line 2` due to missing setup code.

If the "run code" functionality should actually be usable, code examples must be self-containing.