### PR TITLE
ini_get: Update example to use `ini_parse_quantity()`

### DIFF
--- a/reference/info/functions/ini-get.xml
+++ b/reference/info/functions/ini-get.xml
@@ -55,37 +55,15 @@
 Our php.ini contains the following settings:
 
 display_errors = On
-register_globals = Off
+opcache.enable_cli = Off
 post_max_size = 8M
 */
 
 echo 'display_errors = ' . ini_get('display_errors') . "\n";
-echo 'register_globals = ' . (int) ini_get('register_globals') . "\n";
+echo 'opcache.enable_cli = ' . (int) ini_get('opcache.enable_cli') . "\n";
 echo 'post_max_size = ' . ini_get('post_max_size') . "\n";
 echo 'post_max_size + 1 = ' . (rtrim(ini_get('post_max_size'), 'KMG') + 1) . "\n";
-echo 'post_max_size in bytes = ' . return_bytes(ini_get('post_max_size'));
-
-function return_bytes($val)
-{
-    $val = trim($val);
-    $num = (int) rtrim($val, 'KMG');
-    $last = strtolower($val[strlen($val) - 1]);
-
-    switch ($last) {
-        // The 'G' modifier is available
-        case 'g':
-            $num = $num * 1024 * 1024 * 1024;
-            break;
-        case 'm':
-            $num = $num * 1024 * 1024;
-            break;
-        case 'k':
-            $num *= 1024;
-            break;
-    }
-
-    return $num;
-}
+echo 'post_max_size in bytes = ' . ini_parse_quantity(ini_get('post_max_size'));
 
 ?>
 ]]>
@@ -95,7 +73,7 @@ function return_bytes($val)
 <![CDATA[
 
 display_errors = 1
-register_globals = 0
+opcache.enable_cli = 0
 post_max_size = 8M
 post_max_size+1 = 9
 post_max_size in bytes = 8388608
@@ -126,9 +104,9 @@ post_max_size in bytes = 8388608
     <function>ini_get</function> will return the exact string stored in the
     &php.ini; file and <emphasis>NOT</emphasis> its <type>int</type>
     equivalent.  Attempting normal arithmetic functions on these values
-    will not have otherwise expected results.  The example above shows one
-    way to convert shorthand notation into bytes, much like how the PHP
-    source does it.
+    will not have otherwise expected results.  The
+    <function>ini_parse_quantity</function> function can be used to convert
+    the shorthand notation into bytes.
    </para>
   </note>
   <note>
@@ -145,6 +123,7 @@ post_max_size in bytes = 8388608
    <simplelist>
     <member><function>get_cfg_var</function></member>
     <member><function>ini_get_all</function></member>
+    <member><function>ini_parse_quantity</function></member>
     <member><function>ini_restore</function></member>
     <member><function>ini_set</function></member>
    </simplelist>

--- a/reference/info/functions/ini-parse-quantity.xml
+++ b/reference/info/functions/ini-parse-quantity.xml
@@ -77,7 +77,7 @@ var_dump(ini_parse_quantity('10F'));
 ?>
 ]]>
     </programlisting>
-    &example.outputs.similar;
+    &example.outputs;
     <screen>
 <![CDATA[
 


### PR DESCRIPTION
- Use ini_parse_quantity instead of custom code for ini value parsing.
- Replace register_globals ini value with something more current, as register_globals was removed in, I think, PHP 5.4.
- Change the wording for the ini_parse_quantity example to not contain “similar to” as it's deterministic output.

Resolves php/doc-en#4185