### PR TITLE
describe behavior of static variables inside anonymous functions

### DIFF
--- a/language/variables.xml
+++ b/language/variables.xml
@@ -527,6 +527,37 @@ function foo(){
     </example>
    </para>
 
+   <simpara>
+    Static variables inside anonymous functions persist only within that
+    specific function instance. If the anonymous function is recreated on each
+    call, the static variable will be reinitialized.
+   </simpara>
+   <para>
+    <example>
+     <title>Static variables in anonymous functions</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+function exampleFunction($input) {
+    $result = (static function () use ($input) {
+        static $counter = 0;
+        $counter++;
+        return "Input: $input, Counter: $counter\n";
+    });
+
+    return $result();
+}
+
+// Calls to exampleFunction will recreate the anonymous function, so the static
+// variable does not retain its value.
+echo exampleFunction('A'); // Outputs: Input: A, Counter: 1
+echo exampleFunction('B'); // Outputs: Input: B, Counter: 1
+?>
+]]>
+     </programlisting>
+    </example>
+   </para>
+
    <para>
     As of PHP 8.1.0, when a method using static variables is inherited (but not overridden),
     the inherited method will now share static variables with the parent method.


### PR DESCRIPTION
While working with static variables inside anonymous functions, I unexpectedly found that the static variable would not persist across calls because the anonymous function was recreated each time. This behavior was counterintuitive for me, so I updated the documentation to describe it.