### PR TITLE
Update ini.list.xml

### DIFF
--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -777,10 +777,22 @@
        <entry></entry>
       </row>
       <row>
+      <entry><link linkend="ini.zend.max_allowed_stack_size">zend.max_allowed_stack_size</link></entry>
+       <entry><literal>"0"</literal></entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
+       <entry>Available as of PHP 8.3.0</entry>
+      </row>
+      <row>
        <entry><link linkend="ini.zend.multibyte">zend.multibyte</link></entry>
        <entry><literal>"0"</literal></entry>
        <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
+      </row>
+      <row>
+       <entry><link linkend="ini.zend.reserved_stack_size">zend.reserved_stack_size</link></entry>
+       <entry><literal>"0"</literal></entry>
+       <entry><constant>INI_SYSTEM</constant></entry>
+       <entry>Available as of PHP 8.3.0</entry>
       </row>
       <row>
        <entry><link linkend="ini.zend.script-encoding">zend.script_encoding</link></entry>

--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -777,7 +777,7 @@
        <entry></entry>
       </row>
       <row>
-      <entry><link linkend="ini.zend.max_allowed_stack_size">zend.max_allowed_stack_size</link></entry>
+      <entry><link linkend="ini.zend.max-allowed-stack-size">zend.max_allowed_stack_size</link></entry>
        <entry><literal>"0"</literal></entry>
        <entry><constant>INI_SYSTEM</constant></entry>
        <entry>Available as of PHP 8.3.0</entry>
@@ -789,7 +789,7 @@
        <entry></entry>
       </row>
       <row>
-       <entry><link linkend="ini.zend.reserved_stack_size">zend.reserved_stack_size</link></entry>
+       <entry><link linkend="ini.zend.reserved-stack-size">zend.reserved_stack_size</link></entry>
        <entry><literal>"0"</literal></entry>
        <entry><constant>INI_SYSTEM</constant></entry>
        <entry>Available as of PHP 8.3.0</entry>


### PR DESCRIPTION
Added two Zend ini directives that were made available in PHP 8.3, but aren't on this list.
I tested manually to determine the changeable mode, but also looked at source code.