### PR TITLE
Fix hooks example

### DIFF
--- a/language/oop5/property-hooks.xml
+++ b/language/oop5/property-hooks.xml
@@ -498,7 +498,10 @@ class PositivePoint extends Point
     Hooks may not access any other hook except their own parent on their own property.
    </simpara>
    <simpara>
-    The example above could be rewritten more efficiently as follows.
+    The example above could be rewritten as follows, which would allow for the
+    <literal>Point</literal> class to add its own <literal>set</literal> hook
+    in the future without issue.  (In the previous example, a hook added to
+    the parent class would be ignored in the child.)
    </simpara>
    <example>
     <title>Parent hook access (set)</title>
@@ -518,7 +521,7 @@ class PositivePoint extends Point
             if ($value < 0) {
                 throw new \InvalidArgumentException('Too small');
             }
-            $this->x = $value;
+            parent::$x::set($value);
         }
     }
 }


### PR DESCRIPTION
Fixes #4336

Copy-pasta error on my part when cloning the RFC to the docs page.  This should resolve it.