### PR TITLE
remove deprecated example, add multidimensional arrays examples

### DIFF
--- a/reference/var/functions/empty.xml
+++ b/reference/var/functions/empty.xml
@@ -99,7 +99,7 @@ bool(true)
   <example>
    <title><function>empty</function> on multidimensional arrays</title>
    <programlisting role="php">
-    <![CDATA[
+<![CDATA[
 <?php
 $multidimensional = [
     'some' => [

--- a/reference/var/functions/empty.xml
+++ b/reference/var/functions/empty.xml
@@ -109,7 +109,7 @@ $multidimensional = [
     ]
 ];
 
-// we can use empty with multidimensional arrays
+// we can use `empty()` with multidimensional arrays
 if (!empty($multidimensional['some']['some']['nested'])) {
     $someVariable = $multidimensional['some']['deep']['nested'];
 }

--- a/reference/var/functions/empty.xml
+++ b/reference/var/functions/empty.xml
@@ -29,7 +29,7 @@
        No warning is generated if the variable does not exist.
        That means <function>empty</function> is essentially the
        concise equivalent to <command>!isset($var) || $var == false</command>.
-       This also works for multidimensional arrays, you can reference deeply nested structures without raising warnings. 
+       This also applies to nested structures, such as a multidimensional array or chained properties.
       </para>
      </listitem>
     </varlistentry>
@@ -109,7 +109,6 @@ $multidimensional = [
     ]
 ];
 
-// we can use `empty()` with multidimensional arrays
 if (!empty($multidimensional['some']['some']['nested'])) {
     $someVariable = $multidimensional['some']['deep']['nested'];
 }

--- a/reference/var/functions/empty.xml
+++ b/reference/var/functions/empty.xml
@@ -29,6 +29,7 @@
        No warning is generated if the variable does not exist.
        That means <function>empty</function> is essentially the
        concise equivalent to <command>!isset($var) || $var == false</command>.
+       This also works for multidimensional arrays, you can reference deeply nested structures without raising warnings. 
       </para>
      </listitem>
     </varlistentry>
@@ -79,7 +80,6 @@ $expected_array_got_string = 'somestring';
 var_dump(empty($expected_array_got_string['some_key']));
 var_dump(empty($expected_array_got_string[0]));
 var_dump(empty($expected_array_got_string['0']));
-var_dump(empty($expected_array_got_string[0.5]));
 var_dump(empty($expected_array_got_string['0.5']));
 var_dump(empty($expected_array_got_string['0 Mostel']));
 ?>
@@ -91,9 +91,41 @@ var_dump(empty($expected_array_got_string['0 Mostel']));
 bool(true)
 bool(false)
 bool(false)
+bool(true)
+bool(true)
+]]>
+   </screen>
+  </example>
+  <example>
+   <title><function>empty</function> on multidimensional arrays</title>
+   <programlisting role="php">
+    <![CDATA[
+<?php
+$multidimensional = [
+    'some' => [
+        'deep' => [
+            'nested' => 'value'
+        ]
+    ]
+];
+
+// we can use empty with multidimensional arrays
+if (!empty($multidimensional['some']['some']['nested'])) {
+    $someVariable = $multidimensional['some']['deep']['nested'];
+}
+
+var_dump(empty($multidimensional['some-undefined-key']));
+var_dump(empty($multidimensional['some']['deep']['unknown']));
+var_dump(empty($multidimensional['some']['deep']['nested']));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+bool(true)
 bool(false)
-bool(true)
-bool(true)
 ]]>
    </screen>
   </example>


### PR DESCRIPTION
Relates to issue: https://github.com/php/doc-en/issues/4390

This PR addresses issues with the "empty()" documentation.
1- one of the "String Offsets" examples contains an invalid example with deprecated syntax
2- add examples for multidimensional arrays