### PR TITLE
gd: do not use or unnecessary reference imagedestroy()

### DIFF
--- a/reference/image/examples.xml
+++ b/reference/image/examples.xml
@@ -19,7 +19,6 @@ $orange = imagecolorallocate($im, 220, 210, 60);
 $px     = (imagesx($im) - 7.5 * strlen($string)) / 2;
 imagestring($im, 3, $px, 9, $string, $orange);
 imagepng($im);
-imagedestroy($im);
 
 ?>
 ]]>
@@ -57,10 +56,9 @@ $sy = imagesy($stamp);
 // width to calculate positioning of the stamp. 
 imagecopy($im, $stamp, imagesx($im) - $sx - $marge_right, imagesy($im) - $sy - $marge_bottom, 0, 0, imagesx($stamp), imagesy($stamp));
 
-// Output and free memory
+// Output
 header('Content-type: image/png');
 imagepng($im);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>
@@ -103,9 +101,8 @@ $sy = imagesy($stamp);
 // Merge the stamp onto our photo with an opacity of 50%
 imagecopymerge($im, $stamp, imagesx($im) - $sx - $marge_right, imagesy($im) - $sy - $marge_bottom, 0, 0, imagesx($stamp), imagesy($stamp), 50);
 
-// Save the image to file and free memory
+// Save the image to file
 imagepng($im, 'photo_stamp.png');
-imagedestroy($im);
 
 ?>
 ]]>

--- a/reference/image/functions/image-type-to-extension.xml
+++ b/reference/image/functions/image-type-to-extension.xml
@@ -61,7 +61,6 @@ $im = imagecreatetruecolor(100, 100);
 
 // Save image
 imagepng($im, './test' . image_type_to_extension(IMAGETYPE_PNG));
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/image2wbmp.xml
+++ b/reference/image/functions/image2wbmp.xml
@@ -78,7 +78,6 @@ $image = imagecreatefrompng($file);
 
 header('Content-Type: ' . image_type_to_mime_type(IMAGETYPE_WBMP));
 image2wbmp($image); // output the stream directly
-imagedestroy($image);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagealphablending.xml
+++ b/reference/image/functions/imagealphablending.xml
@@ -86,7 +86,6 @@ imagefilledrectangle($im, 30, 30, 70, 70, imagecolorallocate($im, 255, 0, 0));
 header('Content-Type: image/png');
 
 imagepng($im);
-imagedestroy($im);
 ?>
 ]]>
    </programlisting>

--- a/reference/image/functions/imageantialias.xml
+++ b/reference/image/functions/imageantialias.xml
@@ -105,8 +105,6 @@ imagecopymerge($aa, $normal, 200, 0, 0, 0, 200, 100, 100);
 header('Content-type: image/png');
 
 imagepng($aa);
-imagedestroy($aa);
-imagedestroy($normal);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagearc.xml
+++ b/reference/image/functions/imagearc.xml
@@ -143,9 +143,6 @@ imagearc($img, 140,  75,  50,  50,  0, 360, $blue);
 header("Content-type: image/png");
 imagepng($img);
 
-// free memory
-imagedestroy($img);
-
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagebmp.xml
+++ b/reference/image/functions/imagebmp.xml
@@ -96,9 +96,6 @@ imagestring($im, 1, 5, 5,  'BMP with PHP', $text_color);
 
 // Save the image
 imagebmp($im, 'php.bmp');
-
-// Free up memory
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagecolorallocatealpha.xml
+++ b/reference/image/functions/imagecolorallocatealpha.xml
@@ -124,7 +124,6 @@ header('Content-Type: image/png');
 
 // and finally, output the result
 imagepng($image);
-imagedestroy($image);
 ?>
 ]]>
    </programlisting>

--- a/reference/image/functions/imagecolorclosest.xml
+++ b/reference/image/functions/imagecolorclosest.xml
@@ -108,8 +108,6 @@ foreach($colors as $id => $rgb)
 
     echo "#$id: Search ($rgb[0], $rgb[1], $rgb[2]); Closest match: $result.\n";
 }
-
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagecolorclosestalpha.xml
+++ b/reference/image/functions/imagecolorclosestalpha.xml
@@ -95,8 +95,6 @@ foreach($colors as $id => $rgb)
 
     echo "#$id: Search ($rgb[0], $rgb[1], $rgb[2], $rgb[3]); Closest match: $result.\n";
 }
-
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagecolorclosesthwb.xml
+++ b/reference/image/functions/imagecolorclosesthwb.xml
@@ -81,8 +81,6 @@
 $im = imagecreatefromgif('php.gif');
 
 echo 'HWB: ' . imagecolorclosesthwb($im, 116, 115, 152);
-
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagecolorexact.xml
+++ b/reference/image/functions/imagecolorexact.xml
@@ -88,9 +88,6 @@ $colors[] = imagecolorexact($im, 255, 255, 255);
 $colors[] = imagecolorexact($im, 100, 255, 52);
 
 print_r($colors);
-
-// Free from memory
-imagedestroy($im);
 ?>
 ]]>
    </programlisting>

--- a/reference/image/functions/imagecolorexactalpha.xml
+++ b/reference/image/functions/imagecolorexactalpha.xml
@@ -101,9 +101,6 @@ $colors[] = imagecolorexactalpha($im, 255, 255, 255, 55);
 $colors[] = imagecolorexactalpha($im, 100, 255, 52, 20);
 
 print_r($colors);
-
-// Free from memory
-imagedestroy($im);
 ?>
 ]]>
    </programlisting>

--- a/reference/image/functions/imagecolormatch.xml
+++ b/reference/image/functions/imagecolormatch.xml
@@ -91,10 +91,6 @@ $colors[] = imagecolorallocate($im2, 84, 63, 44);
 
 // Match these colors with the true color image
 imagecolormatch($im1, $im2);
-
-// Free from memory
-imagedestroy($im1);
-imagedestroy($im2);
 ?>
 ]]>
    </programlisting>

--- a/reference/image/functions/imagecolorresolve.xml
+++ b/reference/image/functions/imagecolorresolve.xml
@@ -88,8 +88,6 @@ $colors[] = imagecolorresolve($im, 0, 0, 200);
 
 // Output
 print_r($colors);
-
-imagedestroy($im);
 ?>
 ]]>  
    </programlisting>

--- a/reference/image/functions/imagecolorresolvealpha.xml
+++ b/reference/image/functions/imagecolorresolvealpha.xml
@@ -100,8 +100,6 @@ $colors[] = imagecolorresolvealpha($im, 0, 0, 200, 127);
 
 // Output
 print_r($colors);
-
-imagedestroy($im);
 ?>
 ]]>  
    </programlisting>

--- a/reference/image/functions/imagecolorset.xml
+++ b/reference/image/functions/imagecolorset.xml
@@ -113,7 +113,6 @@ imagecolorset($im, $bg, 0, 0, 255);
 header('Content-Type: image/png');
 
 imagepng($im);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagecolorstotal.xml
+++ b/reference/image/functions/imagecolorstotal.xml
@@ -60,9 +60,6 @@
 $im = imagecreatefromgif('php.gif');
 
 echo 'Total colors in image: ' . imagecolorstotal($im);
-
-// Free image
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagecolortransparent.xml
+++ b/reference/image/functions/imagecolortransparent.xml
@@ -86,7 +86,6 @@ imagefilledrectangle($im, 4, 4, 50, 25, $red);
 
 // Save the image
 imagepng($im, './imagecolortransparent.png');
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagecopy.xml
+++ b/reference/image/functions/imagecopy.xml
@@ -141,9 +141,6 @@ imagecopy($dest, $src, 0, 0, 20, 13, 80, 40);
 // Output and free from memory
 header('Content-Type: image/gif');
 imagegif($dest);
-
-imagedestroy($dest);
-imagedestroy($src);
 ?>
 ]]>
    </programlisting>

--- a/reference/image/functions/imagecopymerge.xml
+++ b/reference/image/functions/imagecopymerge.xml
@@ -151,12 +151,9 @@ $src = imagecreatefromgif('php.gif');
 // Copy and merge
 imagecopymerge($dest, $src, 10, 10, 0, 0, 100, 47, 75);
 
-// Output and free from memory
+// Output
 header('Content-Type: image/gif');
 imagegif($dest);
-
-imagedestroy($dest);
-imagedestroy($src);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagecopymergegray.xml
+++ b/reference/image/functions/imagecopymergegray.xml
@@ -156,12 +156,9 @@ $src = imagecreatefromgif('php.gif');
 // Copy and merge - Gray = 20%
 imagecopymergegray($dest, $src, 10, 10, 0, 0, 100, 47, 20);
 
-// Output and free from memory
+// Output
 header('Content-Type: image/gif');
 imagegif($dest);
-
-imagedestroy($dest);
-imagedestroy($src);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagecreate.xml
+++ b/reference/image/functions/imagecreate.xml
@@ -94,7 +94,6 @@ $background_color = imagecolorallocate($im, 0, 0, 0);
 $text_color = imagecolorallocate($im, 233, 14, 91);
 imagestring($im, 1, 5, 5,  "A Simple Text String", $text_color);
 imagepng($im);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>
@@ -111,7 +110,6 @@ imagedestroy($im);
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><function>imagedestroy</function></member>
    <member><function>imagecreatetruecolor</function></member>
   </simplelist>
  </refsect1>

--- a/reference/image/functions/imagecreatefrombmp.xml
+++ b/reference/image/functions/imagecreatefrombmp.xml
@@ -76,7 +76,6 @@ $im = imagecreatefrombmp('./example.bmp');
 
 // Convert it to a PNG file with default settings
 imagepng($im, './example.png');
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagecreatefromgd.xml
+++ b/reference/image/functions/imagecreatefromgd.xml
@@ -80,7 +80,6 @@ if(!$im)
 
 // Save the image
 imagegd($im, './test_updated.gd');
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagecreatefromgd2.xml
+++ b/reference/image/functions/imagecreatefromgd2.xml
@@ -79,7 +79,6 @@ if(function_exists('imagefilter'))
 
 // Save the image
 imagegd2($im, './test_updated.gd2');
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagecreatefromgd2part.xml
+++ b/reference/image/functions/imagecreatefromgd2part.xml
@@ -114,7 +114,6 @@ if(function_exists('imagefilter'))
 
 // Save optimized image
 imagegd2($im, './test_emboss.gd2');
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagecreatefromgif.xml
+++ b/reference/image/functions/imagecreatefromgif.xml
@@ -101,7 +101,6 @@ header('Content-Type: image/gif');
 $img = LoadGif('bogus.image');
 
 imagegif($img);
-imagedestroy($img);
 ?>
 ]]>
    </programlisting>

--- a/reference/image/functions/imagecreatefromjpeg.xml
+++ b/reference/image/functions/imagecreatefromjpeg.xml
@@ -94,7 +94,6 @@ header('Content-Type: image/jpeg');
 $img = LoadJpeg('bogus.image');
 
 imagejpeg($img);
-imagedestroy($img);
 ?>
 ]]>
    </programlisting>

--- a/reference/image/functions/imagecreatefrompng.xml
+++ b/reference/image/functions/imagecreatefrompng.xml
@@ -94,7 +94,6 @@ header('Content-Type: image/png');
 $img = LoadPNG('bogus.image');
 
 imagepng($img);
-imagedestroy($img);
 ?>
 ]]>
    </programlisting>

--- a/reference/image/functions/imagecreatefromstring.xml
+++ b/reference/image/functions/imagecreatefromstring.xml
@@ -97,7 +97,6 @@ $im = imagecreatefromstring($data);
 if ($im !== false) {
     header('Content-Type: image/png');
     imagepng($im);
-    imagedestroy($im);
 }
 else {
     echo 'An error occurred.';

--- a/reference/image/functions/imagecreatefromwbmp.xml
+++ b/reference/image/functions/imagecreatefromwbmp.xml
@@ -100,7 +100,6 @@ header('Content-Type: image/vnd.wap.wbmp');
 $img = LoadWBMP('bogus.image');
 
 imagewbmp($img);
-imagedestroy($img);
 ?>
 ]]>
    </programlisting>

--- a/reference/image/functions/imagecreatefromwebp.xml
+++ b/reference/image/functions/imagecreatefromwebp.xml
@@ -77,7 +77,6 @@ $im = imagecreatefromwebp('./example.webp');
 
 // Convert it to a jpeg file with 100% quality
 imagejpeg($im, './example.jpeg', 100);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagecreatefromxbm.xml
+++ b/reference/image/functions/imagecreatefromxbm.xml
@@ -73,7 +73,6 @@ $xbm = imagecreatefromxbm('./example.xbm');
 
 // Convert it to a png file
 imagepng($xbm, './example.png');
-imagedestroy($xbm);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagecreatefromxpm.xml
+++ b/reference/image/functions/imagecreatefromxpm.xml
@@ -83,7 +83,6 @@ $xpm = imagecreatefromxpm('./example.xpm');
 // so in this case we save the image as a 
 // jpeg file with 100% quality
 imagejpeg($xpm, './example.jpg', 100);
-imagedestroy($xpm);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagecreatetruecolor.xml
+++ b/reference/image/functions/imagecreatetruecolor.xml
@@ -84,7 +84,6 @@ $im = @imagecreatetruecolor(120, 20)
 $text_color = imagecolorallocate($im, 233, 14, 91);
 imagestring($im, 1, 5, 5,  'A Simple Text String', $text_color);
 imagepng($im);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>
@@ -102,7 +101,6 @@ imagedestroy($im);
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><function>imagedestroy</function></member>
    <member><function>imagecreate</function></member>
   </simplelist>
  </refsect1>

--- a/reference/image/functions/imagecrop.xml
+++ b/reference/image/functions/imagecrop.xml
@@ -83,9 +83,7 @@ $size = min(imagesx($im), imagesy($im));
 $im2 = imagecrop($im, ['x' => 0, 'y' => 0, 'width' => $size, 'height' => $size]);
 if ($im2 !== FALSE) {
     imagepng($im2, 'example-cropped.png');
-    imagedestroy($im2);
 }
-imagedestroy($im);
 ?>
 ]]>
    </programlisting>

--- a/reference/image/functions/imagecropauto.xml
+++ b/reference/image/functions/imagecropauto.xml
@@ -188,8 +188,7 @@
 <?php
 $cropped = imagecropauto($im, IMG_CROP_DEFAULT);
 if ($cropped !== false) { // in case a new image object was returned
-    imagedestroy($im);    // we destroy the original image
-    $im = $cropped;       // and assign the cropped image to $im
+    $im = $cropped;       // assign the cropped image to $im
 }
 ?>
 ]]>

--- a/reference/image/functions/imagedashedline.xml
+++ b/reference/image/functions/imagedashedline.xml
@@ -111,7 +111,6 @@ imagedashedline($im, 50, 25, 50, 75, $white);
 
 // Save the image
 imagepng($im, './dashedline.png');
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>
@@ -152,7 +151,6 @@ imageline($im, 50, 25, 50, 75, IMG_COLOR_STYLED);
 
 // Save the image
 imagepng($im, './imageline.png');
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagefill.xml
+++ b/reference/image/functions/imagefill.xml
@@ -93,7 +93,6 @@ imagefill($im, 0, 0, $red);
 
 header('Content-type: image/png');
 imagepng($im);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagefilledarc.xml
+++ b/reference/image/functions/imagefilledarc.xml
@@ -173,7 +173,6 @@ imagefilledarc($image, 50, 50, 100, 50, 75, 360 , $red, IMG_ARC_PIE);
 // flush image
 header('Content-type: image/png');
 imagepng($image);
-imagedestroy($image);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagefilledpolygon.xml
+++ b/reference/image/functions/imagefilledpolygon.xml
@@ -129,7 +129,6 @@ imagefilledpolygon($image, $values, $blue);
 // flush image
 header('Content-type: image/png');
 imagepng($image);
-imagedestroy($image);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagefilledrectangle.xml
+++ b/reference/image/functions/imagefilledrectangle.xml
@@ -111,7 +111,6 @@ imagefilledrectangle($im, 4, 4, 50, 25, $white);
 
 // Save the image
 imagepng($im, './imagefilledrectangle.png');
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagefilltoborder.xml
+++ b/reference/image/functions/imagefilltoborder.xml
@@ -109,10 +109,9 @@ $fill = imagecolorallocate($im, 255, 0, 0);
 // Fill the selection
 imagefilltoborder($im, 50, 50, $border, $fill);
 
-// Output and free memory
+// Output
 header('Content-type: image/png');
 imagepng($im);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagefilter.xml
+++ b/reference/image/functions/imagefilter.xml
@@ -296,8 +296,6 @@ else
 {
     echo 'Conversion to grayscale failed.';
 }
-
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>
@@ -316,7 +314,6 @@ if($im && imagefilter($im, IMG_FILTER_BRIGHTNESS, 20))
     echo 'Image brightness changed.';
 
     imagepng($im, 'sean.png');
-    imagedestroy($im);
 }
 else
 {
@@ -341,7 +338,6 @@ if($im && imagefilter($im, IMG_FILTER_COLORIZE, 0, 255, 0))
     echo 'Image successfully shaded green.';
 
     imagepng($im, 'philip.png');
-    imagedestroy($im);
 }
 else
 {
@@ -389,7 +385,6 @@ if($im && negate($im))
     echo 'Image successfully converted to negative colors.';
 
     imagejpeg($im, 'kalle.jpg', 100);
-    imagedestroy($im);
 }
 else
 {
@@ -423,13 +418,10 @@ imagefilter($logo2, IMG_FILTER_PIXELATE, 3, true);
 // Merge the differences onto the output image
 imagecopy($output, $logo1, 0, 0, 0, 0, imagesx($logo1) - 1, imagesy($logo1) - 1);
 imagecopy($output, $logo2, imagesx($logo2), 0, 0, 0, imagesx($logo2) - 1, imagesy($logo2) - 1);
-imagedestroy($logo1);
-imagedestroy($logo2);
 
 // Output the differences
 header('Content-Type: image/png');
 imagepng($output);
-imagedestroy($output);
 ?>
 ]]>
     </programlisting>
@@ -457,7 +449,6 @@ imagefilter($logo, IMG_FILTER_SCATTER, 3, 5);
 // Output the image with the scatter effect
 header('Content-Type: image/png');
 imagepng($logo);
-imagedestroy($logo);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imageflip.xml
+++ b/reference/image/functions/imageflip.xml
@@ -118,7 +118,6 @@ imageflip($im, IMG_FLIP_VERTICAL);
 
 // Output
 imagejpeg($im);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>
@@ -154,7 +153,6 @@ imageflip($im, IMG_FLIP_HORIZONTAL);
 
 // Output
 imagejpeg($im);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imageftbbox.xml
+++ b/reference/image/functions/imageftbbox.xml
@@ -181,7 +181,6 @@ imagefttext($im, 10, 0, $x, $y, $black, $font, 'The PHP Documentation Group');
 header('Content-Type: image/png');
 
 imagepng($im);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagefttext.xml
+++ b/reference/image/functions/imagefttext.xml
@@ -241,7 +241,6 @@ imagefttext($im, 13, 0, 105, 55, $black, $font_file, 'PHP Manual');
 header('Content-Type: image/png');
 
 imagepng($im);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagegammacorrect.xml
+++ b/reference/image/functions/imagegammacorrect.xml
@@ -80,9 +80,8 @@ $im = imagecreatefromgif('php.gif');
 // Correct gamma, out = 1.537
 imagegammacorrect($im, 1.0, 1.537);
 
-// Save and free image
+// Save
 imagegif($im, './php_gamma_corrected.gif');
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagegd.xml
+++ b/reference/image/functions/imagegd.xml
@@ -85,9 +85,6 @@ imagestring($im, 1, 5, 5,  "A Simple Text String", $text_color);
 
 // Output the image
 imagegd($im);
-
-// Free up memory
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>
@@ -107,9 +104,6 @@ imagestring($im, 1, 5, 5,  "A Simple Text String", $text_color);
 // Save the gd image
 // The file format for GD images is .gd, see http://www.libgd.org/GdFileFormats
 imagegd($im, 'simple.gd');
-
-// Free up memory
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagegd2.xml
+++ b/reference/image/functions/imagegd2.xml
@@ -96,9 +96,6 @@ imagestring($im, 1, 5, 5,  "A Simple Text String", $text_color);
 
 // Output the image
 imagegd2($im);
-
-// Free up memory
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>
@@ -118,9 +115,6 @@ imagestring($im, 1, 5, 5,  "A Simple Text String", $text_color);
 // Save the gd2 image
 // The file format for GD2 images is .gd2, see http://www.libgd.org/GdFileFormats
 imagegd2($im, 'simple.gd2');
-
-// Free up memory
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagegif.xml
+++ b/reference/image/functions/imagegif.xml
@@ -86,7 +86,6 @@ imagestring($im, 3, 40, 20, 'GD Library', 0xFFBA00);
 header('Content-Type: image/gif');
 
 imagegif($im);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>
@@ -102,9 +101,6 @@ $png = imagecreatefrompng('./php.png');
 
 // Save the image as a GIF
 imagegif($png, './php.gif');
-
-// Free from memory
-imagedestroy($png);
 
 // We're done
 echo 'Converted PNG image to GIF with success!';
@@ -163,16 +159,7 @@ elseif(function_exists('imagewbmp'))
 }
 else
 {
-    imagedestroy($im);
-
     die('No image support in this PHP server');
-}
-
-// If image support was found for one of these
-// formats, then free it from memory
-if($im)
-{
-    imagedestroy($im);
 }
 ?>
 ]]>

--- a/reference/image/functions/imagegrabscreen.xml
+++ b/reference/image/functions/imagegrabscreen.xml
@@ -80,7 +80,6 @@
 <?php
 $im = imagegrabscreen();
 imagepng($im, "myscreenshot.png");
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagegrabwindow.xml
+++ b/reference/image/functions/imagegrabwindow.xml
@@ -110,7 +110,6 @@ $browser->Visible = true;
 $im = imagegrabwindow($handle);
 $browser->Quit();
 imagepng($im, "iesnap.png");
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>
@@ -132,7 +131,6 @@ while ($browser->Busy) {
 $im = imagegrabwindow($handle, 0);
 $browser->Quit();
 imagepng($im, "iesnap.png");
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imageinterlace.xml
+++ b/reference/image/functions/imageinterlace.xml
@@ -92,7 +92,6 @@ imageinterlace($im, true);
 
 // Save the interlaced image
 imagegif($im, './php_interlaced.gif');
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imageistruecolor.xml
+++ b/reference/image/functions/imageistruecolor.xml
@@ -67,7 +67,6 @@ if(!imageistruecolor($im))
 
     // Copy over the pixels
     imagecopy($tc, $im, 0, 0, 0, 0, imagesx($im), imagesy($im));
-    imagedestroy($im);
 
     $im = $tc;
     $tc = NULL;

--- a/reference/image/functions/imagejpeg.xml
+++ b/reference/image/functions/imagejpeg.xml
@@ -98,9 +98,6 @@ header('Content-Type: image/jpeg');
 
 // Output the image
 imagejpeg($im);
-
-// Free up memory
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>
@@ -126,9 +123,6 @@ imagestring($im, 1, 5, 5,  'A Simple Text String', $text_color);
 
 // Save the image as 'simpletext.jpg'
 imagejpeg($im, 'simpletext.jpg');
-
-// Free up memory
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>
@@ -150,9 +144,6 @@ header('Content-Type: image/jpeg');
 
 // Skip the file parameter using NULL, then set the quality to 75%
 imagejpeg($im, NULL, 75);
-
-// Free up memory
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagelayereffect.xml
+++ b/reference/image/functions/imagelayereffect.xml
@@ -134,7 +134,6 @@ imagefilledellipse($im, 50, 50, 80, 50, imagecolorallocate($im, 255, 100, 100));
 header('Content-type: image/png');
 
 imagepng($im);
-imagedestroy($im);
 ?>
 ]]>
    </programlisting>

--- a/reference/image/functions/imageloadfont.xml
+++ b/reference/image/functions/imageloadfont.xml
@@ -135,7 +135,6 @@ imagestring($im, $font, 0, 0, 'Hello', $black);
 header('Content-type: image/png');
 
 imagepng($im);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imageopenpolygon.xml
+++ b/reference/image/functions/imageopenpolygon.xml
@@ -146,7 +146,6 @@ imageopenpolygon($image, array(
 header('Content-type: image/png');
 
 imagepng($image);
-imagedestroy($image);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagepalettecopy.xml
+++ b/reference/image/functions/imagepalettecopy.xml
@@ -100,8 +100,6 @@ imagefilledrectangle($palette2, 0, 0, 99, 99, $green);
 header('Content-type: image/png');
 
 imagepng($palette2);
-imagedestroy($palette1);
-imagedestroy($palette2);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagepalettetotruecolor.xml
+++ b/reference/image/functions/imagepalettetotruecolor.xml
@@ -75,7 +75,6 @@ if(!function_exists('imagepalettetotruecolor'))
         $dst = imagecreatetruecolor(imagesx($src), imagesy($src));
 
         imagecopy($dst, $src, 0, 0, 0, 0, imagesx($src), imagesy($src));
-        imagedestroy($src);
 
         $src = $dst;
 
@@ -96,9 +95,6 @@ $typeof();
 // Convert it to true color
 imagepalettetotruecolor($im);
 $typeof();
-
-// Free the memory
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagepng.xml
+++ b/reference/image/functions/imagepng.xml
@@ -117,7 +117,6 @@ $im = imagecreatefrompng("test.png");
 header('Content-Type: image/png');
 
 imagepng($im);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagepolygon.xml
+++ b/reference/image/functions/imagepolygon.xml
@@ -142,7 +142,6 @@ imagepolygon($image, array(
 header('Content-type: image/png');
 
 imagepng($image);
-imagedestroy($image);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagerectangle.xml
+++ b/reference/image/functions/imagerectangle.xml
@@ -115,11 +115,9 @@ imagerectangle($canvas, 50, 50, 150, 150, $pink);
 imagerectangle($canvas, 45, 60, 120, 100, $white);
 imagerectangle($canvas, 100, 120, 75, 160, $green);
 
-// Output and free from memory
+// Output
 header('Content-Type: image/jpeg');
-
 imagejpeg($canvas);
-imagedestroy($canvas);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagerotate.xml
+++ b/reference/image/functions/imagerotate.xml
@@ -117,10 +117,6 @@ $rotate = imagerotate($source, $degrees, 0);
 
 // Output
 imagejpeg($rotate);
-
-// Free the memory
-imagedestroy($source);
-imagedestroy($rotate);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagesavealpha.xml
+++ b/reference/image/functions/imagesavealpha.xml
@@ -100,7 +100,6 @@ imagesavealpha($png, true);
 header('Content-Type: image/png');
 
 imagepng($png);
-imagedestroy($png);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagesetbrush.xml
+++ b/reference/image/functions/imagesetbrush.xml
@@ -104,8 +104,6 @@ imageline($im, 50, 50, 50, 60, IMG_COLOR_BRUSHED);
 header('Content-type: image/png');
 
 imagepng($im);
-imagedestroy($im);
-imagedestroy($php);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagesetstyle.xml
+++ b/reference/image/functions/imagesetstyle.xml
@@ -77,7 +77,6 @@ imagesetbrush($im, $brush);
 imageline($im, 100, 0, 0, 100, IMG_COLOR_STYLEDBRUSHED);
 
 imagejpeg($im);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagesetthickness.xml
+++ b/reference/image/functions/imagesetthickness.xml
@@ -84,7 +84,6 @@ imagerectangle($im, 14, 14, 185, 85, $black);
 header('Content-Type: image/png');
 
 imagepng($im);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagesettile.xml
+++ b/reference/image/functions/imagesettile.xml
@@ -103,8 +103,6 @@ imagefilledrectangle($im, 0, 0, 199, 199, IMG_COLOR_TILED);
 header('Content-Type: image/png');
 
 imagepng($im);
-imagedestroy($im);
-imagedestroy($zend);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagestring.xml
+++ b/reference/image/functions/imagestring.xml
@@ -108,7 +108,6 @@ imagestring($im, 5, 0, 0, 'Hello world!', $textcolor);
 header('Content-type: image/png');
 
 imagepng($im);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagestringup.xml
+++ b/reference/image/functions/imagestringup.xml
@@ -104,7 +104,6 @@ imagestringup($im, 3, 40, 80, 'gd library', $textcolor);
 
 // Save the image
 imagepng($im, './stringup.png');
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagetruecolortopalette.xml
+++ b/reference/image/functions/imagetruecolortopalette.xml
@@ -90,7 +90,6 @@ imagetruecolortopalette($im, false, 255);
 
 // Save the image
 imagepng($im, './paletteimage.png');
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagettfbbox.xml
+++ b/reference/image/functions/imagettfbbox.xml
@@ -181,7 +181,6 @@ imagettftext($im, 10, 45, $x, $y, $black, $font, 'and Zend Engine ' . zend_versi
 header('Content-Type: image/png');
 
 imagepng($im);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagettftext.xml
+++ b/reference/image/functions/imagettftext.xml
@@ -183,7 +183,6 @@ imagettftext($im, 20, 0, 10, 20, $black, $font, $text);
 
 // Using imagepng() results in clearer text compared with imagejpeg()
 imagepng($im);
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagewbmp.xml
+++ b/reference/image/functions/imagewbmp.xml
@@ -92,9 +92,6 @@ header('Content-Type: image/vnd.wap.wbmp');
 
 // Output the image
 imagewbmp($im);
-
-// Free up memory
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>
@@ -113,9 +110,6 @@ imagestring($im, 1, 5, 5,  'A Simple Text String', $text_color);
 
 // Save the image
 imagewbmp($im, 'simpletext.wbmp');
-
-// Free up memory
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>
@@ -140,9 +134,6 @@ header('Content-Type: image/vnd.wap.wbmp');
 $foreground_color = imagecolorallocate($im, 255, 0, 0);
 
 imagewbmp($im, NULL, $foreground_color);
-
-// Free up memory
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagewebp.xml
+++ b/reference/image/functions/imagewebp.xml
@@ -97,9 +97,6 @@ imagestring($im, 1, 5, 5,  'WebP with PHP', $text_color);
 
 // Save the image
 imagewebp($im, 'php.webp');
-
-// Free up memory
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagexbm.xml
+++ b/reference/image/functions/imagexbm.xml
@@ -109,9 +109,6 @@ imagestring($im, 1, 5, 5,  'A Simple Text String', $text_color);
 
 // Save the image
 imagexbm($im, 'simpletext.xbm');
-
-// Free up memory
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>
@@ -133,9 +130,6 @@ $foreground_color = imagecolorallocate($im, 255, 0, 0);
 
 // Save the image
 imagexbm($im, NULL, $foreground_color);
-
-// Free up memory
-imagedestroy($im);
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
Because `imagedestroy()` is NOP in all supported PHP versions (as of 8.0.0), there is no need to reference it.