### PR TITLE
Install java in the docker image

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.2-cli
 
 RUN apt-get update && \
-    apt-get install -y git
+    apt-get install -y git default-jre-headless
 
 WORKDIR /var/www
 


### PR DESCRIPTION
Java is used to run jing, to explain schema violations, [here](https://github.com/php/doc-base/blob/643f7dd80707bef61fa661ca6247d344fc46f4bc/configure.php#L1105).