### PR TITLE
Match expressions doesn't need always to be terminated by a semicolon

### DIFF
--- a/language/control-structures/match.xml
+++ b/language/control-structures/match.xml
@@ -86,13 +86,38 @@ string(8) "Teenager"
     The result of a <literal>match</literal> expression does not need to be used.
    </simpara>
   </note>
-  <note>
-   <simpara>
+  <para>
     A <literal>match</literal> expression <emphasis>must</emphasis> be
-    terminated by a semicolon <literal>;</literal>.
-   </simpara>
-  </note>
- </example>
+    terminated by a semicolon <literal>;</literal> in most scenarios.
+    There may be some exceptions where a semicolon is not required, such as
+    nested matches
+    <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+match ($a) {
+    match (true) {1 => 2} => match (true) {1 => 2}
+};
+?>
+]]>
+   </programlisting>
+  </informalexample>
+
+  or operating with the result of the expression
+
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$output = match ($food) {
+    'apple' => 2,
+    default => 0
+} + 3;
+?>
+]]>
+   </programlisting>
+  </informalexample>
+</para>
 
  <para>
   The <literal>match</literal> expression is similar to a


### PR DESCRIPTION
I'm not sure if this PR is important for the documentation, but "match" doesn't always need to be terminated by semicolon. 

I've learned this today :)