### PR TITLE
unserialize(): fix XML tags for union type

### DIFF
--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -89,7 +89,7 @@
         <tbody>
          <row>
           <entry><literal>allowed_classes</literal></entry>
-          <entry><type>array|bool</type></entry>
+          <entry><type class="union"><type>array</type><type>bool</type></type></entry>
           <entry>
            <simpara>
             Either an <type>array</type> of class names which should be


### PR DESCRIPTION
Fix `unserialize()` manual: modify XML tags for union type to make each type name hyperlink.

https://www.php.net/manual/en/function.unserialize.php

`<type>array|bool</type>` is recognized as single type of `array|bool`, which is not defined. `<type class="union">` tag is appropriate for union types.