### PR TITLE
Missing function and method definitions in Example #1 for register_tick_function()

### DIFF
--- a/reference/funchand/functions/register-tick-function.xml
+++ b/reference/funchand/functions/register-tick-function.xml
@@ -59,13 +59,11 @@
 <?php
 declare(ticks=1);
 
-// Callback function
-function my_function($param) {
+function my_tick_function($param) {
     echo "Tick callback function called with param: $param\n";
 }
 
-// using a function as the callback
-register_tick_function('my_function', true);
+register_tick_function('my_tick_function', true);
 ?>
 ]]>
     </programlisting>

--- a/reference/funchand/functions/register-tick-function.xml
+++ b/reference/funchand/functions/register-tick-function.xml
@@ -64,19 +64,8 @@ function my_function($param) {
     echo "Tick callback function called with param: $param\n";
 }
 
-// Class with a method
-class my_class {
-    public function my_method($param) {
-        echo "Tick callback method called with param: $param\n";
-    }
-}
-
 // using a function as the callback
 register_tick_function('my_function', true);
-
-// using an object->method
-$object = new my_class();
-register_tick_function(array($object, 'my_method'), true);
 ?>
 ]]>
     </programlisting>

--- a/reference/funchand/functions/register-tick-function.xml
+++ b/reference/funchand/functions/register-tick-function.xml
@@ -59,6 +59,18 @@
 <?php
 declare(ticks=1);
 
+// Callback function
+function my_function($param) {
+    echo "Tick callback function called with param: $param\n";
+}
+
+// Class with a method
+class my_class {
+    public function my_method($param) {
+        echo "Tick callback method called with param: $param\n";
+    }
+}
+
 // using a function as the callback
 register_tick_function('my_function', true);
 


### PR DESCRIPTION
The example for [register_tick_function()](https://www.php.net/manual/en/function.register-tick-function.php) is incomplete. It is missing the definitions for the callback function my_function and the class method my_method.

Additionally, due to the missing definitions, the "Sandbox Example" code provided on the PHP documentation page cannot be run directly, making it difficult for users to test or understand the functionality.

![Missing function and method definitions in Example #1 for register_tick_function()](https://github.com/user-attachments/assets/c72cd927-6250-4d7a-890f-c3fc163991ce)