### PR TITLE
pg-pconnect: fix typos

### DIFF
--- a/reference/pgsql/functions/pg-pconnect.xml
+++ b/reference/pgsql/functions/pg-pconnect.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
    <function>pg_pconnect</function> opens a connection to a
-   PostgreSQL database. It returns an <classname>PgSql\Connection</classname> instance that is
+   PostgreSQL database. It returns a <classname>PgSql\Connection</classname> instance that is
    needed by other PostgreSQL functions.
   </para>
   <para>
@@ -27,11 +27,11 @@
    <parameter>flags</parameter>.
   </para>
   <para>
-   To enable persistent connection, the <link linkend="ini.pgsql.allow-persistent">pgsql.allow_persistent</link>
-   &php.ini; directive must be set to &quot;On&quot; (which is the default).
-   The maximum number of persistent connection can be defined with the <link linkend="ini.pgsql.max-persistent">pgsql.max_persistent</link>
-   &php.ini; directive (defaults to -1 for no limit). The total number
-   of connections can be set with the <link linkend="ini.pgsql.max-links">pgsql.max_links</link> 
+   To enable persistent connections, the <link linkend="ini.pgsql.allow-persistent">pgsql.allow_persistent</link>
+   &php.ini; directive must be set to <literal>"On"</literal> (which is the default).
+   The maximum number of persistent connections can be defined with the <link linkend="ini.pgsql.max-persistent">pgsql.max_persistent</link>
+   &php.ini; directive (defaults to <literal>-1</literal> for no limit). The total number
+   of connections can be set with the <link linkend="ini.pgsql.max-links">pgsql.max_links</link>
    &php.ini; directive.
   </para>
   <para>
@@ -54,7 +54,7 @@
        the equal sign are optional. To write an empty value or a value 
        containing spaces, surround it with single quotes, e.g., <literal>keyword = 
        'a value'</literal>. Single quotes and backslashes within the value must be 
-       escaped with a backslash, i.e., \' and \\.  
+       escaped with a backslash, i.e., <literal>\'</literal> and <literal>\\</literal>.
       </para>
       <para>
        The currently recognized parameter keywords are:
@@ -63,7 +63,7 @@
        <parameter>password</parameter>, <parameter>connect_timeout</parameter>,
        <parameter>options</parameter>, <parameter>tty</parameter> (ignored), <parameter>sslmode</parameter>,
        <parameter>requiressl</parameter> (deprecated in favor of <parameter>sslmode</parameter>), and
-       <parameter>service</parameter>.  Which of these arguments exist depends
+       <parameter>service</parameter>. Which of these arguments exist depends
        on your PostgreSQL version.
       </para>
      </listitem>
@@ -85,7 +85,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an <classname>PgSql\Connection</classname> instance on success, &return.falseforfailure;.
+   Returns a <classname>PgSql\Connection</classname> instance on success, &return.falseforfailure;.
   </para>
  </refsect1>
 
@@ -103,7 +103,7 @@
      <row>
       <entry>8.1.0</entry>
       <entry>
-       Returns an <classname>PgSql\Connection</classname> instance now;
+       Returns a <classname>PgSql\Connection</classname> instance now;
        previously, a &resource; was returned.
       </entry>
      </row>
@@ -120,18 +120,18 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+// Connect to a database named "mary"
 $dbconn = pg_pconnect("dbname=mary");
-//connect to a database named "mary"
 
+// Connect to a database named "mary" on "localhost" at port "5432"
 $dbconn2 = pg_pconnect("host=localhost port=5432 dbname=mary");
-// connect to a database named "mary" on "localhost" at port "5432"
 
+// Connect to a database named "mary" on the host "sheep" with a username and password
 $dbconn3 = pg_pconnect("host=sheep port=5432 dbname=mary user=lamb password=foo");
-//connect to a database named "mary" on the host "sheep" with a username and password
 
+// Connect to a database named "test" on the host "sheep" with a username and password
 $conn_string = "host=sheep port=5432 dbname=test user=lamb password=bar";
 $dbconn4 = pg_pconnect($conn_string);
-//connect to a database named "test" on the host "sheep" with a username and password
 ?>
 ]]>
     </programlisting>

--- a/reference/pgsql/functions/pg-pconnect.xml
+++ b/reference/pgsql/functions/pg-pconnect.xml
@@ -27,11 +27,14 @@
    <parameter>flags</parameter>.
   </para>
   <para>
-   To enable persistent connections, the <link linkend="ini.pgsql.allow-persistent">pgsql.allow_persistent</link>
+   To enable persistent connections, the
+   <link linkend="ini.pgsql.allow-persistent">pgsql.allow_persistent</link>
    &php.ini; directive must be set to <literal>"On"</literal> (which is the default).
-   The maximum number of persistent connections can be defined with the <link linkend="ini.pgsql.max-persistent">pgsql.max_persistent</link>
-   &php.ini; directive (defaults to <literal>-1</literal> for no limit). The total number
-   of connections can be set with the <link linkend="ini.pgsql.max-links">pgsql.max_links</link>
+   The maximum number of persistent connections can be defined with the
+   <link linkend="ini.pgsql.max-persistent">pgsql.max_persistent</link>
+   &php.ini; directive (defaults to <literal>-1</literal> for no limit).
+   The total number of connections can be set with the
+   <link linkend="ini.pgsql.max-links">pgsql.max_links</link>
    &php.ini; directive.
   </para>
   <para>
@@ -63,8 +66,8 @@
        <parameter>password</parameter>, <parameter>connect_timeout</parameter>,
        <parameter>options</parameter>, <parameter>tty</parameter> (ignored), <parameter>sslmode</parameter>,
        <parameter>requiressl</parameter> (deprecated in favor of <parameter>sslmode</parameter>), and
-       <parameter>service</parameter>. Which of these arguments exist depends
-       on your PostgreSQL version.
+       <parameter>service</parameter>.
+       Which of these arguments exist depends on the PostgreSQL version.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Also, added some literal tags, fixed minor white spacing issues and improved case and position of code comments