### PR TITLE
ArrayObject::__construct: clarify subtyping of `iteratorClass` parameter

### DIFF
--- a/reference/spl/arrayobject/construct.xml
+++ b/reference/spl/arrayobject/construct.xml
@@ -46,7 +46,7 @@
      <listitem>
       <para>
        Specify the class that will be used for iteration of the <classname>ArrayObject</classname> object.
-       The class must extend the <classname>ArrayIterator</classname> class.
+       The class must be a subtype of the <classname>ArrayIterator</classname> class.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Related with https://github.com/php/doc-en/pull/4416