### PR TITLE
Add function-scoped static variable example to New in initializers docs

### DIFF
--- a/language/oop5/decon.xml
+++ b/language/oop5/decon.xml
@@ -203,6 +203,10 @@ static $x = new Foo;
 const C = new Foo;
  
 function test($param = new Foo) {}
+
+function testStatic() {
+    static $x = new Foo;
+}
  
 #[AnAttribute(new Foo)]
 class Test {


### PR DESCRIPTION
I think demonstrating a static variable that holds an object in a function is essential to include in this document, for example :  
```php
<?php

class Foo {
	public string $name;
	public function __construct(string $name) {
		$this->name = $name;
	}
}

function testStatic(?string $entryName = NULL) {
    static $x = new Foo($entryName);
	echo $x->name, PHP_EOL;
    
}
testStatic('iman'); // output : iman
testStatic();       // output : iman (as the object type is static in function, it retains its state) 
```