### PR TITLE
fix function wording pcntl

### DIFF
--- a/reference/pcntl/functions/pcntl-waitpid.xml
+++ b/reference/pcntl/functions/pcntl-waitpid.xml
@@ -54,7 +54,7 @@
            <entry><literal>-1</literal></entry>
            <entry>
             wait for any child process; this is the same behaviour that
-            the wait function exhibits.
+            the <function>pcntl_wait</function> function exhibits.
            </entry>
           </row>
           <row>


### PR DESCRIPTION
[Issue php doc fr](https://github.com/php/doc-fr/pull/2031#issuecomment-2631090273)

This pull request includes a small change to the `reference/pcntl/functions/pcntl-waitpid.xml` file. The change updates the documentation to correctly reference the `pcntl_wait` function instead of the generic `wait` function.

* [`reference/pcntl/functions/pcntl-waitpid.xml`](diffhunk://#diff-dbd5da28d4f8fd870fca632443c4669cbb6be67f68313e8ad43b88bd866775e1L57-R57): Updated the documentation to specify that the behavior is the same as the `pcntl_wait` function.