### PR TITLE
getimagesize() is agnostic of image metadata

### DIFF
--- a/reference/image/functions/getimagesize.xml
+++ b/reference/image/functions/getimagesize.xml
@@ -117,6 +117,14 @@
     zero for width and height in these cases.
    </para>
   </note>
+  <note>
+   <simpara>
+    <function>getimagesize</function> is agnostic of any image metadata.
+    If e.g. the Exif <literal>Orientation</literal> flag is set to a value which
+    rotates the image by 90 or 270 degress, index 0 and 1 are swapped,
+    i.e. the contain the height and width, respectively.
+   </simpara>
+  </note>
   <para>
    Index 2 is one of the <constant>IMAGETYPE_<replaceable>*</replaceable></constant> constants indicating
    the type of the image.


### PR DESCRIPTION
See <https://github.com/php/php-src/issues/17707>.