### PR TITLE
Modernize `foreach` docs

### DIFF
--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -105,14 +105,14 @@ foreach (range(1, 5) as $value) {
   <?phpdoc print-version-for="foreach.list"?>
   <para>
    It is possible to iterate over an array of arrays and unpack the nested array
-   into loop variables by using either 
+   into loop variables by using either
    <link linkend="language.types.array.syntax.destructuring">array destructuring</link>
-   via <literal>[]</literal> or by using the <function>list</function> language 
+   via <literal>[]</literal> or by using the <function>list</function> language
    construct as the value.
 
    <note>
     <para>
-     Please note that 
+     Please note that
      <link linkend="language.types.array.syntax.destructuring">array destructuring</link>
      via <literal>[]</literal> is only possible as of PHP 7.1.0
     </para>
@@ -122,8 +122,8 @@ foreach (range(1, 5) as $value) {
   <para>
    <informalexample>
     <simpara>
-     In both of the following examples <literal>$a</literal> will be set to 
-     the first element of the nested array and <literal>$b</literal> will 
+     In both of the following examples <literal>$a</literal> will be set to
+     the first element of the nested array and <literal>$b</literal> will
      contain the second element:
     </simpara>
     <programlisting role="php">
@@ -303,14 +303,12 @@ foreach ([1, 2, 3, 4] as &$value) {
 
  <sect2 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><link linkend="language.types.array">array</link></member>
-    <member><interfacename>Traversable</interfacename></member>
-    <member><link linkend="language.types.iterable">iterable</link></member>
-    <member><function>list</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><link linkend="language.types.array">array</link></member>
+   <member><interfacename>Traversable</interfacename></member>
+   <member><link linkend="language.types.iterable">iterable</link></member>
+   <member><function>list</function></member>
+  </simplelist>
  </sect2>
 
 </sect1>

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -5,13 +5,14 @@
  <?phpdoc print-version-for="foreach"?>
  <para>
   The <literal>foreach</literal> construct provides an easy way to
-  iterate over <literal>arrays</literal> and <literal>Traversable</literal> objects.
+  iterate over <type>array</type>s and <interfacename>Traversable</interfacename> objects.
   <literal>foreach</literal> will issue an error when you try to use it
   on a variable with a different data type or an uninitialized variable.
-
-  Foreach can optionally get the <literal>key</literal> of each element:
   <informalexample>
-   <programlisting>
+  <simpara>
+   <literal>foreach</literal> can optionally get the <literal>key</literal> of each element:
+  </simpara>
+  <programlisting>
 <![CDATA[
 foreach (iterable_expression as $value) {
     statement_list
@@ -43,10 +44,9 @@ foreach (iterable_expression as $key => $value) {
   <link linkend="language.oop5.iterations">customize object iteration</link>.
  </simpara>
 
- <para>
-  Examples usages:
-  <informalexample>
-   <programlisting role="php">
+ <example>
+  <title>Common <literal>foreach</literal> usages</title>
+  <programlisting role="php">
 <![CDATA[
 <?php
 /* Example: value only */
@@ -90,38 +90,42 @@ foreach (range(1, 5) as $value) {
 }
 ?>
 ]]>
-   </programlisting>
-  </informalexample>
- </para>
- <para>
-  <note>
-   <para>
-    <literal>foreach</literal> does not support the ability to
-    suppress error messages using
-    <literal linkend="language.operators.errorcontrol">@</literal>.
-   </para>
-  </note>
- </para>
+  </programlisting>
+ </example>
+ <note>
+  <para>
+   <literal>foreach</literal> does not support the ability to
+   suppress error messages using
+   <literal linkend="language.operators.errorcontrol">@</literal>.
+  </para>
+ </note>
 
  <sect2 xml:id="control-structures.foreach.list">
   <title>Unpacking nested arrays</title>
   <?phpdoc print-version-for="foreach.list"?>
   <para>
    It is possible to iterate over an array of arrays and unpack the nested array
-   into loop variables by using the <function>list</function> language construct as the value.
+   into loop variables by using either 
+   <link linkend="language.types.array.syntax.destructuring">array destructuring</link>
+   via <literal>[]</literal> or by using the <function>list</function> language 
+   construct as the value.
 
    <note>
     <para>
-     Arrays can also be unpacked using
+     Please note that 
      <link linkend="language.types.array.syntax.destructuring">array destructuring</link>
-     via <literal>[]</literal> (as of PHP 7.1.0)
+     via <literal>[]</literal> is only possible as of PHP 7.1.0
     </para>
    </note>
   </para>
 
   <para>
-   For example:
    <informalexample>
+    <simpara>
+     In both of the following examples <literal>$a</literal> will be set to 
+     the first element of the nested array and <literal>$b</literal> will 
+     contain the second element:
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -129,10 +133,6 @@ $array = [
     [1, 2],
     [3, 4],
 ];
-
-// In both examples
-// $a contains the first element of the nested array
-// $b contains the second element.
 
 foreach ($array as [$a, $b]) {
     echo "A: $a; B: $b\n";
@@ -155,8 +155,9 @@ A: 3; B: 4
   </para>
 
   <para>
-   You can provide fewer elements than there are in the nested array,
-   in which case the leftover array values will be ignored:
+   When providing fewer variables than there are elements in the array,
+   the remaining elements will be ignored. Similarly, elements can be skipped
+   over by using a comma:
    <informalexample>
     <programlisting role="php">
 <![CDATA[
@@ -166,7 +167,7 @@ $array = [
     [3, 4, 6],
 ];
 
-foreach ($array as [$a, $b, ]) {
+foreach ($array as [$a, $b]) {
     // Note that there is no $c here.
     echo "$a $b\n";
 }
@@ -231,7 +232,7 @@ A: 3; B: 4; C:
    <link linkend="language.references">reference</link>.
    <informalexample>
     <programlisting role="php">
-    <![CDATA[
+<![CDATA[
 <?php
 $arr = [1, 2, 3, 4];
 foreach ($arr as &$value) {
@@ -246,10 +247,10 @@ unset($value); // break the reference with the last element
   </para>
   <warning>
    <para>
-    Reference of a <literal>$value</literal> and the last array element
+    Reference to a <literal>$value</literal> of the last array element
     remain even after the <literal>foreach</literal> loop. It is recommended
-    to destroy it by <function>unset</function>.
-    Otherwise you will experience the following behavior:
+    to destroy these using <function>unset</function>.
+    Otherwise, the following behavior will occur:
    </para>
    <informalexample>
     <programlisting role="php">

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -5,10 +5,10 @@
  <?phpdoc print-version-for="foreach"?>
  <para>
   The <literal>foreach</literal> construct provides an easy way to
-  iterate over <literal>arrays</literal> and <literal>Traversable</literal> objects. 
-  <literal>foreach</literal> will issue an error when you try to use it 
+  iterate over <literal>arrays</literal> and <literal>Traversable</literal> objects.
+  <literal>foreach</literal> will issue an error when you try to use it
   on a variable with a different data type or an uninitialized variable.
-  
+
   Foreach can optionally get the <literal>key</literal> of each element:
   <informalexample>
    <programlisting>
@@ -16,7 +16,7 @@
 foreach (iterable_expression as $value) {
     statement_list
 }
-    
+
 foreach (iterable_expression as $key => $value) {
     statement_list
 }
@@ -107,12 +107,12 @@ foreach (range(1, 5) as $value) {
   <title>Unpacking nested arrays</title>
   <?phpdoc print-version-for="foreach.list"?>
   <para>
-   It is possible to iterate over an array of arrays and unpack the nested array 
+   It is possible to iterate over an array of arrays and unpack the nested array
    into loop variables by using the <function>list</function> language construct as the value.
-   
+
    <note>
     <para>
-     Arrays can also be unpacked using 
+     Arrays can also be unpacked using
      <link linkend="language.types.array.syntax.destructuring">array destructuring</link>
      via <literal>[]</literal> (as of PHP 7.1.0)
     </para>
@@ -213,10 +213,10 @@ foreach ($array as [$a, $b, $c]) {
     <screen>
 <![CDATA[
 Notice: Undefined offset: 2 in example.php on line 7
-A: 1; B: 2; C: 
+A: 1; B: 2; C:
 
 Notice: Undefined offset: 2 in example.php on line 7
-A: 3; B: 4; C: 
+A: 3; B: 4; C:
 ]]>
     </screen>
    </informalexample>

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -67,7 +67,7 @@ $array = [
 ];
 
 foreach ($array as $key => $value) {
-    echo "\$array['$key'] => $value.\n";
+    printf("\$array['%s'] => %s\n", $key, $value);
 }
 
 /* Example: multi-dimensional key-value arrays */
@@ -85,7 +85,7 @@ foreach ($grid as $y => $row) {
 
 /* Example: dynamic arrays */
 
-foreach (range(1,5) as $value) {
+foreach (range(1, 5) as $value) {
     echo "$value\n";
 }
 ?>
@@ -289,7 +289,7 @@ foreach ($arr as $key => $value) {
     <programlisting role="php">
     <![CDATA[
 <?php
-foreach (array(1, 2, 3, 4) as &$value) {
+foreach ([1, 2, 3, 4] as &$value) {
     $value = $value * 2;
 }
 ?>

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -12,7 +12,7 @@
    <simpara>
     <literal>foreach</literal> can optionally get the <literal>key</literal> of each element:
    </simpara>
-  <programlisting>
+   <programlisting>
 <![CDATA[
 foreach (iterable_expression as $value) {
     statement_list
@@ -96,7 +96,7 @@ foreach (range(1, 5) as $value) {
   <para>
    <literal>foreach</literal> does not support the ability to
    suppress error messages using the
-   <link linkend="language.operators.errorcontrol">@</link>.
+   <link linkend="language.operators.errorcontrol"><literal>@</literal></link>.
   </para>
  </note>
 
@@ -287,7 +287,7 @@ foreach ($arr as $key => $value) {
   </warning>
   <example>
   <title>Iterate a constant array's values by reference</title>
-    <programlisting role="php">
+   <programlisting role="php">
 <![CDATA[
 <?php
 foreach ([1, 2, 3, 4] as &$value) {
@@ -295,8 +295,8 @@ foreach ([1, 2, 3, 4] as &$value) {
 }
 ?>
 ]]>
-    </programlisting>
-   </example>
+   </programlisting>
+  </example>
  </sect2>
 
  <sect2 role="seealso">

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -9,9 +9,9 @@
   <literal>foreach</literal> will issue an error when you try to use it
   on a variable with a different data type or an uninitialized variable.
   <informalexample>
-  <simpara>
-   <literal>foreach</literal> can optionally get the <literal>key</literal> of each element:
-  </simpara>
+   <simpara>
+    <literal>foreach</literal> can optionally get the <literal>key</literal> of each element:
+   </simpara>
   <programlisting>
 <![CDATA[
 foreach (iterable_expression as $value) {
@@ -67,7 +67,7 @@ $array = [
 ];
 
 foreach ($array as $key => $value) {
-    printf("\$array['%s'] => %s\n", $key, $value);
+    echo "Key: $key => Value: $value\n";
 }
 
 /* Example: multi-dimensional key-value arrays */
@@ -95,8 +95,8 @@ foreach (range(1, 5) as $value) {
  <note>
   <para>
    <literal>foreach</literal> does not support the ability to
-   suppress error messages using
-   <literal linkend="language.operators.errorcontrol">@</literal>.
+   suppress error messages using the
+   <link linkend="language.operators.errorcontrol">@</link>.
   </para>
  </note>
 
@@ -111,11 +111,11 @@ foreach (range(1, 5) as $value) {
    construct as the value.
 
    <note>
-    <para>
+    <simpara>
      Please note that
      <link linkend="language.types.array.syntax.destructuring">array destructuring</link>
      via <literal>[]</literal> is only possible as of PHP 7.1.0
-    </para>
+    </simpara>
    </note>
   </para>
 
@@ -156,8 +156,8 @@ A: 3; B: 4
 
   <para>
    When providing fewer variables than there are elements in the array,
-   the remaining elements will be ignored. Similarly, elements can be skipped
-   over by using a comma:
+   the remaining elements will be ignored.
+   Similarly, elements can be skipped over by using a comma:
    <informalexample>
     <programlisting role="php">
 <![CDATA[
@@ -228,7 +228,8 @@ A: 3; B: 4; C:
   <title>foreach and references</title>
   <para>
    It is possible to directly modify array elements within a loop by preceding
-   <literal>$value</literal> with &amp;. In that case the value will be assigned by
+   <literal>$value</literal> with <literal>&amp;</literal>.
+   In that case the value will be assigned by
    <link linkend="language.references">reference</link>.
    <informalexample>
     <programlisting role="php">
@@ -246,15 +247,15 @@ unset($value); // break the reference with the last element
    </informalexample>
   </para>
   <warning>
-   <para>
+   <simpara>
     Reference to a <literal>$value</literal> of the last array element
     remain even after the <literal>foreach</literal> loop. It is recommended
     to destroy these using <function>unset</function>.
     Otherwise, the following behavior will occur:
-   </para>
+   </simpara>
    <informalexample>
     <programlisting role="php">
-    <![CDATA[
+<![CDATA[
 <?php
 $arr = [1, 2, 3, 4];
 foreach ($arr as &$value) {
@@ -275,7 +276,7 @@ foreach ($arr as $key => $value) {
     </programlisting>
     &example.outputs;
     <screen>
-     <![CDATA[
+<![CDATA[
 0 => 2 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 2 )
 1 => 4 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 4 )
 2 => 6 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 6 )
@@ -284,11 +285,10 @@ foreach ($arr as $key => $value) {
     </screen>
    </informalexample>
   </warning>
-  <para>
-   It is possible to iterate a constant array's value by reference:
-   <informalexample>
+  <example>
+  <title>Iterate a constant array's values by reference</title>
     <programlisting role="php">
-    <![CDATA[
+<![CDATA[
 <?php
 foreach ([1, 2, 3, 4] as &$value) {
     $value = $value * 2;
@@ -296,9 +296,7 @@ foreach ([1, 2, 3, 4] as &$value) {
 ?>
 ]]>
     </programlisting>
-
-   </informalexample>
-  </para>
+   </example>
  </sect2>
 
  <sect2 role="seealso">

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -184,18 +184,23 @@ foreach (array(1, 2, 3, 4, 5) as $v) {
  </para>
 
  <sect2 xml:id="control-structures.foreach.list">
-  <title>Unpacking nested arrays with list()</title>
+  <title>Unpacking nested arrays</title>
   <?phpdoc print-version-for="foreach.list"?>
-
   <para>
-   It is possible to iterate over an array of arrays and unpack the
-   nested array into loop variables by providing a <function>list</function>
-   as the value.
+   It is possible to iterate over an array of arrays and unpack the nested array 
+   into loop variables by using the <function>list</function> language construct as the value.
+   
+   <note>
+    <para>
+     Arrays can also be unpacked using 
+     <link linkend="language.types.array.syntax.destructuring">array destructuring</link>
+     via <literal>[]</literal> (as of PHP 7.1.0)
+    </para>
+   </note>
   </para>
 
   <para>
    For example:
-
    <informalexample>
     <programlisting role="php">
 <![CDATA[
@@ -205,9 +210,15 @@ $array = [
     [3, 4],
 ];
 
+// In both examples
+// $a contains the first element of the nested array
+// $b contains the second element.
+
+foreach ($array as [$a, $b]) {
+    echo "A: $a; B: $b\n";
+}
+
 foreach ($array as list($a, $b)) {
-    // $a contains the first element of the nested array,
-    // and $b contains the second element.
     echo "A: $a; B: $b\n";
 }
 ?>
@@ -224,22 +235,25 @@ A: 3; B: 4
   </para>
 
   <para>
-   You can provide fewer elements in the <function>list</function> than there
-   are in the nested array, in which case the leftover array values will be
-   ignored:
-
+   You can provide fewer elements than there are in the nested array,
+   in which case the leftover array values will be ignored:
    <informalexample>
     <programlisting role="php">
 <![CDATA[
 <?php
 $array = [
-    [1, 2],
-    [3, 4],
+    [1, 2, 3],
+    [3, 4, 6],
 ];
 
-foreach ($array as list($a)) {
-    // Note that there is no $b here.
-    echo "$a\n";
+foreach ($array as [$a, $b, ]) {
+    // Note that there is no $c here.
+    echo "$a $b\n";
+}
+
+foreach ($array as [, , $c]) {
+    // Skipping over $a and $b
+    echo "$c\n";
 }
 ?>
 ]]>
@@ -247,8 +261,10 @@ foreach ($array as list($a)) {
     &example.outputs;
     <screen>
 <![CDATA[
-1
-3
+1 2
+3 4
+5
+6
 ]]>
     </screen>
    </informalexample>
@@ -267,7 +283,7 @@ $array = [
     [3, 4],
 ];
 
-foreach ($array as list($a, $b, $c)) {
+foreach ($array as [$a, $b, $c]) {
     echo "A: $a; B: $b; C: $c\n";
 }
 ?>
@@ -276,7 +292,6 @@ foreach ($array as list($a, $b, $c)) {
     &example.outputs;
     <screen>
 <![CDATA[
-
 Notice: Undefined offset: 2 in example.php on line 7
 A: 1; B: 2; C: 
 

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -13,10 +13,13 @@
   <informalexample>
    <programlisting>
 <![CDATA[
-foreach (iterable_expression as $value)
-    statement
-foreach (iterable_expression as $key => $value)
-    statement
+foreach (iterable_expression as $value) {
+    statement_list
+}
+    
+foreach (iterable_expression as $key => $value) {
+    statement_list
+}
 ]]>
    </programlisting>
   </informalexample>

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -44,68 +44,49 @@ foreach (iterable_expression as $key => $value) {
  </simpara>
 
  <para>
-  In order to be able to directly modify array elements within the loop precede
- <literal>$value</literal> with &amp;. In that case the value will be assigned by
- <link linkend="language.references">reference</link>.
+  Examples usages:
   <informalexample>
    <programlisting role="php">
 <![CDATA[
 <?php
-$arr = array(1, 2, 3, 4);
-foreach ($arr as &$value) {
-    $value = $value * 2;
-}
-// $arr is now array(2, 4, 6, 8)
-unset($value); // break the reference with the last element
-?>
-]]>
-   </programlisting>
-  </informalexample>
- </para>
- <warning>
-  <para>
-   Reference of a <literal>$value</literal> and the last array element
-   remain even after the <literal>foreach</literal> loop. It is recommended
-   to destroy it by <function>unset</function>.
-   Otherwise you will experience the following behavior:
-  </para>
-  <informalexample>
-   <programlisting role="php">
-<![CDATA[
-<?php
-$arr = array(1, 2, 3, 4);
-foreach ($arr as &$value) {
-    $value = $value * 2;
-}
-// $arr is now array(2, 4, 6, 8)
+/* Example: value only */
 
-// without an unset($value), $value is still a reference to the last item: $arr[3]
+$array = [1, 2, 3, 17];
 
-foreach ($arr as $key => $value) {
-    // $arr[3] will be updated with each value from $arr...
-    echo "{$key} => {$value} ";
-    print_r($arr);
+foreach ($array as $value) {
+    echo "Current element of \$array: $value.\n";
 }
-// ...until ultimately the second-to-last value is copied onto the last value
 
-// output:
-// 0 => 2 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 2 )
-// 1 => 4 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 4 )
-// 2 => 6 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 6 )
-// 3 => 6 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 6 )
-?>
-]]>
-   </programlisting>
-  </informalexample>
- </warning>
- <para>
-  It is possible to iterate a constant array's value by reference:
-  <informalexample>
-   <programlisting role="php">
-<![CDATA[
-<?php
-foreach (array(1, 2, 3, 4) as &$value) {
-    $value = $value * 2;
+/* Example: key and value */
+
+$array = [
+    "one" => 1,
+    "two" => 2,
+    "three" => 3,
+    "seventeen" => 17
+];
+
+foreach ($array as $key => $value) {
+    echo "\$array['$key'] => $value.\n";
+}
+
+/* Example: multi-dimensional key-value arrays */
+$grid = [];
+$grid[0][0] = "a";
+$grid[0][1] = "b";
+$grid[1][0] = "y";
+$grid[1][1] = "z";
+
+foreach ($grid as $y => $row) {
+    foreach ($row as $x => $value) {
+        echo "Value at position x=$x and y=$y: $value\n";
+    }
+}
+
+/* Example: dynamic arrays */
+
+foreach (range(1,5) as $value) {
+    echo "$value\n";
 }
 ?>
 ]]>
@@ -120,67 +101,6 @@ foreach (array(1, 2, 3, 4) as &$value) {
     <literal linkend="language.operators.errorcontrol">@</literal>.
    </para>
   </note>
- </para>
- <para>
-  Some more examples to demonstrate usage:
-  <informalexample>
-   <programlisting role="php">
-<![CDATA[
-<?php
-/* foreach example 1: value only */
-
-$a = array(1, 2, 3, 17);
-
-foreach ($a as $v) {
-    echo "Current value of \$a: $v.\n";
-}
-
-/* foreach example 2: value (with its manual access notation printed for illustration) */
-
-$a = array(1, 2, 3, 17);
-
-$i = 0; /* for illustrative purposes only */
-
-foreach ($a as $v) {
-    echo "\$a[$i] => $v.\n";
-    $i++;
-}
-
-/* foreach example 3: key and value */
-
-$a = array(
-    "one" => 1,
-    "two" => 2,
-    "three" => 3,
-    "seventeen" => 17
-);
-
-foreach ($a as $k => $v) {
-    echo "\$a[$k] => $v.\n";
-}
-
-/* foreach example 4: multi-dimensional arrays */
-$a = array();
-$a[0][0] = "a";
-$a[0][1] = "b";
-$a[1][0] = "y";
-$a[1][1] = "z";
-
-foreach ($a as $v1) {
-    foreach ($v1 as $v2) {
-        echo "$v2\n";
-    }
-}
-
-/* foreach example 5: dynamic arrays */
-
-foreach (array(1, 2, 3, 4, 5) as $v) {
-    echo "$v\n";
-}
-?>
-]]>
-   </programlisting>
-  </informalexample>
  </para>
 
  <sect2 xml:id="control-structures.foreach.list">
@@ -300,6 +220,95 @@ A: 3; B: 4; C:
 ]]>
     </screen>
    </informalexample>
+  </para>
+ </sect2>
+
+ <sect2 xml:id="control-structures.foreach.reference">
+  <title>foreach and references</title>
+  <para>
+   It is possible to directly modify array elements within a loop by preceding
+   <literal>$value</literal> with &amp;. In that case the value will be assigned by
+   <link linkend="language.references">reference</link>.
+   <informalexample>
+    <programlisting role="php">
+    <![CDATA[
+<?php
+$arr = [1, 2, 3, 4];
+foreach ($arr as &$value) {
+    $value = $value * 2;
+}
+// $arr is now [2, 4, 6, 8]
+unset($value); // break the reference with the last element
+?>
+]]>
+    </programlisting>
+   </informalexample>
+  </para>
+  <warning>
+   <para>
+    Reference of a <literal>$value</literal> and the last array element
+    remain even after the <literal>foreach</literal> loop. It is recommended
+    to destroy it by <function>unset</function>.
+    Otherwise you will experience the following behavior:
+   </para>
+   <informalexample>
+    <programlisting role="php">
+    <![CDATA[
+<?php
+$arr = [1, 2, 3, 4];
+foreach ($arr as &$value) {
+    $value = $value * 2;
+}
+// $arr is now [2, 4, 6, 8]
+
+// without an unset($value), $value is still a reference to the last item: $arr[3]
+
+foreach ($arr as $key => $value) {
+    // $arr[3] will be updated with each value from $arr...
+    echo "{$key} => {$value} ";
+    print_r($arr);
+}
+// ...until ultimately the second-to-last value is copied onto the last value
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+     <![CDATA[
+0 => 2 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 2 )
+1 => 4 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 4 )
+2 => 6 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 6 )
+3 => 6 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 6 )
+]]>
+    </screen>
+   </informalexample>
+  </warning>
+  <para>
+   It is possible to iterate a constant array's value by reference:
+   <informalexample>
+    <programlisting role="php">
+    <![CDATA[
+<?php
+foreach (array(1, 2, 3, 4) as &$value) {
+    $value = $value * 2;
+}
+?>
+]]>
+    </programlisting>
+
+   </informalexample>
+  </para>
+ </sect2>
+
+ <sect2 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><link linkend="language.types.array">array</link></member>
+    <member><interfacename>Traversable</interfacename></member>
+    <member><link linkend="language.types.iterable">iterable</link></member>
+    <member><function>list</function></member>
+   </simplelist>
   </para>
  </sect2>
 

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <sect1 xml:id="control-structures.foreach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>foreach</title>
  <?phpdoc print-version-for="foreach"?>
  <para>
   The <literal>foreach</literal> construct provides an easy way to
-  iterate over arrays. <literal>foreach</literal> works only on arrays
-  and objects, and will issue an error when you try to use it on a variable
-  with a different data type or an uninitialized variable. There are two
-  syntaxes:
+  iterate over <literal>arrays</literal> and <literal>Traversable</literal> objects. 
+  <literal>foreach</literal> will issue an error when you try to use it 
+  on a variable with a different data type or an uninitialized variable.
+  
+  Foreach can optionally get the <literal>key</literal> of each element:
   <informalexample>
    <programlisting>
 <![CDATA[

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -6,8 +6,8 @@
  <para>
   The <literal>foreach</literal> construct provides an easy way to
   iterate over <type>array</type>s and <interfacename>Traversable</interfacename> objects.
-  <literal>foreach</literal> will issue an error when you try to use it
-  on a variable with a different data type or an uninitialized variable.
+  <literal>foreach</literal> will issue an error when used with
+  a variable containing a different data type or with an uninitialized variable.
   <informalexample>
    <simpara>
     <literal>foreach</literal> can optionally get the <literal>key</literal> of each element:


### PR DESCRIPTION
The goal of this rework is to, hopefully, bring the `foreach` docs up to current practices and widely used syntax

https://www.php.net/manual/en/control-structures.foreach.php

The main motivation for this was that the *first* example on the current page is the following: 

```
<?php
$arr = array(1, 2, 3, 4);
foreach ($arr as &$value) {
    $value = $value * 2;
}
```

Given that this uses a reference and classic array syntax, I felt we can showcase `foreach` better.

The focused on the following aspects:

- Use short array syntax everywhere
- Easier to visually parse pseudocode example 
- Prefer names to abbreviations `[$a => $array, $k => $key, $v => $value]` for readability
- Implicitly prefer `array destructuring []` over `list()` by mentioning it first in the examples, as it's the more commonly used syntax as far as I'm aware.
- Push `foreach and references` down on the page to showcase common usages first.
- Add `See also` to link to `array`, `Traversable`, `iterable` and `list()`
- Don't rewrite the whole page but keep what's there for the most part

Happy to make any changes 