### PR TITLE
password_hash: Update for PHP 8.4

### DIFF
--- a/reference/password/functions/password-hash.xml
+++ b/reference/password/functions/password-hash.xml
@@ -34,9 +34,9 @@
     </listitem>
     <listitem>
      <simpara>
-      <constant>PASSWORD_BCRYPT</constant> - Use the <constant>CRYPT_BLOWFISH</constant> algorithm to
+      <constant>PASSWORD_BCRYPT</constant> - Use the bcrypt algorithm to
       create the hash. This will produce a standard <function>crypt</function> compatible hash using
-      the "$2y$" identifier. The result will always be a 60 character string, &return.falseforfailure;.
+      the <literal>$2y$</literal> identifier. The result will always be a 60 character string, &return.falseforfailure;.
      </simpara>
     </listitem>
     <listitem>
@@ -81,8 +81,8 @@
       Examples of these values can be found on the <function>crypt</function> page.
      </para>
      <para>
-      If omitted, a default value of <literal>10</literal> will be used. This is a good
-      baseline cost, but you may want to consider increasing it depending on your hardware.
+      If omitted, a default value of <literal>12</literal> will be used. This is a good
+      baseline cost, but you may want to consider adjusting it depending on your hardware.
      </para>
     </listitem>
    </itemizedlist>
@@ -153,10 +153,6 @@
      <para>
       &password.parameter.options;
      </para>
-     <para>
-      If omitted, a random salt will be created and the default cost will be
-      used.
-     </para>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -187,6 +183,14 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        The default value of the <literal>cost</literal> option of the
+        <constant>PASSWORD_BCRYPT</constant> algorithm was increased from
+        <literal>10</literal> to <literal>12</literal>.
+       </entry>
+      </row>
       <row>
        <entry>8.3.0</entry>
        <entry>
@@ -265,7 +269,7 @@ echo password_hash("rasmuslerdorf", PASSWORD_DEFAULT);
     &example.outputs.similar;
     <screen>
 <![CDATA[
-$2y$10$.vGA1O9wmRjrwAVXD98HNOgsNpDczlqm3Jq7KnEd1rVAGv3Fykk1a
+$2y$12$4Umg0rCJwMswRw/l.SwHvuQV01coP0eWmGzd61QH2RvAOMANUBGC.
 ]]>
     </screen>
    </example>
@@ -277,11 +281,10 @@ $2y$10$.vGA1O9wmRjrwAVXD98HNOgsNpDczlqm3Jq7KnEd1rVAGv3Fykk1a
 <![CDATA[
 <?php
 /**
- * In this case, we want to increase the default cost for BCRYPT to 12.
- * Note that we also switched to BCRYPT, which will always be 60 characters.
+ * In this case, we want to increase the cost for bcrypt to 13.
  */
 $options = [
-    'cost' => 12,
+    'cost' => 13,
 ];
 echo password_hash("rasmuslerdorf", PASSWORD_BCRYPT, $options);
 ?>
@@ -290,7 +293,7 @@ echo password_hash("rasmuslerdorf", PASSWORD_BCRYPT, $options);
     &example.outputs.similar;
     <screen>
 <![CDATA[
-$2y$12$QjSH496pcT5CEbzjD/vtVeH03tfHKFy36d4J0Ltp3lRtee9HDxY3K
+$2y$13$xeDfQumlmdm0Sco.4qmH1OGfUUmOcuRmfae0dPJhjX1Bq0yYhqbNi
 ]]>
     </screen>
    </example>
@@ -304,13 +307,13 @@ $2y$12$QjSH496pcT5CEbzjD/vtVeH03tfHKFy36d4J0Ltp3lRtee9HDxY3K
 /**
  * This code will benchmark your server to determine how high of a cost you can
  * afford. You want to set the highest cost that you can without slowing down
- * you server too much. 10 is a good baseline, and more is good if your servers
+ * you server too much. 11 is a good baseline, and more is good if your servers
  * are fast enough. The code below aims for ≤ 350 milliseconds stretching time,
  * which is an appropriate delay for systems handling interactive logins.
  */
 $timeTarget = 0.350; // 350 milliseconds
 
-$cost = 10;
+$cost = 11;
 do {
     $cost++;
     $start = microtime(true);
@@ -325,7 +328,7 @@ echo "Appropriate Cost Found: " . $cost;
     &example.outputs.similar;
     <screen>
 <![CDATA[
-Appropriate Cost Found: 12
+Appropriate Cost Found: 13
 ]]>
     </screen>
    </example>

--- a/reference/password/functions/password-needs-rehash.xml
+++ b/reference/password/functions/password-needs-rehash.xml
@@ -96,11 +96,11 @@
 <?php
 
 $password = 'rasmuslerdorf';
-$hash = '$2y$10$YCFsG6elYca568hBi2pZ0.3LDL5wjgxct1N8w/oLR/jfHsiQwCqTS';
+$hash = '$2y$12$4Umg0rCJwMswRw/l.SwHvuQV01coP0eWmGzd61QH2RvAOMANUBGC.';
 
 $algorithm = PASSWORD_BCRYPT;
 // bcrypt's cost parameter can change over time as hardware improves
-$options = ['cost' => 12];
+$options = ['cost' => 13];
 
 // Verify stored hash against plain-text password
 if (password_verify($password, $hash)) {

--- a/reference/password/functions/password-verify.xml
+++ b/reference/password/functions/password-verify.xml
@@ -72,7 +72,7 @@
 <![CDATA[
 <?php
 // See the password_hash() example to see where this came from.
-$hash = '$2y$10$.vGA1O9wmRjrwAVXD98HNOgsNpDczlqm3Jq7KnEd1rVAGv3Fykk1a';
+$hash = '$2y$12$4Umg0rCJwMswRw/l.SwHvuQV01coP0eWmGzd61QH2RvAOMANUBGC.';
 
 if (password_verify('rasmuslerdorf', $hash)) {
     echo 'Password is valid!';


### PR DESCRIPTION
This updates the `password_hash()` documentation for the updated default cost of bcrypt in PHP 8.4. It also performs some general cleanup.