### PR TITLE
Add one necessary step to enable DTrace

### DIFF
--- a/features/dtrace.xml
+++ b/features/dtrace.xml
@@ -91,9 +91,12 @@
     </informalexample>
    </para>
    <para>
-    This enables the static probes in core PHP.  Any PHP extensions
+    This makes the static probes available in core PHP.  Any PHP extensions
     that provide their own probes should be built separately as shared
     extensions.
+   </para>
+   <para>
+    To enable probes, set <option>USE_ZEND_DTRACE=1</option> environment variable to the target PHP processes.
    </para>
   </sect2>
 


### PR DESCRIPTION
From PHP 7.0.14,  `USE_ZEND_DTRACE=1` must be set to target PHP processes to enable DTrace actually.
https://github.com/php/php-src/commit/0c78fe4bb55a9d39afc79cbcbadb9a273f2ec2ef

Though this requirement is not explained explicitly in the manual, so this PR adds the step.

I personally discovered this when I tried to trace USDT probe points using eBPF.
I hope this could help someone who want to use this feature. 