### PR TITLE
Add output screens for last two exception examples

### DIFF
--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -325,6 +325,12 @@ try {
 ?>
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+A SpecificException was thrown, but we don't care about the details.
+]]>
+    </screen>
    </example>
    <example>
     <title>Throw as an expression</title>
@@ -337,6 +343,10 @@ function test() {
     do_something_risky() or throw new Exception('It did not work');
 }
 
+function do_something_risky() {
+    return false; // Simulate failure
+}
+
 try {
     test();
 } catch (Exception $e) {
@@ -345,6 +355,12 @@ try {
 ?>
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+It did not work
+]]>
+    </screen>
    </example>
   </sect1>
 


### PR DESCRIPTION
Adjusted the last example to prevent an 'undefined function' error and added output screens for the last two exception examples.