### PR TITLE
Re-add mysqli::__construct return value description

### DIFF
--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -124,6 +124,10 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
+   <methodname>mysqli::__construct</methodname> always returns an object which represents the connection to a MySQL Server,
+   regardless of it being successful or not.
+  </para>
+  <para>
    <function>mysqli_connect</function> returns an object which represents the connection to a MySQL Server,
    &return.falseforfailure;.
   </para>

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -124,7 +124,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <methodname>mysqli::__construct</methodname> always returns an object which represents the connection to a MySQL Server,
+   <methodname>mysqli::__construct</methodname> always returns an object
+   which represents the connection to a MySQL Server,
    regardless of it being successful or not.
   </para>
   <para>


### PR DESCRIPTION
In https://github.com/php/doc-en/commit/390278d79b453af8f2f0837596c4cd25882b951a, lines 126-129 were incorrectly removed - `__construct` will still return an object in all circumstances.