### PR TITLE
More precise IteratorAggregate::getIterator() description

### DIFF
--- a/language/predefined/iteratoraggregate/getiterator.xml
+++ b/language/predefined/iteratoraggregate/getiterator.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="iteratoraggregate.getiterator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IteratorAggregate::getIterator</refname>
-  <refpurpose>Retrieve an external iterator</refpurpose>
+  <refpurpose>Retrieve an external iterator or traversable</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,7 +13,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Returns an external traversable.
+   Returns an external iterator or traversable.
   </para>
  </refsect1>
 

--- a/language/predefined/iteratoraggregate/getiterator.xml
+++ b/language/predefined/iteratoraggregate/getiterator.xml
@@ -13,7 +13,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Returns an external iterator.
+   Returns an external traversable.
   </para>
  </refsect1>
 


### PR DESCRIPTION
the return type is not always a iterator, therefore use less wording which implies it would

triggered by https://github.com/phpstan/phpstan/issues/12619#issuecomment-2670970120