### PR TITLE
Adjust column width in resources.xml for improved layout

### DIFF
--- a/appendices/resources.xml
+++ b/appendices/resources.xml
@@ -13,7 +13,7 @@
    <tgroup cols="5">
      <colspec colwidth='1*'/>
      <colspec colwidth='1*'/>
-     <colspec colwidth='1.4*'/>
+     <colspec colwidth='2*'/>
      <colspec colwidth='1*'/>
      <colspec colwidth='1*'/>
      <thead>


### PR DESCRIPTION
Fix #4471

```html
     <col width="1*"/>
     <col style="width: 1.4*;"/>
```

Firefox renders the style. But it's an invalid property value in Chrome.


https://github.com/php/phd/blob/3c00a1a7539b660a5d792d4306d4c5a355676eea/phpdotnet/phd/Package/Generic/XHTML.php#L2054-L2063