### PR TITLE
update workflow integrate yaml ubuntu

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: "Build"
 
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
 
     strategy:
       matrix:
@@ -44,11 +44,11 @@ jobs:
 
       - name: "Quality Assurance scripts"
         run: |
-          php8.0 doc-base/scripts/qa/extensions.xml.php --check
-          php8.0 doc-base/scripts/qa/section-order.php
+          php8.1 doc-base/scripts/qa/extensions.xml.php --check
+          php8.1 doc-base/scripts/qa/section-order.php
 
       - name: "Build documentation for ${{ matrix.language }}"
-        run: "php8.0 doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}"
+        run: "php8.1 doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}"
 
       - name: "Upload .manual.xml"
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request includes updates to the build environment and the PHP version used for building documentation in the GitHub Actions workflow.

Issue:  [https://github.com/actions/runner-images/issues/11101](https://github.com/actions/runner-images/issues/11101)

Improvements to the build environment:

* [`.github/workflows/integrate.yaml`](diffhunk://#diff-d684acc09c646fd347d0ee93598101fb403664cc70e38cb6f671355ab6de1854L18-R18): Updated the runner to use `ubuntu-22.04` instead of `ubuntu-20.04`.

Updates to PHP version:

* [`.github/workflows/integrate.yaml`](diffhunk://#diff-d684acc09c646fd347d0ee93598101fb403664cc70e38cb6f671355ab6de1854L51-R51): Changed the PHP version from `php8.0` to `php8.1` for the documentation build step.