### PR TITLE
Fix missing PropertyHookType link

### DIFF
--- a/reference/reflection/propertyhooktype.xml
+++ b/reference/reflection/propertyhooktype.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="enum.reflection.propertyhooktype" role="enum">
- <title>The \PropertyHookType Enum</title>
- <titleabbrev>\PropertyHookType</titleabbrev>
+ <title>The PropertyHookType Enum</title>
+ <titleabbrev>PropertyHookType</titleabbrev>
 
  <partintro>
   <section xml:id="enum.reflection.propertyhooktype.intro">
    &reftitle.intro;
    <simpara>
-    The <enumname>\PropertyHookType</enumname> enum lists the legal
+    The <enumname>PropertyHookType</enumname> enum lists the legal
     types of <link linkend="language.oop5.property-hooks">property hook</link>.
    </simpara>
   </section>
@@ -16,7 +16,7 @@
    &reftitle.enumsynopsis;
 
    <enumsynopsis>
-    <enumname>\PropertyHookType</enumname>
+    <enumname>PropertyHookType</enumname>
 
     <enumitem>
      <enumidentifier>Get</enumidentifier>


### PR DESCRIPTION
Close #4485

I'm not sure there's any special significance to adding `\` before it. cc @Crell 