### PR TITLE
password_verify: Remove reference to userland implementation

### DIFF
--- a/reference/password/functions/password-verify.xml
+++ b/reference/password/functions/password-verify.xml
@@ -98,7 +98,6 @@ Password is valid!
    <simplelist>
     <member><function>password_needs_rehash</function></member>
     <member><function>password_hash</function></member>
-    <member><link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.password.compat;">userland implementation</link></member>
     <member><function>sodium_crypto_pwhash_str_verify</function></member>
    </simplelist>
   </para>


### PR DESCRIPTION
This was already removed from `password_hash()` in abc0c909d5a642fbc9008c5ed1a4c3ead5ecb9a2. Given that `password_hash()` is built-in since PHP 5.5, we no longer need this in the manual.