### PR TITLE
Align whitespace for examples on foreach

### DIFF
--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -49,8 +49,8 @@ foreach (iterable_expression as $key => $value) {
   <programlisting role="php">
 <![CDATA[
 <?php
-/* Example: value only */
 
+/* Example: value only */
 $array = [1, 2, 3, 17];
 
 foreach ($array as $value) {
@@ -58,7 +58,6 @@ foreach ($array as $value) {
 }
 
 /* Example: key and value */
-
 $array = [
     "one" => 1,
     "two" => 2,
@@ -84,7 +83,6 @@ foreach ($grid as $y => $row) {
 }
 
 /* Example: dynamic arrays */
-
 foreach (range(1, 5) as $value) {
     echo "$value\n";
 }


### PR DESCRIPTION
Ensure each /* Example: */ block is directly on top of the code it's describing, instead of sometimes hovering between code blocks.

I missed this inconsistency in https://github.com/php/doc-en/pull/4451
