### PR TITLE
memory-get-usage.xml Clarify what kind of memory we are talking about

### DIFF
--- a/reference/info/functions/memory-get-usage.xml
+++ b/reference/info/functions/memory-get-usage.xml
@@ -3,9 +3,9 @@
 <refentry xml:id="function.memory-get-usage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>memory_get_usage</refname>
-  <refpurpose>Returns the amount of memory allocated to PHP</refpurpose>
+  <refpurpose>Returns the amount of memory consumed by PHP script or allocated by system to PHP process</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -13,8 +13,8 @@
    <methodparam choice="opt"><type>bool</type><parameter>real_usage</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Returns the amount of memory, in bytes, that's currently being
-   allocated to your PHP script.
+   Returns the amount of memory, in bytes, that the PHP script is
+   currently using.
   </para>
  </refsect1>
 
@@ -27,15 +27,17 @@
      <listitem>
       <para>
        Set this to &true; to get total memory allocated from
-       system, including unused pages. 
-       If not set or &false; only the used memory is reported.
+       the system to the PHP process, including unused memory pages.
+       If not set or &false; only the memory used by PHP script is reported.
       </para>
      </listitem>
     </varlistentry>
    </variablelist>
   </para>
   <note>
-   <para>PHP does not track memory that is not allocated by <literal>emalloc()</literal></para>
+   <para>
+    PHP tracks only memory that is allocated by the internal function <literal>emalloc()</literal>.
+   </para>
   </note>
  </refsect1>
 
@@ -54,18 +56,19 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// This is only an example, the numbers below will
-// differ depending on your system
 
-echo memory_get_usage() . "\n"; // 36640
+// This is only an example, the numbers below will
+// differ depending on the specific system
+
+echo memory_get_usage(), "\n"; // 36640
 
 $a = str_repeat("Hello", 4242);
 
-echo memory_get_usage() . "\n"; // 57960
+echo memory_get_usage(), "\n"; // 57960
 
 unset($a);
 
-echo memory_get_usage() . "\n"; // 36744
+echo memory_get_usage(), "\n"; // 36744
 
 ?>
 ]]>

--- a/reference/info/functions/memory-get-usage.xml
+++ b/reference/info/functions/memory-get-usage.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.memory-get-usage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>memory_get_usage</refname>
-  <refpurpose>Returns the amount of memory consumed by PHP script or allocated by system to PHP process</refpurpose>
+  <refpurpose>Returns the amount of memory consumed by the PHP script or allocated by the system to PHP process</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/info/functions/memory-get-usage.xml
+++ b/reference/info/functions/memory-get-usage.xml
@@ -3,7 +3,10 @@
 <refentry xml:id="function.memory-get-usage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>memory_get_usage</refname>
-  <refpurpose>Returns the amount of memory consumed by the PHP script or allocated by the system to PHP process</refpurpose>
+  <refpurpose>
+   Returns the amount of memory allocated to the PHP script, or reserved
+   from the system by PHP's memory manager
+  </refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -12,32 +15,43 @@
    <type>int</type><methodname>memory_get_usage</methodname>
    <methodparam choice="opt"><type>bool</type><parameter>real_usage</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Returns the amount of memory, in bytes, that the PHP script is
-   currently using.
-  </para>
+  <simpara>
+   Returns the amount of memory, in bytes, that is currently allocated to
+   the PHP script by PHP's memory manager. The reported value is rounded up
+   to the granularity of the allocator, so it is larger than the exact
+   number of bytes that were requested.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>real_usage</parameter></term>
-     <listitem>
-      <para>
-       Set this to &true; to get total memory allocated from
-       the system to the PHP process, including unused memory pages.
-       If not set or &false; only the memory used by PHP script is reported.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>real_usage</parameter></term>
+    <listitem>
+     <simpara>
+      Set this to &true; to get the total amount of memory that PHP's memory
+      manager has reserved from the system, including pages that are not
+      currently in use. This is the value that
+      <link linkend="ini.memory-limit">memory_limit</link> is enforced
+      against. It is not the amount of memory the operating system has given
+      to the PHP process, which is typically much larger.
+     </simpara>
+     <simpara>
+      If not set or &false; only the memory currently allocated to the PHP
+      script is reported.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
   <note>
-   <para>
-    PHP tracks only memory that is allocated by the internal function <literal>emalloc()</literal>.
-   </para>
+   <simpara>
+    PHP only tracks memory allocated through its own memory manager, that is
+    through the internal <literal>emalloc()</literal> function and the related
+    ones. Memory allocated persistently, or directly with
+    <literal>malloc()</literal> by an extension, is not reported, even when
+    <parameter>real_usage</parameter> is &true;.
+   </simpara>
   </note>
  </refsect1>
 


### PR DESCRIPTION
The current description confuses the reader and does not explain who allocates memory to whom. I'm not sure about the accuracy of the proposed formulations, but it seems that the changes better explain the difference between function calls without arguments or with the value `false`, or with the argument `true`.

I think that mentioning the engine, Zend Memory Manager (ZMM), or other internal details would be redundant, and the current description is enough to understand the difference.

Please check the proposal and make corrections to eliminate linguistic or semantic inaccuracies, if any, in the updated text.

And if the suggestion is OK, I will make the same changes with `memory_get_peak_usage()` ;-)