### PR TITLE
registerphpfunctionns.xml Remove mentioning restriction

### DIFF
--- a/reference/dom/domxpath/registerphpfunctionns.xml
+++ b/reference/dom/domxpath/registerphpfunctionns.xml
@@ -69,6 +69,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+
 $xml = <<<EOB
 <books>
 <book>
@@ -87,7 +88,7 @@ $xml = <<<EOB
 </books>
 EOB;
 
-$doc = new DOMDocument;
+$doc = new DOMDocument();
 $doc->loadXML($xml);
 
 $xpath = new DOMXPath($doc);
@@ -95,7 +96,7 @@ $xpath = new DOMXPath($doc);
 // Register the my: namespace (required)
 $xpath->registerNamespace("my", "urn:my.ns");
 
-// Register PHP functions (no restrictions)
+// Register PHP function
 $xpath->registerPHPFunctionNS(
     'urn:my.ns',
     'substring',


### PR DESCRIPTION
The `DOMXPath::registerPhpFunctionNS` method has no `restrict` parameter; obviously, the comment migrated from the `DOMXPath::registerPhpFunctions`