### PR TITLE
curl-share-init-persistent.xml Remove extra dot, fix fn name, remove …

### DIFF
--- a/reference/curl/functions/curl-share-init-persistent.xml
+++ b/reference/curl/functions/curl-share-init-persistent.xml
@@ -2,7 +2,7 @@
 <refentry xml:id="function.curl-share-init-persistent" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_share_init_persistent</refname>
-  <refpurpose>Initialize a <emphasis role="bold">persistent</emphasis> cURL share handle.</refpurpose>
+  <refpurpose>Initialize a <emphasis role="bold">persistent</emphasis> cURL share handle</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -96,26 +96,24 @@
    <programlisting role="php">
     <![CDATA[
 <?php
-// Create or retrieve a persistent cURL share handle set to share DNS lookups and connections.
-$sh = curl_share_init([CURL_LOCK_DATA_DNS, CURL_LOCK_DATA_CONNECT]);
 
-// Initialize the first cURL handle and assign the share handle to it.
+// Create or retrieve a persistent cURL share handle set to share DNS lookups and connections
+$sh = curl_share_init_persistent([CURL_LOCK_DATA_DNS, CURL_LOCK_DATA_CONNECT]);
+
+// Initialize the first cURL handle and assign the share handle to it
 $ch1 = curl_init("http://example.com/");
 curl_setopt($ch1, CURLOPT_SHARE, $sh);
 
-// Execute the first cURL handle. This may reuse the connection from an earlier SAPI request.
+// Execute the first cURL handle. This may reuse the connection from an earlier SAPI request
 curl_exec($ch1);
 
-// Initialize the second cURL handle and assign the share handle to it.
+// Initialize the second cURL handle and assign the share handle to it
 $ch2 = curl_init("http://example.com/");
 curl_setopt($ch2, CURLOPT_SHARE, $sh);
 
-// Execute the second cURL handle. This will reuse the connection from $ch1.
+// Execute the second cURL handle. This will reuse the connection from $ch1
 curl_exec($ch2);
 
-// Close the cURL handles
-curl_close($ch1);
-curl_close($ch2);
 ?>
 
     ]]>


### PR DESCRIPTION
…curl_close()

Should we call `curl_close()` in PHP 8.5?

What have i changed:

0. Remove the extra dot in `refpurpose` element
1. Fix copy-pasting: `curl_share_init` → `curl_share_init_persistent`
2. Add a new line after the `<?php` tag
3. Remove the `curl_close()` call because, as of PHP 8.0.0, this function has no effect, and  is not needed to maintain backward compatibility, because `curl_share_init_persistent` is not available for older versions
4. Remove the period at the end of the comments, they behave excessively "strictly" in these places and reduce the smoothness of reading, it feels like you're stumbling :-)