### PR TITLE
method_exists: Add changelog and note regarding not supporting `__call`.

### DIFF
--- a/reference/classobj/functions/method-exists.xml
+++ b/reference/classobj/functions/method-exists.xml
@@ -49,6 +49,28 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>7.4.0</entry>
+      <entry>
+       Class checks against inherited private methods now return <parameter>false</parameter>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -91,6 +113,13 @@ bool(true)
  <refsect1 role="notes">
   &reftitle.notes;
   &note.uses-autoload;
+  <note>
+   <para>
+    The <function>method_exists</function> function cannot detect methods
+    that are magically accessible using the <link linkend="language.oop5.overloading.methods"><literal>__call</literal></link>
+    magic method.
+   </para>
+  </note>
  </refsect1>
  
  <refsect1 role="seealso">

--- a/reference/classobj/functions/method-exists.xml
+++ b/reference/classobj/functions/method-exists.xml
@@ -114,11 +114,12 @@ bool(true)
   &reftitle.notes;
   &note.uses-autoload;
   <note>
-   <para>
+   <simpara>
     The <function>method_exists</function> function cannot detect methods
-    that are magically accessible using the <link linkend="language.oop5.overloading.methods"><literal>__call</literal></link>
+    that are magically accessible using the
+    <link linkend="language.oop5.overloading.methods"><literal>__call</literal></link>
     magic method.
-   </para>
+   </simpara>
   </note>
  </refsect1>
  


### PR DESCRIPTION
Incorporate the top two comments as part of the documentation. It copies a similar note from `property_exists` around support for `__get`.