### PR TITLE
property_exists: Update example to show more scenarios.

### DIFF
--- a/reference/classobj/functions/property-exists.xml
+++ b/reference/classobj/functions/property-exists.xml
@@ -65,26 +65,55 @@
 <![CDATA[
 <?php
 
-class myClass {
-    public $mine;
-    private $xpto;
-    static protected $test;
+#[AllowDynamicProperties]
+class MyClass {
+    public $public;
+    private $private;
+    static protected $protectedStatic;
 
-    static function test() {
-        var_dump(property_exists('myClass', 'xpto')); //true
+    // ignored by property_exists
+    public function __isset(string $name) {
+        return true;
+    }
+
+    // ignored by property_exists
+    public function __get(string $name) {
+        return '';
     }
 }
 
-var_dump(property_exists('myClass', 'mine'));   //true
-var_dump(property_exists(new myClass, 'mine')); //true
-var_dump(property_exists('myClass', 'xpto'));   //true
-var_dump(property_exists('myClass', 'bar'));    //false
-var_dump(property_exists('myClass', 'test'));   //true
-myClass::test();
+$instance = new MyClass();
+$instance->instanced = 'abc';
+
+foreach (['$instance' => $instance, 'MyClass::class' => MyClass::class] as $type => $value) {
+    foreach (['public', 'protectedStatic', 'private', 'undefined', 'instanced'] as $property) {
+        printf(
+            "property_exists(%s, %s) === %s\n",
+            $type,
+            var_export($property, true),
+            var_export(property_exists($value, $property), true),
+        );
+    }
+}
 
 ?>
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+property_exists($instance, 'public') === true
+property_exists($instance, 'protectedStatic') === true
+property_exists($instance, 'private') === true
+property_exists($instance, 'undefined') === false
+property_exists($instance, 'instanced') === true
+property_exists(MyClass::class, 'public') === true
+property_exists(MyClass::class, 'protectedStatic') === true
+property_exists(MyClass::class, 'private') === true
+property_exists(MyClass::class, 'undefined') === false
+property_exists(MyClass::class, 'instanced') === false
+]]>
+    </screen>
    </example>
   </para>
  </refsect1>

--- a/reference/classobj/functions/property-exists.xml
+++ b/reference/classobj/functions/property-exists.xml
@@ -65,6 +65,42 @@
 <![CDATA[
 <?php
 
+class myClass {
+    public $mine;
+    private $xpto;
+    static protected $test;
+
+    static function test() {
+        var_dump(property_exists('myClass', 'xpto')); //true
+    }
+}
+
+var_dump(property_exists('myClass', 'mine'));   //true
+var_dump(property_exists(new myClass, 'mine')); //true
+var_dump(property_exists('myClass', 'xpto'));   //true
+var_dump(property_exists('myClass', 'bar'));    //false
+var_dump(property_exists('myClass', 'test'));   //true
+myClass::test();
+
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Visibility, dynamic properties, and magic methods</title>
+    <para>
+     <function>property_exists</function> returns &true; regardless of property
+     visibility, detects dynamic properties added to instances (when the class
+     uses <literal>#[AllowDynamicProperties]</literal>), and ignores
+     <link linkend="language.oop5.overloading.members"><literal>__isset</literal></link>
+     and <literal>__get</literal> magic methods.
+    </para>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
 #[AllowDynamicProperties]
 class MyClass {
     public $public;
@@ -72,12 +108,12 @@ class MyClass {
     static protected $protectedStatic;
 
     // ignored by property_exists
-    public function __isset(string $name) {
+    public function __isset(string $name): bool {
         return true;
     }
 
     // ignored by property_exists
-    public function __get(string $name) {
+    public function __get(string $name): string {
         return '';
     }
 }
@@ -85,16 +121,15 @@ class MyClass {
 $instance = new MyClass();
 $instance->instanced = 'abc';
 
-foreach (['$instance' => $instance, 'MyClass::class' => MyClass::class] as $type => $value) {
-    foreach (['public', 'protectedStatic', 'private', 'undefined', 'instanced'] as $property) {
-        printf(
-            "property_exists(%s, %s) === %s\n",
-            $type,
-            var_export($property, true),
-            var_export(property_exists($value, $property), true),
-        );
-    }
-}
+var_dump(property_exists($instance, 'public'));          // true  (public)
+var_dump(property_exists($instance, 'private'));         // true  (visibility ignored)
+var_dump(property_exists($instance, 'protectedStatic')); // true  (visibility ignored)
+var_dump(property_exists($instance, 'instanced'));       // true  (dynamic property on instance)
+var_dump(property_exists($instance, 'undefined'));       // false (not declared, __isset ignored)
+
+var_dump(property_exists(MyClass::class, 'public'));    // true
+var_dump(property_exists(MyClass::class, 'instanced')); // false (dynamic props not on class)
+var_dump(property_exists(MyClass::class, 'undefined')); // false
 
 ?>
 ]]>
@@ -102,16 +137,14 @@ foreach (['$instance' => $instance, 'MyClass::class' => MyClass::class] as $type
     &example.outputs;
     <screen>
 <![CDATA[
-property_exists($instance, 'public') === true
-property_exists($instance, 'protectedStatic') === true
-property_exists($instance, 'private') === true
-property_exists($instance, 'undefined') === false
-property_exists($instance, 'instanced') === true
-property_exists(MyClass::class, 'public') === true
-property_exists(MyClass::class, 'protectedStatic') === true
-property_exists(MyClass::class, 'private') === true
-property_exists(MyClass::class, 'undefined') === false
-property_exists(MyClass::class, 'instanced') === false
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(false)
 ]]>
     </screen>
    </example>

--- a/reference/classobj/functions/property-exists.xml
+++ b/reference/classobj/functions/property-exists.xml
@@ -87,13 +87,13 @@ myClass::test();
     </programlisting>
    </example>
   </para>
-  <para>
+  <simpara>
    <function>property_exists</function> returns &true; regardless of property
    visibility, detects dynamic properties added to instances (when the class
    uses <literal>#[AllowDynamicProperties]</literal>), and ignores
    <link linkend="language.oop5.overloading.members"><literal>__isset</literal></link>
    and <literal>__get</literal> magic methods.
-  </para>
+  </simpara>
   <para>
    <example>
     <title>Visibility, dynamic properties, and magic methods</title>

--- a/reference/classobj/functions/property-exists.xml
+++ b/reference/classobj/functions/property-exists.xml
@@ -88,15 +88,15 @@ myClass::test();
    </example>
   </para>
   <para>
+   <function>property_exists</function> returns &true; regardless of property
+   visibility, detects dynamic properties added to instances (when the class
+   uses <literal>#[AllowDynamicProperties]</literal>), and ignores
+   <link linkend="language.oop5.overloading.members"><literal>__isset</literal></link>
+   and <literal>__get</literal> magic methods.
+  </para>
+  <para>
    <example>
     <title>Visibility, dynamic properties, and magic methods</title>
-    <para>
-     <function>property_exists</function> returns &true; regardless of property
-     visibility, detects dynamic properties added to instances (when the class
-     uses <literal>#[AllowDynamicProperties]</literal>), and ignores
-     <link linkend="language.oop5.overloading.members"><literal>__isset</literal></link>
-     and <literal>__get</literal> magic methods.
-    </para>
     <programlisting role="php">
 <![CDATA[
 <?php


### PR DESCRIPTION
The main thing to highlight is that property visibility and `__get` and `__isset` is not checked.

This example may be a little too complex and hides the intent. Would it be better to explicitly state the lack of visibility check in the description instead?