### PR TITLE
throw.xml Add an example

### DIFF
--- a/language/predefined/fiber/throw.xml
+++ b/language/predefined/fiber/throw.xml
@@ -41,6 +41,43 @@
   </para>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>Fiber::throw</function> example</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$fiber = new Fiber(function () {
+    try {
+        // Suspend execution of the fiber declaring an interruption point
+        Fiber::suspend();
+    } catch (Throwable $e) {
+        echo $e->getMessage();
+    }
+});
+
+$fiber->start();
+
+// Resumes execution of the fiber with
+// passing the Exception to throw at the interruption point
+$fiber->throw(new Exception('Message of an exception thrown at the current interrupt point'));
+
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+Message of an exception thrown at the current interrupt point
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/language/predefined/fiber/throw.xml
+++ b/language/predefined/fiber/throw.xml
@@ -43,20 +43,18 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title><function>Fiber::throw</function> example</title>
-    <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
 
 $fiber = new Fiber(function () {
-    try {
-        // Suspend execution of the fiber declaring an interruption point
-        Fiber::suspend();
-    } catch (Throwable $e) {
-        echo $e->getMessage();
-    }
+   try {
+       // Suspend execution of the fiber declaring an interruption point
+       Fiber::suspend();
+   } catch (Throwable $e) {
+       echo $e->getMessage();
+   }
 });
 
 $fiber->start();
@@ -67,15 +65,14 @@ $fiber->throw(new Exception('Message of an exception thrown at the current inter
 
 ?>
 ]]>
-    </programlisting>
-    &example.outputs.similar;
-    <screen>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
 <![CDATA[
 Message of an exception thrown at the current interrupt point
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </informalexample>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Can we add an example that shows how the `Fiber::throw()` method passes an exception to the fiber?