### PR TITLE
Fixed Nullable types example in migration71/new-features.xml

### DIFF
--- a/appendices/migration71/new-features.xml
+++ b/appendices/migration71/new-features.xml
@@ -19,19 +19,19 @@
 <![CDATA[
 <?php
 
-function testReturn(): ?string
+function testReturnA(): ?string
 {
     return 'elePHPant';
 }
 
-var_dump(testReturn());
+var_dump(testReturnA());
 
-function testReturn(): ?string
+function testReturnB(): ?string
 {
     return null;
 }
 
-var_dump(testReturn());
+var_dump(testReturnB());
 
 function test(?string $name)
 {
@@ -46,11 +46,11 @@ test();
    &example.outputs;
    <screen>
 <![CDATA[
-string(10) "elePHPant"
+string(9) "elePHPant"
 NULL
-string(10) "elePHPant"
+string(9) "elePHPant"
 NULL
-Uncaught Error: Too few arguments to function test(), 0 passed in...
+Fatal error: Uncaught ArgumentCountError: Too few arguments to function test(), 0 passed in...
 ]]>
    </screen>
   </informalexample>


### PR DESCRIPTION
Old example would actually have output:
Fatal error: Cannot redeclare testReturn()
We can also see that the output was not from real code execution because "elePHPant" should be string(9) not string(10).