### PR TITLE
Simplify xdiff_string_diff example

### DIFF
--- a/reference/xdiff/functions/xdiff-string-diff.xml
+++ b/reference/xdiff/functions/xdiff-string-diff.xml
@@ -89,10 +89,8 @@ $old_article = file_get_contents('./old_article.txt');
 $new_article = $_REQUEST['article']; /* Let's say that someone pasted a new article to html form */
 
 $diff = xdiff_string_diff($old_article, $new_article, 1);
-if (is_string($diff)) {
-    echo "Differences between two articles:\n";
-    echo $diff;
-}
+echo "Differences between two articles:\n";
+echo $diff;
 
 ?>
 ]]>


### PR DESCRIPTION
since the method can only return `string`s, there is no point in checking the return type with `is_string`.