### PR TITLE
Update constants.xml

### DIFF
--- a/reference/json/constants.xml
+++ b/reference/json/constants.xml
@@ -381,19 +381,6 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.json-error-non-backed-enum">
-   <term>
-    <constant>JSON_ERROR_NON_BACKED_ENUM</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     The value passed to <function>json_encode</function>
-     includes a non-backed enum which cannot be serialized.
-     Available as of PHP 8.1.0.
-    </simpara>
-   </listitem>
-  </varlistentry>
  </variablelist>
 
 </appendix>

--- a/reference/json/constants.xml
+++ b/reference/json/constants.xml
@@ -144,6 +144,19 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.json-error-non-backed-enum">
+   <term>
+    <constant>JSON_ERROR_NON_BACKED_ENUM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The value passed to <function>json_encode</function>
+     includes a non-backed enum which cannot be serialized.
+     Available as of PHP 8.1.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
  </variablelist>
 
  <para>


### PR DESCRIPTION
The previous commit added the new error constant at the bottom of the page, instead of the section of the page listing error constants. Moved it there.