### PR TITLE
set-error-handler.xml Remove the misleading statement

### DIFF
--- a/reference/errorfunc/functions/set-error-handler.xml
+++ b/reference/errorfunc/functions/set-error-handler.xml
@@ -159,11 +159,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the previously defined error handler (if any). If
-   the built-in error handler is used &null; is returned.
-   If the previous error handler
-   was a class method, this function will return an indexed array with the class
-   and the method name.
+   Returns the previously defined error handler (if any) as a <type>callable</type>.
+   If the built-in error handler is used &null; is returned.
   </para>
  </refsect1>
 


### PR DESCRIPTION
For the method of the class as an error handler, the `set_error_handler` function may return a `callable`:

a) a string

b) a Closure

c) an indexed array (with the name of the class or an instance of the class in the first element, and the name of the method in the second one)

However, it is not limited to just "an indexed array with the class and method name".

I suggest removing the mention of the array as a return value, otherwise we will have to list every possible type of callable value :)