### PR TITLE
Change line mentioning assert should only be used when debugging

### DIFF
--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -20,7 +20,7 @@
    zero cost in production.
   </para>
   <para>
-   Assertions can be used to aid debugging. 
+   Assertions can be used to aid debugging.
    One use case for them is to act as sanity-checks for preconditions
    that should always be &true; and that if they aren't upheld this indicates
    some programming errors.

--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -20,7 +20,7 @@
    zero cost in production.
   </para>
   <para>
-   Assertions should be used as a debugging feature only.
+   Assertions can be used to aid debugging. 
    One use case for them is to act as sanity-checks for preconditions
    that should always be &true; and that if they aren't upheld this indicates
    some programming errors.


### PR DESCRIPTION
The implication of only being used as a debugging tool is that it should never hit production code. This is contradicted by the line above ("but are optimised away to have zero cost in production") above and the paragraph following it which requires asserts to exist in running code to make sense.

As mentioned in a comment on the php.net page (https://www.php.net/manual/en/function.assert.php#129271), `assert` sees widespread usage in code in the wild. It definitely is used outside of debugging.

Instead of removing it, this changes the line to mention its relation to debugging which is relevant and otherwise absent from the article.