### PR TITLE
Add information about type declarations to Class Constants

### DIFF
--- a/language/oop5/constants.xml
+++ b/language/oop5/constants.xml
@@ -28,6 +28,12 @@
   Note that class constants are allocated once per class, and not for each
   class instance.
  </para>
+ <para>
+  As of PHP 8.3.0, class constants can have a scalar type such as <literal>bool</literal>,
+  <literal>int</literal>, <literal>float</literal>, <literal>string</literal>, or even
+  <literal>array</literal>. When using <literal>array</literal>, the contents can only be
+  other scalar types.
+ </para>
  <example>
   <title>Defining and using a constant</title>
   <programlisting role="php">
@@ -174,6 +180,47 @@ echo Foo::{$name}, PHP_EOL; // bar
    variable.
   </para>
  </note>
+ <example>
+  <title>Assigning types to class constants, as of PHP 8.3.0</title>
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+class MyClass {
+    public const bool MY_BOOL = true;
+    public const int MY_INT = 1;
+    public const float MY_FLOAT = 1.01;
+    public const string MY_STRING = 'one';
+    public const array MY_ARRAY = [self::MY_BOOL, self::MY_INT, self::MY_FLOAT, self::MY_STRING];
+}
+
+var_dump(MyClass::MY_BOOL);
+var_dump(MyClass::MY_INT);
+var_dump(MyClass::MY_FLOAT);
+var_dump(MyClass::MY_STRING);
+var_dump(MyClass::MY_ARRAY);
+?>
+]]>
+  </programlisting>
+  &example.outputs.83;
+  <screen>
+<![CDATA[
+bool(true)
+int(1)
+float(1.01)
+string(3) "one"
+array(4) {
+  [0]=>
+  bool(true)
+  [1]=>
+  int(1)
+  [2]=>
+  float(1.01)
+  [3]=>
+  string(3) "one"
+}
+   ]]>
+ </example>
 </sect1>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/language/oop5/constants.xml
+++ b/language/oop5/constants.xml
@@ -220,6 +220,7 @@ array(4) {
   string(3) "one"
 }
    ]]>
+  </screen>
  </example>
 </sect1>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
PHP 8.3 introduced types to class constants, but the documentation doesn't seem to mention this yet. This PR updates the doc to mention it & provide an example.