### PR TITLE
Fix typo

### DIFF
--- a/reference/array/functions/array-key-exists.xml
+++ b/reference/array/functions/array-key-exists.xml
@@ -73,9 +73,9 @@
       <entry>8.0.0</entry>
       <entry>
        The <parameter>key</parameter> parameter now accepts
-       <parameter>bool</parameter>, <parameter>float</parameter>, <parameter>int</parameter>,
-       <parameter>null</parameter>, <parameter>resource</parameter>, and
-       <parameter>string</parameter> as arguments.
+       <type>bool</type>, <type>float</type>, <type>int</type>,
+       <type>null</type>, <type>resource</type>, and
+       <type>string</type> as arguments.
       </entry>
      </row>
      <row>


### PR DESCRIPTION
Shouldn't this be tagged type instead of parameter?