### PR TITLE
Fix buggy code examples for `ReflectionParameter::getAttributes`

### DIFF
--- a/reference/reflection/reflectionparameter/getattributes.xml
+++ b/reference/reflection/reflectionparameter/getattributes.xml
@@ -57,7 +57,7 @@ function fruitBasket(
 ) { }
 
 $reflection = new ReflectionFunction('fruitBasket');
-$parameter = $reflection->getParameter('apple');
+$parameter = $reflection->getParameters()[0];
 $attributes = $parameter->getAttributes();
 print_r(array_map(fn($attribute) => $attribute->getName(), $attributes));
 ?>
@@ -96,7 +96,7 @@ function fruitBasket(
 ) { }
 
 $reflection = new ReflectionFunction('fruitBasket');
-$parameter = $reflection->getParameter('apple');
+$parameter = $reflection->getParameters()[0];
 $attributes = $parameter->getAttributes('Fruit');
 print_r(array_map(fn($attribute) => $attribute->getName(), $attributes));
 ?>
@@ -126,6 +126,10 @@ interface Color {
 class Fruit {
 }
 
+#[Attribute]
+class Red implements Color {
+}
+
 function fruitBasket(
    #[Fruit]
    #[Red]
@@ -133,7 +137,7 @@ function fruitBasket(
 ) { }
 
 $reflection = new ReflectionFunction('fruitBasket');
-$parameter = $reflection->getParameter('apple');
+$parameter = $reflection->getParameters()[0];
 $attributes = $parameter->getAttributes('Color', ReflectionAttribute::IS_INSTANCEOF);
 print_r(array_map(fn($attribute) => $attribute->getName(), $attributes));
 ?>


### PR DESCRIPTION
- Fix calls to non-existent `getParameter` method of `ReflectionFunction`.
- Add missing `Red` attribute class definition implementing `Color`.

---

[Current page](https://www.php.net/manual/en/reflectionparameter.getattributes.php) in question.

Although I like the idea of being able to filter/get a specific function parameter by name, as far as I can tell, there is no such method on [`ReflectionFunctionAbstract`](https://www.php.net/manual/en/class.reflectionfunctionabstract.php) or its subclasses.

Also, the entire point of the [third example](https://www.php.net/manual/en/reflectionparameter.getattributes.php#example-5485) presumably was to illustrate that sub-type relationships are honored by passing the `IS_INSTANCEOF` flag to `getAttributes`. Therefore including the `Red` class in this example and making it implement `Color` is surely necessary.