### PR TITLE
Fix property hooks example

### DIFF
--- a/language/oop5/property-hooks.xml
+++ b/language/oop5/property-hooks.xml
@@ -315,7 +315,7 @@ class Example
    <programlisting role="php">
 <![CDATA[
 <?php
-readonly class Rectangle
+class Rectangle
 {
     // A virtual property.
     public int $area {


### PR DESCRIPTION
Property hooks are incompatible with read only properties, yet an example was given with a read only class.