### PR TITLE
add "Flags" title in `format` parameter of `sprintf`

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -3957,6 +3957,7 @@ local: {
    </para>
   </formalpara>
 
+  <title>Flags</title>
   <para>
    <table>
     <title>Flags</title>


### PR DESCRIPTION
In `format` parameter of `sprintf` function, there is no title for the `flags` parameters.

**BEFORE**
Flags seems to be for Argnum parameter
<img width="1103" alt="Screenshot 2025-03-20 at 14 48 38" src="https://github.com/user-attachments/assets/bbc8abde-8202-4427-9218-cb9215d9be9d" />

**AFTER**
(I make the change with my browser inspector)
Flags are in a flags section, we understand that it's for flags
<img width="1102" alt="Screenshot 2025-03-20 at 14 49 58" src="https://github.com/user-attachments/assets/c2a4b15f-f415-4927-bf25-2cd56314028e" />

