### PR TITLE
random: Fix right-open / left-open confusion for Random\IntervalBoundary

### DIFF
--- a/reference/random/random.intervalboundary.xml
+++ b/reference/random/random.intervalboundary.xml
@@ -22,7 +22,7 @@
     <enumitem>
      <enumidentifier>ClosedOpen</enumidentifier>
      <enumitemdescription>
-      A left-open interval.
+      A right-open interval.
       The lower boundary is included in the interval,
       the upper boundary is not.
      </enumitemdescription>
@@ -39,7 +39,7 @@
     <enumitem>
      <enumidentifier>OpenClosed</enumidentifier>
      <enumitemdescription>
-      A right-open interval.
+      A left-open interval.
       The upper boundary is included in the interval,
       the lower boundary is not.
      </enumitemdescription>


### PR DESCRIPTION
This was correct in my initial suggestions (https://github.com/php/doc-en/pull/3419#discussion_r1617712920), but incorrect in my later suggestions (https://github.com/php/doc-en/pull/3419#discussion_r1845547942) 😔 

---------------

see #3419