### PR TITLE
Prefer comma over || for match conditions

### DIFF
--- a/language/control-structures/match.xml
+++ b/language/control-structures/match.xml
@@ -290,8 +290,8 @@ string(11) "young adult"
 $text = 'Bienvenue chez nous';
 
 $result = match (true) {
-    str_contains($text, 'Welcome') || str_contains($text, 'Hello') => 'en',
-    str_contains($text, 'Bienvenue') || str_contains($text, 'Bonjour') => 'fr',
+    str_contains($text, 'Welcome'), str_contains($text, 'Hello') => 'en',
+    str_contains($text, 'Bienvenue'), str_contains($text, 'Bonjour') => 'fr',
     // ...
 };
 


### PR DESCRIPTION
Above in this text it states:

> match expression arms may contain multiple expressions separated by a comma. That is a logical OR, and is a short-hand for multiple match arms with the same right-hand side.

So in the code example below we prefer to use the comma instead of a logical OR.