### PR TITLE
intval: changed example from 4.2 to 4.7

### DIFF
--- a/reference/var/functions/intval.xml
+++ b/reference/var/functions/intval.xml
@@ -132,7 +132,7 @@
 <![CDATA[
 <?php
 echo intval(42);                      // 42
-echo intval(4.2);                     // 4
+echo intval(4.7);                     // 4
 echo intval('42');                    // 42
 echo intval('+42');                   // 42
 echo intval('-42');                   // -42


### PR DESCRIPTION
This is to emphasize intval truncates the value to 4, and there's another function for rounding