### PR TITLE
ext/reflection: `PropertyHookType` - Fixed id for enum autolinking

### DIFF
--- a/reference/reflection/propertyhooktype.xml
+++ b/reference/reflection/propertyhooktype.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<reference xmlns="http://docbook.org/ns/docbook" xml:id="enum.reflection.propertyhooktype" role="enum">
+<reference xmlns="http://docbook.org/ns/docbook" xml:id="enum.propertyhooktype" role="enum">
  <title>The PropertyHookType Enum</title>
  <titleabbrev>PropertyHookType</titleabbrev>
 
  <partintro>
-  <section xml:id="enum.reflection.propertyhooktype.intro">
+  <section xml:id="enum.propertyhooktype.intro">
    &reftitle.intro;
    <simpara>
     The <enumname>PropertyHookType</enumname> enum lists the legal
@@ -12,7 +12,7 @@
    </simpara>
   </section>
 
-  <section xml:id="enum.reflection.propertyhooktype.synopsis">
+  <section xml:id="enum.propertyhooktype.synopsis">
    &reftitle.enumsynopsis;
 
    <enumsynopsis>


### PR DESCRIPTION
Other than `<reference xmlns="http://docbook.org/ns/docbook" xml:id="enum.propertyhooktype" role="enum">`, they are not required, but I modified it for consistency.