### PR TITLE
Add example that shows array_chunk() within a loop and without a whole multiple

### DIFF
--- a/reference/array/functions/array-chunk.xml
+++ b/reference/array/functions/array-chunk.xml
@@ -159,6 +159,55 @@ Array
     </screen>
    </example>
   </para>
+  <para>
+   <example>
+    <title>Using <function>array_chunk</function> in a loop</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+foreach (array_chunk($array, 3) as $chunk) {
+    var_dump($chunk);
+}
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+array(3) {
+  [0]=>
+  int(0)
+  [1]=>
+  int(1)
+  [2]=>
+  int(2)
+}
+array(3) {
+  [0]=>
+  int(3)
+  [1]=>
+  int(4)
+  [2]=>
+  int(5)
+}
+array(3) {
+  [0]=>
+  int(6)
+  [1]=>
+  int(7)
+  [2]=>
+  int(8)
+}
+array(1) {
+  [0]=>
+  int(9)
+}
+]]>
+    </screen>
+   </example>
+  </para>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
https://www.php.net/manual/en/function.array-chunk.php

The intent with this example is to show how to use `array_chunk()` within a loop, and what happens when the total amount of elements doesn't divide evenly with the `$length` argument.