### PR TITLE
apache2.xml Add notes about FallbackResource

### DIFF
--- a/install/unix/apache2.xml
+++ b/install/unix/apache2.xml
@@ -266,6 +266,34 @@ LoadModule php7_module modules/libphp7.so
    </informalexample>
 
    <para>
+    To allow use of a PHP file as the default handler if no other handler is found,
+    for example when using a routing engine, the <literal>FallbackResource</literal> directive may be used.
+    This is available in Apache 2.4.4 and later.
+   </para>
+
+   <para>
+    Because the <literal>SetHandler</literal> directive is applied whether the file exists or not, and the
+    <literal>FallbackResource</literal> is only applied if a handler has not already been set,
+    you may need to use the <literal>If</literal> directive to ensure that the handler is only
+    applied if the file exists.
+    This allows the <literal>FallbackResource</literal> to handle paths which end in <literal>.php</literal>
+    but do not exist, which may be useful for error handling and routing.
+   </para>
+
+   <informalexample>
+    <programlisting role="apache-conf">
+<![CDATA[
+<FilesMatch "\.php$">
+    <If "-f %{REQUEST_FILENAME}">
+        SetHandler application/x-httpd-php
+    </If>
+</FilesMatch>
+FallbackResource /index.php
+]]>
+    </programlisting>
+   </informalexample>
+
+   <para>
     <literal>mod_rewrite</literal> may be used to allow any arbitrary <literal>.php</literal> file to be displayed
     as syntax-highlighted source code, without having to rename or copy it
     to a <literal>.phps</literal> file:

--- a/install/unix/apache2.xml
+++ b/install/unix/apache2.xml
@@ -265,20 +265,20 @@ LoadModule php7_module modules/libphp7.so
     </programlisting>
    </informalexample>
 
-   <para>
+   <simpara>
     To allow use of a PHP file as the default handler if no other handler is found,
     for example when using a routing engine, the <literal>FallbackResource</literal> directive may be used.
     This is available in Apache 2.4.4 and later.
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     Because the <literal>SetHandler</literal> directive is applied whether the file exists or not, and the
     <literal>FallbackResource</literal> is only applied if a handler has not already been set,
     you may need to use the <literal>If</literal> directive to ensure that the handler is only
     applied if the file exists.
     This allows the <literal>FallbackResource</literal> to handle paths which end in <literal>.php</literal>
     but do not exist, which may be useful for error handling and routing.
-   </para>
+   </simpara>
 
    <informalexample>
     <programlisting role="apache-conf">


### PR DESCRIPTION
I recently encountered an issue when configuring a `FallbackResource` for Apache.

We are in the process of migrating legacy paths to use a routing engine and as part of the migration we are providing a shim. As a result we have users hitting paths such as `/example.php` which are now expected to be handled by the Routing system.

We discovered that our Apache2 test images were not hitting the Routing system for these paths and, after digging, that it's because the `SetHandler` and `AddHandler` directives are set based on the _path_ location rather than the _file_. That is, if the location `https://example.com/example.php` is requested then the `<FilesMatch>` directive is always applied based on the `\.php$` regex match. As a result, the `FallbackResource` directive is not applied (beceause a Handler has already been applied).

This has previously been [rejected as a bug in Apache2](https://bz.apache.org/bugzilla/show_bug.cgi?id=52403#c7) as it is the expected behaviour.

I have:
- Raised an issue againt the Docker PHP docker images: https://github.com/docker-library/php/issues/1576
- Raised a [bug against the Apache docs and provided a patch](https://bz.apache.org/bugzilla/show_bug.cgi?id=69640) there

Given that the `FallbackResource` is the recommended way to use a routing system such as [Symfony](https://symfony.com/doc/current/setup/web_server_configuration.html#apache) it is probably worth documenting:
- the use of the `FallbackResource` directive; and
- the need to use an `If -f` directive when setting the handler to only apply it when the requested file actually exists.