### PR TITLE
Fix BulkWrite::insert() example for always returning document _id

### DIFF
--- a/reference/mongodb/mongodb/driver/bulkwrite/insert.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/insert.xml
@@ -87,15 +87,15 @@
 
 $bulk = new MongoDB\Driver\BulkWrite;
 
-$document1 = ['title' => 'one'];
-$document2 = ['_id' => 'custom ID', 'title' => 'two'];
-$document3 = ['_id' => new MongoDB\BSON\ObjectId, 'title' => 'three'];
+$doc1 = ['x' => 1];
+$doc2 = ['_id' => 'custom-id', 'x' => 2];
+$doc3 = ['_id' => new MongoDB\BSON\ObjectId('0123456789abcdef01234567'), 'x' => 3];
 
-$_id1 = $bulk->insert($document1);
-$_id2 = $bulk->insert($document2);
-$_id3 = $bulk->insert($document3);
+$id1 = $bulk->insert($doc1);
+$id2 = $bulk->insert($doc2);
+$id3 = $bulk->insert($doc3);
 
-var_dump($_id1, $_id2, $_id3);
+var_dump($id1, $id2, $id3);
 
 $manager = new MongoDB\Driver\Manager('mongodb://localhost:27017');
 $result = $manager->executeBulkWrite('db.collection', $bulk);
@@ -108,10 +108,13 @@ $result = $manager->executeBulkWrite('db.collection', $bulk);
 <![CDATA[
 object(MongoDB\BSON\ObjectId)#3 (1) {
   ["oid"]=>
-  string(24) "54d51146bd21b91405401d92"
+  string(24) "67f58058d1a0aa2fd80d55d0"
 }
-NULL
-NULL
+string(9) "custom-id"
+object(MongoDB\BSON\ObjectId)#4 (1) {
+  ["oid"]=>
+  string(24) "0123456789abcdef01234567"
+}
 ]]>
    </screen>
   </example>


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-471

This was missed in ca221144de6ad1d213ccffb9a57f0eb5ee6fd799