### PR TITLE
Update examples to pass WriteConcern and ReadPreference as options

### DIFF
--- a/reference/mongodb/mongodb/driver/bulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite.xml
@@ -107,7 +107,7 @@ $manager = new MongoDB\Driver\Manager('mongodb://localhost:27017');
 $writeConcern = new MongoDB\Driver\WriteConcern(MongoDB\Driver\WriteConcern::MAJORITY, 1000);
 
 try {
-    $result = $manager->executeBulkWrite('db.collection', $bulk, $writeConcern);
+    $result = $manager->executeBulkWrite('db.collection', $bulk, ['writeConcern' => $writeConcern]);
 } catch (MongoDB\Driver\Exception\BulkWriteException $e) {
     $result = $e->getWriteResult();
 

--- a/reference/mongodb/mongodb/driver/bulkwrite/construct.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/construct.xml
@@ -156,7 +156,7 @@ $manager = new MongoDB\Driver\Manager('mongodb://localhost:27017');
 $writeConcern = new MongoDB\Driver\WriteConcern(1);
 
 try {
-    $result = $manager->executeBulkWrite('db.collection', $bulk, $writeConcern);
+    $result = $manager->executeBulkWrite('db.collection', $bulk, ['writeConcern' => $writeConcern]);
 } catch (MongoDB\Driver\Exception\BulkWriteException $e) {
     $result = $e->getWriteResult();
 

--- a/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
@@ -154,7 +154,7 @@ $bulk->delete(['x' => 1], ['limit' => 1]);
 
 $manager = new MongoDB\Driver\Manager('mongodb://localhost:27017');
 $writeConcern = new MongoDB\Driver\WriteConcern(MongoDB\Driver\WriteConcern::MAJORITY, 100);
-$result = $manager->executeBulkWrite('db.collection', $bulk, $writeConcern);
+$result = $manager->executeBulkWrite('db.collection', $bulk, ['writeConcern' => $writeConcern]);
 
 printf("Inserted %d document(s)\n", $result->getInsertedCount());
 printf("Matched  %d document(s)\n", $result->getMatchedCount());

--- a/reference/mongodb/mongodb/driver/query/construct.xml
+++ b/reference/mongodb/mongodb/driver/query/construct.xml
@@ -541,7 +541,7 @@ $query = new MongoDB\Driver\Query($filter, $options);
 
 $manager = new MongoDB\Driver\Manager('mongodb://localhost:27017');
 $readPreference = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY);
-$cursor = $manager->executeQuery('databaseName.collectionName', $query, $readPreference);
+$cursor = $manager->executeQuery('databaseName.collectionName', $query, ['readPreference' => $readPreference]);
 
 foreach($cursor as $document) {
     var_dump($document);

--- a/reference/mongodb/mongodb/driver/writeconcernerror/getcode.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror/getcode.xml
@@ -55,7 +55,7 @@ $bulk->insert(['x' => 1]);
 $writeConcern = new MongoDB\Driver\WriteConcern(2, 1);
 
 try {
-    $manager->executeBulkWrite('db.collection', $bulk, $writeConcern);
+    $manager->executeBulkWrite('db.collection', $bulk, ['writeConcern' => $writeConcern]);
 } catch(MongoDB\Driver\Exception\BulkWriteException $e) {
     var_dump($e->getWriteResult()->getWriteConcernError()->getCode());
 }

--- a/reference/mongodb/mongodb/driver/writeconcernerror/getinfo.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror/getinfo.xml
@@ -56,7 +56,7 @@ $bulk->insert(['x' => 1]);
 $writeConcern = new MongoDB\Driver\WriteConcern(2, 1);
 
 try {
-    $manager->executeBulkWrite('db.collection', $bulk, $writeConcern);
+    $manager->executeBulkWrite('db.collection', $bulk, ['writeConcern' => $writeConcern]);
 } catch(MongoDB\Driver\Exception\BulkWriteException $e) {
     var_dump($e->getWriteResult()->getWriteConcernError()->getInfo());
 }

--- a/reference/mongodb/mongodb/driver/writeconcernerror/getmessage.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror/getmessage.xml
@@ -55,7 +55,7 @@ $bulk->insert(['x' => 1]);
 $writeConcern = new MongoDB\Driver\WriteConcern(2, 1);
 
 try {
-    $manager->executeBulkWrite('db.collection', $bulk, $writeConcern);
+    $manager->executeBulkWrite('db.collection', $bulk, ['writeConcern' => $writeConcern]);
 } catch(MongoDB\Driver\Exception\BulkWriteException $e) {
     var_dump($e->getWriteResult()->getWriteConcernError()->getMessage());
 }

--- a/reference/mongodb/mongodb/driver/writeresult/getwriteconcernerror.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getwriteconcernerror.xml
@@ -57,7 +57,7 @@ $bulk->insert(['x' => 1]);
 $writeConcern = new MongoDB\Driver\WriteConcern(2, 1);
 
 try {
-    $manager->executeBulkWrite('db.collection', $bulk, $writeConcern);
+    $manager->executeBulkWrite('db.collection', $bulk, ['writeConcern' => $writeConcern]);
 } catch(MongoDB\Driver\Exception\BulkWriteException $e) {
     var_dump($e->getWriteResult()->getWriteConcernError());
 }

--- a/reference/mongodb/mongodb/driver/writeresult/isacknowledged.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/isacknowledged.xml
@@ -78,7 +78,9 @@ $manager = new MongoDB\Driver\Manager;
 $bulk = new MongoDB\Driver\BulkWrite;
 $bulk->insert(['x' => 1]);
 
-$result = $manager->executeBulkWrite('db.collection', $bulk, new MongoDB\Driver\WriteConcern(0));
+$writeConcern = new MongoDB\Driver\WriteConcern(0);
+
+$result = $manager->executeBulkWrite('db.collection', $bulk, ['writeConcern' => $writeConcern]);
 
 var_dump($result->isAcknowledged());
 


### PR DESCRIPTION
This was missed in 51ea49d0a56569458483a36478f6e5571a59bdc8

https://jira.mongodb.org/browse/PHPC-2489