### PR TITLE
sqlsrv: Delete invalid constant

### DIFF
--- a/reference/sqlsrv/constants.xml
+++ b/reference/sqlsrv/constants.xml
@@ -356,18 +356,6 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.utf-8">
-    <term>
-     <constant>UTF-8</constant> 
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     Specifies that data is returned with UTF-8 encoding. For usage information, 
-     see <link xlink:href="&url.sqlsrv.specify.phptype;">How to: Specify PHP Types</link>.
-     </simpara>
-    </listitem>
-   </varlistentry>
    <varlistentry xml:id="constant.sqlsrv-sqltype-bigint">
     <term>
      <constant>SQLSRV_SQLTYPE_BIGINT</constant> 


### PR DESCRIPTION
No such constant at https://github.com/microsoft/msphpsql/blob/master/source/sqlsrv/init.cpp or in runtime.