### PR TITLE
Swoole: Fix typo in Swoole\Server::__construct

### DIFF
--- a/reference/swoole/swoole/server/construct.xml
+++ b/reference/swoole/swoole/server/construct.xml
@@ -13,7 +13,7 @@
    <modifier>public</modifier> <methodname>Swoole\Server::__construct</methodname>
    <methodparam><type>string</type><parameter>host</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>port</parameter></methodparam>
-   <methodparam choice="opt"><type>integr</type><parameter>mode</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>mode</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>sock_type</parameter></methodparam>
   </constructorsynopsis>
   <para>


### PR DESCRIPTION
Reference: https://wiki.swoole.com/en/#/server/methods?id=__construct