### PR TITLE
Add back authors previously featured on the frontpage

### DIFF
--- a/contributors.xml
+++ b/contributors.xml
@@ -16,6 +16,7 @@
 
   <para>
    &Credit.Past.Authors.Text;
+   Mehdi Achour,            <!-- didou -->
    Bill Abt,                <!-- pdo howto via ibm -->
    Jouni Ahto,              <!-- jah -->
    Alexander Aulbach,       <!-- ssilk [at] ssilk.de  [no cvs user] -->
@@ -23,6 +24,7 @@
    George Peter Banyard,    <!-- girgias -->
    Christoph M. Becker,     <!-- cmb -->
    Daniel Beckham,          <!-- danbeck -->
+   Friedhelm Betz,          <!-- betz -->
    Nilgün Belma Bugüner,    <!-- nilgun -->
    Jesus M. Castagnetto,    <!-- jmcastagnetto -->
    Ron Chmara,              <!-- ronabop -->
@@ -30,7 +32,7 @@
    John Coggeshall,         <!-- john -->
    Simone Cortesi,          <!-- cortesi -->
    Peter Cowburn,           <!-- salathe -->
-   Antony Dovgal,
+   Antony Dovgal,           <!-- tony2001 -->
    Daniel Egeberg,          <!-- degeberg -->
    Markus Fischer,          <!-- mfischer -->
    Wez Furlong,             <!-- wez -->
@@ -42,6 +44,8 @@
    Moriyoshi Koizumi,       <!-- moriyoshi -->
    Rasmus Lerdorf,          <!-- rasmus -->
    Andrew Lindeman,         <!-- alindeman -->
+   Nuno Lopes,              <!-- nlopess -->
+   Hannes Magnusson,        <!-- bjori -->
    Stanislav Malyshev,      <!-- stas -->
    Justin Martin,           <!-- frozenfire -->
    Rafael Martinez,         <!-- rafael -->
@@ -53,15 +57,17 @@
    Richard Quadling,        <!-- rquadling -->
    Derick Rethans,          <!-- derick -->
    Rob Richards,            <!-- rrichards -->
-   Georg Richter,
+   Georg Richter,           <!-- georg -->
    Sander Roobol,           <!-- sander -->
    Egon Schmid,             <!-- eschmid -->
    Thomas Schoefbeck,       <!-- tom -->
    Sascha Schumann,         <!-- sas -->
    Dan Scott,               <!-- dbs -->
+   Damien Seguy,            <!-- dams -->
    Masahiro Takagi,         <!-- takagi -->
    Yoshinari Takaoka,       <!-- mumumu -->
    Yannick Torres,          <!-- yannick -->
+   Jakub Vrana,             <!-- vrana -->
    Michael Wallner,         <!-- mike -->
    Lars Torben Wilson,      <!-- torben and also cslawi -->
    Jim Winstead,            <!-- jimw and also jim(?) -->
@@ -72,6 +78,7 @@
   <para>
    &Credit.Past.Editors.Text;
    Stig Bakken,                    <!-- ssb -->
+   Peter Cowburn,                  <!-- salathe -->
    Gabor Hojtsy,                   <!-- goba -->
    Hartmut Holzgraefe,             <!-- hholzgra -->
    Philip Olson&listendand;        <!-- philip -->


### PR DESCRIPTION
I just couldn't believe that @haszi removed people with the biggest contributions in fde7fc4. Only two of them were added in 169faf3.