### PR TITLE
Remove note about MongoDB 2.6 in getModifiedCount()

### DIFF
--- a/reference/mongodb/mongodb/driver/writeresult/getmodifiedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getmodifiedcount.xml
@@ -32,11 +32,6 @@
    Returns the number of existing documents updated, or &null; if the write was
    not acknowledged.
   </para>
-  <para>
-   The modified count is not available on versions of MongoDB before 2.6, which
-   used the legacy wire protocol version (i.e. OP_UPDATE). If this is the case,
-   the modified count will also be &null;.
-  </para>
  </refsect1>
 
  <refsect1 role="errors">


### PR DESCRIPTION
Support for MongoDB 2.6 was dropped in ext-mongodb 1.5.0

https://jira.mongodb.org/browse/PHPC-1662