### PR TITLE
Tokens: Close PHP code in example

### DIFF
--- a/appendices/tokens.xml
+++ b/appendices/tokens.xml
@@ -34,6 +34,7 @@
 <?php
 // Prior to PHP 7.4.0, T_FN is not defined.
 defined('T_FN') || define('T_FN', 10001);
+?>
 ]]>
    </programlisting>
   </para>


### PR DESCRIPTION
Examples close PHP code elsewhere.
Otherwise syntax highlighting is confused in my editor.