### PR TITLE
Improve fpm configuration reference

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -401,8 +401,8 @@
        <para>
         The number of child processes to be created when <literal>pm</literal> is set to
         <literal>static</literal> and the maximum number of child processes to be created
-        when <literal>pm</literal> is set to <literal>dynamic</literal>. This
-        option is mandatory.
+        when <literal>pm</literal> is set to <literal>dynamic</literal> or <literal>ondemand</literal>.
+        This option is mandatory.
        </para>
        <para>
         This option sets the limit on the number of simultaneous requests that

--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -383,7 +383,7 @@
        <para>
         <literal>ondemand</literal> - the processes spawn on demand (when requested,
         as opposed to dynamic, where <literal>pm.start_servers</literal> are started
-        when the service is started.
+        when the service is started).
        </para>
        <para>
         <literal>dynamic</literal> - the number of child processes is set dynamically based on the

--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -398,12 +398,12 @@
        <type>int</type>
       </term>
       <listitem>
-       <para>
+       <simpara>
         The number of child processes to be created when <literal>pm</literal> is set to
         <literal>static</literal> and the maximum number of child processes to be created
         when <literal>pm</literal> is set to <literal>dynamic</literal> or <literal>ondemand</literal>.
         This option is mandatory.
-       </para>
+       </simpara>
        <para>
         This option sets the limit on the number of simultaneous requests that
         will be served. Equivalent to the ApacheMaxClients directive with

--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -380,16 +380,16 @@
        <para>
         <literal>static</literal> - the number of child processes is fixed (<literal>pm.max_children</literal>).
        </para>
-       <para>
+       <simpara>
         <literal>ondemand</literal> - the processes spawn on demand (when requested,
         as opposed to dynamic, where <literal>pm.start_servers</literal> are started
         when the service is started).
-       </para>
-       <para>
+       </simpara>
+       <simpara>
         <literal>dynamic</literal> - the number of child processes is set dynamically based on the
         following directives: <literal>pm.max_children</literal>, <literal>pm.start_servers</literal>,
         <literal>pm.min_spare_servers</literal>, <literal>pm.max_spare_servers</literal>.
-       </para>
+       </simpara>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="pm.max-children">


### PR DESCRIPTION
Add a missing closing brace and mention `pm = ondemand` at the directive `pm.max_children`, for which it is mandatory, too.