### PR TITLE
Fix return type of SolrUtils::escapeQueryChars

### DIFF
--- a/reference/solr/solrutils/escapequerychars.xml
+++ b/reference/solr/solrutils/escapequerychars.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>SolrUtils::escapeQueryChars</methodname>
+   <modifier>public</modifier> <modifier>static</modifier> <type>string</type><methodname>SolrUtils::escapeQueryChars</methodname>
    <methodparam><type>string</type><parameter>str</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -47,7 +47,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-  Returns the escaped string&return.falseforfailure;.
+  Returns the escaped string.
   </para>
  </refsect1>
 


### PR DESCRIPTION
As noted in https://github.com/php/pecl-search_engine-solr/issues/83, and fixed in https://github.com/php/pecl-search_engine-solr/pull/84 the method actually never returns anything else then a string.