### PR TITLE
password: add missing required options to enable argon2 support in PHP 8.4+

### DIFF
--- a/reference/password/setup.xml
+++ b/reference/password/setup.xml
@@ -23,7 +23,8 @@
    libargon2 support using the
    <option role="configure">--with-password-argon2</option> configure option
    or, starting from PHP 8.4.0, with OpenSSL using
-   <option role="configure">--with-openssl</option>.
+   <option role="configure">--with-openssl</option> and
+   <option role="configure">--with-openssl-argon2</option>.
   </para>
   <para>
    Prior to PHP 8.1.0, it was possible to specify the argon2 directory with


### PR DESCRIPTION
Since PHP 8.4, PHP can use OpenSSL's Argon2 hashing. To enable it, PHP must be built with `--with-openssl` and `--with-openssl-argon2` options, but the documentation mentions only the former. This PR will add the latter.

PHP built with `--with-openssl` and `--with-openssl-argon2` supports `argon2i` and `argon2id`:

```
$ ./configure --disable-all --disable-mbregex --disable-fiber-asm --enable-cli --disable-cgi --disable-phpdbg --disable-embed --without-iconv --without-libxml --without-pcre-jit --without-pdo-sqlite --without-sqlite3 --with-openssl --with-openssl-argon2
$ make
$ sapi/cli/php -r 'echo join(", ", password_algos()), PHP_EOL;'
2y, argon2i, argon2id
```

PHP built with `--with-openssl` does not supports `argon2i` nor `argon2id`:

```
$ ./configure --disable-all --disable-mbregex --disable-fiber-asm --enable-cli --disable-cgi --disable-phpdbg --disable-embed --without-iconv --without-libxml --without-pcre-jit --without-pdo-sqlite --without-sqlite3 --with-openssl
$ make
$ sapi/cli/php -r 'echo join(", ", password_algos()), PHP_EOL;'
2y
```
