### PR TITLE
Use explicit nullable type in language/exceptions.xml

### DIFF
--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -386,7 +386,7 @@ class Exception implements Throwable
     private   $trace;                           // backtrace
     private   $previous;                        // previous exception if nested exception
 
-    public function __construct($message = '', $code = 0, Throwable $previous = null);
+    public function __construct($message = '', $code = 0, ?Throwable $previous = null);
 
     final private function __clone();           // Inhibits cloning of exceptions.
 
@@ -432,7 +432,7 @@ class Exception implements Throwable
 class MyException extends Exception
 {
     // Redefine the exception so message isn't optional
-    public function __construct($message, $code = 0, Throwable $previous = null) {
+    public function __construct($message, $code = 0, ?Throwable $previous = null) {
         // some code
 
         // make sure everything is assigned properly


### PR DESCRIPTION
PHP 8.4 deprecates inferred nullable parameters. Many people copy this code directly into their codebase so it's good to make sure it won't break anything soon.