### PR TITLE
IntlDateFormatter::localtime: Fix example

### DIFF
--- a/reference/intl/dateformatter/localtime.xml
+++ b/reference/intl/dateformatter/localtime.xml
@@ -28,7 +28,7 @@
   <para>
    Converts string $value to a field-based time value ( an array of various fields), starting at
 $parse_pos and consuming as much of the input value as possible.
-  </para> 
+  </para>
   </refsect1>
 
  <refsect1 role="parameters">
@@ -39,7 +39,7 @@ $parse_pos and consuming as much of the input value as possible.
      <term><parameter>formatter</parameter></term>
      <listitem>
       <para>
-       The formatter resource      
+       The formatter resource
       </para>
      </listitem>
     </varlistentry>
@@ -47,7 +47,7 @@ $parse_pos and consuming as much of the input value as possible.
      <term><parameter>string</parameter></term>
      <listitem>
       <para>
-       string to convert to a time      
+       string to convert to a time
       </para>
      </listitem>
     </varlistentry>
@@ -58,14 +58,14 @@ $parse_pos and consuming as much of the input value as possible.
        Position at which to start the parsing in $value (zero-based).
        If no error occurs before $value is consumed, $parse_pos will contain -1
        otherwise it will contain the position at which parsing ended .
-       If $parse_pos &gt; strlen($value), the parse fails immediately.  
+       If $parse_pos &gt; strlen($value), the parse fails immediately.
       </para>
      </listitem>
     </varlistentry>
    </variablelist>
   </para>
  </refsect1>
-   
+
  
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
@@ -90,7 +90,7 @@ $fmt = datefmt_create(
     'America/Los_Angeles',
     IntlDateFormatter::GREGORIAN
 );
-$arr = datefmt_localtime($fmt, 'Wednesday, December 31, 1969 4:00:00 PM PT', 0);
+$arr = datefmt_localtime($fmt, 'Wednesday, December 31, 1969 at 4:00:00 PM Pacific Standard Time', $offset);
 echo 'First parsed output is ';
 if ($arr) {
     foreach ($arr as $key => $value) {
@@ -129,8 +129,8 @@ if ($arr) {
      &example.outputs;
      <screen>
          <![CDATA[
-First parsed output is tm_sec : 0 , tm_min : 0 , tm_hour : 16 , tm_year : 69 , 
-tm_mday : 31 , tm_wday : 3 , tm_yday : 365 , tm_mon : 11 , tm_isdst : 0 , 
+First parsed output is tm_sec : 0 , tm_min : 0 , tm_hour : 16 , tm_year : 69 ,
+tm_mday : 31 , tm_wday : 3 , tm_yday : 365 , tm_mon : 11 , tm_isdst : 0 ,
 ]]>
      </screen>
  </refsect1>

--- a/reference/intl/dateformatter/localtime.xml
+++ b/reference/intl/dateformatter/localtime.xml
@@ -114,7 +114,7 @@ $fmt = new IntlDateFormatter(
     'America/Los_Angeles',
     IntlDateFormatter::GREGORIAN
 );
-$arr = $fmt->localtime('Wednesday, December 31, 1969 4:00:00 PM PT', 0);
+$arr = $fmt->localtime('Wednesday, December 31, 1969 at 4:00:00 PM Pacific Standard Time', $offset);
 echo 'First parsed output is ';
 if ($arr) {
     foreach ($arr as $key => $value) {
@@ -129,8 +129,8 @@ if ($arr) {
      &example.outputs;
      <screen>
          <![CDATA[
-First parsed output is tm_sec : 0 , tm_min : 0 , tm_hour : 16 , tm_year : 1969 , 
-tm_mday : 31 , tm_wday : 4 , tm_yday : 365 , tm_mon : 11 , tm_isdst : 0 , 
+First parsed output is tm_sec : 0 , tm_min : 0 , tm_hour : 16 , tm_year : 69 , 
+tm_mday : 31 , tm_wday : 3 , tm_yday : 365 , tm_mon : 11 , tm_isdst : 0 , 
 ]]>
      </screen>
  </refsect1>


### PR DESCRIPTION
Date/time format adjusted to match the specified one in the first line.
Last parameter is a reference.