### PR TITLE
Document file permission requirements for file_exists function

### DIFF
--- a/reference/filesystem/functions/file-exists.xml
+++ b/reference/filesystem/functions/file-exists.xml
@@ -32,6 +32,9 @@
        <filename>\\computername\share\filename</filename> to check files on
        network shares.
       </para>
+      <para>
+       On Linux, both read and execute permissions are required for the function to return true.
+      </para>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
This PR updates the documentation for the file_exists function to clarify the file permission requirements on Linux. Specifically, it mentions that both read and execute permissions are required for the function to return true.

Changes:
- Added details about Linux file permission requirements in the "Parameters" section of the file_exists function documentation.

This change ensures developers have a clearer understanding of the behavior of file_exists across different platforms (i've wasted an hour on finding hy it returned false on me).