### PR TITLE
these are not available in 32bit pack: q, Q, J, P

### DIFF
--- a/reference/misc/functions/pack.xml
+++ b/reference/misc/functions/pack.xml
@@ -255,6 +255,9 @@ $binarydata = pack("nvc*", 0x1234, 0x5678, 65, 66);
  <refsect1 role="notes">
   &reftitle.notes;
   <caution>
+    <para>Warning: format codes <literal>q</literal>, <literal>Q</literal>, <literal>J</literal> and <literal>P</literal> are not available on 32-bit PHP builds.</para>
+  </caution>
+  <caution>
    <para>Note that PHP internally stores <type>int</type> values as
     signed values of a machine-dependent size.
     Integer literals and operations that yield numbers outside the bounds of the  


### PR DESCRIPTION
see https://github.com/php/php-src/blob/156d034d3da314925a77115538b55c7097c662cc/ext/standard/pack.c#L320-L330