### PR TITLE
Fix 'detected dubious ownership in repository' error in Docker build and run process

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM php:8.2-cli
 
+ARG UID=1000
+ARG GID=1000
+
 RUN apt-get update && \
     apt-get install -y git default-jre-headless
 
@@ -9,7 +12,8 @@ ADD https://api.github.com/repos/php/phd/git/refs/heads/master version-phd.json
 ADD https://api.github.com/repos/php/doc-base/git/refs/heads/master version-doc-base.json
 
 RUN git clone --depth 1 https://github.com/php/phd.git &&  \
-    git clone --depth 1 https://github.com/php/doc-base.git
+    git clone --depth 1 https://github.com/php/doc-base.git && \
+    chown -R ${UID}:${GID} /var/www/phd /var/www/doc-base
 
 RUN echo 'memory_limit = 512M' >> /usr/local/etc/php/conf.d/local.ini
 

--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,5 @@ php: .docker/built
 build: .docker/built
 
 .docker/built:
-	docker build .docker -t php/doc-en
+	docker build .docker -t php/doc-en --build-arg UID=$(CURRENT_UID) --build-arg GID=$(CURRENT_GID)
 	touch .docker/built


### PR DESCRIPTION
This pull request solves the problem `fatal: detected dubious ownership in repository at ...` when executing the make command. This was solved by passing the UID and GID of the host user as build arguments and adjusting the ownership of the cloned repository in the Dockerfile.

## Steps to reproduce
Precondition: Ensure that the doc-base and phd repositories are not cloned in directories adjacent to this directory.
Run the following command in the project root directory:

```bash
make
```

This will trigger the Docker build and run process, which previously resulted in the "detected dubious ownership in repository" error.


## Changes
- Added `UID` and `GID` build arguments in the Makefile docker build command.
- Modified Dockerfile to use these arguments and change ownership of `/var/www/phd` and `/var/www/doc-base` directories.

## Verification
- Confirmed that `make` completes successfully without the dubious ownership error.
- Verified that the container runs correctly and updates repositories as expected.

## Note to reviewers
I'm new to contributing to this repo, so please bear with me.
If you have any feedback or suggestions, I'd really appreciate it!

