### PR TITLE
Language snippets: fix `odbc.changelog.connection-return`

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1923,8 +1923,7 @@ and <literal xmlns="http://docbook.org/ns/docbook">_</literal> to match a single
  </entry>
 </row>'>
 
-<!ENTITY odbc.changelog.connection-return '&odbc.changelog.connection-param;
- <row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY odbc.changelog.connection-return '<row xmlns="http://docbook.org/ns/docbook">
   <entry>8.4.0</entry>
   <entry>
    This function returns a <classname>Odbc\Connection</classname> instance now;


### PR DESCRIPTION
Don't include `odbc.changelog.connection-param`, not every function that returns a connection has a connection parameter (and, in fact, neither of the existing uses of the connection-return entity, for `odbc_connect()` and `odbc_pconnect()`, has such a parameter).