### PR TITLE
Fix name of `rows_buffered_from_client_ps` MySQLnd statistic

### DIFF
--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -662,8 +662,8 @@ $res->close();
     </listitem>
    </varlistentry>
 
-   <varlistentry xml:id="mysqlnd.stats.statistics.rows-buffered-from-server-ps">
-    <term><literal>rows_buffered_from_server_ps</literal></term>
+   <varlistentry xml:id="mysqlnd.stats.statistics.rows-buffered-from-client-ps">
+    <term><literal>rows_buffered_from_client_ps</literal></term>
     <listitem>
      <simpara>
       Same as <literal>rows_buffered_from_client_normal</literal>


### PR DESCRIPTION
There is no `buffered_from_server` statistic.