### PR TITLE
$php_errormsg was removed in PHP 8.0

### DIFF
--- a/language/predefined/variables/phperrormsg.xml
+++ b/language/predefined/variables/phperrormsg.xml
@@ -8,7 +8,7 @@
  </refnamediv>
 
  <refsynopsisdiv>
-  &warn.deprecated.feature-7-2-0;
+  &warn.deprecated.function-7-2-0.removed-8-0-0;
   <simpara>
    Use <function>error_get_last</function> instead.
   </simpara>

--- a/language/predefined/variables/phperrormsg.xml
+++ b/language/predefined/variables/phperrormsg.xml
@@ -8,7 +8,7 @@
  </refnamediv>
 
  <refsynopsisdiv>
-  &warn.deprecated.function-7-2-0.removed-8-0-0;
+  &warn.deprecated.feature-7-2-0.removed-8-0-0;
   <simpara>
    Use <function>error_get_last</function> instead.
   </simpara>


### PR DESCRIPTION
See php/php-src@920b4b249f71e6cbfd795f81c6a08126a33c659e
Use `&warn.deprecated.feature-7-2-0.removed-8-0-0;` instead of `&warn.deprecated.feature-7-2-0;`