### PR TITLE
Array type: Add a top of page link to the array functions docs

### DIFF
--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -4,7 +4,7 @@
  <title>Arrays</title>
 
  <para>
-  See also the <link linkend="ref.array">array functions</link> documentation.
+  For a list of all array functions, see the <link linkend="ref.array">array functions</link> chapter in the documentation.
  </para>
 
  <para>

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -4,6 +4,10 @@
  <title>Arrays</title>
 
  <para>
+  See also the <link linkend="ref.array">array functions</link> documentation.
+ </para>
+
+ <para>
   An <type>array</type> in PHP is actually an ordered map. A map is a type that
   associates <emphasis>values</emphasis> to <emphasis>keys</emphasis>. This type
   is optimized for several different uses; it can be treated as an array,


### PR DESCRIPTION
It's not uncommon to end up on the array type documentation page - for example, if you go to https://php.net/array - when you really want the functions documentation.

While there are links further down the page, you currently need to know they're there (and where they are), and then scroll down to them for access.

A top of page link allows for users to quickly get to where they want to go.