### PR TITLE
Fix build: Add title to example of isset()

### DIFF
--- a/reference/var/functions/isset.xml
+++ b/reference/var/functions/isset.xml
@@ -108,6 +108,7 @@ var_dump(isset($foo));   // FALSE
   <para>
    This also work for elements in arrays:
    <example>
+    <title>Example of <function>isset</function> with array elements</title>
     <programlisting role="php">
 <![CDATA[
 <?php


### PR DESCRIPTION
Manual does not build without a title tag (DTD).