### PR TITLE
MongoDB: Fix docs errors for 2.0 version

### DIFF
--- a/reference/mongodb/bson/persistable/bsonserialize.xml
+++ b/reference/mongodb/bson/persistable/bsonserialize.xml
@@ -59,6 +59,7 @@
       </row>
      </thead>
      <tbody>
+      &mongodb.changelog.tentative-return-types-enforced;
       <row>
        <entry>PECL mongodb 1.17.0</entry>
        <entry>

--- a/reference/mongodb/bson/serializable/bsonserialize.xml
+++ b/reference/mongodb/bson/serializable/bsonserialize.xml
@@ -63,6 +63,7 @@
       </row>
      </thead>
      <tbody>
+      &mongodb.changelog.tentative-return-types-enforced;
       <row>
        <entry>PECL mongodb 1.17.0</entry>
        <entry>

--- a/reference/mongodb/bson/unserializable/bsonunserialize.xml
+++ b/reference/mongodb/bson/unserializable/bsonunserialize.xml
@@ -52,6 +52,24 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.tentative-return-types-enforced;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/mongodb/mongodb/driver/exception/bulkwriteexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwriteexception.xml
@@ -53,6 +53,9 @@
     <!-- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('runtimeexception.synopsis')/descendant::db:fieldsynopsis)" /> -->
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)" />
 
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-exception-bulkwriteexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <!-- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-exception-serverexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />-->
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-exception-runtimeexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
@@ -110,6 +113,8 @@
    </para>
   </section>
  </partintro>
+
+ &reference.mongodb.mongodb.driver.exception.entities.bulkwriteexception;
 
 </reference>
 


### PR DESCRIPTION
This adds changelog entries and methods that were missed when initially adding the 2.0 documentation.