### PR TITLE
random: clarify that `getrandmax` was small only before PHP 7.1

### DIFF
--- a/reference/random/functions/rand.xml
+++ b/reference/random/functions/rand.xml
@@ -27,8 +27,8 @@
   &caution.cryptographically-insecure;
   <note>
    <simpara>
-    On some platforms (such as Windows), <function>getrandmax</function>
-    is only 32767.  If you require a range larger than 32767, specifying
+    Prior to PHP 7.1.0, <function>getrandmax</function> was only 32767 on some
+    platforms (such as Windows). If you require a range larger than 32767, specifying
     <parameter>min</parameter> and <parameter>max</parameter> will allow
     you to create a range larger than this, or consider using
     <function>mt_rand</function> instead.


### PR DESCRIPTION
Since PHP 7.1 `getrandmax` is an alias of `mt_getrandmax`, which returns 2**31 - 1