### PR TITLE
Fix links to magic constants page

### DIFF
--- a/appendices/tokens.xml
+++ b/appendices/tokens.xml
@@ -145,7 +145,7 @@ defined('T_FN') || define('T_FN', 10001);
      <entry><constant>T_CLASS_C</constant></entry>
      <entry>__CLASS__</entry>
      <entry>
-      <link linkend="language.constants.predefined">magic constants</link>
+      <link linkend="language.constants.magic">magic constants</link>
      </entry>
     </row>
     <row xml:id="constant.t-clone">
@@ -230,7 +230,7 @@ defined('T_FN') || define('T_FN', 10001);
     <row xml:id="constant.t-dir">
      <entry><constant>T_DIR</constant></entry>
      <entry>__DIR__</entry>
-     <entry><link linkend="language.constants.predefined">magic constants</link></entry>
+     <entry><link linkend="language.constants.magic">magic constants</link></entry>
     </row>
     <row xml:id="constant.t-div-equal">
      <entry><constant>T_DIV_EQUAL</constant></entry>
@@ -377,7 +377,7 @@ defined('T_FN') || define('T_FN', 10001);
     <row xml:id="constant.t-file">
      <entry><constant>T_FILE</constant></entry>
      <entry>__FILE__</entry>
-     <entry><link linkend="language.constants.predefined">magic constants</link></entry>
+     <entry><link linkend="language.constants.magic">magic constants</link></entry>
     </row>
     <row xml:id="constant.t-final">
      <entry><constant>T_FINAL</constant></entry>
@@ -416,7 +416,7 @@ defined('T_FN') || define('T_FN', 10001);
      <entry><constant>T_FUNC_C</constant></entry>
      <entry>__FUNCTION__</entry>
      <entry>
-      <link linkend="language.constants.predefined">magic constants</link>
+      <link linkend="language.constants.magic">magic constants</link>
      </entry>
     </row>
     <row xml:id="constant.t-global">
@@ -526,7 +526,7 @@ defined('T_FN') || define('T_FN', 10001);
     <row xml:id="constant.t-line">
      <entry><constant>T_LINE</constant></entry>
      <entry>__LINE__</entry>
-     <entry><link linkend="language.constants.predefined">magic constants</link></entry>
+     <entry><link linkend="language.constants.magic">magic constants</link></entry>
     </row>
     <row xml:id="constant.t-list">
      <entry><constant>T_LIST</constant></entry>
@@ -564,7 +564,7 @@ defined('T_FN') || define('T_FN', 10001);
      <entry><constant>T_METHOD_C</constant></entry>
      <entry>__METHOD__</entry>
      <entry>
-      <link linkend="language.constants.predefined">magic constants</link>
+      <link linkend="language.constants.magic">magic constants</link>
      </entry>
     </row>
     <row xml:id="constant.t-minus-equal">
@@ -720,7 +720,7 @@ defined('T_FN') || define('T_FN', 10001);
      <entry><constant>T_PROPERTY_C</constant></entry>
      <entry>__PROPERTY__</entry>
      <entry>
-      <link linkend="language.constants.predefined">magic constants</link>
+      <link linkend="language.constants.magic">magic constants</link>
      </entry>
     </row>
     <row xml:id="constant.t-protected">

--- a/language/control-structures/include.xml
+++ b/language/control-structures/include.xml
@@ -84,7 +84,7 @@ echo "A $color $fruit"; // A green apple
   though it had been defined inside that function.  So, it will follow
   the variable scope of that function.
   An exception to this rule are <link
-  linkend="language.constants.predefined">magic constants</link> which are
+  linkend="language.constants.magic">magic constants</link> which are
   evaluated by the parser before the include occurs.
  </simpara>
  <para>

--- a/language/predefined/variables/server.xml
+++ b/language/predefined/variables/server.xml
@@ -49,7 +49,7 @@
        <varname>$_SERVER['PHP_SELF']</varname> in a script at the
        address <filename>http://example.com/foo/bar.php</filename>
        would be <filename>/foo/bar.php</filename>.
-       The <link linkend="language.constants.predefined">__FILE__</link>
+       The <link linkend="language.constants.magic">__FILE__</link>
        constant contains the full path and filename of the current (i.e.
        included) file.
       </simpara>
@@ -346,7 +346,7 @@
       <simpara>
        Contains the current script's path. This is useful for pages
        which need to point to themselves.
-       The <link linkend="language.constants.predefined">__FILE__</link>
+       The <link linkend="language.constants.magic">__FILE__</link>
        constant contains the full path and filename of the current (i.e.
        included) file.
       </simpara>

--- a/reference/errorfunc/functions/debug-backtrace.xml
+++ b/reference/errorfunc/functions/debug-backtrace.xml
@@ -134,7 +134,7 @@
        <entry><type>string</type></entry>
        <entry>
         The current function name.  See also
-        <link linkend="language.constants.predefined">__FUNCTION__</link>.
+        <link linkend="language.constants.magic">__FUNCTION__</link>.
        </entry>
       </row>
       <row>
@@ -142,7 +142,7 @@
        <entry><type>int</type></entry>
        <entry>
         The current line number.  See also
-        <link linkend="language.constants.predefined">__LINE__</link>.
+        <link linkend="language.constants.magic">__LINE__</link>.
        </entry>
       </row>
       <row>
@@ -150,7 +150,7 @@
        <entry><type>string</type></entry>
        <entry>
         The current file name.  See also
-        <link linkend="language.constants.predefined">__FILE__</link>.
+        <link linkend="language.constants.magic">__FILE__</link>.
        </entry>
       </row>
       <row>
@@ -158,7 +158,7 @@
        <entry><type>string</type></entry>
        <entry>
         The current <link linkend="language.oop5">class</link> name.  See also
-        <link linkend="language.constants.predefined">__CLASS__</link>
+        <link linkend="language.constants.magic">__CLASS__</link>
        </entry>
       </row>
       <row>

--- a/reference/misc/functions/define.xml
+++ b/reference/misc/functions/define.xml
@@ -157,7 +157,7 @@ echo ANIMALS[1]; // outputs "cat"
     <para>
      This example illustrates the <emphasis>possibility</emphasis> to define a
      constant with the same name as a
-     <link linkend="language.constants.predefined">magic constant</link>.
+     <link linkend="language.constants.magic">magic constant</link>.
      Since the resulting behavior is obviously confusing, it is not recommended
      to do this in practise, though.
     </para>


### PR DESCRIPTION
Not sure what happened here, but found quite a few incorrect links for the magic constants page.

Fixed now.