### PR TITLE
Add missing `false` return type in `hash_file` documentation

### DIFF
--- a/reference/hash/functions/hash-file.xml
+++ b/reference/hash/functions/hash-file.xml
@@ -66,7 +66,7 @@
   <para>
    Returns a string containing the calculated message digest as lowercase hexits
    unless <parameter>binary</parameter> is set to true in which case the raw
-   binary representation of the message digest is returned.
+   binary representation of the message digest is returned, &return.falseforfailure;.
   </para>
  </refsect1>
 


### PR DESCRIPTION
`hash_file()` return type is `string|false`, but this does not appears in the returned values doc block.