### PR TITLE
Add missing `false` return type in `openssl_x509_parse` documentation

### DIFF
--- a/reference/openssl/functions/openssl-x509-parse.xml
+++ b/reference/openssl/functions/openssl-x509-parse.xml
@@ -50,6 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
+   Returns an array containing the certificate information, &return.falseforfailure;.
    <emphasis>The structure of the returned data is (deliberately) not
    yet documented, as it is still subject to change.</emphasis>
   </para>


### PR DESCRIPTION
`openssl_x509_parse()` return type is `string|false`, but this does not appears in the returned values doc block.