### PR TITLE
Remove bundled expat default support and rename --with-expat-dir to --with-expat

### DIFF
--- a/reference/xml/configure.xml
+++ b/reference/xml/configure.xml
@@ -7,17 +7,31 @@
   <option role="configure">--disable-xml</option>
  </para>
  <!-- TODO the following needs researched and updated -->
- <para>
-  These functions are enabled by default, using the bundled expat library.
-  You can disable XML support with
-  <option role="configure">--disable-xml</option>.
-  If you compile PHP as a module for Apache 1.3.9 or later, PHP will
-  automatically use the bundled <productname>expat</productname> library from
-  Apache. If you don't want to use the bundled expat library, configure
-  PHP with <option role="configure">--with-expat-dir=DIR</option>, where DIR should
-  point to the base installation directory of expat.
- </para>
  &windows.builtin;
+ <simplesect role="changelog">
+ &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>7.4.0</entry>
+       <entry>
+        The <option role="configure">--with-libexpat-dir</option> has been renamed to 
+        <option role="configure">--with-expat</option> and no longer accepts a directory argument.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </simplesect>
 </section>
 
 <!-- Keep this comment at the end of the file

--- a/reference/xml/configure.xml
+++ b/reference/xml/configure.xml
@@ -6,7 +6,6 @@
   &installation.enabled.disable;
   <option role="configure">--disable-xml</option>
  </para>
- <!-- TODO the following needs researched and updated -->
  &windows.builtin;
  <simplesect role="changelog">
  &reftitle.changelog;

--- a/reference/xml/configure.xml
+++ b/reference/xml/configure.xml
@@ -22,7 +22,7 @@
       <row>
        <entry>7.4.0</entry>
        <entry>
-        The <option role="configure">--with-libexpat-dir</option> has been renamed to 
+        The <option role="configure">--with-libexpat-dir</option> has been renamed to
         <option role="configure">--with-expat</option> and no longer accepts a directory argument.
        </entry>
       </row>

--- a/reference/xml/configure.xml
+++ b/reference/xml/configure.xml
@@ -24,6 +24,7 @@
        <entry>
         The <option role="configure">--with-libexpat-dir</option> has been renamed to
         <option role="configure">--with-expat</option> and no longer accepts a directory argument.
+        The bundled expat library has been removed.
        </entry>
       </row>
      </tbody>


### PR DESCRIPTION
- Remove documentation for default bundled expat support.
- Deprecate the `--with-expat-dir` configure option.
- Introduce the new `--with-expat` option (no longer accepts a directory argument) and document it in the Changelog.