### PR TITLE
Correct memory usage estimation in range() documentation

### DIFF
--- a/language/generators.xml
+++ b/language/generators.xml
@@ -33,7 +33,7 @@
    function as a generator. The standard <function>range</function> function
    has to generate an array with every value in it and return it, which can
    result in large arrays: for example, calling
-   <command>range(0, 1000000)</command> will result in well over 100 MB of
+   <command>range(0, 1000000)</command> will result in well over 10 MB of
    memory being used.
   </para>
 

--- a/language/generators.xml
+++ b/language/generators.xml
@@ -28,14 +28,14 @@
    Like with iterators, random data access is not possible.
   </para>
 
-  <para>
+  <simpara>
    A simple example of this is to reimplement the <function>range</function>
    function as a generator. The standard <function>range</function> function
    has to generate an array with every value in it and return it, which can
    result in large arrays: for example, calling
    <command>range(0, 1000000)</command> will result in well over 10 MB of
    memory being used.
-  </para>
+  </simpara>
 
   <para>
    As an alternative, we can implement an <literal>xrange()</literal>


### PR DESCRIPTION
Hello,
I found that the PHP manual states that executing range(0, 1000000) uses more than 100MB of memory ([link to the documentation](https://www.php.net/manual/en/language.generators.overview.php)). However, when I tested it, the actual memory usage was around 18MB, which is significantly lower than the documented value.
Here is the test script I used:
```
<?php
    // Memory usage before execution
    $memoryUsageBefore = memory_get_usage(true) / 1024 / 1024;
    echo "Used memory before process: " . $memoryUsageBefore . " MB" . PHP_EOL;

    $arr = range(0, 1000000);

    // Memory usage after execution
    $memoryUsageAfter = memory_get_usage(true) / 1024 / 1024;
    echo "Used memory after process: " . $memoryUsageAfter . " MB" . PHP_EOL;
```


Given this discrepancy, I suggest updating the documentation to reflect a more accurate memory usage estimate (e.g., 10MB instead of 100MB).
Please let me know if further testing or clarification is needed.
Thank you!