### PR TITLE
filter_has_var: Fix grammar

### DIFF
--- a/reference/filter/functions/filter-has-var.xml
+++ b/reference/filter/functions/filter-has-var.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.filter-has-var" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>filter_has_var</refname>
-  <refpurpose>Checks if variable of specified type exists</refpurpose>
+  <refpurpose>Checks if a variable of the specified type exists</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;


### PR DESCRIPTION
This PR fixes a minor grammatical issue in the description of the `filter_has_var` function. Adding "a" and "the" makes the sentence grammatically complete and easier to understand.