### PR TITLE
Update the definition of the Z pack format code

### DIFF
--- a/reference/misc/functions/pack.xml
+++ b/reference/misc/functions/pack.xml
@@ -166,7 +166,7 @@
           </row>
           <row>
            <entry>Z</entry>
-           <entry>NUL-terminated (ASCIZ) string, will be NUL padded</entry>
+           <entry>NUL-terminated (ASCIIZ) string, will be NUL padded</entry>
           </row>
           <row>
            <entry>@</entry>

--- a/reference/misc/functions/pack.xml
+++ b/reference/misc/functions/pack.xml
@@ -166,7 +166,7 @@
           </row>
           <row>
            <entry>Z</entry>
-           <entry>NUL-terminated string</entry>
+           <entry>NUL-terminated (ASCIZ) string, will be NUL padded</entry>
           </row>
           <row>
            <entry>@</entry>

--- a/reference/misc/functions/pack.xml
+++ b/reference/misc/functions/pack.xml
@@ -166,7 +166,7 @@
           </row>
           <row>
            <entry>Z</entry>
-           <entry>NUL-padded string</entry>
+           <entry>NUL-terminated string</entry>
           </row>
           <row>
            <entry>@</entry>


### PR DESCRIPTION
a and Z had the same definition, but Z is the NUL-terminated variation.