### PR TITLE
Incorrect result in BcMath\Number::round() example

### DIFF
--- a/reference/bc/bcmath/number/round.xml
+++ b/reference/bc/bcmath/number/round.xml
@@ -164,9 +164,9 @@ var_dump(
 <![CDATA[
 object(BcMath\Number)#2 (2) {
   ["value"]=>
-  string(6) "123.45"
+  string(7) "123.450"
   ["scale"]=>
-  int(2)
+  int(3)
 }
 object(BcMath\Number)#3 (2) {
   ["value"]=>


### PR DESCRIPTION
https://www.php.net/manual/en/bcmath-number.round.php

The current doc:

```php
<?php
$number = new BcMath\Number('123.45');

var_dump(
    $number->round(3),
    // ...
);
?>
```

```
object(BcMath\Number)#2 (2) {
  ["value"]=>
  string(6) "123.45"
  ["scale"]=>
  int(2)
}
...
```

the actual current behavior:

```
> new BcMath\Number('123.45')->round(3);
= BcMath\Number {#4083
    +value: "123.450",
    +scale: 3,
  }

> new BcMath\Number('123.45')->round(10);
= BcMath\Number {#4094
    +value: "123.4500000000",
    +scale: 10,
  }
```

since [bcround](https://www.php.net/manual/en/function.bcround.php) behaves this way too, I assume it's a documentation issue