### PR TITLE
Fix error in deconstructor example 5

### DIFF
--- a/language/oop5/decon.xml
+++ b/language/oop5/decon.xml
@@ -262,7 +262,7 @@ class Product {
     public static function fromXml(string $xml): static {
         $data = simplexml_load_string($xml);
         $new = new static();
-        $new->id = $data->id;
+        $new->id = (int) $data->id;
         $new->name = $data->name;
         return $new;
     }


### PR DESCRIPTION
When we run example #5, we get:

```
Fatal error: Uncaught TypeError: Cannot assign SimpleXMLElement to property Product::$id of type ?int in script:28
Stack trace:
#0 script(36): Product::fromXml('<animal><id>100...')
#1 {main}
  thrown in script on line 28
```