### PR TITLE
Reverse hash_equals parameters

### DIFF
--- a/reference/hash/functions/hash-equals.xml
+++ b/reference/hash/functions/hash-equals.xml
@@ -76,7 +76,7 @@ $secretKey = '8uRhAeH89naXfFXKGOEj';
 $value = 'username=rasmuslerdorf';
 $signature = '8c35009d3b50caf7f5d2c1e031842e6b7823a1bb781d33c5237cd27b57b5f327';
 
-if (hash_equals(hash_hmac('sha256', $value, $secretKey), $signature)) {
+if (hash_equals($signature, hash_hmac('sha256', $value, $secretKey))) {
     echo "The value is correctly signed.", PHP_EOL;
 } else {
     echo "The value was tampered with.", PHP_EOL;


### PR DESCRIPTION
As stated in the document, the user provided string is supposed to be the second parameter. Whereas before this pull request, the user provided string is the first parameter.