### PR TITLE
#[\Override]: document restriction on __construct()

### DIFF
--- a/language/predefined/attributes/override.xml
+++ b/language/predefined/attributes/override.xml
@@ -20,7 +20,7 @@
    <simpara>
     The attribute cannot be used on the
     <link linkend="object.construct">__construct()</link>
-    method.
+    method, which is exempt from signature checks.
    </simpara>
   </section>
 


### PR DESCRIPTION
Prompted by a note on the manual page