### PR TITLE
fix(reference/stream): HTTP Headers are U+0D U+0A (CRLF) separated

### DIFF
--- a/language/context/http.xml
+++ b/language/context/http.xml
@@ -208,19 +208,19 @@
 <?php
 
 $postdata = http_build_query(
-    array(
+    [
         'var1' => 'some content',
-        'var2' => 'doh'
-    )
+        'var2' => 'doh',
+    ]
 );
 
-$opts = array('http' =>
-    array(
+$opts = [
+    'http' => [
         'method'  => 'POST',
         'header'  => 'Content-type: application/x-www-form-urlencoded',
-        'content' => $postdata
-    )
-);
+        'content' => $postdata,
+    ]
+];
 
 $context = stream_context_create($opts);
 
@@ -240,13 +240,13 @@ $result = file_get_contents('http://example.com/submit.php', false, $context);
 
 $url = "http://www.example.org/header.php";
 
-$opts = array('http' =>
-    array(
-        'method' => 'GET',
+$opts = [
+    'http' => [
+        'method'        => 'GET',
         'max_redirects' => '0',
-        'ignore_errors' => '1'
-    )
-);
+        'ignore_errors' => '1',
+    ]
+];
 
 $context = stream_context_create($opts);
 $stream = fopen($url, 'r', false, $context);

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -204,13 +204,13 @@ string(14) "lle Bjori Ro"
 <![CDATA[
 <?php
 // Create a stream
-$opts = array(
-  'http'=>array(
-    'method'=>"GET",
-    'header'=>"Accept-language: en\r\n" .
-              "Cookie: foo=bar\r\n"
-  )
-);
+$opts = [
+  'http' => [
+    'method' => "GET",
+    'header' => "Accept-language: en\r\n" .
+                "Cookie: foo=bar",
+  ]
+];
 
 $context = stream_context_create($opts);
 

--- a/reference/libxml/functions/libxml-set-streams-context.xml
+++ b/reference/libxml/functions/libxml-set-streams-context.xml
@@ -83,11 +83,11 @@
     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-$opts = array(
-    'http' => array(
+$opts = [
+    'http' => [
         'user_agent' => 'PHP libxml agent',
-    )
-);
+    ]
+];
 
 $context = stream_context_create($opts);
 libxml_set_streams_context($context);

--- a/reference/stream/functions/stream-context-create.xml
+++ b/reference/stream/functions/stream-context-create.xml
@@ -88,8 +88,9 @@
 $opts = [
   'http' => [
     'method' => "GET",
-    // Use newline \n to separate multiple headers
-    'header' => "Accept-language: en\nCookie: foo=bar",
+    // Use CRLF \r\n to separate multiple headers
+    'header' => "Accept-language: en\r\n" .
+                "Cookie: foo=bar",
   ]
 ];
 

--- a/reference/stream/functions/stream-context-get-default.xml
+++ b/reference/stream/functions/stream-context-get-default.xml
@@ -76,24 +76,24 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$default_opts = array(
-  'http'=>array(
-    'method'=>"GET",
-    'header'=>"Accept-language: en\r\n" .
-              "Cookie: foo=bar",
-    'proxy'=>"tcp://10.54.1.39:8000"
-  )
-);
+$default_opts = [
+  'http' => [
+    'method' => "GET",
+    'header' => "Accept-language: en\r\n" .
+                "Cookie: foo=bar",
+    'proxy' =>  "tcp://10.54.1.39:8000",
+  ]
+];
 
 
-$alternate_opts = array(
-  'http'=>array(
-    'method'=>"POST",
-    'header'=>"Content-type: application/x-www-form-urlencoded\r\n" .
-              "Content-length: " . strlen("baz=bomb"),
-    'content'=>"baz=bomb"
-  )
-);
+$alternate_opts = [
+  'http' => [
+    'method'  => "POST",
+    'header'  => "Content-type: application/x-www-form-urlencoded\r\n" .
+                 "Content-length: " . strlen("baz=bomb"),
+    'content' => "baz=bomb",
+  ]
+];
 
 $default = stream_context_get_default($default_opts);
 $alternate = stream_context_create($alternate_opts);

--- a/reference/stream/functions/stream-context-set-default.xml
+++ b/reference/stream/functions/stream-context-set-default.xml
@@ -58,14 +58,14 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$default_opts = array(
-  'http'=>array(
-    'method'=>"GET",
-    'header'=>"Accept-language: en\r\n" .
-              "Cookie: foo=bar",
-    'proxy'=>"tcp://10.54.1.39:8000"
-  )
-);
+$default_opts = [
+  'http' => [
+    'method' => "GET",
+    'header' => "Accept-language: en\r\n" .
+                "Cookie: foo=bar",
+    'proxy'  => "tcp://10.54.1.39:8000",
+  ]
+];
 
 $default = stream_context_set_default($default_opts);
 

--- a/reference/xmlrpc/functions/xmlrpc-encode-request.xml
+++ b/reference/xmlrpc/functions/xmlrpc-encode-request.xml
@@ -72,12 +72,14 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$request = xmlrpc_encode_request("method", array(1, 2, 3));
-$context = stream_context_create(array('http' => array(
-    'method' => "POST",
-    'header' => "Content-Type: text/xml",
-    'content' => $request
-)));
+$request = xmlrpc_encode_request("method", [1, 2, 3]);
+$context = stream_context_create([
+    'http' => [
+        'method'  => "POST",
+        'header'  => "Content-Type: text/xml",
+        'content' => $request,
+    ]
+]);
 $file = file_get_contents("http://www.example.com/xmlrpc", false, $context);
 $response = xmlrpc_decode($file);
 if ($response && xmlrpc_is_fault($response)) {


### PR DESCRIPTION
compare Section 4.1 of RFC-2616 etc.

        generic-message = start-line
                          *(message-header CRLF)
                          CRLF
                          [ message-body ]

RFC-2616: https://www.rfc-editor.org/rfc/rfc2616#section-4.1
ok: /reference/stream/functions/stream-context-set-default.xml etc.