### PR TITLE
update `CURLOPT_CAINFO_BLOB` desc

### DIFF
--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -183,8 +183,8 @@
    </term>
    <listitem>
     <para>
-     A <type>string</type> with the name of a PEM file holding one or more certificates to verify the
-     peer with. This option overrides <constant>CURLOPT_CAINFO</constant>.
+     A binary <type>string</type> of PEM encoded content holding one or more certificates to verify
+     the peer with. This option overrides <constant>CURLOPT_CAINFO</constant>.
      Available as of PHP 8.2.0 and cURL 7.77.0.
     </para>
    </listitem>


### PR DESCRIPTION
It seems as though this option was using a description copied from `CURLOPT_CAINFO`, and not the actual description. I've updated it to match https://curl.se/libcurl/c/CURLOPT_CAINFO_BLOB.html.