### PR TITLE
Improve documentation on callables

### DIFF
--- a/language/types/callable.xml
+++ b/language/types/callable.xml
@@ -205,6 +205,25 @@ class NumberTripler
 // prints "15"
 $tripler = new NumberTripler();
 processNumber($tripler, 5);
+
+// define a class with a private instance method, to be called with the callable syntax
+class HiddenFactory
+{
+    private function hiddenWork()
+    {
+        echo "256" . PHP_EOL;
+    }
+
+    public function getProof()
+    {
+        return Closure::fromCallable([$this, 'hiddenWork']);
+    }
+}
+
+// prints "256"
+$factory = new HiddenFactory();
+$theProof = $factory->getProof();
+invokeCallback($theProof);
 ?>
     </programlisting>
     &example.outputs;
@@ -213,6 +232,7 @@ processNumber($tripler, 5);
 42
 72
 15
+256
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
This implements #4355 :
- added a note that warns about passing protected/private class/instance methods
- provide additional examples of manually invoking the callbacks

The goal is that, by providing examples of how callbacks may be manually used, the reader becomes convinced that passing protected/private methods as callables to the outside world is generally a bad idea.