### PR TITLE
Clarify purpose of $data in updateTimestamp()

### DIFF
--- a/reference/session/sessionupdatetimestamphandlerinterface/updatetimestamp.xml
+++ b/reference/session/sessionupdatetimestamphandlerinterface/updatetimestamp.xml
@@ -34,7 +34,7 @@
     <term><parameter>data</parameter></term>
     <listitem>
      <para>
-      The session data.
+      The session data. The serialized session data may be used to determine whether the session data has changed and therefore should be updated.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/session/sessionupdatetimestamphandlerinterface/updatetimestamp.xml
+++ b/reference/session/sessionupdatetimestamphandlerinterface/updatetimestamp.xml
@@ -33,9 +33,9 @@
    <varlistentry>
     <term><parameter>data</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       The session data. The serialized session data may be used to determine whether the session data has changed and therefore should be updated.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>


### PR DESCRIPTION
The current documentation only says "$data — The session data" without context.

This update explains that $data contains the serialized session and may be used  to conditionally update the session expiry. It also clarifies that most  implementations can ignore it.