### PR TITLE
substr.xml Remove the redundant mention of the offset

### DIFF
--- a/reference/strings/functions/substr.xml
+++ b/reference/strings/functions/substr.xml
@@ -80,10 +80,8 @@ echo substr("abcdef", -3, 1), PHP_EOL; // returns "d"
       </para>
       <para>
        If <parameter>length</parameter> is given and is negative, then that many
-       characters will be omitted from the end of <parameter>string</parameter>
-       (after the start position has been calculated when a
-       <parameter>offset</parameter> is negative).  If
-       <parameter>offset</parameter> denotes the position of this truncation or
+       characters will be omitted from the end of <parameter>string</parameter>.
+       If <parameter>offset</parameter> denotes the position of this truncation or
        beyond, an empty string will be returned.
       </para>
       <para>


### PR DESCRIPTION
The function first determines the starting position of the substring (part of the original string), and then drops abs($length) characters from the tail of this substring if the value of the $length parameter is negative. I don't understand the meaning of the parenthesized notation, and it seems redundant to me; as if the $length parameter behaves differently with a positive offset. My point is that with a negative value of the $offset parameter, the behavior of the $length parameter does not change, so why mention the negative offset separately. Moreover, the end of the original string and the end of the substring that remained after applying the offset are the same ends, no matter how you look at it, and it is from these ends that the function will discard characters.

PS The Spanish and French translators would seem to agree with me, since in these versions of the translation the note in parentheses is no longer included in the function description