### PR TITLE
Document boolean support for allowed_classes in unserialize

### DIFF
--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -409,9 +409,9 @@
    <simpara>
     The <literal>"allowed_classes"</literal> option for
     <function>unserialize</function> now throws
-    <exceptionname>TypeError</exceptionname>s and
-    <exceptionname>ValueError</exceptionname>s if it is not an
-    <type>array</type> of class names.
+    <exceptionname>TypeError</exceptionname> and
+    <exceptionname>ValueError</exceptionname> if it is neither an
+    <type>array</type> of class names nor a <type>boolean</type>.
    </simpara>
   </sect3>
 

--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -411,7 +411,7 @@
     <function>unserialize</function> now throws
     <exceptionname>TypeError</exceptionname> and
     <exceptionname>ValueError</exceptionname> if it is neither an
-    <type>array</type> of class names nor a <type>boolean</type>.
+    <type>array</type> of class names nor a <type>bool</type>.
    </simpara>
   </sect3>
 

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -149,9 +149,9 @@
   </simpara>
   <simpara>
    As of PHP 8.4.0, if the <literal>allowed_classes</literal> element of
-   <parameter>options</parameter> is not an <type>array</type> of class names,
-   <function>unserialize</function> throws <exceptionname>TypeError</exceptionname>s
-   and <exceptionname>ValueError</exceptionname>s.
+   <parameter>options</parameter> is neither a <type>array</type> of class names
+   nor a <type>boolean</type>, <function>unserialize</function> throws
+   <exceptionname>TypeError</exceptionname> and <exceptionname>ValueError</exceptionname>.
   </simpara>
  </refsect1>
 
@@ -170,9 +170,10 @@
       <row>
        <entry>8.4.0</entry>
        <entry>
-        Now throws <exceptionname>TypeError</exceptionname>s and
-        <exceptionname>ValueError</exceptionname>s if the <literal>allowed_classes</literal>
-        element of <parameter>options</parameter> is not an <type>array</type> of class names.
+        Now throws <exceptionname>TypeError</exceptionname> and
+        <exceptionname>ValueError</exceptionname> if the <literal>allowed_classes</literal>
+        element of <parameter>options</parameter> is neither a <type>array</type> of class names
+        nor a <type>boolean</type>.
        </entry>
       </row>
       <row>

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -149,8 +149,8 @@
   </simpara>
   <simpara>
    As of PHP 8.4.0, if the <literal>allowed_classes</literal> element of
-   <parameter>options</parameter> is neither a <type>array</type> of class names
-   nor a <type>boolean</type>, <function>unserialize</function> throws
+   <parameter>options</parameter> is neither an <type>array</type> of class names
+   nor a <type>bool</type>, <function>unserialize</function> throws
    <exceptionname>TypeError</exceptionname> and <exceptionname>ValueError</exceptionname>.
   </simpara>
  </refsect1>
@@ -172,8 +172,8 @@
        <entry>
         Now throws <exceptionname>TypeError</exceptionname> and
         <exceptionname>ValueError</exceptionname> if the <literal>allowed_classes</literal>
-        element of <parameter>options</parameter> is neither a <type>array</type> of class names
-        nor a <type>boolean</type>.
+        element of <parameter>options</parameter> is neither an <type>array</type> of class names
+        nor a <type>bool</type>.
        </entry>
       </row>
       <row>


### PR DESCRIPTION
- In appendices/migration84/incompatible.xml, update the description of the allowed_classes option to indicate it may be an array of class names or at boolean.
- In reference/var/functions/unserialize.xml, clarify that unserialize() throws TypeError and ValueError if options.allowed_classes is not an array or boolean.