### PR TITLE
add a note for callback and array with less than 2 items

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -753,6 +753,11 @@ use.</simpara></note>'>
   <literal>0.99</literal> and <literal>0.1</literal> will both be cast to an
   integer value of <literal>0</literal>, which will compare such values as equal.
  </para>
+ <note>
+   <para>
+    The callback is only called if the input array has 2 or more items.
+   </para>
+ </note>
 </caution>'>
 
 <!ENTITY sort.callback.description.presort '<caution xmlns="http://docbook.org/ns/docbook">


### PR DESCRIPTION
Fixes #4760

- #4760

~~I can't test it right now because of an issue with `git`:~~

- https://github.com/php/doc-base/issues/247

Here is the result:

> <img width="1115" height="327" alt="image" src="https://github.com/user-attachments/assets/e2c65e04-2281-469d-977f-7658018eeb0d" />