### PR TITLE
Add INI_ALL to ini.xml in manual

### DIFF
--- a/install/ini.xml
+++ b/install/ini.xml
@@ -218,7 +218,7 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
   </simpara>
   <simpara>
    Only INI settings with the
-   modes <constant>INI_PERDIR</constant> and
+   modes <constant>INI_ALL</constant>, <constant>INI_PERDIR</constant> and
    <constant>INI_USER</constant> will be recognized in .user.ini-style INI
    files.
   </simpara>


### PR DESCRIPTION
While the mentioned INI_PERDIR and INI_USER are essentially subsets of INI_ALL, INI_ALL was not explicitly mentioned on this page. I think adding it to the list will make it significantly clearer.