### PR TITLE
Fix pg_lo_import return type

### DIFF
--- a/reference/pgsql/functions/pg-lo-import.xml
+++ b/reference/pgsql/functions/pg-lo-import.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>int</type><methodname>pg_lo_import</methodname>
+   <type>int|string|false</type><methodname>pg_lo_import</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
    <methodparam><type>string</type><parameter>pathname</parameter></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>object_id</parameter></methodparam>


### PR DESCRIPTION
Cf https://github.com/php/php-src/blob/dd3a098a9bf967831e889d2e19e873d09c71c9b9/ext/pgsql/pgsql.stub.php#L788

And the doc is already saying it returns false on failure.

So it should be at least `int|false`.
For the string part I'm not fully sure but I think it's confirmed by
https://github.com/php/php-src/blob/dd3a098a9bf967831e889d2e19e873d09c71c9b9/ext/pgsql/pgsql_arginfo.h#L265

The issue exists on every languages.
Should I do a PR on every `doc-*` repository ?