### PR TITLE
Rename parameter 'generator' to 'callback' in apcu_entry documentation

### DIFF
--- a/reference/apcu/functions/apcu-entry.xml
+++ b/reference/apcu/functions/apcu-entry.xml
@@ -12,24 +12,24 @@
   <methodsynopsis>
    <type>mixed</type><methodname>apcu_entry</methodname>
    <methodparam><type>string</type><parameter>key</parameter></methodparam>
-   <methodparam><type>callable</type><parameter>generator</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Atomically attempts to find <parameter>key</parameter> in the cache, if it cannot be found <parameter>generator</parameter>
+   Atomically attempts to find <parameter>key</parameter> in the cache, if it cannot be found <parameter>callback</parameter>
    is called, passing <parameter>key</parameter> as the only argument. The return value of the call is then cached with the optionally specified
    <parameter>ttl</parameter>, and returned.
   </para>
   <note>
    <simpara>
     When control enters <function>apcu_entry</function> the lock for the cache is acquired exclusively, it is released when control leaves <function>apcu_entry</function>: 
-    In effect, this turns the body of <parameter>generator</parameter> into a critical section, disallowing two processes from executing the same code paths concurrently.
+    In effect, this turns the body of <parameter>callback</parameter> into a critical section, disallowing two processes from executing the same code paths concurrently.
     In addition, it prohibits the concurrent execution of any other APCu functions, since they will acquire the same lock.
    </simpara>
   </note>
   <warning>
    <simpara>
-    The only APCu function that can be called safely by <parameter>generator</parameter> is <function>apcu_entry</function>.
+    The only APCu function that can be called safely by <parameter>callback</parameter> is <function>apcu_entry</function>.
    </simpara>
   </warning>
  </refsect1>
@@ -46,7 +46,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>generator</parameter></term>
+     <term><parameter>callback</parameter></term>
      <listitem>
       <para>
        A callable that accepts <parameter>key</parameter> as the only argument and returns the value to cache.


### PR DESCRIPTION
Fix #4789