### PR TITLE
array-map.xml Change the misleading wording

### DIFF
--- a/reference/array/functions/array-map.xml
+++ b/reference/array/functions/array-map.xml
@@ -41,7 +41,7 @@
       <para>
        &null; can be passed as a value to <parameter>callback</parameter>
        to perform a zip operation on multiple arrays and return an array
-       whose elements are each an array holding the elements of the input arrays of the
+       where each element is an array containing the elements from the input arrays at the
        same position of the internal array pointer (see example below).
        If only <parameter>array</parameter> is provided,
        <methodname>array_map</methodname> will return the input array.

--- a/reference/array/functions/array-map.xml
+++ b/reference/array/functions/array-map.xml
@@ -41,7 +41,8 @@
       <para>
        &null; can be passed as a value to <parameter>callback</parameter>
        to perform a zip operation on multiple arrays and return an array
-       whose elements are each an array holding the elements of the input arrays of the same index (see example below).
+       whose elements are each an array holding the elements of the input arrays of the
+       same position of the internal array pointer (see example below).
        If only <parameter>array</parameter> is provided,
        <methodname>array_map</methodname> will return the input array.
       </para>


### PR DESCRIPTION
When performing a zip operation, keys of input arrays are ignored. The function only considers the sequential order of elements (as determined by their internal pointers), not their indices:

```php
<?php

$a = [42 => 1, 'foo' => 2, '' => 3, 0 => 4, -4 => 5];
$b = [4 => 'one', 3 => 'two', 2 => 'three', 1 => 'four', 0 => 'five'];
$c = [-4 => 'uno', 0 => 'dos', '' => 'tres', 'foo' => 'cuatro', 42 => 'cinco'];

$d = array_map(null, $a, $b, $c);
print_r($d);
```

Output:

```
Array
(
    [0] => Array
        (
            [0] => 1
            [1] => one
            [2] => uno
        )

    [1] => Array
        (
            [0] => 2
            [1] => two
            [2] => dos
        )

    [2] => Array
        (
            [0] => 3
            [1] => three
            [2] => tres
        )

    [3] => Array
        (
            [0] => 4
            [1] => four
            [2] => cuatro
        )

    [4] => Array
        (
            [0] => 5
            [1] => five
            [2] => cinco
        )

)
```

As we can see, the indexes were ignored