### PR TITLE
fix: build with docker and make

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -12,6 +12,7 @@ RUN git clone --depth 1 https://github.com/php/phd.git &&  \
     git clone --depth 1 https://github.com/php/doc-base.git
 
 RUN echo 'memory_limit = 512M' >> /usr/local/etc/php/conf.d/local.ini
+RUN printf '[safe]\ndirectory=/var/www/doc-base\n' > /.gitconfig
 
 ENV FORMAT=xhtml
 


### PR DESCRIPTION
Fixes #247:

- #247

Then I ran `make -B build`.

There is no git warning anymore, but I encounter a new issue:

```
make --debug
GNU Make 4.3
Built for x86_64-pc-linux-gnu
Copyright (C) 1988-2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Reading makefiles...
Updating makefiles....
Updating goal targets....
 File 'xhtml' does not exist.
Must remake target 'xhtml'.
docker run --rm -v .:/var/www/en -w /var/www -u 1000:1000 php/doc-en
configure.php on PHP 8.2.29, libxml 2.9.14

Checking for source directory... 
error: Source directory doesn't exist or can't be written to.
make: *** [Makefile:22: xhtml] Error 1
```