### PR TITLE
apcu-entry.xml Change the parameter name

### DIFF
--- a/reference/apcu/functions/apcu-entry.xml
+++ b/reference/apcu/functions/apcu-entry.xml
@@ -57,7 +57,7 @@
      <term><parameter>ttl</parameter></term>
      <listitem>
       <para>
-       Time To Live; store <parameter>var</parameter> in the cache for
+       Time To Live; store the <parameter>callback</parameter>'s return value in the cache for
        <parameter>ttl</parameter> seconds. After the
        <parameter>ttl</parameter> has passed, the stored variable will be
        expunged from the cache (on the next request). If no <parameter>ttl</parameter>

--- a/reference/apcu/functions/apcu-entry.xml
+++ b/reference/apcu/functions/apcu-entry.xml
@@ -59,7 +59,7 @@
       <para>
        Time To Live; store the <parameter>callback</parameter>'s return value in the cache for
        <parameter>ttl</parameter> seconds. After the
-       <parameter>ttl</parameter> has passed, the stored variable will be
+       <parameter>ttl</parameter> has passed, the stored entry will be
        expunged from the cache (on the next request). If no <parameter>ttl</parameter>
        is supplied (or if the <parameter>ttl</parameter> is
        <literal>0</literal>), the value will persist until it is removed from


### PR DESCRIPTION
Probably, the `<parameter>var</parameter>` is an artifact that came from another APCu function, such as `apcu_store()`, where it is valid