### PR TITLE
localtime.xml Change the parameter name + nits

### DIFF
--- a/reference/intl/dateformatter/localtime.xml
+++ b/reference/intl/dateformatter/localtime.xml
@@ -26,7 +26,7 @@
    <methodparam choice="opt"><type>int</type><parameter role="reference">offset</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Converts string $value to a field-based time value (an array of various fields), starting at
+   Converts string $string to a field-based time value (an array of various fields), starting at
    $offset and consuming as much of the input value as possible.
   </para>
   </refsect1>
@@ -55,10 +55,10 @@
      <term><parameter>offset</parameter></term>
      <listitem>
       <para>
-       Position at which to start the parsing in $value (zero-based).
-       If no error occurs before $value is consumed, $offset will contain -1
+       Position at which to start the parsing in $string (zero-based).
+       If no error occurs before $string is consumed, $offset will contain -1
        otherwise it will contain the position at which parsing ended.
-       If $offset &gt; strlen($value), the parse fails immediately.
+       If $offset &gt; strlen($string), the parse fails immediately.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/intl/dateformatter/localtime.xml
+++ b/reference/intl/dateformatter/localtime.xml
@@ -26,7 +26,7 @@
    <methodparam choice="opt"><type>int</type><parameter role="reference">offset</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Converts string $string to a field-based time value (an array of various fields), starting at
+   Converts string <parameter>$string</parameter> to a field-based time value (an array of various fields), starting at
    $offset and consuming as much of the input value as possible.
   </para>
   </refsect1>

--- a/reference/intl/dateformatter/localtime.xml
+++ b/reference/intl/dateformatter/localtime.xml
@@ -39,7 +39,7 @@
      <term><parameter>formatter</parameter></term>
      <listitem>
       <para>
-       The formatter resource.
+       The <classname>IntlDateFormatter</classname> object.
       </para>
      </listitem>
     </varlistentry>
@@ -69,7 +69,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Localtime compatible array of integers  : contains 24 hour clock value in tm_hour field,
+   Localtime compatible array of integers: contains 24 hour clock value in tm_hour field,
    &return.falseforfailure;.
    </para>
  </refsect1>

--- a/reference/intl/dateformatter/localtime.xml
+++ b/reference/intl/dateformatter/localtime.xml
@@ -55,10 +55,10 @@
      <term><parameter>offset</parameter></term>
      <listitem>
       <para>
-       Position at which to start the parsing in $string (zero-based).
-       If no error occurs before $string is consumed, $offset will contain -1
+       Position at which to start the parsing in <parameter>$string</parameter> (zero-based).
+       If no error occurs before <parameter>$string</parameter> is consumed, <parameter>$offset</parameter> will contain <literal>-1</literal>
        otherwise it will contain the position at which parsing ended.
-       If $offset &gt; strlen($string), the parse fails immediately.
+       If <code>$offset &gt; strlen($string)</code>, the parse fails immediately.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/intl/dateformatter/localtime.xml
+++ b/reference/intl/dateformatter/localtime.xml
@@ -26,8 +26,8 @@
    <methodparam choice="opt"><type>int</type><parameter role="reference">offset</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Converts string $value to a field-based time value ( an array of various fields), starting at
-$parse_pos and consuming as much of the input value as possible.
+   Converts string $value to a field-based time value (an array of various fields), starting at
+   $offset and consuming as much of the input value as possible.
   </para>
   </refsect1>
 
@@ -39,7 +39,7 @@ $parse_pos and consuming as much of the input value as possible.
      <term><parameter>formatter</parameter></term>
      <listitem>
       <para>
-       The formatter resource
+       The formatter resource.
       </para>
      </listitem>
     </varlistentry>
@@ -47,7 +47,7 @@ $parse_pos and consuming as much of the input value as possible.
      <term><parameter>string</parameter></term>
      <listitem>
       <para>
-       string to convert to a time
+       String to convert to a time.
       </para>
      </listitem>
     </varlistentry>
@@ -56,9 +56,9 @@ $parse_pos and consuming as much of the input value as possible.
      <listitem>
       <para>
        Position at which to start the parsing in $value (zero-based).
-       If no error occurs before $value is consumed, $parse_pos will contain -1
-       otherwise it will contain the position at which parsing ended .
-       If $parse_pos &gt; strlen($value), the parse fails immediately.
+       If no error occurs before $value is consumed, $offset will contain -1
+       otherwise it will contain the position at which parsing ended.
+       If $offset &gt; strlen($value), the parse fails immediately.
       </para>
      </listitem>
     </varlistentry>
@@ -66,7 +66,6 @@ $parse_pos and consuming as much of the input value as possible.
   </para>
  </refsect1>
 
- 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
@@ -74,7 +73,7 @@ $parse_pos and consuming as much of the input value as possible.
    &return.falseforfailure;.
    </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
    <example>
@@ -90,7 +89,9 @@ $fmt = datefmt_create(
     'America/Los_Angeles',
     IntlDateFormatter::GREGORIAN
 );
+
 $arr = datefmt_localtime($fmt, 'Wednesday, December 31, 1969 at 4:00:00 PM Pacific Standard Time', $offset);
+
 echo 'First parsed output is ';
 if ($arr) {
     foreach ($arr as $key => $value) {
@@ -107,6 +108,7 @@ if ($arr) {
     <programlisting role="php">
 <![CDATA[
 <?php
+
 $fmt = new IntlDateFormatter(
     'en_US',
     IntlDateFormatter::FULL,
@@ -114,7 +116,9 @@ $fmt = new IntlDateFormatter(
     'America/Los_Angeles',
     IntlDateFormatter::GREGORIAN
 );
+
 $arr = $fmt->localtime('Wednesday, December 31, 1969 at 4:00:00 PM Pacific Standard Time', $offset);
+
 echo 'First parsed output is ';
 if ($arr) {
     foreach ($arr as $key => $value) {

--- a/reference/intl/dateformatter/localtime.xml
+++ b/reference/intl/dateformatter/localtime.xml
@@ -25,10 +25,10 @@
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter role="reference">offset</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Converts string <parameter>$string</parameter> to a field-based time value (an array of various fields), starting at
    $offset and consuming as much of the input value as possible.
-  </para>
+  </simpara>
   </refsect1>
 
  <refsect1 role="parameters">
@@ -38,17 +38,17 @@
     <varlistentry>
      <term><parameter>formatter</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The <classname>IntlDateFormatter</classname> object.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>string</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        String to convert to a time.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/intl/dateformatter/localtime.xml
+++ b/reference/intl/dateformatter/localtime.xml
@@ -25,11 +25,12 @@
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter role="reference">offset</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Converts string $value to a field-based time value ( an array of various fields), starting at
-$parse_pos and consuming as much of the input value as possible.
-  </para>
-  </refsect1>
+  <simpara>
+   Converts <parameter>string</parameter> to a field-based time value (an array
+   of various fields), starting at <parameter>offset</parameter> and consuming
+   as much of the input string as possible.
+  </simpara>
+ </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -38,43 +39,48 @@ $parse_pos and consuming as much of the input value as possible.
     <varlistentry>
      <term><parameter>formatter</parameter></term>
      <listitem>
-      <para>
-       The formatter resource
-      </para>
+      <simpara>
+       The <classname>IntlDateFormatter</classname> object.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>string</parameter></term>
      <listitem>
-      <para>
-       string to convert to a time
-      </para>
+      <simpara>
+       String to convert to a time.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>offset</parameter></term>
      <listitem>
-      <para>
-       Position at which to start the parsing in $value (zero-based).
-       If no error occurs before $value is consumed, $parse_pos will contain -1
-       otherwise it will contain the position at which parsing ended .
-       If $parse_pos &gt; strlen($value), the parse fails immediately.
-      </para>
+      <simpara>
+       Position at which to start the parsing in <parameter>string</parameter>
+       (zero-based).
+       On return, <parameter>offset</parameter> holds the position at which
+       parsing ended, whether or not the parse succeeded.
+       If <parameter>offset</parameter> is negative or greater than
+       <literal>strlen($string)</literal>, the parse fails immediately and
+       <parameter>offset</parameter> is left unchanged.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
   </para>
  </refsect1>
 
- 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Localtime compatible array of integers  : contains 24 hour clock value in tm_hour field,
-   &return.falseforfailure;.
-   </para>
+  <simpara>
+   An associative array of integers whose keys are those of
+   <function>localtime</function>, with the hour given on a 24-hour clock in
+   <literal>tm_hour</literal>&return.falseforfailure;.
+   Note that <literal>tm_yday</literal> is 1-based here, whereas
+   <function>localtime</function> returns it 0-based.
+  </simpara>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
    <example>
@@ -90,7 +96,9 @@ $fmt = datefmt_create(
     'America/Los_Angeles',
     IntlDateFormatter::GREGORIAN
 );
+
 $arr = datefmt_localtime($fmt, 'Wednesday, December 31, 1969 at 4:00:00 PM Pacific Standard Time', $offset);
+
 echo 'First parsed output is ';
 if ($arr) {
     foreach ($arr as $key => $value) {
@@ -107,6 +115,7 @@ if ($arr) {
     <programlisting role="php">
 <![CDATA[
 <?php
+
 $fmt = new IntlDateFormatter(
     'en_US',
     IntlDateFormatter::FULL,
@@ -114,7 +123,9 @@ $fmt = new IntlDateFormatter(
     'America/Los_Angeles',
     IntlDateFormatter::GREGORIAN
 );
+
 $arr = $fmt->localtime('Wednesday, December 31, 1969 at 4:00:00 PM Pacific Standard Time', $offset);
+
 echo 'First parsed output is ';
 if ($arr) {
     foreach ($arr as $key => $value) {

--- a/reference/intl/dateformatter/localtime.xml
+++ b/reference/intl/dateformatter/localtime.xml
@@ -26,7 +26,7 @@
    <methodparam choice="opt"><type>int</type><parameter role="reference">offset</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Converts string <parameter>$string</parameter> to a field-based time value (an array of various fields), starting at
+   Converts string <parameter>string</parameter> to a field-based time value (an array of various fields), starting at
    $offset and consuming as much of the input value as possible.
   </simpara>
   </refsect1>
@@ -56,7 +56,7 @@
      <listitem>
       <para>
        Position at which to start the parsing in <parameter>$string</parameter> (zero-based).
-       If no error occurs before <parameter>$string</parameter> is consumed, <parameter>$offset</parameter> will contain <literal>-1</literal>
+       If no error occurs before <parameter>string</parameter> is consumed, <parameter>offset</parameter> will contain <literal>-1</literal>
        otherwise it will contain the position at which parsing ended.
        If <code>$offset &gt; strlen($string)</code>, the parse fails immediately.
       </para>

--- a/reference/intl/dateformatter/parse.xml
+++ b/reference/intl/dateformatter/parse.xml
@@ -38,9 +38,9 @@
     <varlistentry>
      <term><parameter>formatter</parameter></term>
      <listitem>
-      <para>
-       The formatter resource      
-      </para>
+      <simpara>
+       The <classname>IntlDateFormatter</classname> object.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -54,13 +54,15 @@
     <varlistentry>
      <term><parameter>offset</parameter></term>
      <listitem>
-      <para>
-       Position at which to start the parsing in <parameter>string</parameter> (zero-based).
-       If no error occurs before <parameter>string</parameter> is consumed, <parameter>offset</parameter> will contain -1
-       otherwise it will contain the position at which parsing ended (and the error occurred).
-       This variable will contain the end position if the parse fails.
-       If <parameter>offset</parameter> &gt; <code>strlen($string)</code>, the parse fails immediately.
-     </para>
+      <simpara>
+       Position at which to start the parsing in <parameter>string</parameter>
+       (zero-based).
+       On return, <parameter>offset</parameter> holds the position at which
+       parsing ended, whether or not the parse succeeded.
+       If <parameter>offset</parameter> is negative or greater than
+       <literal>strlen($string)</literal>, the parse fails immediately and
+       <parameter>offset</parameter> is left unchanged.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/intl/dateformatter/parsetocalendar.xml
+++ b/reference/intl/dateformatter/parsetocalendar.xml
@@ -37,12 +37,13 @@
     <term><parameter>offset</parameter></term>
     <listitem>
      <simpara>
-      Position at which to start the parsing in <parameter>string</parameter> (zero-based).
-      If no error occurs before <parameter>string</parameter> is consumed,
-      <parameter>offset</parameter> will contain -1, otherwise it will contain the position
-      at which parsing ended (and the error occurred).
-      This variable will contain the end position if the parse fails.
-      If <parameter>offset</parameter> &gt; <code>strlen($string)</code>, the parse fails immediately.
+      Position at which to start the parsing in <parameter>string</parameter>
+      (zero-based).
+      On return, <parameter>offset</parameter> holds the position at which
+      parsing ended, whether or not the parse succeeded.
+      If <parameter>offset</parameter> is greater than
+      <literal>strlen($string)</literal>, the parse fails immediately and
+      <parameter>offset</parameter> is left unchanged.
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
It looks like the name `$parse_pos` migrated from the source code. It is better to leave the name `$offset` in the user land