### PR TITLE
Override: document usage with properties (PHP 8.5)

### DIFF
--- a/language/predefined/attributes/override.xml
+++ b/language/predefined/attributes/override.xml
@@ -8,12 +8,12 @@
   <section xml:id="override.intro">
    &reftitle.intro;
    <simpara>
-    This attribute is used to indicate that a method is intended
-    to override a method of a parent class or that it implements
-    a method defined in an interface.
+    This attribute is used to indicate that a method or a property is intended
+    to override a method or a property of a parent class or that it implements
+    a method or a property defined in an interface.
    </simpara>
    <simpara>
-    If no method with the same name exists in a parent class or
+    If no method or property with the same name exists in a parent class or
     in an implemented interface a compile-time error will be
     emitted.
    </simpara>
@@ -41,9 +41,32 @@
 
   </section>
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        <classname>Override</classname> can be applied to properties.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
   <section>
    &reftitle.examples;
-   <informalexample>
+   <example>
+    <title>Usage with methods</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -66,7 +89,32 @@ final class Extended extends Base {
 Fatal error: Extended::boo() has #[\Override] attribute, but no matching parent method exists
 ]]>
     </screen>
-   </informalexample>
+   </example>
+   <example>
+    <title>Usage with properties</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+
+class Base {
+    protected string $foo;
+}
+
+final class Extended extends Base {
+    #[\Override]
+    protected string $boo;
+}
+
+?>
+]]>
+    </programlisting>
+    &example.outputs.85.similar;
+    <screen>
+     <![CDATA[
+Fatal error: Extended::$boo has #[\Override] attribute, but no matching parent property exists
+]]>
+    </screen>
+   </example>
   </section>
 
   <section xml:id="override.seealso">


### PR DESCRIPTION
This documents https://wiki.php.net/rfc/override_properties. It won't build because it uses `&example.outputs.85.similar;` that does not exist yet. I don't know when's the right time to document PHP 8.5 additions and removals, but I thought I'd prepare it now while I'm at it and let it wait here rather than in my todo list.