### PR TITLE
fix: use strict comparsions of returns in openssl_verify examples

### DIFF
--- a/reference/ldap/functions/ldap-compare.xml
+++ b/reference/ldap/functions/ldap-compare.xml
@@ -76,6 +76,14 @@
    Returns &true; if <parameter>value</parameter> matches otherwise returns
    &false;. Returns -1 on error.
   </para>
+  <warning>
+   <simpara>
+    Both &true; and <literal>-1</literal> are
+    <link linkend="language.types.boolean.casting">truthy</link>, so a plain
+    truth test such as <code>if (ldap_compare(...))</code> treats an error as a
+    match. The result must be compared strictly against &true;.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/openssl/functions/openssl-pkcs7-verify.xml
+++ b/reference/openssl/functions/openssl-pkcs7-verify.xml
@@ -105,6 +105,15 @@
    (the message has been tampered with, or the signing certificate is invalid),
    or -1 on error.
   </para>
+  <warning>
+   <simpara>
+    Both &true; and <literal>-1</literal> are
+    <link linkend="language.types.boolean.casting">truthy</link>, so a plain
+    truth test such as <code>if (openssl_pkcs7_verify(...))</code> treats an error as a
+    successful verification. The result must be compared strictly against
+    &true;.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/openssl/functions/openssl-verify.xml
+++ b/reference/openssl/functions/openssl-verify.xml
@@ -119,9 +119,9 @@ $pubkeyid = openssl_pkey_get_public("file://src/openssl-0.9.6/demos/sign/cert.pe
 
 // state whether signature is okay or not
 $ok = openssl_verify($data, $signature, $pubkeyid);
-if ($ok == 1) {
+if ($ok === 1) {
     echo "good";
-} elseif ($ok == 0) {
+} elseif ($ok === 0) {
     echo "bad";
 } else {
     echo "ugly, error checking signature";
@@ -153,9 +153,9 @@ openssl_sign($data, $signature, $private_key_res, "sha256WithRSAEncryption");
 
 //verify signature
 $ok = openssl_verify($data, $signature, $public_key_res, OPENSSL_ALGO_SHA256);
-if ($ok == 1) {
+if ($ok === 1) {
     echo "valid";
-} elseif ($ok == 0) {
+} elseif ($ok === 0) {
     echo "invalid";
 } else {
     echo "error: ".openssl_error_string();

--- a/reference/openssl/functions/openssl-verify.xml
+++ b/reference/openssl/functions/openssl-verify.xml
@@ -88,6 +88,15 @@ MIIBCgK...</literal>)
    Returns 1 if the signature is correct, 0 if it is incorrect, and
    -1 or &false; on error.
   </para>
+  <warning>
+   <simpara>
+    Both the success value and the error value are
+    <link linkend="language.types.boolean.casting">truthy</link>, so a plain
+    truth test such as <code>if (openssl_verify(...))</code> treats an error as a
+    successful verification. The result must be compared strictly against
+    <literal>1</literal>.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/openssl/functions/openssl-verify.xml
+++ b/reference/openssl/functions/openssl-verify.xml
@@ -136,9 +136,9 @@ $pubkeyid = openssl_pkey_get_public("file://src/openssl-0.9.6/demos/sign/cert.pe
 
 // state whether signature is okay or not
 $ok = openssl_verify($data, $signature, $pubkeyid);
-if ($ok == 1) {
+if ($ok === 1) {
     echo "good";
-} elseif ($ok == 0) {
+} elseif ($ok === 0) {
     echo "bad";
 } else {
     echo "ugly, error checking signature";
@@ -170,9 +170,9 @@ openssl_sign($data, $signature, $private_key_res, "sha256WithRSAEncryption");
 
 //verify signature
 $ok = openssl_verify($data, $signature, $public_key_res, OPENSSL_ALGO_SHA256);
-if ($ok == 1) {
+if ($ok === 1) {
     echo "valid";
-} elseif ($ok == 0) {
+} elseif ($ok === 0) {
     echo "invalid";
 } else {
     echo "error: ".openssl_error_string();

--- a/reference/openssl/functions/openssl-x509-checkpurpose.xml
+++ b/reference/openssl/functions/openssl-x509-checkpurpose.xml
@@ -115,6 +115,15 @@
    Returns &true; if the certificate can be used for the intended purpose,
    &false; if it cannot, or -1 on error.
   </para>
+  <warning>
+   <simpara>
+    Both &true; and <literal>-1</literal> are
+    <link linkend="language.types.boolean.casting">truthy</link>, so a plain
+    truth test such as <code>if (openssl_x509_checkpurpose(...))</code> treats an error as a
+    successful verification. The result must be compared strictly against
+    &true;.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/openssl/functions/openssl-x509-verify.xml
+++ b/reference/openssl/functions/openssl-x509-verify.xml
@@ -47,6 +47,15 @@ MIIBCgK...</literal>)
    Returns 1 if the signature is correct, 0 if it is incorrect, and
    -1 on error.
   </para>
+  <warning>
+   <simpara>
+    Both the success value and the error value are
+    <link linkend="language.types.boolean.casting">truthy</link>, so a plain
+    truth test such as <code>if (openssl_x509_verify(...))</code> treats an error as a
+    successful verification. The result must be compared strictly against
+    <literal>1</literal>.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -110,8 +119,8 @@ foreach($cont["options"]["ssl"]["peer_certificate_chain"] as $chaincert)
 {
     $chainparsed = openssl_x509_parse($chaincert);
     $chain_public_key = openssl_get_publickey($chaincert);
-    $r = openssl_x509_verify($x509, $chain_public_key);   
-    if ($r==1)
+    $r = openssl_x509_verify($x509, $chain_public_key);
+    if ($r === 1)
     {
         echo $certparsed['subject']['CN'];
         echo " was digitally signed by ";

--- a/reference/zip/ziparchive/getarchiveflag.xml
+++ b/reference/zip/ziparchive/getarchiveflag.xml
@@ -69,6 +69,14 @@
   <simpara>
    Returns 1 if flag is set for archive, 0 if not, and -1 if an error occurred.
   </simpara>
+  <warning>
+   <simpara>
+    Both <literal>1</literal> and <literal>-1</literal> are
+    <link linkend="language.types.boolean.casting">truthy</link>, so a plain
+    truth test treats an error as the flag being set. The result must be
+    compared strictly against <literal>1</literal>.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Fixes #4574 for openssl_verify