### PR TITLE
Undefined constant throws an error instead of E_NOTICE

### DIFF
--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -902,12 +902,12 @@ $arr = array('fruit' => 'apple', 'veggie' => 'carrot');
 echo $arr['fruit'], PHP_EOL;  // apple
 echo $arr['veggie'], PHP_EOL; // carrot
 
-// Incorrect. This works but also throws a PHP Error because
+// Incorrect. This does not work and throws a PHP Error because
 // of an undefined constant named fruit
 //
 // Error: Undefined constant "fruit"
 try {
-    echo $arr[fruit];    // apple
+    echo $arr[fruit];
 } catch (Error $e) {
     echo get_class($e), ': ', $e->getMessage(), PHP_EOL;
 }
@@ -921,7 +921,7 @@ echo $arr['fruit'], PHP_EOL;  // apple
 echo $arr[fruit], PHP_EOL;    // carrot
 
 // The following is okay, as it's inside a string. Constants are not looked for
-// within strings, so no E_NOTICE occurs here
+// within strings, so no error occurs here
 echo "Hello $arr[fruit]", PHP_EOL;      // Hello apple
 
 // With one exception: braces surrounding arrays within strings allows constants
@@ -949,15 +949,6 @@ print "Hello $_GET['foo']";
 ]]>
     </programlisting>
    </informalexample>
-
-   <para>
-    When <link linkend="ini.error-reporting">error_reporting</link> is set to
-    show <constant>E_NOTICE</constant> level errors (by setting it to
-    <constant>E_ALL</constant>, for example), such uses will become immediately
-    visible. By default,
-    <link linkend="ini.error-reporting">error_reporting</link> is set not to
-    show notices.
-   </para>
 
    <para>
     As stated in the <link linkend="language.types.array.syntax">syntax</link>


### PR DESCRIPTION
Undefined constant throws E_WARNING since PHP 7.2 and Error since PHP 8.0.

Some lines were fixed in e587d0655e426f97b3fcb431453da5030e743b23 but there remained some lines not fixed.