### PR TITLE
Add missing string type for $title property in Asymmetric Property inheritance example

### DIFF
--- a/language/oop5/visibility.xml
+++ b/language/oop5/visibility.xml
@@ -194,7 +194,7 @@ class Book
 
 class SpecialBook extends Book
 {
-    public protected(set) $title; // OK, as reading is wider and writing the same.
+    public protected(set) string $title; // OK, as reading is wider and writing the same.
     public string $author; // OK, as reading is the same and writing is wider.
     public protected(set) int $pubYear; // Fatal Error. private(set) properties are final.
 }


### PR DESCRIPTION
Add the missing string type to $title property in the SpecialBook class. The parent defines $title as string; the child must not drop the declared type.