### PR TITLE
mbstring: PHP version of deprecated ini settings

### DIFF
--- a/reference/mbstring/ini.xml
+++ b/reference/mbstring/ini.xml
@@ -32,19 +32,25 @@
       <entry><link linkend="ini.mbstring.http-input">mbstring.http_input</link></entry>
       <entry>"pass"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Deprecated</entry>
+      <entry>
+       Deprecated as of PHP 5.6.
+      </entry>
      </row>
      <row>
       <entry><link linkend="ini.mbstring.http-output">mbstring.http_output</link></entry>
       <entry>"pass"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Deprecated</entry>
+      <entry>
+       Deprecated as of PHP 5.6.
+      </entry>
      </row>
      <row>
       <entry><link linkend="ini.mbstring.internal-encoding">mbstring.internal_encoding</link></entry>
       <entry>NULL</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Deprecated</entry>
+      <entry>
+       Deprecated as of PHP 5.6.
+      </entry>
      </row>
      <row>
       <entry><link linkend="ini.mbstring.substitute-character">mbstring.substitute_character</link></entry>


### PR DESCRIPTION
Relevant RFC: https://wiki.php.net/rfc/default_encoding