### PR TITLE
Cleanup dangling line

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -195,8 +195,7 @@ enum Suit: string
    The equivalent values may be a constant scalar expression.
    Prior to PHP 8.2.0, the equivalent values had to be literals or literal expressions.
    This means that constants and constant expressions were not supported.
-   That is, <code>1 + 1</code> was allowed, but not <code>1 + SOME_CONST</code>.
-   is not.
+   That is, <code>1 + 1</code> was allowed, but <code>1 + SOME_CONST</code> was not.
   </para>
 
   <para>


### PR DESCRIPTION
Small cleanup to remove a dangling `is not.` from previous cleanup 06e4d8f936c5b102e60b59c02a048601e9beaf82

I also changed the previous line to flow better (in my opinion) but that could be reverted.