### PR TITLE
Add compatibility note to 'c' date format

### DIFF
--- a/reference/datetime/datetimeinterface/format.xml
+++ b/reference/datetime/datetimeinterface/format.xml
@@ -321,7 +321,7 @@
          </row>
          <row>
           <entry><literal>c</literal></entry>
-          <entry>ISO 8601 date</entry>
+          <entry>ISO 8601 date. Only compatible with the non-expanded format (up to year 9999). Later dates will result in an invalid string. For later dates and expanded format, see <literal>x</literal> and <literal>X</literal>.</entry>
           <entry>2004-02-12T15:19:21+00:00</entry>
          </row>
          <row>


### PR DESCRIPTION
The 'c' format produces invalid ISO8601 dates for years 10000 and above. This is not necessarily wrong, but the documentation should warn about this explicitly.