### PR TITLE
mb_*code_numericentity Clarify the ValueError conditions

### DIFF
--- a/reference/mbstring/functions/mb-decode-numericentity.xml
+++ b/reference/mbstring/functions/mb-decode-numericentity.xml
@@ -63,7 +63,7 @@
   <simpara>
    Throws a <exceptionname>ValueError</exceptionname> if
    <parameter>map</parameter> contains any value that is not an
-   &integer;, &float;, &boolean;, &null;, or a numeric &string;.
+   &integer;, &float;, &boolean;, &null;, or a <link linkend="language.types.numeric-strings">numeric string</link>.
   </simpara>
  </refsect1>
 
@@ -81,9 +81,10 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <function>mb_decode_numericentity</function> now throws a
+       The <function>mb_decode_numericentity</function> function now throws a
        <exceptionname>ValueError</exceptionname> if <parameter>map</parameter>
-       is not a list of &integer;s.
+       contains any value that is not an
+       &integer;, &float;, &boolean;, &null;, or a <link linkend="language.types.numeric-strings">numeric string</link>.
       </entry>
      </row>
      &mbstring.changelog.encoding-nullable;

--- a/reference/mbstring/functions/mb-decode-numericentity.xml
+++ b/reference/mbstring/functions/mb-decode-numericentity.xml
@@ -83,8 +83,7 @@
       <entry>
        The <function>mb_decode_numericentity</function> function now throws a
        <exceptionname>ValueError</exceptionname> if <parameter>map</parameter>
-       contains any value that is not an
-       &integer;, &float;, &boolean;, &null;, or a <link linkend="language.types.numeric-strings">numeric string</link>.
+       contains any value that cannot be implicitly converted to int.
       </entry>
      </row>
      &mbstring.changelog.encoding-nullable;

--- a/reference/mbstring/functions/mb-decode-numericentity.xml
+++ b/reference/mbstring/functions/mb-decode-numericentity.xml
@@ -62,7 +62,8 @@
   &reftitle.errors;
   <simpara>
    Throws a <exceptionname>ValueError</exceptionname> if
-   <parameter>map</parameter> is not a list of &integer;s.
+   <parameter>map</parameter> contains any value that is not an
+   &integer;, &boolean;, &null;, or a numeric &string;.
   </simpara>
  </refsect1>
 

--- a/reference/mbstring/functions/mb-decode-numericentity.xml
+++ b/reference/mbstring/functions/mb-decode-numericentity.xml
@@ -63,7 +63,7 @@
   <simpara>
    Throws a <exceptionname>ValueError</exceptionname> if
    <parameter>map</parameter> contains any value that is not an
-   &integer;, &boolean;, &null;, or a numeric &string;.
+   &integer;, &float;, &boolean;, &null;, or a numeric &string;.
   </simpara>
  </refsect1>
 

--- a/reference/mbstring/functions/mb-encode-numericentity.xml
+++ b/reference/mbstring/functions/mb-encode-numericentity.xml
@@ -73,7 +73,8 @@
   &reftitle.errors;
   <simpara>
    Throws a <exceptionname>ValueError</exceptionname> if
-   <parameter>map</parameter> is not a list of &integer;s.
+   <parameter>map</parameter> contains any value that is not an
+   &integer;, &boolean;, &null;, or a numeric &string;.
   </simpara>
  </refsect1>
 

--- a/reference/mbstring/functions/mb-encode-numericentity.xml
+++ b/reference/mbstring/functions/mb-encode-numericentity.xml
@@ -74,7 +74,7 @@
   <simpara>
    Throws a <exceptionname>ValueError</exceptionname> if
    <parameter>map</parameter> contains any value that is not an
-   &integer;, &float;, &boolean;, &null;, or a numeric &string;.
+   &integer;, &float;, &boolean;, &null;, or a <link linkend="language.types.numeric-strings">numeric string</link>.
   </simpara>
  </refsect1>
 
@@ -92,9 +92,10 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <function>mb_encode_numericentity</function> now throws a
+       The <function>mb_encode_numericentity</function> function now throws a
        <exceptionname>ValueError</exceptionname> if <parameter>map</parameter>
-       is not a list of &integer;s.
+       contains any value that is not an
+       &integer;, &float;, &boolean;, &null;, or a <link linkend="language.types.numeric-strings">numeric string</link>.
       </entry>
      </row>
      &mbstring.changelog.encoding-nullable;

--- a/reference/mbstring/functions/mb-encode-numericentity.xml
+++ b/reference/mbstring/functions/mb-encode-numericentity.xml
@@ -74,7 +74,7 @@
   <simpara>
    Throws a <exceptionname>ValueError</exceptionname> if
    <parameter>map</parameter> contains any value that is not an
-   &integer;, &boolean;, &null;, or a numeric &string;.
+   &integer;, &float;, &boolean;, &null;, or a numeric &string;.
   </simpara>
  </refsect1>
 

--- a/reference/mbstring/functions/mb-encode-numericentity.xml
+++ b/reference/mbstring/functions/mb-encode-numericentity.xml
@@ -94,8 +94,7 @@
       <entry>
        The <function>mb_encode_numericentity</function> function now throws a
        <exceptionname>ValueError</exceptionname> if <parameter>map</parameter>
-       contains any value that is not an
-       &integer;, &float;, &boolean;, &null;, or a <link linkend="language.types.numeric-strings">numeric string</link>.
+       contains any value that cannot be implicitly converted to int.
       </entry>
      </row>
      &mbstring.changelog.encoding-nullable;


### PR DESCRIPTION
In the `map` parameter of the `mb_*code_numericentity` functions, any scalar values are allowed, with the caveat that the string scalar must be a numeric string