### PR TITLE
Document opcache.huge_code_pages prerequisites when JIT is on

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -819,7 +819,11 @@
     <listitem>
      <para>
       Enables or disables copying of PHP code (text segment) into HUGE PAGES.
-      This should improve performance, but requires appropriate OS configuration.
+      This should improve performance, but requires appropriate OS configuration
+      to allocate enough HUGE PAGES for the sum of
+      <link linkend="ini.opcache.memory_consumption">opcache.memory_consumption</link>
+      and
+      <link linkend="ini.opcache.jit_buffer_size">opcache.jit_buffer_size</link>.
       Available on Linux as of PHP 7.0.0, and on FreeBSD as of PHP 7.4.0.
      </para>
     </listitem>

--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -821,9 +821,9 @@
       Enables or disables copying of PHP code (text segment) into HUGE PAGES.
       This should improve performance, but requires appropriate OS configuration
       to allocate enough HUGE PAGES for the sum of
-      <link linkend="ini.opcache.memory_consumption">opcache.memory_consumption</link>
+      <link linkend="ini.opcache.memory-consumption">opcache.memory_consumption</link>
       and
-      <link linkend="ini.opcache.jit_buffer_size">opcache.jit_buffer_size</link>.
+      <link linkend="ini.opcache.jit-buffer-size">opcache.jit_buffer_size</link>.
       Available on Linux as of PHP 7.0.0, and on FreeBSD as of PHP 7.4.0.
      </para>
     </listitem>

--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -409,6 +409,14 @@
      The minimum permissible value is <literal>"8"</literal>,
      which is enforced if a smaller value is set.
     </simpara>
+    <simpara>
+     When the JIT is enabled, the shared memory segment also holds the JIT
+     buffer, so its total size is this value plus
+     <link linkend="ini.opcache.jit-buffer-size">opcache.jit_buffer_size</link>.
+     OPcache first attempts to allocate the segment using HUGE PAGES, and
+     silently falls back to regular pages when the operating system has not
+     set aside enough of them.
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="ini.opcache.interned-strings-buffer">
@@ -977,6 +985,11 @@ function getA() { return A; }
     <simpara>
      Enables or disables copying of PHP code (text segment) into HUGE PAGES.
      This should improve performance, but requires appropriate OS configuration.
+     Only the text segment of the PHP binary is remapped; the shared memory
+     segment described under
+     <link linkend="ini.opcache.memory-consumption">opcache.memory_consumption</link>
+     is unaffected by this directive. When the remapping fails, OPcache emits
+     an <constant>E_WARNING</constant>.
      Available on Linux as of PHP 7.0.0, and on FreeBSD as of PHP 7.4.0.
     </simpara>
    </listitem>


### PR DESCRIPTION
opcache.huge_code_pages was broken in 8.4 (https://github.com/php/php-src/issues/19638), and has recently been fixed in https://github.com/php/php-src/commit/0ee7732.

It comes with new requirements: in order for PHP to reserve huge pages at all, the OS has to set aside enough to also cover opcache.jit_buffer_size.

This PR documents how to calculate the number to allocate.