### PR TITLE
Update Hash extension installation notes

### DIFF
--- a/reference/hash/setup.xml
+++ b/reference/hash/setup.xml
@@ -8,17 +8,15 @@
  <section xml:id="hash.installation">
   &reftitle.install;
   <para>
-   As of PHP 5.1.2, the Hash extension is bundled and compiled into PHP by
-   default.
+   The Hash extension is a core PHP extension, so it is always enabled.
   </para>
   <para>
-   It may be explicitly disabled by using the --disable-hash switch to
-   configure.  Earlier versions of PHP may incorporate the Hash extension by
-   installing the
+   Prior to PHP 7.4.0, the Hash extension was bundled and compiled into PHP by
+   default, but could be explicitly disabled using <option role="configure">--disable-hash</option>.
+  </para>
+  <para>
+   Prior to 5.1.2, the Hash extension was installed as a
    <link xlink:href="&url.pecl.package;hash">PECL module</link>.
-  </para>
-  <para>
-   As of PHP 7.4.0, the Hash extension is a core PHP extension, so it is always enabled.
   </para>
  </section>
  <!-- }}} -->


### PR DESCRIPTION
- Streamline the opener to focus on current state of things
- Move older/EoL version stuff down
- Drop vague "earlier versions" reference
- properly encapsulate `configure` parameter