### PR TITLE
Update JSON extension installation notes

### DIFF
--- a/reference/json/setup.xml
+++ b/reference/json/setup.xml
@@ -10,7 +10,7 @@
    The JSON extension is a core PHP extension, so it is always enabled.
   </para>
   <para>
-   Prior to PHP 8.0.0, the JSON extension was bundled and compiled into PHP by 
+   Prior to PHP 8.0.0, the JSON extension was bundled and compiled into PHP by
    default, but could be explicitly disabled using <option role="configure">--disable-json</option>.
   </para>
   <para>


### PR DESCRIPTION
- Make the opener focus on current state of things
- Move older/EoL version stuff down and add <PHP 8.0.0 context
- Drop inclusion of the verbose [`pecl.info` installation snippet](https://github.com/php/doc-en/blob/e3257766221ace07316deebc972f17ebc05debc2/language-snippets.ent#L2193-L2197) since it's not particularly relevant to 99% of readers
- properly encapsulate `configure` parameter