### PR TITLE
Refactor extensions list / categories XML entities

### DIFF
--- a/extensions.ent
+++ b/extensions.ent
@@ -4,8 +4,8 @@
  ==========================================================================
  Entities for the categorized extension list for the PHP manual.
  These entities are not translated, preventing them from becoming outdated.
- --------------------------------------------------------------------------
- Structure:
+
+  Structure:
   - Introduction
   - Alphabetical List
   - Purpose Categories
@@ -314,8 +314,8 @@
  </title>
  <para xmlns='http://docbook.org/ns/docbook'>
   This part lists extensions not intended for production use
-  — they are either too "new" (experimental)
-  — or "old" (deprecated). Use at your own risk.
+  — they are either too &quot;new&quota" (experimental)
+  — or &quot;old&quot (deprecated). Use at your own risk.
  </para>
 ">
 

--- a/extensions.ent
+++ b/extensions.ent
@@ -299,7 +299,7 @@
    These extensions are available from &link.pecl;.
    They may require external libraries
    or have other special requirements.
-   More PECL extensions exist 
+   More PECL extensions exist
    but they are not documented in the PHP manual yet.
   </para>
  ">
@@ -314,8 +314,8 @@
  </title>
  <para xmlns='http://docbook.org/ns/docbook'>
   This part lists extensions not intended for production use
-  — they are either too &quot;new&quota" (experimental)
-  — or &quot;old&quot (deprecated). Use at your own risk.
+  — they are either too &quot;new&quot; (experimental)
+  — or &quot;old&quot; (deprecated). Use at your own risk.
  </para>
 ">
 

--- a/extensions.ent
+++ b/extensions.ent
@@ -1,96 +1,340 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-
 <!--
-  Entities for the categorized extension list, so it does not need
-  to be translated, and thus it is not going to be outdated.
+ $Revision$
+ ==========================================================================
+ Entities for the categorized extension list for the PHP manual.
+ These entities are not translated, preventing them from becoming outdated.
+ --------------------------------------------------------------------------
+ Structure:
+  - Introduction
+  - Alphabetical List
+  - Purpose Categories
+  - Membership Categories
+  - State Categories
+ ==========================================================================
 -->
 
-<!ENTITY extcat.intro '<title xmlns="http://docbook.org/ns/docbook">Extension List/Categorization</title><para xmlns="http://docbook.org/ns/docbook">This
-appendix categorizes more than 150 extensions documented in the PHP
-Manual by several criteria.</para>'>
-
-<!ENTITY extcat.alphabetical '<title xmlns="http://docbook.org/ns/docbook">Alphabetical</title>'>
-
+<!-- ======================================================================= -->
+<!-- Introduction -->
 <!-- ======================================================================= -->
 
-<!ENTITY extcat.purpose '<title xmlns="http://docbook.org/ns/docbook">Purpose</title>'>
-
-<!ENTITY extcat.purpose.basic '<title xmlns="http://docbook.org/ns/docbook">Basic PHP Extensions</title>'>
-<!ENTITY extcat.purpose.basic.vartype '<title xmlns="http://docbook.org/ns/docbook">Variable and Type Related Extensions</title>'>
-<!ENTITY extcat.purpose.basic.text '<title xmlns="http://docbook.org/ns/docbook">Text Processing</title>'>
-<!ENTITY extcat.purpose.basic.php "<title xmlns='http://docbook.org/ns/docbook'>Affecting PHP's Behaviour</title>">
-<!ENTITY extcat.purpose.basic.session '<title xmlns="http://docbook.org/ns/docbook">Session Extensions</title>'>
-<!ENTITY extcat.purpose.basic.other '<title xmlns="http://docbook.org/ns/docbook">Other Basic Extensions</title>'>
-
-<!ENTITY extcat.purpose.database '<title xmlns="http://docbook.org/ns/docbook">Database Extensions</title>'>
-<!ENTITY extcat.purpose.database.abstract '<title xmlns="http://docbook.org/ns/docbook">Abstraction Layers</title>'>
-<!ENTITY extcat.purpose.database.vendors '<title xmlns="http://docbook.org/ns/docbook">Vendor Specific Database Extensions</title>'>
-
-<!ENTITY extcat.purpose.xml '<title xmlns="http://docbook.org/ns/docbook">XML Manipulation</title>'>
-
-<!ENTITY extcat.purpose.webservice '<title xmlns="http://docbook.org/ns/docbook">Web Services</title>'>
-
-<!ENTITY extcat.purpose.creditcard '<title xmlns="http://docbook.org/ns/docbook">Credit Card Processing</title>'>
-   
-<!ENTITY extcat.purpose.mathcrypto '<title xmlns="http://docbook.org/ns/docbook">Math and Cryptography</title>'>
-<!ENTITY extcat.purpose.mathcrypto.math '<title xmlns="http://docbook.org/ns/docbook">Mathematical Extensions</title>'>
-<!ENTITY extcat.purpose.mathcrypto.crypto '<title xmlns="http://docbook.org/ns/docbook">Cryptography Extensions</title>'>
-
-<!ENTITY extcat.purpose.international '<title xmlns="http://docbook.org/ns/docbook">Human Language and Character Encoding Support</title>'>
-   
-<!ENTITY extcat.purpose.fileprocess '<title xmlns="http://docbook.org/ns/docbook">File System and Process Control</title>'>
-<!ENTITY extcat.purpose.fileprocess.file '<title xmlns="http://docbook.org/ns/docbook">File System Related Extensions</title>'>
-<!ENTITY extcat.purpose.fileprocess.process '<title xmlns="http://docbook.org/ns/docbook">Process Control Extensions</title>'>
-
-<!ENTITY extcat.purpose.remote '<title xmlns="http://docbook.org/ns/docbook">Accessing Services</title>'>
-<!ENTITY extcat.purpose.remote.mail '<title xmlns="http://docbook.org/ns/docbook">Mail Related Extensions</title>'>
-<!ENTITY extcat.purpose.remote.auth '<title xmlns="http://docbook.org/ns/docbook">Authentication Services</title>'>
-<!ENTITY extcat.purpose.remote.other '<title xmlns="http://docbook.org/ns/docbook">Other Services</title>'>
-
-<!ENTITY extcat.purpose.compression '<title xmlns="http://docbook.org/ns/docbook">Compression and Archive Extensions</title>'>
-
-<!ENTITY extcat.purpose.calendar '<title xmlns="http://docbook.org/ns/docbook">Date and Time Related Extensions</title>'>
-
-<!ENTITY extcat.purpose.utilspec '<title xmlns="http://docbook.org/ns/docbook">Utilization Area Specific Extensions</title>'>
-<!ENTITY extcat.purpose.utilspec.nontext '<title xmlns="http://docbook.org/ns/docbook">Non-Text MIME Output</title>'>
-<!ENTITY extcat.purpose.utilspec.image '<title xmlns="http://docbook.org/ns/docbook">Image Processing and Generation</title>'>
-<!ENTITY extcat.purpose.utilspec.audio '<title xmlns="http://docbook.org/ns/docbook">Audio Formats Manipulation</title>'>
-<!ENTITY extcat.purpose.utilspec.cmdline '<title xmlns="http://docbook.org/ns/docbook">Command Line Specific Extensions</title>'>
-<!ENTITY extcat.purpose.utilspec.windows '<title xmlns="http://docbook.org/ns/docbook">Windows Only Extensions</title>'>
-<!ENTITY extcat.purpose.utilspec.server '<title xmlns="http://docbook.org/ns/docbook">Server Specific Extensions</title>'>
-    
-<!-- ======================================================================= -->
-
-<!ENTITY extcat.membership '<title xmlns="http://docbook.org/ns/docbook">Membership</title>'>
-
-<!ENTITY extcat.membership.core '<title xmlns="http://docbook.org/ns/docbook">Core Extensions</title><para xmlns="http://docbook.org/ns/docbook">These
-are not actual extensions. They are part of the PHP core and cannot be
-left out of a PHP binary with compilation options.</para>'>
-
-<!ENTITY extcat.membership.bundled '<title xmlns="http://docbook.org/ns/docbook">Bundled Extensions</title><para xmlns="http://docbook.org/ns/docbook">These
-extensions are bundled with PHP.</para>'>
-
-<!ENTITY extcat.membership.external '<title xmlns="http://docbook.org/ns/docbook">External Extensions</title><para xmlns="http://docbook.org/ns/docbook">These
-extensions are bundled with PHP but in order to compile them, external libraries will be needed.</para>'>
-
-<!ENTITY extcat.membership.pecl '<title xmlns="http://docbook.org/ns/docbook">
-PECL Extensions</title>
-<para xmlns="http://docbook.org/ns/docbook">These extensions are available from
-&link.pecl;. They may require external libraries. More PECL extensions exist but
-they are not documented in the PHP manual yet.</para>'>
+<!ENTITY extcat.intro "
+ <title xmlns='http://docbook.org/ns/docbook'>
+  Extension List/Categorization
+ </title>
+ <para xmlns='http://docbook.org/ns/docbook'>
+  This appendix categorizes more than 150 extensions documented in the
+  PHP Manual by several criteria.
+ </para>
+">
 
 <!-- ======================================================================= -->
+<!-- Alphabetical -->
+<!-- ======================================================================= -->
 
-<!ENTITY extcat.state '<title xmlns="http://docbook.org/ns/docbook">State</title><para xmlns="http://docbook.org/ns/docbook">This part lists extensions not
-intended for the production use - they are either too "old" (deprecated) or
-"new" (experimental).</para>'>
+<!ENTITY extcat.alphabetical "
+ <title xmlns='http://docbook.org/ns/docbook'>
+  Alphabetical
+ </title>
+">
 
-<!ENTITY extcat.state.deprecated '<title xmlns="http://docbook.org/ns/docbook">Deprecated Extensions</title><para xmlns="http://docbook.org/ns/docbook">These
-extensions have been deprecated usually in the favor of some other extensions.</para>'>
+<!-- ======================================================================= -->
+<!-- Purpose Categories -->
+<!-- ======================================================================= -->
 
-<!ENTITY extcat.state.experimental '<title xmlns="http://docbook.org/ns/docbook">Experimental Extensions</title><para xmlns="http://docbook.org/ns/docbook">The
-behaviour of these extensions - including the names of their functions and anything
-else documented about these extensions - may change without notice in a future release
-of PHP. Use these extensions at your own risk.</para>'>
+<!ENTITY extcat.purpose "
+ <title xmlns='http://docbook.org/ns/docbook'>
+  Purpose
+ </title>
+">
 
+ <!-- Basic PHP Extensions -->
+ <!ENTITY extcat.purpose.basic "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Basic PHP Extensions
+  </title>
+ ">
+ <!ENTITY extcat.purpose.basic.vartype "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Variable and Type Related Extensions
+  </title>
+ ">
+ <!ENTITY extcat.purpose.basic.text "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Text Processing
+  </title>
+ ">
+ <!ENTITY extcat.purpose.basic.php "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Affecting PHP's Behaviour
+  </title>
+ ">
+ <!ENTITY extcat.purpose.basic.session "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Session Extensions
+  </title>
+ ">
+ <!ENTITY extcat.purpose.basic.other "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Other Basic Extensions
+  </title>
+ ">
+
+ <!-- Database Extensions -->
+ <!ENTITY extcat.purpose.database "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Database Extensions
+  </title>
+ ">
+ <!ENTITY extcat.purpose.database.abstract "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Abstraction Layers
+  </title>
+ ">
+ <!ENTITY extcat.purpose.database.vendors "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Vendor Specific Database Extensions
+  </title>
+ ">
+
+ <!-- XML Manipulation -->
+ <!ENTITY extcat.purpose.xml "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   XML Manipulation
+  </title>
+ ">
+
+ <!-- Web Services -->
+ <!ENTITY extcat.purpose.webservice "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Web Services
+  </title>
+ ">
+
+ <!-- Credit Card Processing -->
+ <!ENTITY extcat.purpose.creditcard "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Credit Card Processing
+  </title>
+ ">
+
+ <!-- Math and Cryptography -->
+ <!ENTITY extcat.purpose.mathcrypto "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Math and Cryptography
+  </title>
+ ">
+ <!ENTITY extcat.purpose.mathcrypto.math "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Mathematical Extensions
+  </title>
+ ">
+ <!ENTITY extcat.purpose.mathcrypto.crypto "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Cryptography Extensions
+  </title>
+ ">
+
+ <!-- Internationalization -->
+ <!ENTITY extcat.purpose.international "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Human Language and Character Encoding Support
+  </title>
+ ">
+
+ <!-- File System and Process Control -->
+ <!ENTITY extcat.purpose.fileprocess "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   File System and Process Control
+  </title>
+ ">
+ <!ENTITY extcat.purpose.fileprocess.file "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   File System Related Extensions
+  </title>
+ ">
+ <!ENTITY extcat.purpose.fileprocess.process "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Process Control Extensions
+  </title>
+ ">
+
+ <!-- Accessing Services -->
+ <!ENTITY extcat.purpose.remote "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Accessing Services
+  </title>
+ ">
+ <!ENTITY extcat.purpose.remote.mail "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Mail Related Extensions
+  </title>
+ ">
+ <!ENTITY extcat.purpose.remote.auth "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Authentication Services
+  </title>
+ ">
+ <!ENTITY extcat.purpose.remote.other "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Other Services
+  </title>
+ ">
+
+ <!-- Compression and Archive -->
+ <!ENTITY extcat.purpose.compression "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Compression and Archive Extensions
+  </title>
+ ">
+
+ <!-- Date and Time -->
+ <!ENTITY extcat.purpose.calendar "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Date and Time Related Extensions
+  </title>
+ ">
+
+ <!-- Utilization Area Specific Extensions -->
+ <!ENTITY extcat.purpose.utilspec "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Utilization Area Specific Extensions
+  </title>
+ ">
+ <!ENTITY extcat.purpose.utilspec.nontext "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Non-Text MIME Output
+  </title>
+ ">
+ <!ENTITY extcat.purpose.utilspec.image "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Image Processing and Generation
+  </title>
+ ">
+ <!ENTITY extcat.purpose.utilspec.audio "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Audio Formats Manipulation
+  </title>
+ ">
+ <!ENTITY extcat.purpose.utilspec.cmdline "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Command Line Specific Extensions
+  </title>
+ ">
+ <!ENTITY extcat.purpose.utilspec.windows "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Windows Only Extensions
+  </title>
+ ">
+ <!ENTITY extcat.purpose.utilspec.server "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Server Specific Extensions
+  </title>
+ ">
+
+<!-- ======================================================================= -->
+<!-- Membership Categories -->
+<!-- ======================================================================= -->
+
+<!ENTITY extcat.membership "
+ <title xmlns='http://docbook.org/ns/docbook'>
+  Membership
+ </title>
+">
+
+ <!ENTITY extcat.membership.core "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Core Extensions
+  </title>
+  <para xmlns='http://docbook.org/ns/docbook'>
+   These extensions are built into the PHP core
+   and are included in every PHP installation.
+   They cannot be disabled or removed at compile time.
+  </para>
+  <para xmlns='http://docbook.org/ns/docbook'>
+   Some core extensions provide compile-time configuration options
+   that allow for customization of specific behaviors or functionality.
+  </para>
+  <para xmlns='http://docbook.org/ns/docbook'>
+   For clarity, some of the functionality listed below
+   is provided by the <literal>standard</literal> extension
+   and does not represent distinct, standalone extensions.
+   These features are described separately for convenience
+   and to highlight the specific aspects of functionality they provide.
+  </para>
+ ">
+ <!ENTITY extcat.membership.bundled "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Bundled Extensions
+  </title>
+ <para xmlns='http://docbook.org/ns/docbook'>
+  These extensions and features are included with PHP,
+  but may not always be enabled by default.
+  Each can be disabled during compilation.
+ </para>
+ <para xmlns='http://docbook.org/ns/docbook'>
+  Some bundled extensions require specific system resources
+  or may offer additional functionality
+  when supplementary libraries are installed.
+  In some cases, their availability is limited
+  to certain platforms or use cases.
+ </para>
+ ">
+ <!ENTITY extcat.membership.external "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   External Extensions
+  </title>
+  <para xmlns='http://docbook.org/ns/docbook'>
+   These extensions are included with PHP,
+   but require require external libraries to be enabled.
+   Each can be enabled during compilation
+   (if dependency requirements are met).
+  </para>
+ ">
+ <!ENTITY extcat.membership.pecl "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   PECL Extensions
+  </title>
+  <para xmlns='http://docbook.org/ns/docbook'>
+   These extensions are available from &link.pecl;.
+   They may require external libraries
+   or have other special requirements.
+   More PECL extensions exist 
+   but they are not documented in the PHP manual yet.
+  </para>
+ ">
+
+<!-- ======================================================================= -->
+<!-- State Categories -->
+<!-- ======================================================================= -->
+
+<!ENTITY extcat.state "
+ <title xmlns='http://docbook.org/ns/docbook'>
+  State
+ </title>
+ <para xmlns='http://docbook.org/ns/docbook'>
+  This part lists extensions not intended for production use
+  — they are either too "new" (experimental)
+  — or "old" (deprecated). Use at your own risk.
+ </para>
+">
+
+ <!ENTITY extcat.state.experimental "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Experimental Extensions
+  </title>
+  <para xmlns='http://docbook.org/ns/docbook'>
+   The behaviour of these extensions
+   — including function names and anything else documented
+   — may change without notice in a future release of PHP.
+  </para>
+ ">
+ <!ENTITY extcat.state.deprecated "
+  <title xmlns='http://docbook.org/ns/docbook'>
+   Deprecated Extensions
+  </title>
+  <para xmlns='http://docbook.org/ns/docbook'>
+   These extensions have been deprecated
+   usually in favor of some other extensions.
+  </para>
+ ">


### PR DESCRIPTION
This PR refactors the XML entities page used for the extensions categories pages (https://www.php.net/manual/en/extensions.php / etc).

Key changes:

- reformatted the code for easier maintenance (and incorporated PHP Style guidelines)
- improved introductory paragraphs for each category (that hopefully offering additional clarity)
- swapped ordering of State page sections (emphasizing experimental first followed by deprecated)

There are other follow-ups pending as I get time.