### PR TITLE
Update srand.xml Fix incorrect description

### DIFF
--- a/reference/random/functions/srand.xml
+++ b/reference/random/functions/srand.xml
@@ -14,7 +14,7 @@
   </methodsynopsis>
   <para>
    Seeds the random number generator with <parameter>seed</parameter>
-   or with a random value if <parameter>seed</parameter> is <literal>0</literal>.
+   or with a random value if <parameter>seed</parameter> is &null;.
   </para>
 
   &note.randomseed;

--- a/reference/random/functions/srand.xml
+++ b/reference/random/functions/srand.xml
@@ -13,8 +13,9 @@
    <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>MT_RAND_MT19937</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
-   Seeds the random number generator with <parameter>seed</parameter>
-   or with a random value if <parameter>seed</parameter> is &null;.
+   Seeds the random number generator with
+   <parameter>seed</parameter> or with a random value
+   if no <parameter>seed</parameter> is given.
   </para>
 
   &note.randomseed;


### PR DESCRIPTION
`srand(0)` uses `0` as seed, random seeding only occurs when seed is `null` or omitted.