### PR TITLE
DomNode::$ownerDocument: add missing word to description

### DIFF
--- a/reference/dom/domnode.xml
+++ b/reference/dom/domnode.xml
@@ -353,7 +353,7 @@
     <varlistentry xml:id="domnode.props.ownerdocument">
      <term><varname>ownerDocument</varname></term>
      <listitem>
-      <para>The <classname>DOMDocument</classname> object associated with this node, or &null; if this node  does not have an associated document (e.g. if it is detached, or if it is a <classname>DOMDocument</classname>).</para>
+      <para>The <classname>DOMDocument</classname> object associated with this node, or &null; if this node does not have an associated document (e.g. if it is detached, or if it is a <classname>DOMDocument</classname>).</para>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="domnode.props.namespaceuri">


### PR DESCRIPTION
Ref: https://www.php.net/manual/en/class.domnode.php#domnode.props.ownerdocument