### PR TITLE
Update declarations.xml

### DIFF
--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -359,7 +359,7 @@ NULL
      </listitem>
      <listitem>
       <simpara>
-       Using <type>mixed</type> results in an error.
+       Using <type>mixed</type> or <type>never</type> results in an error.
       </simpara>
      </listitem>
      <listitem>


### PR DESCRIPTION
The bottom type can't be used in a composite type for the same (rather, dual) reason the top type can't.