### PR TITLE
Update documentation for apc.entries_hint

### DIFF
--- a/reference/apcu/ini.xml
+++ b/reference/apcu/ini.xml
@@ -77,9 +77,9 @@
      </row>
      <row>
       <entry><link linkend="ini.apcu.entries-hint">apc.entries_hint</link></entry>
-      <entry>4096</entry>
+      <entry>512 * apc.shm_size</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
-      <entry></entry>
+      <entry>Prior to APcu 5.1.25, the default was 4096</entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.ttl">apc.ttl</link></entry>


### PR DESCRIPTION
https://pecl.php.net/package-changelog.php?package=APCu

For [5.1.25](https://pecl.php.net/package-info.php?package=APCu&version=5.1.25):

- **apc.entries_hint now defaults to 512 entries per 1MB of shared memory**. Previously the
default was 4096, independent of shm_size. This could lead to a large number of hash
collisions if shm_size was increased without also increasing entries_hint.
