### PR TITLE
unset is not guaranteed to flush cookie list.

### DIFF
--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -338,7 +338,7 @@
        As of PHP 8.0.0, <function>curl_close</function> is a no-op
        and does <emphasis>not</emphasis> destroy the handle.
        If cookies need to be written prior to the handle being automatically
-       destroyed, call <function>unset</function> on the handle.
+       destroyed, run <code>curl_setopt($ch, CURLOPT_COOKIELIST, "FLUSH");</code>.
       </simpara>
      </warning>
     </para>


### PR DESCRIPTION
unset() happens to work if the curl handle reference count reach zero, which unset does not guarantee. better to use CURLOPT_COOKIELIST flush.