### PR TITLE
Add entity for PHP 8.5 deprecations.

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -371,14 +371,14 @@ xmlns="http://docbook.org/ns/docbook"><simpara>This feature has been
 <emphasis>DEPRECATED</emphasis> as of PHP 8.4.0. Relying on this feature
 is highly discouraged.</simpara></warning>'>
 
-<!ENTITY warn.deprecated.feature-8-5-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This feature has been
-<emphasis>DEPRECATED</emphasis> as of PHP 8.5.0. Relying on this feature
-is highly discouraged.</simpara></warning>'>
-
 <!ENTITY warn.deprecated.function-8-4-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
 <emphasis>DEPRECATED</emphasis> as of PHP 8.4.0. Relying on this function
+is highly discouraged.</simpara></warning>'>
+
+<!ENTITY warn.deprecated.feature-8-5-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara>This feature has been
+<emphasis>DEPRECATED</emphasis> as of PHP 8.5.0. Relying on this feature
 is highly discouraged.</simpara></warning>'>
 
 <!ENTITY warn.deprecated.function-8-5-0 '<warning

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -376,6 +376,11 @@ xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
 <emphasis>DEPRECATED</emphasis> as of PHP 8.4.0. Relying on this function
 is highly discouraged.</simpara></warning>'>
 
+<!ENTITY warn.deprecated.function-8-5-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
+<emphasis>DEPRECATED</emphasis> as of PHP 8.5.0. Relying on this function
+is highly discouraged.</simpara></warning>'>
+
 <!ENTITY removed.php.future 'This deprecated feature <emphasis xmlns="http://docbook.org/ns/docbook">will</emphasis>
 certainly be <emphasis xmlns="http://docbook.org/ns/docbook">removed</emphasis> in the future.'>
 

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -371,6 +371,11 @@ xmlns="http://docbook.org/ns/docbook"><simpara>This feature has been
 <emphasis>DEPRECATED</emphasis> as of PHP 8.4.0. Relying on this feature
 is highly discouraged.</simpara></warning>'>
 
+<!ENTITY warn.deprecated.feature-8-5-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara>This feature has been
+<emphasis>DEPRECATED</emphasis> as of PHP 8.5.0. Relying on this feature
+is highly discouraged.</simpara></warning>'>
+
 <!ENTITY warn.deprecated.function-8-4-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
 <emphasis>DEPRECATED</emphasis> as of PHP 8.4.0. Relying on this function


### PR DESCRIPTION
Apparently it hasn't been added yet, so here it is.

This should unblock #4892, #4893, and the many other deprecations to document for 8.5.