### PR TITLE
Add deprecation/changelog for switch statement semicolons.

### DIFF
--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -290,7 +290,7 @@ switch($beer)
 ]]>
    </programlisting>
   </informalexample>
-  This syntax has been deprecated as of PHP 8.5.0.
+  &warn.deprecated.feature-8-5-0;
  </para>
 
 

--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -269,7 +269,7 @@ endswitch;
   </informalexample>
  </para>
  <para>
-  It's possible to use a semicolon instead of a colon after a case like:
+  Prior to PHP 8.5.0, it was possible to use a semicolon instead of a colon after a case like:
   <informalexample>
    <programlisting role="php">
 <![CDATA[
@@ -290,7 +290,31 @@ switch($beer)
 ]]>
    </programlisting>
   </informalexample>
+  This syntax has been deprecated as of PHP 8.5.0.
  </para>
+
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       The alternate syntax using a semicolon after <literal>case</literal> has been deprecated.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
 
  <sect2 role="seealso">
   &reftitle.seealso;

--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -294,7 +294,7 @@ switch($beer)
  </para>
 
 
- <refsect1 role="changelog">
+ <section role="changelog">
   &reftitle.changelog;
   <informaltable>
    <tgroup cols="2">
@@ -314,7 +314,7 @@ switch($beer)
     </tbody>
    </tgroup>
   </informaltable>
- </refsect1>
+ </section>
 
  <sect2 role="seealso">
   &reftitle.seealso;

--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -294,7 +294,7 @@ switch($beer)
  </para>
 
 
- <section role="changelog">
+ <sect2 role="changelog">
   &reftitle.changelog;
   <informaltable>
    <tgroup cols="2">
@@ -314,7 +314,7 @@ switch($beer)
     </tbody>
    </tgroup>
   </informaltable>
- </section>
+ </sect2>
 
  <sect2 role="seealso">
   &reftitle.seealso;

--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -269,7 +269,7 @@ endswitch;
   </informalexample>
  </para>
  <para>
-  Prior to PHP 8.5.0, it was possible to use a semicolon instead of a colon after a case like:
+  It's possible to use a semicolon instead of a colon after a case like:
   <informalexample>
    <programlisting role="php">
 <![CDATA[


### PR DESCRIPTION
I'm not sure if it makes sense to use the "deprecated" entities here, since it's just a tiny part of the syntax that's deprecated, not the whole thing.  The "feature" warning seems like it would be overkill.  So I just adjusted the text and added a changelog.