### PR TITLE
Fix Example 10 in oop5/basic.xml

### DIFF
--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -535,7 +535,7 @@ $extended->displayVar();
     <screen>
 <![CDATA[
 Extending class
-a default value
+Parent class
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
Example 10 on "The Basics" page of the "Classes and Objects" documentation had incorrect output.