### PR TITLE
Missing function documentation for pcntl_wifcontinued and pcntl_forkx

### DIFF
--- a/reference/pcntl/functions/pcntl-fork.xml
+++ b/reference/pcntl/functions/pcntl-fork.xml
@@ -66,6 +66,7 @@ if ($pid == -1) {
   &reftitle.seealso;
   <para>
    <simplelist>
+    <member><function>pcntl_forkx</function></member>
     <member><function>pcntl_rfork</function></member>
     <member><function>pcntl_waitpid</function></member>
     <member><function>pcntl_signal</function></member>

--- a/reference/pcntl/functions/pcntl-forkx.xml
+++ b/reference/pcntl/functions/pcntl-forkx.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.pcntl-forkx" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_forkx</refname>
+  <refpurpose>Forks the currently running process, with additional options (Solaris only)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pcntl_forkx</methodname>
+   <methodparam><type>int</type><parameter>flags</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   The <function>pcntl_forkx</function> function creates a child
+   process that differs from the parent process only in its PID and
+   PPID. Please see your system's forkx(2) man page for specific details as to
+   how forkx works on your system.
+  </para>
+  <para>
+   This function is only available on <productname>Solaris</productname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>flags</parameter></term>
+     <listitem>
+      <para>
+       The <parameter>flags</parameter> parameter must be one of the following values:
+       <table>
+        <title>Possible values for <parameter>flags</parameter></title>
+        <tgroup cols="2">
+         <tbody>
+          <row>
+           <entry><constant>FORK_WAITPID</constant></entry>
+           <entry>
+            The parent process must call <function>pcntl_waitpid</function> or
+            <function>pcntl_waitid</function> with the childs processid. Calls
+            that wait on multiple process IDs do not qualify. Otherwise, the
+            child will remain as a zombie process until the parent exits.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>FORK_NOSIGCHLD</constant></entry>
+           <entry>
+            Do not post a <constant>SIGCHLD</constant> signal to the parent
+            process when the child terminates.
+           </entry>
+          </row>
+         </tbody>
+        </tgroup>
+       </table>
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   On success, the PID of the child process is returned in the
+   parent's thread of execution, and a 0 is returned in the child's
+   thread of execution.  On failure, a -1 will be returned in the
+   parent's context, no child process will be created, and a PHP
+   error is raised.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>pcntl_forkx</function> example</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$pid = pcntl_forkx(FORK_WAITPID);
+if ($pid == -1) {
+     die('Could not fork');
+} else if ($pid) {
+     // we are the parent
+     // Protect against Zombie children
+     pcntl_waitpid($pid, $status);
+} else {
+     // we are the child
+}
+
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pcntl_fork</function></member>
+    <member><function>pcntl_waitid</function></member>
+    <member><function>pcntl_waitpid</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/pcntl/functions/pcntl-wait.xml
+++ b/reference/pcntl/functions/pcntl-wait.xml
@@ -105,6 +105,7 @@
    <simplelist>
     <member><function>pcntl_fork</function></member>
     <member><function>pcntl_signal</function></member>
+    <member><function>pcntl_wifcontinued</function></member>
     <member><function>pcntl_wifexited</function></member>
     <member><function>pcntl_wifstopped</function></member>
     <member><function>pcntl_wifsignaled</function></member>

--- a/reference/pcntl/functions/pcntl-waitid.xml
+++ b/reference/pcntl/functions/pcntl-waitid.xml
@@ -328,6 +328,7 @@
     <member><function>pcntl_wait</function></member>
     <member><function>pcntl_fork</function></member>
     <member><function>pcntl_signal</function></member>
+    <member><function>pcntl_wifcontinued</function></member>
     <member><function>pcntl_wifexited</function></member>
     <member><function>pcntl_wifstopped</function></member>
     <member><function>pcntl_wifsignaled</function></member>

--- a/reference/pcntl/functions/pcntl-waitpid.xml
+++ b/reference/pcntl/functions/pcntl-waitpid.xml
@@ -149,6 +149,7 @@
    <simplelist>
     <member><function>pcntl_fork</function></member>
     <member><function>pcntl_signal</function></member>
+    <member><function>pcntl_wifcontinued</function></member>
     <member><function>pcntl_wifexited</function></member>
     <member><function>pcntl_wifstopped</function></member>
     <member><function>pcntl_wifsignaled</function></member>

--- a/reference/pcntl/functions/pcntl-wifcontinued.xml
+++ b/reference/pcntl/functions/pcntl-wifcontinued.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.pcntl-wifcontinued" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_wifcontinued</refname>
+  <refpurpose>Checks if status code represents a process that was resumed with SIGCONT</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>pcntl_wifcontinued</methodname>
+   <methodparam><type>int</type><parameter>status</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Checks whether the child status code represents a process that was resumed
+   due to a <constant>SIGCONT</constant> signal.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>status</parameter></term>
+     <listitem>
+      &pcntl.parameter.status;
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns &true; if the child status code represents a process that was resumed
+   due to a <constant>SIGCONT</constant> signal, &false;
+   otherwise.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pcntl_wait</function></member>
+    <member><function>pcntl_waitid</function></member>
+    <member><function>pcntl_waitpid</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/pcntl/versions.xml
+++ b/reference/pcntl/versions.xml
@@ -9,6 +9,7 @@
  <function name="pcntl_errno" from="PHP 5 &gt;= 5.3.4, PHP 7, PHP 8"/>
  <function name="pcntl_exec" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_fork" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pcntl_forkx" from="PHP 8 &gt;= 8.2.0"/>
  <function name="pcntl_getcpuaffinity" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pcntl_getpriority" from="PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_get_last_error" from="PHP 5 &gt;= 5.3.4, PHP 7, PHP 8"/>

--- a/reference/pcntl/versions.xml
+++ b/reference/pcntl/versions.xml
@@ -27,6 +27,7 @@
  <function name="pcntl_waitpid" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_waitid" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pcntl_wexitstatus" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pcntl_wifcontinued" from="PHP 7, PHP 8"/>
  <function name="pcntl_wifexited" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_wifsignaled" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_wifstopped" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>


### PR DESCRIPTION
Related to #2163 

As I don't have a Solaris box, the pcntl_forkx documentation is based on the php-src code and comments, combined with [the Solaris documentation](https://docs.oracle.com/cd/E86824_01/html/E54765/forkx-2.html)

pcntl_wifcontinued is wrapped in an ifdef in php-src. Based on commit / NEWS history this was because it wasn't available on NetBSD (but based on search results appears to be in more recent versions). Is this significant enough to note? eg. A note along the lines of:

> This function may not be available on some systems. Check you systems fork(2) man page for availability.