### PR TITLE
Document Litespeed SAPI functions

### DIFF
--- a/appendices/extensions.xml
+++ b/appendices/extensions.xml
@@ -70,6 +70,7 @@
    <listitem><simpara><xref linkend="book.json"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.ldap"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.libxml"/></simpara></listitem>
+   <listitem><simpara><xref linkend="book.litespeed"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.lua"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.luasandbox"/></simpara></listitem>
    <listitem><simpara><xref linkend="book.lzf"/></simpara></listitem>
@@ -251,6 +252,7 @@
     <listitem><para><xref linkend="book.iconv"/></para></listitem>
     <listitem><para><xref linkend="book.image"/></para></listitem>
     <listitem><para><xref linkend="book.intl"/></para></listitem>
+    <listitem><para><xref linkend="book.litespeed"/></para></listitem>
     <listitem><para><xref linkend="book.mbstring"/></para></listitem>
     <listitem><para><xref linkend="book.mhash"/></para></listitem>
     <listitem><para><xref linkend="book.pcntl"/></para></listitem>

--- a/appendices/migration74/other-changes.xml
+++ b/appendices/migration74/other-changes.xml
@@ -201,7 +201,7 @@
    </listitem>
 
    <listitem>
-    <simpara>Litespeed:</simpara>
+    <simpara>LiteSpeed:</simpara>
     <itemizedlist>
      <listitem>
       <simpara>

--- a/reference/apache/book.xml
+++ b/reference/apache/book.xml
@@ -9,7 +9,9 @@
  <preface xml:id="intro.apache">
   &reftitle.intro;
   <para>
-   These functions are only available when running PHP as an Apache module.
+   These functions are available when running PHP as an Apache module. Some
+   functions may be available when running under other web Server APIs. Check
+   individual function documentation for details.
   </para>
  </preface>
  <!-- }}} -->

--- a/reference/apache/book.xml
+++ b/reference/apache/book.xml
@@ -10,7 +10,7 @@
   &reftitle.intro;
   <para>
    These functions are available when running PHP as an Apache module. Some
-   functions may be available when running under other web Server APIs. Check
+   functions may be available when running under other web server APIs. Check
    individual function documentation for details.
   </para>
  </preface>

--- a/reference/apache/book.xml
+++ b/reference/apache/book.xml
@@ -8,11 +8,11 @@
  <!-- {{{ preface -->
  <preface xml:id="intro.apache">
   &reftitle.intro;
-  <para>
+  <simpara>
    These functions are available when running PHP as an Apache module. Some
    functions may be available when running under other web server APIs. Check
    individual function documentation for details.
-  </para>
+  </simpara>
  </preface>
  <!-- }}} -->
 

--- a/reference/apache/functions/apache-request-headers.xml
+++ b/reference/apache/functions/apache-request-headers.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Fetches all HTTP request headers from the current request. Works in the
-   Apache, FastCGI, CLI, and FPM webservers.
+   Apache, Litespeed, FastCGI, CLI, and FPM webservers.
   </para>
  </refsect1>
 

--- a/reference/apache/functions/apache-request-headers.xml
+++ b/reference/apache/functions/apache-request-headers.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Fetches all HTTP request headers from the current request. Works in the
-   Apache, Litespeed, FastCGI, CLI, and FPM webservers.
+   Apache, LiteSpeed, FastCGI, CLI, and FPM webservers.
   </para>
  </refsect1>
 

--- a/reference/apache/functions/apache-request-headers.xml
+++ b/reference/apache/functions/apache-request-headers.xml
@@ -13,22 +13,22 @@
    <type>array</type><methodname>apache_request_headers</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Fetches all HTTP request headers from the current request. Works in the
    Apache, LiteSpeed, FastCGI, CLI, and FPM webservers.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   &no.function.parameters;
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    An associative array of all the HTTP headers in the current request.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -54,7 +54,7 @@
    </informaltable>
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -89,13 +89,13 @@ Connection: Keep-Alive
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     You can also get at the value of the common <acronym>CGI</acronym> variables by
     reading them from the environment, which works whether or not
     you are using PHP as an <productname>Apache</productname> module. Use
     <function>phpinfo</function> to see a list of all of the available
     <link linkend="language.variables.predefined">environment variables</link>.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/apache/functions/apache-response-headers.xml
+++ b/reference/apache/functions/apache-response-headers.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Fetch all HTTP response headers.  Works in the
-   Apache, FastCGI, CLI, and FPM webservers.
+   Apache, Litespeed, FastCGI, CLI, and FPM webservers.
   </para>
  </refsect1>
 

--- a/reference/apache/functions/apache-response-headers.xml
+++ b/reference/apache/functions/apache-response-headers.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Fetch all HTTP response headers.  Works in the
-   Apache, Litespeed, FastCGI, CLI, and FPM webservers.
+   Apache, LiteSpeed, FastCGI, CLI, and FPM webservers.
   </para>
  </refsect1>
 

--- a/reference/apache/functions/apache-response-headers.xml
+++ b/reference/apache/functions/apache-response-headers.xml
@@ -13,10 +13,10 @@
    <type>array</type><methodname>apache_response_headers</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Fetch all HTTP response headers.  Works in the
    Apache, LiteSpeed, FastCGI, CLI, and FPM webservers.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,11 +26,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    An array of all Apache response headers on success.
-  </para>
+  </simpara>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/litespeed/book.xml
+++ b/reference/litespeed/book.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<book xml:id="book.litespeed" xmlns="http://docbook.org/ns/docbook">
+ <?phpdoc extension-membership="bundled" ?>
+ <title>Litespeed</title>
+
+ <preface xml:id="intro.litespeed">
+  &reftitle.intro;
+  <para>
+   An optimized Server API for running PHP with the Litespeed web server.
+  </para>
+  <para>
+   This SAPI is bundled with PHP.
+  </para>
+ </preface>
+
+ &reference.litespeed.setup;
+ &reference.litespeed.reference;
+
+</book>
+
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/litespeed/book.xml
+++ b/reference/litespeed/book.xml
@@ -3,7 +3,7 @@
 
 <book xml:id="book.litespeed" xmlns="http://docbook.org/ns/docbook">
  <?phpdoc extension-membership="bundled" ?>
- <title>Litespeed</title>
+ <title>LiteSpeed</title>
 
  <preface xml:id="intro.litespeed">
   &reftitle.intro;

--- a/reference/litespeed/book.xml
+++ b/reference/litespeed/book.xml
@@ -8,7 +8,7 @@
  <preface xml:id="intro.litespeed">
   &reftitle.intro;
   <para>
-   An optimized Server API for running PHP with the Litespeed web server.
+   An optimized Server API for running PHP with the LiteSpeed web server.
   </para>
   <para>
    This SAPI is bundled with PHP.

--- a/reference/litespeed/book.xml
+++ b/reference/litespeed/book.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<book xml:id="book.litespeed" xmlns="http://docbook.org/ns/docbook">
+<book xml:id="book.litespeed" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="bundled" ?>
  <title>LiteSpeed</title>
 
  <preface xml:id="intro.litespeed">
   &reftitle.intro;
-  <para>
+  <simpara>
    An optimized Server API for running PHP with the LiteSpeed web server.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    This SAPI is bundled with PHP.
-  </para>
+  </simpara>
  </preface>
 
  &reference.litespeed.setup;

--- a/reference/litespeed/functions/litespeed-finish-request.xml
+++ b/reference/litespeed/functions/litespeed-finish-request.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<refentry xml:id="function.litespeed-finish-request" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>litespeed_finish_request</refname>
+  <refpurpose>Flushes all response data to the client</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>litespeed_finish_request</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   This function flushes all response data to the client and finishes the
+   request. This allows for time consuming tasks to be performed without
+   leaving the connection to the client open.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+</refentry>
+
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/litespeed/functions/litespeed-finish-request.xml
+++ b/reference/litespeed/functions/litespeed-finish-request.xml
@@ -31,6 +31,13 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>fastcgi_finish_request</function></member>
+  </simplelist>
+ </refsect1>
 </refentry>
 
  <!-- Keep this comment at the end of the file

--- a/reference/litespeed/functions/litespeed-finish-request.xml
+++ b/reference/litespeed/functions/litespeed-finish-request.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
-<refentry xml:id="function.litespeed-finish-request" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="function.litespeed-finish-request" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>litespeed_finish_request</refname>
   <refpurpose>Flushes all response data to the client</refpurpose>

--- a/reference/litespeed/functions/litespeed-finish-request.xml
+++ b/reference/litespeed/functions/litespeed-finish-request.xml
@@ -13,11 +13,11 @@
    <type>bool</type><methodname>litespeed_finish_request</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    This function flushes all response data to the client and finishes the
    request. This allows for time consuming tasks to be performed without
    leaving the connection to the client open.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,31 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>7.2.18</entry>
+      <entry>
+       This function became available.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/litespeed/functions/litespeed-request-headers.xml
+++ b/reference/litespeed/functions/litespeed-request-headers.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.litespeed-request-headers" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>litespeed_request_headers</refname>
+  <refpurpose>&Alias;
+   <function>apache_request_headers</function>
+  </refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <simpara>
+   &info.function.alias;
+   <function>apache_request_headers</function>.
+  </simpara>
+ </refsect1>
+</refentry>
+
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/litespeed/functions/litespeed-response-headers.xml
+++ b/reference/litespeed/functions/litespeed-response-headers.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.litespeed-response-headers" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>litespeed_response_headers</refname>
+  <refpurpose>&Alias;
+   <function>apache_response_headers</function>
+  </refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <simpara>
+   &info.function.alias;
+   <function>apache_response_headers</function>.
+  </simpara>
+ </refsect1>
+</refentry>
+
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/litespeed/reference.xml
+++ b/reference/litespeed/reference.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<reference xml:id="ref.litespeed" xmlns="http://docbook.org/ns/docbook">
+ <title>Litespeed &Functions;</title>
+
+ &reference.litespeed.entities.functions;
+
+</reference>
+
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/litespeed/reference.xml
+++ b/reference/litespeed/reference.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 
 <reference xml:id="ref.litespeed" xmlns="http://docbook.org/ns/docbook">
- <title>Litespeed &Functions;</title>
+ <title>LiteSpeed &Functions;</title>
 
  &reference.litespeed.entities.functions;
 

--- a/reference/litespeed/setup.xml
+++ b/reference/litespeed/setup.xml
@@ -9,7 +9,7 @@
   &reftitle.install;
   <para>
    For PHP installation on Litespeed see the <link
-   linkend="install">installation chapter</link>.
+   linkend="install.unix.litespeed">installation chapter</link>.
   </para>
  </section>
  <!-- }}} -->

--- a/reference/litespeed/setup.xml
+++ b/reference/litespeed/setup.xml
@@ -36,4 +36,3 @@
  vim: et tw=78 syn=sgml
  vi: ts=1 sw=1
  -->
-

--- a/reference/litespeed/setup.xml
+++ b/reference/litespeed/setup.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<chapter xml:id="litespeed.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ &reftitle.setup;
+
+ <!-- {{{ Installation -->
+ <section xml:id="litespeed.installation">
+  &reftitle.install;
+  <para>
+   For PHP installation on Litespeed see the <link
+   linkend="install">installation chapter</link>.
+  </para>
+ </section>
+ <!-- }}} -->
+
+</chapter>
+
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->
+

--- a/reference/litespeed/setup.xml
+++ b/reference/litespeed/setup.xml
@@ -8,7 +8,7 @@
  <section xml:id="litespeed.installation">
   &reftitle.install;
   <para>
-   For PHP installation on Litespeed see the <link
+   For PHP installation on LiteSpeed see the <link
    linkend="install.unix.litespeed">installation chapter</link>.
   </para>
  </section>

--- a/reference/litespeed/setup.xml
+++ b/reference/litespeed/setup.xml
@@ -7,10 +7,10 @@
  <!-- {{{ Installation -->
  <section xml:id="litespeed.installation">
   &reftitle.install;
-  <para>
+  <simpara>
    For PHP installation on LiteSpeed see the <link
    linkend="install.unix.litespeed">installation chapter</link>.
-  </para>
+  </simpara>
  </section>
  <!-- }}} -->
 

--- a/reference/litespeed/versions.xml
+++ b/reference/litespeed/versions.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!--
+  Do NOT translate this file
+-->
+
+<versions>
+ <function name="litespeed_request_headers" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="litespeed_response_headers" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="litespeed_finish_request" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+</versions>
+
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/litespeed/versions.xml
+++ b/reference/litespeed/versions.xml
@@ -7,7 +7,7 @@
 <versions>
  <function name="litespeed_request_headers" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="litespeed_response_headers" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
- <function name="litespeed_finish_request" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="litespeed_finish_request" from="PHP 7 &gt;= 7.2.18, PHP 8"/>
 </versions>
 
  <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Related: #2163 

This requires an additional change to doc-base/manual.xml to reference the new book.

(How does the above mentioned change work with regards to translations? Would this PR need to wait for all translations to implement the new book?)

While technically the opposite way round (according to the php-src stubs), I've documented these as aliases for the apache_* functions where appropriate - seems like the simplest way to implement this.