### PR TITLE
Document `Y` format footgun

### DIFF
--- a/reference/datetime/datetimeimmutable/createfromformat.xml
+++ b/reference/datetime/datetimeimmutable/createfromformat.xml
@@ -169,7 +169,7 @@
          </row>
          <row>
           <entry><literal>X</literal> and <literal>x</literal></entry>
-          <entry>A full numeric representation of a year, up to 19 digits,
+          <entry>A full numeric representation of a year, <emphasis>up to</emphasis> 19 digits,
            optionally prefixed by <literal>+</literal> or
            <literal>-</literal></entry>
           <entry>Examples: <literal>0055</literal>, <literal>787</literal>,
@@ -178,9 +178,9 @@
          </row>
          <row>
           <entry><literal>Y</literal></entry>
-          <entry>A full numeric representation of a year, up to 4 digits</entry>
-          <entry>Examples: <literal>0055</literal>, <literal>787</literal>,
-           <literal>1999</literal>, <literal>2003</literal></entry>
+          <entry>A full numeric representation of a year, <emphasis>up to</emphasis> 4 digits</entry>
+          <entry>Examples: <literal>25</literal> (same as <literal>0025</literal>),
+           <literal>787</literal>, <literal>1999</literal>, <literal>2003</literal></entry>
          </row>
          <row>
           <entry><literal>y</literal></entry>


### PR DESCRIPTION
Updated descriptions for `Y` format to clearly shows that 2 digit years may lead to unexpected results.

I removed `0055` as the same example is provided as `0025`.

To me this is not clear enough, I wanted to parse a `Y-m-d` or `y-m-d`:
```php
$date = '25-10-13';
$parsed = DateTime::createFromFormat('Y-m-d', $date) ?: DateTime::createFromFormat('y-m-d', $date); // 13-10-0025
$parsed = DateTime::createFromFormat('y-m-d', $date) ?: DateTime::createFromFormat('Y-m-d', $date); // 13-10-2025
```