### PR TITLE
Type juggling: fix incorrect deprecation version info for (real)

### DIFF
--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -330,7 +330,8 @@ var_dump($bar);
 
   <warning>
    <simpara>
-    The <literal>(real)</literal> cast alias has been deprecated as of PHP 8.0.0.
+    The <literal>(real)</literal> cast alias has been deprecated as of PHP 7.4.0
+    and removed as of PHP 8.0.0.
    </simpara>
   </warning>
 


### PR DESCRIPTION
Page: https://www.php.net/manual/en/language.types.type-juggling.php#language.types.typecasting

The `(real)` cast was deprecated in PHP 7.4 and removed in PHP 8.0.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_4#the_real_type
* https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.real