### PR TITLE
stream_context_set_option(): fix incorrect parameter name

### DIFF
--- a/reference/stream/functions/stream-context-set-option.xml
+++ b/reference/stream/functions/stream-context-set-option.xml
@@ -12,7 +12,7 @@
    <type>bool</type><methodname>stream_context_set_option</methodname>
    <methodparam><type>resource</type><parameter>stream_or_context</parameter></methodparam>
    <methodparam><type>string</type><parameter>wrapper</parameter></methodparam>
-   <methodparam><type>string</type><parameter>option</parameter></methodparam>
+   <methodparam><type>string</type><parameter>option_name</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -53,7 +53,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>option</parameter></term>
+     <term><parameter>option_name</parameter></term>
      <listitem>
       <para>
        The name of the option.


### PR DESCRIPTION
I vaguely remember these signatures are normally updated automatically from the stub files ? Not sure what happened here, but this one is clearly wrong.

Page: https://www.php.net/manual/en/function.stream-context-set-option.php

Signature as per the stub: https://github.com/php/php-src/blob/40a42cffd81b7f01fed25b3f7d02cb4d2ead700d/ext/standard/basic_functions.stub.php#L3384C78-L3384C103