### PR TITLE
pcntl_waitid(): add changelog section

### DIFF
--- a/reference/pcntl/functions/pcntl-waitid.xml
+++ b/reference/pcntl/functions/pcntl-waitid.xml
@@ -320,6 +320,28 @@
   </table>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>resource_usage</parameter> was added.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>


### PR DESCRIPTION
Page: https://www.php.net/manual/en/function.pcntl-waitid.php

The PHP 8.5 new `$resource_usage` parameter was added to the docs in PR #3854, but no changelog section was added, giving the reader the impression that the parameter was part of the function signature since the function was introduced, which is not true.

Refs:
* php/php-src#15921