### PR TITLE
List of other reserved words: add "parent" and "self"

### DIFF
--- a/appendices/reserved.xml
+++ b/appendices/reserved.xml
@@ -520,39 +520,47 @@
       <tbody>
        <row>
         <entry>
+         parent
+        </entry>
+        <entry>
+         self
+        </entry>
+        <entry>
          int
         </entry>
         <entry>
          float
         </entry>
+       </row>
+       <row>
         <entry>
          bool
         </entry>
         <entry>
          string
         </entry>
-       </row>
-       <row>
         <entry>
          true
         </entry>
         <entry>
          false
         </entry>
+       </row>
+       <row>
         <entry>
          null
         </entry>
         <entry>
          void (as of PHP 7.1)
         </entry>
-       </row>
-       <row>
         <entry>
          iterable (as of PHP 7.1)
         </entry>
         <entry>
          object (as of PHP 7.2)
         </entry>
+       </row>
+       <row>
         <entry>
          mixed (as of PHP 8.0)
         </entry>


### PR DESCRIPTION
Page: https://www.php.net/manual/en/reserved.other-reserved-words.php

`parent` and `self` can be used as function names and constant names, but cannot be used as OO construct names since PHP 5.0, making them part of the "other" reserved keywords.
Example: https://3v4l.org/P6c7v

Note sure why these weren't listed, but feels like they should be.