### PR TITLE
Fix misleading wording

### DIFF
--- a/reference/array/functions/array-walk.xml
+++ b/reference/array/functions/array-walk.xml
@@ -56,7 +56,7 @@
       <note>
         <para>
           Many internal functions (for example <function>strtolower</function>)
-          will throw if more than the expected number of argument
+          will throw if more than the expected number of arguments
           are passed in and are not usable directly as a
           <parameter>callback</parameter>.
         </para>


### PR DESCRIPTION
Since PHP8 this is no longer a warning but an actual exception. Throw was never really right in the first place however, as warnings are _emitted_, not _thrown_.