### PR TITLE
Document locale_canonicalize

### DIFF
--- a/reference/intl/locale/canonicalize.xml
+++ b/reference/intl/locale/canonicalize.xml
@@ -17,7 +17,7 @@
    Canonicalizes the passed locale string to ICU format.
   </simpara>
   <simpara>
-   This does not necessarily indicate or return a valid locale. Only a
+   This does not necessarily indicate or return a valid locale. It is only a
    version of the input that has been canonicalized according to ICU rules.
   </simpara>
   <simpara>


### PR DESCRIPTION
Related to #2163 
See also https://github.com/php/php-src/issues/20320

I've explicitly chosen not to link to [the related ICU documentation](https://unicode-org.github.io/icu/userguide/locale/#canonicalization) because it's misleading (specifically it details canonicalization that hasn't been performed [since ICU 64](https://icu.unicode.org/download/64#h.plg55ia6o3du)

I did look for further examples that might be useful to show, but after the ICU 64 changes this function doesn't actually appear to do a lot!