### PR TITLE
Typo: Fix angle brackets in curl constants

### DIFF
--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1600,7 +1600,7 @@
      Set a <type>string</type> with the authentication address (identity)
      of a submitted message that is being relayed to another server.
      The address should not be specified within a pair of angled brackets
-     (<literal>&gt;&lt;</literal>).
+     (<literal>&lt;&gt;</literal>).
      If an empty <type>string</type> is used then a pair of brackets are sent by cURL
      as required by RFC 2554.
      Available as of cURL 7.25.0.
@@ -1616,7 +1616,7 @@
     <para>
      Set a <type>string</type> with the sender's email address when sending SMTP mail.
      The email address should be specified with angled brackets
-     (<literal>&gt;&lt;</literal>) around it,
+     (<literal>&lt;&gt;</literal>) around it,
      which if not specified are added automatically.
      If this parameter is not specified then an empty address is sent
      to the SMTP server which might cause the email to be rejected.
@@ -1634,7 +1634,7 @@
      Set to an <type>array</type> of <type>string</type>s
      with the recipients to pass to the server in an SMTP mail request.
      Each recipient should be specified within a pair of angled brackets
-     (<literal>&gt;&lt;</literal>).
+     (<literal>&lt;&gt;</literal>).
      If an angled bracket is not used as the first character,
      cURL assumes a single email address has been provided
      and encloses that address within brackets.
@@ -3926,7 +3926,7 @@
    <listitem>
     <para>
      Set an <type>array</type> of <type>string</type>s to pass to the telnet negotiations.
-     The variables should be in the format <literal>&gt;option=value&lt;</literal>.
+     The variables should be in the format <literal>&lt;option=value&gt;</literal>.
      cURL supports the options <literal>TTYPE</literal>,
      <literal>XDISPLOC</literal> and <literal>NEW_ENV</literal>.
      Available as of cURL 7.7.0.


### PR DESCRIPTION
Fix typo in https://www.php.net/manual/en/curl.constants.php. For example,

>  The address should not be specified within a pair of angled brackets (><). 

* Incorrect: `><`
* Correct: `<>`