### PR TITLE
Fix typo

### DIFF
--- a/reference/wkhtmltox/wkhtmltox/pdf/converter/construct.xml
+++ b/reference/wkhtmltox/wkhtmltox/pdf/converter/construct.xml
@@ -97,7 +97,7 @@
          </row>
          <row>
           <entry>resolution</entry>
-          <entry>resoluition of the output document</entry>
+          <entry>resolution of the output document</entry>
           <entry>most likely has no effect</entry>
           <entry>&gt;= 0.1.0</entry>
          </row>


### PR DESCRIPTION
'resoluition' to 'resolution' in `reference/wkhtmltox/wkhtmltox/pdf/converter/construct.xml`