### PR TITLE
Document PHP 8.4.0 change to http_build_query in relation to BackedEnums

### DIFF
--- a/reference/url/functions/http-build-query.xml
+++ b/reference/url/functions/http-build-query.xml
@@ -109,6 +109,7 @@
      </row>
     </thead>
     <tbody>
+     <row>
       <entry>8.4.0</entry>
       <entry>
        Prior to PHP 8.4.0, <interfacename>BackedEnum</interfacename> properties of


### PR DESCRIPTION
Hey, ran into this earlier - my fault for having not running the same version across my stack... documenting it to hopefully save others time in future.

I think https://github.com/php/doc-en/issues/3872 will need updating once merged?

* [Related issue](https://github.com/php/php-src/issues/15650)
* [Related PR](https://github.com/php/php-src/pull/15704)

My first contribution here 😅 

---

Explain that `http_build_query` didn't convert BackedEnums to their scalar equilvalents, and instead converted them to objects.