### PR TITLE
PHP 8.5 deprecations: remove output handler return deprecation

### DIFF
--- a/appendices/migration85/deprecated.xml
+++ b/appendices/migration85/deprecated.xml
@@ -10,19 +10,11 @@
    <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4 -->
 
    <simpara>
-    Returning a non-string from a user output handler is deprecated. The
-    deprecation warning will bypass the handler with the bad return to ensure
-    it is visible; if there are nested output handlers the next one will still
-    be used.
-   </simpara>
-
-   <simpara>
     Trying to produce output (e.g. with <function>echo</function>) within
     a user output handler is deprecated.
     The deprecation warning will bypass the handler producing the output to
     ensure it is visible; if there are nested output handlers the next
-    one will still be used. If a user output handler returns a non-string and
-    produces output, the warning about producing an output is emitted first.
+    one will still be used.
    </simpara>
 
   </sect3>


### PR DESCRIPTION
Deprecation was reverted, see php/php-src#20455