### PR TITLE
Add missing PDO_SQLITE constants to documentation

### DIFF
--- a/reference/pdo_sqlite/reference.xml
+++ b/reference/pdo_sqlite/reference.xml
@@ -147,18 +147,6 @@ sqlite:
    </seealso>
   </constant>
 
-  <constant>
-   <name>PDO::SQLITE_DETERMINISTIC</name>
-   <description>
-    Indicates that a user-defined function behaves deterministically, which allows
-    SQLite to perform additional optimizations.
-   </description>
-   <since version="7.1.4"/>
-   <seealso>
-    <link xlink:href="https://www.sqlite.org/c3ref/create_function.html">sqlite3_create_function()</link>
-   </seealso>
-  </constant>
-
  </section>
 
  &reference.pdo-sqlite.entities.pdo-overloaded;


### PR DESCRIPTION
📝 Description de la Pull Request

This PR adds missing constants for the PDO_SQLITE driver that are currently available in PHP but not documented.

Fixes https://github.com/php/doc-en/issues/1394

Newly added constants:
```
PDO::SQLITE_ATTR_OPEN_FLAGS
PDO::SQLITE_OPEN_READONLY
PDO::SQLITE_OPEN_READWRITE
PDO::SQLITE_OPEN_CREATE
PDO::SQLITE_ATTR_READONLY_STATEMENT
PDO::SQLITE_ATTR_EXTENDED_RESULT_CODES
PDO::SQLITE_DETERMINISTIC
```
