### PR TITLE
Fix indentation and type

### DIFF
--- a/appendices/migration85/other-changes.xml
+++ b/appendices/migration85/other-changes.xml
@@ -103,7 +103,7 @@
    </simpara>
 
    <simpara>
-   The following functions now support a <parameter>$locale</parameter> argument:
+    The following functions now support a <parameter>$locale</parameter> argument:
     <function>grapheme_strpos</function>,
     <function>grapheme_stripos</function>,
     <function>grapheme_strrpos</function>,
@@ -273,7 +273,7 @@
     The <parameter>$use_include_path</parameter> argument for the
     <function>gzfile</function>, <function>gzopen</function> and
     <function>readgzfile</function> functions has been changed
-    from <type>int</type> to <type>boolean</type>.
+    from <type>int</type> to <type>bool</type>.
    </simpara>
 
    <simpara>


### PR DESCRIPTION
Detected during the Spanish translation.

While there is a fair amount of `... a <parameter>$locale</parameter> argument:`, there are also many arguments mixed in with the text (without tags). If you'd like, I'd like to put all the arguments and function names in labels.