### PR TITLE
Fix outdated reference to E_NOTICE in notes for unserialize

### DIFF
--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -272,7 +272,7 @@ unserialize($serialized_object);
     the serialized &false; value. It is possible to catch this special case by
     comparing <parameter>data</parameter> with
     <literal>serialize(false)</literal> or by catching the issued
-    <constant>E_NOTICE</constant>.
+    <constant>E_WARNING</constant>.
    </para>
   </warning>
  </refsect1>


### PR DESCRIPTION
Since 8.3 `unserialize` was updated to emit `E_WARNING` instead of `E_NOTICE`. The docs were mostly updated in https://github.com/php/doc-en/pull/3106 except the notes section still mentions `E_NOTICE`.