### PR TITLE
Remove <para> in invalid places

### DIFF
--- a/appendices/filters.xml
+++ b/appendices/filters.xml
@@ -118,9 +118,7 @@ fwrite($fp, "This is a test.\n");
     second parameter of the <function>strip_tags</function> function,
     or as an array of tag names.
    </simpara>
-   <para>
-    &warn.deprecated.feature-7-3-0;
-   </para>
+   &warn.deprecated.feature-7-3-0;
    <example>
     <title>string.strip_tags</title>
     <programlisting role="php">
@@ -464,9 +462,7 @@ The compressed file is 1488 bytes long.
 
   <section xml:id="filters.encryption.mcrypt">
    <title>mcrypt.* and mdecrypt.*</title>
-   <para>
-     &warn.deprecated.feature-7-1-0;
-   </para>
+   &warn.deprecated.feature-7-1-0;
 
    <simpara>
     <literal>mcrypt.*</literal> and <literal>mdecrypt.*</literal>

--- a/language/types/null.xml
+++ b/language/types/null.xml
@@ -35,9 +35,7 @@ $var = NULL;
  <sect2 xml:id="language.types.null.casting">
   <title>Casting to &null;</title>
 
-  <para>
-   &warn.deprecated.feature-7-2-0.removed-8-0-0;
-  </para>
+  &warn.deprecated.feature-7-2-0.removed-8-0-0;
 
   <para>
    Casting a variable to <type>null</type> using <literal>(unset) $var</literal>

--- a/reference/info/constants.xml
+++ b/reference/info/constants.xml
@@ -263,8 +263,8 @@
    <listitem>
     <para>
      Enable <function xmlns="http://docbook.org/ns/docbook">assert</function> evaluation.
-     &warn.deprecated.feature-8-3-0;
     </para>
+    &warn.deprecated.feature-8-3-0;
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.assert-callback">
@@ -275,8 +275,8 @@
    <listitem>
     <para>
      Callback to call on failed assertions.
-     &warn.deprecated.feature-8-3-0;
     </para>
+    &warn.deprecated.feature-8-3-0;
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.assert-bail">
@@ -287,8 +287,8 @@
    <listitem>
     <para>
      Terminate execution on failed assertions.
-     &warn.deprecated.feature-8-3-0;
     </para>
+    &warn.deprecated.feature-8-3-0;
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.assert-exception">
@@ -299,8 +299,8 @@
    <listitem>
     <para>
      Throws an <classname>AssertionError</classname> for each failed assertion
-     &warn.deprecated.feature-8-3-0;
     </para>
+    &warn.deprecated.feature-8-3-0;
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.assert-warning">
@@ -311,8 +311,8 @@
    <listitem>
     <para>
      Issues a PHP warning for each failed assertion
-     &warn.deprecated.feature-8-3-0;
     </para>
+    &warn.deprecated.feature-8-3-0;
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.assert-quiet-eval">

--- a/reference/mbstring/overloading.xml
+++ b/reference/mbstring/overloading.xml
@@ -6,9 +6,8 @@
   Function Overloading Feature
  </title>
 
- <para>
-  &warn.deprecated.feature-7-2-0.removed-8-0-0;
- </para>
+ &warn.deprecated.feature-7-2-0.removed-8-0-0;
+
  <para>
   You might often find it difficult to get an existing PHP application
   to work in a given multibyte environment. This happens because most 


### PR DESCRIPTION
`<warning>` is a block element and cannot be put inside an inline element. Doing so results in a broken HTML. 