### PR TITLE
PDO Fetch Modes: Remove extraneous print

### DIFF
--- a/reference/pdo/constants.fetch-modes.xml
+++ b/reference/pdo/constants.fetch-modes.xml
@@ -1013,7 +1013,6 @@ $stmt->bindColumn('country', $country);
 // For example: referrer.name AS referrer_name
 $stmt->bindColumn(4, $referrerName);
 
-print "\nfetch:\n";
 while ($stmt->fetch(\PDO::FETCH_BOUND)) {
     print join("\t", [$userId, $name, $country, ($referrerName ?? 'NULL')]) . "\n";
 }


### PR DESCRIPTION
Alternative to #5000 

Remove an extraneous print. This additional output serves no purpose here, so should be removed rather than correcting the output.