### PR TITLE
Fix 2 docker build problems: volume name too short, dubious ownership

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,6 @@
 FROM php:8.2-cli
+ARG UID=1000
+ARG GID=1000
 
 RUN apt-get update && \
     apt-get install -y git default-jre-headless
@@ -9,7 +11,8 @@ ADD https://api.github.com/repos/php/phd/git/refs/heads/master version-phd.json
 ADD https://api.github.com/repos/php/doc-base/git/refs/heads/master version-doc-base.json
 
 RUN git clone --depth 1 https://github.com/php/phd.git &&  \
-    git clone --depth 1 https://github.com/php/doc-base.git
+    git clone --depth 1 https://github.com/php/doc-base.git && \
+    chown -R $UID:$GID phd doc-base
 
 RUN echo 'memory_limit = 512M' >> /usr/local/etc/php/conf.d/local.ini
 

--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,7 @@ php: .docker/built
 build: .docker/built
 
 .docker/built:
-	docker build .docker -t php/doc-en
+	docker build\
+		--build-arg UID=${CURRENT_UID} --build-arg GID=${CURRENT_GID}\
+		.docker -t php/doc-en
 	touch .docker/built


### PR DESCRIPTION
When trying to build on a Debian 12 installation with docker 20.10.24 I get multiple errors:

```
$ make
docker run --rm -v .:/var/www/en -w /var/www -u 1000:1000 php/doc-en
docker: Error response from daemon: create .: volume name is too short, names should be at least two alphanumeric characters.
See 'docker run --help'.
make: *** [Makefile:22: xhtml] Fehler 125
```

and

```
$ make
docker run --rm -v :/var/www/en -w /var/www -u 1000:1000 php/doc-en
configure.php on PHP 8.2.29, libxml 2.9.14

fatal: detected dubious ownership in repository at '/var/www/doc-base'
To add an exception for this directory, call:

       git config --global --add safe.directory /var/www/doc-base
doc-base/temp clean up FAILED.
make: *** [Makefile:22: xhtml] Fehler 1
```

The two commits in this PR fix both errors.

Related: https://github.com/php/doc-en/pull/4645