### PR TITLE
Fix Generator::rewind() docs to match actual behavior

### DIFF
--- a/language/predefined/generator/rewind.xml
+++ b/language/predefined/generator/rewind.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="generator.rewind" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Generator::rewind</refname>
-  <refpurpose>Rewind the generator to the first yield</refpurpose>
+  <refpurpose>Execute the generator up to and including the first yield</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,11 +13,11 @@
    <void/>
   </methodsynopsis>
   <para>
-   The method rewinds the generator back to the point before the first &yield;.
-   If the generator is not at a first &yield; expression when this method is called,
-   it will first be let to advance to the first &yield; expression before rewinding.
-   If the generator has already at the point of beginning of the second &yield;,
-   this will throw an <classname>Exception</classname>.
+   Executes the generator up to and including the <emphasis>first</emphasis> &yield;.
+   If the generator is already at the <emphasis>first</emphasis> &yield;,
+   no action will be taken.
+   If the generator has ever advanced beyond a &yield; expression,
+   this method will throw an <classname>Exception</classname>.
   </para>
   <note>
    <para>


### PR DESCRIPTION
This PR addresses issue #5030.

Clarify the Generator::rewind() documentation to accurately reflect the function’s behavior.