### PR TITLE
Document key_length param deprecation in openssl_pkey_derive

### DIFF
--- a/reference/openssl/functions/openssl-pkey-derive.xml
+++ b/reference/openssl/functions/openssl-pkey-derive.xml
@@ -50,9 +50,9 @@
      </para>
      <caution>
       <simpara>
-       This parameter should not be used, as it does not work as expected. It never returns a secret
-       longer than the size of the prime. If the desired length is smaller than the size of the
-       prime, it truncates the length only for ECDH keys but fails for DH keys.
+       This parameter is deprecated and should not be used, as it does not work as expected. It
+       never returns a secret longer than the size of the prime. If the desired length is smaller
+       than the size of the prime, it truncates the length only for ECDH keys but fails for DH keys.
       </simpara>
      </caution>
     </listitem>
@@ -65,6 +65,28 @@
   <para>
    The derived secret on success&return.falseforfailure;.
   </para>
+ </refsect1>
+
+  <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       The parameter <parameter>key_length</parameter> is now deprecated.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
PHP 8.5 change introduced through the deprecation RFC.