### PR TITLE
PHP 8.5 | Add IMAGETYPE_HEIF constant to the migration guide and image constant pages

### DIFF
--- a/appendices/migration85/constants.xml
+++ b/appendices/migration85/constants.xml
@@ -161,6 +161,9 @@
 
   <simplelist>
    <member>
+    <constant>IMAGETYPE_HEIF</constant>
+   </member>
+   <member>
     <constant>IMAGETYPE_SVG</constant>
     when libxml is loaded.
    </member>

--- a/reference/exif/functions/exif-imagetype.xml
+++ b/reference/exif/functions/exif-imagetype.xml
@@ -135,6 +135,10 @@
         <entry>19</entry>
         <entry><constant>IMAGETYPE_AVIF</constant></entry>
        </row>
+       <row>
+        <entry>20</entry>
+        <entry><constant>IMAGETYPE_HEIF</constant></entry>
+       </row>
       </tbody>
      </tgroup>
     </table>
@@ -172,6 +176,12 @@
        <entry>8.1.0</entry>
        <entry>
         Added AVIF support.
+       </entry>
+      </row>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Added HEIF support.
        </entry>
       </row>
      </tbody>

--- a/reference/image/constants.xml
+++ b/reference/image/constants.xml
@@ -701,6 +701,18 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.imagetype-heif">
+   <term>
+    <constant>IMAGETYPE_HEIF</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    &gd.constants.type;
+    <simpara>
+     (Available as of PHP 8.5.0)
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.imagetype-unknown">
    <term>
     <constant>IMAGETYPE_UNKNOWN</constant>

--- a/reference/image/functions/image-type-to-mime-type.xml
+++ b/reference/image/functions/image-type-to-mime-type.xml
@@ -125,6 +125,10 @@
        <entry><constant>IMAGETYPE_AVIF</constant></entry>
        <entry><literal>image/avif</literal></entry>
       </row>
+      <row>
+       <entry><constant>IMAGETYPE_HEIF</constant></entry>
+       <entry><literal>image/heif</literal></entry>
+      </row>
      </tbody>
     </tgroup>
    </table>


### PR DESCRIPTION
Add the `IMAGETYPE_HEIF` constant to the PHP 8.5 migration guide and image constants pages.

~This is my first contribution to this repository. I wonder if `reference/image/constants.xml` should also be updated to document this constant?~ I added another commit updating `reference/image/constants.xml`.

Refs:
* https://github.com/php/php-src/pull/18940
* https://github.com/php/php-src/pull/20713