### PR TITLE
PHP 8.1 | Migration guide: add IMAGETYPE_AVIF constant

### DIFF
--- a/appendices/migration81/constants.xml
+++ b/appendices/migration81/constants.xml
@@ -145,22 +145,22 @@
   </itemizedlist>
  </sect2>
 
- <sect2 xml:id="migration81.constants.tokenizer">
-  <title>Tokenizer</title>
-
-  <itemizedlist>
-   <listitem>
-    <simpara><constant>T_READONLY</constant></simpara>
-   </listitem>
-  </itemizedlist>
- </sect2>
-
  <sect2 xml:id="migration81.constants.standard">
   <title>Standard</title>
 
   <itemizedlist>
    <listitem>
     <simpara><constant>IMAGETYPE_AVIF</constant></simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.constants.tokenizer">
+  <title>Tokenizer</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>T_READONLY</constant></simpara>
    </listitem>
   </itemizedlist>
  </sect2>


### PR DESCRIPTION
Add the `IMAGETYPE_AVIF` constant to the PHP 8.1 migration guide.

The Standard section was placed at the end of the file, after Tokenizer, following the pattern used in the PHP 8.5 migration guide. I'm not sure if this is correct or not.

Refs:
* https://github.com/php/php-src/pull/7091