### PR TITLE
Remove strange "if required"

### DIFF
--- a/reference/pdo/pdo/quote.xml
+++ b/reference/pdo/pdo/quote.xml
@@ -16,8 +16,8 @@
   </methodsynopsis>
 
   <para>
-   <methodname>PDO::quote</methodname> places quotes around the input string (if
-   required) and escapes special characters within the input string, using a
+   <methodname>PDO::quote</methodname> places quotes around the input string
+   and escapes special characters within the input string, using a
    quoting style appropriate to the underlying driver.
   </para>
   <para>


### PR DESCRIPTION
It's literally in the name that this function quotes the string. It was never specified what that "if requires" actually meant. I checked the current drivers which implement it and all of them quote the string. 