### PR TITLE
Add partitioned for setcookie and setrawcookie

### DIFF
--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -157,7 +157,7 @@
       <simpara>
        An associative <type>array</type> which may have any of the keys
        <literal>expires</literal>, <literal>path</literal>, <literal>domain</literal>,
-       <literal>secure</literal>, <literal>httponly</literal> and <literal>samesite</literal>.
+       <literal>secure</literal>, <literal>httponly</literal>, <literal>partitioned</literal> and <literal>samesite</literal>.
       </simpara>
       <simpara>
        The values have the same meaning as described for the
@@ -229,6 +229,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       The "partitioned" entry was added in the <parameter>options</parameter> array.
+       If set to <literal>true</literal>, the cookie will be marked as Partitioned (CHIPS).
+      </entry>
+     </row>
      <row>
       <entry>8.2.0</entry>
       <entry>

--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -183,6 +183,13 @@
         blocked by the client.
        </simpara>
       </note>
+      <note>
+       <simpara>
+        If <literal>partitioned</literal> is &true;, then
+        <literal>secure</literal> must also be enabled, otherwise a
+        <exceptionname>ValueError</exceptionname> is thrown.
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/network/functions/setrawcookie.xml
+++ b/reference/network/functions/setrawcookie.xml
@@ -49,8 +49,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
+  <informaltable>
     <tgroup cols="2">
      <thead>
       <row>
@@ -59,6 +58,13 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        The "partitioned" entry was added in the <parameter>options</parameter> array.
+        If set to <literal>true</literal>, the cookie will be marked as Partitioned (CHIPS).
+       </entry>
+      </row>
       <row>
        <entry>7.3.0</entry>
        <entry>
@@ -70,7 +76,6 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/session/functions/session-get-cookie-params.xml
+++ b/reference/session/functions/session-get-cookie-params.xml
@@ -112,6 +112,9 @@
      <link linkend="ini.session.cookie-httponly">session.cookie_httponly</link>
     </member>
     <member>
+     <link linkend="ini.session.cookie-partitioned">session.cookie_partitioned</link>
+    </member>
+    <member>
      <link linkend="ini.session.cookie-samesite">session.cookie_samesite</link>
     </member>
     <member>

--- a/reference/session/functions/session-get-cookie-params.xml
+++ b/reference/session/functions/session-get-cookie-params.xml
@@ -54,6 +54,12 @@
     </listitem>
     <listitem>
      <simpara>
+      <link linkend="ini.session.cookie-partitioned">"partitioned"</link> - The
+      cookie is marked as Partitioned (CHIPS).
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
       <link linkend="ini.session.cookie-httponly">"httponly"</link> - The
       cookie can only be accessed through the HTTP protocol.
      </simpara>
@@ -80,6 +86,12 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        The "partitioned" entry was added in the returned array.
+       </entry>
+      </row>
       <row>
        <entry>7.3.0</entry>
        <entry>

--- a/reference/session/functions/session-set-cookie-params.xml
+++ b/reference/session/functions/session-set-cookie-params.xml
@@ -168,6 +168,9 @@
      <link linkend="ini.session.cookie-httponly">session.cookie_httponly</link>
     </member>
     <member>
+     <link linkend="ini.session.cookie-httponly">session.cookie_partitioned</link>
+    </member>
+    <member>
      <link linkend="ini.session.cookie-samesite">session.cookie_samesite</link>
     </member>
     <member><function>session_get_cookie_params</function></member>

--- a/reference/session/functions/session-set-cookie-params.xml
+++ b/reference/session/functions/session-set-cookie-params.xml
@@ -168,7 +168,7 @@
      <link linkend="ini.session.cookie-httponly">session.cookie_httponly</link>
     </member>
     <member>
-     <link linkend="ini.session.cookie-httponly">session.cookie_partitioned</link>
+     <link linkend="ini.session.cookie-partitioned">session.cookie_partitioned</link>
     </member>
     <member>
      <link linkend="ini.session.cookie-samesite">session.cookie_samesite</link>

--- a/reference/session/functions/session-set-cookie-params.xml
+++ b/reference/session/functions/session-set-cookie-params.xml
@@ -44,7 +44,7 @@
        When using the first signature, <link linkend="ini.session.cookie-lifetime">lifetime</link> of the
        session cookie, defined in seconds.
       </para>
-      <para>
+      <simpara>
        When using the second signature,
        an associative <type>array</type> which may have any of the keys
        <literal>lifetime</literal>, <literal>path</literal>, <literal>domain</literal>,
@@ -57,7 +57,7 @@
        same as the default values of the explicit parameters. If the
        <literal>samesite</literal> element is omitted, no SameSite cookie
        attribute is set.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/session/functions/session-set-cookie-params.xml
+++ b/reference/session/functions/session-set-cookie-params.xml
@@ -48,7 +48,8 @@
        When using the second signature,
        an associative <type>array</type> which may have any of the keys
        <literal>lifetime</literal>, <literal>path</literal>, <literal>domain</literal>,
-       <literal>secure</literal>, <literal>httponly</literal> and <literal>samesite</literal>.
+       <literal>secure</literal>, <literal>httponly</literal>, <literal>partitioned</literal>
+       and <literal>samesite</literal>.
        The values have the same meaning as described for the parameters with the
        same name. The value of the <literal>samesite</literal> element should be
        either <literal>Lax</literal> or <literal>Strict</literal>.
@@ -121,6 +122,13 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        The "partitioned" entry was added in the <parameter>lifetime_or_options</parameter> array.
+        If set to <literal>true</literal>, the cookie will be marked as Partitioned (CHIPS).
+       </entry>
+      </row>
       <row>
        <entry>8.0.0</entry>
        <entry>

--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -95,7 +95,7 @@
      <entry>Prior to PHP 7.2.0, the default was <literal>""</literal>.</entry>
     </row>
     <row>
-     <entry><link linkend="ini.session.cookie-httponly">session.cookie_partitioned</link></entry>
+     <entry><link linkend="ini.session.cookie-partitioned">session.cookie_partitioned</link></entry>
      <entry>"0"</entry>
      <entry><constant>INI_ALL</constant></entry>
      <entry>Available as of PHP 8.5.0.</entry>

--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -703,6 +703,11 @@
      isolated to a first-party context. This setting can help mitigate
      cross-site tracking (although it is not supported by all browsers).
     </simpara>
+    <simpara>
+     If enabled, <link linkend="ini.session.cookie-secure">session.cookie_secure</link>
+     must also be enabled, otherwise the session cookie will not be sent and a
+     warning is raised.
+    </simpara>
    </listitem>
   </varlistentry>
 

--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -95,6 +95,12 @@
      <entry>Prior to PHP 7.2.0, the default was <literal>""</literal>.</entry>
     </row>
     <row>
+     <entry><link linkend="ini.session.cookie-httponly">session.cookie_partitioned</link></entry>
+     <entry>"0"</entry>
+     <entry><constant>INI_ALL</constant></entry>
+     <entry>Available as of PHP 8.5.0.</entry>
+    </row>
+    <row>
      <entry><link linkend="ini.session.cookie-samesite">session.cookie_samesite</link></entry>
      <entry>""</entry>
      <entry><constant>INI_ALL</constant></entry>
@@ -682,6 +688,20 @@
      that the cookie won't be accessible by scripting languages, such as
      JavaScript. This setting can effectively help to reduce identity theft
      through XSS attacks (although it is not supported by all browsers).
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+  <varlistentry xml:id="ini.session.cookie-partitioned">
+   <term>
+    <parameter>session.cookie_partitioned</parameter>
+    <type>bool</type>
+   </term>
+   <listitem>
+    <simpara>
+     Marks the cookie as partitioned (CHIPS), which means that the cookie will be
+     isolated to a first-party context. This setting can help mitigate
+     cross-site tracking (although it is not supported by all browsers).
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
Add documentation for the new "partitioned" cookie option introduced in PHP 8.5.0 (CHIPS support). Updates include:

- Added "partitioned" to the list of supported cookie options in setcookie() and setrawcookie() functions
- Documented the new session.cookie_partitioned INI directive with description of CHIPS functionality
- Added changelog entries for PHP 8.5.0 in affected function documentation
- Updated session cookie parameter function references to include the new partitioned option

Ref: https://github.com/php/doc-en/issues/4886