### PR TITLE
Document Locale::isRightToLeft (PHP 8.5)

### DIFF
--- a/reference/intl/locale.xml
+++ b/reference/intl/locale.xml
@@ -46,6 +46,34 @@
   </section>
   <!-- }}} -->
 
+  <section xml:id="locale.isrighttoleft">
+   <title>Locale::isRightToLeft</title>
+
+   <para>
+    As of PHP 8.5, the <methodname>Locale::isRightToLeft</methodname> method
+    can be used to determine whether a locale uses a right-to-left writing
+    system.
+   </para>
+
+   <para>
+    This method relies on the ICU library and evaluates the dominant script
+    associated with the locale.
+   </para>
+
+   <para>
+    If an empty string is provided, the default locale is used.
+   </para>
+
+   <example>
+    <title>Checking text direction for a locale</title>
+    <programlisting><![CDATA[
+var_dump(Locale::isRightToLeft('en-US')); // bool(false)
+var_dump(Locale::isRightToLeft('ar'));    // bool(true)
+]]></programlisting>
+   </example>
+  </section>
+
+
   <section xml:id="locale.synopsis">
    &reftitle.classsynopsis;
 

--- a/reference/intl/locale.xml
+++ b/reference/intl/locale.xml
@@ -46,34 +46,6 @@
   </section>
   <!-- }}} -->
 
-  <section xml:id="locale.isrighttoleft">
-   <title>Locale::isRightToLeft</title>
-
-   <para>
-    As of PHP 8.5, the <methodname>Locale::isRightToLeft</methodname> method
-    can be used to determine whether a locale uses a right-to-left writing
-    system.
-   </para>
-
-   <para>
-    This method relies on the ICU library and evaluates the dominant script
-    associated with the locale.
-   </para>
-
-   <para>
-    If an empty string is provided, the default locale is used.
-   </para>
-
-   <example>
-    <title>Checking text direction for a locale</title>
-    <programlisting><![CDATA[
-var_dump(Locale::isRightToLeft('en-US')); // bool(false)
-var_dump(Locale::isRightToLeft('ar'));    // bool(true)
-]]></programlisting>
-   </example>
-  </section>
-
-
   <section xml:id="locale.synopsis">
    &reftitle.classsynopsis;
 

--- a/reference/intl/locale/isrighttoleft.xml
+++ b/reference/intl/locale/isrighttoleft.xml
@@ -22,18 +22,18 @@
    </methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Determines whether a locale uses a right-to-left writing system.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    This method relies on the ICU library and evaluates the dominant script
    associated with the locale.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    If an empty string is provided, the default locale is used.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/intl/locale/isrighttoleft.xml
+++ b/reference/intl/locale/isrighttoleft.xml
@@ -11,11 +11,6 @@
 
  <refsect1 role="description">
   &reftitle.description;
-
-  <para>
-   &style.oop;
-  </para>
-
   <methodsynopsis role="Locale">
    <modifier>public</modifier>
    <modifier>static</modifier>

--- a/reference/intl/locale/isrighttoleft.xml
+++ b/reference/intl/locale/isrighttoleft.xml
@@ -70,7 +70,7 @@
     </thead>
     <tbody>
      <row>
-      <entry>PHP 8.5.0</entry>
+      <entry>8.5.0</entry>
       <entry>
        Added <methodname>Locale::isRightToLeft</methodname>.
       </entry>

--- a/reference/intl/locale/isrighttoleft.xml
+++ b/reference/intl/locale/isrighttoleft.xml
@@ -86,10 +86,16 @@
    <title>Checking text direction for a locale</title>
    <programlisting>
 <![CDATA[
-var_dump(Locale::isRightToLeft('en-US')); // bool(false)
-var_dump(Locale::isRightToLeft('ar'));    // bool(true)
+var_dump(Locale::isRightToLeft('en-US'));
+var_dump(Locale::isRightToLeft('ar'));
 ]]>
    </programlisting>
+   <screen>
+<![CDATA[
+bool(false)
+bool(true)
+]]>
+   </screen>
   </example>
  </refsect1>
 

--- a/reference/intl/locale/isrighttoleft.xml
+++ b/reference/intl/locale/isrighttoleft.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="locale.isrighttoleft"
+          xmlns="http://docbook.org/ns/docbook"
+          xmlns:xlink="http://www.w3.org/1999/xlink">
+
+ <refnamediv>
+  <refname>Locale::isRightToLeft</refname>
+  <refpurpose>Check whether a locale uses a right-to-left writing system</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+
+  <para>
+   &style.oop;
+  </para>
+
+  <methodsynopsis role="Locale">
+   <modifier>public</modifier>
+   <modifier>static</modifier>
+   <type>bool</type>
+   <methodname>Locale::isRightToLeft</methodname>
+   <methodparam choice="opt">
+    <type>string</type><parameter>locale</parameter>
+    <initializer>""</initializer>
+   </methodparam>
+  </methodsynopsis>
+
+  <para>
+   Determines whether a locale uses a right-to-left writing system.
+  </para>
+
+  <para>
+   This method relies on the ICU library and evaluates the dominant script
+   associated with the locale.
+  </para>
+
+  <para>
+   If an empty string is provided, the default locale is used.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>locale</parameter></term>
+     <listitem>
+      <para>
+       The locale identifier. If empty, the default locale is used.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns <constant>true</constant> if the locale uses a right-to-left
+   writing system, or <constant>false</constant> otherwise.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PHP 8.5.0</entry>
+      <entry>
+       Added <methodname>Locale::isRightToLeft</methodname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Checking text direction for a locale</title>
+   <programlisting><![CDATA[
+var_dump(Locale::isRightToLeft('en-US')); // bool(false)
+var_dump(Locale::isRightToLeft('ar'));    // bool(true)
+]]></programlisting>
+  </example>
+ </refsect1>
+
+</refentry>

--- a/reference/intl/locale/isrighttoleft.xml
+++ b/reference/intl/locale/isrighttoleft.xml
@@ -90,6 +90,7 @@ var_dump(Locale::isRightToLeft('en-US'));
 var_dump(Locale::isRightToLeft('ar'));
 ]]>
    </programlisting>
+   &example.outputs;
    <screen>
 <![CDATA[
 bool(false)

--- a/reference/intl/locale/isrighttoleft.xml
+++ b/reference/intl/locale/isrighttoleft.xml
@@ -59,10 +59,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Returns <constant>true</constant> if the locale uses a right-to-left
-   writing system, or <constant>false</constant> otherwise.
-  </para>
+  <simpara>
+   Returns &true; if the locale uses a right-to-left
+   writing system, or &false; otherwise.
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/intl/locale/isrighttoleft.xml
+++ b/reference/intl/locale/isrighttoleft.xml
@@ -91,10 +91,12 @@
   &reftitle.examples;
   <example>
    <title>Checking text direction for a locale</title>
-   <programlisting><![CDATA[
+   <programlisting>
+<![CDATA[
 var_dump(Locale::isRightToLeft('en-US')); // bool(false)
 var_dump(Locale::isRightToLeft('ar'));    // bool(true)
-]]></programlisting>
+]]>
+   </programlisting>
   </example>
  </refsect1>
 

--- a/reference/intl/locale/isrighttoleft.xml
+++ b/reference/intl/locale/isrighttoleft.xml
@@ -43,18 +43,16 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>locale</parameter></term>
-     <listitem>
-      <para>
-       The locale identifier. If empty, the default locale is used.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>locale</parameter></term>
+    <listitem>
+     <simpara>
+      The locale identifier. If empty, the default locale is used.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">


### PR DESCRIPTION
This PR adds documentation for `Locale::isRightToLeft()`, which was introduced in PHP 8.5 but was not previously documented in the manual.

The new section describes the method behavior, its reliance on ICU for determining text direction, and provides a simple usage example.  

Fixes [#5013](https://github.com/php/doc-en/issues/5013)