### PR TITLE
Document legacy and clarify bestfit parameters for Imagick::resizeImage

### DIFF
--- a/reference/imagick/imagick/adaptiveresizeimage.xml
+++ b/reference/imagick/imagick/adaptiveresizeimage.xml
@@ -106,6 +106,12 @@
        Pass zero as either parameter for proportional scaling.  
        </entry>
       </row>
+      <row>
+       <entry>PECL imagick 3.4.0</entry>
+       <entry>
+        Added the <parameter>legacy</parameter> parameter.
+       </entry>
+      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/imagick/imagick/adaptiveresizeimage.xml
+++ b/reference/imagick/imagick/adaptiveresizeimage.xml
@@ -54,18 +54,18 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term><parameter>legacy</parameter></term>
+     <listitem>
+      <para>
+       Optional <type>bool</type> parameter.
+       If set to true, the calculations are done with the small rounding bug
+       that existed in Imagick before 3.4.0. If set to false, the calculations
+       should produce the same results as the ImageMagick command-line tools.
+      </para>
+     </listitem>
+    </varlistentry>
    </variablelist>
-   <varlistentry>
-    <term><parameter>legacy</parameter></term>
-    <listitem>
-     <para>
-      Optional <type>bool</type> parameter.
-      If set to true, the calculations are done with the small rounding bug
-      that existed in Imagick before 3.4.0. If set to false, the calculations
-      should produce the same results as the ImageMagick command-line tools.
-     </para>
-    </listitem>
-   </varlistentry>
   </para>
 
  </refsect1>

--- a/reference/imagick/imagick/adaptiveresizeimage.xml
+++ b/reference/imagick/imagick/adaptiveresizeimage.xml
@@ -49,11 +49,23 @@
      <term><parameter>bestfit</parameter></term>
      <listitem>
       <para>
-       Whether to fit the image inside a bounding box.
+       Whether to fit the image within the given dimensions while preserving
+       the aspect ratio.
       </para>
      </listitem>
     </varlistentry>
    </variablelist>
+   <varlistentry>
+    <term><parameter>legacy</parameter></term>
+    <listitem>
+     <para>
+      Optional <type>bool</type> parameter.
+      If set to true, the calculations are done with the small rounding bug
+      that existed in Imagick before 3.4.0. If set to false, the calculations
+      should produce the same results as the ImageMagick command-line tools.
+     </para>
+    </listitem>
+   </varlistentry>
   </para>
 
  </refsect1>

--- a/reference/imagick/imagick/adaptiveresizeimage.xml
+++ b/reference/imagick/imagick/adaptiveresizeimage.xml
@@ -85,37 +85,35 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL imagick 2.1.0</entry>
-       <entry>Added optional fit parameter.</entry>
-      </row>
-      <row>
-       <entry>PECL imagick 2.1.0</entry>
-       <entry>
-       This method now supports proportional scaling.
-       Pass zero as either parameter for proportional scaling.  
-       </entry>
-      </row>
-      <row>
-       <entry>PECL imagick 3.4.0</entry>
-       <entry>
-        Added the <parameter>legacy</parameter> parameter.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL imagick 2.1.0</entry>
+      <entry>Added optional fit parameter.</entry>
+     </row>
+     <row>
+      <entry>PECL imagick 2.1.0</entry>
+      <entry>
+      This method now supports proportional scaling.
+      Pass zero as either parameter for proportional scaling.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL imagick 3.4.0</entry>
+      <entry>
+       Added the <parameter>legacy</parameter> parameter.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/imagick/imagick/adaptiveresizeimage.xml
+++ b/reference/imagick/imagick/adaptiveresizeimage.xml
@@ -48,21 +48,21 @@
     <varlistentry>
      <term><parameter>bestfit</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Whether to fit the image within the given dimensions while preserving
        the aspect ratio.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>legacy</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Optional <type>bool</type> parameter.
        If set to true, the calculations are done with the small rounding bug
        that existed in Imagick before 3.4.0. If set to false, the calculations
        should produce the same results as the ImageMagick command-line tools.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/imagick/imagick/adaptiveresizeimage.xml
+++ b/reference/imagick/imagick/adaptiveresizeimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.adaptiveresizeimage">
+<refentry xml:id="imagick.adaptiveresizeimage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Imagick::adaptiveResizeImage</refname>
   <refpurpose>Adaptively resize image with data dependent triangulation</refpurpose>
@@ -48,9 +48,21 @@
     <varlistentry>
      <term><parameter>bestfit</parameter></term>
      <listitem>
-      <para>
-       Whether to fit the image inside a bounding box.
-      </para>
+      <simpara>
+       Whether to fit the image within the given dimensions while preserving
+       the aspect ratio.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>legacy</parameter></term>
+     <listitem>
+      <simpara>
+       Optional <type>bool</type> parameter.
+       If set to true, the calculations are done with the small rounding bug
+       that existed in Imagick before 3.4.0. If set to false, the calculations
+       should produce the same results as the ImageMagick command-line tools.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -73,31 +85,35 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL imagick 2.1.0</entry>
-       <entry>Added optional fit parameter.</entry>
-      </row>
-      <row>
-       <entry>PECL imagick 2.1.0</entry>
-       <entry>
-       This method now supports proportional scaling.
-       Pass zero as either parameter for proportional scaling.  
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL imagick 2.1.0</entry>
+      <entry>Added optional fit parameter.</entry>
+     </row>
+     <row>
+      <entry>PECL imagick 2.1.0</entry>
+      <entry>
+      This method now supports proportional scaling.
+      Pass zero as either parameter for proportional scaling.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL imagick 3.4.0</entry>
+      <entry>
+       Added the <parameter>legacy</parameter> parameter.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/imagick/imagick/adaptiveresizeimage.xml
+++ b/reference/imagick/imagick/adaptiveresizeimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.adaptiveresizeimage">
+<refentry xml:id="imagick.adaptiveresizeimage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Imagick::adaptiveResizeImage</refname>
   <refpurpose>Adaptively resize image with data dependent triangulation</refpurpose>

--- a/reference/imagick/imagick/cropthumbnailimage.xml
+++ b/reference/imagick/imagick/cropthumbnailimage.xml
@@ -55,6 +55,29 @@
   </para>
 
  </refsect1>
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL imagick 3.4.0</entry>
+       <entry>
+        Added the <parameter>legacy</parameter> parameter.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/imagick/imagick/cropthumbnailimage.xml
+++ b/reference/imagick/imagick/cropthumbnailimage.xml
@@ -40,6 +40,17 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term><parameter>legacy</parameter></term>
+     <listitem>
+      <para>
+       Optional <type>bool</type> parameter.
+       If set to true, the calculations are done with the small rounding bug
+       that existed in Imagick before 3.4.0. If set to false, the calculations
+       should produce the same results as the ImageMagick command-line tools.
+      </para>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
 

--- a/reference/imagick/imagick/cropthumbnailimage.xml
+++ b/reference/imagick/imagick/cropthumbnailimage.xml
@@ -55,6 +55,19 @@
   </para>
 
  </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &imagick.return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   &imagick.imagick.throws;
+  </para>
+ </refsect1>
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -76,19 +89,6 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &imagick.return.success;
-  </para>
- </refsect1>
-
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   &imagick.imagick.throws;
   </para>
  </refsect1>
 

--- a/reference/imagick/imagick/cropthumbnailimage.xml
+++ b/reference/imagick/imagick/cropthumbnailimage.xml
@@ -43,12 +43,12 @@
     <varlistentry>
      <term><parameter>legacy</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Optional <type>bool</type> parameter.
        If set to true, the calculations are done with the small rounding bug
        that existed in Imagick before 3.4.0. If set to false, the calculations
        should produce the same results as the ImageMagick command-line tools.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/imagick/imagick/cropthumbnailimage.xml
+++ b/reference/imagick/imagick/cropthumbnailimage.xml
@@ -70,26 +70,24 @@
  </refsect1>
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL imagick 3.4.0</entry>
-       <entry>
-        Added the <parameter>legacy</parameter> parameter.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL imagick 3.4.0</entry>
+      <entry>
+       Added the <parameter>legacy</parameter> parameter.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 </refentry>

--- a/reference/imagick/imagick/cropthumbnailimage.xml
+++ b/reference/imagick/imagick/cropthumbnailimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.cropthumbnailimage">
+<refentry xml:id="imagick.cropthumbnailimage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Imagick::cropThumbnailImage</refname>
   <refpurpose>Creates a crop thumbnail</refpurpose>
@@ -40,6 +40,17 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term><parameter>legacy</parameter></term>
+     <listitem>
+      <simpara>
+       Optional <type>bool</type> parameter.
+       If set to true, the calculations are done with the small rounding bug
+       that existed in Imagick before 3.4.0. If set to false, the calculations
+       should produce the same results as the ImageMagick command-line tools.
+      </simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
 
@@ -56,6 +67,27 @@
   <para>
    &imagick.imagick.throws;
   </para>
+ </refsect1>
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL imagick 3.4.0</entry>
+      <entry>
+       Added the <parameter>legacy</parameter> parameter.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 </refentry>

--- a/reference/imagick/imagick/cropthumbnailimage.xml
+++ b/reference/imagick/imagick/cropthumbnailimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.cropthumbnailimage">
+<refentry xml:id="imagick.cropthumbnailimage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Imagick::cropThumbnailImage</refname>
   <refpurpose>Creates a crop thumbnail</refpurpose>

--- a/reference/imagick/imagick/resizeimage.xml
+++ b/reference/imagick/imagick/resizeimage.xml
@@ -64,7 +64,17 @@
      <term><parameter>bestfit</parameter></term>
      <listitem>
       <para>
-       Optional fit parameter.
+       If set to true, the image is resized to fit within the given dimensions
+       while preserving the aspect ratio.
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry>
+    <term><parameter>legacy</parameter></term>
+     <listitem>
+      <para>
+       If set to true, uses legacy ImageMagick resizing behavior for backward compatibility.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/imagick/imagick/resizeimage.xml
+++ b/reference/imagick/imagick/resizeimage.xml
@@ -75,7 +75,9 @@
     <term><parameter>legacy</parameter></term>
      <listitem>
       <para>
-       If set to true, uses legacy ImageMagick resizing behavior for backward compatibility.
+       Optional <type>bool</type> parameter.
+       If set to true, the calculations are done with the small rounding bug that existed in
+    Imagick before 3.4.0.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/imagick/imagick/resizeimage.xml
+++ b/reference/imagick/imagick/resizeimage.xml
@@ -77,7 +77,8 @@
       <para>
        Optional <type>bool</type> parameter.
        If set to true, the calculations are done with the small rounding bug that existed in
-    Imagick before 3.4.0.
+       Imagick before 3.4.0. If set to false, the calculations should produce the same results
+       as the ImageMagick command-line tools.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/imagick/imagick/resizeimage.xml
+++ b/reference/imagick/imagick/resizeimage.xml
@@ -64,6 +64,7 @@
      <term><parameter>bestfit</parameter></term>
      <listitem>
       <para>
+       Optional <type>bool</type> parameter.
        If set to true, the image is resized to fit within the given dimensions
        while preserving the aspect ratio.
       </para>

--- a/reference/imagick/imagick/resizeimage.xml
+++ b/reference/imagick/imagick/resizeimage.xml
@@ -112,6 +112,12 @@
        Pass zero as either parameter for proportional scaling.  
        </entry>
       </row>
+      <row>
+       <entry>PECL imagick 3.4.0</entry>
+       <entry>
+        Added the <parameter>legacy</parameter> parameter.
+       </entry>
+      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/imagick/imagick/resizeimage.xml
+++ b/reference/imagick/imagick/resizeimage.xml
@@ -95,33 +95,31 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL imagick 2.1.0</entry>
-       <entry>
-       Added optional fit parameter. This method now supports proportional scaling.
-       Pass zero as either parameter for proportional scaling.  
-       </entry>
-      </row>
-      <row>
-       <entry>PECL imagick 3.4.0</entry>
-       <entry>
-        Added the <parameter>legacy</parameter> parameter.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL imagick 2.1.0</entry>
+      <entry>
+      Added optional fit parameter. This method now supports proportional scaling.
+      Pass zero as either parameter for proportional scaling.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL imagick 3.4.0</entry>
+      <entry>
+       Added the <parameter>legacy</parameter> parameter.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 

--- a/reference/imagick/imagick/resizeimage.xml
+++ b/reference/imagick/imagick/resizeimage.xml
@@ -63,11 +63,11 @@
     <varlistentry>
      <term><parameter>bestfit</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Optional <type>bool</type> parameter.
        If set to true, the image is resized to fit within the given dimensions
        while preserving the aspect ratio.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/imagick/imagick/resizeimage.xml
+++ b/reference/imagick/imagick/resizeimage.xml
@@ -74,12 +74,12 @@
     <varlistentry>
     <term><parameter>legacy</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Optional <type>bool</type> parameter.
        If set to true, the calculations are done with the small rounding bug that existed in
        Imagick before 3.4.0. If set to false, the calculations should produce the same results
        as the ImageMagick command-line tools.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/imagick/imagick/resizeimage.xml
+++ b/reference/imagick/imagick/resizeimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.resizeimage">
+<refentry xml:id="imagick.resizeimage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Imagick::resizeImage</refname>
   <refpurpose>Scales an image</refpurpose>
@@ -63,9 +63,23 @@
     <varlistentry>
      <term><parameter>bestfit</parameter></term>
      <listitem>
-      <para>
-       Optional fit parameter.
-      </para>
+      <simpara>
+       Optional <type>bool</type> parameter.
+       If set to true, the image is resized to fit within the given dimensions
+       while preserving the aspect ratio.
+      </simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry>
+    <term><parameter>legacy</parameter></term>
+     <listitem>
+      <simpara>
+       Optional <type>bool</type> parameter.
+       If set to true, the calculations are done with the small rounding bug that existed in
+       Imagick before 3.4.0. If set to false, the calculations should produce the same results
+       as the ImageMagick command-line tools.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -81,27 +95,31 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL imagick 2.1.0</entry>
-       <entry>
-       Added optional fit parameter. This method now supports proportional scaling.
-       Pass zero as either parameter for proportional scaling.  
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL imagick 2.1.0</entry>
+      <entry>
+      Added optional fit parameter. This method now supports proportional scaling.
+      Pass zero as either parameter for proportional scaling.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL imagick 3.4.0</entry>
+      <entry>
+       Added the <parameter>legacy</parameter> parameter.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 

--- a/reference/imagick/imagick/resizeimage.xml
+++ b/reference/imagick/imagick/resizeimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.resizeimage">
+<refentry xml:id="imagick.resizeimage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Imagick::resizeImage</refname>
   <refpurpose>Scales an image</refpurpose>

--- a/reference/imagick/imagick/scaleimage.xml
+++ b/reference/imagick/imagick/scaleimage.xml
@@ -30,6 +30,7 @@
      <term><parameter>columns</parameter></term>
      <listitem>
       <para>
+       The number of columns in the scaled image.
       </para>
      </listitem>
     </varlistentry>
@@ -37,6 +38,7 @@
      <term><parameter>rows</parameter></term>
      <listitem>
       <para>
+       The number of rows in the scaled image.
       </para>
      </listitem>
     </varlistentry>
@@ -44,6 +46,19 @@
      <term><parameter>bestfit</parameter></term>
      <listitem>
       <para>
+       Whether to fit the image within the given dimensions while preserving
+       the aspect ratio.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>legacy</parameter></term>
+     <listitem>
+      <para>
+       Optional <type>bool</type> parameter.
+       If set to true, the calculations are done with the small rounding bug
+       that existed in Imagick before 3.4.0. If set to false, the calculations
+       should produce the same results as the ImageMagick command-line tools.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/imagick/imagick/scaleimage.xml
+++ b/reference/imagick/imagick/scaleimage.xml
@@ -99,6 +99,12 @@
        Pass zero as either parameter for proportional scaling.  
        </entry>
       </row>
+      <row>
+       <entry>PECL imagick 3.4.0</entry>
+       <entry>
+        Added the <parameter>legacy</parameter> parameter.
+       </entry>
+      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/imagick/imagick/scaleimage.xml
+++ b/reference/imagick/imagick/scaleimage.xml
@@ -82,33 +82,31 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL imagick 2.1.0</entry>
-       <entry>
-       Added optional fit parameter. This method now supports proportional scaling.
-       Pass zero as either parameter for proportional scaling.  
-       </entry>
-      </row>
-      <row>
-       <entry>PECL imagick 3.4.0</entry>
-       <entry>
-        Added the <parameter>legacy</parameter> parameter.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL imagick 2.1.0</entry>
+      <entry>
+      Added optional fit parameter. This method now supports proportional scaling.
+      Pass zero as either parameter for proportional scaling.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL imagick 3.4.0</entry>
+      <entry>
+       Added the <parameter>legacy</parameter> parameter.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 

--- a/reference/imagick/imagick/scaleimage.xml
+++ b/reference/imagick/imagick/scaleimage.xml
@@ -29,37 +29,37 @@
     <varlistentry>
      <term><parameter>columns</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The number of columns in the scaled image.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>rows</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The number of rows in the scaled image.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>bestfit</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Whether to fit the image within the given dimensions while preserving
        the aspect ratio.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>legacy</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Optional <type>bool</type> parameter.
        If set to true, the calculations are done with the small rounding bug
        that existed in Imagick before 3.4.0. If set to false, the calculations
        should produce the same results as the ImageMagick command-line tools.
-      </para>
+</simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/imagick/imagick/scaleimage.xml
+++ b/reference/imagick/imagick/scaleimage.xml
@@ -59,7 +59,7 @@
        If set to true, the calculations are done with the small rounding bug
        that existed in Imagick before 3.4.0. If set to false, the calculations
        should produce the same results as the ImageMagick command-line tools.
-</simpara>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/imagick/imagick/scaleimage.xml
+++ b/reference/imagick/imagick/scaleimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.scaleimage">
+<refentry xml:id="imagick.scaleimage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Imagick::scaleImage</refname>
   <refpurpose>Scales the size of an image</refpurpose>

--- a/reference/imagick/imagick/scaleimage.xml
+++ b/reference/imagick/imagick/scaleimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.scaleimage">
+<refentry xml:id="imagick.scaleimage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Imagick::scaleImage</refname>
   <refpurpose>Scales the size of an image</refpurpose>
@@ -29,22 +29,37 @@
     <varlistentry>
      <term><parameter>columns</parameter></term>
      <listitem>
-      <para>
-      </para>
+      <simpara>
+       The number of columns in the scaled image.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>rows</parameter></term>
      <listitem>
-      <para>
-      </para>
+      <simpara>
+       The number of rows in the scaled image.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>bestfit</parameter></term>
      <listitem>
-      <para>
-      </para>
+      <simpara>
+       Whether to fit the image within the given dimensions while preserving
+       the aspect ratio.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>legacy</parameter></term>
+     <listitem>
+      <simpara>
+       Optional <type>bool</type> parameter.
+       If set to true, the calculations are done with the small rounding bug
+       that existed in Imagick before 3.4.0. If set to false, the calculations
+       should produce the same results as the ImageMagick command-line tools.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -67,27 +82,31 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL imagick 2.1.0</entry>
-       <entry>
-       Added optional fit parameter. This method now supports proportional scaling.
-       Pass zero as either parameter for proportional scaling.  
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL imagick 2.1.0</entry>
+      <entry>
+      Added optional fit parameter. This method now supports proportional scaling.
+      Pass zero as either parameter for proportional scaling.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL imagick 3.4.0</entry>
+      <entry>
+       Added the <parameter>legacy</parameter> parameter.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 


### PR DESCRIPTION
This PR clarifies two optional parameters of `Imagick::resizeImage()` 

Fixes https://github.com/php/doc-en/issues/4816