### PR TITLE
Fix outdated documentation for ReflectionClass::setStaticPropertyValue visibility handling

### DIFF
--- a/reference/reflection/reflectionclass/setstaticpropertyvalue.xml
+++ b/reference/reflection/reflectionclass/setstaticpropertyvalue.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="reflectionclass.setstaticpropertyvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionClass::setStaticPropertyValue</refname>
-  <refpurpose>Sets public static property value</refpurpose>
+  <refpurpose>Sets static property value</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,12 +14,12 @@
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Sets the value of a public static property.
-   If the property is private or protected, the method will fail.
+   Sets the value of a static property on this class, regardless of the
+   property's visibility.
   </simpara>
   <simpara>
-   <methodname>ReflectionProperty::setValue</methodname> allows setting
-   the value of public, private, and protected properties.
+   <methodname>ReflectionProperty::setValue</methodname> can also be
+   used to set the value of static properties.
   </simpara>
  </refsect1>
 
@@ -66,11 +66,11 @@
     </thead>
     <tbody>
      <row>
-      <entry>7.4.0</entry>
+      <entry>7.4.9, 8.0.0</entry>
       <entry>
-       Using <methodname>ReflectionClass::setStaticPropertyValue</methodname> to set
-       a private or protected property now results in a fatal error. Previously, it
-       threw a <classname>ReflectionException</classname>.
+       <methodname>ReflectionClass::setStaticPropertyValue</methodname> can now
+       set private and protected static properties. Previously, a
+       <exceptionname>ReflectionException</exceptionname> was thrown.
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
Fixes https://github.com/php/doc-en/issues/4600
The documentation for `ReflectionClass::setStaticPropertyValue()` is outdated.