### PR TITLE
Add PHP_BUILD_DATE and PHP_BUILD_PROVIDER constants

### DIFF
--- a/appendices/reserved.constants.core.xml
+++ b/appendices/reserved.constants.core.xml
@@ -87,7 +87,7 @@
    </term>
    <listitem>
     <simpara>
-     The date and time when PHP was built, in "M d Y H:i:s" format. Available as of PHP 8.5.0.
+     The date and time when PHP was built, in <literal>"M d Y H:i:s"</literal> format. Available as of PHP 8.5.0.
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
Document two new predefined constants introduced in PHP 8.5.0:
- PHP_BUILD_DATE: Returns the date and time when PHP was built
- PHP_BUILD_PROVIDER: Returns the provider who built PHP

Ref: https://github.com/php/doc-en/issues/4886