### PR TITLE
Add reserved words restrictions for class-alias in PHP 8.5

### DIFF
--- a/appendices/reserved.xml
+++ b/appendices/reserved.xml
@@ -567,6 +567,12 @@
         <entry>
          never (as of PHP 8.1)
         </entry>
+        <entry>
+         array (as of PHP 8.5)
+        </entry>
+        <entry>
+         callable (as of PHP 8.5)
+        </entry>
        </row>
       </tbody>
      </tgroup>

--- a/reference/classobj/functions/class-alias.xml
+++ b/reference/classobj/functions/class-alias.xml
@@ -18,6 +18,9 @@
    based on the user defined class <parameter>class</parameter>.
    The aliased class is exactly the same as the original class.
   </para>
+  <para>
+   The class alias cannot be any of the PHP <link linkend="reserved.other-reserved-words">reserved words</link>.
+  </para>
    <note>
    <simpara>
     As of PHP 8.3.0, <function>class_alias</function> also supports

--- a/reference/classobj/functions/class-alias.xml
+++ b/reference/classobj/functions/class-alias.xml
@@ -18,9 +18,9 @@
    based on the user defined class <parameter>class</parameter>.
    The aliased class is exactly the same as the original class.
   </para>
-  <para>
+  <simpara>
    The class alias cannot be any of the PHP <link linkend="reserved.other-reserved-words">reserved words</link>.
-  </para>
+  </simpara>
    <note>
    <simpara>
     As of PHP 8.3.0, <function>class_alias</function> also supports


### PR DESCRIPTION
Documentation updated for new reserved class names

 - Update reserved words documentation to include array and callable as reserved words as of PHP 8.5. 
 - Clarify in class_alias() function that aliases cannot use reserved words, with link to reserved words reference.

Ref: https://github.com/php/doc-en/issues/4886