### PR TITLE
Refactor NULL and TRUE/FALSE to use their lowercase variant

### DIFF
--- a/appendices/comparisons.xml
+++ b/appendices/comparisons.xml
@@ -70,7 +70,7 @@
      </row>
      <row>
       <entry><literal>$x = null;</literal></entry>
-      <entry><type>NULL</type></entry>
+      <entry><type>null</type></entry>
       <entry>&true;</entry>
       <entry>&true;</entry>
       <entry>&false;</entry>
@@ -78,7 +78,7 @@
      </row>
      <row>
       <entry><literal>var $x;</literal></entry>
-      <entry><type>NULL</type></entry>
+      <entry><type>null</type></entry>
       <entry>&true;</entry>
       <entry>&true;</entry>
       <entry>&false;</entry>
@@ -86,7 +86,7 @@
      </row>
      <row>
       <entry><varname>$x</varname> is undefined</entry>
-      <entry><type>NULL</type></entry>
+      <entry><type>null</type></entry>
       <entry>&true;</entry>
       <entry>&true;</entry>
       <entry>&false;</entry>

--- a/appendices/filters.xml
+++ b/appendices/filters.xml
@@ -593,8 +593,8 @@ class AES_CBC
    }
    public static function decryptFile($password, $aes_filename, $out_stream) {
       $iv_size = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC);
-      $hmac_raw = file_get_contents($aes_filename, false, NULL,  0, 32);
-      $hmac_salt = file_get_contents($aes_filename, false, NULL, 32, $iv_size);
+      $hmac_raw = file_get_contents($aes_filename, false, null,  0, 32);
+      $hmac_salt = file_get_contents($aes_filename, false, null, 32, $iv_size);
       $hmac_calc = self::calculate_hmac_after_32bytes($password, $hmac_salt, $aes_filename);
       $fc = fopen($aes_filename, "rb");
       $fout = fopen($out_stream, 'wb');

--- a/appendices/migration56/openssl.xml
+++ b/appendices/migration56/openssl.xml
@@ -81,10 +81,10 @@
 <![CDATA[
 <?php
 $ctx = stream_context_create(['ssl' => [
-    'capture_session_meta' => TRUE
+    'capture_session_meta' => true
 ]]);
  
-$html = file_get_contents('https://google.com/', FALSE, $ctx);
+$html = file_get_contents('https://google.com/', false, $ctx);
 $meta = stream_context_get_options($ctx)['ssl']['session_meta'];
 var_dump($meta);
 ?>

--- a/appendices/migration72/incompatible.xml
+++ b/appendices/migration72/incompatible.xml
@@ -132,7 +132,7 @@ int(1)
 <?php
 
 var_dump(
-    count(null), // NULL is not countable
+    count(null), // null is not countable
     count(1), // integers are not countable
     count('abc'), // strings are not countable
     count(new stdClass), // objects not implementing the Countable interface are not countable

--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1887,7 +1887,7 @@ if ($path["extension"] == "el") {
     readfile($_SERVER["SCRIPT_FILENAME"]);
 }
 else {
-    return FALSE;
+    return false;
 }
 ?>]]>
    </programlisting>

--- a/language/control-structures/include.xml
+++ b/language/control-structures/include.xml
@@ -181,7 +181,7 @@ include 'http://www.example.com/file.php?foo=1&bar=2';
  </para>
  <simpara>
   Handling Returns: <literal>include</literal> returns
-  <literal>FALSE</literal> on failure and raises a warning. Successful
+  <literal>false</literal> on failure and raises a warning. Successful
   includes, unless overridden by the included file, return
   <literal>1</literal>. It is possible to execute a <function>return</function>
   statement inside an included file in order to terminate processing in
@@ -203,13 +203,13 @@ include 'http://www.example.com/file.php?foo=1&bar=2';
    <programlisting role="php">
 <![CDATA[
 <?php
-// won't work, evaluated as include(('vars.php') == TRUE), i.e. include('1')
-if (include('vars.php') == TRUE) {
+// won't work, evaluated as include(('vars.php') == true), i.e. include('1')
+if (include('vars.php') == true) {
     echo 'OK';
 }
 
 // works
-if ((include 'vars.php') == TRUE) {
+if ((include 'vars.php') == true) {
     echo 'OK';
 }
 ?>

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -332,7 +332,7 @@ Making a cup of espresso.
       <programlisting role="php">
 <![CDATA[
 <?php
-function makecoffee($types = array("cappuccino"), $coffeeMaker = NULL)
+function makecoffee($types = array("cappuccino"), $coffeeMaker = null)
 {
     $device = is_null($coffeeMaker) ? "hands" : $coffeeMaker;
     return "Making a cup of ".join(", ", $types)." with $device.\n";
@@ -1273,7 +1273,7 @@ class Cart
     public function getQuantity($product)
     {
         return isset($this->products[$product]) ? $this->products[$product] :
-               FALSE;
+               false;
     }
     
     public function getTotal($tax)

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -1531,7 +1531,7 @@ $a = \Bar\FOO; // fatal error, undefined namespace constant Bar\FOO
       <![CDATA[
 <?php
 namespace bar;
-const NULL = 0; // fatal error;
+const null = 0; // fatal error;
 const true = 'stupid'; // also fatal error;
 // etc.
 ?>

--- a/language/oop5/object-comparison.xml
+++ b/language/oop5/object-comparison.xml
@@ -23,9 +23,9 @@
 function bool2str($bool)
 {
     if ($bool === false) {
-        return 'FALSE';
+        return 'false';
     } else {
-        return 'TRUE';
+        return 'true';
     }
 }
 
@@ -75,22 +75,22 @@ compareObjects($o, $r);
      <screen>
 <![CDATA[
 Two instances of the same class
-o1 == o2 : TRUE
-o1 != o2 : FALSE
-o1 === o2 : FALSE
-o1 !== o2 : TRUE
+o1 == o2 : true
+o1 != o2 : false
+o1 === o2 : false
+o1 !== o2 : true
 
 Two references to the same instance
-o1 == o2 : TRUE
-o1 != o2 : FALSE
-o1 === o2 : TRUE
-o1 !== o2 : FALSE
+o1 == o2 : true
+o1 != o2 : false
+o1 === o2 : true
+o1 !== o2 : false
 
 Instances of two different classes
-o1 == o2 : FALSE
-o1 != o2 : TRUE
-o1 === o2 : FALSE
-o1 !== o2 : TRUE
+o1 == o2 : false
+o1 != o2 : true
+o1 === o2 : false
+o1 !== o2 : true
 ]]>
      </screen>
     </example>

--- a/language/operators/comparison.xml
+++ b/language/operators/comparison.xml
@@ -266,11 +266,11 @@ echo $a <=> $b, ' '; // 1
 <![CDATA[
 <?php
 // Bool and null are compared as bool always
-var_dump(1 == TRUE);  // TRUE - same as (bool) 1 == TRUE
-var_dump(0 == FALSE); // TRUE - same as (bool) 0 == FALSE
-var_dump(100 < TRUE); // FALSE - same as (bool) 100 < TRUE
-var_dump(-10 < FALSE);// FALSE - same as (bool) -10 < FALSE
-var_dump(min(-100, -10, NULL, 10, 100)); // NULL - (bool) NULL < (bool) -100 is FALSE < TRUE
+var_dump(1 == true);  // true - same as (bool) 1 == true
+var_dump(0 == false); // true - same as (bool) 0 == false
+var_dump(100 < true); // false - same as (bool) 100 < true
+var_dump(-10 < false);// false - same as (bool) -10 < false
+var_dump(min(-100, -10, null, 10, 100)); // null - (bool) null < (bool) -100 is false < true
 ?>
 ]]>
    </programlisting>

--- a/language/operators/type.xml
+++ b/language/operators/type.xml
@@ -173,12 +173,12 @@ bool(false)
 <![CDATA[
 <?php
 $a = 1;
-$b = NULL;
+$b = null;
 $c = fopen('/tmp/', 'r');
 var_dump($a instanceof stdClass); // $a is an integer
-var_dump($b instanceof stdClass); // $b is NULL
+var_dump($b instanceof stdClass); // $b is null
 var_dump($c instanceof stdClass); // $c is a resource
-var_dump(FALSE instanceof stdClass);
+var_dump(false instanceof stdClass);
 ?>
 ]]>
    </programlisting>
@@ -201,7 +201,7 @@ PHP Fatal error:  instanceof expects an object instance, constant given
    <programlisting role="php">
 <![CDATA[
 <?php
-var_dump(FALSE instanceof stdClass);
+var_dump(false instanceof stdClass);
 ?>
 ]]>
    </programlisting>

--- a/language/predefined/generator/rewind.xml
+++ b/language/predefined/generator/rewind.xml
@@ -66,7 +66,7 @@ $generator = generator();
 $generator->rewind(); // I'm a generator!
 
 // Nothing happens here; the generator is already rewound
-$generator->rewind(); // No output (NULL)
+$generator->rewind(); // No output (null)
 
 // This rewinds the generator to the first yield expression,
 // if it's not already there, and iterates over the generator

--- a/language/predefined/weakreference.xml
+++ b/language/predefined/weakreference.xml
@@ -95,7 +95,7 @@ NULL
        <entry>8.4.0</entry>
        <entry>
         The output of <methodname>WeakReference::__debugInfo</methodname> now includes
-        the referenced object, or <literal>NULL</literal> if the reference is no longer
+        the referenced object, or <type>null</type> if the reference is no longer
         valid.
        </entry>
       </row>

--- a/language/types/boolean.xml
+++ b/language/types/boolean.xml
@@ -19,7 +19,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$foo = True; // assign the value TRUE to $foo
+$foo = true; // assign the value true to $foo
 ?>
 ]]>
    </programlisting>
@@ -45,7 +45,7 @@ if ($action == "show_version") {
 }
 
 // this is not necessary...
-if ($show_separators == TRUE) {
+if ($show_separators == true) {
     echo "<hr>\n";
 }
 
@@ -106,7 +106,7 @@ if ($show_separators) {
    </listitem>
    <listitem>
     <simpara>
-     the unit type <link linkend="language.types.null">NULL</link> (including
+     the unit type <type>null</type> (including
      unset variables)
     </simpara>
    </listitem>

--- a/language/types/integer.xml
+++ b/language/types/integer.xml
@@ -261,7 +261,7 @@ echo (int) ( (0.1+0.7) * 10 ); // echoes 7!
   </sect3>
 
   <sect3 xml:id="language.types.integer.casting-from-null">
-   <title>From <type>NULL</type></title>
+   <title>From <type>null</type></title>
 
    <simpara>
     &null; is always converted to zero (<literal>0</literal>).

--- a/language/types/null.xml
+++ b/language/types/null.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <sect1 xml:id="language.types.null">
- <title>NULL</title>
+ <title>null</title>
   
  <para>
   The <type>null</type> type is PHP's unit type, i.e. it has only one value:
@@ -25,7 +25,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$var = NULL;       
+$var = null;       
 ?>
 ]]>
    </programlisting>

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -314,7 +314,7 @@ var_dump($bar);
    <member><literal>(string)</literal> - cast to <type>string</type></member>
    <member><literal>(array)</literal> - cast to <type>array</type></member>
    <member><literal>(object)</literal> - cast to <type>object</type></member>
-   <member><literal>(unset)</literal> - cast to <type>NULL</type></member>
+   <member><literal>(unset)</literal> - cast to <type>null</type></member>
   </simplelist>
 
   <note>
@@ -339,7 +339,7 @@ var_dump($bar);
    <simpara>
     The <literal>(unset)</literal> cast has been deprecated as of PHP 7.2.0.
     Note that the <literal>(unset)</literal> cast is the same as assigning the
-    value <type>NULL</type> to the variable or call.
+    value <type>null</type> to the variable or call.
     The <literal>(unset)</literal> cast is removed as of PHP 8.0.0.
    </simpara>
   </warning>
@@ -421,7 +421,7 @@ if ($fst === $str) {
     <member><link linkend="language.types.array.casting">Converting to array</link></member>
     <member><link linkend="language.types.object.casting">Converting to object</link></member>
     <member><link linkend="language.types.resource.casting">Converting to resource</link></member>
-    <member><link linkend="language.types.null.casting">Converting to NULL</link></member>
+    <member><link linkend="language.types.null.casting">Converting to null</link></member>
     <member><link linkend="types.comparisons">The type comparison tables</link></member>
    </simplelist>
   </para>

--- a/reference/apcu/functions/apcu-add.xml
+++ b/reference/apcu/functions/apcu-add.xml
@@ -18,7 +18,7 @@
   <methodsynopsis>
    <type>array</type><methodname>apcu_add</methodname>
    <methodparam><type>array</type><parameter>values</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>unused</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>unused</parameter><initializer>null</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
@@ -86,7 +86,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns TRUE if something has effectively been added into the cache, FALSE otherwise.
+   Returns <type>true</type> if something has effectively been added into the cache, <type>false</type> otherwise.
    Second syntax returns array with error keys.
   </para>
  </refsect1>

--- a/reference/apcu/functions/apcu-store.xml
+++ b/reference/apcu/functions/apcu-store.xml
@@ -18,7 +18,7 @@
   <methodsynopsis>
    <type>array</type><methodname>apcu_store</methodname>
    <methodparam><type>array</type><parameter>values</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>unused</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>unused</parameter><initializer>null</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/array/functions/array-key-first.xml
+++ b/reference/array/functions/array-key-first.xml
@@ -85,7 +85,7 @@ if (!function_exists('array_key_first')) {
         foreach($arr as $key => $unused) {
             return $key;
         }
-        return NULL;
+        return null;
     }
 }
 ?>

--- a/reference/com/constants.xml
+++ b/reference/com/constants.xml
@@ -505,7 +505,7 @@
    </term>
    <listitem>
     <simpara>
-     Either expression is NULL.
+     Either expression is <type>null</type>.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/com/functions/variant-add.xml
+++ b/reference/com/functions/variant-add.xml
@@ -44,8 +44,8 @@
       <entry>Addition</entry>
      </row>
      <row>
-      <entry>Either expression is NULL</entry>
-      <entry>NULL is returned</entry>
+      <entry>Either expression is <type>null</type></entry>
+      <entry><type>null</type> is returned</entry>
      </row>
      <row>
       <entry>Both expressions are empty</entry>

--- a/reference/com/functions/variant-cmp.xml
+++ b/reference/com/functions/variant-cmp.xml
@@ -135,7 +135,7 @@
       <row>
        <entry><constant>VARCMP_NULL</constant></entry>
        <entry>Either <parameter>left</parameter>,
-        <parameter>right</parameter> or both are &null;
+        <parameter>right</parameter> or both are <type>null</type>;
        </entry>
       </row>
      </tbody>

--- a/reference/com/functions/variant-div.xml
+++ b/reference/com/functions/variant-div.xml
@@ -72,8 +72,8 @@
        <entry>Division and a double is returned</entry>
       </row>
       <row>
-       <entry>Either expression is NULL</entry>
-       <entry>NULL is returned</entry>
+       <entry>Either expression is <type>null</type></entry>
+       <entry><type>null</type> is returned</entry>
       </row>
       <row>
        <entry><parameter>right</parameter> is empty and

--- a/reference/com/functions/variant-idiv.xml
+++ b/reference/com/functions/variant-idiv.xml
@@ -72,8 +72,8 @@
        <entry>Division</entry>
       </row>
       <row>
-       <entry>Either expression is NULL</entry>
-       <entry>NULL is returned</entry>
+       <entry>Either expression is <type>null</type></entry>
+       <entry><type>null</type> is returned</entry>
       </row>
       <row>
        <entry>Both expressions are empty</entry>

--- a/reference/com/functions/variant-mul.xml
+++ b/reference/com/functions/variant-mul.xml
@@ -72,8 +72,8 @@
        <entry>Multiplication</entry>
       </row>
       <row>
-       <entry>Either expression is NULL</entry>
-       <entry>NULL is returned</entry>
+       <entry>Either expression is <type>null</type></entry>
+       <entry><type>null</type> is returned</entry>
       </row>
       <row>
        <entry>Both expressions are empty</entry>

--- a/reference/com/functions/variant-sub.xml
+++ b/reference/com/functions/variant-sub.xml
@@ -71,8 +71,8 @@
        <entry>Subtraction</entry>
       </row>
       <row>
-       <entry>Either expression is NULL</entry>
-       <entry>NULL is returned</entry>
+       <entry>Either expression is <type>null</type></entry>
+       <entry><type>null</type> is returned</entry>
       </row>
       <row>
        <entry>Both expressions are empty</entry>

--- a/reference/cubrid/cubridmysql/cubrid-fetch-assoc.xml
+++ b/reference/cubrid/cubridmysql/cubrid-fetch-assoc.xml
@@ -17,7 +17,7 @@
   <para>
     This function returns the associative array, that corresponds to the
     fetched row, and then moves the internal data pointer ahead, or returns
-    FALSE when the end is reached.
+    <type>false</type> when the end is reached.
   </para>
  </refsect1>
 
@@ -44,7 +44,7 @@
     Associative array, when process is successful.
   </para>
    <para>
-    &false;, when there are no more rows; NULL, when process is unsuccessful.
+    &false;, when there are no more rows; <type>null</type>, when process is unsuccessful.
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-fetch-lengths.xml
+++ b/reference/cubrid/cubridmysql/cubrid-fetch-lengths.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
     This function returns a numeric array with the lengths of the values of
-    each field from the current row of the result set or it returns FALSE on
+    each field from the current row of the result set or it returns <type>false</type> on
     failure.
   </para>
   <note>

--- a/reference/cubrid/cubridmysql/cubrid-fetch-object.xml
+++ b/reference/cubrid/cubridmysql/cubrid-fetch-object.xml
@@ -69,7 +69,7 @@
     An object, when process is successful.
   </para>
    <para>
-    &false;, when there are no more rows; NULL, when process is unsuccessful.
+    &false;, when there are no more rows; <type>null</type>, when process is unsuccessful.
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-fetch-row.xml
+++ b/reference/cubrid/cubridmysql/cubrid-fetch-row.xml
@@ -44,7 +44,7 @@
     A numerical array, when process is successful.
   </para>
    <para>
-    &false;, when there are no more rows; NULL, when process is unsuccessful.
+    &false;, when there are no more rows; <type>null</type>, when process is unsuccessful.
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-field-len.xml
+++ b/reference/cubrid/cubridmysql/cubrid-field-len.xml
@@ -15,7 +15,7 @@
    <methodparam><type>int</type><parameter>field_offset</parameter></methodparam>
   </methodsynopsis>
   <para>
-    This function returns the maximum length of the specified field on success, or it returns FALSE on failure.
+    This function returns the maximum length of the specified field on success, or it returns <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-field-name.xml
+++ b/reference/cubrid/cubridmysql/cubrid-field-name.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
     This function returns the name of the specified field index on success or
-    it returns FALSE on failure.
+    it returns <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-field-seek.xml
+++ b/reference/cubrid/cubridmysql/cubrid-field-seek.xml
@@ -17,7 +17,7 @@
   <para>
     This function moves the result set cursor to the specified field offset.
     This offset is used by <function>cubrid_fetch_field</function> if it
-    doesn't include a field offset. It returns TRUE on success or FALSE on
+    doesn't include a field offset. It returns <type>true</type> on success or <type>false</type> on
     failure.
   </para>
  </refsect1>

--- a/reference/cubrid/cubridmysql/cubrid-num-fields.xml
+++ b/reference/cubrid/cubridmysql/cubrid-num-fields.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
     This function returns the number of columns in the result set, on success,
-    or it returns FALSE on failure.
+    or it returns <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/cubrid/cubridmysql/cubrid-result.xml
+++ b/reference/cubrid/cubridmysql/cubrid-result.xml
@@ -50,7 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Value of a specific field, on success (NULL if value if null).
+   Value of a specific field on success; <type>null</type>, when process is unsuccessful.
   </para>
    <para>
     &false; on failure.

--- a/reference/cubrid/functions/cubrid-col-get.xml
+++ b/reference/cubrid/functions/cubrid-col-get.xml
@@ -50,7 +50,7 @@
   </para>
     <para>
     &false; (to distinguish the error from the situation of attribute having
-    empty collection or NULL, in case of error, a warning message is shown; in
+     empty collection or <type>null</type>, in case of error, a warning message is shown; in
     such case you can check the error by using
     <function>cubrid_error_code</function>), when process is unsuccessful.
   </para>

--- a/reference/cubrid/functions/cubrid-commit.xml
+++ b/reference/cubrid/functions/cubrid-commit.xml
@@ -79,7 +79,7 @@ $req = cubrid_prepare($conn, "INSERT INTO publishers VALUES(?, ?, ?, ?, ?)");
 $id_list = array("P01", "P02", "P03", "P04");
 $name_list = array("Abatis Publishers", "Core Dump Books", "Schadenfreude Press", "Tenterhooks Press");
 $city_list = array("New York", "San Francisco", "Hamburg", "Berkeley");
-$state_list = array("NY", "CA", NULL, "CA");
+$state_list = array("NY", "CA", null, "CA");
 $country_list = array("USA", "USA", "Germany", "USA");
 
 for ($i = 0, $size = count($id_list); $i < $size; $i++) {

--- a/reference/cubrid/functions/cubrid-fetch.xml
+++ b/reference/cubrid/functions/cubrid-fetch.xml
@@ -40,7 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>Result array or object, when process is successful.</para>
-  <para>&false;, when there are no more rows; NULL, when process is unsuccessful.</para>
+  <para>&false;, when there are no more rows; <type>null</type>, when process is unsuccessful.</para>
   <para>The result can be received either as an array or as an object, and you can decide which data type to use by setting the <parameter>type</parameter> argument. The <parameter>type</parameter> variable can be set to one of the following values:</para>
     <simplelist>
         <member>CUBRID_NUM : Numerical array (0-based)</member>

--- a/reference/cubrid/functions/cubrid-get.xml
+++ b/reference/cubrid/functions/cubrid-get.xml
@@ -56,8 +56,8 @@
    attributes are received in array form.
   </para>
   <para>
-   &false; when process is unsuccessful or result is NULL (If error occurs to
-   distinguish empty string from NULL, then it prints the warning message.
+   &false; when process is unsuccessful or result is <type>null</type> (If error occurs to
+   distinguish empty string from <type>null</type>, then it prints the warning message.
    You can check the error by using <function>cubrid_error_code</function>)
   </para>
  </refsect1>

--- a/reference/cubrid/functions/cubrid-insert-id.xml
+++ b/reference/cubrid/functions/cubrid-insert-id.xml
@@ -17,7 +17,7 @@
    The <function>cubrid_insert_id</function> function retrieves the ID
    generated for the AUTO_INCREMENT column which is updated by the previous
    INSERT query. It returns 0 if the previous query does not generate new
-   rows, or FALSE on failure. 
+   rows, or <type>false</type> on failure. 
   </para>
 
   <note>

--- a/reference/cubrid/functions/cubrid-rollback.xml
+++ b/reference/cubrid/functions/cubrid-rollback.xml
@@ -78,7 +78,7 @@ $req = cubrid_prepare($conn, "INSERT INTO publishers VALUES(?, ?, ?, ?, ?)");
 $id_list = array("P01", "P02", "P03", "P04");
 $name_list = array("Abatis Publishers", "Core Dump Books", "Schadenfreude Press", "Tenterhooks Press");
 $city_list = array("New York", "San Francisco", "Hamburg", "Berkeley");
-$state_list = array("NY", "CA", NULL, "CA");
+$state_list = array("NY", "CA", null, "CA");
 $country_list = array("USA", "USA", "Germany", "USA");
 
 for ($i = 0, $size = count($id_list); $i < $size; $i++) {

--- a/reference/curl/constants_curl_getinfo.xml
+++ b/reference/curl/constants_curl_getinfo.xml
@@ -147,7 +147,7 @@
   <listitem>
    <simpara>
     <literal>Content-Type</literal> of the requested document.
-    NULL indicates server did not send valid <literal>Content-Type</literal> header
+    <type>null</type> indicates server did not send valid <literal>Content-Type</literal> header
    </simpara>
   </listitem>
  </varlistentry>

--- a/reference/eio/examples.xml
+++ b/reference/eio/examples.xml
@@ -167,8 +167,8 @@ function my_grp_file_read_callback($data, $result) {
 $grp = eio_grp("my_grp_done", "my_grp_data");
 
 // Create eio_open() request and add it to the group
-$req = eio_open($temp_filename, EIO_O_RDWR | EIO_O_APPEND , NULL,
-  EIO_PRI_DEFAULT, "my_grp_file_opened_callback", NULL);
+$req = eio_open($temp_filename, EIO_O_RDWR | EIO_O_APPEND , null,
+  EIO_PRI_DEFAULT, "my_grp_file_opened_callback", null);
 eio_grp_add($grp, $req);
 var_dump($grp);
 

--- a/reference/eio/functions/eio-busy.xml
+++ b/reference/eio/functions/eio-busy.xml
@@ -16,9 +16,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
   <function>eio_busy</function> artificially increases load taking

--- a/reference/eio/functions/eio-chmod.xml
+++ b/reference/eio/functions/eio-chmod.xml
@@ -16,9 +16,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
   <function>eio_chmod</function> changes file, or directory permissions. The

--- a/reference/eio/functions/eio-chown.xml
+++ b/reference/eio/functions/eio-chown.xml
@@ -18,9 +18,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
   Changes file, or directory permissions.

--- a/reference/eio/functions/eio-close.xml
+++ b/reference/eio/functions/eio-close.xml
@@ -15,9 +15,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
   <function>eio_close</function> closes file specified by

--- a/reference/eio/functions/eio-custom.xml
+++ b/reference/eio/functions/eio-custom.xml
@@ -15,7 +15,7 @@
    <methodparam><type>int</type><parameter>pri</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>eio_custom</function> executes custom function specified by

--- a/reference/eio/functions/eio-dup2.xml
+++ b/reference/eio/functions/eio-dup2.xml
@@ -16,9 +16,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
 
   </methodsynopsis>
   <para>

--- a/reference/eio/functions/eio-fallocate.xml
+++ b/reference/eio/functions/eio-fallocate.xml
@@ -19,9 +19,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
 
   </methodsynopsis>
 

--- a/reference/eio/functions/eio-fchmod.xml
+++ b/reference/eio/functions/eio-fchmod.xml
@@ -16,9 +16,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
   <function>eio_fchmod</function> changes permissions for the file specified

--- a/reference/eio/functions/eio-fchown.xml
+++ b/reference/eio/functions/eio-fchown.xml
@@ -17,9 +17,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>eio_fchown</function> changes ownership of the file specified by

--- a/reference/eio/functions/eio-fdatasync.xml
+++ b/reference/eio/functions/eio-fdatasync.xml
@@ -15,9 +15,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
   <function>eio_fdatasync</function> synchronizes a file's in-core state with storage device.

--- a/reference/eio/functions/eio-fstat.xml
+++ b/reference/eio/functions/eio-fstat.xml
@@ -103,7 +103,7 @@ function my_open_cb($data, $result) {
 }
 
 // Open temporary file
-eio_open($tmp_filename, EIO_O_RDONLY, NULL, EIO_PRI_DEFAULT,
+eio_open($tmp_filename, EIO_O_RDONLY, null, EIO_PRI_DEFAULT,
   "my_open_cb", $tmp_filename);
 eio_event_loop();
 ?>

--- a/reference/eio/functions/eio-fsync.xml
+++ b/reference/eio/functions/eio-fsync.xml
@@ -15,9 +15,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
   Synchronize a file's in-core state with storage device

--- a/reference/eio/functions/eio-ftruncate.xml
+++ b/reference/eio/functions/eio-ftruncate.xml
@@ -16,9 +16,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
   <function>eio_ftruncate</function> causes a regular file referenced by

--- a/reference/eio/functions/eio-futime.xml
+++ b/reference/eio/functions/eio-futime.xml
@@ -17,9 +17,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
 
   </methodsynopsis>
   <para>

--- a/reference/eio/functions/eio-grp-add.xml
+++ b/reference/eio/functions/eio-grp-add.xml
@@ -103,8 +103,8 @@ $grp = eio_grp("my_grp_done", $temp_filename);
 var_dump($grp);
 
 // Create eio_open() request and add it to the group
-$req = eio_open($temp_filename, EIO_O_RDWR | EIO_O_APPEND , NULL,
-  EIO_PRI_DEFAULT, "my_grp_file_opened_callback", NULL);
+$req = eio_open($temp_filename, EIO_O_RDWR | EIO_O_APPEND , null,
+  EIO_PRI_DEFAULT, "my_grp_file_opened_callback", null);
 eio_grp_add($grp, $req);
 
 // Process requests

--- a/reference/eio/functions/eio-grp.xml
+++ b/reference/eio/functions/eio-grp.xml
@@ -13,7 +13,7 @@
    <type>resource</type><methodname>eio_grp</methodname>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam
-   choice="opt"><type>string</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>string</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>eio_grp</function> creates a request group.
@@ -59,7 +59,7 @@ $temp_filename = dirname(__FILE__) ."/eio-file.tmp";
 $fp = fopen($temp_filename, "w");
 fwrite($fp, "some data");
 fclose($fp);
-$my_file_fd = NULL;
+$my_file_fd = null;
 
 /* Is called when the group requests are done */
 function my_grp_done($data, $result) {
@@ -95,8 +95,8 @@ function my_grp_file_read_callback($data, $result) {
 $grp = eio_grp("my_grp_done", $temp_filename);
 
 // Create request
-$req = eio_open($temp_filename, EIO_O_RDWR | EIO_O_APPEND , NULL,
-  EIO_PRI_DEFAULT, "my_grp_file_opened_callback", NULL);
+$req = eio_open($temp_filename, EIO_O_RDWR | EIO_O_APPEND , null,
+  EIO_PRI_DEFAULT, "my_grp_file_opened_callback", null);
 
 // Add request to the group
 eio_grp_add($grp, $req);

--- a/reference/eio/functions/eio-link.xml
+++ b/reference/eio/functions/eio-link.xml
@@ -16,9 +16,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
   <function>eio_link</function> creates a hardlink
@@ -101,7 +101,7 @@ function my_symlink_cb($data, $result) {
     global $link, $filename;
     var_dump(file_exists($data) && is_link($data));
 
-    if (!eio_readlink($data, EIO_PRI_DEFAULT, "my_readlink_cb", NULL)) {
+    if (!eio_readlink($data, EIO_PRI_DEFAULT, "my_readlink_cb", null)) {
         @unlink($link);
         @unlink($filename);
     }

--- a/reference/eio/functions/eio-lstat.xml
+++ b/reference/eio/functions/eio-lstat.xml
@@ -15,7 +15,7 @@
    <methodparam><type>int</type><parameter>pri</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>eio_lstat</function> returns file status information in
@@ -88,7 +88,7 @@ function my_open_cb($data, $result) {
 }
 
 eio_lstat($tmp_filename, EIO_PRI_DEFAULT, "my_res_cb", "eio_lstat");
-eio_open($tmp_filename, EIO_O_RDONLY, NULL,
+eio_open($tmp_filename, EIO_O_RDONLY, null,
  EIO_PRI_DEFAULT, "my_open_cb", $tmp_filename);
 eio_event_loop();
 ?>

--- a/reference/eio/functions/eio-mkdir.xml
+++ b/reference/eio/functions/eio-mkdir.xml
@@ -16,9 +16,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
   <function>eio_mkdir</function> creates directory with specified access

--- a/reference/eio/functions/eio-mknod.xml
+++ b/reference/eio/functions/eio-mknod.xml
@@ -17,9 +17,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
 
   </methodsynopsis>
   <para>

--- a/reference/eio/functions/eio-nop.xml
+++ b/reference/eio/functions/eio-nop.xml
@@ -14,9 +14,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>eio_nop</function> does nothing, except go through the whole

--- a/reference/eio/functions/eio-open.xml
+++ b/reference/eio/functions/eio-open.xml
@@ -17,7 +17,7 @@
    <methodparam><type>int</type><parameter>pri</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
   <function>eio_open</function> opens file specified by

--- a/reference/eio/functions/eio-read.xml
+++ b/reference/eio/functions/eio-read.xml
@@ -17,7 +17,7 @@
    <methodparam><type>int</type><parameter>pri</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>eio_read</function> reads up to <parameter>length</parameter>
@@ -129,7 +129,7 @@ function my_file_opened_callback($data, $result) {
 }
 
 // Open the file for reading and writing
-eio_open($temp_filename, EIO_O_RDWR, NULL,
+eio_open($temp_filename, EIO_O_RDWR, null,
     EIO_PRI_DEFAULT, "my_file_opened_callback", $temp_filename);
 eio_event_loop();
 ?>

--- a/reference/eio/functions/eio-readahead.xml
+++ b/reference/eio/functions/eio-readahead.xml
@@ -17,9 +17,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
   <function>eio_readahead</function> populates the page cache with data from a file so that subsequent reads from

--- a/reference/eio/functions/eio-readdir.xml
+++ b/reference/eio/functions/eio-readdir.xml
@@ -16,7 +16,7 @@
    <methodparam><type>int</type><parameter>pri</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam
-   choice="opt"><type>string</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>string</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Reads through a whole directory(via the <literal>opendir</literal>, <literal>readdir</literal> and

--- a/reference/eio/functions/eio-readlink.xml
+++ b/reference/eio/functions/eio-readlink.xml
@@ -15,7 +15,7 @@
    <methodparam><type>int</type><parameter>pri</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
 
@@ -88,7 +88,7 @@ function my_symlink_cb($data, $result) {
     global $link, $filename;
     var_dump(file_exists($data) && is_link($data));
 
-    if (!eio_readlink($data, EIO_PRI_DEFAULT, "my_readlink_cb", NULL)) {
+    if (!eio_readlink($data, EIO_PRI_DEFAULT, "my_readlink_cb", null)) {
         @unlink($link);
         @unlink($filename);
     }

--- a/reference/eio/functions/eio-realpath.xml
+++ b/reference/eio/functions/eio-realpath.xml
@@ -15,7 +15,7 @@
    <methodparam><type>int</type><parameter>pri</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam
-   choice="opt"><type>string</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>string</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
   <function>eio_realpath</function> returns the canonicalized absolute

--- a/reference/eio/functions/eio-rename.xml
+++ b/reference/eio/functions/eio-rename.xml
@@ -16,9 +16,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>eio_rename</function> renames or moves a file to new location.

--- a/reference/eio/functions/eio-rmdir.xml
+++ b/reference/eio/functions/eio-rmdir.xml
@@ -15,9 +15,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>eio_rmdir</function> removes a directory.

--- a/reference/eio/functions/eio-seek.xml
+++ b/reference/eio/functions/eio-seek.xml
@@ -17,9 +17,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>eio_seek</function> repositions the offset of the open file associated with 

--- a/reference/eio/functions/eio-stat.xml
+++ b/reference/eio/functions/eio-stat.xml
@@ -15,7 +15,7 @@
    <methodparam><type>int</type><parameter>pri</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>eio_stat</function> returns file status information in
@@ -90,7 +90,7 @@ function my_open_cb($data, $result) {
 }
 
 eio_stat($tmp_filename, EIO_PRI_DEFAULT, "my_res_cb", "eio_stat");
-eio_open($tmp_filename, EIO_O_RDONLY, NULL,
+eio_open($tmp_filename, EIO_O_RDONLY, null,
  EIO_PRI_DEFAULT, "my_open_cb", $tmp_filename);
 eio_event_loop();
 ?>

--- a/reference/eio/functions/eio-symlink.xml
+++ b/reference/eio/functions/eio-symlink.xml
@@ -16,9 +16,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
 
   </methodsynopsis>
   <para>
@@ -92,7 +92,7 @@ function my_symlink_cb($data, $result) {
     global $link, $filename;
     var_dump(file_exists($data) && is_link($data));
 
-    if (!eio_readlink($data, EIO_PRI_DEFAULT, "my_readlink_cb", NULL)) {
+    if (!eio_readlink($data, EIO_PRI_DEFAULT, "my_readlink_cb", null)) {
         @unlink($link);
         @unlink($filename);
     }

--- a/reference/eio/functions/eio-sync-file-range.xml
+++ b/reference/eio/functions/eio-sync-file-range.xml
@@ -18,9 +18,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>eio_sync_file_range</function> permits fine control when synchronizing the open file referred to by the file

--- a/reference/eio/functions/eio-sync.xml
+++ b/reference/eio/functions/eio-sync.xml
@@ -12,8 +12,8 @@
   <methodsynopsis>
    <type>resource</type><methodname>eio_sync</methodname>
    <methodparam choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
-   <methodparam choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
 

--- a/reference/eio/functions/eio-syncfs.xml
+++ b/reference/eio/functions/eio-syncfs.xml
@@ -15,9 +15,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
 

--- a/reference/eio/functions/eio-truncate.xml
+++ b/reference/eio/functions/eio-truncate.xml
@@ -16,9 +16,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
   <function>eio_truncate</function> causes the regular file named by <parameter>path</parameter> to be truncated to

--- a/reference/eio/functions/eio-unlink.xml
+++ b/reference/eio/functions/eio-unlink.xml
@@ -15,9 +15,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
   <function>eio_unlink</function> deletes  a  name from the file system.

--- a/reference/eio/functions/eio-utime.xml
+++ b/reference/eio/functions/eio-utime.xml
@@ -17,9 +17,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
 

--- a/reference/eio/functions/eio-write.xml
+++ b/reference/eio/functions/eio-write.xml
@@ -18,9 +18,9 @@
    <methodparam
    choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
    <methodparam
-   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>callable</type><parameter>callback</parameter><initializer>null</initializer></methodparam>
    <methodparam
-   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+   choice="opt"><type>mixed</type><parameter>data</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
   <function>eio_write</function> writes up to <parameter>length</parameter>

--- a/reference/errorfunc/examples.xml
+++ b/reference/errorfunc/examples.xml
@@ -71,12 +71,12 @@ function distance($vect1, $vect2)
 {
     if (!is_array($vect1) || !is_array($vect2)) {
         trigger_error("Incorrect parameters, arrays expected", E_USER_ERROR);
-        return NULL;
+        return null;
     }
 
     if (count($vect1) != count($vect2)) {
         trigger_error("Vectors need to be of the same size", E_USER_ERROR);
-        return NULL;
+        return null;
     }
 
     for ($i=0; $i<count($vect1); $i++) {

--- a/reference/ev/ev/embeddablebackends.xml
+++ b/reference/ev/ev/embeddablebackends.xml
@@ -51,8 +51,8 @@
 * http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod#Examples_CONTENT-9
 */
 $loop        = EvLoop::defaultLoop();
-$socket_loop = NULL;
-$embed       = NULL;
+$socket_loop = null;
+$embed       = null;
 
 if (Ev::supportedBackends() & ~Ev::recommendedBackends() & Ev::BACKEND_KQUEUE) {
  if (($socket_loop = new EvLoop(Ev::BACKEND_KQUEUE))) {

--- a/reference/ev/ev/supportedbackends.xml
+++ b/reference/ev/ev/supportedbackends.xml
@@ -52,8 +52,8 @@
 * http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod#Examples_CONTENT-9
 */
 $loop        = EvLoop::defaultLoop();
-$socket_loop = NULL;
-$embed       = NULL;
+$socket_loop = null;
+$embed       = null;
 
 if (Ev::supportedBackends() & ~Ev::recommendedBackends() & Ev::BACKEND_KQUEUE) {
  if (($socket_loop = new EvLoop(Ev::BACKEND_KQUEUE))) {

--- a/reference/ev/evembed/construct.xml
+++ b/reference/ev/evembed/construct.xml
@@ -116,8 +116,8 @@
  * http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod#Examples_CONTENT-9
  */
 $loop        = EvLoop::defaultLoop();
-$socket_loop = NULL;
-$embed       = NULL;
+$socket_loop = null;
+$embed       = null;
 
 if (Ev::supportedBackends() & ~Ev::recommendedBackends() & Ev::BACKEND_KQUEUE) {
     if (($socket_loop = new EvLoop(Ev::BACKEND_KQUEUE))) {

--- a/reference/ev/evloop/construct.xml
+++ b/reference/ev/evloop/construct.xml
@@ -18,7 +18,7 @@
    choice="opt">
     <type>mixed</type>
     <parameter>data</parameter>
-    <initializer>NULL</initializer>
+    <initializer>null</initializer>
    </methodparam>
    <methodparam
    choice="opt">

--- a/reference/ev/evloop/defaultloop.xml
+++ b/reference/ev/evloop/defaultloop.xml
@@ -22,7 +22,7 @@
    choice="opt">
     <type>mixed</type>
     <parameter>data</parameter>
-    <initializer>NULL</initializer>
+    <initializer>null</initializer>
    </methodparam>
    <methodparam
    choice="opt">

--- a/reference/ev/evperiodic/construct.xml
+++ b/reference/ev/evperiodic/construct.xml
@@ -145,7 +145,7 @@ Ev::run();
 <![CDATA[
 <?php
 // Tick every 10.5 seconds starting at now
-$w = new EvPeriodic(fmod(Ev::now(), 10.5), 10.5, NULL, function ($w, $revents) {
+$w = new EvPeriodic(fmod(Ev::now(), 10.5), 10.5, null, function ($w, $revents) {
  echo time(), PHP_EOL;
 });
 Ev::run();
@@ -158,7 +158,7 @@ Ev::run();
    <programlisting role="php">
 <![CDATA[
 <?php
-$hourly = EvPeriodic(0, 3600, NULL, function () {
+$hourly = EvPeriodic(0, 3600, null, function () {
  echo "once per hour\n";
 });
 ?>

--- a/reference/ev/evwatcher/keepalive.xml
+++ b/reference/ev/evwatcher/keepalive.xml
@@ -76,7 +76,7 @@
 <?php
 $udp_socket = ...
 $udp_watcher = new EvIo($udp_socket, Ev::READ, function () { /* ... */ });
-$udp_watcher->keepalive(FALSE);
+$udp_watcher->keepalive(false);
 ?>
 ]]>
    </programlisting>

--- a/reference/ev/examples.xml
+++ b/reference/ev/examples.xml
@@ -84,7 +84,7 @@ END
   <programlisting role="php">
 <![CDATA[
 <?php
-$w = new EvPeriodic(0., 10.5, NULL, function ($w, $revents) {
+$w = new EvPeriodic(0., 10.5, null, function ($w, $revents) {
     echo time(), PHP_EOL;
 });
 
@@ -120,7 +120,7 @@ Ev::run();
 <![CDATA[
 <?php
 // Tick every 10.5 seconds starting at now
-$w = new EvPeriodic(fmod(Ev::now(), 10.5), 10.5, NULL, function ($w, $revents) {
+$w = new EvPeriodic(fmod(Ev::now(), 10.5), 10.5, null, function ($w, $revents) {
     echo time(), PHP_EOL;
 });
 
@@ -165,7 +165,7 @@ $address = gethostbyname('google.co.uk');
 
 // Create a TCP/IP socket
 $socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
-if ($socket === FALSE) {
+if ($socket === false) {
     echo "socket_create() failed: reason: "
         .socket_strerror(socket_last_error()) . "\n";
 }
@@ -264,8 +264,8 @@ Connection: close
 * http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod#Examples_CONTENT-9
 */
 $loop_hi = EvLoop::defaultLoop();
-$loop_lo = NULL;
-$embed   = NULL;
+$loop_lo = null;
+$embed   = null;
 
 /*
 * See if there is a chance of getting one that works
@@ -299,8 +299,8 @@ if ($loop_lo) {
 * http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod#Examples_CONTENT-9
 */
 $loop        = EvLoop::defaultLoop();
-$socket_loop = NULL;
-$embed       = NULL;
+$socket_loop = null;
+$embed       = null;
 
 if (Ev::supportedBackends() & ~Ev::recommendedBackends() & Ev::BACKEND_KQUEUE) {
     if (($socket_loop = new EvLoop(Ev::BACKEND_KQUEUE))) {
@@ -394,7 +394,7 @@ $pid = pcntl_fork();
 if ($pid == -1) {
     fprintf(STDERR, "pcntl_fork failed\n");
 } elseif ($pid) {
-    $w = new EvChild($pid, FALSE, function ($w, $revents) {
+    $w = new EvChild($pid, false, function ($w, $revents) {
         $w->stop();
 
         printf("Process %d exited with status %d\n", $w->rpid, $w->rstatus);

--- a/reference/ev/periodic-modes.xml
+++ b/reference/ev/periodic-modes.xml
@@ -53,7 +53,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$hourly = EvPeriodic(0, 3600, NULL, function () {
+$hourly = EvPeriodic(0, 3600, null, function () {
   echo "once per hour\n";
 });
 ?>

--- a/reference/ev/watcher-callbacks.xml
+++ b/reference/ev/watcher-callbacks.xml
@@ -27,13 +27,13 @@
    choice="opt">
    <type>object</type>
    <parameter>watcher</parameter>
-   <initializer>NULL</initializer>
+   <initializer>null</initializer>
   </methodparam>
   <methodparam
    choice="opt">
    <type>int</type>
    <parameter>revents</parameter>
-   <initializer>NULL</initializer>
+   <initializer>null</initializer>
   </methodparam>
  </methodsynopsis>
  <para>

--- a/reference/event/event/construct.xml
+++ b/reference/event/event/construct.xml
@@ -30,7 +30,7 @@
    choice="opt">
     <type>mixed</type>
     <parameter>arg</parameter>
-    <initializer>NULL</initializer>
+    <initializer>null</initializer>
    </methodparam>
   </methodsynopsis>
   <para>

--- a/reference/event/eventbuffer/search.xml
+++ b/reference/event/eventbuffer/search.xml
@@ -102,7 +102,7 @@ function count_instances($buf, $str) {
 
     while (1) {
         $p = $buf->search($str, $p);
-        if ($p === FALSE) {
+        if ($p === false) {
             break;
         }
         ++$total;

--- a/reference/event/eventbufferevent/connect.xml
+++ b/reference/event/eventbufferevent/connect.xml
@@ -111,14 +111,14 @@ function eventcb($bev, $events, $base) {
 $base = new EventBase();
 
 echo "step 1\n";
-$bev = new EventBufferEvent($base, /* use internal socket */ NULL,
+$bev = new EventBufferEvent($base, /* use internal socket */ null,
     EventBufferEvent::OPT_CLOSE_ON_FREE | EventBufferEvent::OPT_DEFER_CALLBACKS);
 if (!$bev) {
     exit("Failed creating bufferevent socket\n");
 }
 
 echo "step 2\n";
-$bev->setCallbacks("readcb", /* writecb */ NULL, "eventcb", $base);
+$bev->setCallbacks("readcb", /* writecb */ null, "eventcb", $base);
 $bev->enable(Event::READ | Event::WRITE);
 
 echo "step 3\n";
@@ -172,8 +172,8 @@ class MyUnixSocketClient {
 
     function __construct($base, $sock_path) {
         $this->base = $base;
-        $this->bev = new EventBufferEvent($base, NULL, EventBufferEvent::OPT_CLOSE_ON_FREE,
-            array ($this, "read_cb"), NULL, array ($this, "event_cb"));
+        $this->bev = new EventBufferEvent($base, null, EventBufferEvent::OPT_CLOSE_ON_FREE,
+            array ($this, "read_cb"), null, array ($this, "event_cb"));
 
         if (!$this->bev->connect("unix:$sock_path")) {
             trigger_error("Failed to connect to socket `$sock_path'", E_USER_ERROR);
@@ -185,7 +185,7 @@ class MyUnixSocketClient {
     function __destruct() {
         if ($this->bev) {
             $this->bev->free();
-            $this->bev = NULL;
+            $this->bev = null;
         }
     }
 
@@ -201,8 +201,8 @@ class MyUnixSocketClient {
         printf("%ld:\t%s\n", (int) $in->length, $in->pullup(-1));
 
         $this->bev->free();
-        $this->bev = NULL;
-        $this->base->exit(NULL);
+        $this->bev = null;
+        $this->base->exit(null);
     }
 
     function event_cb($bev, $events, $unused) {
@@ -212,7 +212,7 @@ class MyUnixSocketClient {
 
         if ($events & (EventBufferEvent::EOF | EventBufferEvent::ERROR)) {
             $bev->free();
-            $bev = NULL;
+            $bev = null;
         } elseif ($events & EventBufferEvent::CONNECTED) {
             $bev->output->add("test\n");
         }

--- a/reference/event/eventbufferevent/connecthost.xml
+++ b/reference/event/eventbufferevent/connecthost.xml
@@ -175,20 +175,20 @@ function eventcb($bev, $events, $base) {
 
 $base = new EventBase();
 
-$dns_base = new EventDnsBase($base, TRUE); // We'll use async DNS resolving
+$dns_base = new EventDnsBase($base, true); // We'll use async DNS resolving
 if (!$dns_base) {
     exit("Failed to init DNS Base\n");
 }
 
-$bev = new EventBufferEvent($base, /* use internal socket */ NULL,
+$bev = new EventBufferEvent($base, /* use internal socket */ null,
     EventBufferEvent::OPT_CLOSE_ON_FREE | EventBufferEvent::OPT_DEFER_CALLBACKS,
-    "readcb", /* writecb */ NULL, "eventcb", $base
+    "readcb", /* writecb */ null, "eventcb", $base
 );
 if (!$bev) {
     exit("Failed creating bufferevent socket\n");
 }
 
-//$bev->setCallbacks("readcb", /* writecb */ NULL, "eventcb", $base);
+//$bev->setCallbacks("readcb", /* writecb */ null, "eventcb", $base);
 $bev->enable(Event::READ | Event::WRITE);
 
 $output = $bev->output; //$bev->getOutput();

--- a/reference/event/eventbufferevent/getoutput.xml
+++ b/reference/event/eventbufferevent/getoutput.xml
@@ -51,14 +51,14 @@
 <?php
 $base = new EventBase();
 
-$dns_base = new EventDnsBase($base, TRUE); // Use async DNS resolving
+$dns_base = new EventDnsBase($base, true); // Use async DNS resolving
 if (!$dns_base) {
     exit("Failed to init DNS Base\n");
 }
 
-$bev = new EventBufferEvent($base, /* use internal socket */ NULL,
+$bev = new EventBufferEvent($base, /* use internal socket */ null,
     EventBufferEvent::OPT_CLOSE_ON_FREE | EventBufferEvent::OPT_DEFER_CALLBACKS,
-    "readcb", /* writecb */ NULL, "eventcb", $base
+    "readcb", /* writecb */ null, "eventcb", $base
 );
 if (!$bev) {
     exit("Failed creating bufferevent socket\n");

--- a/reference/event/eventhttp/setcallback.xml
+++ b/reference/event/eventhttp/setcallback.xml
@@ -60,13 +60,13 @@
         choice="opt">
        <type>EventHttpRequest</type>
        <parameter>req</parameter>
-       <initializer>NULL</initializer>
+       <initializer>null</initializer>
       </methodparam>
       <methodparam
         choice="opt">
        <type>mixed</type>
        <parameter>arg</parameter>
-       <initializer>NULL</initializer>
+       <initializer>null</initializer>
       </methodparam>
      </methodsynopsis>
      <para>

--- a/reference/event/eventhttp/setdefaultcallback.xml
+++ b/reference/event/eventhttp/setdefaultcallback.xml
@@ -45,13 +45,13 @@
         choice="opt">
        <type>EventHttpRequest</type>
        <parameter>req</parameter>
-       <initializer>NULL</initializer>
+       <initializer>null</initializer>
       </methodparam>
       <methodparam
         choice="opt">
        <type>mixed</type>
        <parameter>arg</parameter>
-       <initializer>NULL</initializer>
+       <initializer>null</initializer>
       </methodparam>
      </methodsynopsis>
      <para>

--- a/reference/event/eventhttpconnection/makerequest.xml
+++ b/reference/event/eventhttpconnection/makerequest.xml
@@ -105,14 +105,14 @@ function _request_handler($req, $base) {
         }
     }
 
-    $base->exit(NULL);
+    $base->exit(null);
 }
 
 $address = "127.0.0.1";
 $port = 80;
 
 $base = new EventBase();
-$conn = new EventHttpConnection($base, NULL, $address, $port);
+$conn = new EventHttpConnection($base, null, $address, $port);
 $conn->setTimeout(5);
 $req = new EventHttpRequest("_request_handler", $base);
 

--- a/reference/event/eventhttpconnection/setclosecallback.xml
+++ b/reference/event/eventhttpconnection/setclosecallback.xml
@@ -112,7 +112,7 @@ function _close_callback($conn)
 function _http_default($req, $dummy)
 {
     $conn = $req->getConnection();
-    $conn->setCloseCallback('_close_callback', NULL);
+    $conn->setCloseCallback('_close_callback', null);
 
     /*
     By enabling Event::READ we protect the server against unclosed conections.
@@ -162,7 +162,7 @@ if ($port <= 0 || $port > 65535) {
 $base = new EventBase();
 $http = new EventHttp($base);
 
-$http->setDefaultCallback("_http_default", NULL);
+$http->setDefaultCallback("_http_default", null);
 $http->bind("0.0.0.0", $port);
 $base->loop();
 

--- a/reference/event/eventhttprequest/construct.xml
+++ b/reference/event/eventhttprequest/construct.xml
@@ -97,7 +97,7 @@ function _request_handler($req, $base) {
         }
     }
 
-    $base->exit(NULL);
+    $base->exit(null);
 }
 
 
@@ -105,7 +105,7 @@ $address = "127.0.0.1";
 $port = 80;
 
 $base = new EventBase();
-$conn = new EventHttpConnection($base, NULL, $address, $port);
+$conn = new EventHttpConnection($base, null, $address, $port);
 $conn->setTimeout(5);
 $req = new EventHttpRequest("_request_handler", $base);
 

--- a/reference/event/eventlistener/construct.xml
+++ b/reference/event/eventlistener/construct.xml
@@ -185,8 +185,8 @@ class MyListenerConnection {
 
         $this->bev = new EventBufferEvent($base, $fd, EventBufferEvent::OPT_CLOSE_ON_FREE);
 
-        $this->bev->setCallbacks(array($this, "echoReadCallback"), NULL,
-            array($this, "echoEventCallback"), NULL);
+        $this->bev->setCallbacks(array($this, "echoReadCallback"), null,
+            array($this, "echoEventCallback"), null);
 
         if (!$this->bev->enable(Event::READ)) {
             echo "Failed to enable READ\n";
@@ -227,7 +227,7 @@ class MyListener {
     private $conn = array();
 
     public function __destruct() {
-        foreach ($this->conn as &$c) $c = NULL;
+        foreach ($this->conn as &$c) $c = null;
     }
 
     public function __construct($port) {
@@ -283,7 +283,7 @@ class MyListener {
             EventUtil::getLastSocketErrno(),
             EventUtil::getLastSocketError());
 
-        $base->exit(NULL);
+        $base->exit(null);
     }
 }
 

--- a/reference/event/examples.xml
+++ b/reference/event/examples.xml
@@ -46,20 +46,20 @@ EOS;
 
 $base = new EventBase();
 
-$dns_base = new EventDnsBase($base, TRUE); // We'll use async DNS resolving
+$dns_base = new EventDnsBase($base, true); // We'll use async DNS resolving
 if (!$dns_base) {
     exit("Failed to init DNS Base\n");
 }
 
-$bev = new EventBufferEvent($base, /* use internal socket */ NULL,
+$bev = new EventBufferEvent($base, /* use internal socket */ null,
     EventBufferEvent::OPT_CLOSE_ON_FREE | EventBufferEvent::OPT_DEFER_CALLBACKS,
-    "readcb", /* writecb */ NULL, "eventcb"
+    "readcb", /* writecb */ null, "eventcb"
 );
 if (!$bev) {
     exit("Failed creating bufferevent socket\n");
 }
 
-//$bev->setCallbacks("readcb", /* writecb */ NULL, "eventcb", $base);
+//$bev->setCallbacks("readcb", /* writecb */ null, "eventcb", $base);
 $bev->enable(Event::READ | Event::WRITE);
 
 $output = $bev->output; //$bev->getOutput();
@@ -149,14 +149,14 @@ function eventcb($bev, $events, $base) {
 $base = new EventBase();
 
 echo "step 1\n";
-$bev = new EventBufferEvent($base, /* use internal socket */ NULL,
+$bev = new EventBufferEvent($base, /* use internal socket */ null,
     EventBufferEvent::OPT_CLOSE_ON_FREE | EventBufferEvent::OPT_DEFER_CALLBACKS);
 if (!$bev) {
     exit("Failed creating bufferevent socket\n");
 }
 
 echo "step 2\n";
-$bev->setCallbacks("readcb", /* writecb */ NULL, "eventcb", $base);
+$bev->setCallbacks("readcb", /* writecb */ null, "eventcb", $base);
 $bev->enable(Event::READ | Event::WRITE);
 
 echo "step 3\n";
@@ -213,8 +213,8 @@ class MyListenerConnection {
 
         $this->bev = new EventBufferEvent($base, $fd, EventBufferEvent::OPT_CLOSE_ON_FREE);
 
-        $this->bev->setCallbacks(array($this, "echoReadCallback"), NULL,
-            array($this, "echoEventCallback"), NULL);
+        $this->bev->setCallbacks(array($this, "echoReadCallback"), null,
+            array($this, "echoEventCallback"), null);
 
         if (!$this->bev->enable(Event::READ)) {
             echo "Failed to enable READ\n";
@@ -255,7 +255,7 @@ class MyListener {
     private $conn = array();
 
     public function __destruct() {
-        foreach ($this->conn as &$c) $c = NULL;
+        foreach ($this->conn as &$c) $c = null;
     }
 
     public function __construct($port) {
@@ -311,7 +311,7 @@ class MyListener {
             EventUtil::getLastSocketErrno(),
             EventUtil::getLastSocketError());
 
-        $base->exit(NULL);
+        $base->exit(null);
     }
 }
 
@@ -413,13 +413,13 @@ class MySslEchoServer {
 
         if (!$this->bev) {
             echo "Failed creating ssl buffer\n";
-            $this->base->exit(NULL);
+            $this->base->exit(null);
             exit(1);
         }
 
         $this->bev->enable(Event::READ);
-        $this->bev->setCallbacks(array($this, "ssl_read_cb"), NULL,
-            array($this, "ssl_event_cb"), NULL);
+        $this->bev->setCallbacks(array($this, "ssl_read_cb"), null,
+            array($this, "ssl_event_cb"), null);
     }
 
     // This callback is invoked when we failed to setup new connection for a client
@@ -429,7 +429,7 @@ class MySslEchoServer {
             EventUtil::getLastSocketErrno(),
             EventUtil::getLastSocketError());
 
-        $this->base->exit(NULL);
+        $this->base->exit(null);
     }
 
     // Initialize SSL structures, create an EventSslContext
@@ -450,7 +450,7 @@ class MySslEchoServer {
                 "  openssl req -new -key $local_pk -out cert.req\n",
                 "  openssl x509 -req -days 365 -in cert.req -signkey $local_pk -out $local_cert\n";
 
-            return FALSE;
+            return false;
         }
 
         $ctx = new EventSslContext(EventSslContext::SSLv3_SERVER_METHOD, array (
@@ -911,7 +911,7 @@ function _request_handler($req, $base) {
         }
     }
 
-    $base->exit(NULL);
+    $base->exit(null);
 }
 
 function _init_ssl() {
@@ -941,7 +941,7 @@ if (!$base) {
     trigger_error("Failed to initialize event base", E_USER_ERROR);
 }
 
-$conn = new EventHttpConnection($base, NULL, $host, $port, $ctx);
+$conn = new EventHttpConnection($base, null, $host, $port, $ctx);
 $conn->setTimeout(50);
 
 $req = new EventHttpRequest("_request_handler", $base);
@@ -986,14 +986,14 @@ function _request_handler($req, $base) {
         }
     }
 
-    $base->exit(NULL);
+    $base->exit(null);
 }
 
 $address = "127.0.0.1";
 $port = 80;
 
 $base = new EventBase();
-$conn = new EventHttpConnection($base, NULL, $address, $port);
+$conn = new EventHttpConnection($base, null, $address, $port);
 $conn->setTimeout(5);
 $req = new EventHttpRequest("_request_handler", $base);
 
@@ -1052,8 +1052,8 @@ class MyListenerConnection {
 
         $this->bev = new EventBufferEvent($base, $fd, EventBufferEvent::OPT_CLOSE_ON_FREE);
 
-        $this->bev->setCallbacks(array($this, "echoReadCallback"), NULL,
-            array($this, "echoEventCallback"), NULL);
+        $this->bev->setCallbacks(array($this, "echoReadCallback"), null,
+            array($this, "echoEventCallback"), null);
 
         if (!$this->bev->enable(Event::READ)) {
             echo "Failed to enable READ\n";
@@ -1073,7 +1073,7 @@ class MyListenerConnection {
 
         if ($events & (EventBufferEvent::EOF | EventBufferEvent::ERROR)) {
             $bev->free();
-            $bev = NULL;
+            $bev = null;
         }
     }
 }
@@ -1085,7 +1085,7 @@ class MyListener {
     private $conn = array();
 
     public function __destruct() {
-        foreach ($this->conn as &$c) $c = NULL;
+        foreach ($this->conn as &$c) $c = null;
     }
 
     public function __construct($sock_path) {
@@ -1130,7 +1130,7 @@ class MyListener {
             EventUtil::getLastSocketErrno(),
             EventUtil::getLastSocketError());
 
-        $base->exit(NULL);
+        $base->exit(null);
     }
 }
 
@@ -1162,7 +1162,7 @@ $l->dispatch();
  */
 
 class Handler {
-    public $domainName = FALSE;
+    public $domainName = false;
     public $connections = [];
     public $buffers = [];
     public $maxRead = 256000;
@@ -1205,11 +1205,11 @@ class Handler {
 
         if (!$this->connections[$id]['cnx']) {
             echo "Failed creating buffer\n";
-            $this->base->exit(NULL);
+            $this->base->exit(null);
             exit(1);
         }
 
-        $this->connections[$id]['cnx']->setCallbacks([$this, "ev_read"], NULL,
+        $this->connections[$id]['cnx']->setCallbacks([$this, "ev_read"], null,
             [$this, 'ev_error'], $id);
         $this->connections[$id]['cnx']->enable(Event::READ | Event::WRITE);
 
@@ -1223,7 +1223,7 @@ class Handler {
             $errno, EventUtil::getLastSocketError());
 
         if ($errno != 0) {
-            $this->base->exit(NULL);
+            $this->base->exit(null);
             exit();
         }
     }
@@ -1279,7 +1279,7 @@ class Handler {
                     $this->connections[$id]['cnx'], $this->ctx,
                     EventBufferEvent::SSL_ACCEPTING,
                     EventBufferEvent::OPT_CLOSE_ON_FREE);
-                $this->connections[$id]['cnx']->setCallbacks([$this, "ev_read"], NULL, [$this, 'ev_error'], $id);
+                $this->connections[$id]['cnx']->setCallbacks([$this, "ev_read"], null, [$this, 'ev_error'], $id);
                 $this->connections[$id]['cnx']->enable(Event::READ | Event::WRITE);
                 break;
 

--- a/reference/filesystem/functions/feof.xml
+++ b/reference/filesystem/functions/feof.xml
@@ -51,7 +51,7 @@
      <programlisting role="php">
 <![CDATA[
 <?php
-function safe_feof($fp, &$start = NULL) {
+function safe_feof($fp, &$start = null) {
  $start = microtime(true);
 
  return feof($fp);
@@ -59,7 +59,7 @@ function safe_feof($fp, &$start = NULL) {
 
 /* Assuming $fp is previously opened by fsockopen() */
 
-$start = NULL;
+$start = null;
 $timeout = ini_get('default_socket_timeout');
 
 while(!safe_feof($fp, $start) && (microtime(true) - $start) < $timeout)
@@ -81,10 +81,10 @@ while(!safe_feof($fp, $start) && (microtime(true) - $start) < $timeout)
      <programlisting role="php">
 <![CDATA[
 <?php
-// if file can not be read or doesn't exist fopen function returns FALSE
+// if file can not be read or doesn't exist fopen function returns <type>false</type>
 $file = @fopen("no_such_file", "r");
 
-// FALSE from fopen will issue warning and result in infinite loop here
+// false from fopen will issue warning and result in infinite loop here
 while (!feof($file)) {
 }
 

--- a/reference/filesystem/functions/fgetcsv.xml
+++ b/reference/filesystem/functions/fgetcsv.xml
@@ -198,8 +198,8 @@
 <![CDATA[
 <?php
 $row = 1;
-if (($handle = fopen("test.csv", "r")) !== FALSE) {
-    while (($data = fgetcsv($handle, 1000, ",")) !== FALSE) {
+if (($handle = fopen("test.csv", "r")) !== false) {
+    while (($data = fgetcsv($handle, 1000, ",")) !== false) {
         $num = count($data);
         echo "<p> $num fields in line $row: <br /></p>\n";
         $row++;

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -186,7 +186,7 @@ $file = file_get_contents('./people.txt', FILE_USE_INCLUDE_PATH);
 <![CDATA[
 <?php
 // Read 14 characters starting from the 21st character
-$section = file_get_contents('./people.txt', FALSE, NULL, 20, 14);
+$section = file_get_contents('./people.txt', false, null, 20, 14);
 var_dump($section);
 ?>
 ]]>

--- a/reference/filesystem/functions/fread.xml
+++ b/reference/filesystem/functions/fread.xml
@@ -142,7 +142,7 @@ fclose($handle);
 <![CDATA[
 <?php
 $handle = fopen("http://www.example.com/", "rb");
-if (FALSE === $handle) {
+if (false === $handle) {
     exit("Failed to open stream to URL");
 }
 

--- a/reference/filesystem/functions/fwrite.xml
+++ b/reference/filesystem/functions/fwrite.xml
@@ -113,7 +113,7 @@ if (is_writable($filename)) {
     }
 
     // Write $somecontent to our opened file.
-    if (fwrite($fp, $somecontent) === FALSE) {
+    if (fwrite($fp, $somecontent) === false) {
         echo "Cannot write to file ($filename)";
         exit;
     }

--- a/reference/filter/examples.xml
+++ b/reference/filter/examples.xml
@@ -78,18 +78,18 @@ $options = array(
         'max_range' => 3,
     )
 );
-if (filter_var($int_a, FILTER_VALIDATE_INT, $options) !== FALSE) {
+if (filter_var($int_a, FILTER_VALIDATE_INT, $options) !== false) {
     echo "Integer A '$int_a' is considered valid (between 0 and 3).\n";
 }
-if (filter_var($int_b, FILTER_VALIDATE_INT, $options) !== FALSE) {
+if (filter_var($int_b, FILTER_VALIDATE_INT, $options) !== false) {
     echo "Integer B '$int_b' is considered valid (between 0 and 3).\n";
 }
-if (filter_var($int_c, FILTER_VALIDATE_INT, $options) !== FALSE) {
+if (filter_var($int_c, FILTER_VALIDATE_INT, $options) !== false) {
     echo "Integer C '$int_c' is considered valid (between 0 and 3).\n";
 }
 
 $options['options']['default'] = 1;
-if (($int_c = filter_var($int_c, FILTER_VALIDATE_INT, $options)) !== FALSE) {
+if (($int_c = filter_var($int_c, FILTER_VALIDATE_INT, $options)) !== false) {
     echo "Integer C '$int_c' is considered valid (between 0 and 3).";
 }
 ?>

--- a/reference/gearman/constants.xml
+++ b/reference/gearman/constants.xml
@@ -212,7 +212,7 @@
     </term>
     <listitem>
      <simpara>
-      Trying to register a function name of NULL or using the callback interface
+      Trying to register a function name of <type>null</type> or using the callback interface
       without specifying callbacks.
      </simpara>
     </listitem>
@@ -224,7 +224,7 @@
     </term>
     <listitem>
      <simpara>
-      Trying to register a function with a NULL callback function.
+      Trying to register a function with a <type>null</type> callback function.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/gearman/examples.xml
+++ b/reference/gearman/examples.xml
@@ -308,7 +308,7 @@ $data['foo'] = 'bar';
 
 # add two tasks
 $task= $gmc->addTask("reverse", "foo", $data);
-$task2= $gmc->addTaskLow("reverse", "bar", NULL);
+$task2= $gmc->addTaskLow("reverse", "bar", null);
 
 # run the tasks in parallel (assuming multiple workers)
 if (! $gmc->runTasks())

--- a/reference/gmp/functions/gmp-invert.xml
+++ b/reference/gmp/functions/gmp-invert.xml
@@ -54,7 +54,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-echo gmp_invert("5", "10"); // no inverse, outputs nothing, result is FALSE
+echo gmp_invert("5", "10"); // no inverse, outputs nothing, result is false
 $invert = gmp_invert("5", "11");
 echo gmp_strval($invert) . "\n";
 ?>

--- a/reference/ibase/functions/ibase-server-info.xml
+++ b/reference/ibase/functions/ibase-server-info.xml
@@ -55,7 +55,7 @@
 <![CDATA[
 <?php
     // Attach to the remote Firebird server
-    if (($service = ibase_service_attach('10.1.1.254/3050', 'sysdba', 'masterkey')) != FALSE) {
+    if (($service = ibase_service_attach('10.1.1.254/3050', 'sysdba', 'masterkey')) != false) {
 
         // Successfully attached.
 

--- a/reference/ibase/functions/ibase-service-attach.xml
+++ b/reference/ibase/functions/ibase-service-attach.xml
@@ -65,7 +65,7 @@
 <![CDATA[
 <?php
     // Attach to the remote Firebird server by ip address
-    if (($service = ibase_service_attach('10.1.1.199', 'sysdba', 'masterkey')) != FALSE) {
+    if (($service = ibase_service_attach('10.1.1.199', 'sysdba', 'masterkey')) != false) {
         
         // Successfully attached. 
         // Fetch server version (something like 'LI-V3.0.4.33054 Firebird 3.0')
@@ -100,7 +100,7 @@
 <![CDATA[
 <?php
     // Attach to the remote Firebird server by name. Use Port 3050.
-    if (($service = ibase_service_attach('FB-SRV-01.contoso.local/3050', 'sysdba', 'masterkey')) != FALSE) {
+    if (($service = ibase_service_attach('FB-SRV-01.contoso.local/3050', 'sysdba', 'masterkey')) != false) {
         
         // Successfully attached. 
         // Fetch server version (something like 'LI-V3.0.4.33054 Firebird 3.0')

--- a/reference/ibase/functions/ibase-service-detach.xml
+++ b/reference/ibase/functions/ibase-service-detach.xml
@@ -46,7 +46,7 @@
 <![CDATA[
 <?php
     // Attach to the remote Firebird server by ip address
-    if (($service = ibase_service_attach('10.1.1.199', 'sysdba', 'masterkey')) != FALSE) {
+    if (($service = ibase_service_attach('10.1.1.199', 'sysdba', 'masterkey')) != false) {
         
         // Successfully attached. 
         // Fetch server version (something like 'LI-V3.0.4.33054 Firebird 3.0')
@@ -56,7 +56,7 @@
         $server_implementation = ibase_server_info($service, IBASE_SVC_IMPLEMENTATION);
 
         // Detach from server (disconnect)
-        if(ibase_service_detach($service) == FALSE) {
+        if(ibase_service_detach($service) == false) {
             echo "Error on service detach.";
         }
         else {

--- a/reference/ibm_db2/functions/db2-bind-param.xml
+++ b/reference/ibm_db2/functions/db2-bind-param.xml
@@ -185,7 +185,7 @@ Peaches, dog, 12.3
       <listitem>
        <para>
         an input-output (INOUT) parameter that accepts the name of the second
-        animal as input and returns the string <literal>TRUE</literal> if an
+        animal as input and returns the string <type>true</type> if an
         animal in the database matches that name
        </para>
       </listitem>
@@ -239,7 +239,7 @@ Values of bound parameters _before_ CALL:
   1: Peaches 2: Rickety Ride 3: 0
 
 Values of bound parameters _after_ CALL:
-  1: Peaches 2: TRUE 3: 22
+  1: Peaches 2: true 3: 22
 
 Results:
   Peaches, dog, 12.3

--- a/reference/image/functions/imagecrop.xml
+++ b/reference/image/functions/imagecrop.xml
@@ -81,7 +81,7 @@
 $im = imagecreatefrompng('example.png');
 $size = min(imagesx($im), imagesy($im));
 $im2 = imagecrop($im, ['x' => 0, 'y' => 0, 'width' => $size, 'height' => $size]);
-if ($im2 !== FALSE) {
+if ($im2 !== false) {
     imagepng($im2, 'example-cropped.png');
 }
 ?>

--- a/reference/image/functions/imagegif.xml
+++ b/reference/image/functions/imagegif.xml
@@ -141,7 +141,7 @@ elseif(function_exists('imagejpeg'))
     // For JPEG
     header('Content-Type: image/jpeg');
 
-    imagejpeg($im, NULL, 100);
+    imagejpeg($im, null, 100);
 }
 elseif(function_exists('imagepng'))
 {

--- a/reference/image/functions/imageistruecolor.xml
+++ b/reference/image/functions/imageistruecolor.xml
@@ -69,7 +69,7 @@ if(!imageistruecolor($im))
     imagecopy($tc, $im, 0, 0, 0, 0, imagesx($im), imagesy($im));
 
     $im = $tc;
-    $tc = NULL;
+    $tc = null;
 
     // OR use imagepalettetotruecolor()
 }

--- a/reference/image/functions/imagejpeg.xml
+++ b/reference/image/functions/imagejpeg.xml
@@ -143,7 +143,7 @@ imagestring($im, 1, 5, 5,  'A Simple Text String', $text_color);
 header('Content-Type: image/jpeg');
 
 // Skip the file parameter using NULL, then set the quality to 75%
-imagejpeg($im, NULL, 75);
+imagejpeg($im, null, 75);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagewbmp.xml
+++ b/reference/image/functions/imagewbmp.xml
@@ -133,7 +133,7 @@ header('Content-Type: image/vnd.wap.wbmp');
 // Set a replacement foreground color
 $foreground_color = imagecolorallocate($im, 255, 0, 0);
 
-imagewbmp($im, NULL, $foreground_color);
+imagewbmp($im, null, $foreground_color);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagexbm.xml
+++ b/reference/image/functions/imagexbm.xml
@@ -129,7 +129,7 @@ imagestring($im, 1, 5, 5,  'A Simple Text String', $text_color);
 $foreground_color = imagecolorallocate($im, 255, 0, 0);
 
 // Save the image
-imagexbm($im, NULL, $foreground_color);
+imagexbm($im, null, $foreground_color);
 ?>
 ]]>
     </programlisting>

--- a/reference/imagick/imagick/writeimage.xml
+++ b/reference/imagick/imagick/writeimage.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Imagick::writeImage</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>filename</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>filename</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Writes an image to the specified filename. If the filename parameter is NULL,

--- a/reference/imagick/imagickkernel/frommatrix.xml
+++ b/reference/imagick/imagickkernel/frommatrix.xml
@@ -30,7 +30,7 @@
     <term><parameter>array</parameter></term>
     <listitem>
      <para>
-      A matrix (i.e. 2d array) of values that define the kernel. Each element should be either a float value, or FALSE if that element shouldn't be used by the kernel.
+      A matrix (i.e. 2d array) of values that define the kernel. Each element should be either a float value, or false if that element shouldn't be used by the kernel.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/intl/dateformatter/getcalendarobject.xml
+++ b/reference/intl/dateformatter/getcalendarobject.xml
@@ -57,8 +57,8 @@
 <?php
 $formatter = IntlDateFormatter::create(
     "fr_FR@calendar=islamic", 
-    NULL,
-    NULL,
+    null,
+    null,
     "GMT-01:00",
     IntlDateFormatter::TRADITIONAL
 );

--- a/reference/intl/dateformatter/gettimezone.xml
+++ b/reference/intl/dateformatter/gettimezone.xml
@@ -58,8 +58,8 @@
 <![CDATA[
 <?php
 
-$madrid = IntlDateFormatter::create(NULL, NULL, NULL, 'Europe/Madrid');
-$lisbon = IntlDateFormatter::create(NULL, NULL, NULL, 'Europe/Lisbon');
+$madrid = IntlDateFormatter::create(null, null, null, 'Europe/Madrid');
+$lisbon = IntlDateFormatter::create(null, null, null, 'Europe/Lisbon');
 
 var_dump($madrid->getTimezone());
 echo $madrid->getTimezone()->getDisplayName(

--- a/reference/intl/dateformatter/is-lenient.xml
+++ b/reference/intl/dateformatter/is-lenient.xml
@@ -68,9 +68,9 @@ $fmt = datefmt_create(
 );
 echo 'lenient of the formatter is : ';
 if ($fmt->isLenient()) {
-    echo 'TRUE';
+    echo 'true';
 } else {
-    echo 'FALSE';
+    echo 'false';
 }
 datefmt_parse($fmt, '35/13/1971');
 echo "\n Trying to do parse('35/13/1971').\nResult is : " . datefmt_parse($fmt, '35/13/1971');
@@ -81,9 +81,9 @@ if (intl_get_error_code() != 0) {
 datefmt_set_lenient($fmt,false);
 echo 'Now lenient of the formatter is : ';
 if ($fmt->isLenient()) {
-    echo 'TRUE';
+    echo 'true';
 } else {
-    echo 'FALSE';
+    echo 'false';
 }
 datefmt_parse($fmt, '35/13/1971');
 echo "\n Trying to do parse('35/13/1971').Result is : " . datefmt_parse($fmt, '35/13/1971');
@@ -111,9 +111,9 @@ $fmt = new IntlDateFormatter(
 );
 echo "lenient of the formatter is : ";
 if ($fmt->isLenient()) {
-    echo 'TRUE';
+    echo 'true';
 } else {
-    echo 'FALSE';
+    echo 'false';
 }
 $fmt->parse('35/13/1971');
 echo "\n Trying to do parse('35/13/1971').\nResult is : " . $fmt->parse('35/13/1971');
@@ -125,9 +125,9 @@ if (intl_get_error_code() != 0){
 $fmt->setLenient(FALSE);
 echo 'Now lenient of the formatter is : ';
 if ($fmt->isLenient()) {
-    echo 'TRUE';
+    echo 'true';
 } else {
-    echo 'FALSE';
+    echo 'false';
 }
 $fmt->parse('35/13/1971');
 echo "\n Trying to do parse('35/13/1971').\nResult is : " . $fmt->parse('35/13/1971');
@@ -143,10 +143,10 @@ if (intl_get_error_code() != 0) {
      &example.outputs;
      <screen>
          <![CDATA[
-lenient of the formatter is : TRUE
+lenient of the formatter is : true
 Trying to do parse('35/13/1971').
 Result is : -2147483
-Now lenient of the formatter is : FALSE
+Now lenient of the formatter is : false
 Trying to do parse('35/13/1971').
 Result is : 
 Error_msg is : Date parsing failed: U_PARSE_ERROR 

--- a/reference/intl/dateformatter/set-calendar.xml
+++ b/reference/intl/dateformatter/set-calendar.xml
@@ -153,7 +153,7 @@ Now calendar of the formatter is : 0
 <![CDATA[
 <?php
 $time = strtotime("2013-03-03 00:00:00 UTC");
-$formatter = IntlDateFormatter::create("en_US", NULL, NULL, "Europe/Amsterdam");
+$formatter = IntlDateFormatter::create("en_US", null, null, "Europe/Amsterdam");
 
 echo "before: ", $formatter->format($time), "\n";
 

--- a/reference/intl/dateformatter/set-lenient.xml
+++ b/reference/intl/dateformatter/set-lenient.xml
@@ -80,9 +80,9 @@ $fmt = datefmt_create(
 );
 echo 'lenient of the formatter is : ';
 if ($fmt->isLenient()) {
-    echo 'TRUE';
+    echo 'true';
 } else {
-    echo 'FALSE';
+    echo 'false';
 }
 datefmt_parse($fmt, '35/13/1971');
 echo "\n Trying to do parse('35/13/1971').\nResult is : " . datefmt_parse($fmt, '35/13/1971');
@@ -93,9 +93,9 @@ if (intl_get_error_code() != 0) {
 datefmt_set_lenient($fmt, false);
 echo "\nNow lenient of the formatter is : ";
 if ($fmt->isLenient()) {
-    echo 'TRUE';
+    echo 'true';
 } else {
-    echo 'FALSE';
+    echo 'false';
 }
 datefmt_parse($fmt, '35/13/1971');
 echo "\nTrying to do parse('35/13/1971').\nResult is : " . datefmt_parse($fmt, '35/13/1971');
@@ -123,9 +123,9 @@ $fmt = new IntlDateFormatter(
 );
 echo 'lenient of the formatter is : ';
 if ($fmt->isLenient()) {
-    echo 'TRUE';
+    echo 'true';
 } else {
-    echo 'FALSE';
+    echo 'false';
 }
 $fmt->parse('35/13/1971');
 echo "\n Trying to do parse('35/13/1971').\nResult is : " . $fmt->parse('35/13/1971');
@@ -134,12 +134,12 @@ if (intl_get_error_code() != 0) {
     echo "\nError_code is : " . intl_get_error_code();
 }
 
-$fmt->setLenient(FALSE);
+$fmt->setLenient(false);
 echo "\nNow lenient of the formatter is : ";
 if ($fmt->isLenient()) {
-    echo 'TRUE';
+    echo 'true';
 } else {
-    echo 'FALSE';
+    echo 'false';
 }
 $fmt->parse('35/13/1971');
 echo "\n Trying to do parse('35/13/1971').\nResult is : " . $fmt->parse('35/13/1971');
@@ -155,10 +155,10 @@ if (intl_get_error_code() != 0) {
      &example.outputs;
      <screen>
          <![CDATA[
-lenient of the formatter is : TRUE
+lenient of the formatter is : true
 Trying to do parse('35/13/1971').
 Result is : 66038400
-Now lenient of the formatter is : FALSE
+Now lenient of the formatter is : false
 Trying to do parse('35/13/1971').
 Result is : 
 Error_msg is : Date parsing failed: U_PARSE_ERROR

--- a/reference/intl/dateformatter/settimezone.xml
+++ b/reference/intl/dateformatter/settimezone.xml
@@ -97,9 +97,9 @@
 <?php
 ini_set('date.timezone', 'Europe/Amsterdam');
 
-$formatter = IntlDateFormatter::create(NULL, NULL, NULL, "UTC");
+$formatter = IntlDateFormatter::create(null, null, null, "UTC");
 
-$formatter->setTimeZone(NULL);
+$formatter->setTimeZone(null);
 echo "NULL\n    ", $formatter->getTimeZone()->getId(), "\n";
 
 $formatter->setTimeZone(IntlTimeZone::createTimeZone('Europe/Lisbon'));

--- a/reference/intl/ini.xml
+++ b/reference/intl/ini.xml
@@ -54,7 +54,7 @@
       <para>
        The locale that will be used in intl functions when none is specified
        (either by omitting the corresponding argument or by passing
-       <literal>NULL</literal>). These are ICU locales, not system locales.
+       <type>null</type>). These are ICU locales, not system locales.
        The built-in ICU locales and their data can be explored at
        <link xlink:href="&url.icu.locales;"/>.
       </para>

--- a/reference/intl/intlcalendar/createinstance.xml
+++ b/reference/intl/intlcalendar/createinstance.xml
@@ -92,7 +92,7 @@ var_dump(get_class($cal),
 echo "\n";
 
 echo "Explicit locale (with calendar)\n";
-$cal = IntlCalendar::createInstance(NULL, 'es_ES@calendar=persian');
+$cal = IntlCalendar::createInstance(null, 'es_ES@calendar=persian');
 var_dump(get_class($cal),
         IntlDateFormatter::formatObject($cal, IntlDateFormatter::FULL));
 

--- a/reference/intl/intlcalendar/equals.xml
+++ b/reference/intl/intlcalendar/equals.xml
@@ -69,31 +69,31 @@
 <?php
 ini_set('date.timezone', 'UTC');
 
-$cal1 = IntlCalendar::createInstance(NULL, 'es_ES');
+$cal1 = IntlCalendar::createInstance(null, 'es_ES');
 $cal2 = clone $cal1;
 
-var_dump($cal1->equals($cal2)); //TRUE
+var_dump($cal1->equals($cal2)); //true
 
 //The locale is not included in the comparison
-$cal2 = IntlCalendar::createInstance(NULL, 'pt_PT');
+$cal2 = IntlCalendar::createInstance(null, 'pt_PT');
 $cal2->setTime($cal1->getTime());
-var_dump($cal1->equals($cal2)); //TRUE
+var_dump($cal1->equals($cal2)); //true
 
 //And set fields state is not included as well
 $cal2->clear(IntlCalendar::FIELD_YEAR);
 var_dump($cal1->isSet(IntlCalendar::FIELD_YEAR) ==
-        $cal2->isSet(IntlCalendar::FIELD_YEAR)); //FALSE
-var_dump($cal1->equals($cal2)); //TRUE
+        $cal2->isSet(IntlCalendar::FIELD_YEAR)); //false
+var_dump($cal1->equals($cal2)); //true
 
 //Neither is the calendar type
-$cal2 = IntlCalendar::createInstance(NULL, 'es_ES@calendar=islamic');
+$cal2 = IntlCalendar::createInstance(null, 'es_ES@calendar=islamic');
 $cal2->setTime($cal1->getTime());
-var_dump($cal1->equals($cal2)); //TRUE
+var_dump($cal1->equals($cal2)); //true
 
 //Only the time is
 $cal2 = clone $cal1;
 $cal2->setTime($cal1->getTime() + 1.);
-var_dump($cal1->equals($cal2)); //FALSE
+var_dump($cal1->equals($cal2)); //false
 
 ]]>
     </programlisting>

--- a/reference/intl/intlcalendar/getfirstdayofweek.xml
+++ b/reference/intl/intlcalendar/getfirstdayofweek.xml
@@ -61,12 +61,12 @@
 <?php
 ini_set('date.timezone', 'UTC');
 
-$cal1 = IntlCalendar::createInstance(NULL, 'es_ES');
+$cal1 = IntlCalendar::createInstance(null, 'es_ES');
 var_dump($cal1->getFirstDayOfWeek()); // Monday
 $cal1->set(2013, 1 /* February */, 3); // a Sunday
 var_dump($cal1->get(IntlCalendar::FIELD_WEEK_OF_YEAR)); // 5
 
-$cal2 = IntlCalendar::createInstance(NULL, 'en_US');
+$cal2 = IntlCalendar::createInstance(null, 'en_US');
 var_dump($cal2->getFirstDayOfWeek()); // Sunday
 $cal2->set(2013, 1 /* February */, 3); // a Sunday
 var_dump($cal2->get(IntlCalendar::FIELD_WEEK_OF_YEAR)); // 6

--- a/reference/intl/intlcalendar/getrepeatedwalltimeoption.xml
+++ b/reference/intl/intlcalendar/getrepeatedwalltimeoption.xml
@@ -71,7 +71,7 @@ $cal = new IntlGregorianCalendar(2013, 9 /* October */, 27, 1, 30);
 var_dump($cal->getRepeatedWalltimeOption()); // 0 WALLTIME_LAST
 
 $formatter = IntlDateFormatter::create(
-    NULL,
+    null,
     IntlDateFormatter::FULL,
     IntlDateFormatter::FULL,
     'UTC'

--- a/reference/intl/intlcalendar/getskippedwalltimeoption.xml
+++ b/reference/intl/intlcalendar/getskippedwalltimeoption.xml
@@ -80,7 +80,7 @@ var_dump(
 );
 
 $formatter = IntlDateFormatter::create(
-    NULL,
+    null,
     IntlDateFormatter::FULL,
     IntlDateFormatter::FULL,
     'UTC'

--- a/reference/intl/intlcalendar/gettype.xml
+++ b/reference/intl/intlcalendar/gettype.xml
@@ -60,7 +60,7 @@
 ini_set('date.timezone', 'Europe/Lisbon');
 ini_set('intl.default_locale', 'en_US');
 
-$cal = IntlCalendar::createInstance(NULL, '@calendar=ethiopic-amete-alem');
+$cal = IntlCalendar::createInstance(null, '@calendar=ethiopic-amete-alem');
 var_dump($cal->getType());
 
 $cal = new IntlGregorianCalendar();

--- a/reference/intl/intlcalendar/isweekend.xml
+++ b/reference/intl/intlcalendar/isweekend.xml
@@ -74,13 +74,13 @@
 <?php
 ini_set('date.timezone', 'Europe/Lisbon');
 
-$cal = new IntlGregorianCalendar(NULL, 'en_US');
+$cal = new IntlGregorianCalendar(null, 'en_US');
 $cal->set(2013, 6 /* July */, 7); // a Sunday 
 
 var_dump($cal->isWeekend()); // true
 var_dump($cal->isWeekend(strtotime('2013-07-01 00:00:00'))); // false, Monday
 
-$cal = new IntlGregorianCalendar(NULL, 'ar_SA');
+$cal = new IntlGregorianCalendar(null, 'ar_SA');
 $cal->set(2013, 6 /* July */, 7); // a Sunday 
 var_dump($cal->isWeekend()); // false, Sunday not in weekend in this calendar
 ]]>

--- a/reference/intl/intlcalendar/set.xml
+++ b/reference/intl/intlcalendar/set.xml
@@ -21,10 +21,10 @@
    <modifier>public</modifier> <type>true</type><methodname>IntlCalendar::set</methodname>
    <methodparam><type>int</type><parameter>year</parameter></methodparam>
    <methodparam><type>int</type><parameter>month</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>dayOfMonth</parameter><initializer>NULL</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>hour</parameter><initializer>NULL</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>minute</parameter><initializer>NULL</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>second</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>dayOfMonth</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>hour</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>minute</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>second</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    &style.procedural;
@@ -40,10 +40,10 @@
    <methodparam><type>IntlCalendar</type><parameter>cal</parameter></methodparam>
    <methodparam><type>int</type><parameter>year</parameter></methodparam>
    <methodparam><type>int</type><parameter>month</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>dayOfMonth</parameter><initializer>NULL</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>hour</parameter><initializer>NULL</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>minute</parameter><initializer>NULL</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>second</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>dayOfMonth</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>hour</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>minute</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>second</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Sets either a specific field to the given value, or sets at once several

--- a/reference/intl/spoofchecker/issuspicious.xml
+++ b/reference/intl/spoofchecker/issuspicious.xml
@@ -59,9 +59,9 @@
 <?php
 $checker = new Spoofchecker();
 
-$checker->isSuspicious('google.com'); // FALSE: only ASCII characters
+$checker->isSuspicious('google.com'); // false: only ASCII characters
 
-$checker->isSuspicious('Рaypal.com'); // TRUE
+$checker->isSuspicious('Рaypal.com'); // true
 // The first letter is from Cyrylic, not a regular latin "P"
 ]]>
     </programlisting>

--- a/reference/ldap/examples.xml
+++ b/reference/ldap/examples.xml
@@ -113,7 +113,7 @@ $result = ldap_mod_replace_ext(
     [
         [
             'oid'         => LDAP_CONTROL_ASSERT,
-            'iscritical'  => TRUE,
+            'iscritical'  => true,
             'value'       => ['filter' => '(!(description=*))']
         ]
     ]
@@ -138,7 +138,7 @@ $result = ldap_delete_ext(
     [
         [
             'oid'         => LDAP_CONTROL_PRE_READ,
-            'iscritical'  => TRUE,
+            'iscritical'  => true,
             'value'       => ['attrs' => ['o', 'description']]
         ]
     ]
@@ -162,7 +162,7 @@ $result = ldap_delete_ext(
 $result = ldap_delete_ext(
     $link,
     'cn=reference,dc=example,dc=com',
-    [['oid' => LDAP_CONTROL_MANAGEDSAIT, 'iscritical' => TRUE]]
+    [['oid' => LDAP_CONTROL_MANAGEDSAIT, 'iscritical' => true]]
 );
 
 // Then use ldap_parse_result

--- a/reference/ldap/functions/ldap-exop.xml
+++ b/reference/ldap/functions/ldap-exop.xml
@@ -141,7 +141,7 @@ if ($ds) {
     var_dump($retdata);
 
     // Same thing using $response_data parameter
-    $success = ldap_exop($ds, LDAP_EXOP_WHO_AM_I, NULL, NULL, $retdata, $retoid);
+    $success = ldap_exop($ds, LDAP_EXOP_WHO_AM_I, null, null, $retdata, $retoid);
     if ($success) {
       var_dump($retdata);
     }

--- a/reference/ldap/functions/ldap-modify-batch.xml
+++ b/reference/ldap/functions/ldap-modify-batch.xml
@@ -191,7 +191,7 @@ $modifs = [
     ],
 ];
 ldap_modify_batch($connection, $dn, $modifs);
-ldap_rename($connection, $dn, "cn=Jack Smith-Jones", NULL, TRUE);
+ldap_rename($connection, $dn, "cn=Jack Smith-Jones", null, true);
 ?>
 ]]>
     </programlisting>

--- a/reference/ldap/functions/ldap-set-option.xml
+++ b/reference/ldap/functions/ldap-set-option.xml
@@ -279,7 +279,7 @@ if (ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, 3)) {
 // $ds is a valid LDAP\Connection instance for a directory server
 // control with no value
 $ctrl1 = array("oid" => "1.2.752.58.10.1", "iscritical" => true);
-// iscritical defaults to FALSE
+// iscritical defaults to false
 $ctrl2 = array("oid" => "1.2.752.58.1.10", "value" => "magic");
 // try to set both controls
 if (!ldap_set_option($ds, LDAP_OPT_SERVER_CONTROLS, array($ctrl1, $ctrl2))) {

--- a/reference/lua/lua/construct.xml
+++ b/reference/lua/lua/construct.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <methodname>Lua::__construct</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>lua_script_file</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>lua_script_file</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
 

--- a/reference/math/functions/max.xml
+++ b/reference/math/functions/max.xml
@@ -148,13 +148,13 @@ $val = max('string', array(2, 5, 7), 42);   // array(2, 5, 7)
 var_dump($val);
 
 // If one argument is NULL or a boolean, it will be compared against
-// other values using the rule FALSE < TRUE regardless of the other types involved
-// In the below example, -10 is treated as TRUE in the comparison
-$val = max(-10, FALSE); // -10
+// other values using the rule false < true regardless of the other types involved
+// In the below example, -10 is treated as true in the comparison
+$val = max(-10, false); // -10
 var_dump($val);
 
-// 0, on the other hand, is treated as FALSE, so is "lower than" TRUE
-$val = max(0, TRUE); // TRUE
+// 0, on the other hand, is treated as false, so is "lower than" true
+$val = max(0, true); // true
 var_dump($val);
 ?>
 ]]>

--- a/reference/math/functions/min.xml
+++ b/reference/math/functions/min.xml
@@ -148,17 +148,17 @@ $val = min('string', array(2, 5, 7), 42);   // string
 var_dump($val);
 
 // If one argument is NULL or a boolean, it will be compared against
-// other values using the rules FALSE < TRUE and NULL == FALSE regardless of the 
+// other values using the rules false < true and null == false regardless of the 
 // other types involved
-// In the below examples, both -10 and 10 are treated as TRUE in the comparison
-$val = min(-10, FALSE, 10); // FALSE
+// In the below examples, both -10 and 10 are treated as true in the comparison
+$val = min(-10, false, 10); // false
 var_dump($val);
 
-$val = min(-10, NULL, 10);  // NULL
+$val = min(-10, null, 10);  // null
 var_dump($val);
 
-// 0, on the other hand, is treated as FALSE, so is "lower than" TRUE
-$val = min(0, TRUE); // 0
+// 0, on the other hand, is treated as false, so is "lower than" true
+$val = min(0, true); // 0
 var_dump($val);
 ?>
 ]]>

--- a/reference/mbstring/functions/mb-strcut.xml
+++ b/reference/mbstring/functions/mb-strcut.xml
@@ -63,7 +63,7 @@
      <term><parameter>length</parameter></term>
      <listitem>
       <para>
-       Length in <emphasis>bytes</emphasis>. If omitted or <literal>NULL</literal>
+       Length in <emphasis>bytes</emphasis>. If omitted or <type>null</type>
        is passed, extract all bytes to the end of the string.
       </para>
       <para>

--- a/reference/mbstring/functions/mb-substr.xml
+++ b/reference/mbstring/functions/mb-substr.xml
@@ -61,7 +61,7 @@
      <listitem>
       <para>
        Maximum number of characters to use from <parameter>string</parameter>. If
-       omitted or <literal>NULL</literal> is passed, extract all characters to
+       omitted or <type>null</type> is passed, extract all characters to
        the end of the string.
       </para>
      </listitem>

--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -616,7 +616,7 @@ class UpperClass implements MongoDB\BSON\Persistable
    <para>
     <variablelist>
      <varlistentry>
-      <term><emphasis>not set</emphasis> or <type>NULL</type> (default)</term>
+      <term><emphasis>not set</emphasis> or <type>null</type> (default)</term>
       <listitem>
        <para>
         <itemizedlist>
@@ -777,7 +777,7 @@ class UpperClass implements MongoDB\BSON\Persistable
      </para>
 
      <para>
-      If the value in the map is <type>NULL</type>, it means the same as the
+      If the value in the map is <type>null</type>, it means the same as the
       <emphasis>default</emphasis> value for that item.
      </para>
     </section>

--- a/reference/mysql/functions/mysql-affected-rows.xml
+++ b/reference/mysql/functions/mysql-affected-rows.xml
@@ -20,7 +20,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>mysql_affected_rows</methodname>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Get the number of affected rows by the last INSERT, UPDATE, REPLACE 

--- a/reference/mysql/functions/mysql-client-encoding.xml
+++ b/reference/mysql/functions/mysql-client-encoding.xml
@@ -19,7 +19,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>string</type><methodname>mysql_client_encoding</methodname>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Retrieves the <literal>character_set</literal> variable from MySQL.

--- a/reference/mysql/functions/mysql-close.xml
+++ b/reference/mysql/functions/mysql-close.xml
@@ -20,7 +20,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>mysql_close</methodname>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para> 
    <function>mysql_close</function> closes the non-persistent connection to 

--- a/reference/mysql/functions/mysql-create-db.xml
+++ b/reference/mysql/functions/mysql-create-db.xml
@@ -21,7 +21,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>mysql_create_db</methodname>
    <methodparam><type>string</type><parameter>database_name</parameter></methodparam>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>mysql_create_db</function> attempts to create a new

--- a/reference/mysql/functions/mysql-db-name.xml
+++ b/reference/mysql/functions/mysql-db-name.xml
@@ -21,7 +21,7 @@
    <type>string</type><methodname>mysql_db_name</methodname>
    <methodparam><type>resource</type><parameter>result</parameter></methodparam>
    <methodparam><type>int</type><parameter>row</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>field</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>field</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Retrieve the database name from a call to 

--- a/reference/mysql/functions/mysql-db-query.xml
+++ b/reference/mysql/functions/mysql-db-query.xml
@@ -22,7 +22,7 @@
    <type class="union"><type>resource</type><type>bool</type></type><methodname>mysql_db_query</methodname>
    <methodparam><type>string</type><parameter>database</parameter></methodparam>
    <methodparam><type>string</type><parameter>query</parameter></methodparam>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>mysql_db_query</function> selects a database, and executes a 

--- a/reference/mysql/functions/mysql-drop-db.xml
+++ b/reference/mysql/functions/mysql-drop-db.xml
@@ -20,7 +20,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>mysql_drop_db</methodname>
    <methodparam><type>string</type><parameter>database_name</parameter></methodparam>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>mysql_drop_db</function> attempts to drop (remove) an

--- a/reference/mysql/functions/mysql-errno.xml
+++ b/reference/mysql/functions/mysql-errno.xml
@@ -20,7 +20,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>mysql_errno</methodname>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Returns the error number from the last MySQL function. 

--- a/reference/mysql/functions/mysql-error.xml
+++ b/reference/mysql/functions/mysql-error.xml
@@ -20,7 +20,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>string</type><methodname>mysql_error</methodname>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Returns the error text from the last MySQL function.

--- a/reference/mysql/functions/mysql-get-host-info.xml
+++ b/reference/mysql/functions/mysql-get-host-info.xml
@@ -23,7 +23,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>mysql_get_host_info</methodname>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Describes the type of connection in use for the connection, including the

--- a/reference/mysql/functions/mysql-get-proto-info.xml
+++ b/reference/mysql/functions/mysql-get-proto-info.xml
@@ -19,7 +19,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>int</type><type>false</type></type><methodname>mysql_get_proto_info</methodname>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Retrieves the MySQL protocol.

--- a/reference/mysql/functions/mysql-get-server-info.xml
+++ b/reference/mysql/functions/mysql-get-server-info.xml
@@ -23,7 +23,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>mysql_get_server_info</methodname>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Retrieves the MySQL server version.

--- a/reference/mysql/functions/mysql-info.xml
+++ b/reference/mysql/functions/mysql-info.xml
@@ -19,7 +19,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>string</type><methodname>mysql_info</methodname>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Returns detailed information about the last query.

--- a/reference/mysql/functions/mysql-insert-id.xml
+++ b/reference/mysql/functions/mysql-insert-id.xml
@@ -20,7 +20,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>mysql_insert_id</methodname>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Retrieves the ID generated for an AUTO_INCREMENT column by the previous 

--- a/reference/mysql/functions/mysql-list-dbs.xml
+++ b/reference/mysql/functions/mysql-list-dbs.xml
@@ -19,7 +19,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>resource</type><methodname>mysql_list_dbs</methodname>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Returns a result pointer containing the databases available from the 

--- a/reference/mysql/functions/mysql-list-fields.xml
+++ b/reference/mysql/functions/mysql-list-fields.xml
@@ -21,7 +21,7 @@
    <type>resource</type><methodname>mysql_list_fields</methodname>
    <methodparam><type>string</type><parameter>database_name</parameter></methodparam>
    <methodparam><type>string</type><parameter>table_name</parameter></methodparam>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Retrieves information about the given table name.

--- a/reference/mysql/functions/mysql-list-processes.xml
+++ b/reference/mysql/functions/mysql-list-processes.xml
@@ -19,7 +19,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>resource</type><type>false</type></type><methodname>mysql_list_processes</methodname>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Retrieves the current MySQL server threads.

--- a/reference/mysql/functions/mysql-list-tables.xml
+++ b/reference/mysql/functions/mysql-list-tables.xml
@@ -20,7 +20,7 @@
   <methodsynopsis>
    <type class="union"><type>resource</type><type>false</type></type><methodname>mysql_list_tables</methodname>
    <methodparam><type>string</type><parameter>database</parameter></methodparam>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Retrieves a list of table names from a MySQL database.

--- a/reference/mysql/functions/mysql-ping.xml
+++ b/reference/mysql/functions/mysql-ping.xml
@@ -19,7 +19,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>mysql_ping</methodname>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Checks whether or not the connection to

--- a/reference/mysql/functions/mysql-query.xml
+++ b/reference/mysql/functions/mysql-query.xml
@@ -21,7 +21,7 @@
   <methodsynopsis>
    <type>mixed</type><methodname>mysql_query</methodname>
    <methodparam><type>string</type><parameter>query</parameter></methodparam>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>mysql_query</function> sends a unique query (multiple queries

--- a/reference/mysql/functions/mysql-real-escape-string.xml
+++ b/reference/mysql/functions/mysql-real-escape-string.xml
@@ -21,7 +21,7 @@
   <methodsynopsis>
    <type>string</type><methodname>mysql_real_escape_string</methodname>
    <methodparam><type>string</type><parameter>unescaped_string</parameter></methodparam>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Escapes special characters in the <parameter>unescaped_string</parameter>, 

--- a/reference/mysql/functions/mysql-select-db.xml
+++ b/reference/mysql/functions/mysql-select-db.xml
@@ -21,7 +21,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>mysql_select_db</methodname>
    <methodparam><type>string</type><parameter>database_name</parameter></methodparam>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Sets the current active database on the server that's associated with the 

--- a/reference/mysql/functions/mysql-set-charset.xml
+++ b/reference/mysql/functions/mysql-set-charset.xml
@@ -21,7 +21,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>mysql_set_charset</methodname>
    <methodparam><type>string</type><parameter>charset</parameter></methodparam>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Sets the default character set for the current connection.

--- a/reference/mysql/functions/mysql-stat.xml
+++ b/reference/mysql/functions/mysql-stat.xml
@@ -23,7 +23,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>string</type><methodname>mysql_stat</methodname>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>mysql_stat</function> returns the current server status.

--- a/reference/mysql/functions/mysql-thread-id.xml
+++ b/reference/mysql/functions/mysql-thread-id.xml
@@ -19,7 +19,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>int</type><type>false</type></type><methodname>mysql_thread_id</methodname>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Retrieves the current thread ID. If the connection is lost, and a reconnect 

--- a/reference/mysql/functions/mysql-unbuffered-query.xml
+++ b/reference/mysql/functions/mysql-unbuffered-query.xml
@@ -20,7 +20,7 @@
   <methodsynopsis>
    <type>resource</type><methodname>mysql_unbuffered_query</methodname>
    <methodparam><type>string</type><parameter>query</parameter></methodparam>
-   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>mysql_unbuffered_query</function> sends the SQL query

--- a/reference/mysqli/mysqli_stmt/send-long-data.xml
+++ b/reference/mysqli/mysqli_stmt/send-long-data.xml
@@ -71,7 +71,7 @@
 <![CDATA[
 <?php
 $stmt = $mysqli->prepare("INSERT INTO messages (message) VALUES (?)");
-$null = NULL;
+$null = null;
 $stmt->bind_param("b", $null);
 $fp = fopen("messages.txt", "r");
 while (!feof($fp)) {

--- a/reference/network/functions/getprotobyname.xml
+++ b/reference/network/functions/getprotobyname.xml
@@ -52,7 +52,7 @@
 <?php
 $protocol = 'tcp';
 $get_prot = getprotobyname($protocol);
-if ($get_prot === FALSE) {
+if ($get_prot === false) {
     echo 'Invalid Protocol';
 } else {
     echo 'Protocol #' . $get_prot;

--- a/reference/network/functions/ip2long.xml
+++ b/reference/network/functions/ip2long.xml
@@ -78,7 +78,7 @@ echo $out;
 $ip   = gethostbyname('www.example.com');
 $long = ip2long($ip);
 
-if ($long == -1 || $long === FALSE) {
+if ($long == -1 || $long === false) {
     echo 'Invalid IP, please try again';
 } else {
     echo $ip   . "\n";            // 192.0.34.166

--- a/reference/oauth/oauthprovider/construct.xml
+++ b/reference/oauth/oauthprovider/construct.xml
@@ -60,7 +60,7 @@ try {
     $op->tokenHandler(array($this, 'myTokenHandler'));
 
     // Ignore the foo_uri parameter
-    $op->setParam('foo_uri', NULL);
+    $op->setParam('foo_uri', null);
 
     // No token needed for this end point
     $op->setRequestTokenPath('/v1/oauth/request_token');

--- a/reference/oci8/fan.xml
+++ b/reference/oci8/fan.xml
@@ -59,7 +59,7 @@
 <![CDATA[
     SQL> execute dbms_service.modify_service(
                    SERVICE_NAME        => 'sales',
-                   AQ_HA_NOTIFICATIONS => TRUE);
+                   AQ_HA_NOTIFICATIONS => true);
 ]]>
        </screen>
       </informalexample>

--- a/reference/oci8/functions/oci-bind-by-name.xml
+++ b/reference/oci8/functions/oci-bind-by-name.xml
@@ -488,7 +488,7 @@ $sql = 'SELECT last_name FROM employees WHERE employee_id in (:e1, :e2, :e3)';
 $stid = oci_parse($conn, $sql);
 $mye1 = 103;
 $mye2 = 104;
-$mye3 = NULL; // pretend we were not given this value
+$mye3 = null; // pretend we were not given this value
 oci_bind_by_name($stid, ':e1', $mye1);
 oci_bind_by_name($stid, ':e2', $mye2);
 oci_bind_by_name($stid, ':e3', $mye3);

--- a/reference/oci8/functions/oci-fetch-object.xml
+++ b/reference/oci8/functions/oci-fetch-object.xml
@@ -61,7 +61,7 @@
    the appropriate case for attribute access.
   </para>
   <para>
-    Attribute values will be &null; for any <literal>NULL</literal>
+    Attribute values will be &null; for any <type>null</type>
     data fields.
   </para>
  </refsect1>

--- a/reference/openssl/functions/openssl-get-cipher-methods.xml
+++ b/reference/openssl/functions/openssl-get-cipher-methods.xml
@@ -63,15 +63,15 @@ $ciphers_and_aliases = openssl_get_cipher_methods(true);
 $cipher_aliases      = array_diff($ciphers_and_aliases, $ciphers);
 
 //ECB mode should be avoided
-$ciphers = array_filter( $ciphers, function($n) { return stripos($n,"ecb")===FALSE; } );
+$ciphers = array_filter( $ciphers, function($n) { return stripos($n,"ecb")===false; } );
 
 //At least as early as Aug 2016, Openssl declared the following weak: RC2, RC4, DES, 3DES, MD5 based
-$ciphers = array_filter( $ciphers, function($c) { return stripos($c,"des")===FALSE; } );
-$ciphers = array_filter( $ciphers, function($c) { return stripos($c,"rc2")===FALSE; } );
-$ciphers = array_filter( $ciphers, function($c) { return stripos($c,"rc4")===FALSE; } );
-$ciphers = array_filter( $ciphers, function($c) { return stripos($c,"md5")===FALSE; } );
-$cipher_aliases = array_filter($cipher_aliases,function($c) { return stripos($c,"des")===FALSE; } );
-$cipher_aliases = array_filter($cipher_aliases,function($c) { return stripos($c,"rc2")===FALSE; } );
+$ciphers = array_filter( $ciphers, function($c) { return stripos($c,"des")===false; } );
+$ciphers = array_filter( $ciphers, function($c) { return stripos($c,"rc2")===false; } );
+$ciphers = array_filter( $ciphers, function($c) { return stripos($c,"rc4")===false; } );
+$ciphers = array_filter( $ciphers, function($c) { return stripos($c,"md5")===false; } );
+$cipher_aliases = array_filter($cipher_aliases,function($c) { return stripos($c,"des")===false; } );
+$cipher_aliases = array_filter($cipher_aliases,function($c) { return stripos($c,"rc2")===false; } );
 
 print_r($ciphers);
 print_r($cipher_aliases);

--- a/reference/openssl/functions/openssl-spki-export-challenge.xml
+++ b/reference/openssl/functions/openssl-spki-export-challenge.xml
@@ -51,7 +51,7 @@
   <example xml:id="openssl_spki_export_challenge.example.basic">
    <title><function>openssl_spki_export_challenge</function> example</title>
    <para>
-      Extracts the associated challenge string or NULL on failure.
+      Extracts the associated challenge string or <type>null</type> on failure.
    </para>
    <programlisting role="php">
 <![CDATA[

--- a/reference/openssl/functions/openssl-spki-export.xml
+++ b/reference/openssl/functions/openssl-spki-export.xml
@@ -76,7 +76,7 @@ if ($pubKey) {
 <![CDATA[
 <?php
 $spkac = openssl_spki_export(preg_replace('/SPKAC=/', '', $_POST['spkac']));
-if ($spkac != NULL) {
+if ($spkac != null) {
     echo $spkac;
 } else {
     echo "Extraction of pub key failed";

--- a/reference/openssl/functions/openssl-spki-new.xml
+++ b/reference/openssl/functions/openssl-spki-new.xml
@@ -104,7 +104,7 @@
 $pkey = openssl_pkey_new('secret password');
 $spkac = openssl_spki_new($pkey, 'testing');
 
-if ($spkac !== NULL) {
+if ($spkac !== null) {
     echo $spkac;
 } else {
     echo "SPKAC generation failed";

--- a/reference/pcntl/functions/pcntl-signal.xml
+++ b/reference/pcntl/functions/pcntl-signal.xml
@@ -118,7 +118,7 @@
         As of PHP 7.1.0 the handler callback is given a second argument
         containing the siginfo of the specific signal.  This data is only
         supplied if the operating system has the siginfo_t structure.
-        If the OS does not implement siginfo_t NULL is supplied.
+        If the OS does not implement siginfo_t <type>null</type> is supplied.
        </entry>
       </row>
      </tbody>

--- a/reference/pdo/constants.fetch-modes.xml
+++ b/reference/pdo/constants.fetch-modes.xml
@@ -1014,7 +1014,7 @@ $stmt->bindColumn('country', $country);
 $stmt->bindColumn(4, $referrerName);
 
 while ($stmt->fetch(\PDO::FETCH_BOUND)) {
-    print join("\t", [$userId, $name, $country, ($referrerName ?? 'NULL')]) . "\n";
+    print join("\t", [$userId, $name, $country, ($referrerName ?? 'null')]) . "\n";
 }
 ]]>
   </programlisting>
@@ -1117,7 +1117,7 @@ object(TestEntity)#3 (4) {
   </simpara>
   <caution>
    <simpara>
-    <classname>PDORow</classname> will return <literal>NULL</literal> without
+    <classname>PDORow</classname> will return <type>null</type> without
     any error or warning when accessing properties or keys that are not defined.
     This can make errors such as typos or queries not returning expected data
     harder to spot and debug.

--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -453,8 +453,8 @@
     </term>
     <listitem>
      <simpara>
-      Forces all fetched values (except &null;) to be treated as strings.
-      &null; values remain unchanged unless <constant>PDO::ATTR_ORACLE_NULLS</constant>
+      Forces all fetched values (except <type>null</type>) to be treated as strings.
+      <type>null</type> values remain unchanged unless <constant>PDO::ATTR_ORACLE_NULLS</constant>
       is set to <constant>PDO::NULL_TO_STRING</constant>.
      </simpara>
     </listitem>

--- a/reference/pdo_cubrid/pdo_overloaded/cubrid-schema.xml
+++ b/reference/pdo_cubrid/pdo_overloaded/cubrid-schema.xml
@@ -439,7 +439,7 @@
     Array containing the schema information, when process is successful; 
   </para>
   <para>
-    FALSE, when process is unsuccessful
+   <type>false</type>, when process is unsuccessful
   </para>
  </refsect1>
  

--- a/reference/pgsql/functions/pg-fetch-array.xml
+++ b/reference/pgsql/functions/pg-fetch-array.xml
@@ -69,7 +69,7 @@
    associatively (indexed by field name), or both.
    Each value in the <type>array</type> is represented as a 
    <type>string</type>.  Database <literal>NULL</literal>
-   values are returned as &null;.
+   values are returned as <type>null</type>.
   </para>
   <para>
    &false; is returned if <parameter>row</parameter> exceeds the number
@@ -123,7 +123,7 @@ echo $arr[1] . " <- Row 1 E-mail\n";
 // The row parameter is optional; NULL can be passed instead,
 // to pass a result_type.  Successive calls to pg_fetch_array
 // will return the next row.
-$arr = pg_fetch_array($result, NULL, PGSQL_ASSOC);
+$arr = pg_fetch_array($result, null, PGSQL_ASSOC);
 echo $arr["author"] . " <- Row 2 Author\n";
 echo $arr["email"] . " <- Row 2 E-mail\n";
 

--- a/reference/pgsql/functions/pg-fetch-assoc.xml
+++ b/reference/pgsql/functions/pg-fetch-assoc.xml
@@ -62,7 +62,7 @@
    An <type>array</type> indexed associatively (by field name).
    Each value in the <type>array</type> is represented as a 
    <type>string</type>.  Database <literal>NULL</literal>
-   values are returned as &null;.
+   values are returned as <type>null</type>.
   </para>
   <para>
    &false; is returned if <parameter>row</parameter> exceeds the number

--- a/reference/pgsql/functions/pg-fetch-object.xml
+++ b/reference/pgsql/functions/pg-fetch-object.xml
@@ -77,7 +77,7 @@
   <para>
    An <type>object</type> with one attribute for each field
    name in the result.  Database <literal>NULL</literal>
-   values are returned as &null;.
+   values are returned as <type>null</type>.
   </para>
   <para>
    &false; is returned if <parameter>row</parameter> exceeds the number

--- a/reference/pgsql/functions/pg-fetch-result.xml
+++ b/reference/pgsql/functions/pg-fetch-result.xml
@@ -71,7 +71,7 @@
    other types, including arrays are returned as strings formatted
    in the same default PostgreSQL manner that you would see in the
    <command>psql</command> program.  Database <literal>NULL</literal>
-   values are returned as &null;.
+   values are returned as <type>null</type>.
   </para>
   <para>
    &false; is returned if <parameter>row</parameter> exceeds the number

--- a/reference/pgsql/functions/pg-fetch-row.xml
+++ b/reference/pgsql/functions/pg-fetch-row.xml
@@ -56,7 +56,7 @@
   <para>
    An <type>array</type>, indexed from 0 upwards, with each value
    represented as a <type>string</type>.  Database <literal>NULL</literal>
-   values are returned as &null;.
+   values are returned as <type>null</type>.
   </para>
   <para>
    &false; is returned if <parameter>row</parameter> exceeds the number

--- a/reference/pgsql/functions/pg-query-params.xml
+++ b/reference/pgsql/functions/pg-query-params.xml
@@ -31,7 +31,7 @@
     <parameter>query</parameter> string as $1, $2, etc. The same parameter may
     appear more than once in the <parameter>query</parameter>; the same value
     will be used in that case. <parameter>params</parameter> specifies the
-    actual values of the parameters. A &null; value in this array means the
+    actual values of the parameters. A <type>null</type> value in this array means the
     corresponding parameter is SQL <literal>NULL</literal>.
   </para>
   <para>

--- a/reference/rar/examples.xml
+++ b/reference/rar/examples.xml
@@ -20,11 +20,11 @@ if (!array_key_exists("i", $_GET) || !is_numeric($_GET["i"]))
 $index = (int) $_GET["i"];
     
 $arch = RarArchive::open("example.rar");
-if ($arch === FALSE)
+if ($arch === false)
     die("Cannot open example.rar");
 
 $entries = $arch->getEntries();
-if ($entries === FALSE)
+if ($entries === false)
     die("Cannot retrieve entries");
 
 if (!array_key_exists($index, $entries))
@@ -39,7 +39,7 @@ $filesize = $entries[$index]->getUnpackedSize();
  * "Last modified" header */
 
 $fp = $entries[$index]->getStream();
-if ($fp === FALSE)
+if ($fp === false)
     die("Cannot open file with index $index insided the archive.");
 
 $arch->close(); //no longer needed; stream is independent

--- a/reference/rar/rararchive/getentries.xml
+++ b/reference/rar/rararchive/getentries.xml
@@ -92,11 +92,11 @@
 <![CDATA[
 <?php
 $rar_arch = RarArchive::open('solid.rar');
-if ($rar_arch === FALSE)
+if ($rar_arch === false)
     die("Could not open RAR archive.");
 
 $rar_entries = $rar_arch->getEntries();
-if ($rar_entries === FALSE)
+if ($rar_entries === false)
     die("Could not retrieve entries.");
 
 echo "Found " . count($rar_entries) . " entries.\n";
@@ -126,11 +126,11 @@ RarEntry for file "unrardll.txt" (2ed64b6e)
 <![CDATA[
 <?php
 $rar_arch = rar_open('solid.rar');
-if ($rar_arch === FALSE)
+if ($rar_arch === false)
     die("Could not open RAR archive.");
 
 $rar_entries = rar_list($rar_arch);
-if ($rar_entries === FALSE)
+if ($rar_entries === false)
     die("Could retrieve entries.");
 
 echo "Found " . count($rar_entries) . " entries.\n";

--- a/reference/rar/rararchive/getentry.xml
+++ b/reference/rar/rararchive/getentry.xml
@@ -75,10 +75,10 @@
 <![CDATA[
 <?php
 $rar_arch = RarArchive::open('solid.rar');
-if ($rar_arch === FALSE)
+if ($rar_arch === false)
     die("Could not open RAR archive.");
 $rar_entry = $rar_arch->getEntry('tese.txt');
-if ($rar_entry === FALSE)
+if ($rar_entry === false)
     die("Could not get such entry");
 echo get_class($rar_entry)."\n";
 echo $rar_entry;
@@ -102,10 +102,10 @@ RarEntry for file "tese.txt" (23b93a7a)
 <![CDATA[
 <?php
 $rar_arch = rar_open('solid.rar');
-if ($rar_arch === FALSE)
+if ($rar_arch === false)
     die("Could not open RAR archive.");
 $rar_entry = rar_entry_get($rar_arch, 'tese.txt');
-if ($rar_entry === FALSE)
+if ($rar_entry === false)
     die("Could not get such entry");
 echo get_class($rar_entry)."\n";
 echo $rar_entry;

--- a/reference/rar/rararchive/open.xml
+++ b/reference/rar/rararchive/open.xml
@@ -14,15 +14,15 @@
    <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>RarArchive</type><type>false</type></type><methodname>RarArchive::open</methodname>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>password</parameter><initializer>NULL</initializer></methodparam>
-   <methodparam choice="opt"><type>callable</type><parameter>volume_callback</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>password</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>volume_callback</parameter><initializer>null</initializer></methodparam>
    </methodsynopsis>
   <para>&style.procedural;:</para>
   <methodsynopsis>
    <type class="union"><type>RarArchive</type><type>false</type></type><methodname>rar_open</methodname>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>password</parameter><initializer>NULL</initializer></methodparam>
-   <methodparam choice="opt"><type>callable</type><parameter>volume_callback</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>password</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>volume_callback</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Open specified RAR archive and return <type>RarArchive</type> instance representing it.
@@ -124,11 +124,11 @@
 <![CDATA[
 <?php
 $rar_arch = RarArchive::open('encrypted_headers.rar', 'samplepassword');
-if ($rar_arch === FALSE)
+if ($rar_arch === false)
     die("Failed opening file");
     
 $entries = $rar_arch->getEntries();
-if ($entries === FALSE)
+if ($entries === false)
     die("Failed fetching entries");
 
 echo "Found " . count($entries) . " files.\n";
@@ -137,7 +137,7 @@ if (empty($entries))
     die("No valid entries found.");
     
 $stream = reset($entries)->getStream();
-if ($stream === FALSE)
+if ($stream === false)
     die("Failed opening first file");
 
 $rar_arch->close();
@@ -166,11 +166,11 @@ Encrypted file 1 contents.
 <![CDATA[
 <?php
 $rar_arch = rar_open('encrypted_headers.rar', 'samplepassword');
-if ($rar_arch === FALSE)
+if ($rar_arch === false)
     die("Failed opening file");
     
 $entries = rar_list($rar_arch);
-if ($entries === FALSE)
+if ($entries === false)
     die("Failed fetching entries");
 
 echo "Found " . count($entries) . " files.\n";
@@ -179,7 +179,7 @@ if (empty($entries))
     die("No valid entries found.");
     
 $stream = reset($entries)->getStream();
-if ($stream === FALSE)
+if ($stream === false)
     die("Failed opening first file");
 
 rar_close($rar_arch);

--- a/reference/rar/rarentry/extract.xml
+++ b/reference/rar/rarentry/extract.xml
@@ -12,7 +12,7 @@
     <modifier>public</modifier> <type>bool</type><methodname>RarEntry::extract</methodname>
     <methodparam><type>string</type><parameter>dir</parameter></methodparam>
     <methodparam choice="opt"><type>string</type><parameter>filepath</parameter><initializer>""</initializer></methodparam>
-    <methodparam choice="opt"><type>string</type><parameter>password</parameter><initializer>NULL</initializer></methodparam>
+    <methodparam choice="opt"><type>string</type><parameter>password</parameter><initializer>null</initializer></methodparam>
     <methodparam choice="opt"><type>bool</type><parameter>extended_data</parameter><initializer>&false;</initializer></methodparam>
    </methodsynopsis>
   <para>

--- a/reference/readline/functions/readline-callback-handler-install.xml
+++ b/reference/readline/functions/readline-callback-handler-install.xml
@@ -88,8 +88,8 @@ $prompting = true;
 readline_callback_handler_install("[$c] Enter something: ", 'rl_callback');
 
 while ($prompting) {
-    $w = NULL;
-    $e = NULL;
+    $w = null;
+    $e = null;
     $n = stream_select($r = array(STDIN), $w, $e, null);
     if ($n && in_array(STDIN, $r)) {
         // read a character, will call the callback when a newline is entered

--- a/reference/reflection/reflectionclass/construct.xml
+++ b/reference/reflection/reflectionclass/construct.xml
@@ -75,7 +75,7 @@ Class [ <internal:Core> class Exception implements Stringable, Throwable ] {
     Property [ protected string $file = '' ]
     Property [ protected int $line = 0 ]
     Property [ private array $trace = [] ]
-    Property [ private ?Throwable $previous = NULL ]
+    Property [ private ?Throwable $previous = null ]
   }
 
   - Methods [11] {

--- a/reference/reflection/reflectionmethod/construct.xml
+++ b/reference/reflection/reflectionmethod/construct.xml
@@ -131,7 +131,7 @@ if ($statics= $method->getStaticVariables()) {
 
 // Invoke the method
 printf("---> Invocation results in: ");
-var_dump($method->invoke(NULL));
+var_dump($method->invoke(null));
 ?>
 ]]>
     </programlisting>

--- a/reference/seaslog/seaslog/alert.xml
+++ b/reference/seaslog/seaslog/alert.xml
@@ -54,7 +54,7 @@
      <para>
       The `logger` cased by the third param would be used right this right now, 
       like a temp logger, when the function SeasLog::setLogger() called in pre content.
-      If `logger` NULL or "", SeasLog will use lastest logger setted by <methodname>SeasLog::setLogger</methodname>. 
+      If `logger` <type>null</type> or "", SeasLog will use lastest logger setted by <methodname>SeasLog::setLogger</methodname>. 
      </para>
     </listitem>
    </varlistentry>
@@ -64,7 +64,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   Return <type>true</type> on record log information success, <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/analyzercount.xml
+++ b/reference/seaslog/seaslog/analyzercount.xml
@@ -77,7 +77,7 @@ $countResult2 = SeasLog::analyzerCount(SEASLOG_DEBUG);
 $countResult3 = SeasLog::analyzerCount(SEASLOG_ERROR,date('Ymd',time()));
 
 //with `level` and `key_word`
-$countResult4 = SeasLog::analyzerCount(SEASLOG_DEBUG,NULL,'accessToken');
+$countResult4 = SeasLog::analyzerCount(SEASLOG_DEBUG,null,'accessToken');
 
 var_dump($countResult1,$countResult2,$countResult3,$countResult4);
 

--- a/reference/seaslog/seaslog/analyzerdetail.xml
+++ b/reference/seaslog/seaslog/analyzerdetail.xml
@@ -91,7 +91,7 @@
    Return results as array.
    <note>
     <para>
-     When `start`,`limit` is not NULL and in Windows, 
+     When `start`,`limit` is not <type>null</type> and in Windows, 
      SeasLog will threw exception with message 'Param start and limit don't support Windows'.
     </para>
    </note>

--- a/reference/seaslog/seaslog/closeloggerstream.xml
+++ b/reference/seaslog/seaslog/closeloggerstream.xml
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on released stream flow success, FALSE on failure.
+   Return <type>true</type> on released stream flow success, <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/critical.xml
+++ b/reference/seaslog/seaslog/critical.xml
@@ -53,7 +53,7 @@
      <para>
       The `logger` cased by the third param would be used right this right now, 
       like a temp logger, when the function SeasLog::setLogger() called in pre content.
-      If `logger` NULL or "", SeasLog will use lastest logger setted by <methodname>SeasLog::setLogger</methodname>. 
+      If `logger` <type>null</type> or "", SeasLog will use lastest logger setted by <methodname>SeasLog::setLogger</methodname>. 
      </para>
     </listitem>
    </varlistentry>
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   Return <type>true</type> on record log information success, <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/debug.xml
+++ b/reference/seaslog/seaslog/debug.xml
@@ -53,7 +53,7 @@
      <para>
       The `logger` cased by the third param would be used right this right now, 
       like a temp logger, when the function SeasLog::setLogger() called in pre content.
-      If `logger` NULL or "", SeasLog will use lastest logger setted by <methodname>SeasLog::setLogger</methodname>. 
+      If `logger` <type>null</type> or "", SeasLog will use lastest logger setted by <methodname>SeasLog::setLogger</methodname>. 
      </para>
     </listitem>
    </varlistentry>
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   Return <type>true</type> on record log information success, <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/emergency.xml
+++ b/reference/seaslog/seaslog/emergency.xml
@@ -53,7 +53,7 @@
      <para>
       The `logger` cased by the third param would be used right this right now, 
       like a temp logger, when the function SeasLog::setLogger() called in pre content.
-      If `logger` NULL or "", SeasLog will use lastest logger setted by <methodname>SeasLog::setLogger</methodname>. 
+      If `logger` <type>null</type> or "", SeasLog will use lastest logger setted by <methodname>SeasLog::setLogger</methodname>. 
      </para>
     </listitem>
    </varlistentry>
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   Return <type>true</type> on record log information success, <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/error.xml
+++ b/reference/seaslog/seaslog/error.xml
@@ -53,7 +53,7 @@
      <para>
       The `logger` cased by the third param would be used right this right now, 
       like a temp logger, when the function SeasLog::setLogger() called in pre content.
-      If `logger` NULL or "", SeasLog will use lastest logger setted by <methodname>SeasLog::setLogger</methodname>. 
+      If `logger` <type>null</type> or "", SeasLog will use lastest logger setted by <methodname>SeasLog::setLogger</methodname>. 
      </para>
     </listitem>
    </varlistentry>
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   Return <type>true</type> on record log information success, <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/flushbuffer.xml
+++ b/reference/seaslog/seaslog/flushbuffer.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on flush buffer success, FALSE on failure.
+   Return <type>true</type> on flush buffer success, <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/getbufferenabled.xml
+++ b/reference/seaslog/seaslog/getbufferenabled.xml
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on <link linkend="ini.seaslog.use-buffer">seaslog.use_buffer</link> is true.
+   Return <type>true</type> on <link linkend="ini.seaslog.use-buffer">seaslog.use_buffer</link> is true.
    If switch <link linkend="ini.seaslog.buffer-disabled-in-cli">seaslog.buffer_disabled_in_cli</link> on, and running in cli, 
    seaslog.use_buffer setting will be discarded, Seaslog write to the Data Store IMMEDIATELY.
   </para>

--- a/reference/seaslog/seaslog/getrequestvariable.xml
+++ b/reference/seaslog/seaslog/getrequestvariable.xml
@@ -68,7 +68,7 @@ var_dump($oSeasLog->setRequestVariable(SEASLOG_REQUEST_VARIABLE_REQUEST_URI, $sR
 var_dump($oSeasLog->setRequestVariable(SEASLOG_REQUEST_VARIABLE_REQUEST_METHOD, $sRequestMethod));
 var_dump($oSeasLog->setRequestVariable(SEASLOG_REQUEST_VARIABLE_CLIENT_IP, $sClientIp));
 
-var_dump($oSeasLog->setRequestVariable($iErrorKey,NULL));
+var_dump($oSeasLog->setRequestVariable($iErrorKey,null));
 
 var_dump($oSeasLog->getRequestVariable(SEASLOG_REQUEST_VARIABLE_DOMAIN_PORT) == $sDomainPort);
 var_dump($oSeasLog->getRequestVariable(SEASLOG_REQUEST_VARIABLE_REQUEST_URI) == $sRequestUri);

--- a/reference/seaslog/seaslog/info.xml
+++ b/reference/seaslog/seaslog/info.xml
@@ -53,7 +53,7 @@
      <para>
       The `logger` cased by the third param would be used right this right now, 
       like a temp logger, when the function SeasLog::setLogger() called in pre content.
-      If `logger` NULL or "", SeasLog will use lastest logger setted by <methodname>SeasLog::setLogger</methodname>. 
+      If `logger` <type>null</type> or "", SeasLog will use lastest logger setted by <methodname>SeasLog::setLogger</methodname>. 
      </para>
     </listitem>
    </varlistentry>
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   Return <type>true</type> on record log information success, <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/log.xml
+++ b/reference/seaslog/seaslog/log.xml
@@ -68,7 +68,7 @@
      <para>
       The `logger` cased by the third param would be used right this right now, 
       like a temp logger, when the function SeasLog::setLogger() called in pre content.
-      If `logger` NULL or "", SeasLog will use lastest logger setted by <methodname>SeasLog::setLogger</methodname>. 
+      If `logger` <type>null</type> or "", SeasLog will use lastest logger setted by <methodname>SeasLog::setLogger</methodname>. 
      </para>
     </listitem>
    </varlistentry>
@@ -78,7 +78,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   Return <type>true</type> on record log information success, <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/notice.xml
+++ b/reference/seaslog/seaslog/notice.xml
@@ -53,7 +53,7 @@
      <para>
       The `logger` cased by the third param would be used right this right now, 
       like a temp logger, when the function SeasLog::setLogger() called in pre content.
-      If `logger` NULL or "", SeasLog will use lastest logger setted by <methodname>SeasLog::setLogger</methodname>. 
+      If `logger` null or "", SeasLog will use lastest logger setted by <methodname>SeasLog::setLogger</methodname>. 
      </para>
     </listitem>
    </varlistentry>
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   Return <type>true</type> on record log information success, <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/setbasepath.xml
+++ b/reference/seaslog/seaslog/setbasepath.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on setted base path success, FALSE on failure.
+   Return <type>true</type> on setted base path success, <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/setdatetimeformat.xml
+++ b/reference/seaslog/seaslog/setdatetimeformat.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on setted datetime format success, FALSE on failure.
+   Return <type>true</type> on setted datetime format success, <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/setlogger.xml
+++ b/reference/seaslog/seaslog/setlogger.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on created logger disectory success, FALSE on failure.
+   Return <type>true</type> on created logger disectory success, <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/setrequestid.xml
+++ b/reference/seaslog/seaslog/setrequestid.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on set request_id success, FALSE on failure.
+   Return <type>true</type> on set request_id success, <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/seaslog/seaslog/setrequestvariable.xml
+++ b/reference/seaslog/seaslog/setrequestvariable.xml
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on set success, FALSE on failure.
+   Return <type>true</type> on set success, <type>false</type> on failure.
   </para>
  </refsect1>
 
@@ -77,7 +77,7 @@ var_dump($oSeasLog->setRequestVariable(SEASLOG_REQUEST_VARIABLE_REQUEST_URI, $sR
 var_dump($oSeasLog->setRequestVariable(SEASLOG_REQUEST_VARIABLE_REQUEST_METHOD, $sRequestMethod));
 var_dump($oSeasLog->setRequestVariable(SEASLOG_REQUEST_VARIABLE_CLIENT_IP, $sClientIp));
 
-var_dump($oSeasLog->setRequestVariable($iErrorKey,NULL));
+var_dump($oSeasLog->setRequestVariable($iErrorKey,null));
 
 var_dump($oSeasLog->getRequestVariable(SEASLOG_REQUEST_VARIABLE_DOMAIN_PORT) == $sDomainPort);
 var_dump($oSeasLog->getRequestVariable(SEASLOG_REQUEST_VARIABLE_REQUEST_URI) == $sRequestUri);

--- a/reference/seaslog/seaslog/warning.xml
+++ b/reference/seaslog/seaslog/warning.xml
@@ -54,7 +54,7 @@
      <para>
       The `logger` cased by the third param would be used right this right now, 
       like a temp logger, when the function SeasLog::setLogger() called in pre content.
-      If `logger` NULL or "", SeasLog will use lastest logger setted by <methodname>SeasLog::setLogger</methodname>. 
+      If `logger` <type>null</type> or "", SeasLog will use lastest logger setted by <methodname>SeasLog::setLogger</methodname>. 
      </para>
     </listitem>
    </varlistentry>
@@ -64,7 +64,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE on record log information success, FALSE on failure.
+   Return <type>true</type> on record log information success, <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/simplexml/simplexmlelement/children.xml
+++ b/reference/simplexml/simplexmlelement/children.xml
@@ -115,13 +115,13 @@ $sxe = new SimpleXMLElement($xml);
 $kids = $sxe->children('foo');
 var_dump(count($kids));
 
-$kids = $sxe->children('foo', TRUE);
+$kids = $sxe->children('foo', true);
 var_dump(count($kids));
 
 $kids = $sxe->children('my.foo.urn');
 var_dump(count($kids));
 
-$kids = $sxe->children('my.foo.urn', TRUE);
+$kids = $sxe->children('my.foo.urn', true);
 var_dump(count($kids));
 
 $kids = $sxe->children();

--- a/reference/simplexml/simplexmlelement/getDocNamespaces.xml
+++ b/reference/simplexml/simplexmlelement/getDocNamespaces.xml
@@ -108,7 +108,7 @@ XML;
  
 $sxe = new SimpleXMLElement($xml);
 
-$namespaces = $sxe->getDocNamespaces(TRUE);
+$namespaces = $sxe->getDocNamespaces(true);
 var_dump($namespaces);
 
 ?>

--- a/reference/snmp/snmp/walk.xml
+++ b/reference/snmp/snmp/walk.xml
@@ -115,9 +115,9 @@ Array
 <?php
   $session = new SNMP(SNMP::VERSION_1, "127.0.0.1", "public");
   $session->valueretrieval = SNMP_VALUE_PLAIN;
-  $ifDescr = $session->walk(".1.3.6.1.2.1.2.2.1.2", TRUE);
+  $ifDescr = $session->walk(".1.3.6.1.2.1.2.2.1.2", true);
   $session->valueretrieval = SNMP_VALUE_LIBRARY;
-  $ifType = $session->walk(".1.3.6.1.2.1.2.2.1.3", TRUE);
+  $ifType = $session->walk(".1.3.6.1.2.1.2.2.1.3", true);
   print_r($ifDescr);
   print_r($ifType);
   $result = array();

--- a/reference/soap/soapclient/soapcall.xml
+++ b/reference/soap/soapclient/soapcall.xml
@@ -119,7 +119,7 @@ $client = new SoapClient("some.wsdl");
 $client->SomeFunction($a, $b, $c);
 
 $client->__soapCall("SomeFunction", array($a, $b, $c));
-$client->__soapCall("SomeFunction", array($a, $b, $c), NULL,
+$client->__soapCall("SomeFunction", array($a, $b, $c), null,
                     new SoapHeader(), $output_headers);
 
 

--- a/reference/soap/soapserver/getfunctions.xml
+++ b/reference/soap/soapserver/getfunctions.xml
@@ -40,7 +40,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$server = new SoapServer(NULL, array("uri" => "http://test-uri"));
+$server = new SoapServer(null, array("uri" => "http://test-uri"));
 $server->addFunction(SOAP_FUNCTIONS_ALL);
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
   $server->handle();

--- a/reference/sockets/functions/socket-select.xml
+++ b/reference/sockets/functions/socket-select.xml
@@ -107,7 +107,7 @@
      <programlisting role="php">
 <![CDATA[
 <?php
-$e = NULL;
+$e = null;
 socket_select($r, $w, $e, 0);
 ?>
 ]]>
@@ -136,7 +136,7 @@ socket_select($r, $w, $e, 0);
      <programlisting role="php">
 <![CDATA[
 <?php
-$e = NULL;
+$e = null;
 if (false === socket_select($r, $w, $e, 0)) {
     echo "socket_select() failed, reason: " .
         socket_strerror(socket_last_error()) . "\n";
@@ -159,8 +159,8 @@ if (false === socket_select($r, $w, $e, 0)) {
 <?php
 /* Prepare the read array */
 $read   = array($socket1, $socket2);
-$write  = NULL;
-$except = NULL;
+$write  = null;
+$except = null;
 $num_changed_sockets = socket_select($read, $write, $except, 0);
 
 if ($num_changed_sockets === false) {

--- a/reference/spl/callbackfilteriterator.xml
+++ b/reference/spl/callbackfilteriterator.xml
@@ -69,7 +69,7 @@
  * @param $current   Current item's value
  * @param $key       Current item's key
  * @param $iterator  Iterator being filtered
- * @return boolean   TRUE to accept the current item, FALSE otherwise
+ * @return boolean   true to accept the current item, false otherwise
  */
 function my_callback($current, $key, $iterator) {
     // Your filtering code here

--- a/reference/spl/directoryiterator/valid.xml
+++ b/reference/spl/directoryiterator/valid.xml
@@ -43,9 +43,9 @@ while($iterator->valid()) {
     $iterator->next();
 }
 
-$iterator->valid(); // FALSE
+$iterator->valid(); // false
 $iterator->rewind(); 
-$iterator->valid(); // TRUE
+$iterator->valid(); // true
 
 ?>
 ]]>

--- a/reference/spl/functions/iterator-apply.xml
+++ b/reference/spl/functions/iterator-apply.xml
@@ -80,7 +80,7 @@
 <?php
 function print_caps(Iterator $iterator) {
     echo strtoupper($iterator->current()) . "\n";
-    return TRUE;
+    return true;
 }
 
 $it = new ArrayIterator(array("Apples", "Bananas", "Cherries"));

--- a/reference/spl/recursivecallbackfilteriterator.xml
+++ b/reference/spl/recursivecallbackfilteriterator.xml
@@ -77,7 +77,7 @@
  * @param $current   Current item's value
  * @param $key       Current item's key
  * @param $iterator  Iterator being filtered
- * @return boolean   TRUE to accept the current item, FALSE otherwise
+ * @return boolean   true to accept the current item, false otherwise
  */
 function my_callback($current, $key, $iterator) {
     // Your filtering code here
@@ -106,13 +106,13 @@ $dir = new RecursiveDirectoryIterator(__DIR__);
 $files = new RecursiveCallbackFilterIterator($dir, function ($current, $key, $iterator) {
     // Allow recursion
     if ($iterator->hasChildren()) {
-        return TRUE;
+        return true;
     }
     // Check for large file
     if ($current->isFile() && $current->getSize() > 104857600) {
-        return TRUE;
+        return true;
     }
-    return FALSE;
+    return false;
 });
  
 foreach (new RecursiveIteratorIterator($files) as $file) {

--- a/reference/spl/recursivecallbackfilteriterator/haschildren.xml
+++ b/reference/spl/recursivecallbackfilteriterator/haschildren.xml
@@ -44,13 +44,13 @@ $dir = new RecursiveDirectoryIterator(__DIR__);
 $files = new RecursiveCallbackFilterIterator($dir, function ($current, $key, $iterator) {
     // Allow recursion into directories
     if ($iterator->hasChildren()) {
-        return TRUE;
+        return true;
     }
     // Check for XML file
     if (!strcasecmp($current->getExtension(), 'xml')) {
-        return TRUE;
+        return true;
     }
-    return FALSE;
+    return false;
 });
 
 ?>

--- a/reference/spl/recursivefilteriterator/construct.xml
+++ b/reference/spl/recursivefilteriterator/construct.xml
@@ -46,7 +46,7 @@ class TestsOnlyFilter extends RecursiveFilterIterator {
     public function accept() {
         // Accept the current item if we can recurse into it
         // or it is a value starting with "test"
-        return $this->hasChildren() || (strpos($this->current(), "test") !== FALSE);
+        return $this->hasChildren() || (strpos($this->current(), "test") !== false);
     }
 }
 

--- a/reference/spl/splobjectstorage/attach.xml
+++ b/reference/spl/splobjectstorage/attach.xml
@@ -65,7 +65,7 @@
 $o1 = new stdClass;
 $o2 = new stdClass;
 $s = new SplObjectStorage();
-$s->attach($o1); // similar to $s[$o1] = NULL;
+$s->attach($o1); // similar to $s[$o1] = null;
 $s->attach($o2, "hello"); // similar to $s[$o2] = "hello";
 
 var_dump($s[$o1]);

--- a/reference/sqlite3/sqlite3result/fetcharray.xml
+++ b/reference/sqlite3/sqlite3result/fetcharray.xml
@@ -72,7 +72,7 @@
    as follows: integers are mapped to <type>int</type> if they fit into the
    range <constant>PHP_INT_MIN</constant>..<constant>PHP_INT_MAX</constant>, and
    to <type>string</type> otherwise. Floats are mapped to <type>float</type>,
-   <literal>NULL</literal> values are mapped to <type>null</type>, and strings
+   <type>null</type> values are mapped to <type>null</type>, and strings
    and blobs are mapped to <type>string</type>.
   </para>
  </refsect1>

--- a/reference/sqlite3/sqlite3stmt/getsql.xml
+++ b/reference/sqlite3/sqlite3stmt/getsql.xml
@@ -70,7 +70,7 @@ var_dump($stmt->getSQL(true));
    &example.outputs.similar;
    <screen>
 <![CDATA[
-string(24) "SELECT 'foo', '42', NULL"
+string(24) "SELECT 'foo', '42', null"
 ]]>
    </screen>
   </example>

--- a/reference/stream/functions/stream-select.xml
+++ b/reference/stream/functions/stream-select.xml
@@ -168,8 +168,8 @@
 <?php
 /* Prepare the read array */
 $read   = array($stream1, $stream2);
-$write  = NULL;
-$except = NULL;
+$write  = null;
+$except = null;
 if (false === ($num_changed_streams = stream_select($read, $write, $except, 0))) {
     /* Error handling */
 } elseif ($num_changed_streams > 0) {
@@ -194,7 +194,7 @@ if (false === ($num_changed_streams = stream_select($read, $write, $except, 0)))
     <programlisting role="php">
 <![CDATA[
 <?php
-$e = NULL;
+$e = null;
 stream_select($r, $w, $e, 0);
 ?>
 ]]>
@@ -209,7 +209,7 @@ stream_select($r, $w, $e, 0);
    <programlisting role="php">
 <![CDATA[
 <?php
-$e = NULL;
+$e = null;
 if (false === stream_select($r, $w, $e, 0)) {
     echo "stream_select() failed\n";
 }

--- a/reference/strings/functions/stristr.xml
+++ b/reference/strings/functions/stristr.xml
@@ -122,7 +122,7 @@
 <![CDATA[
 <?php
   $string = 'Hello World!';
-  if (stristr($string, 'earth') === FALSE) {
+  if (stristr($string, 'earth') === false) {
     echo '"earth" not found in string';
   }
 // outputs: "earth" not found in string

--- a/reference/swoole/swoole/connection/iterator/offsetexists.xml
+++ b/reference/swoole/swoole/connection/iterator/offsetexists.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns TRUE if the offset exists, otherwise FALSE.
+   Returns <type>true</type> if the offset exists, otherwise <type>false</type>.
   </para>
  </refsect1>
 

--- a/reference/swoole/swoole/connection/iterator/valid.xml
+++ b/reference/swoole/swoole/connection/iterator/valid.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns TRUE if the current iterator position is valid, otherwise FALSE.
+   Returns <type>true</type> if the current iterator position is valid, otherwise <type>false</type>.
   </para>
  </refsect1>
 

--- a/reference/swoole/swoole/process/signal.xml
+++ b/reference/swoole/swoole/process/signal.xml
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   If signal sent successfully, it returns TRUE, otherwise it returns FALSE.
+   If signal sent successfully, it returns <type>true</type>, otherwise it returns <type>false</type>.
   </para>
  </refsect1>
 

--- a/reference/sync/syncreaderwriter/construct.xml
+++ b/reference/sync/syncreaderwriter/construct.xml
@@ -51,7 +51,7 @@
      </para>
      <warning>
       <para>
-       If an object is:  A named reader-writer with an autounlock of FALSE, the
+       If an object is:  A named reader-writer with an autounlock of <type>false</type>, the
        object is locked for either reading or writing, and the PHP script concludes
        before the object is unlocked, then the underlying objects will end up in an
        inconsistent state.

--- a/reference/taint/functions/is-tainted.xml
+++ b/reference/taint/functions/is-tainted.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return TRUE if the string is tainted, FALSE otherwise.
+   Return <type>true</type> if the string is tainted, <type>false</type> otherwise.
   </para>
  </refsect1>
 

--- a/reference/taint/functions/taint.xml
+++ b/reference/taint/functions/taint.xml
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-      Return TRUE if the transformation is done. Always return TRUE if the taint
+      Return <type>true</type> if the transformation is done. Always return <type>false</type> if the taint
       extension is not enabled.    
   </para>
  </refsect1>

--- a/reference/tidy/tidy/getconfig.xml
+++ b/reference/tidy/tidy/getconfig.xml
@@ -59,8 +59,8 @@
 <![CDATA[
 <?php
 $html = '<p>test</p>';
-$config = array('indent' => TRUE,
-                'output-xhtml' => TRUE,
+$config = array('indent' => true,
+                'output-xhtml' => true,
                 'wrap' => 200);
 
 $tidy = tidy_parse_string($html, $config);

--- a/reference/tidy/tidy/parsestring.xml
+++ b/reference/tidy/tidy/parsestring.xml
@@ -126,8 +126,8 @@ ob_start();
 <?php
 
 $buffer = ob_get_clean();
-$config = array('indent' => TRUE,
-                'output-xhtml' => TRUE,
+$config = array('indent' => true,
+                'output-xhtml' => true,
                 'wrap' => 200);
 
 $tidy = tidy_parse_string($buffer, $config, 'UTF8');

--- a/reference/var/functions/gettype.xml
+++ b/reference/var/functions/gettype.xml
@@ -109,7 +109,7 @@
 <![CDATA[
 <?php
 
-$data = array(1, 1., NULL, new stdClass, 'foo');
+$data = array(1, 1., null, new stdClass, 'foo');
 
 foreach ($data as $value) {
     echo gettype($value), "\n";

--- a/reference/var/functions/is-int.xml
+++ b/reference/var/functions/is-int.xml
@@ -70,7 +70,7 @@ is_int(23) = bool(true)
 is_int('23') = bool(false)
 is_int(23.5) = bool(false)
 is_int('23.5') = bool(false)
-is_int(NULL) = bool(false)
+is_int(null) = bool(false)
 is_int(true) = bool(false)
 is_int(false) = bool(false)
 

--- a/reference/var/functions/is-null.xml
+++ b/reference/var/functions/is-null.xml
@@ -50,7 +50,7 @@
 
 error_reporting(E_ALL);
 
-$foo = NULL;
+$foo = null;
 var_dump(is_null($inexistent), is_null($foo));
 
 ?>

--- a/reference/var/functions/is-string.xml
+++ b/reference/var/functions/is-string.xml
@@ -60,7 +60,7 @@ foreach ($values as $value) {
 <![CDATA[
 is_string(false) = bool(false)
 is_string(true) = bool(false)
-is_string(NULL) = bool(false)
+is_string(null) = bool(false)
 is_string('abc') = bool(true)
 is_string('23') = bool(true)
 is_string(23) = bool(false)

--- a/reference/var/functions/isset.xml
+++ b/reference/var/functions/isset.xml
@@ -78,7 +78,7 @@
 
 $var = '';
 
-// This will evaluate to TRUE so the text will be printed.
+// This will evaluate to true so the text will be printed.
 if (isset($var)) {
     echo "This var is set so I will print.", PHP_EOL;
 }
@@ -89,16 +89,16 @@ if (isset($var)) {
 $a = "test";
 $b = "anothertest";
 
-var_dump(isset($a));      // TRUE
-var_dump(isset($a, $b)); // TRUE
+var_dump(isset($a));      // true
+var_dump(isset($a, $b)); // true
 
 unset ($a);
 
-var_dump(isset($a));     // FALSE
-var_dump(isset($a, $b)); // FALSE
+var_dump(isset($a));     // false
+var_dump(isset($a, $b)); // false
 
-$foo = NULL;
-var_dump(isset($foo));   // FALSE
+$foo = null;
+var_dump(isset($foo));   // false
 
 ?>
 ]]>
@@ -113,20 +113,20 @@ var_dump(isset($foo));   // FALSE
 <![CDATA[
 <?php
 
-$a = array ('test' => 1, 'hello' => NULL, 'pie' => array('a' => 'apple'));
+$a = array ('test' => 1, 'hello' => null, 'pie' => array('a' => 'apple'));
 
-var_dump(isset($a['test']));            // TRUE
-var_dump(isset($a['foo']));             // FALSE
-var_dump(isset($a['hello']));           // FALSE
+var_dump(isset($a['test']));            // true
+var_dump(isset($a['foo']));             // false
+var_dump(isset($a['hello']));           // false
 
 // The key 'hello' equals NULL so is considered unset
 // If you want to check for NULL key values then try: 
-var_dump(array_key_exists('hello', $a)); // TRUE
+var_dump(array_key_exists('hello', $a)); // true
 
 // Checking deeper array values
-var_dump(isset($a['pie']['a']));        // TRUE
-var_dump(isset($a['pie']['b']));        // FALSE
-var_dump(isset($a['cake']['a']['b']));  // FALSE
+var_dump(isset($a['pie']['a']));        // true
+var_dump(isset($a['pie']['b']));        // false
+var_dump(isset($a['cake']['a']['b']));  // false
 
 ?>
 ]]>

--- a/reference/wincache/functions/wincache-refresh-if-changed.xml
+++ b/reference/wincache/functions/wincache-refresh-if-changed.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>wincache_refresh_if_changed</methodname>
-   <methodparam choice="opt"><type>array</type><parameter>files</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter>files</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Refreshes the cache entries for the files, whose names were passed in the input argument. 
@@ -60,7 +60,7 @@
 <?php 
 $filename = 'C:\inetpub\wwwroot\config.php';
 $handle = fopen($filename, 'w+');
-if ($handle === FALSE) die('Failed to open file '.$filename.' for writing');
+if ($handle === false) die('Failed to open file '.$filename.' for writing');
 fwrite($handle, '<?php $setting=something; ?>');
 fclose($handle);
 wincache_refresh_if_changed(array($filename));

--- a/reference/wincache/functions/wincache-ucache-add.xml
+++ b/reference/wincache/functions/wincache-ucache-add.xml
@@ -18,7 +18,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>wincache_ucache_add</methodname>
    <methodparam><type>array</type><parameter>values</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>unused</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>unused</parameter><initializer>null</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/wincache/functions/wincache-ucache-info.xml
+++ b/reference/wincache/functions/wincache-ucache-info.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <type class="union"><type>array</type><type>false</type></type><methodname>wincache_ucache_info</methodname>
    <methodparam choice="opt"><type>bool</type><parameter>summaryonly</parameter><initializer>&false;</initializer></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>key</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>key</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
    Retrieves information about data stored in the user cache.

--- a/reference/wincache/functions/wincache-ucache-set.xml
+++ b/reference/wincache/functions/wincache-ucache-set.xml
@@ -18,7 +18,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>wincache_ucache_set</methodname>
    <methodparam><type>array</type><parameter>values</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>unused</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>unused</parameter><initializer>null</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/xmldiff/xmldiff-dom/diff.xml
+++ b/reference/xmldiff/xmldiff-dom/diff.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   DOMDocument with the diff information or NULL.
+   DOMDocument with the diff information or <type>null</type>.
   </para>
  </refsect1>
 

--- a/reference/xmldiff/xmldiff-dom/merge.xml
+++ b/reference/xmldiff/xmldiff-dom/merge.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Merged DOMDocument or NULL. 
+   Merged DOMDocument or <type>null</type>. 
   </para>
  </refsect1>
 

--- a/reference/xmldiff/xmldiff-file/diff.xml
+++ b/reference/xmldiff/xmldiff-file/diff.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   String with the XML document containing the diff information or NULL. 
+   String with the XML document containing the diff information or <type>null</type>. 
   </para>
  </refsect1>
 

--- a/reference/xmldiff/xmldiff-file/merge.xml
+++ b/reference/xmldiff/xmldiff-file/merge.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   String with the new XML document or NULL. 
+   String with the new XML document or <type>null</type>. 
   </para>
  </refsect1>
 

--- a/reference/xmldiff/xmldiff-memory/diff.xml
+++ b/reference/xmldiff/xmldiff-memory/diff.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   String with the XML document containing the diff information or NULL. 
+   String with the XML document containing the diff information or <type>null</type>. 
   </para>
  </refsect1>
 

--- a/reference/xmldiff/xmldiff-memory/merge.xml
+++ b/reference/xmldiff/xmldiff-memory/merge.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   String with the new XML document or NULL. 
+   String with the new XML document or <type>null</type>. 
   </para>
  </refsect1>
 

--- a/reference/yaconf/yaconf/get.xml
+++ b/reference/yaconf/yaconf/get.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type>mixed</type><methodname>Yaconf::get</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>default_value</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>default_value</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <para>
 

--- a/reference/yaf/yaf-plugin-abstract.xml
+++ b/reference/yaf/yaf-plugin-abstract.xml
@@ -73,7 +73,7 @@
 
    Class IndexController extends Yaf_Controller_Abstract {
         public function indexAction() {
-            return FALSE; //prevent rendering
+            return false; //prevent rendering
         }
    }
 

--- a/reference/yaf/yaf_controller_abstract/forward.xml
+++ b/reference/yaf/yaf_controller_abstract/forward.xml
@@ -45,7 +45,7 @@
     <term><parameter>module</parameter></term>
     <listitem>
      <para>
-       destination module name, if NULL was given, then default module name
+       destination module name, if <type>null</type> was given, then default module name
        is assumed
      </para>
     </listitem>
@@ -97,7 +97,7 @@ class IndexController extends Yaf_Controller_Abstract
          $logined = $_SESSION["login"];
          if (!$logined) {
              $this->forward("login", array("from" => "Index")); // forward to login action
-             return FALSE;  // this is important, this finish current working flow
+             return false;  // this is important, this finish current working flow
                             // and tell the Yaf do not doing auto-render
          }
 

--- a/reference/yaf/yaf_dispatcher/autorender.xml
+++ b/reference/yaf/yaf_dispatcher/autorender.xml
@@ -66,7 +66,7 @@ class IndexController extends Yaf_Controller_Abstract {
          if ($this->getRequest()->isXmlHttpRequest()) {
              //do not call render for ajax request
              //we will outpu a json string
-             Yaf_Dispatcher::getInstance()->autoRender(FALSE);
+             Yaf_Dispatcher::getInstance()->autoRender(false);
          }
      } 
 

--- a/reference/yaf/yaf_dispatcher/catchexception.xml
+++ b/reference/yaf/yaf_dispatcher/catchexception.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
      While the application.dispatcher.throwException is On(you can also calling
-     to <methodname>Yaf_Dispatcher::throwException(TRUE)</methodname> to enable it),  Yaf will throw Exception when
+     to <methodname>Yaf_Dispatcher::throwException(true)</methodname> to enable it),  Yaf will throw Exception when
      error occurs instead of trigger error. 
   </para>
   <para>   

--- a/reference/yaf/yaf_dispatcher/setview.xml
+++ b/reference/yaf/yaf_dispatcher/setview.xml
@@ -168,11 +168,11 @@ class Smarty_Adapter implements Yaf_View_Interface
      * @param string $name The template to process.
      * @return string The output.
      */
-    public function render($name, $value = NULL) {
+    public function render($name, $value = null) {
         return $this->_smarty->fetch($name);
     }
 
-    public function display($name, $value = NULL) {
+    public function display($name, $value = null) {
         echo $this->_smarty->fetch($name);
     }
 

--- a/reference/yaf/yaf_plugin_abstract/routershutdown.xml
+++ b/reference/yaf/yaf_plugin_abstract/routershutdown.xml
@@ -68,16 +68,16 @@ class UserInitPlugin extends Yaf_Plugin_Abstract {
         if (in_array(strtolower($controller), array(
             'api',  
         ))) {
-            return TRUE;
+            return true;
         }
        
         if (Yaf_Session::getInstance()->has("login")) {
-            return TRUE;
+            return true;
         }
  
         /* Use access check failed, need to login */
         $response->setRedirect("http://yourdomain.com/login/");
-        return FALSE;
+        return false;
     }
 }
 ?>

--- a/reference/yaf/yaf_request_http/getraw.xml
+++ b/reference/yaf/yaf_request_http/getraw.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return string on success, FALSE on failure.
+   Return string on success, <type>false</type> on failure.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_response_abstract/getbody.xml
+++ b/reference/yaf/yaf_response_abstract/getbody.xml
@@ -60,7 +60,7 @@ $response->setBody("Hello")->setBody(" World", "footer");
 var_dump($response->getBody()); //default 
 var_dump($response->getBody(Yaf_Response_Abstract::DEFAULT_BODY)); //same as above
 var_dump($response->getBody("footer"));
-var_dump($response->getBody(NULL)); //get all
+var_dump($response->getBody(null)); //get all
 ?>
 ]]>
    </programlisting>

--- a/reference/yaf/yaf_route_map/construct.xml
+++ b/reference/yaf/yaf_route_map/construct.xml
@@ -118,7 +118,7 @@ array(
     $config = array(
         "name" => array(
            "type"  => "map",         //Yaf_Route_Map route
-           "controllerPrefer" => FALSE,
+           "controllerPrefer" => false,
            "delimiter"        => "#!", 
            ),
     );

--- a/reference/yaf/yaf_view_simple/assignref.xml
+++ b/reference/yaf/yaf_view_simple/assignref.xml
@@ -68,7 +68,7 @@ class IndexController extends Yaf_Controller_Abstract {
         echo $value;
 
         //prevent the auto-render
-        Yaf_Dispatcher::getInstance()->autoRender(FALSE);
+        Yaf_Dispatcher::getInstance()->autoRender(false);
     }
 }
 ?>

--- a/reference/yar/yar_concurrent_client/call.xml
+++ b/reference/yar/yar_concurrent_client/call.xml
@@ -87,9 +87,9 @@ function error_callback($type, $error, $callinfo) {
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));   // if the callback is not specificed, 
                                                                                // callback in loop will be used
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", null, array(YAR_OPT_PACKAGER => "json"));
                                                                                //this server accept json packager
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT=>1));
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", null, array(YAR_OPT_TIMEOUT=>1));
                                                                                //custom timeout 
 
 //The requests are not sent yet

--- a/reference/yar/yar_concurrent_client/loop.xml
+++ b/reference/yar/yar_concurrent_client/loop.xml
@@ -27,7 +27,7 @@
     <listitem>
      <para>
       If this callback is set, then Yar will call this callback after all
-      calls are sent and before any response return, with a $callinfo NULL.
+      calls are sent and before any response return, with a $callinfo <type>null</type>.
      </para>
      <para>
       Then, if user didn't specify callback when registering concurrent call,
@@ -63,7 +63,7 @@
 <![CDATA[
 <?php
 function callback($retval, $callinfo) {
-     if ($callinfo == NULL) {
+     if ($callinfo == null) {
         echo "Now, all requests are sent, and no any response available\n";
      } else {
         echo "This is a remote call response, the method name is", $callinfo["method"], 
@@ -79,9 +79,9 @@ function error_callback($type, $error, $callinfo) {
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));   // if the callback is not specificed, 
                                                                                // callback in loop will be used
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", null, array(YAR_OPT_PACKAGER => "json"));
                                                                                //this server accept json packager
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT=>1));
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", null, array(YAR_OPT_TIMEOUT=>1));
                                                                                //custom timeout 
 
 Yar_Concurrent_Client::loop("callback", "error_callback"); //send the requests, 

--- a/reference/yaz/functions/yaz-record.xml
+++ b/reference/yaz/functions/yaz-record.xml
@@ -270,7 +270,7 @@ $rec = yaz_record($id, $p, "xml; charset=marc-8,utf-8");
 $xslfile = 'display.xsl';
 $processor = xslt_create();
 $parms = array('/_xml' => $rec);
-$res = xslt_process($processor, 'arg:/_xml', $xslfile, NULL, $parms);
+$res = xslt_process($processor, 'arg:/_xml', $xslfile, null, $parms);
 xslt_free($processor);
 $res = preg_replace("'</?html[^>]*>'", '', $res);
 echo $res;

--- a/reference/zip/examples.xml
+++ b/reference/zip/examples.xml
@@ -12,7 +12,7 @@
 $zip = new ZipArchive();
 $filename = "./test112.zip";
 
-if ($zip->open($filename, ZipArchive::CREATE)!==TRUE) {
+if ($zip->open($filename, ZipArchive::CREATE)!==true) {
     exit("cannot open <$filename>\n");
 }
 

--- a/reference/zip/ziparchive/addemptydir.xml
+++ b/reference/zip/ziparchive/addemptydir.xml
@@ -85,7 +85,7 @@
 <![CDATA[
 <?php
 $zip = new ZipArchive;
-if ($zip->open('test.zip') === TRUE) {
+if ($zip->open('test.zip') === true) {
     if($zip->addEmptyDir('newDirectory')) {
         echo 'Created a new root directory';
     } else {

--- a/reference/zip/ziparchive/addfile.xml
+++ b/reference/zip/ziparchive/addfile.xml
@@ -135,7 +135,7 @@
 <![CDATA[
 <?php
 $zip = new ZipArchive;
-if ($zip->open('test.zip') === TRUE) {
+if ($zip->open('test.zip') === true) {
     $zip->addFile('/path/to/index.txt', 'newname.txt');
     $zip->close();
     echo 'ok';

--- a/reference/zip/ziparchive/addfromstring.xml
+++ b/reference/zip/ziparchive/addfromstring.xml
@@ -96,7 +96,7 @@
 <?php
 $zip = new ZipArchive;
 $res = $zip->open('test.zip', ZipArchive::CREATE);
-if ($res === TRUE) {
+if ($res === true) {
     $zip->addFromString('test.txt', 'file content goes here');
     $zip->close();
     echo 'ok';
@@ -113,7 +113,7 @@ if ($res === TRUE) {
 <![CDATA[
 <?php
 $zip = new ZipArchive;
-if ($zip->open('test.zip') === TRUE) {
+if ($zip->open('test.zip') === true) {
     $zip->addFromString('dir/test.txt', 'file content goes here');
     $zip->close();
     echo 'ok';

--- a/reference/zip/ziparchive/addglob.xml
+++ b/reference/zip/ziparchive/addglob.xml
@@ -185,10 +185,10 @@
 <?php
 $zip = new ZipArchive();
 $ret = $zip->open('application.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE);
-if ($ret !== TRUE) {
+if ($ret !== true) {
     printf('Failed with code %d', $ret);
 } else {
-    $options = array('add_path' => 'sources/', 'remove_all_path' => TRUE);
+    $options = array('add_path' => 'sources/', 'remove_all_path' => true);
     $zip->addGlob('*.{php,txt}', GLOB_BRACE, $options);
     $zip->close();
 }

--- a/reference/zip/ziparchive/addpattern.xml
+++ b/reference/zip/ziparchive/addpattern.xml
@@ -69,7 +69,7 @@
 <?php
 $zip = new ZipArchive();
 $ret = $zip->open('application.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE);
-if ($ret !== TRUE) {
+if ($ret !== true) {
     printf('Failed with code %d', $ret);
 } else {
     $directory = realpath('.');

--- a/reference/zip/ziparchive/deleteindex.xml
+++ b/reference/zip/ziparchive/deleteindex.xml
@@ -44,7 +44,7 @@
 <![CDATA[
 <?php
 $zip = new ZipArchive;
-if ($zip->open('test.zip') === TRUE) {
+if ($zip->open('test.zip') === true) {
     $zip->deleteIndex(2);
     $zip->close();
     echo 'ok';

--- a/reference/zip/ziparchive/deletename.xml
+++ b/reference/zip/ziparchive/deletename.xml
@@ -44,7 +44,7 @@
 <![CDATA[
 <?php
 $zip = new ZipArchive;
-if ($zip->open('test1.zip') === TRUE) {
+if ($zip->open('test1.zip') === true) {
     $zip->deleteName('testfromfile.php');
     $zip->deleteName('testDir/');
     $zip->close();

--- a/reference/zip/ziparchive/extractto.xml
+++ b/reference/zip/ziparchive/extractto.xml
@@ -69,7 +69,7 @@
 <![CDATA[
 <?php
 $zip = new ZipArchive;
-if ($zip->open('test.zip') === TRUE) {
+if ($zip->open('test.zip') === true) {
     $zip->extractTo('/my/destination/dir/');
     $zip->close();
     echo 'ok';
@@ -87,7 +87,7 @@ if ($zip->open('test.zip') === TRUE) {
 <?php
 $zip = new ZipArchive;
 $res = $zip->open('test_im.zip');
-if ($res === TRUE) {
+if ($res === true) {
     $zip->extractTo('/my/destination/dir/', array('pear_item.gif', 'testfromfile.php'));
     $zip->close();
     echo 'ok';

--- a/reference/zip/ziparchive/getarchivecomment.xml
+++ b/reference/zip/ziparchive/getarchivecomment.xml
@@ -49,7 +49,7 @@
 <?php
 $zip = new ZipArchive;
 $res = $zip->open('test_with_comment.zip');
-if ($res === TRUE) {
+if ($res === true) {
     var_dump($zip->getArchiveComment());
     /* Or using the archive property */
     var_dump($zip->comment);

--- a/reference/zip/ziparchive/getcommentindex.xml
+++ b/reference/zip/ziparchive/getcommentindex.xml
@@ -55,7 +55,7 @@
 <?php
 $zip = new ZipArchive;
 $res = $zip->open('test1.zip');
-if ($res === TRUE) {
+if ($res === true) {
     var_dump($zip->getCommentIndex(1));
 } else {
     echo 'failed, code:' . $res;

--- a/reference/zip/ziparchive/getcommentname.xml
+++ b/reference/zip/ziparchive/getcommentname.xml
@@ -55,7 +55,7 @@
 <?php
 $zip = new ZipArchive;
 $res = $zip->open('test1.zip');
-if ($res === TRUE) {
+if ($res === true) {
     var_dump($zip->getCommentName('test/entry1.txt'));
 } else {
     echo 'failed, code:' . $res;

--- a/reference/zip/ziparchive/getexternalattributesindex.xml
+++ b/reference/zip/ziparchive/getexternalattributesindex.xml
@@ -77,7 +77,7 @@
 <![CDATA[
 <?php
 $zip = new ZipArchive();
-if ($zip->open('test.zip') === TRUE) {
+if ($zip->open('test.zip') === true) {
     for ($idx=0 ; $s = $zip->statIndex($idx) ; $idx++) {
         if ($zip->extractTo('.', $s['name'])) {
             if ($zip->getExternalAttributesIndex($idx, $opsys, $attr) 

--- a/reference/zip/ziparchive/getfromindex.xml
+++ b/reference/zip/ziparchive/getfromindex.xml
@@ -76,7 +76,7 @@
 <![CDATA[
 <?php
 $zip = new ZipArchive;
-if ($zip->open('test.zip') === TRUE) {
+if ($zip->open('test.zip') === true) {
     echo $zip->getFromIndex(2);
     $zip->close();
 } else {

--- a/reference/zip/ziparchive/getfromname.xml
+++ b/reference/zip/ziparchive/getfromname.xml
@@ -81,7 +81,7 @@
 <![CDATA[
 <?php
 $zip = new ZipArchive;
-if ($zip->open('test1.zip') === TRUE) {
+if ($zip->open('test1.zip') === true) {
     echo $zip->getFromName('testfromfile.php');
     $zip->close();
 } else {

--- a/reference/zip/ziparchive/getnameindex.xml
+++ b/reference/zip/ziparchive/getnameindex.xml
@@ -54,7 +54,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-if ($zip->open('test.zip') == TRUE) {
+if ($zip->open('test.zip') == true) {
  for ($i = 0; $i < $zip->numFiles; $i++) {
      $filename = $zip->getNameIndex($i);
      // ...

--- a/reference/zip/ziparchive/locatename.xml
+++ b/reference/zip/ziparchive/locatename.xml
@@ -68,7 +68,7 @@
 $file = 'testlocate.zip';
 
 $zip = new ZipArchive;
-if ($zip->open($file, ZipArchive::CREATE) !== TRUE) {
+if ($zip->open($file, ZipArchive::CREATE) !== true) {
     exit('failed');
 }
 
@@ -81,7 +81,7 @@ if ($zip->status !== ZipArchive::ER_OK) {
 }
 $zip->close();
 
-if ($zip->open($file) !== TRUE) {
+if ($zip->open($file) !== true) {
     exit('failed');
 }
 

--- a/reference/zip/ziparchive/open.xml
+++ b/reference/zip/ziparchive/open.xml
@@ -140,7 +140,7 @@
 <?php
 $zip = new ZipArchive;
 $res = $zip->open('test.zip');
-if ($res === TRUE) {
+if ($res === true) {
     echo 'ok';
     $zip->extractTo('test');
     $zip->close();
@@ -158,7 +158,7 @@ if ($res === TRUE) {
 <?php
 $zip = new ZipArchive;
 $res = $zip->open('test.zip', ZipArchive::CREATE);
-if ($res === TRUE) {
+if ($res === true) {
     $zip->addFromString('test.txt', 'file content goes here');
     $zip->addFile('data.txt', 'entryname.txt');
     $zip->close();
@@ -178,7 +178,7 @@ if ($res === TRUE) {
 $name = tempnam(sys_get_temp_dir(), "FOO");
 $zip = new ZipArchive;
 $res = $zip->open($name, ZipArchive::OVERWRITE); /* truncate as empty file is not valid */
-if ($res === TRUE) {
+if ($res === true) {
     $zip->addFile('data.txt', 'entryname.txt');
     $zip->close();
     echo 'ok';

--- a/reference/zip/ziparchive/renameindex.xml
+++ b/reference/zip/ziparchive/renameindex.xml
@@ -54,7 +54,7 @@
 <?php
 $zip = new ZipArchive;
 $res = $zip->open('test.zip');
-if ($res === TRUE) {
+if ($res === true) {
     $zip->renameIndex(2,'newname.txt');
     $zip->close();
 } else {

--- a/reference/zip/ziparchive/renamename.xml
+++ b/reference/zip/ziparchive/renamename.xml
@@ -54,7 +54,7 @@
 <?php
 $zip = new ZipArchive;
 $res = $zip->open('test.zip');
-if ($res === TRUE) {
+if ($res === true) {
     $zip->renameName('currentname.txt','newname.txt');
     $zip->close();
 } else {

--- a/reference/zip/ziparchive/replacefile.xml
+++ b/reference/zip/ziparchive/replacefile.xml
@@ -127,7 +127,7 @@
 <![CDATA[
 <?php
 $zip = new ZipArchive;
-if ($zip->open('test.zip') === TRUE) {
+if ($zip->open('test.zip') === true) {
     $zip->replaceFile('/path/to/index.txt', 1);
     $zip->close();
     echo 'ok';

--- a/reference/zip/ziparchive/setarchivecomment.xml
+++ b/reference/zip/ziparchive/setarchivecomment.xml
@@ -45,7 +45,7 @@
 <?php
 $zip = new ZipArchive;
 $res = $zip->open('test.zip', ZipArchive::CREATE);
-if ($res === TRUE) {
+if ($res === true) {
     $zip->addFromString('test.txt', 'file content goes here');
     $zip->setArchiveComment('new archive comment');
     $zip->close();

--- a/reference/zip/ziparchive/setarchiveflag.xml
+++ b/reference/zip/ziparchive/setarchiveflag.xml
@@ -68,7 +68,7 @@
 <?php
 $zip = new ZipArchive;
 $res = $zip->open('test.zip', ZipArchive::CREATE);
-if ($res === TRUE) {
+if ($res === true) {
     $zip->setArchiveFlag(ZipArchive::AFL_WANT_TORRENTZIP, 1);
     $zip->addFromString('test.txt', 'file content goes here');
     $zip->close();

--- a/reference/zip/ziparchive/setcommentindex.xml
+++ b/reference/zip/ziparchive/setcommentindex.xml
@@ -54,7 +54,7 @@
 <?php
 $zip = new ZipArchive;
 $res = $zip->open('test.zip');
-if ($res === TRUE) {
+if ($res === true) {
     $zip->setCommentIndex(2, 'new entry comment');
     $zip->close();
     echo 'ok';

--- a/reference/zip/ziparchive/setcommentname.xml
+++ b/reference/zip/ziparchive/setcommentname.xml
@@ -54,7 +54,7 @@
 <?php
 $zip = new ZipArchive;
 $res = $zip->open('test.zip');
-if ($res === TRUE) {
+if ($res === true) {
     $zip->setCommentName('entry1.txt', 'new entry comment');
     $zip->close();
     echo 'ok';

--- a/reference/zip/ziparchive/setcompressionindex.xml
+++ b/reference/zip/ziparchive/setcompressionindex.xml
@@ -64,7 +64,7 @@
 <?php
 $zip = new ZipArchive;
 $res = $zip->open('test.zip', ZipArchive::CREATE);
-if ($res === TRUE) {
+if ($res === true) {
     $zip->addFromString('foo', 'Some text');
     $zip->addFromString('bar', 'Some other text');
     $zip->setCompressionIndex(0, ZipArchive::CM_STORE);

--- a/reference/zip/ziparchive/setcompressionname.xml
+++ b/reference/zip/ziparchive/setcompressionname.xml
@@ -64,7 +64,7 @@
 <?php
 $zip = new ZipArchive;
 $res = $zip->open('test.zip', ZipArchive::CREATE);
-if ($res === TRUE) {
+if ($res === true) {
     $zip->addFromString('foo', 'Some text');
     $zip->addFromString('bar', 'Some other text');
     $zip->setCompressionName('foo', ZipArchive::CM_STORE);
@@ -85,7 +85,7 @@ if ($res === TRUE) {
 <?php
 $zip = new ZipArchive;
 $res = $zip->open('test.zip', ZipArchive::CREATE);
-if ($res === TRUE) {
+if ($res === true) {
     $zip->addFile('foo.jpg', 'bar.jpg');
     $zip->setCompressionName('bar.jpg', ZipArchive::CM_XZ);
     $zip->close();

--- a/reference/zip/ziparchive/setencryptionname.xml
+++ b/reference/zip/ziparchive/setencryptionname.xml
@@ -91,7 +91,7 @@
 <![CDATA[
 <?php
 $zip = new ZipArchive();
-if ($zip->open('test.zip', ZipArchive::CREATE) === TRUE) {
+if ($zip->open('test.zip', ZipArchive::CREATE) === true) {
     $zip->setPassword('secret');
     $zip->addFile('text.txt');
     $zip->setEncryptionName('text.txt', ZipArchive::EM_AES_256);

--- a/reference/zip/ziparchive/setexternalattributesname.xml
+++ b/reference/zip/ziparchive/setexternalattributesname.xml
@@ -78,7 +78,7 @@
 <?php
 $zip = new ZipArchive();
 $stat = stat($filename='test.txt');
-if (is_array($stat) && $zip->open('test.zip', ZipArchive::CREATE) === TRUE) {
+if (is_array($stat) && $zip->open('test.zip', ZipArchive::CREATE) === true) {
     $zip->addFile($filename);
     $zip->setExternalAttributesName($filename, ZipArchive::OPSYS_UNIX, $stat['mode'] << 16);
     $zip->close();

--- a/reference/zip/ziparchive/setmtimeindex.xml
+++ b/reference/zip/ziparchive/setmtimeindex.xml
@@ -69,7 +69,7 @@
 <![CDATA[
 <?php
 $zip = new ZipArchive();
-if ($zip->open('test.zip', ZipArchive::CREATE) === TRUE) {
+if ($zip->open('test.zip', ZipArchive::CREATE) === true) {
     $zip->addFile('text.txt');
     $zip->setMtimeIndex(0, mktime(0,0,0,12,25,2019));
     $zip->close();

--- a/reference/zip/ziparchive/setmtimename.xml
+++ b/reference/zip/ziparchive/setmtimename.xml
@@ -69,7 +69,7 @@
 <![CDATA[
 <?php
 $zip = new ZipArchive();
-if ($zip->open('test.zip', ZipArchive::CREATE) === TRUE) {
+if ($zip->open('test.zip', ZipArchive::CREATE) === true) {
     $zip->addFile('text.txt');
     $zip->setMtimeName('text.txt', mktime(0,0,0,12,25,2019));
     $zip->close();

--- a/reference/zip/ziparchive/statindex.xml
+++ b/reference/zip/ziparchive/statindex.xml
@@ -57,7 +57,7 @@
 <?php
 $zip = new ZipArchive;
 $res = $zip->open('test.zip');
-if ($res === TRUE) {
+if ($res === true) {
     print_r($zip->statIndex(3));
     $zip->close();
 } else {

--- a/reference/zip/ziparchive/statname.xml
+++ b/reference/zip/ziparchive/statname.xml
@@ -75,7 +75,7 @@
 <?php
 $zip = new ZipArchive;
 $res = $zip->open('test.zip');
-if ($res === TRUE) {
+if ($res === true) {
     print_r($zip->statName('foobar/baz'));
     $zip->close();
 } else {

--- a/reference/zlib/examples.xml
+++ b/reference/zlib/examples.xml
@@ -63,7 +63,7 @@ $compressed .= deflate_add($deflateContext, ", and even more data!", ZLIB_FINISH
 // Perform GZIP decompression:
 $inflateContext = inflate_init(ZLIB_ENCODING_GZIP);
 $uncompressed = inflate_add($inflateContext, $compressed, ZLIB_NO_FLUSH);
-$uncompressed .= inflate_add($inflateContext, NULL, ZLIB_FINISH);
+$uncompressed .= inflate_add($inflateContext, null, ZLIB_FINISH);
 echo $uncompressed;
 ?>
 ]]>

--- a/reference/zookeeper/zookeeper/get.xml
+++ b/reference/zookeeper/zookeeper/get.xml
@@ -42,7 +42,7 @@
     <term><parameter>stat</parameter></term>
     <listitem>
      <para>
-      If not NULL, will hold the value of stat for the path on return.
+      If not <type>null</type>, will hold the value of stat for the path on return.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/zookeeper/zookeeper/set.xml
+++ b/reference/zookeeper/zookeeper/set.xml
@@ -50,7 +50,7 @@
     <term><parameter>stat</parameter></term>
     <listitem>
      <para>
-      If not NULL, will hold the value of stat for the path on return.
+      If not <type>null</type>, will hold the value of stat for the path on return.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/zookeeper/zookeeper/setlogstream.xml
+++ b/reference/zookeeper/zookeeper/setlogstream.xml
@@ -15,7 +15,7 @@
    <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
   </methodsynopsis>
   <para>
-   The zookeeper library uses stderr as its default log stream. Application must make sure the stream is writable. Passing in NULL resets the stream to its default value (stderr).
+   The zookeeper library uses stderr as its default log stream. Application must make sure the stream is writable. Passing in <type>null</type> resets the stream to its default value (stderr).
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeperconfig/add.xml
+++ b/reference/zookeeper/zookeeperconfig/add.xml
@@ -42,7 +42,7 @@
     <term><parameter>stat</parameter></term>
     <listitem>
      <para>
-      If not NULL, will hold the value of stat for the path on return.
+      If not <type>null</type>, will hold the value of stat for the path on return.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/zookeeper/zookeeperconfig/get.xml
+++ b/reference/zookeeper/zookeeperconfig/get.xml
@@ -32,7 +32,7 @@
     <term><parameter>stat</parameter></term>
     <listitem>
      <para>
-      If not NULL, will hold the value of stat for the path on return.
+      If not <type>null</type>, will hold the value of stat for the path on return.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/zookeeper/zookeeperconfig/remove.xml
+++ b/reference/zookeeper/zookeeperconfig/remove.xml
@@ -41,7 +41,7 @@
     <term><parameter>stat</parameter></term>
     <listitem>
      <para>
-      If not NULL, will hold the value of stat for the path on return.
+      If not <type>null</type>, will hold the value of stat for the path on return.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/zookeeper/zookeeperconfig/set.xml
+++ b/reference/zookeeper/zookeeperconfig/set.xml
@@ -41,7 +41,7 @@
     <term><parameter>stat</parameter></term>
     <listitem>
      <para>
-      If not NULL, will hold the value of stat for the path on return.
+      If not <type>null</type>, will hold the value of stat for the path on return.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Within the documentation there are many inconsistencies. One of those is how null and booleans are written.
At some places it is written as NULL where in other places null is used.

Within parameters you generally want to use the lowercase variants. And also when mentioning the type null on its own.
At places like var dump results, you generally want to use the uppercase variant to make it in line with what PHP returns.

This change tries to tackle these inconsistencies. I did my very best not to touch values that are irrelevant, for example the value NULL within SQL. But since it we touch a lot of different files, have a good look.

The same has been done with TRUE/FALSE. Though in those situations it is almost always the lowercase variant.