### PR TITLE
Add new 8.4 DateTime functions

### DIFF
--- a/reference/datetime/datetime/createfromtimestamp.xml
+++ b/reference/datetime/datetime/createfromtimestamp.xml
@@ -2,7 +2,7 @@
 <refentry xml:id="datetime.createfromtimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTime::createFromTimestamp</refname>
-  <refpurpose>Returns new DateTime object representing given Unix timestamp</refpurpose>
+  <refpurpose>Creates an instance from a Unix timestamp</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,7 +13,7 @@
   </methodsynopsis>
   
   <simpara>
-   Returns new DateTime object representing given Unix timestamp.
+   Creates an instance from a Unix timestamp.
   </simpara>
  </refsect1>
 
@@ -53,9 +53,6 @@
   &reftitle.examples;
   <example xml:id="datetime.createfromtimestamp.example.basic">
    <title><methodname>DateTime::createFromTimestamp</methodname> example</title>
-   <simpara>
-    Description.
-   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/datetime/datetime/createfromtimestamp.xml
+++ b/reference/datetime/datetime/createfromtimestamp.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="datetime.createfromtimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>DateTime::createFromTimestamp</refname>
+  <refpurpose>Returns new DateTime object representing given Unix timestamp</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DateTime">
+   <modifier>public</modifier> <modifier>static</modifier> <type>static</type><methodname>DateTime::createFromTimestamp</methodname>
+   <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>timestamp</parameter></methodparam>
+  </methodsynopsis>
+  
+  <simpara>
+   Returns new DateTime object representing given Unix timestamp.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  
+  <variablelist>
+   <varlistentry>
+    <term><parameter>timestamp</parameter></term>
+    <listitem>
+     <simpara>
+      Unix timestamp representing the date.
+      A &float; value is also accepted which allows for microsecond precision.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ 
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns a new <classname>DateTime</classname> instance.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   If the <parameter>timestamp</parameter> is outside the range [<constant>PHP_INT_MIN</constant>, <constant>PHP_INT_MAX</constant>],
+   a <exceptionname>DateRangeError</exceptionname> is thrown.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="datetime.createfromtimestamp.example.basic">
+   <title><methodname>DateTime::createFromTimestamp</methodname> example</title>
+   <simpara>
+    Description.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$date = DateTime::createFromTimestamp(123.456789);
+echo $date->format('Y-m-d H:i:s.u');
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1970-01-01 00:02:03.456789
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datetime/setmicrosecond.xml
+++ b/reference/datetime/datetime/setmicrosecond.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="datetime.setmicrosecond" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>DateTime::setMicrosecond</refname>
+  <refpurpose>Sets microsecond part of the time</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DateTime">
+   <modifier>public</modifier> <type>static</type><methodname>DateTime::setMicrosecond</methodname>
+   <methodparam><type>int</type><parameter>microsecond</parameter></methodparam>
+  </methodsynopsis>
+  
+  <simpara>
+   Sets microsecond part of the time.
+  </simpara>
+  <simpara>
+   Like <methodname>DateTimeImmutable::setMicrosecond</methodname> but works with
+   <classname>DateTime</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  
+  <variablelist>
+   <varlistentry>
+    <term><parameter>microsecond</parameter></term>
+    <listitem>
+     <simpara>
+      The microsecond value to set (<literal>0</literal> to <literal>999999</literal>).
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ 
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &date.datetime.return.modifiedobject;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   If the <parameter>timestamp</parameter> is outside the range [<literal>0</literal>, <literal>999999</literal>],
+   a <exceptionname>DateRangeError</exceptionname> is thrown.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="datetime.setmicrosecond.example.basic">
+   <title><methodname>DateTime::setMicrosecond</methodname> example</title>
+
+   <programlisting role="php">
+<![CDATA[
+<?php
+$date = DateTime::createFromTimestamp(123.456789);
+echo $date->format('Y-m-d H:i:s.u') . PHP_EOL;
+$date->setMicrosecond(987654);
+echo $date->format('Y-m-d H:i:s.u') . PHP_EOL;
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1970-01-01 00:02:03.456789
+1970-01-01 00:02:03.987654
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DateTimeInterface::getMicrosecond</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datetime/setmicrosecond.xml
+++ b/reference/datetime/datetime/setmicrosecond.xml
@@ -47,7 +47,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <simpara>
-   If the <parameter>timestamp</parameter> is outside the range [<literal>0</literal>, <literal>999999</literal>],
+   If the <parameter>microsecond</parameter> is outside the range [<literal>0</literal>, <literal>999999</literal>],
    a <exceptionname>DateRangeError</exceptionname> is thrown.
   </simpara>
  </refsect1>

--- a/reference/datetime/datetime/settimestamp.xml
+++ b/reference/datetime/datetime/settimestamp.xml
@@ -61,6 +61,7 @@
   &reftitle.seealso;
   <simplelist>
    <member><function>DateTimeImmutable::setTimestamp</function></member>
+   <member><function>DateTime::setMicrotime</function></member>
   </simplelist>
  </refsect1>
 </refentry>

--- a/reference/datetime/datetime/settimestamp.xml
+++ b/reference/datetime/datetime/settimestamp.xml
@@ -61,7 +61,7 @@
   &reftitle.seealso;
   <simplelist>
    <member><function>DateTimeImmutable::setTimestamp</function></member>
-   <member><function>DateTime::setMicrotime</function></member>
+   <member><function>DateTime::setMicrosecond</function></member>
   </simplelist>
  </refsect1>
 </refentry>

--- a/reference/datetime/datetimeimmutable/add.xml
+++ b/reference/datetime/datetimeimmutable/add.xml
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::add() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::add</methodname>
    <methodparam><type>DateInterval</type><parameter>interval</parameter></methodparam>
   </methodsynopsis>

--- a/reference/datetime/datetimeimmutable/createfromtimestamp.xml
+++ b/reference/datetime/datetimeimmutable/createfromtimestamp.xml
@@ -2,7 +2,7 @@
 <refentry xml:id="datetimeimmutable.createfromtimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::createFromTimestamp</refname>
-  <refpurpose>Returns new DateTimeImmutable object representing given Unix timestamp</refpurpose>
+  <refpurpose>Creates an instance from a Unix timestamp</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,7 +13,7 @@
   </methodsynopsis>
   
   <simpara>
-   Returns new DateTimeImmutable object representing given Unix timestamp.
+   Creates an instance from a Unix timestamp.
   </simpara>
  </refsect1>
 
@@ -53,9 +53,6 @@
   &reftitle.examples;
   <example xml:id="datetimeimmutable.createfromtimestamp.example.basic">
    <title><methodname>DateTimeImmutable::createFromTimestamp</methodname> example</title>
-   <simpara>
-    Description.
-   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/datetime/datetimeimmutable/createfromtimestamp.xml
+++ b/reference/datetime/datetimeimmutable/createfromtimestamp.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="datetimeimmutable.createfromtimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>DateTimeImmutable::createFromTimestamp</refname>
+  <refpurpose>Returns new DateTimeImmutable object representing given Unix timestamp</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DateTimeImmutable">
+   <modifier>public</modifier> <modifier>static</modifier> <type>static</type><methodname>DateTimeImmutable::createFromTimestamp</methodname>
+   <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>timestamp</parameter></methodparam>
+  </methodsynopsis>
+  
+  <simpara>
+   Returns new DateTimeImmutable object representing given Unix timestamp.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  
+  <variablelist>
+   <varlistentry>
+    <term><parameter>timestamp</parameter></term>
+    <listitem>
+     <simpara>
+      Unix timestamp representing the date.
+      A &float; value is also accepted which allows for microsecond precision.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ 
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns a new <classname>DateTimeImmutable</classname> instance.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   If the <parameter>timestamp</parameter> is outside the range [<constant>PHP_INT_MIN</constant>, <constant>PHP_INT_MAX</constant>],
+   a <exceptionname>DateRangeError</exceptionname> is thrown.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="datetimeimmutable.createfromtimestamp.example.basic">
+   <title><methodname>DateTimeImmutable::createFromTimestamp</methodname> example</title>
+   <simpara>
+    Description.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$date = DateTimeImmutable::createFromTimestamp(123.456789);
+echo $date->format('Y-m-d H:i:s.u');
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1970-01-01 00:02:03.456789
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datetimeimmutable/modify.xml
+++ b/reference/datetime/datetimeimmutable/modify.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::modify() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::modify</methodname>
    <methodparam><type>string</type><parameter>modifier</parameter></methodparam>
   </methodsynopsis>

--- a/reference/datetime/datetimeimmutable/setdate.xml
+++ b/reference/datetime/datetimeimmutable/setdate.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::setDate() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setDate</methodname>
    <methodparam><type>int</type><parameter>year</parameter></methodparam>
    <methodparam><type>int</type><parameter>month</parameter></methodparam>

--- a/reference/datetime/datetimeimmutable/setisodate.xml
+++ b/reference/datetime/datetimeimmutable/setisodate.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::setISODate() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setISODate</methodname>
    <methodparam><type>int</type><parameter>year</parameter></methodparam>
    <methodparam><type>int</type><parameter>week</parameter></methodparam>

--- a/reference/datetime/datetimeimmutable/setmicrosecond.xml
+++ b/reference/datetime/datetimeimmutable/setmicrosecond.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="datetimeimmutable.setmicrosecond" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>DateTimeImmutable::setMicrosecond</refname>
+  <refpurpose>Sets microsecond part of the time</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DateTimeImmutable">
+   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier>public</modifier> <type>static</type><methodname>DateTimeImmutable::setMicrosecond</methodname>
+   <methodparam><type>int</type><parameter>microsecond</parameter></methodparam>
+  </methodsynopsis>
+  
+  <simpara>
+   Returns a new <type>DateTimeImmutable</type> object constructed from the
+   old one, with modified microsecond part.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  
+  <variablelist>
+   <varlistentry>
+    <term><parameter>microsecond</parameter></term>
+    <listitem>
+     <simpara>
+      The microsecond value to set (<literal>0</literal> to <literal>999999</literal>).
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ 
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &date.datetimeimmutable.return.modifiedobject;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   If the <parameter>timestamp</parameter> is outside the range [<literal>0</literal>, <literal>999999</literal>],
+   a <exceptionname>DateRangeError</exceptionname> is thrown.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="datetimeimmutable.setmicrosecond.example.basic">
+   <title><methodname>DateTimeImmutable::setMicrosecond</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$date = DateTimeImmutable::createFromTimestamp(123.456789);
+echo $date->format('Y-m-d H:i:s.u') . PHP_EOL;
+$date = $date->setMicrosecond(987654);
+echo $date->format('Y-m-d H:i:s.u') . PHP_EOL;
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1970-01-01 00:02:03.456789
+1970-01-01 00:02:03.987654
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DateTimeInterface::getMicrosecond</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datetimeimmutable/setmicrosecond.xml
+++ b/reference/datetime/datetimeimmutable/setmicrosecond.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::setMicrosecond() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>static</type><methodname>DateTimeImmutable::setMicrosecond</methodname>
    <methodparam><type>int</type><parameter>microsecond</parameter></methodparam>
   </methodsynopsis>

--- a/reference/datetime/datetimeimmutable/setmicrosecond.xml
+++ b/reference/datetime/datetimeimmutable/setmicrosecond.xml
@@ -45,7 +45,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <simpara>
-   If the <parameter>timestamp</parameter> is outside the range [<literal>0</literal>, <literal>999999</literal>],
+   If the <parameter>microsecond</parameter> is outside the range [<literal>0</literal>, <literal>999999</literal>],
    a <exceptionname>DateRangeError</exceptionname> is thrown.
   </simpara>
  </refsect1>

--- a/reference/datetime/datetimeimmutable/settime.xml
+++ b/reference/datetime/datetimeimmutable/settime.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::setTime() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setTime</methodname>
    <methodparam><type>int</type><parameter>hour</parameter></methodparam>
    <methodparam><type>int</type><parameter>minute</parameter></methodparam>

--- a/reference/datetime/datetimeimmutable/settimestamp.xml
+++ b/reference/datetime/datetimeimmutable/settimestamp.xml
@@ -71,6 +71,7 @@ echo $newDate->format('U = Y-m-d H:i:s') . "\n";
   &reftitle.seealso;
   <simplelist>
    <member><function>DateTimeImmutable::getTimestamp</function></member>
+   <member><function>DateTimeImmutable::setMicrosecond</function></member>
   </simplelist>
  </refsect1>
 

--- a/reference/datetime/datetimeimmutable/settimestamp.xml
+++ b/reference/datetime/datetimeimmutable/settimestamp.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::setTimestamp() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setTimestamp</methodname>
    <methodparam><type>int</type><parameter>timestamp</parameter></methodparam>
   </methodsynopsis>

--- a/reference/datetime/datetimeimmutable/settimezone.xml
+++ b/reference/datetime/datetimeimmutable/settimezone.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::setTimezone() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setTimezone</methodname>
    <methodparam><type>DateTimeZone</type><parameter>timezone</parameter></methodparam>
   </methodsynopsis>

--- a/reference/datetime/datetimeimmutable/sub.xml
+++ b/reference/datetime/datetimeimmutable/sub.xml
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::sub() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::sub</methodname>
    <methodparam><type>DateInterval</type><parameter>interval</parameter></methodparam>
   </methodsynopsis>

--- a/reference/datetime/datetimeinterface/getmicrosecond.xml
+++ b/reference/datetime/datetimeinterface/getmicrosecond.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="datetimeinterface.getmicrosecond" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>DateTimeInterface::getMicrosecond</refname>
+  <refname>DateTimeImmutable::getMicrosecond</refname>
+  <refname>DateTime::getMicrosecond</refname>
+  <refpurpose>Gets the microsecond part of the Unix timestamp</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DateTimeInterface">
+   <modifier>public</modifier> <type>int</type><methodname>DateTimeInterface::getMicrosecond</methodname>
+   <void/>
+  </methodsynopsis>
+  <methodsynopsis role="DateTimeImmutable">
+   <modifier>public</modifier> <type>int</type><methodname>DateTimeImmutable::getMicrosecond</methodname>
+   <void/>
+  </methodsynopsis>
+  <methodsynopsis role="DateTime">
+   <modifier>public</modifier> <type>int</type><methodname>DateTime::getMicrosecond</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Gets the microsecond part of the Unix timestamp.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns the microsecond part of the Unix timestamp representing the date.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="datetimeinterface.getmicrosecond.example.basic">
+   <title><methodname>DateTimeInterface::getMicrosecond</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$date = new DateTimeImmutable('2024-01-01 12:34:56.789123');
+var_dump($date->format('u'));
+var_dump($date->getMicrosecond());
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+string(6) "789123"
+int(789123)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DateTimeInterface::getTimestamp</methodname></member>
+   <member><methodname>DateTimeInterface::format</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datetimeinterface/gettimestamp.xml
+++ b/reference/datetime/datetimeinterface/gettimestamp.xml
@@ -155,6 +155,7 @@ echo $milli, "\n", $micro, "\n";
    <member><function>DateTime::setTimestamp</function></member>
    <member><function>DateTimeImmutable::setTimestamp</function></member>
    <member><function>DateTimeInterface::format</function></member>
+   <member><function>DateTimeInterface::getMicrosecond</function></member>
   </simplelist>
  </refsect1>
 

--- a/reference/datetime/versions.xml
+++ b/reference/datetime/versions.xml
@@ -15,9 +15,11 @@
  <function name="datetime::createfromformat" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="datetime::createfromimmutable" from="PHP 7 &gt;= 7.3.0, PHP 8"/>
  <function name="datetime::createfrominterface" from="PHP 8"/>
+ <function name="datetime::createfromtimestamp" from="PHP 8 &gt;= 8.4.0"/>
  <function name="datetime::diff" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="datetime::format" from="PHP 5 &gt;= 5.2.1, PHP 7, PHP 8"/>
  <function name="datetime::getlasterrors" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="datetime::getMicrosecond" from="PHP 8 &gt;= 8.4.0"/>
  <function name="datetime::getoffset" from="PHP 5 &gt;= 5.2.1, PHP 7, PHP 8"/>
  <function name="datetime::gettimestamp" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="datetime::gettimezone" from="PHP 5 &gt;= 5.2.1, PHP 7, PHP 8"/>
@@ -27,6 +29,7 @@
  <function name="datetime::settime" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="datetime::settimezone" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="datetime::settimestamp" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="datetime::setmicrosecond" from="PHP 8 &gt;= 8.4.0"/>
  <function name="datetime::sub" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
  <function name="datetimeinterface" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
@@ -35,6 +38,7 @@
  <function name="datetimeinterface::__wakeup" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8" deprecated="PHP 8.5.0"/>
  <function name="datetimeinterface::diff" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="datetimeinterface::format" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
+ <function name="datetimeinterface::getMicrosecond" from="PHP 8 &gt;= 8.4.0"/>
  <function name="datetimeinterface::getoffset" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="datetimeinterface::gettimestamp" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="datetimeinterface::gettimezone" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
@@ -48,9 +52,11 @@
  <function name="datetimeimmutable::createfromformat" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="datetimeimmutable::createfrommutable" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
  <function name="datetimeimmutable::createfrominterface" from="PHP 8"/>
+ <function name="datetimeimmutable::createfromtimestamp" from="PHP 8 &gt;= 8.4.0"/>
  <function name="datetimeimmutable::diff" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="datetimeimmutable::format" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="datetimeimmutable::getlasterrors" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::getMicrosecond" from="PHP 8 &gt;= 8.4.0"/>
  <function name="datetimeimmutable::gettimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="datetimeimmutable::getoffset" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="datetimeimmutable::gettimestamp" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
@@ -62,6 +68,7 @@
  <function name="datetimeimmutable::setdate" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="datetimeimmutable::setisodate" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="datetimeimmutable::settimestamp" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
+ <function name="datetimeimmutable::setmicrosecond" from="PHP 8 &gt;= 8.4.0"/>
 
  <function name="datetimezone" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="datetimezone::__construct" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>

--- a/reference/datetime/versions.xml
+++ b/reference/datetime/versions.xml
@@ -19,7 +19,7 @@
  <function name="datetime::diff" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="datetime::format" from="PHP 5 &gt;= 5.2.1, PHP 7, PHP 8"/>
  <function name="datetime::getlasterrors" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
- <function name="datetime::getMicrosecond" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="datetime::getmicrosecond" from="PHP 8 &gt;= 8.4.0"/>
  <function name="datetime::getoffset" from="PHP 5 &gt;= 5.2.1, PHP 7, PHP 8"/>
  <function name="datetime::gettimestamp" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="datetime::gettimezone" from="PHP 5 &gt;= 5.2.1, PHP 7, PHP 8"/>

--- a/reference/datetime/versions.xml
+++ b/reference/datetime/versions.xml
@@ -38,7 +38,7 @@
  <function name="datetimeinterface::__wakeup" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8" deprecated="PHP 8.5.0"/>
  <function name="datetimeinterface::diff" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="datetimeinterface::format" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
- <function name="datetimeinterface::getMicrosecond" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="datetimeinterface::getmicrosecond" from="PHP 8 &gt;= 8.4.0"/>
  <function name="datetimeinterface::getoffset" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="datetimeinterface::gettimestamp" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="datetimeinterface::gettimezone" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
@@ -56,7 +56,7 @@
  <function name="datetimeimmutable::diff" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="datetimeimmutable::format" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="datetimeimmutable::getlasterrors" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
- <function name="datetimeimmutable::getMicrosecond" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="datetimeimmutable::getmicrosecond" from="PHP 8 &gt;= 8.4.0"/>
  <function name="datetimeimmutable::gettimezone" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="datetimeimmutable::getoffset" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="datetimeimmutable::gettimestamp" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>


### PR DESCRIPTION
ℹ️  Documentation tracker #3872

Adding new `DateTime` functions added in `8.4`

⚠️ According to my tests, it seems that `createFromTimestamp` accepts some timestamp values below `PHP_INT_MIN` (until `PHP_INT_MIN - 1024`, see related [tests](https://github.com/php/php-src/blob/master/ext/date/tests/createFromTimestamp.phpt#L22C6-L22C26)).
Since returned date are all the same for this specific values, I think it may be an error, because it doesn't throw any exception.
I'm not sure if we should document the actual _bogus_ behavior, to prevent anyone to rely on this 🤔 

Also:
* I'm not native English speaker
* This is my first PR on PHP's doc

Then, no offense if you think it can be improved 🙂 

Thanks for your huge work, happy if this PR can help 🙇 