### PR TITLE
Document 8.5 CLI SAPI changes

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -358,7 +358,6 @@ Usage: php [options] [-f] <file> [--] [args...]
   -s               Output HTML syntax highlighted source.
   -v               Version number
   -w               Output source with stripped comments and whitespace.
-  -z <file>        Load Zend extension <file>.
 
   args...          Arguments passed to script. Use -- args when first argument
                    starts with - or script is read from stdin
@@ -834,26 +833,13 @@ Zend Engine v2.3.0, Copyright (c) 1998-2009 Zend Technologies
        </entry>
       </row>
       <row>
-       <entry>-z</entry>
-       <entry>--zend-extension</entry>
-       <entry>
-        <para>
-         Load Zend extension. If only a filename is given, PHP tries to load
-         this extension from the current default library path on your system
-         (usually <filename>/etc/ld.so.conf</filename> on Linux systems, for
-         example). Passing a filename with an absolute path will
-         not use the system's library search path. A relative filename including
-         directory information will tell PHP to try
-         loading the extension relative to the current directory.
-        </para>
-       </entry>
-      </row>
-      <row>
        <entry></entry>
        <entry>--ini</entry>
        <entry>
         <para>
-         Show configuration file names and scanned directories.
+         Show configuration file names and scanned directories. Optionally,
+         pass <literal>--ini=diff</literal> to show the differences between
+         the loaded configuration files and the default configuration.
          <example>
           <title><literal>--ini</literal> example</title>
           <programlisting role="shell">
@@ -866,6 +852,11 @@ Additional .ini files parsed:      (none)
 ]]>
           </programlisting>
          </example>
+         <note>
+          <para>
+           The <literal>--ini=diff</literal> option is not available prior to PHP 8.5.0.
+          </para>
+         </note>
         </para>
        </entry>
       </row>

--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -853,9 +853,9 @@ Additional .ini files parsed:      (none)
           </programlisting>
          </example>
          <note>
-          <para>
+          <simpara>
            The <literal>--ini=diff</literal> option is not available prior to PHP 8.5.0.
-          </para>
+          </simpara>
          </note>
         </para>
        </entry>

--- a/reference/info/functions/cli-get-process-title.xml
+++ b/reference/info/functions/cli-get-process-title.xml
@@ -46,7 +46,29 @@
    is unsupported.
   </para>
  </refsect1>
- 
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <function>cli_get_process_title</function> will now return an <constant>E_WARNING</constant> 
+       if the process title is too long to be retrieved.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/info/functions/cli-get-process-title.xml
+++ b/reference/info/functions/cli-get-process-title.xml
@@ -61,7 +61,7 @@
      <row>
       <entry>8.5.0</entry>
       <entry>
-       <function>cli_get_process_title</function> will now return an <constant>E_WARNING</constant> 
+       <function>cli_get_process_title</function> will now return an <constant>E_WARNING</constant>
        if the process title is too long to be retrieved.
       </entry>
      </row>

--- a/reference/info/functions/cli-get-process-title.xml
+++ b/reference/info/functions/cli-get-process-title.xml
@@ -47,28 +47,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <informaltable>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>&Version;</entry>
-      <entry>&Description;</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>8.5.0</entry>
-      <entry>
-       <function>cli_get_process_title</function> will now return an <constant>E_WARNING</constant>
-       if the process title is too long to be retrieved.
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </informaltable>
- </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/info/functions/cli-set-process-title.xml
+++ b/reference/info/functions/cli-set-process-title.xml
@@ -14,11 +14,11 @@
    <methodparam><type>string</type><parameter>title</parameter></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Sets the process title visible in tools such as <command>top</command> and
    <command>ps</command>. This function is available only in
    <link linkend="features.commandline">CLI</link> mode.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,9 +28,9 @@
    <varlistentry>
     <term><parameter>title</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       The new title.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -38,26 +38,48 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
    
-  <para>
+  <simpara>
    An <constant>E_WARNING</constant> will be generated if the operating system
    is unsupported.
-  </para>
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <function>cli_set_process_title</function> will now emit an
+       <constant>E_WARNING</constant> when setting a process title
+       that is too long; previously the title would be truncated.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title><function>cli_set_process_title</function> example</title>
-    <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $title = "My Amazing PHP Script";
@@ -72,18 +94,15 @@ if (!cli_set_process_title($title)) {
 }
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </informalexample>
  </refsect1>
  
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>cli_get_process_title</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>cli_get_process_title</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 


### PR DESCRIPTION
 - Remove deprecated -z/--zend-extension command-line option documentation
 - Document new --ini=diff feature
 - Add changelog entry for cli_set_process_title() E_WARNING behavior change
  
I decided to silently remove the -z feature since the `-z` option as it was non-functional. If we wish to document I'd like to have suggestions of where to put.