### PR TITLE
docs(printf): fix incorrect cutoff value in examples

### DIFF
--- a/reference/strings/functions/printf.xml
+++ b/reference/strings/functions/printf.xml
@@ -115,8 +115,8 @@ printf("[%-10s]\n",     $s); // left-justification with spaces
 printf("[%010s]\n",     $s); // zero-padding works on strings too
 printf("[%'#10s]\n",    $s); // use the custom padding character '#'
 printf("[%'#*s]\n", 10, $s); // Provide the padding width as an additional argument
-printf("[%10.9s]\n",    $t); // right-justification but with a cutoff of 8 characters
-printf("[%-10.9s]\n",   $t); // left-justification but with a cutoff of 8 characters
+printf("[%10.9s]\n",    $t); // right-justification but with a cutoff of 9 characters
+printf("[%-10.9s]\n",   $t); // left-justification but with a cutoff of 9 characters
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
Found a regression from 2019 where the comment says "8 characters" but the code uses .9s. Correcting it to "9 characters" for consistency with the actual output.