### PR TITLE
Describe precedence for pipe and throw operators

### DIFF
--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -145,7 +145,7 @@
       </entry>
      </row>
      <row>
-      <entry>(n/a)</entry>
+      <entry>left</entry>
       <entry><literal>|&gt;</literal></entry>
       <entry>
        <link linkend="language.operators.functional">pipe</link>


### PR DESCRIPTION
Pipe operator docs was introduced in 8.5 (https://github.com/php/doc-en/pull/4890), but currently missing in precedence table.

Throw operator was intorduced in 8.0 (https://wiki.php.net/rfc/throw_expression), but precedence still not documented.