### PR TITLE
Update ssl:// transport description for modern TLS

### DIFF
--- a/appendices/transports.xml
+++ b/appendices/transports.xml
@@ -22,6 +22,13 @@
    <literal>ssl://</literal>, <literal>tls://</literal>,
    <literal>sslv2://</literal> &amp; <literal>sslv3://</literal>.
   </simpara>
+  <note>
+   <simpara>
+    The <literal>sslv2://</literal> and <literal>sslv3://</literal> transports
+    are obsolete and should not be used. They are documented for
+    backward compatibility only.
+   </simpara>
+  </note>
 
   <note>
    <simpara>
@@ -38,8 +45,6 @@
    <listitem><simpara><literal>tcp://www.example.com</literal></simpara></listitem>
    <listitem><simpara><literal>udp://www.example.com</literal></simpara></listitem>
    <listitem><simpara><literal>ssl://www.example.com</literal></simpara></listitem>
-   <listitem><simpara><literal>sslv2://www.example.com</literal></simpara></listitem>
-   <listitem><simpara><literal>sslv3://www.example.com</literal></simpara></listitem>
    <listitem><simpara><literal>tls://www.example.com</literal></simpara></listitem>
   </itemizedlist>
 
@@ -78,11 +83,18 @@
   </simpara>
 
   <simpara>
-   <literal>ssl://</literal> will attempt to negotiate an SSL V2,
-   or SSL V3 connection depending on the capabilities and preferences
-   of the remote host.  <literal>sslv2://</literal> and 
-   <literal>sslv3://</literal> will select the SSL V2 or SSL V3
-   protocol explicitly.
+   <literal>ssl://</literal> will attempt to negotiate a secure SSL/TLS
+   connection depending on the capabilities and preferences of both the
+   client and the remote host. The actual protocols that may be used are
+   determined by the OpenSSL configuration and by any options provided
+   through <function>stream_context_create</function>, such as
+   <literal>ssl.crypto_method</literal>.
+  </simpara>
+
+  <simpara>
+   The SSLv2 and SSLv3 protocols are obsolete and insecure. Their use is
+   strongly discouraged and they are no longer enabled by default in
+   modern versions of PHP and OpenSSL.
   </simpara>
  </section>
 


### PR DESCRIPTION
Fixes #5081

Update the ssl:// stream transport description which still references SSLv2/SSLv3 negotiation. Since PHP 5.6 (Improved TLS Defaults RFC), ssl:// negotiates the best available TLS protocol.

Happy to adjust if needed.