### PR TITLE
Document offsetSet() as alias of deprecated SplObjectStorage::attach()

### DIFF
--- a/reference/spl/splobjectstorage/attach.xml
+++ b/reference/spl/splobjectstorage/attach.xml
@@ -21,6 +21,10 @@
   <para>
    Adds an <type>object</type> inside the storage, and optionally associate it to some data.
   </para>
+  <para>
+   This method is an alias of <methodname>SplObjectStorage::offsetSet</methodname>.
+  </para>
+
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/spl/splobjectstorage/attach.xml
+++ b/reference/spl/splobjectstorage/attach.xml
@@ -21,9 +21,9 @@
   <para>
    Adds an <type>object</type> inside the storage, and optionally associate it to some data.
   </para>
-  <para>
+  <simpara>
    This method is an alias of <methodname>SplObjectStorage::offsetSet</methodname>.
-  </para>
+  </simpara>
 
  </refsect1>
 


### PR DESCRIPTION
`SplObjectStorage::offsetSet()` is an alias of `SplObjectStorage::attach()`,
which is deprecated as of PHP 8.5.

This change makes the alias relationship explicit in the documentation.
Issue: https://github.com/php/doc-en/issues/4957