### PR TITLE
docs(fann): fix grammar, punctuation, and terminology in constants

### DIFF
--- a/reference/fann/constants.xml
+++ b/reference/fann/constants.xml
@@ -28,9 +28,9 @@
     <listitem>
      <simpara>
       Standard backpropagation algorithm, where the weights are updated after calculating the mean square error
-      for the whole training set. This means that the weights are only updated once during a epoch.
-      For this reason some problems, will train slower with this algorithm. But since the mean square
-      error is calculated more correctly than in incremental training, some problems will reach a better
+      for the whole training set. This means that the weights are only updated once during an epoch.
+      For this reason, some problems will train slower with this algorithm. But since the mean square
+      error is calculated more correctly than in incremental training, some problems will reach better
       solutions with this algorithm.
      </simpara>
     </listitem>
@@ -43,11 +43,11 @@
     <listitem>
      <simpara>
       A more advanced batch training algorithm which achieves good results for many problems. The RPROP
-      training algorithm is adaptive, and does therefore not use the learning_rate. Some other parameters
+      training algorithm is adaptive, and therefore does not use the learning_rate. Some other parameters
       can however be set to change the way the RPROP algorithm works, but it is only recommended
       for users with insight in how the RPROP training algorithm works. The RPROP training algorithm
       is described by [Riedmiller and Braun, 1993], but the actual learning algorithm used here is
-      the iRPROP- training algorithm which is described by [Igel and Husken, 2000] which is an variety
+      the iRPROP- training algorithm which is described by [Igel and Husken, 2000] which is a variety
       of the standard RPROP training algorithm.
      </simpara>
     </listitem>
@@ -61,7 +61,7 @@
      <simpara>
       A more advanced batch training algorithm which achieves good results for many problems.
       The quickprop training algorithm uses the learning_rate parameter along with other more advanced parameters,
-      but it is only recommended to change these advanced parameters, for users with insight in how the quickprop
+      but it is only recommended to change these advanced parameters for users with insight into how the quickprop
       training algorithm works. The quickprop training algorithm is described by [Fahlman, 1988].
      </simpara>
     </listitem>
@@ -175,7 +175,7 @@
     </term>
     <listitem>
      <simpara>
-      Symmetric gaussian activation function.
+      Symmetric Gaussian activation function.
      </simpara>
     </listitem>
    </varlistentry>
@@ -186,7 +186,7 @@
     </term>
     <listitem>
      <simpara>
-      Stepwise gaussian activation function.
+      Stepwise Gaussian activation function.
      </simpara>
     </listitem>
    </varlistentry>
@@ -197,7 +197,7 @@
     </term>
     <listitem>
      <simpara>
-      Fast (sigmoid like) activation function defined by David Elliott.
+      Fast (sigmoid-like) activation function defined by David Elliott.
      </simpara>
     </listitem>
    </varlistentry>
@@ -208,7 +208,7 @@
     </term>
     <listitem>
      <simpara>
-      Fast (symmetric sigmoid like) activation function defined by David Elliott.
+      Fast (symmetric sigmoid-like) activation function defined by David Elliott.
      </simpara>
     </listitem>
    </varlistentry>
@@ -300,7 +300,7 @@
     <listitem>
      <simpara>
       Tanh error function; usually better but may require a lower learning rate. This error function aggressively
-      targets outputs that differ much from the desired, while not targeting outputs that only differ slightly.
+      targets outputs that differ much from the desired output, while not targeting outputs that differ only slightly.
       Not recommended for cascade or incremental training.
      </simpara>
     </listitem>
@@ -326,8 +326,8 @@
     </term>
     <listitem>
      <simpara>
-      Stop criteria is number of bits that fail.  The number of bits means the number of output neurons
-      which differs more than the bit fail limit (see fann_get_bit_fail_limit, fann_set_bit_fail_limit). The bits are counted
+      Stop criterion is number of bits that fail. The number of bits means the number of output neurons
+      which differ more than the bit fail limit (see fann_get_bit_fail_limit, fann_set_bit_fail_limit). The bits are counted
       in all of the training data, so this number can be higher than the number of training data.
      </simpara>
     </listitem>


### PR DESCRIPTION
This PR improves the linguistic quality and professional tone of the FANN constants documentation. While reviewing the `constants.xml` file, I found several recurring grammatical and typographical issues that were likely inherited from the original library's documentation.

### Changes:
- **Articles:** Fixed "a/an" usage (e.g., `an epoch` instead of `a epoch`).
- **Subject-Verb Agreement:** Fixed singular/plural consistency (e.g., `neurons which differ`, `criterion is`).
- **Terminology & Clarity:** - Capitalized **Gaussian** as a proper noun.
  - Added missing hyphens in compound adjectives (e.g., **sigmoid-like**).
  - Fixed preposition usage (**insight into** instead of **insight in**).
  - Completed the elliptical phrase "from the desired" to **from the desired output**.
- **Punctuation:** Removed redundant commas that were disrupting the flow of technical descriptions.

These changes make the documentation more accurate and professional for the PHP community.