### PR TITLE
Fix #5003: LIBXML_XINCLUDE is not supported for non-pull parsers, sho…

### DIFF
--- a/reference/libxml/constants.xml
+++ b/reference/libxml/constants.xml
@@ -323,7 +323,7 @@
    </term>
    <listitem>
     <simpara>
-     Implement XInclude substitution
+     Perform XInclude substitution (only for pull parsers, i.e. <classname>XMLReader</classname>).
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
…uld be documented