### PR TITLE
Fix incorrect Last-Modified header description in session_cache_limiter()

### DIFF
--- a/reference/session/functions/session-cache-limiter.xml
+++ b/reference/session/functions/session-cache-limiter.xml
@@ -72,7 +72,7 @@
 <![CDATA[
 Expires: (sometime in the future, according session.cache_expire)
 Cache-Control: public, max-age=(sometime in the future, according to session.cache_expire)
-Last-Modified: (the timestamp of when the session was last saved)
+Last-Modified: (the timestamp of the current script)
 ]]>
            </programlisting>
           </entry>
@@ -83,7 +83,7 @@ Last-Modified: (the timestamp of when the session was last saved)
            <programlisting role="header">
 <![CDATA[
 Cache-Control: private, max-age=(session.cache_expire in the future)
-Last-Modified: (the timestamp of when the session was last saved)
+Last-Modified: (the timestamp of the current script)
 ]]>
            </programlisting>
           </entry>
@@ -95,7 +95,7 @@ Last-Modified: (the timestamp of when the session was last saved)
 <![CDATA[
 Expires: Thu, 19 Nov 1981 08:52:00 GMT
 Cache-Control: private, max-age=(session.cache_expire in the future)
-Last-Modified: (the timestamp of when the session was last saved)
+Last-Modified: (the timestamp of the current script)
 ]]>
            </programlisting>
           </entry>


### PR DESCRIPTION
The documentation stated that the Last-Modified header was based on the session save time.

In practice, the value is derived from the current script timestamp. This change aligns the documentation with the actual runtime behavior.

Issue https://github.com/php/doc-en/issues/4865