### PR TITLE
Document deprecation of non-callable strings in xml_set_* handler functions

### DIFF
--- a/appendices/migration84/deprecated.xml
+++ b/appendices/migration84/deprecated.xml
@@ -467,7 +467,7 @@ class _MyClass {}
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#xml_set_object_and_xml_set_handler_with_string_method_names -->
   <simpara>
    Passing non-<type>callable</type> strings to the
-   <function>xml_set_<replaceable>*</replaceable></function>
+   <literal>xml_set_*</literal>
    functions is now deprecated.
   </simpara>
  </sect2>

--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -818,7 +818,7 @@ nodeData: 3
   <title>XML</title>
 
   <simpara>
-   The <function>xml_set_<replaceable>*</replaceable>_handler</function>
+   The <literal>xml_set_*_handler</literal>
    functions now declare and check for an effective
    signature of <type class="union"><type>callable</type><type>string</type><type>null</type></type> for the
    <parameter>handler</parameter> parameters.


### PR DESCRIPTION
Passing non-callable strings to xml_set_* handler functions is now deprecated.

This change documents the deprecation to align the manual with current engine behavior
and helps avoid confusion around valid handler values.

https://github.com/php/phd/issues/171