### PR TITLE
Clarify intval() behavior with scientific notation numeric strings

### DIFF
--- a/reference/var/functions/intval.xml
+++ b/reference/var/functions/intval.xml
@@ -97,26 +97,25 @@
    apply.
   </para>
   <note>
-   <para>
+   <simpara>
     Numeric strings using scientific notation (for example containing
     the letter <literal>e</literal>) are first parsed as numbers before
     being converted to an integer.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     This may lead to unexpected results for large exponents:
-   </para>
-   <example>
-    <title>Example</title>
+   </simpara>
+   <informalexample>
     <programlisting role="php">
 <![CDATA[
 echo intval('42.42e42'); // 9223372036854775807 on 64-bit systems
 ]]>
     </programlisting>
-   </example>
-   <para>
+   </informalexample>
+   <simpara>
     See <link linkend="language.types.numeric-strings">Numeric strings</link>
     for details on how such strings are interpreted.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/var/functions/intval.xml
+++ b/reference/var/functions/intval.xml
@@ -96,6 +96,27 @@
    <link linkend="language.types.integer.casting">integer casting</link> 
    apply.
   </para>
+  <note>
+   <para>
+    Numeric strings using scientific notation (for example containing 
+    the letter <literal>e</literal>) are first parsed as numbers before
+    being converted to an integer.
+   </para>
+   <para>
+    This may lead to unexpected results for large exponents:
+   </para>
+   <example>
+    <programlisting role="php">
+<![CDATA[
+echo intval('42.42e42'); // 9223372036854775807 on 64-bit systems
+]]>
+    </programlisting>
+   </example>
+   <para>
+    See <link linkend="language.types.numeric-strings">Numeric strings</link>
+    for details on how such strings are interpreted.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/var/functions/intval.xml
+++ b/reference/var/functions/intval.xml
@@ -98,7 +98,7 @@
   </para>
   <note>
    <para>
-    Numeric strings using scientific notation (for example containing 
+    Numeric strings using scientific notation (for example containing
     the letter <literal>e</literal>) are first parsed as numbers before
     being converted to an integer.
    </para>

--- a/reference/var/functions/intval.xml
+++ b/reference/var/functions/intval.xml
@@ -106,6 +106,7 @@
     This may lead to unexpected results for large exponents:
    </para>
    <example>
+    <title>Example</title>
     <programlisting role="php">
 <![CDATA[
 echo intval('42.42e42'); // 9223372036854775807 on 64-bit systems

--- a/reference/var/functions/intval.xml
+++ b/reference/var/functions/intval.xml
@@ -103,7 +103,9 @@
     being converted to an integer.
    </simpara>
    <simpara>
-    This may lead to unexpected results for large exponents:
+    Because the whole numeric string is parsed, the result is not simply
+    the leading integer part. Large exponents can additionally overflow to
+    <constant>PHP_INT_MAX</constant>:
    </simpara>
    <informalexample>
     <programlisting role="php">

--- a/reference/var/functions/intval.xml
+++ b/reference/var/functions/intval.xml
@@ -98,19 +98,21 @@
   </para>
   <note>
    <simpara>
-    Numeric strings using scientific notation (for example containing
-    the letter <literal>e</literal>) are first parsed as numbers before
-    being converted to an integer.
+    Numeric strings using scientific notation (containing the letter
+    <literal>e</literal> or <literal>E</literal>) are first parsed as
+    numbers before being converted to an integer.
    </simpara>
    <simpara>
-    Because the whole numeric string is parsed, the result is not simply
-    the leading integer part. Large exponents can additionally overflow to
-    <constant>PHP_INT_MAX</constant>:
+    Because the numeric part of the string is parsed as a whole, the result
+    is not simply the leading integer part. Large exponents can additionally
+    overflow to <constant>PHP_INT_MAX</constant>:
    </simpara>
    <informalexample>
     <programlisting role="php">
 <![CDATA[
+<?php
 echo intval('42.42e42'); // 9223372036854775807 on 64-bit systems
+?>
 ]]>
     </programlisting>
    </informalexample>


### PR DESCRIPTION
This PR clarifies how intval() behaves when passed numeric strings using scientific notation.

While this behavior is documented in the Numeric strings section, it was not explicitly referenced from the intval() manual page,
which could lead to confusion.

A short note and example have been added to make this behavior easier to discover.

Issue: https://github.com/php/doc-en/issues/5019