### PR TITLE
Fix setcookie() documentation for invalid options in PHP 8.0+

### DIFF
--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -212,7 +212,7 @@
    </listitem>
    <listitem>
     <simpara>
-     As of PHP 8.0.0, a <classname>ValueError</classname> is thrown.
+     As of PHP 8.0.0, a <exceptionname>ValueError</exceptionname> is thrown.
     </simpara>
    </listitem>
   </itemizedlist>


### PR DESCRIPTION
The setcookie() documentation states that passing an invalid key in the options array triggers an E_WARNING.

Since PHP 8.0, invalid option keys throw a ValueError instead. This PR updates the documentation to accurately reflect the current behavior while preserving the pre-8.0 behavior for reference.

Issue: https://github.com/php/doc-en/issues/4985