### PR TITLE
Fix inconsistent bounds description in stats_rand_gen_funiform()

### DIFF
--- a/reference/stats/functions/stats-rand-gen-funiform.xml
+++ b/reference/stats/functions/stats-rand-gen-funiform.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.stats-rand-gen-funiform" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>stats_rand_gen_funiform</refname>
-  <refpurpose>Generates uniform float between low (inclusive) and high (exclusive)</refpurpose>
+  <refpurpose>Generates uniform float between low (exclusive) and high (exclusive)</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -25,7 +25,7 @@
      <term><parameter>low</parameter></term>
      <listitem>
       <para>
-       The lower bound (inclusive)
+       The lower bound (exclusive)
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
The function description stated that both bounds were exclusive, while the parameter documentation specifies that the lower bound is inclusive and the upper bound exclusive.

This change aligns the refpurpose with the documented parameter behavior and removes an internal inconsistency. 
Issue: https://github.com/php/doc-en/issues/4984