### PR TITLE
Fix incorrect return value description for yaml_parse_file()

### DIFF
--- a/reference/yaml/functions/yaml-parse-file.xml
+++ b/reference/yaml/functions/yaml-parse-file.xml
@@ -69,10 +69,15 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the value encoded in <parameter>filename</parameter> in appropriate
-   PHP type&return.falseforfailure;. If <parameter>pos</parameter> is <literal>-1</literal> an
-   <type>array</type> will be returned with one entry for each document found
-   in the stream.
+   Returns the value encoded in <parameter>filename</parameter> in the appropriate
+   PHP type.
+  </para>
+  <para>
+   On failure, a string containing an error message is returned.
+  </para>
+  <para>
+   If <parameter>pos</parameter> is <literal>-1</literal>, an <type>array</type>
+   will be returned with one entry for each document found in the stream.
   </para>
  </refsect1>
 

--- a/reference/yaml/functions/yaml-parse-file.xml
+++ b/reference/yaml/functions/yaml-parse-file.xml
@@ -68,17 +68,17 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the value encoded in <parameter>filename</parameter> in the appropriate
    PHP type.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    On failure, a string containing an error message is returned.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    If <parameter>pos</parameter> is <literal>-1</literal>, an <type>array</type>
    will be returned with one entry for each document found in the stream.
-  </para>
+</simpara>
  </refsect1>
 
  <refsect1 role="notes">


### PR DESCRIPTION
The manual stated that yaml_parse_file() returns false on failure.

In practice, the function returns either the parsed value (usually an array) or a string containing an error message, and does not return false.

This PR updates the return value documentation to reflect the actual behavior observed with ext-yaml on PHP 8.2 and 8.3.
Issue: https://github.com/php/doc-en/issues/4978