### PR TITLE
dba: fix XML to get remove of useless wrapping para tags

### DIFF
--- a/reference/dba/configure.xml
+++ b/reference/dba/configure.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<section xml:id="dba.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="dba.installation">
  &reftitle.install;
  <para>
   By using the <option role="configure">--enable-dba=shared</option>
@@ -14,235 +14,232 @@
   <para>
    After configuring and compiling PHP you must execute the following test
    from commandline: <literal>php run-tests.php ext/dba</literal>. This shows
-   whether your combination of handlers works. Most problematic are 
+   whether your combination of handlers works. Most problematic are
    <literal>dbm</literal> and <literal>ndbm</literal> which conflict with
    many installations. The reason for this is that on several systems these
    libraries are part of more than one other library. The configuration test
-   only prevents you from configuring malfunctioning single handlers but not 
+   only prevents you from configuring malfunctioning single handlers but not
    combinations.
   </para>
  </warning>
- <para>
-  <table>
-   <title>Supported DBA handlers</title>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>Handler</entry>
-      <entry>Configure Switch</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry><literal>dbm</literal></entry>
-      <entry>
+ <table>
+  <title>Supported DBA handlers</title>
+  <tgroup cols="2">
+   <thead>
+    <row>
+     <entry>Handler</entry>
+     <entry>Configure Switch</entry>
+    </row>
+   </thead>
+   <tbody>
+    <row>
+     <entry><literal>dbm</literal></entry>
+     <entry>
+      <para>
+      To enable support for dbm add
+      <option role="configure">--with-dbm[=DIR]</option>.
+      <note>
        <para>
-       To enable support for dbm add
-       <option role="configure">--with-dbm[=DIR]</option>.
-       <note>
-        <para>
-         dbm normally is a wrapper which often results in failures.
-         This means you should only use dbm if you are sure it works
-         and if you really need this format.
-        </para>
-       </note>
+        dbm normally is a wrapper which often results in failures.
+        This means you should only use dbm if you are sure it works
+        and if you really need this format.
        </para>
-      </entry>
-     </row>
-
-     <row>
-      <entry><literal>ndbm</literal></entry>
-      <entry>
-       <para>
-       To enable support for ndbm add
-       <option role="configure">--with-ndbm[=DIR]</option>.
-       <note>
-        <para>
-         ndbm normally is a wrapper which often results in failures.
-         This means you should only use ndbm if you are sure it works
-         and if you really need this format.
-        </para>
-       </note>
-       </para>
-      </entry>
-     </row>
-
-     <row>
-      <entry><literal>gdbm</literal></entry>
-      <entry>
-       To enable support for gdbm add
-       <option role="configure">--with-gdbm[=DIR]</option>.
-      </entry>
-     </row>
-
-     <row>
-      <entry><literal>db2</literal></entry>
-      <entry>
-       <para>
-       To enable support for Oracle Berkeley DB 2 add
-       <option role="configure">--with-db2[=DIR]</option>.
-       <note>
-        <para>
-         db2 conflicts with db3 and db4.
-        </para>
-       </note>
-       </para>
-      </entry>
-     </row>
-
-     <row>
-      <entry><literal>db3</literal></entry>
-      <entry>
-       <para>
-       To enable support for Oracle Berkeley DB 3 add
-       <option role="configure">--with-db3[=DIR]</option>.
-       <note>
-        <para>
-         db3 conflicts with db2 and db4.
-        </para>
-       </note>
-       </para>
-      </entry>
-     </row>
-
-     <row>
-      <entry><literal>db4</literal></entry>
-      <entry>
-       <para>
-       To enable support for Oracle Berkeley DB 4 or 5 add
-       <option role="configure">--with-db4[=DIR]</option>.
-       <note>
-        <para>
-         db4 conflicts with db2 and db3.
-        </para>
-       </note>
-       <note>
-        <para>
-         The db libraries with
-         versions 4.1 through 4.1.24 cannot be used in any PHP version.
-        </para>
-        <para>
-         Support for BDB 5 was added in PHP 5.3.3.
-        </para>
-       </note>
+      </note>
       </para>
-      </entry>
-     </row>
+     </entry>
+    </row>
 
-     <row>
-      <entry><literal>cdb</literal></entry>
-      <entry>
+    <row>
+     <entry><literal>ndbm</literal></entry>
+     <entry>
+      <para>
+      To enable support for ndbm add
+      <option role="configure">--with-ndbm[=DIR]</option>.
+      <note>
        <para>
-       To enable support for cdb add
-       <option role="configure">--with-cdb[=DIR]</option>.
-       <note>
-        <para>
-         You can omit DIR to use the bundled cdb library 
-         that adds the cdb_make handler which allows creation of cdb files
-         and allows to access cdb files on the network using PHP's streams.
-        </para>
-       </note>
+        ndbm normally is a wrapper which often results in failures.
+        This means you should only use ndbm if you are sure it works
+        and if you really need this format.
        </para>
-      </entry>
-     </row>
+      </note>
+      </para>
+     </entry>
+    </row>
 
-     <row>
-      <entry><literal>flatfile</literal></entry>
-      <entry>
+    <row>
+     <entry><literal>gdbm</literal></entry>
+     <entry>
+      To enable support for gdbm add
+      <option role="configure">--with-gdbm[=DIR]</option>.
+     </entry>
+    </row>
+
+    <row>
+     <entry><literal>db2</literal></entry>
+     <entry>
+      <para>
+      To enable support for Oracle Berkeley DB 2 add
+      <option role="configure">--with-db2[=DIR]</option>.
+      <note>
        <para>
-       To enable support for flatfile add
-       <option role="configure">--enable-flatfile</option>.
-       Before PHP 5.2.1 the <option role="configure">--with-flatfile</option>
-       had to be used instead.
-       <note>
-        <para>
-         This was added to add compatibility with deprecated
-         <literal>dbm</literal> extension. Use this handler only
-         when you cannot install one of the libraries required by the other
-         handlers and when you cannot use bundled cdb handler.
-        </para>
-       </note>
+        db2 conflicts with db3 and db4.
        </para>
-      </entry>
-     </row>
+      </note>
+      </para>
+     </entry>
+    </row>
 
-     <row>
-      <entry><literal>inifile</literal></entry>
-      <entry>
+    <row>
+     <entry><literal>db3</literal></entry>
+     <entry>
+      <para>
+      To enable support for Oracle Berkeley DB 3 add
+      <option role="configure">--with-db3[=DIR]</option>.
+      <note>
        <para>
-       To enable support for <literal>inifile</literal> add
-       <option role="configure">--enable-inifile</option>.
-       Before PHP 5.2.1 the <option role="configure">--with-inifile</option>
-       had to be used instead.
-       <note>
-        <para>
-         This was added to allow to read and set microsoft style
-         <filename>.ini</filename> files (like the &php.ini; file).
-        </para>
-       </note>
+        db3 conflicts with db2 and db4.
        </para>
-      </entry>
-     </row>
+      </note>
+      </para>
+     </entry>
+    </row>
 
-     <row>
-      <entry><literal>qdbm</literal></entry>
-      <entry>
+    <row>
+     <entry><literal>db4</literal></entry>
+     <entry>
+      <para>
+      To enable support for Oracle Berkeley DB 4 or 5 add
+      <option role="configure">--with-db4[=DIR]</option>.
+      <note>
        <para>
-       To enable support for qdbm add
-       <option role="configure">--with-qdbm[=DIR]</option>.
-       <note>
-        <para>
-         qdbm conflicts with dbm and gdbm.
-        </para>
-       </note>
-       <note>
-        <para>
-         The qdbm library can be downloaded from
-         <link xlink:href="&url.qdbm;"/>.
-        </para>
-       </note>
+        db4 conflicts with db2 and db3.
        </para>
-      </entry>
-     </row>
-
-     <row>
-      <entry><literal>tcadb</literal></entry>
-      <entry>
+      </note>
+      <note>
        <para>
-       To enable support for Tokyo Cabinet add
-       <option role="configure">--with-tcadb[=DIR]</option>.
-       <note>
-        <para>
-         The Tokyo Cabinet library can be downloaded from
-         <link xlink:href="&url.tcadb;"/>.
-        </para>
-       </note>
+        The db libraries with
+        versions 4.1 through 4.1.24 cannot be used in any PHP version.
        </para>
-      </entry>
-     </row>
-
-     <row>
-      <entry><literal>lmdb</literal></entry>
-      <entry>
        <para>
-       To enable support for the Lightning Memory-Mapped Database add
-       <option role="configure">--with-lmdb[=DIR]</option>.
-       <note>
-        <para>
-         This was added in PHP 7.2.0. The Lightning Memory-Mapped Database
-         library can be downloaded from <link xlink:href="&url.lmdb;"/>.
-        </para>
-       </note>
+        Support for BDB 5 was added in PHP 5.3.3.
        </para>
-      </entry>
-     </row>
+      </note>
+     </para>
+     </entry>
+    </row>
 
-    </tbody>
-   </tgroup>
-  </table>
- </para>
+    <row>
+     <entry><literal>cdb</literal></entry>
+     <entry>
+      <para>
+      To enable support for cdb add
+      <option role="configure">--with-cdb[=DIR]</option>.
+      <note>
+       <para>
+        You can omit DIR to use the bundled cdb library
+        that adds the cdb_make handler which allows creation of cdb files
+        and allows to access cdb files on the network using PHP's streams.
+       </para>
+      </note>
+      </para>
+     </entry>
+    </row>
+
+    <row>
+     <entry><literal>flatfile</literal></entry>
+     <entry>
+      <para>
+      To enable support for flatfile add
+      <option role="configure">--enable-flatfile</option>.
+      Before PHP 5.2.1 the <option role="configure">--with-flatfile</option>
+      had to be used instead.
+      <note>
+       <para>
+        This was added to add compatibility with deprecated
+        <literal>dbm</literal> extension. Use this handler only
+        when you cannot install one of the libraries required by the other
+        handlers and when you cannot use bundled cdb handler.
+       </para>
+      </note>
+      </para>
+     </entry>
+    </row>
+
+    <row>
+     <entry><literal>inifile</literal></entry>
+     <entry>
+      <para>
+      To enable support for <literal>inifile</literal> add
+      <option role="configure">--enable-inifile</option>.
+      Before PHP 5.2.1 the <option role="configure">--with-inifile</option>
+      had to be used instead.
+      <note>
+       <para>
+        This was added to allow to read and set microsoft style
+        <filename>.ini</filename> files (like the &php.ini; file).
+       </para>
+      </note>
+      </para>
+     </entry>
+    </row>
+
+    <row>
+     <entry><literal>qdbm</literal></entry>
+     <entry>
+      <para>
+      To enable support for qdbm add
+      <option role="configure">--with-qdbm[=DIR]</option>.
+      <note>
+       <para>
+        qdbm conflicts with dbm and gdbm.
+       </para>
+      </note>
+      <note>
+       <para>
+        The qdbm library can be downloaded from
+        <link xlink:href="&url.qdbm;"/>.
+       </para>
+      </note>
+      </para>
+     </entry>
+    </row>
+
+    <row>
+     <entry><literal>tcadb</literal></entry>
+     <entry>
+      <para>
+      To enable support for Tokyo Cabinet add
+      <option role="configure">--with-tcadb[=DIR]</option>.
+      <note>
+       <para>
+        The Tokyo Cabinet library can be downloaded from
+        <link xlink:href="&url.tcadb;"/>.
+       </para>
+      </note>
+      </para>
+     </entry>
+    </row>
+
+    <row>
+     <entry><literal>lmdb</literal></entry>
+     <entry>
+      <para>
+      To enable support for the Lightning Memory-Mapped Database add
+      <option role="configure">--with-lmdb[=DIR]</option>.
+      <note>
+       <para>
+        This was added in PHP 7.2.0. The Lightning Memory-Mapped Database
+        library can be downloaded from <link xlink:href="&url.lmdb;"/>.
+       </para>
+      </note>
+      </para>
+     </entry>
+    </row>
+
+   </tbody>
+  </tgroup>
+ </table>
 </section>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/dba/examples.xml
+++ b/reference/dba/examples.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
-<chapter xml:id="dba.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="dba.examples">
  &reftitle.examples;
  <section xml:id="dba.example">
   <title>Basic usage</title>
-   <para>
-    <example>
-     <title>DBA example</title>
-     <programlisting role="php">
+   <example>
+    <title>DBA example</title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 
@@ -29,9 +27,8 @@ if (dba_exists("key", $id)) {
 dba_close($id);
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
   <para>
    DBA is binary safe and does not have any arbitrary limits.
    However, it inherits all limits set by the underlying
@@ -47,11 +44,10 @@ dba_close($id);
    You can access all entries of a database in a linear way by using the
    <function>dba_firstkey</function> and <function>dba_nextkey</function>
    functions. You may not change the database while traversing it.
-  </para> 
-  <para>
-   <example>
-    <title>Traversing a database</title>
-    <programlisting role="php">
+  </para>
+  <example>
+   <title>Traversing a database</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 
@@ -72,12 +68,10 @@ foreach ($handle_later as $val) {
 
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </section>
 </chapter>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
@@ -98,4 +92,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/dba/functions/dba-close.xml
+++ b/reference/dba/functions/dba-close.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="function.dba-close" xmlns="http://docbook.org/ns/docbook">
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.dba-close">
  <refnamediv>
   <refname>dba_close</refname>
   <refpurpose>Close a DBA database</refpurpose>
@@ -18,18 +18,16 @@
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>dba</parameter></term>
-     <listitem>
-      <para>
-       &dba.parameter.dba;
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>dba</parameter></term>
+    <listitem>
+     <para>
+      &dba.parameter.dba;
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
@@ -57,12 +55,10 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>dba_open</function></member>
-    <member><function>dba_popen</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>dba_open</function></member>
+   <member><function>dba_popen</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/dba/functions/dba-delete.xml
+++ b/reference/dba/functions/dba-delete.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="function.dba-delete" xmlns="http://docbook.org/ns/docbook">
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.dba-delete">
  <refnamediv>
   <refname>dba_delete</refname>
   <refpurpose>Delete DBA entry specified by key</refpurpose>
@@ -18,26 +18,24 @@
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>key</parameter></term>
-     <listitem>
-      <para>
-       The key of the entry which is deleted.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>dba</parameter></term>
-     <listitem>
-      <para>
-       &dba.parameter.dba;
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+      The key of the entry which is deleted.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>dba</parameter></term>
+    <listitem>
+     <para>
+      &dba.parameter.dba;
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
@@ -65,14 +63,12 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>dba_exists</function></member>
-    <member><function>dba_fetch</function></member>
-    <member><function>dba_insert</function></member>
-    <member><function>dba_replace</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>dba_exists</function></member>
+   <member><function>dba_fetch</function></member>
+   <member><function>dba_insert</function></member>
+   <member><function>dba_replace</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/dba/functions/dba-exists.xml
+++ b/reference/dba/functions/dba-exists.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="function.dba-exists" xmlns="http://docbook.org/ns/docbook">
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.dba-exists">
  <refnamediv>
   <refname>dba_exists</refname>
   <refpurpose>Check whether key exists</refpurpose>
@@ -19,26 +19,24 @@
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>key</parameter></term>
-     <listitem>
-      <para>
-       The key the check is performed for.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>dba</parameter></term>
-     <listitem>
-      <para>
-       &dba.parameter.dba;
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+      The key the check is performed for.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>dba</parameter></term>
+    <listitem>
+     <para>
+      &dba.parameter.dba;
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
@@ -66,14 +64,12 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>dba_delete</function></member>
-    <member><function>dba_fetch</function></member>
-    <member><function>dba_insert</function></member>
-    <member><function>dba_replace</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>dba_delete</function></member>
+   <member><function>dba_fetch</function></member>
+   <member><function>dba_insert</function></member>
+   <member><function>dba_replace</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/dba/functions/dba-fetch.xml
+++ b/reference/dba/functions/dba-fetch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="function.dba-fetch" xmlns="http://docbook.org/ns/docbook">
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.dba-fetch">
  <refnamediv>
   <refname>dba_fetch</refname>
   <refpurpose>Fetch data specified by key</refpurpose>
@@ -30,49 +30,47 @@
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>key</parameter></term>
-     <listitem>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+      The key the data is specified by.
+     </para>
+     <note>
       <para>
-       The key the data is specified by.
+       When working with inifiles this function accepts arrays as keys
+       where index 0 is the group and index 1 is the value name. See:
+       <function>dba_key_split</function>.
       </para>
-      <note>
-       <para>
-        When working with inifiles this function accepts arrays as keys
-        where index 0 is the group and index 1 is the value name. See:
-        <function>dba_key_split</function>.
-       </para>
-      </note>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>dba</parameter></term>
-     <listitem>
-      <para>
-       &dba.parameter.dba;
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>skip</parameter></term>
-     <listitem>
-      <para>
-       The number of key-value pairs to ignore when using cdb databases.
-       This value is ignored for all other databases which do not support
-       multiple keys with the same name.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+     </note>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>dba</parameter></term>
+    <listitem>
+     <para>
+      &dba.parameter.dba;
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>skip</parameter></term>
+    <listitem>
+     <para>
+      The number of key-value pairs to ignore when using cdb databases.
+      This value is ignored for all other databases which do not support
+      multiple keys with the same name.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the associated string if the key/data pair is found, &false; 
+   Returns the associated string if the key/data pair is found, &false;
    otherwise.
   </para>
  </refsect1>
@@ -111,15 +109,13 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>dba_exists</function></member>
-    <member><function>dba_delete</function></member>
-    <member><function>dba_insert</function></member>
-    <member><function>dba_replace</function></member>
-    <member><function>dba_key_split</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>dba_exists</function></member>
+   <member><function>dba_delete</function></member>
+   <member><function>dba_insert</function></member>
+   <member><function>dba_replace</function></member>
+   <member><function>dba_key_split</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/dba/functions/dba-firstkey.xml
+++ b/reference/dba/functions/dba-firstkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="function.dba-firstkey" xmlns="http://docbook.org/ns/docbook">
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.dba-firstkey">
  <refnamediv>
   <refname>dba_firstkey</refname>
   <refpurpose>Fetch first key</refpurpose>
@@ -19,23 +19,21 @@
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>dba</parameter></term>
-     <listitem>
-      <para>
-       &dba.parameter.dba;
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>dba</parameter></term>
+    <listitem>
+     <para>
+      &dba.parameter.dba;
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the key on success&return.falseforfailure;. 
+   Returns the key on success&return.falseforfailure;.
   </para>
  </refsect1>
 
@@ -58,13 +56,11 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>dba_nextkey</function></member>
-    <member><function>dba_key_split</function></member>
-    <member>Example 2 in the <link linkend="dba.examples">DBA examples</link></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>dba_nextkey</function></member>
+   <member><function>dba_key_split</function></member>
+   <member>Example 2 in the <link linkend="dba.examples">DBA examples</link></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/dba/functions/dba-handlers.xml
+++ b/reference/dba/functions/dba-handlers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="function.dba-handlers" xmlns="http://docbook.org/ns/docbook">
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.dba-handlers">
  <refnamediv>
   <refname>dba_handlers</refname>
   <refpurpose>List all the handlers available</refpurpose>
@@ -18,18 +18,16 @@
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>full_info</parameter></term>
-     <listitem>
-      <para>
-       Turns on/off full information display in the result.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>full_info</parameter></term>
+    <listitem>
+     <para>
+      Turns on/off full information display in the result.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
@@ -37,21 +35,20 @@
    Returns an array of database handlers. If <parameter>full_info</parameter>
    is set to &true;, the array will be associative with the handlers names as
    keys, and their version information as value. Otherwise, the result will be
-   an indexed array of handlers names.  
+   an indexed array of handlers names.
   </para>
   <note>
    <para>
-    When the internal cdb library is used you will see 
+    When the internal cdb library is used you will see
     <literal>cdb</literal> and <literal>cdb_make</literal>.
    </para>
   </note>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title><function>dba_handlers</function> Example</title>
-    <programlisting role="php">
+  <example>
+   <title><function>dba_handlers</function> Example</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 
@@ -64,23 +61,21 @@ foreach (dba_handlers(true) as $handler_name => $handler_version) {
 
 ?>
 ]]>
-    </programlisting>
-    &example.outputs.similar;
-    <screen>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
 <![CDATA[
 Available DBA handlers:
- - cdb: 0.75, Revision: 1.3.2.3 
- - cdb_make: 0.75, Revision: 1.2.2.4 
+ - cdb: 0.75, Revision: 1.3.2.3
+ - cdb_make: 0.75, Revision: 1.2.2.4
  - db2: Sleepycat Software: Berkeley DB 2.7.7: (08/20/99)
- - inifile: 1.0, Revision: 1.6.2.3 
- - flatfile: 1.0, Revision: 1.5.2.4 
+ - inifile: 1.0, Revision: 1.6.2.3
+ - flatfile: 1.0, Revision: 1.5.2.4
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/dba/functions/dba-insert.xml
+++ b/reference/dba/functions/dba-insert.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="function.dba-insert" xmlns="http://docbook.org/ns/docbook">
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.dba-insert">
  <refnamediv>
   <refname>dba_insert</refname>
   <refpurpose>Insert entry</refpurpose>
@@ -21,36 +21,34 @@
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>key</parameter></term>
-     <listitem>
-      <para>
-       The key of the entry to be inserted. If this key already exist in the 
-       database, this function will fail. Use <function>dba_replace</function>
-       if you need to replace an existent key.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>value</parameter></term>
-     <listitem>
-      <para>
-       The value to be inserted.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>dba</parameter></term>
-     <listitem>
-      <para>
-       &dba.parameter.dba;
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+      The key of the entry to be inserted. If this key already exist in the
+      database, this function will fail. Use <function>dba_replace</function>
+      if you need to replace an existent key.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <para>
+      The value to be inserted.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>dba</parameter></term>
+    <listitem>
+     <para>
+      &dba.parameter.dba;
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
@@ -78,14 +76,12 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>dba_exists</function></member>
-    <member><function>dba_delete</function></member>
-    <member><function>dba_fetch</function></member>
-    <member><function>dba_replace</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>dba_exists</function></member>
+   <member><function>dba_delete</function></member>
+   <member><function>dba_fetch</function></member>
+   <member><function>dba_replace</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/dba/functions/dba-key-split.xml
+++ b/reference/dba/functions/dba-key-split.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="function.dba-key-split" xmlns="http://docbook.org/ns/docbook">
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.dba-key-split">
  <refnamediv>
   <refname>dba_key_split</refname>
   <refpurpose>
@@ -20,24 +20,22 @@
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>key</parameter></term>
-     <listitem>
-      <para>
-       The key in string representation.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+      The key in string representation.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns an array of the form <literal>array(0 =&gt; group, 1 =&gt; 
-   value_name)</literal>. This function will return &false; if 
+   Returns an array of the form <literal>array(0 =&gt; group, 1 =&gt;
+   value_name)</literal>. This function will return &false; if
    <parameter>key</parameter> is &null; or &false;.
   </para>
  </refsect1>
@@ -67,13 +65,11 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>dba_firstkey</function></member>
-    <member><function>dba_nextkey</function></member>
-    <member><function>dba_fetch</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>dba_firstkey</function></member>
+   <member><function>dba_nextkey</function></member>
+   <member><function>dba_fetch</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/dba/functions/dba-nextkey.xml
+++ b/reference/dba/functions/dba-nextkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="function.dba-nextkey" xmlns="http://docbook.org/ns/docbook">
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.dba-nextkey">
  <refnamediv>
   <refname>dba_nextkey</refname>
   <refpurpose>Fetch next key</refpurpose>
@@ -14,27 +14,25 @@
   <para>
    <function>dba_nextkey</function> returns the next key of the database
    and advances the internal key pointer.
-  </para> 
+  </para>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>dba</parameter></term>
-     <listitem>
-      <para>
-       &dba.parameter.dba;
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>dba</parameter></term>
+    <listitem>
+     <para>
+      &dba.parameter.dba;
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the key on success&return.falseforfailure;. 
+   Returns the key on success&return.falseforfailure;.
   </para>
  </refsect1>
 
@@ -57,13 +55,11 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>dba_firstkey</function></member>
-    <member><function>dba_key_split</function></member>
-    <member>Example 2 in the <link linkend="dba.examples">DBA examples</link></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>dba_firstkey</function></member>
+   <member><function>dba_key_split</function></member>
+   <member>Example 2 in the <link linkend="dba.examples">DBA examples</link></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/dba/functions/dba-open.xml
+++ b/reference/dba/functions/dba-open.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="function.dba-open" xmlns="http://docbook.org/ns/docbook">
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.dba-open">
  <refnamediv>
   <refname>dba_open</refname>
   <refpurpose>Open database</refpurpose>
@@ -25,186 +25,184 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>path</parameter></term>
-     <listitem>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+      Commonly a regular path in your filesystem.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>mode</parameter></term>
+    <listitem>
+     <para>
+      It is <literal>r</literal> for read access, <literal>w</literal> for
+      read/write access to an already existing database, <literal>c</literal>
+      for read/write access and database creation if it doesn't currently exist,
+      and <literal>n</literal> for create, truncate and read/write access.
+      The database is created in BTree mode, other modes (like Hash or Queue)
+      are not supported.
+     </para>
+     <para>
+      Additionally you can set the database lock method with the next char.
+      Use <literal>l</literal> to lock the database with a <filename>.lck</filename>
+      file or <literal>d</literal> to lock the databasefile itself. It is
+      important that all of your applications do this consistently.
+     </para>
+     <para>
+      If you want to test the access and do not want to wait for the lock
+      you can add <literal>t</literal> as third character. When you are
+      absolutely sure that you do not require database locking you can do
+      so by using <literal>-</literal> instead of <literal>l</literal> or
+      <literal>d</literal>. When none of <literal>d</literal>,
+      <literal>l</literal> or <literal>-</literal> is used, dba will lock
+      on the database file as it would with <literal>d</literal>.
+     </para>
+     <note>
       <para>
-       Commonly a regular path in your filesystem.
+       There can only be one writer for one database file. When you use dba on
+       a web server and more than one request requires write operations they can
+       only be done one after another. Also read during write is not allowed.
+       The dba extension uses locks to prevent this. See the following table:
+       <table>
+        <title>DBA locking</title>
+        <tgroup cols="9">
+         <thead>
+          <row>
+           <entry>already open</entry>
+           <entry><parameter>mode</parameter> = "rl"</entry>
+           <entry><parameter>mode</parameter> = "rlt"</entry>
+           <entry><parameter>mode</parameter> = "wl"</entry>
+           <entry><parameter>mode</parameter> = "wlt"</entry>
+           <entry><parameter>mode</parameter> = "rd"</entry>
+           <entry><parameter>mode</parameter> = "rdt"</entry>
+           <entry><parameter>mode</parameter> = "wd"</entry>
+           <entry><parameter>mode</parameter> = "wdt"</entry>
+          </row>
+         </thead>
+         <tbody>
+          <row>
+           <entry>not open</entry>
+           <entry>ok</entry>
+           <entry>ok</entry>
+           <entry>ok</entry>
+           <entry>ok</entry>
+           <entry>ok</entry>
+           <entry>ok</entry>
+           <entry>ok</entry>
+           <entry>ok</entry>
+          </row>
+          <row>
+           <entry><parameter>mode</parameter> = "rl"</entry>
+           <entry>ok</entry>
+           <entry>ok</entry>
+           <entry>wait</entry>
+           <entry>false</entry>
+           <entry>illegal</entry>
+           <entry>illegal</entry>
+           <entry>illegal</entry>
+           <entry>illegal</entry>
+          </row>
+          <row>
+           <entry><parameter>mode</parameter> = "wl"</entry>
+           <entry>wait</entry>
+           <entry>false</entry>
+           <entry>wait</entry>
+           <entry>false</entry>
+           <entry>illegal</entry>
+           <entry>illegal</entry>
+           <entry>illegal</entry>
+           <entry>illegal</entry>
+          </row>
+          <row>
+           <entry><parameter>mode</parameter> = "rd"</entry>
+           <entry>illegal</entry>
+           <entry>illegal</entry>
+           <entry>illegal</entry>
+           <entry>illegal</entry>
+           <entry>ok</entry>
+           <entry>ok</entry>
+           <entry>wait</entry>
+           <entry>false</entry>
+          </row>
+          <row>
+           <entry><parameter>mode</parameter> = "wd"</entry>
+           <entry>illegal</entry>
+           <entry>illegal</entry>
+           <entry>illegal</entry>
+           <entry>illegal</entry>
+           <entry>wait</entry>
+           <entry>false</entry>
+           <entry>wait</entry>
+           <entry>false</entry>
+          </row>
+         </tbody>
+        </tgroup>
+       </table>
+       <simplelist>
+        <member>ok: the second call will be successful.</member>
+        <member>wait: the second call waits until <function>dba_close</function> is called for the first.</member>
+        <member>false: the second call returns false.</member>
+        <member>illegal: you must not mix <literal>"l"</literal> and <literal>"d"</literal> modifiers for <parameter>mode</parameter> parameter.</member>
+       </simplelist>
       </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>mode</parameter></term>
-     <listitem>
-      <para>
-       It is <literal>r</literal> for read access, <literal>w</literal> for
-       read/write access to an already existing database, <literal>c</literal>
-       for read/write access and database creation if it doesn't currently exist,
-       and <literal>n</literal> for create, truncate and read/write access.
-       The database is created in BTree mode, other modes (like Hash or Queue)
-       are not supported.
-      </para>
-      <para>
-       Additionally you can set the database lock method with the next char. 
-       Use <literal>l</literal> to lock the database with a <filename>.lck</filename>
-       file or <literal>d</literal> to lock the databasefile itself. It is 
-       important that all of your applications do this consistently.
-      </para>
-      <para>
-       If you want to test the access and do not want to wait for the lock 
-       you can add <literal>t</literal> as third character. When you are 
-       absolutely sure that you do not require database locking you can do 
-       so by using <literal>-</literal> instead of <literal>l</literal> or
-       <literal>d</literal>. When none of <literal>d</literal>, 
-       <literal>l</literal> or <literal>-</literal> is used, dba will lock
-       on the database file as it would with <literal>d</literal>.
-      </para>
-      <note>
-       <para>
-        There can only be one writer for one database file. When you use dba on 
-        a web server and more than one request requires write operations they can
-        only be done one after another. Also read during write is not allowed.
-        The dba extension uses locks to prevent this. See the following table:
-        <table>
-         <title>DBA locking</title>
-         <tgroup cols="9">
-          <thead>
-           <row>
-            <entry>already open</entry>
-            <entry><parameter>mode</parameter> = "rl"</entry>
-            <entry><parameter>mode</parameter> = "rlt"</entry>
-            <entry><parameter>mode</parameter> = "wl"</entry>
-            <entry><parameter>mode</parameter> = "wlt"</entry>
-            <entry><parameter>mode</parameter> = "rd"</entry>
-            <entry><parameter>mode</parameter> = "rdt"</entry>
-            <entry><parameter>mode</parameter> = "wd"</entry>
-            <entry><parameter>mode</parameter> = "wdt"</entry>
-           </row>
-          </thead>
-          <tbody>
-           <row>
-            <entry>not open</entry>
-            <entry>ok</entry>
-            <entry>ok</entry>
-            <entry>ok</entry>
-            <entry>ok</entry>
-            <entry>ok</entry>
-            <entry>ok</entry>
-            <entry>ok</entry>
-            <entry>ok</entry>
-           </row>
-           <row>
-            <entry><parameter>mode</parameter> = "rl"</entry>
-            <entry>ok</entry>
-            <entry>ok</entry>
-            <entry>wait</entry>
-            <entry>false</entry>
-            <entry>illegal</entry>
-            <entry>illegal</entry>
-            <entry>illegal</entry>
-            <entry>illegal</entry>
-           </row>
-           <row>
-            <entry><parameter>mode</parameter> = "wl"</entry>
-            <entry>wait</entry>
-            <entry>false</entry>
-            <entry>wait</entry>
-            <entry>false</entry>
-            <entry>illegal</entry>
-            <entry>illegal</entry>
-            <entry>illegal</entry>
-            <entry>illegal</entry>
-           </row>
-           <row>
-            <entry><parameter>mode</parameter> = "rd"</entry>
-            <entry>illegal</entry>
-            <entry>illegal</entry>
-            <entry>illegal</entry>
-            <entry>illegal</entry>
-            <entry>ok</entry>
-            <entry>ok</entry>
-            <entry>wait</entry>
-            <entry>false</entry>
-           </row>
-           <row>
-            <entry><parameter>mode</parameter> = "wd"</entry>
-            <entry>illegal</entry>
-            <entry>illegal</entry>
-            <entry>illegal</entry>
-            <entry>illegal</entry>
-            <entry>wait</entry>
-            <entry>false</entry>
-            <entry>wait</entry>
-            <entry>false</entry>
-           </row>
-          </tbody>
-         </tgroup>
-        </table>
-        <simplelist>
-         <member>ok: the second call will be successful.</member>
-         <member>wait: the second call waits until <function>dba_close</function> is called for the first.</member>
-         <member>false: the second call returns false.</member>
-         <member>illegal: you must not mix <literal>"l"</literal> and <literal>"d"</literal> modifiers for <parameter>mode</parameter> parameter.</member>
-        </simplelist>
-       </para>
-      </note>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>handler</parameter></term>
-     <listitem>
-      <para>
-       The name of the <link linkend="dba.requirements">handler</link> which
-       shall be used for accessing <parameter>path</parameter>. It is passed
-       all optional parameters given to <function>dba_open</function> and
-       can act on behalf of them. If <parameter>handler</parameter> is &null;,
-       then the default handler is invoked.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>permission</parameter></term>
-     <listitem>
-      <para>
-       Optional &integer; parameter which is passed to the driver. It has the same meaning as
-       the <parameter>permissions</parameter> parameter of <function>chmod</function>,
-       and defaults to <literal>0644</literal>.
-      </para>
-      <para>
-       The <literal>db1</literal>, <literal>db2</literal>, <literal>db3</literal>,
-       <literal>db4</literal>, <literal>dbm</literal>, <literal>gdbm</literal>,
-       <literal>ndbm</literal>, and <literal>lmdb</literal> drivers support the
-       <parameter>permission</parameter> parameter.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>map_size</parameter></term>
-     <listitem>
-      <para>
-       Optional &integer; parameter which is passed to the driver. Its value should be a multiple of the
-       page size of the OS, or zero, to use the default map size.
-      </para>
-      <para>
-       Only the <literal>lmdb</literal> driver accepts the <parameter>map_size</parameter> parameter.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>flags</parameter></term>
-     <listitem>
-      <para>
-       Flags to pass to the database drivers. If &null; the default flags will be provided.
-       Currently, only the LMDB driver supports the following flags
-       <constant>DBA_LMDB_USE_SUB_DIR</constant> and
-       <constant>DBA_LMDB_NO_SUB_DIR</constant>.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+     </note>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>handler</parameter></term>
+    <listitem>
+     <para>
+      The name of the <link linkend="dba.requirements">handler</link> which
+      shall be used for accessing <parameter>path</parameter>. It is passed
+      all optional parameters given to <function>dba_open</function> and
+      can act on behalf of them. If <parameter>handler</parameter> is &null;,
+      then the default handler is invoked.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>permission</parameter></term>
+    <listitem>
+     <para>
+      Optional &integer; parameter which is passed to the driver. It has the same meaning as
+      the <parameter>permissions</parameter> parameter of <function>chmod</function>,
+      and defaults to <literal>0644</literal>.
+     </para>
+     <para>
+      The <literal>db1</literal>, <literal>db2</literal>, <literal>db3</literal>,
+      <literal>db4</literal>, <literal>dbm</literal>, <literal>gdbm</literal>,
+      <literal>ndbm</literal>, and <literal>lmdb</literal> drivers support the
+      <parameter>permission</parameter> parameter.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>map_size</parameter></term>
+    <listitem>
+     <para>
+      Optional &integer; parameter which is passed to the driver. Its value should be a multiple of the
+      page size of the OS, or zero, to use the default map size.
+     </para>
+     <para>
+      Only the <literal>lmdb</literal> driver accepts the <parameter>map_size</parameter> parameter.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>flags</parameter></term>
+    <listitem>
+     <para>
+      Flags to pass to the database drivers. If &null; the default flags will be provided.
+      Currently, only the LMDB driver supports the following flags
+      <constant>DBA_LMDB_USE_SUB_DIR</constant> and
+      <constant>DBA_LMDB_NO_SUB_DIR</constant>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
@@ -266,12 +264,10 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>dba_popen</function></member>
-    <member><function>dba_close</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>dba_popen</function></member>
+   <member><function>dba_close</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/dba/functions/dba-optimize.xml
+++ b/reference/dba/functions/dba-optimize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="function.dba-optimize" xmlns="http://docbook.org/ns/docbook">
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.dba-optimize">
  <refnamediv>
   <refname>dba_optimize</refname>
   <refpurpose>Optimize database</refpurpose>
@@ -17,18 +17,16 @@
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>dba</parameter></term>
-     <listitem>
-      <para>
-       &dba.parameter.dba;
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>dba</parameter></term>
+    <listitem>
+     <para>
+      &dba.parameter.dba;
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
@@ -56,11 +54,9 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>dba_sync</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>dba_sync</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/dba/functions/dba-popen.xml
+++ b/reference/dba/functions/dba-popen.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="function.dba-popen" xmlns="http://docbook.org/ns/docbook">
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.dba-popen">
  <refnamediv>
   <refname>dba_popen</refname>
   <refpurpose>Open database persistently</refpurpose>
@@ -25,78 +25,76 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>path</parameter></term>
-     <listitem>
-      <para>
-       Commonly a regular path in your filesystem.
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+      Commonly a regular path in your filesystem.
+    </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>mode</parameter></term>
+    <listitem>
+     <para>
+      It is <literal>r</literal> for read access, <literal>w</literal> for
+      read/write access to an already existing database, <literal>c</literal>
+      for read/write access and database creation if it doesn't currently exist,
+      and <literal>n</literal> for create, truncate and read/write access.
      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>mode</parameter></term>
-     <listitem>
-      <para>
-       It is <literal>r</literal> for read access, <literal>w</literal> for
-       read/write access to an already existing database, <literal>c</literal>
-       for read/write access and database creation if it doesn't currently exist,
-       and <literal>n</literal> for create, truncate and read/write access.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>handler</parameter></term>
-     <listitem>
-      <para>
-       The name of the <link linkend="dba.requirements">handler</link> which
-       shall be used for accessing <parameter>path</parameter>. It is passed 
-       all optional parameters given to <function>dba_popen</function> and 
-       can act on behalf of them. If <parameter>handler</parameter> is &null;,
-       then the default handler is invoked.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>permission</parameter></term>
-     <listitem>
-      <para>
-       Optional &integer; parameter which is passed to the driver. It has the same meaning as
-       the <parameter>permissions</parameter> parameter of <function>chmod</function>,
-       and defaults to <literal>0644</literal>.
-      </para>
-      <para>
-       The <literal>db1</literal>, <literal>db2</literal>, <literal>db3</literal>,
-       <literal>db4</literal>, <literal>dbm</literal>, <literal>gdbm</literal>,
-       <literal>ndbm</literal>, and <literal>lmdb</literal> drivers support the
-       <parameter>permission</parameter> parameter.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>map_size</parameter></term>
-     <listitem>
-      <para>
-       Optional &integer; parameter which is passed to the driver. Its value should be a multiple of the
-       page size of the OS, or zero, to use the default mapsize.
-      </para>
-      <para>
-       The <literal>lmdb</literal> driver accepts the <parameter>map_size</parameter> parameter.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>flags</parameter></term>
-     <listitem>
-      <para>
-       Allows to pass flags to the DB drivers. Currently, only LMDB with
-       <constant>DBA_LMDB_USE_SUB_DIR</constant> and <constant>DBA_LMDB_NO_SUB_DIR</constant> are supported.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>handler</parameter></term>
+    <listitem>
+     <para>
+      The name of the <link linkend="dba.requirements">handler</link> which
+      shall be used for accessing <parameter>path</parameter>. It is passed
+      all optional parameters given to <function>dba_popen</function> and
+      can act on behalf of them. If <parameter>handler</parameter> is &null;,
+      then the default handler is invoked.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>permission</parameter></term>
+    <listitem>
+     <para>
+      Optional &integer; parameter which is passed to the driver. It has the same meaning as
+      the <parameter>permissions</parameter> parameter of <function>chmod</function>,
+      and defaults to <literal>0644</literal>.
+     </para>
+     <para>
+      The <literal>db1</literal>, <literal>db2</literal>, <literal>db3</literal>,
+      <literal>db4</literal>, <literal>dbm</literal>, <literal>gdbm</literal>,
+      <literal>ndbm</literal>, and <literal>lmdb</literal> drivers support the
+      <parameter>permission</parameter> parameter.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>map_size</parameter></term>
+    <listitem>
+     <para>
+      Optional &integer; parameter which is passed to the driver. Its value should be a multiple of the
+      page size of the OS, or zero, to use the default mapsize.
+     </para>
+     <para>
+      The <literal>lmdb</literal> driver accepts the <parameter>map_size</parameter> parameter.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>flags</parameter></term>
+    <listitem>
+     <para>
+      Allows to pass flags to the DB drivers. Currently, only LMDB with
+      <constant>DBA_LMDB_USE_SUB_DIR</constant> and <constant>DBA_LMDB_NO_SUB_DIR</constant> are supported.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
@@ -158,12 +156,10 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>dba_open</function></member>
-    <member><function>dba_close</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>dba_open</function></member>
+   <member><function>dba_close</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/dba/functions/dba-replace.xml
+++ b/reference/dba/functions/dba-replace.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="function.dba-replace" xmlns="http://docbook.org/ns/docbook">
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.dba-replace">
  <refnamediv>
   <refname>dba_replace</refname>
   <refpurpose>Replace or insert entry</refpurpose>
@@ -17,38 +17,36 @@
    <function>dba_replace</function> replaces or inserts the entry described
    with <parameter>key</parameter> and <parameter>value</parameter> into the
    database specified by <parameter>dba</parameter>.
-  </para> 
+  </para>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>key</parameter></term>
-     <listitem>
-      <para>
-       The key of the entry to be replaced.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>value</parameter></term>
-     <listitem>
-      <para>
-       The value to be replaced.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>dba</parameter></term>
-     <listitem>
-      <para>
-       &dba.parameter.dba;
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+      The key of the entry to be replaced.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <para>
+      The value to be replaced.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>dba</parameter></term>
+    <listitem>
+     <para>
+      &dba.parameter.dba;
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
@@ -76,14 +74,12 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>dba_exists</function></member>
-    <member><function>dba_delete</function></member>
-    <member><function>dba_fetch</function></member>
-    <member><function>dba_insert</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>dba_exists</function></member>
+   <member><function>dba_delete</function></member>
+   <member><function>dba_fetch</function></member>
+   <member><function>dba_insert</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/dba/functions/dba-sync.xml
+++ b/reference/dba/functions/dba-sync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="function.dba-sync" xmlns="http://docbook.org/ns/docbook">
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.dba-sync">
  <refnamediv>
   <refname>dba_sync</refname>
   <refpurpose>Synchronize database</refpurpose>
@@ -12,24 +12,22 @@
    <methodparam><type>Dba\Connection</type><parameter>dba</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>dba_sync</function> synchronizes the database. This will probably 
+   <function>dba_sync</function> synchronizes the database. This will probably
    trigger a physical write to the disk, if supported.
   </para>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>dba</parameter></term>
-     <listitem>
-      <para>
-       &dba.parameter.dba;
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>dba</parameter></term>
+    <listitem>
+     <para>
+      &dba.parameter.dba;
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
@@ -57,11 +55,9 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>dba_optimize</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>dba_optimize</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/dba/setup.xml
+++ b/reference/dba/setup.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
-<chapter xml:id="dba.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="dba.setup">
  &reftitle.setup;
- 
+
  <!-- {{{ Requirements -->
  <section xml:id="dba.requirements">
   &reftitle.required;
@@ -33,7 +32,7 @@
         handle the original dbm format.
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>ndbm</literal></entry>
        <entry>
@@ -42,7 +41,7 @@
         deprecated).
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>gdbm</literal></entry>
        <entry>
@@ -50,7 +49,7 @@
         manager</link>.
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>db2</literal></entry>
        <entry>
@@ -60,7 +59,7 @@
         standalone and client/server applications."
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>db3</literal></entry>
        <entry>
@@ -68,7 +67,7 @@
         3</link>.
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>db4</literal></entry>
        <entry>
@@ -77,7 +76,7 @@
         be used with BDB 5 as of PHP 5.3.3.
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>cdb</literal></entry>
        <entry>
@@ -88,39 +87,39 @@
         We support writing (not updating) through the internal cdb library.
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>cdb_make</literal></entry>
        <entry>
-        We support creation (not updating) of cdb files 
+        We support creation (not updating) of cdb files
         when the bundled cdb library is used.
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>flatfile</literal></entry>
        <entry>
         This is available for compatibility with the deprecated
-        <literal>dbm</literal> extension only and should be avoided. 
+        <literal>dbm</literal> extension only and should be avoided.
         However you may use this where files were created in this format. That
         happens when configure could not find any external library.
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>inifile</literal></entry>
        <entry>
-        This is available to be able to modify php.ini files 
-        from within PHP scripts. When working with ini files you can pass arrays 
-        of the form array(0=>group,1=>value_name) or strings of the form 
-        "[group]value_name" where group is optional. As the functions 
+        This is available to be able to modify php.ini files
+        from within PHP scripts. When working with ini files you can pass arrays
+        of the form array(0=&gt;group,1=&gt;value_name) or strings of the form
+        "[group]value_name" where group is optional. As the functions
         <function>dba_firstkey</function> and <function>dba_nextkey</function>
         return string representations of the key there is the function
         <function>dba_key_split</function> which allows
         to convert the string keys into array keys without loosing &false;.
        </entry>
       </row>
-      
+
       <row>
        <entry><literal>qdbm</literal></entry>
        <entry>
@@ -132,7 +131,7 @@
       <row>
        <entry><literal>tcadb</literal></entry>
        <entry>
-        The Tokyo Cabinet library can be 
+        The Tokyo Cabinet library can be
         downloaded from <link xlink:href="&url.tcadb;"/>.
        </entry>
       </row>
@@ -140,11 +139,11 @@
       <row>
        <entry><literal>lmdb</literal></entry>
        <entry>
-        This is available since PHP 7.2.0. The Lightning Memory-Mapped Database library 
+        This is available since PHP 7.2.0. The Lightning Memory-Mapped Database library
         can be downloaded from <link xlink:href="&url.lmdb;"/>.
        </entry>
       </row>
-      
+
      </tbody>
     </tgroup>
    </table>
@@ -158,43 +157,41 @@
   </para>
  </section>
  <!-- }}} -->
- 
+
  <!-- {{{ Installation -->
  &reference.dba.configure;
  <!-- }}} -->
- 
+
  <!-- {{{ Configuration -->
  <section xml:id="dba.configuration">
   &reftitle.runtime;
   &extension.runtime;
-  <para>
-   <table>
-    <title>DBA &ConfigureOptions;</title>
-    <tgroup cols="4">
-     <thead>
-      <row>
-       <entry>&Name;</entry>
-       <entry>&Default;</entry>
-       <entry>&Changeable;</entry>
-       <entry>&Changelog;</entry>
-      </row>
-     </thead>
-     <tbody xml:id="dba.configuration.list">
-      <row>
-       <entry>
-        <link linkend="ini.dba.default_handler">dba.default_handler</link>
-       </entry>
-       <entry>DBA_DEFAULT</entry>
-       <entry><constant>INI_ALL</constant></entry>
-       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </table>
-  </para>
-  
+  <table>
+   <title>DBA &ConfigureOptions;</title>
+   <tgroup cols="4">
+    <thead>
+     <row>
+      <entry>&Name;</entry>
+      <entry>&Default;</entry>
+      <entry>&Changeable;</entry>
+      <entry>&Changelog;</entry>
+     </row>
+    </thead>
+    <tbody xml:id="dba.configuration.list">
+     <row>
+      <entry>
+       <link linkend="ini.dba.default_handler">dba.default_handler</link>
+      </entry>
+      <entry>DBA_DEFAULT</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+
   &ini.descriptions.title;
-  
+
   <para>
    <variablelist>
     <varlistentry xml:id="ini.dba.default_handler">
@@ -208,12 +205,12 @@
       </para>
      </listitem>
     </varlistentry>
-    
+
    </variablelist>
   </para>
  </section>
  <!-- }}} -->
- 
+
  <!-- {{{ Resources -->
  <section xml:id="dba.resources">
   &reftitle.resources;
@@ -223,9 +220,8 @@
   </para>
  </section>
  <!-- }}} -->
- 
-</chapter>
 
+</chapter>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
@@ -246,4 +242,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-


### PR DESCRIPTION
Done via a new script I am working on to do bulk changes across translations.

The script in question is https://gist.github.com/Girgias/156ad2af8df711ab038710d1a741205f

It should only ever be run on paths where translations can automatically have their revcheck tag updated. And the DBA extension docs are one such case.