### PR TITLE
Clarify REQUEST_TIME and REQUEST_TIME_FLOAT initialization timing

### DIFF
--- a/language/predefined/variables/server.xml
+++ b/language/predefined/variables/server.xml
@@ -162,7 +162,7 @@
      <term>'<varname>REQUEST_TIME</varname>'</term>
      <listitem>
       <simpara>
-       The timestamp of the start of the request.
+       The timestamp when PHP started processing the request.
       </simpara>
      </listitem>
     </varlistentry>
@@ -171,7 +171,7 @@
      <term>'<varname>REQUEST_TIME_FLOAT</varname>'</term>
      <listitem>
       <simpara>
-       The timestamp of the start of the request, with microsecond precision.
+       The timestamp when PHP started processing the request, with microsecond precision.
       </simpara>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
The documentation suggested that $_SERVER['REQUEST_TIME'] and $_SERVER['REQUEST_TIME_FLOAT'] reflect when the web server received the request.

In practice, these values are initialized when PHP starts processing the request. This updates the wording to accurately reflect the actual behavior without changing semantics.

Issue: https://github.com/php/doc-en/issues/4412