### PR TITLE
Extend Iterator::rewind note to mention NoRewindIterator

### DIFF
--- a/language/predefined/iterator/rewind.xml
+++ b/language/predefined/iterator/rewind.xml
@@ -29,7 +29,7 @@
    <simpara>
     To iterate without rewinding the iterator, wrap it in a
     <classname>NoRewindIterator</classname>.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 


### PR DESCRIPTION
This extends the note on `Iterator::rewind()` to clarify that foreach always rewinds the iterator before iteration and points users to `NoRewindIterator` when rewinding should be avoided.

Issue: https://github.com/php/doc-en/issues/3308