### PR TITLE
Document all available options for mysqli::options

### DIFF
--- a/reference/mysqli/mysqli/options.xml
+++ b/reference/mysqli/mysqli/options.xml
@@ -68,6 +68,12 @@
            <entry>Enable/disable use of <literal>LOAD LOCAL INFILE</literal></entry>
           </row>
           <row>
+           <entry><constant>MYSQLI_OPT_LOAD_DATA_LOCAL_DIR</constant></entry>
+           <entry>
+            Directory to be used for <literal>LOAD DATA LOCAL INFILE</literal>.
+           </entry>
+          </row>
+          <row>
            <entry><constant>MYSQLI_INIT_COMMAND</constant></entry>
            <entry>Command to execute after when connecting to MySQL server</entry>
           </row>
@@ -121,6 +127,18 @@
            <entry><constant>MYSQLI_OPT_SSL_VERIFY_SERVER_CERT</constant></entry>
            <entry>
             Whether to verify server certificate or not.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>MYSQLI_OPT_CAN_HANDLE_EXPIRED_PASSWORDS</constant></entry>
+           <entry>
+            Whether the client should accept expired passwords.
+           </entry>
+          </row>
+          <row>
+           <entry><literal>1</literal></entry>
+           <entry>
+            Whether to use network communication compression.
            </entry>
           </row>
          </tbody>


### PR DESCRIPTION
There are 18 acceptable options, but only 12 are documented. 3 are unsupported by mysqlnd so I propose to remove them from mysqli. 2 of them can be easily documented. And for compression, there doesn't seem to be a constant available, so it can only be used by providing a numerical value. 