### PR TITLE
fsockopen's error_code & error_message are nullable.

### DIFF
--- a/reference/network/functions/fsockopen.xml
+++ b/reference/network/functions/fsockopen.xml
@@ -12,8 +12,8 @@
    <type class="union"><type>resource</type><type>false</type></type><methodname>fsockopen</methodname>
    <methodparam><type>string</type><parameter>hostname</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>port</parameter><initializer>-1</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter role="reference">error_code</parameter><initializer>&null;</initializer></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter role="reference">error_message</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter role="reference">error_code</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter role="reference">error_message</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>float</type><type>null</type></type><parameter>timeout</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>


### PR DESCRIPTION
tested on 8.3.4.