### PR TITLE
Add strict inequality check for Suit enumeration

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -105,6 +105,8 @@ $b = Suit::Spades;
 $a === $b; // true
 
 $a instanceof Suit;  // true
+
+$a !== 'Spades'; // true
 ?>
 ]]>
    </programlisting>


### PR DESCRIPTION
The paragraph above the examples states:

> By default, cases are not intrinsically backed by a scalar value. That is, Suit::Hearts is not equal to "0". Instead, each case is backed by a singleton object of that name.

This new example demonstrates that more clearly than the others.