### PR TITLE
Document environment variable expansion in configuration

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -1018,6 +1018,7 @@ group = ${USER_NAME:-www-data}
         </programlisting>
        </example>
     </para>
+    <para>
      It's possible to pass additional environment variables and update PHP settings of a certain pool.
      To do this, you need to add the following options to the pool configuration file.
      <example>

--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -1004,6 +1004,20 @@
      </varlistentry>
     </variablelist>
     <para>
+     Configuration values can be set using environment variable expansion.
+     Setting default values when the environment variable is unset or null is also supported.
+     For example:
+        <example>
+        <title>Using environment variable expansion</title>
+        <programlisting role="ini">
+<![CDATA[
+listen = /var/run/php-fpm-$POOL_NAME.sock
+user = ${USER_NAME:-www-data}
+group = ${USER_NAME:-www-data}
+]]>
+        </programlisting>
+       </example>
+    </para>
      It's possible to pass additional environment variables and update PHP settings of a certain pool.
      To do this, you need to add the following options to the pool configuration file.
      <example>

--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -1011,7 +1011,7 @@
         <title>Using environment variable expansion</title>
         <programlisting role="ini">
 <![CDATA[
-listen = /var/run/php-fpm-$POOL_NAME.sock
+listen = /var/run/php-fpm-${POOL_NAME}.sock
 user = ${USER_NAME:-www-data}
 group = ${USER_NAME:-www-data}
 ]]>

--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -1005,7 +1005,7 @@
     </variablelist>
     <para>
      Configuration values can be set using environment variable expansion.
-     Setting default values when the environment variable is unset or null is also supported.
+     Setting default values when the environment variable is unset or null is also supported as of PHP 8.3.0.
      For example:
         <example>
         <title>Using environment variable expansion</title>


### PR DESCRIPTION
I noticed that I can use variable expansion within `php-fpm.conf` files. The documentation page does not explicitly mentions this. Instead it only provides examples of passing environment variables on to the child process.

At the very top of the page there is a mention that `php.ini` syntax is used. This somewhat implies that variable expansion is supported just like in `php.ini`. I suggest though that we update the discussion on environment variables with an example of how it php-fpm can be configured using env vars to make the support for this more explicit.
