### PR TITLE
Improve date format documentation a little bit

### DIFF
--- a/reference/datetime/constants.xml
+++ b/reference/datetime/constants.xml
@@ -68,7 +68,7 @@
    </term>
    <listitem>
     <simpara>
-     Atom (example: <literal>2005-08-15T15:52:01+00:00</literal>)
+     Atom (example: <literal>2005-08-15T15:52:01+00:00</literal>); compatible with ISO-8601, RFC 3399, and XML Schema
     </simpara>
    </listitem>
   </varlistentry>
@@ -92,7 +92,7 @@
    </term>
    <listitem>
     <simpara>
-     ISO-8601 (example: <literal>2005-08-15T15:52:01+0000</literal>)
+     ISO-8601-like (example: <literal>2005-08-15T15:52:01+0000</literal>)
     </simpara>
     <note>
      <simpara>

--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -158,7 +158,7 @@
      <term><constant>DATE_ATOM</constant></term>
      <listitem>
       <simpara>
-       Atom (example: 2005-08-15T15:52:01+00:00)
+       Atom (example: 2005-08-15T15:52:01+00:00); compatible with ISO-8601, RFC 3399, and XML Schema
       </simpara>
      </listitem>
     </varlistentry>
@@ -184,7 +184,7 @@
      <term><constant>DATE_ISO8601</constant></term>
      <listitem>
       <simpara>
-       ISO-8601 (example: 2005-08-15T15:52:01+0000)
+       ISO-8601-like (example: 2005-08-15T15:52:01+0000)
       </simpara>
       <note>
        <simpara>


### PR DESCRIPTION
Make it a bit more visible yet that `DATE_ISO8601` is not compatible with ISO-8601 (anyone wondering “why ‘like’?” will hopefully see the note immediately below), and mention the standards that Atom is compatible with (straight from RFC 4287, section 3.3; I omitted the “Date and Time Formats” W3C note as it doesn’t seem as prominent as the others) in the hope of encouraging more people to use it.