### PR TITLE
Document DEBUG_BACKTRACE_PROVIDE_OBJECT as inert for debug_print_backtrace()

### DIFF
--- a/reference/errorfunc/functions/debug-print-backtrace.xml
+++ b/reference/errorfunc/functions/debug-print-backtrace.xml
@@ -42,6 +42,14 @@
             to save memory.
            </entry>
           </row>
+          <row>
+           <entry>DEBUG_BACKTRACE_PROVIDE_OBJECT</entry>
+           <entry>
+            Accepted for compatibility with <function>debug_backtrace</function>,
+            but has no effect: the generated backtrace is rendered as a string
+            and the "object" entry is never printed.
+           </entry>
+          </row>
          </tbody>
         </tgroup>
        </table>


### PR DESCRIPTION
`debug_print_backtrace()` accepts the same `$options` as `debug_backtrace()`, but the manual only documents `DEBUG_BACKTRACE_IGNORE_ARGS`. The linked issue asks whether `DEBUG_BACKTRACE_PROVIDE_OBJECT` does anything at all.

It does not. Measured on PHP 8.5.4, with an object method in the stack:

```
--- no option (default 0) ---
#0 t.php(5): A->go()
#1 t.php(6): wrap('...')
--- DEBUG_BACKTRACE_PROVIDE_OBJECT ---
#0 t.php(5): A->go()
#1 t.php(6): wrap('...')          identical
--- DEBUG_BACKTRACE_IGNORE_ARGS ---
#0 t.php(5): A->go()
#1 t.php(6): wrap()               differs
```

`ZEND_FUNCTION(debug_print_backtrace)` in `Zend/zend_builtin_functions.c` builds the backtrace array, renders it with `zend_trace_to_string()`, writes the string and frees the array. The option does populate the `object` key of that array, but the rendering never reads it and the array is discarded, so nothing is observable. Consistently with that, `debug_print_backtrace()` defaults to `0`, while `debug_backtrace()` defaults to `DEBUG_BACKTRACE_PROVIDE_OBJECT`.

The row therefore documents the option as accepted and inert, rather than describing an effect a reader cannot observe. Whether passing it should be deprecated is a php-src question and is not addressed here.

Fixes: #4734
