### PR TITLE
Fix ldap_count_entries() return value documentation

### DIFF
--- a/reference/ldap/functions/ldap-count-entries.xml
+++ b/reference/ldap/functions/ldap-count-entries.xml
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns number of entries in the result,&return.falseforfailure;.
+   Returns the number of entries in the result, or <literal>-1</literal> on error.
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-count-entries.xml
+++ b/reference/ldap/functions/ldap-count-entries.xml
@@ -45,9 +45,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the number of entries in the result, or <literal>-1</literal> on error.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">


### PR DESCRIPTION
The manual stated that `ldap_count_entries()` returns false on failure.
According to the OpenLDAP documentation and the PHP implementation, the function returns `-1` on error.
This PR corrects the return value documentation.

Reference: https://www.openldap.org/software/man.cgi?query=ldap_count_entries ("If an error occurs in ldap_count_entries(), -1 is returned, and ld_errno is set appropriately.")

Fixes https://github.com/php/doc-en/issues/4683
