### PR TITLE
Clarify Argon2 memory_cost and time_cost units in password_hash()

### DIFF
--- a/reference/password/constants.xml
+++ b/reference/password/constants.xml
@@ -87,7 +87,7 @@
       </listitem>
       <listitem>
        <para>
-        <literal>time_cost</literal> (<type>int</type>) - Number of iterations (passes) used 
+        <literal>time_cost</literal> (<type>int</type>) - Number of iterations (passes) used
         to compute the Argon2 hash. Defaults to <constant>PASSWORD_ARGON2_DEFAULT_TIME_COST</constant>.
        </para>
       </listitem>
@@ -127,7 +127,7 @@
     </term>
     <listitem>
      <para>
-      Default amount of memory in kibibytes (KiB) that will be used 
+      Default amount of memory in kibibytes (KiB) that will be used
       to compute a hash.
      </para>
      <para>

--- a/reference/password/constants.xml
+++ b/reference/password/constants.xml
@@ -57,8 +57,11 @@
     </term>
     <listitem>
      <para>
+      Default algorithmic cost used by <function>password_hash</function> when
+      hashing passwords with <constant>PASSWORD_BCRYPT</constant>.
      </para>
      <para>
+      Available as of PHP 7.0.0.
      </para>
     </listitem>
    </varlistentry>
@@ -84,8 +87,8 @@
       </listitem>
       <listitem>
        <para>
-        <literal>time_cost</literal> (<type>int</type>) - Maximum amount of time it may
-        take to compute the Argon2 hash. Defaults to <constant>PASSWORD_ARGON2_DEFAULT_TIME_COST</constant>.
+        <literal>time_cost</literal> (<type>int</type>) - Number of iterations (passes) used 
+        to compute the Argon2 hash. Defaults to <constant>PASSWORD_ARGON2_DEFAULT_TIME_COST</constant>.
        </para>
       </listitem>
       <listitem>
@@ -124,8 +127,8 @@
     </term>
     <listitem>
      <para>
-      Default amount of memory in bytes that will be used while trying to
-      compute a hash.
+      Default amount of memory in kibibytes (KiB) that will be used 
+      to compute a hash.
      </para>
      <para>
       Available as of PHP 7.2.0.
@@ -139,7 +142,7 @@
     </term>
     <listitem>
      <para>
-      Default amount of time that will be spent trying to compute a hash.
+      Default number of iterations (passes) used to compute a hash.
      </para>
      <para>
       Available as of PHP 7.2.0.

--- a/reference/password/constants.xml
+++ b/reference/password/constants.xml
@@ -56,13 +56,13 @@
      (<type>int</type>)
     </term>
     <listitem>
-     <para>
+     <simpara>
       Default algorithmic cost used by <function>password_hash</function> when
       hashing passwords with <constant>PASSWORD_BCRYPT</constant>.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Available as of PHP 7.0.0.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.password-argon2i">
@@ -86,10 +86,10 @@
        </para>
       </listitem>
       <listitem>
-       <para>
+       <simpara>
         <literal>time_cost</literal> (<type>int</type>) - Number of iterations (passes) used
         to compute the Argon2 hash. Defaults to <constant>PASSWORD_ARGON2_DEFAULT_TIME_COST</constant>.
-       </para>
+       </simpara>
       </listitem>
       <listitem>
        <para>
@@ -126,13 +126,13 @@
      (<type>int</type>)
     </term>
     <listitem>
-     <para>
+     <simpara>
       Default amount of memory in kibibytes (KiB) that will be used
       to compute a hash.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Available as of PHP 7.2.0.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.password-argon2-default-time-cost">
@@ -141,12 +141,12 @@
      (<type>int</type>)
     </term>
     <listitem>
-     <para>
+     <simpara>
       Default number of iterations (passes) used to compute a hash.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Available as of PHP 7.2.0.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.password-argon2-default-threads">

--- a/reference/password/functions/password-hash.xml
+++ b/reference/password/functions/password-hash.xml
@@ -101,8 +101,8 @@
     </listitem>
     <listitem>
      <para>
-      <literal>time_cost</literal> (<type>int</type>) - Maximum amount of time it may 
-      take to compute the Argon2 hash. Defaults to <constant>PASSWORD_ARGON2_DEFAULT_TIME_COST</constant>.
+      <literal>time_cost</literal> (<type>int</type>) - Number of iterations (passes)
+      used to compute the Argon2 hash. Defaults to <constant>PASSWORD_ARGON2_DEFAULT_TIME_COST</constant>.
      </para>
     </listitem>
     <listitem>

--- a/reference/password/functions/password-hash.xml
+++ b/reference/password/functions/password-hash.xml
@@ -100,10 +100,10 @@
      </para>
     </listitem>
     <listitem>
-     <para>
+     <simpara>
       <literal>time_cost</literal> (<type>int</type>) - Number of iterations (passes)
       used to compute the Argon2 hash. Defaults to <constant>PASSWORD_ARGON2_DEFAULT_TIME_COST</constant>.
-     </para>
+     </simpara>
     </listitem>
     <listitem>
      <para>


### PR DESCRIPTION
Clarifies Argon2 option semantics: `memory_cost` is expressed in KiB and `time_cost` represents the number of iterations, not a duration.

Fixes https://github.com/php/doc-en/issues/4577