### PR TITLE
Clarify executable lookup when using proc_open() with array command

### DIFF
--- a/reference/exec/functions/proc-open.xml
+++ b/reference/exec/functions/proc-open.xml
@@ -69,6 +69,15 @@
        In this case the process will be opened directly (without going through a shell)
        and PHP will take care of any necessary argument escaping.
       </para>
+      <simpara>
+       When <parameter>command</parameter> is provided as an array and the first element
+       is a simple filename without directory separators, the executable is searched
+       using the current <envar>PATH</envar> environment variable.
+      </simpara>
+      <simpara>
+       If <envar>PATH</envar> is not set, the system default search paths are used, as
+       defined by the operating system.
+      </simpara>
       <note>
        <para>
         On Windows, the argument escaping of the &array; elements assumes that the


### PR DESCRIPTION
Fixes https://github.com/php/doc-en/issues/3558