### PR TITLE
Explain atomic groups referenced in PCRE Unicode documentation

### DIFF
--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -1052,15 +1052,15 @@
    composed character, regardless of how many individual characters are
    actually used to render it.
   </para>
-  <para>
+  <simpara>
    In versions of PCRE older than 8.32 (which corresponds to PHP versions
    before 5.4.14 when using the bundled PCRE library), <literal>\X</literal>
    is equivalent to <literal>(?>\PM\pM*)</literal>. That is, it matches a
    character without the "mark" property, followed by zero or more characters
    with the "mark" property, and treats the sequence as an atomic group (see
-   below). Characters with the "mark" property are typically accents that
-   affect the preceding character.
-  </para>
+   <xref linkend="regexp.reference.onlyonce"/>). Characters with the "mark"
+   property are typically accents that affect the preceding character.
+  </simpara>
   <para>
    Matching characters by Unicode property is not fast, because PCRE has
    to search a structure that contains data for over fifteen thousand
@@ -1987,6 +1987,9 @@
 
  <section xml:id="regexp.reference.onlyonce">
   <title>Once-only subpatterns</title>
+  <simpara>
+   Once-only subpatterns are also known as <emphasis>atomic groups</emphasis>.
+  </simpara>
   <para>
    With both maximizing and minimizing repetition, failure of
    what follows normally causes the repeated item to be


### PR DESCRIPTION
This adds a brief explanation of atomic groups in the PCRE Unicode documentation.

Fixes https://github.com/php/doc-en/issues/5126