### PR TITLE
Clarify PCRE delimiters must be single-byte characters

### DIFF
--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -28,12 +28,20 @@
  </section>
  <section xml:id="regexp.reference.delimiters">
   <title>Delimiters</title>
-  <para>
+  <simpara>
    When using the PCRE functions, it is required that the pattern is enclosed
    by <emphasis>delimiters</emphasis>. A delimiter can be any non-alphanumeric,
-   non-backslash, non-whitespace character.
+   non-backslash, non-whitespace single-byte character.
    Leading whitespace before a valid delimiter is silently ignored.
-  </para>
+  </simpara>
+  <note>
+   <simpara>
+    Multi-byte characters (such as UTF-8 encoded characters like <literal>§</literal>)
+    cannot be used as delimiters. PHP reads exactly one byte as the delimiter;
+    using a multi-byte character would cause the remaining bytes to be
+    misinterpreted as unknown pattern modifiers.
+   </simpara>
+  </note>
   <para>
    Often used delimiters are forward slashes (<literal>/</literal>), hash
    signs (<literal>#</literal>) and tildes (<literal>~</literal>). The


### PR DESCRIPTION
The previous wording stated that delimiters must be non-alphanumeric, non-backslash, non-whitespace characters, without mentioning the single-byte requirement. Multi-byte characters (e.g. UTF-8 sequences) silently fail: PHP reads only the first byte as the delimiter, causing the remaining bytes to be misinterpreted as pattern modifiers.

Fixes #4817