### PR TITLE
Move default flag clarification to top of flags description (#4831)

### DIFF
--- a/reference/pcre/functions/preg-match-all.xml
+++ b/reference/pcre/functions/preg-match-all.xml
@@ -60,6 +60,10 @@
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
+      <simpara>
+       If no order flag is given, <constant>PREG_PATTERN_ORDER</constant> is
+       assumed.
+      </simpara>
       <para>
        Can be a combination of the following flags (note that it doesn't make
        sense to use <constant>PREG_PATTERN_ORDER</constant> together with
@@ -245,10 +249,6 @@ Array
          </listitem>
         </varlistentry>  
        </variablelist>
-      </para>
-      <para>
-       If no order flag is given, <constant>PREG_PATTERN_ORDER</constant> is
-       assumed.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
The note about PREG_PATTERN_ORDER being the default was buried at the end of the flags list, making it easy to miss.

https://github.com/php/doc-en/issues/4831