### PR TITLE
Document named arguments support in Reflection ...Args methods

### DIFF
--- a/reference/reflection/reflectionclass/newinstanceargs.xml
+++ b/reference/reflection/reflectionclass/newinstanceargs.xml
@@ -26,9 +26,24 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The parameters to be passed to the class constructor as an <type>array</type>.
-      </para>
+      </simpara>
+      <simpara>
+       If the keys of <parameter>args</parameter> are all numeric, the keys are
+       ignored and each element is passed to the constructor as a positional
+       argument, in order.
+      </simpara>
+      <simpara>
+       If any keys of <parameter>args</parameter> are strings, those elements are
+       passed to the constructor as named arguments, with the name given by the
+       key.
+      </simpara>
+      <simpara>
+       An <exceptionname>Error</exceptionname> is thrown if a numeric key in
+       <parameter>args</parameter> appears after a string key, or if a string key
+       does not match the name of any constructor parameter.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -52,7 +67,29 @@
    and the <parameter>args</parameter> parameter contains one or more parameters.
   </para>
  </refsect1>
- 
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       <parameter>args</parameter> keys will now be interpreted as parameter names, instead of being silently ignored.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/reflection/reflectionfunction/invokeargs.xml
+++ b/reference/reflection/reflectionfunction/invokeargs.xml
@@ -25,10 +25,25 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
-       The passed arguments to the function as an array, much like 
-       <function>call_user_func_array</function> works.
-      </para>
+      <simpara>
+       The parameters to be passed to the function, as an <type>array</type>,
+       much like <function>call_user_func_array</function> works.
+      </simpara>
+      <simpara>
+       If the keys of <parameter>args</parameter> are all numeric, the keys are
+       ignored and each element is passed to the function as a positional
+       argument, in order.
+      </simpara>
+      <simpara>
+       If any keys of <parameter>args</parameter> are strings, those elements are
+       passed to the function as named arguments, with the name given by the
+       key.
+      </simpara>
+      <simpara>
+       An <exceptionname>Error</exceptionname> is thrown if a numeric key in
+       <parameter>args</parameter> appears after a string key, or if a string key
+       does not match the name of any parameter of the function.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/reflection/reflectionmethod/invokeargs.xml
+++ b/reference/reflection/reflectionmethod/invokeargs.xml
@@ -35,9 +35,24 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
-       The parameters to be passed to the function, as an <type>array</type>.
-      </para>
+      <simpara>
+       The parameters to be passed to the method, as an <type>array</type>.
+      </simpara>
+      <simpara>
+       If the keys of <parameter>args</parameter> are all numeric, the keys are
+       ignored and each element is passed to the method as a positional
+       argument, in order.
+      </simpara>
+      <simpara>
+       If any keys of <parameter>args</parameter> are strings, those elements are
+       passed to the method as named arguments, with the name given by the
+       key.
+      </simpara>
+      <simpara>
+       An <exceptionname>Error</exceptionname> is thrown if a numeric key in
+       <parameter>args</parameter> appears after a string key, or if a string key
+       does not match the name of any parameter of the method.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Document that `args` keys are interpreted as parameter names since PHP 8.0 on `ReflectionClass::newInstanceArgs`, which was the only Reflection method taking an array of arguments still missing that changelog entry.

The `args` parameter description now states the current contract explicitly on the three methods, the way `call_user_func_array()` does: numeric keys are positional, string keys are named arguments, and an `Error` is thrown for a numeric key after a string key or for a string key matching no parameter. Previously the two `invokeArgs` pages carried the changelog row but never said what the keys do.

Behaviour verified on php:7.4-cli through php:8.4-cli; the three methods behave identically.

Fixes: #3355

Sources:
- Named arguments RFC: https://wiki.php.net/rfc/named_params
- php-src d92229d8c7 ("Implement named parameters"), first release tag php-8.0.0; it changes ReflectionClass::newInstanceArgs to pass the array as named_params to zend_call_known_function()