### PR TITLE
Document that readonly properties cannot be initialized by reference

### DIFF
--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -259,6 +259,35 @@ $test1->prop = "foobar";
    </para>
    <note>
     <para>
+     Readonly properties can only be initialized by a direct assignment.
+     An uninitialized readonly property cannot be initialized by reference, not even
+     from the scope where it has been declared: passing it to a function parameter that
+     expects to be passed by reference, or assigning it by reference, results in an
+     <exceptionname>Error</exceptionname> exception.
+     <informalexample>
+      <programlisting role="php" annotations="non-interactive">
+<![CDATA[
+<?php
+
+class Test {
+    public readonly array $matches;
+
+    public function __construct(string $subject) {
+        // Illegal initialization by reference.
+        preg_match('/\d+/', $subject, $this->matches);
+        // Error: Cannot indirectly modify readonly property Test::$matches
+    }
+}
+
+new Test('abc 42');
+?>
+]]>
+      </programlisting>
+     </informalexample>
+    </para>
+   </note>
+   <note>
+    <para>
      Specifying an explicit default value on readonly properties is not allowed, because a readonly property with a default value is essentially the same as a constant, and thus not particularly useful.
      <informalexample>
       <programlisting role="php" annotations="non-interactive">


### PR DESCRIPTION
Clarify that an uninitialized readonly property must be initialized by a direct assignment, and cannot be initialized by reference, neither by being passed to a parameter that expects to be passed by reference nor by reference assignment.

Fixes https://github.com/php/doc-en/issues/3250