### PR TITLE
Fix SplFixedArray example for non-integer key error type

### DIFF
--- a/reference/spl/splfixedarray.xml
+++ b/reference/spl/splfixedarray.xml
@@ -85,6 +85,14 @@
       <row>
        <entry>8.1.0</entry>
        <entry>
+        Using a non-integer key on a <classname>SplFixedArray</classname> now throws
+        a <exceptionname>TypeError</exceptionname> instead of a
+        <exceptionname>RuntimeException</exceptionname>.
+       </entry>
+      </row>
+      <row>
+       <entry>8.1.0</entry>
+       <entry>
         <classname>SplFixedArray</classname> implements
         <interfacename>JsonSerializable</interfacename> now.
        </entry>
@@ -130,23 +138,25 @@ $array[9] = "asdf";
 // Shrink the array to a size of 2
 $array->setSize(2);
 
-// The following lines throw a RuntimeException: Index invalid or out of range
-try {
-    var_dump($array["non-numeric"]);
-} catch(RuntimeException $re) {
-    echo "RuntimeException: ".$re->getMessage()."\n";
-}
-
+// The following two blocks throw a RuntimeException: Index invalid or out of range
 try {
     var_dump($array[-1]);
-} catch(RuntimeException $re) {
-    echo "RuntimeException: ".$re->getMessage()."\n";
+} catch(RuntimeException $e) {
+    echo "RuntimeException: ".$e->getMessage()."\n";
 }
 
 try {
     var_dump($array[5]);
-} catch(RuntimeException $re) {
-    echo "RuntimeException: ".$re->getMessage()."\n";
+} catch(RuntimeException $e) {
+    echo "RuntimeException: ".$e->getMessage()."\n";
+}
+
+// As of PHP 8.1.0, using a non-integer key throws a TypeError.
+// Prior to PHP 8.1.0, a RuntimeException was thrown instead.
+try {
+    var_dump($array["non-numeric"]);
+} catch(TypeError $e) {
+    echo "TypeError: ".$e->getMessage()."\n";
 }
 ?>
 ]]>
@@ -159,11 +169,18 @@ int(2)
 string(3) "foo"
 RuntimeException: Index invalid or out of range
 RuntimeException: Index invalid or out of range
-RuntimeException: Index invalid or out of range
+TypeError: Illegal offset type
 ]]>
      </screen>
     </example>
    </para>
+   <note>
+    <simpara>
+     Prior to PHP 8.1.0, accessing a <classname>SplFixedArray</classname> with a
+     non-integer key threw a <exceptionname>RuntimeException</exceptionname>
+     instead of a <exceptionname>TypeError</exceptionname>.
+    </simpara>
+   </note>
   </section>
 <!-- }}} -->
  


### PR DESCRIPTION
Since PHP 8.1.0, using a non-integer key throws TypeError instead of RuntimeException. Updated the example to correctly catch TypeError and document this behavior change.

Fixes https://github.com/php/doc-en/issues/3679