### PR TITLE
Fix and factor out the SNMPv3 security parameter descriptions

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2083,6 +2083,42 @@ while <constant>PGSQL_BOTH</constant> will return both numerical and associative
  </entry>
 </row>'>
 
+<!-- SNMP entities -->
+
+<!ENTITY snmp.changelog.auth-protocol-sha2 '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.1.0</entry>
+ <entry>
+  The authentication protocol now accepts <literal>"SHA256"</literal>
+  and <literal>"SHA512"</literal> when supported by the Net-SNMP library.
+ </entry>
+</row>'>
+
+<!ENTITY snmp.changelog.privacy-protocol-aes '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.6.0</entry>
+ <entry>
+  The privacy protocol now accepts <literal>"AES192"</literal>,
+  <literal>"AES192C"</literal>, <literal>"AES256"</literal>, and
+  <literal>"AES256C"</literal> when supported by the Net-SNMP library.
+ </entry>
+</row>'>
+
+<!ENTITY snmp.parameter.security-name '<simpara xmlns="http://docbook.org/ns/docbook">The security name, usually some kind of username.</simpara>'>
+
+<!ENTITY snmp.parameter.security-level '<simpara xmlns="http://docbook.org/ns/docbook">The security level: <literal>"noAuthNoPriv"</literal>,
+<literal>"authNoPriv"</literal>, or <literal>"authPriv"</literal>.</simpara>'>
+
+<!ENTITY snmp.parameter.auth-protocol '<simpara xmlns="http://docbook.org/ns/docbook">The authentication protocol: <literal>"MD5"</literal>, <literal>"SHA"</literal>,
+<literal>"SHA256"</literal>, or <literal>"SHA512"</literal>.</simpara>'>
+
+<!ENTITY snmp.parameter.auth-passphrase '<simpara xmlns="http://docbook.org/ns/docbook">The authentication passphrase.</simpara>'>
+
+<!ENTITY snmp.parameter.privacy-protocol '<simpara xmlns="http://docbook.org/ns/docbook">The privacy protocol: <literal>"DES"</literal>, or <literal>"AES"</literal>,
+also accepted as <literal>"AES128"</literal>. <literal>"AES192"</literal>, <literal>"AES192C"</literal>,
+<literal>"AES256"</literal>, and <literal>"AES256C"</literal> are accepted when supported by the
+Net-SNMP library.</simpara>'>
+
+<!ENTITY snmp.parameter.privacy-passphrase '<simpara xmlns="http://docbook.org/ns/docbook">The privacy passphrase.</simpara>'>
+
 <!-- Common pieces for reference part END -->
 
 <!ENTITY windows.builtin '<simpara xmlns="http://docbook.org/ns/docbook">The Windows version of PHP has built-in

--- a/reference/snmp/functions/snmp3-get.xml
+++ b/reference/snmp/functions/snmp3-get.xml
@@ -42,50 +42,37 @@
    <varlistentry>
     <term><parameter>security_name</parameter></term>
     <listitem>
-     <simpara>
-      the security name, usually some kind of username
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>security_level</parameter></term>
     <listitem>
-     <simpara>
-      the security level (noAuthNoPriv|authNoPriv|authPriv)
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
-     <simpara>
-      the authentication protocol (<literal>"MD5"</literal>, <literal>"SHA"</literal>,
-      <literal>"SHA256"</literal>, or <literal>"SHA512"</literal>)
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      the authentication pass phrase
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
-     <simpara>
-      the privacy protocol (DES or AES)
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      the privacy pass phrase
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -133,6 +120,7 @@
      </row>
     </thead>
     <tbody>
+     &snmp.changelog.privacy-protocol-aes;
      <row>
       <entry>8.5.0</entry>
       <entry>
@@ -142,13 +130,7 @@
        are lower than -1 or too large.
       </entry>
      </row>
-     <row>
-      <entry>8.1.0</entry>
-      <entry>
-       The <parameter>auth_protocol</parameter> now accepts <literal>"SHA256"</literal>
-       and <literal>"SHA512"</literal> when supported by libnetsnmp.
-      </entry>
-     </row>
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/snmp/functions/snmp3-getnext.xml
+++ b/reference/snmp/functions/snmp3-getnext.xml
@@ -43,50 +43,37 @@
    <varlistentry>
     <term><parameter>security_name</parameter></term>
     <listitem>
-     <simpara>
-      the security name, usually some kind of username
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>security_level</parameter></term>
     <listitem>
-     <simpara>
-      the security level (noAuthNoPriv|authNoPriv|authPriv)
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
-     <simpara>
-      the authentication protocol (<literal>"MD5"</literal>, <literal>"SHA"</literal>,
-      <literal>"SHA256"</literal>, or <literal>"SHA512"</literal>)
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      the authentication pass phrase
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
-     <simpara>
-      the privacy protocol (DES or AES)
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      the privacy pass phrase
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -135,13 +122,8 @@
      </row>
     </thead>
     <tbody>
-     <row>
-      <entry>8.1.0</entry>
-      <entry>
-       The <parameter>auth_protocol</parameter> now accepts <literal>"SHA256"</literal>
-       and <literal>"SHA512"</literal> when supported by libnetsnmp.
-      </entry>
-     </row>
+     &snmp.changelog.privacy-protocol-aes;
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/snmp/functions/snmp3-real-walk.xml
+++ b/reference/snmp/functions/snmp3-real-walk.xml
@@ -50,9 +50,7 @@
      <parameter>security_name</parameter>
     </term>
     <listitem>
-     <simpara>
-      the security name, usually some kind of username
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -60,9 +58,7 @@
      <parameter>security_level</parameter>
     </term>
     <listitem>
-     <simpara>
-      the security level (noAuthNoPriv|authNoPriv|authPriv)
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -70,9 +66,7 @@
      <parameter>auth_protocol</parameter>
     </term>
     <listitem>
-     <simpara>
-      the authentication protocol (MD5 or SHA)
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -80,9 +74,7 @@
      <parameter>auth_passphrase</parameter>
     </term>
     <listitem>
-     <simpara>
-      the authentication pass phrase
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -90,10 +82,7 @@
      <parameter>privacy_protocol</parameter>
     </term>
     <listitem>
-     <simpara>
-      the authentication protocol (<literal>"MD5"</literal>, <literal>"SHA"</literal>,
-      <literal>"SHA256"</literal>, or <literal>"SHA512"</literal>)
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -101,9 +90,7 @@
      <parameter>privacy_passphrase</parameter>
     </term>
     <listitem>
-     <simpara>
-      the privacy pass phrase
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -159,13 +146,8 @@
      </row>
     </thead>
     <tbody>
-     <row>
-      <entry>8.1.0</entry>
-      <entry>
-       The <parameter>auth_protocol</parameter> now accepts <literal>"SHA256"</literal>
-       and <literal>"SHA512"</literal> when supported by libnetsnmp.
-      </entry>
-     </row>
+     &snmp.changelog.privacy-protocol-aes;
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/snmp/functions/snmp3-set.xml
+++ b/reference/snmp/functions/snmp3-set.xml
@@ -28,7 +28,9 @@
    specified by the <parameter>object_id</parameter>.
   </simpara>
   <simpara>
-   Even if the security level does not use an auth or priv protocol/password valid values have to be specified.
+   The authentication and privacy arguments must always be passed, but their
+   values are ignored when <parameter>security_level</parameter> does not use
+   them.
   </simpara>
 
  </refsect1>
@@ -47,49 +49,37 @@
    <varlistentry>
     <term><parameter>security_name</parameter></term>
     <listitem>
-     <simpara>
-      the security name, usually some kind of username
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>security_level</parameter></term>
     <listitem>
-     <simpara>
-      the security level (noAuthNoPriv|authNoPriv|authPriv)
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
-     <simpara>
-      the authentication protocol (MD5 or SHA)
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      the authentication pass phrase
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
-     <simpara>
-      the privacy protocol (DES or AES)
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      the privacy pass phrase
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -158,6 +148,7 @@
      </row>
     </thead>
     <tbody>
+     &snmp.changelog.privacy-protocol-aes;
      <row>
       <entry>8.5.0</entry>
       <entry>
@@ -167,6 +158,7 @@
        are lower than -1 or too large.
       </entry>
      </row>
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/snmp/functions/snmp3-walk.xml
+++ b/reference/snmp/functions/snmp3-walk.xml
@@ -26,7 +26,9 @@
    an <acronym>SNMP</acronym> agent specified by the <parameter>hostname</parameter>.
   </simpara>
   <simpara>
-   Even if the security level does not use an auth or priv protocol/password valid values have to be specified.
+   The authentication and privacy arguments must always be passed, but their
+   values are ignored when <parameter>security_level</parameter> does not use
+   them.
   </simpara>
  </refsect1>
 
@@ -44,59 +46,46 @@
    <varlistentry>
     <term><parameter>security_name</parameter></term>
     <listitem>
-     <simpara>
-      the security name, usually some kind of username
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>security_level</parameter></term>
     <listitem>
-     <simpara>
-      the security level (noAuthNoPriv|authNoPriv|authPriv)
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
-     <simpara>
-      the authentication protocol (<literal>"MD5"</literal>, <literal>"SHA"</literal>,
-      <literal>"SHA256"</literal>, or <literal>"SHA512"</literal>)
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      the authentication pass phrase
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
-     <simpara>
-      the privacy protocol (DES or AES)
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      the privacy pass phrase
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>object_id</parameter></term>
     <listitem>
      <simpara>
-      If &null;, <parameter>object_id</parameter> is taken as the root of
-      the <acronym>SNMP</acronym> objects tree and all objects under that tree are returned as
-      an array.
+      If an empty string, <parameter>object_id</parameter> is taken as
+      <literal>.1.3.6.1.2.1</literal>, the root of the <acronym>SNMP</acronym>
+      objects tree, and all objects under that tree are returned as an array.
      </simpara>
      <simpara>
       If <parameter>object_id</parameter> is specified, all the <acronym>SNMP</acronym> objects
@@ -143,13 +132,8 @@
      </row>
     </thead>
     <tbody>
-     <row>
-      <entry>8.1.0</entry>
-      <entry>
-       The <parameter>auth_protocol</parameter> now accepts <literal>"SHA256"</literal>
-       and <literal>"SHA512"</literal> when supported by libnetsnmp.
-      </entry>
-     </row>
+     &snmp.changelog.privacy-protocol-aes;
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/snmp/snmp/construct.xml
+++ b/reference/snmp/snmp/construct.xml
@@ -68,9 +68,9 @@
     <term><parameter>community</parameter></term>
     <listitem>
      <simpara>
-      Specifies the security level for given <parameter>version</parameter>.
-      The purpose of <parameter>community</parameter> access string is
-      <acronym>SNMP</acronym> version specific:
+      The community string, or, for <constant>SNMP::VERSION_3</constant>, the
+      security name. The purpose of the <parameter>community</parameter> access
+      string is <acronym>SNMP</acronym> version specific:
      </simpara>
      <informaltable>
       <tgroup cols="2">
@@ -98,11 +98,7 @@
           <constant>SNMP::VERSION_3</constant>
          </entry>
          <entry>
-          <acronym>SNMP</acronym>v3 security name, may be one of:
-          <literal>noAuthNoPriv</literal>,
-          <literal>authNoPriv</literal> (an auth passphrase and auth protocol are required), or
-          <literal>authPriv</literal> (both an auth passphrase and a protocol, as well as
-          a privacy passphrase and protocol are required)
+          &snmp.parameter.security-name;
          </entry>
         </row>
        </tbody>

--- a/reference/snmp/snmp/setsecurity.xml
+++ b/reference/snmp/snmp/setsecurity.xml
@@ -30,41 +30,31 @@
    <varlistentry>
     <term><parameter>securityLevel</parameter></term>
     <listitem>
-     <simpara>
-      the security level (noAuthNoPriv|authNoPriv|authPriv)
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>authProtocol</parameter></term>
     <listitem>
-     <simpara>
-      the authentication protocol (MD5 or SHA)
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>authPassphrase</parameter></term>
     <listitem>
-     <simpara>
-      the authentication pass phrase
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacyProtocol</parameter></term>
     <listitem>
-     <simpara>
-      the privacy protocol (DES or AES)
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacyPassphrase</parameter></term>
     <listitem>
-     <simpara>
-      the privacy pass phrase
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -91,6 +81,24 @@
   <simpara>
    &return.success;
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &snmp.changelog.privacy-protocol-aes;
+     &snmp.changelog.auth-protocol-sha2;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Fixes: #3690

`snmp3_real_walk()` described `privacy_protocol` with the authentication protocols, which it does not accept. 1051736a4c had landed on the wrong `varlistentry`, overwriting `privacy_protocol` and leaving `auth_protocol` stale, and had skipped `snmp3_set()` and `SNMP::setSecurity()` entirely. All of it is repaired here, including the two missing 8.1.0 changelog entries.