### PR TITLE
Document privateKey parameter in PharData::setSignatureAlgorithm

### DIFF
--- a/reference/phar/Phar/setSignatureAlgorithm.xml
+++ b/reference/phar/Phar/setSignatureAlgorithm.xml
@@ -53,6 +53,7 @@
        <programlisting role="php">
         <![CDATA[
 <?php
+$p = new Phar('archive.phar');
 $private = openssl_get_privatekey(file_get_contents('private.pem'));
 $pkey = '';
 openssl_pkey_export($private, $pkey);

--- a/reference/phar/PharData/setSignatureAlgorithm.xml
+++ b/reference/phar/PharData/setSignatureAlgorithm.xml
@@ -37,6 +37,27 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term><parameter>privateKey</parameter></term>
+     <listitem>
+      <para>
+       The contents of an OpenSSL private key, as extracted from a certificate or
+       OpenSSL key file:
+       <programlisting role="php">
+        <![CDATA[
+<?php
+$private = openssl_get_privatekey(file_get_contents('private.pem'));
+$pkey = '';
+openssl_pkey_export($private, $pkey);
+$p->setSignatureAlgorithm(Phar::OPENSSL, $pkey);
+?>
+        ]]>
+       </programlisting>
+       See <link linkend="phar.using">phar introduction</link> for instructions on
+       naming and placement of the public key file.
+      </para>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
 

--- a/reference/phar/PharData/setSignatureAlgorithm.xml
+++ b/reference/phar/PharData/setSignatureAlgorithm.xml
@@ -46,6 +46,7 @@
        <programlisting role="php">
         <![CDATA[
 <?php
+$p = new PharData('archive.tar');
 $private = openssl_get_privatekey(file_get_contents('private.pem'));
 $pkey = '';
 openssl_pkey_export($private, $pkey);


### PR DESCRIPTION
The privateKey parameter was present in the method signature but missing from the parameters documentation section.

Also makes the OPENSSL example runnable on both `Phar::setSignatureAlgorithm` and `PharData::setSignatureAlgorithm`: it called `$p->setSignatureAlgorithm()` on a variable that was never defined. The archive is now instantiated first, keeping the two pages in sync.

Fixes https://github.com/php/doc-en/issues/3019