### PR TITLE
Fix filter_input() return value documentation

### DIFF
--- a/reference/filter/functions/filter-input.xml
+++ b/reference/filter/functions/filter-input.xml
@@ -58,8 +58,8 @@
   &reftitle.returnvalues;
   <simpara>
    On success returns the filtered variable.
-   If the variable is not set &false; is returned.
-   On failure &false; is returned,
+   If the variable is not set &null; is returned.
+   If the filter fails &false; is returned,
    unless the <constant>FILTER_NULL_ON_FAILURE</constant> flag is used,
    in which case &null; is returned.
   </simpara>


### PR DESCRIPTION
Fixes #4361 - The function returns null when the variable is not set, not false. False is only returned when the filter fails validation.