### PR TITLE
Split the illegal string offsets example output by PHP version

### DIFF
--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -1084,7 +1084,9 @@ var_dump($str);
 
    <para>
     String offsets have to either be integers or integer-like strings,
-    otherwise a warning will be thrown.
+    otherwise a warning will be thrown. As of PHP 8.0, a
+    <exceptionname>TypeError</exceptionname> is thrown for non-integer-like
+    strings.
    </para>
 
    <example>
@@ -1110,7 +1112,7 @@ foreach ($keys as $keyToTry) {
 ?>
 ]]>
     </programlisting>
-    &example.outputs;
+    &example.outputs.8;
     <screen>
 <![CDATA[
 bool(true)
@@ -1124,7 +1126,29 @@ Cannot access offset of type string on string
 
 bool(false)
 
-Warning: Illegal string offset "1x" in Standard input code on line 10
+Warning: Illegal string offset "1x" in example.php on line 10
+string(1) "b"
+]]>
+    </screen>
+    &example.outputs.7;
+    <screen>
+<![CDATA[
+bool(true)
+string(1) "b"
+
+bool(true)
+
+Warning: Illegal string offset '1.0' in example.php on line 10
+string(1) "b"
+
+bool(false)
+
+Warning: Illegal string offset 'x' in example.php on line 10
+string(1) "a"
+
+bool(true)
+
+Warning: Illegal string offset '1x' in example.php on line 10
 string(1) "b"
 ]]>
     </screen>

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -1088,10 +1088,15 @@ var_dump($str);
     </programlisting>
    </example>
 
-   <para>
-    String offsets have to either be integers or integer-like strings,
-    otherwise a warning will be thrown.
-   </para>
+   <simpara>
+    String offsets must be either integers or integer-like strings.
+    As of PHP 8.0.0, any other string throws a
+    <exceptionname>TypeError</exceptionname>, except for a string starting
+    with an integer followed by other characters, which emits
+    <constant>E_WARNING</constant> and is interpreted as that leading integer.
+    Prior to PHP 8.0.0, no <exceptionname>TypeError</exceptionname> was
+    thrown: an illegal offset emitted <constant>E_WARNING</constant> instead.
+   </simpara>
 
    <example>
     <title>Example of Illegal String Offsets</title>
@@ -1116,7 +1121,7 @@ foreach ($keys as $keyToTry) {
 ?>
 ]]>
     </programlisting>
-    &example.outputs;
+    &example.outputs.8;
     <screen>
 <![CDATA[
 bool(true)
@@ -1130,7 +1135,29 @@ Cannot access offset of type string on string
 
 bool(false)
 
-Warning: Illegal string offset "1x" in Standard input code on line 10
+Warning: Illegal string offset "1x" in example.php on line 10
+string(1) "b"
+]]>
+    </screen>
+    &example.outputs.7;
+    <screen>
+<![CDATA[
+bool(true)
+string(1) "b"
+
+bool(false)
+
+Warning: Illegal string offset '1.0' in example.php on line 10
+string(1) "b"
+
+bool(false)
+
+Warning: Illegal string offset 'x' in example.php on line 10
+string(1) "a"
+
+bool(false)
+
+Notice: A non well formed numeric value encountered in example.php on line 10
 string(1) "b"
 ]]>
     </screen>


### PR DESCRIPTION
Fixes: #4312

The output reported in the issue was already corrected in master. What the thread still asked for was making the version difference visible and documenting the change.