### PR TITLE
Document curl_errno/curl_error behavior with multi handles

### DIFF
--- a/reference/curl/functions/curl-errno.xml
+++ b/reference/curl/functions/curl-errno.xml
@@ -15,6 +15,15 @@
   <para>
    Returns the error number for the last cURL operation.
   </para>
+  <note>
+   <para>
+    When a handle has been added to a multi handle and executed via
+    <function>curl_multi_exec</function>, this function will always
+    return <literal>0</literal>. To retrieve errors for individual
+    transfers, use <function>curl_multi_info_read</function> instead
+    and check the <literal>result</literal> key of the returned array.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/curl/functions/curl-errno.xml
+++ b/reference/curl/functions/curl-errno.xml
@@ -15,15 +15,6 @@
   <para>
    Returns the error number for the last cURL operation.
   </para>
-  <note>
-   <para>
-    When a handle has been added to a multi handle and executed via
-    <function>curl_multi_exec</function>, this function will always
-    return <literal>0</literal>. To retrieve errors for individual
-    transfers, use <function>curl_multi_info_read</function> instead
-    and check the <literal>result</literal> key of the returned array.
-   </para>
-  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -41,6 +32,15 @@
    Returns the error number or <literal>0</literal> (zero) if no error
    occurred.
   </para>
+  <note>
+   <simpara>
+    When a <type>CurlHandle</type> is executed via
+    <function>curl_multi_exec</function>, this function always returns
+    <literal>0</literal>. The error code for each individual handle is
+    available as the <literal>result</literal> key returned by
+    <function>curl_multi_info_read</function>.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -92,6 +92,7 @@ if(curl_errno($ch))
   <para>
    <simplelist>
     <member><function>curl_error</function></member>
+    <member><function>curl_multi_info_read</function></member>
     <member><link xlink:href="&url.curl.error;">Curl error codes</link></member>
    </simplelist>
   </para>

--- a/reference/curl/functions/curl-error.xml
+++ b/reference/curl/functions/curl-error.xml
@@ -15,6 +15,15 @@
   <para>
    Returns a clear text error message for the last cURL operation.
   </para>
+  <note>
+   <para>
+    When a handle has been added to a multi handle and executed via
+    <function>curl_multi_exec</function>, this function will always
+    return an empty string. To retrieve errors for individual
+    transfers, use <function>curl_multi_info_read</function> instead
+    and check the <literal>result</literal> key of the returned array.
+   </para>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/curl/functions/curl-error.xml
+++ b/reference/curl/functions/curl-error.xml
@@ -15,15 +15,6 @@
   <para>
    Returns a clear text error message for the last cURL operation.
   </para>
-  <note>
-   <para>
-    When a handle has been added to a multi handle and executed via
-    <function>curl_multi_exec</function>, this function will always
-    return an empty string. To retrieve errors for individual
-    transfers, use <function>curl_multi_info_read</function> instead
-    and check the <literal>result</literal> key of the returned array.
-   </para>
-  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -41,6 +32,16 @@
    Returns the error message or <literal>''</literal> (the empty string) if no
    error occurred.
   </para>
+  <note>
+   <simpara>
+    When a <type>CurlHandle</type> is executed via
+    <function>curl_multi_exec</function>, this function always returns
+    <literal>''</literal> (the empty string). To retrieve the error string for
+    each individual handle, pass the <literal>result</literal> key returned by
+    <function>curl_multi_info_read</function> to
+    <function>curl_strerror</function>.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -92,6 +93,8 @@ else
   <para>
    <simplelist>
     <member><function>curl_errno</function></member>
+    <member><function>curl_strerror</function></member>
+    <member><function>curl_multi_info_read</function></member>
     <member><link xlink:href="&url.curl.error;">Curl error codes</link></member>
    </simplelist>
   </para>


### PR DESCRIPTION
Add a note to `curl_errno()` and `curl_error()` documentation explaining that these functions always return 0 or empty string when the handle was executed via `curl_multi_exec()`. Users should use `curl_multi_info_read()` to retrieve errors for individual transfers.

Fixes #5047