### PR TITLE
Add deprecation notice for auto_detect_line_endings

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -100,11 +100,12 @@ and missing arguments are replaced with their defaults.
 This function ignores the collection of unknown named variadic arguments.
 Unknown named arguments which are collected can only be accessed through the variadic parameter.</simpara></note>'>
 
-<!ENTITY note.line-endings '<note xmlns="http://docbook.org/ns/docbook"><simpara>If PHP is not properly recognizing
-the line endings when reading files either on or created by a Macintosh
-computer, enabling the
+<!ENTITY note.line-endings '<note xmlns="http://docbook.org/ns/docbook"><simpara>Prior to PHP 8.1.0, the
 <link linkend="ini.auto-detect-line-endings">auto_detect_line_endings</link>
-run-time configuration option may help resolve the problem.</simpara></note>'>
+run-time configuration option could be enabled to help PHP properly recognize
+line endings when reading files created on Macintosh systems. This option has
+been deprecated as of PHP 8.1.0. If necessary, handle <literal>"\r"</literal>
+line breaks manually instead.</simpara></note>'>
 
 <!ENTITY note.no-remote '<note xmlns="http://docbook.org/ns/docbook"><simpara>This function will not work on
 <link linkend="features.remote-files">remote files</link> as the file to

--- a/reference/filesystem/ini.xml
+++ b/reference/filesystem/ini.xml
@@ -148,17 +148,22 @@
      <type>bool</type>
     </term>
     <listitem>
-     <para>
+     <simpara>
       When turned on, PHP will examine the data read by
       <function>fgets</function> and <function>file</function> to see if it
       is using Unix, MS-Dos or Macintosh line-ending conventions.
-     </para>
-     <para>This enables PHP to interoperate with Macintosh systems,
+     </simpara>
+     <simpara>This enables PHP to interoperate with Macintosh systems,
       but defaults to Off, as there is a very small performance penalty
       when detecting the EOL conventions for the first line, and also
       because people using carriage-returns as item separators under
       Unix systems would experience non-backwards-compatible behaviour.
-     </para>
+     </simpara>
+     <warning>
+      <simpara>
+       This option has been deprecated as of PHP 8.1.0.
+      </simpara>
+     </warning>
     </listitem>
    </varlistentry>
    


### PR DESCRIPTION
## Summary                                                                                                                                                                                              
                                                                                                                                                                                                          
  - Add deprecation notice in the `auto_detect_line_endings` INI directive description                                                                                                                    
  - Update the `&note.line-endings;` entity to mention the deprecation                                                                                                                                    
                                                                                                                                                                                                          
  The `auto_detect_line_endings` directive has been deprecated since PHP 8.1.0. While this was noted in the configuration table, the detailed description and the shared note entity (used by `fgets`,    
  `file`, etc.) still recommended using it without mentioning the deprecation.                                                                                                                            
                                                                                                                                                                                                          
  Fixes #4586 