### PR TITLE
Document ValueError for empty filename in getimagesize()

### DIFF
--- a/reference/image/functions/getimagesize.xml
+++ b/reference/image/functions/getimagesize.xml
@@ -185,6 +185,10 @@ if ($size && $fp) {
    <function>getimagesize</function> will generate an error of level
    <constant>E_NOTICE</constant>.
   </para>
+  <para>
+   As of PHP 8.0.0, a <exceptionname>ValueError</exceptionname> is thrown
+   if <parameter>filename</parameter> is empty.
+  </para>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -205,6 +209,14 @@ if ($size && $fp) {
         Now returns the actual image dimensions, bits and channels of AVIF images;
         previously, the dimensions were reported as <literal>0x0</literal>,
         and bits and channels were not reported at all.
+       </entry>
+      </row>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        A <exceptionname>ValueError</exceptionname> is now thrown if
+        <parameter>filename</parameter> is empty; previously an
+        <constant>E_WARNING</constant> was raised and the function returned &false;.
        </entry>
       </row>
       <row>


### PR DESCRIPTION
Fixes #3714

Document the ValueError thrown by getimagesize() for empty filenames since PHP 8.0.0.

Happy to adjust if needed.