### PR TITLE
Document underflow limitation in Randomizer::getFloat()

### DIFF
--- a/reference/random/random/randomizer/getfloat.xml
+++ b/reference/random/random/randomizer/getfloat.xml
@@ -346,7 +346,7 @@ Lat: +69.244304 Lng: -53.548951
     Underflow is intentionally left unhandled in the γ-section algorithm.
     This may result in incorrect values being returned for intervals with
     boundaries in the subnormal range of floating point numbers, i.e.
-    for values smaller than approximately
+    for boundaries with an absolute value smaller than approximately
     <literal>2<superscript>-1020</superscript></literal> (about <literal>8.9e-308</literal>).
    </para>
   </caution>


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                              
                                                                                                                                                                                                          
  Add a caution note documenting that the γ-section algorithm intentionally leaves underflow unhandled. This may result in incorrect values for intervals with boundaries in the subnormal range of       
  floating point numbers (values smaller than approximately 2^-1020).                                                                                                                                     
                                                                                                                                                                                                          
  This limitation is inherent to the algorithm as stated in the reference paper: "all our results hold in the absence of underflow."                                                                      
                                                                                                                                                                                                          
  Refs #3339 