### PR TITLE
Fix forward_static_call_array() can be used outside a class

### DIFF
--- a/reference/funchand/functions/forward-static-call-array.xml
+++ b/reference/funchand/functions/forward-static-call-array.xml
@@ -15,12 +15,10 @@
   </methodsynopsis>
   <para>
    Calls a user defined function or method given by the <parameter>callback</parameter>
-   parameter. This function must be called within a method context, it can't be 
-   used outside a class.
-   It uses the <link linkend="language.oop5.late-static-bindings">late static
-   binding</link>.
-   All arguments of the forwarded method are passed as values,
-   and as an array, similarly to <function>call_user_func_array</function>.
+   parameter, with arguments passed as an array, similarly to
+   <function>call_user_func_array</function>.
+   When called from within a method context, it uses the
+   <link linkend="language.oop5.late-static-bindings">late static binding</link>.
   </para>
  </refsect1>
 

--- a/reference/funchand/functions/forward-static-call-array.xml
+++ b/reference/funchand/functions/forward-static-call-array.xml
@@ -13,13 +13,13 @@
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam><type>array</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Calls a user defined function or method given by the <parameter>callback</parameter>
    parameter, with arguments passed as an array, similarly to
    <function>call_user_func_array</function>.
    When called from within a method context, it uses the
    <link linkend="language.oop5.late-static-bindings">late static binding</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/funchand/functions/forward-static-call-array.xml
+++ b/reference/funchand/functions/forward-static-call-array.xml
@@ -19,6 +19,8 @@
    <function>call_user_func_array</function>.
    When called from within a method context, it uses the
    <link linkend="language.oop5.late-static-bindings">late static binding</link>.
+   When called outside a class context, it behaves like
+   <function>call_user_func_array</function>, without late static binding.
   </simpara>
  </refsect1>
 

--- a/reference/funchand/functions/forward-static-call-array.xml
+++ b/reference/funchand/functions/forward-static-call-array.xml
@@ -13,15 +13,23 @@
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam><type>array</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Calls a user defined function or method given by the <parameter>callback</parameter>
-   parameter. This function must be called within a method context, it can't be 
-   used outside a class.
-   It uses the <link linkend="language.oop5.late-static-bindings">late static
-   binding</link>.
-   All arguments of the forwarded method are passed as values,
-   and as an array, similarly to <function>call_user_func_array</function>.
-  </para>
+   parameter, with arguments passed as an array, similarly to
+   <function>call_user_func_array</function>.
+   When called from within a method context, it uses the
+   <link linkend="language.oop5.late-static-bindings">late static binding</link>.
+   When called outside a class context, it behaves like
+   <function>call_user_func_array</function>, without late static binding.
+  </simpara>
+  <note>
+   <simpara>
+    Unlike <function>forward_static_call</function>, this function does not
+    require an active class scope: calling
+    <function>forward_static_call</function> outside a class throws an
+    <exceptionname>Error</exceptionname>, while this function does not.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Fixes #3282

Remove incorrect statement that `forward_static_call_array()` must be called within a method context. See https://3v4l.org/Cb8AZ