### PR TITLE
filter: version the FILTER_CALLBACK flags note

### DIFF
--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -1215,12 +1215,6 @@ NULL
 ]]>
      </screen>
     </example>
-    <warning>
-     <simpara>
-      This filter cannot be used with any other filter flags, e.g.
-      <constant>FILTER_NULL_ON_FAILURE</constant>.
-     </simpara>
-    </warning>
    </listitem>
   </varlistentry>
  </variablelist>

--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -720,9 +720,9 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      Validates value as IP address.
-    </para>
+    </simpara>
     <variablelist xml:id="filter.constants.validation.ip.options">
      <title>Available options</title>
      <varlistentry>

--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -1235,12 +1235,6 @@ NULL
 ]]>
      </screen>
     </example>
-    <warning>
-     <simpara>
-      This filter cannot be used with any other filter flags, e.g.
-      <constant>FILTER_NULL_ON_FAILURE</constant>.
-     </simpara>
-    </warning>
    </listitem>
   </varlistentry>
  </variablelist>

--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -720,9 +720,9 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      Validates value as IP address.
-    </para>
+    </simpara>
     <variablelist xml:id="filter.constants.validation.ip.options">
      <title>Available options</title>
      <varlistentry>
@@ -1235,12 +1235,20 @@ NULL
 ]]>
      </screen>
     </example>
-    <warning>
+    <note>
      <simpara>
-      This filter cannot be used with any other filter flags, e.g.
-      <constant>FILTER_NULL_ON_FAILURE</constant>.
+      As of PHP 8.1.25 and 8.2.12, the structural flags
+      <constant>FILTER_REQUIRE_ARRAY</constant>,
+      <constant>FILTER_FORCE_ARRAY</constant> and
+      <constant>FILTER_REQUIRE_SCALAR</constant> apply to this filter, and
+      <constant>FILTER_NULL_ON_FAILURE</constant> changes how such a
+      structural failure is reported. In earlier versions all flags were
+      ignored. Filter specific flags are always ignored, and since the return
+      value of the callback is the result, the callback itself cannot fail: no
+      flag turns a <literal>false</literal> returned by the callback into
+      &null; or an exception.
      </simpara>
-    </warning>
+    </note>
    </listitem>
   </varlistentry>
  </variablelist>


### PR DESCRIPTION
`FILTER_CALLBACK` carries this warning:

> This filter cannot be used with any other filter flags, e.g. `FILTER_NULL_ON_FAILURE`.

It was accurate, but it is now outdated: the behaviour changed in PHP 8.1.25 and 8.2.12. Measured with `filter_var()` and a `strtoupper()` callback:

| Version | `FILTER_REQUIRE_SCALAR` on an array | `+ FILTER_NULL_ON_FAILURE` | `FILTER_FORCE_ARRAY` on a scalar |
| --- | --- | --- | --- |
| 8.0.30 | `array(2)` | `array(2)` | `'A'` |
| 8.1.24 | `array(2)` | `array(2)` | `'A'` |
| **8.1.25** | `false` | `NULL` | `array(1)` |
| 8.2.11 | `array(2)` | `array(2)` | `'A'` |
| **8.2.12** | `false` | `NULL` | `array(1)` |
| 8.3.0 to 8.5.8 | `false` | `NULL` | `array(1)` |

The cause is in `php_filter_call()`. Up to 8.1.24 the `flags` key was read first and the `options` key then reset `filter_flags` to `0` for `FILTER_CALLBACK`, wiping it. The two blocks were swapped, so `flags` now overrides the reset. Source: php-src `c2fb10d2d2` ("Fix filter_var with callback and explicit REQUIRE_SCALAR", GH-12203), NEWS entry filed under PHP 8.1.25.

What holds in every version, and is worth stating explicitly: filter specific flags are ignored, and the callback cannot fail, since its return value is the result. A `false` returned by the callback stays `false` with `FILTER_NULL_ON_FAILURE`, and with `FILTER_THROW_ON_FAILURE` on 8.5.

The warning is therefore replaced by a versioned note rather than removed, so the statement stays correct for 8.1.24 and 8.2.11.

Also converts one inline-only `<para>` to `<simpara>` in the same file, required by the DocBook style check.

Fixes: #2708
