### PR TITLE
Remove descriptions of obsolete parameters not in synopsis

### DIFF
--- a/reference/imap/functions/imap-headerinfo.xml
+++ b/reference/imap/functions/imap-headerinfo.xml
@@ -49,13 +49,6 @@
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry>
-     <term><parameter>defaulthost</parameter></term>
-     <listitem>
-      <para>
-      </para>
-     </listitem>
-    </varlistentry>
    </variablelist>
   </para>
  </refsect1>

--- a/reference/mbstring/functions/mb-decode-numericentity.xml
+++ b/reference/mbstring/functions/mb-decode-numericentity.xml
@@ -47,14 +47,6 @@
       &mbstring.encoding.parameter;
      </listitem>
     </varlistentry>
-    <varlistentry>
-     <term><parameter>is_hex</parameter></term>
-     <listitem>
-      <para>
-       This parameter is not used.
-      </para>
-     </listitem>
-    </varlistentry>
    </variablelist>
   </para>
  </refsect1>


### PR DESCRIPTION
The function `imap_headerinfo` had an empty description for parameter `defaulthost`.
The function `mb_decode_numericentity` had an obsolete description for parameter `is_hex`.

Both were removed to make the parameter descriptions match the synopsis of the function.