### PR TITLE
Fix parameter names to match between synopsis and description part

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -896,7 +896,7 @@ function.</simpara></warning>'>
 
 <!-- OpenSSL -->
 <!ENTITY openssl.param.x509 '<varlistentry xmlns="http://docbook.org/ns/docbook">
- <term><parameter>x509</parameter></term>
+ <term><parameter>certificate</parameter></term>
  <listitem>
   <para>
    See <link linkend="openssl.certparams">Key/Certificate parameters</link> for a list of valid values.

--- a/reference/calendar/functions/jdmonthname.xml
+++ b/reference/calendar/functions/jdmonthname.xml
@@ -70,7 +70,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>jday</parameter></term>
+     <term><parameter>julian_day</parameter></term>
      <listitem>
       <para>
        The Julian Day to operate on

--- a/reference/funchand/functions/forward-static-call-array.xml
+++ b/reference/funchand/functions/forward-static-call-array.xml
@@ -39,7 +39,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>parameter</parameter></term>
+     <term><parameter>args</parameter></term>
      <listitem>
       <para>
        One parameter, gathering all the method parameter in one array.

--- a/reference/image/functions/imageinterlace.xml
+++ b/reference/image/functions/imageinterlace.xml
@@ -26,7 +26,7 @@
    <variablelist>
     &gd.image.description;
     <varlistentry>
-     <term><parameter>interlace</parameter></term>
+     <term><parameter>enable</parameter></term>
      <listitem>
       <para>
        If &true;, the image will be interlaced, if &false; the interlace bit is turned off.

--- a/reference/oci8/functions/oci-free-descriptor.xml
+++ b/reference/oci8/functions/oci-free-descriptor.xml
@@ -22,7 +22,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>descriptor</parameter></term>
+     <term><parameter>lob</parameter></term>
      <listitem>
       <para>
        Descriptor allocated by <function>oci_new_descriptor</function>.

--- a/reference/ps/functions/ps-begin-pattern.xml
+++ b/reference/ps/functions/ps-begin-pattern.xml
@@ -56,7 +56,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>x-step</parameter></term>
+     <term><parameter>xstep</parameter></term>
      <listitem>
       <para>
        The distance in pixel of placements of the pattern in
@@ -65,7 +65,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>y-step</parameter></term>
+     <term><parameter>ystep</parameter></term>
      <listitem>
       <para>
        The distance in pixel of placements of the pattern in

--- a/reference/ps/functions/ps-open-image.xml
+++ b/reference/ps/functions/ps-open-image.xml
@@ -15,7 +15,7 @@
    <methodparam><type>string</type><parameter>type</parameter></methodparam>
    <methodparam><type>string</type><parameter>source</parameter></methodparam>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
-   <methodparam><type>int</type><parameter>lenght</parameter></methodparam>
+   <methodparam><type>int</type><parameter>length</parameter></methodparam>
    <methodparam><type>int</type><parameter>width</parameter></methodparam>
    <methodparam><type>int</type><parameter>height</parameter></methodparam>
    <methodparam><type>int</type><parameter>components</parameter></methodparam>

--- a/reference/ps/functions/ps-set-info.xml
+++ b/reference/ps/functions/ps-set-info.xml
@@ -11,9 +11,9 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ps_set_info</methodname>
-   <methodparam><type>resource</type><parameter>p</parameter></methodparam>
+   <methodparam><type>resource</type><parameter>psdoc</parameter></methodparam>
    <methodparam><type>string</type><parameter>key</parameter></methodparam>
-   <methodparam><type>string</type><parameter>val</parameter></methodparam>
+   <methodparam><type>string</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
    Sets certain information fields of the document. This fields will be shown


### PR DESCRIPTION
There were some mismatches between the parameter name in the function synopsis and the parameter description below.
This was cleaned up and a typo in a parameter name was fixed along the way.