### PR TITLE
Fix mb_http_input ValueError version from 8.4.0 to 8.0.0

### DIFF
--- a/reference/mbstring/functions/mb-http-input.xml
+++ b/reference/mbstring/functions/mb-http-input.xml
@@ -66,16 +66,11 @@
     </thead>
     <tbody>
      <row>
-      <entry>8.4.0</entry>
+      <entry>8.0.0</entry>
       <entry>
        <function>mb_http_input</function> now throws a
        <exceptionname>ValueError</exceptionname> if <parameter>type</parameter>
        is invalid.
-      </entry>
-     </row>
-     <row>
-      <entry>8.0.0</entry>
-      <entry>
        <parameter>type</parameter> is nullable now.
       </entry>
      </row>


### PR DESCRIPTION
## Summary

- Fix incorrect version for ValueError in mb_http_input() changelog: was documented as 8.4.0, but the exception has been thrown since 8.0.0
- Merged the two 8.0.0 changelog entries (ValueError + nullable type) into a single row

  Fixes #5244