### PR TITLE
Remove unused pecl.windows.download.unbundled entity

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2236,8 +2236,6 @@ section.'>
 <!ENTITY pecl.windows.download.avail 'Windows binaries (<acronym xmlns="http://docbook.org/ns/docbook">DLL</acronym> files)
 for this <acronym xmlns="http://docbook.org/ns/docbook">PECL</acronym> extension are available from the PECL website.'>
 
-<!ENTITY pecl.windows.download.unbundled '&pecl.windows.download;'>
-
 <!ENTITY pecl.moved-ver 'This extension has been moved to the &link.pecl;
 repository and is no longer bundled with PHP as of PHP '>
 


### PR DESCRIPTION
 ## Summary

  - Remove the `pecl.windows.download.unbundled` entity from `language-snippets.ent` which is just a
  redundant alias of `pecl.windows.download` and is not referenced anywhere in the codebase

  Fixes #4655