### PR TITLE
Add namespace caveats to define(), defined(), and constant()

### DIFF
--- a/reference/misc/functions/constant.xml
+++ b/reference/misc/functions/constant.xml
@@ -38,6 +38,27 @@
       <para>
        The constant name.
       </para>
+      <note>
+       <simpara>
+        <function>constant</function> takes the name as an ordinary
+        <type>string</type> and does not resolve it against the current
+        <link linkend="language.namespaces.dynamic">namespace</link>: the name
+        is looked up in the global namespace, so an unqualified name may
+        silently return a different constant from the one the same bare
+        identifier would refer to.
+        To retrieve the value of a constant declared in a namespace, the
+        namespace must be part of the name, as in
+        <literal>constant('My\Namespace\MYCONST')</literal> or
+        <literal>constant(__NAMESPACE__ . '\MYCONST')</literal>.
+        Because the name is a plain string, aliases introduced by
+        <literal>use</literal> statements and the
+        <literal>namespace\</literal> prefix are not applied to it.
+        In a double-quoted string the namespace separators must be escaped,
+        as in <literal>"My\\Namespace\\MYCONST"</literal>.
+        The namespace part of the name is case-insensitive, the constant name
+        is not.
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/misc/functions/define.xml
+++ b/reference/misc/functions/define.xml
@@ -35,6 +35,27 @@
         even invalid names, whose value can (only) be retrieved with
         <function>constant</function>. However, doing so is not recommended.
        </para>
+       <simpara>
+        <function>define</function> takes the name as an ordinary
+        <type>string</type> and does not resolve it against the current
+        <link linkend="language.namespaces.dynamic">namespace</link>.
+        Inside <literal>namespace My\Namespace;</literal>,
+        <literal>define('MYCONST', 1)</literal> therefore defines
+        <literal>MYCONST</literal> in the global namespace, silently and
+        without error.
+        To place the constant in a namespace, the namespace must be part of
+        the name, written without a leading namespace separator, as in
+        <literal>define('My\Namespace\MYCONST', 1)</literal> or
+        <literal>define(__NAMESPACE__ . '\MYCONST', 1)</literal>.
+        Unlike <function>defined</function> and <function>constant</function>,
+        <function>define</function> does not strip a leading separator:
+        <literal>define('\My\Namespace\MYCONST', 1)</literal> returns &true;
+        but creates a constant that can never be retrieved.
+        Because the name is a plain string, aliases introduced by
+        <literal>use</literal> statements are not applied to it.
+        In a double-quoted string the namespace separators must be escaped,
+        as in <literal>"My\\Namespace\\MYCONST"</literal>.
+       </simpara>
       </note>
      </listitem>
     </varlistentry>

--- a/reference/misc/functions/defined.xml
+++ b/reference/misc/functions/defined.xml
@@ -40,6 +40,27 @@
       <para>
        The constant name.
       </para>
+      <note>
+       <simpara>
+        <function>defined</function> takes the name as an ordinary
+        <type>string</type> and does not resolve it against the current
+        <link linkend="language.namespaces.dynamic">namespace</link>: the name
+        is looked up in the global namespace, so an unqualified name may
+        silently report on a different constant from the one the same bare
+        identifier would refer to.
+        To check whether a constant declared in a namespace is defined, the
+        namespace must be part of the name, as in
+        <literal>defined('My\Namespace\MYCONST')</literal> or
+        <literal>defined(__NAMESPACE__ . '\MYCONST')</literal>.
+        Because the name is a plain string, aliases introduced by
+        <literal>use</literal> statements and the
+        <literal>namespace\</literal> prefix are not applied to it.
+        In a double-quoted string the namespace separators must be escaped,
+        as in <literal>"My\\Namespace\\MYCONST"</literal>.
+        The namespace part of the name is case-insensitive, the constant name
+        is not.
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Fixes #4628

Add a note about namespace handling in define(), defined(), and constant().