### PR TITLE
Fix LOCK_NB documented as standalone mode instead of bitmask flag

### DIFF
--- a/reference/stream/streamwrapper/stream-lock.xml
+++ b/reference/stream/streamwrapper/stream-lock.xml
@@ -47,14 +47,12 @@
           <constant>LOCK_UN</constant> to release a lock (shared or exclusive).
          </simpara>
         </listitem>
-        <listitem>
-         <simpara>
-          <constant>LOCK_NB</constant> if you don't want
-          <function>flock</function> to block while locking.
-          (not supported on Windows)
-         </simpara>
-        </listitem>
        </itemizedlist>
+      </para>
+      <para>
+       It is also possible to have <constant>LOCK_NB</constant> added as a
+       bitmask to one of the above operations, if the lock should not block
+       during the locking attempt (not supported on Windows).
       </para>
      </listitem>
     </varlistentry>

--- a/reference/stream/streamwrapper/stream-lock.xml
+++ b/reference/stream/streamwrapper/stream-lock.xml
@@ -13,13 +13,13 @@
    <modifier>public</modifier> <type>bool</type><methodname>streamWrapper::stream_lock</methodname>
    <methodparam><type>int</type><parameter>operation</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    This method is called in response to <function>flock</function>, when
    <function>file_put_contents</function> (when <parameter>flags</parameter>
    contains <constant>LOCK_EX</constant>),
    <function>stream_set_blocking</function> and when closing the stream
    (<constant>LOCK_UN</constant>).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -49,11 +49,11 @@
         </listitem>
        </itemizedlist>
       </para>
-      <para>
+      <simpara>
        It is also possible to have <constant>LOCK_NB</constant> added as a
        bitmask to one of the above operations, if the lock should not block
        during the locking attempt (not supported on Windows).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -62,16 +62,16 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors"><!-- {{{ -->
   &reftitle.errors;
-  <para>
+  <simpara>
    Emits <constant>E_WARNING</constant> if call to this method fails (i.e. not implemented).
-  </para>
+  </simpara>
  </refsect1><!-- }}} -->
  
 


### PR DESCRIPTION
Fixes #4299

Document LOCK_NB as a bitmask flag rather than a standalone lock operation, consistent with flock() documentation.