### PR TITLE
Add explicit linkend to CURLINFO_HEADER_OUT references

### DIFF
--- a/appendices/migration84/new-features.xml
+++ b/appendices/migration84/new-features.xml
@@ -240,13 +240,13 @@ $object = $reflector->newLazyGhost($initializer);
    <simplelist>
     <member><constant>CURLINFO_TEXT</constant></member>
     <member><constant>CURLINFO_HEADER_IN</constant></member>
-    <member><constant>CURLINFO_HEADER_OUT</constant></member>
+    <member><constant linkend="constant.curlinfo-header-out-debug">CURLINFO_HEADER_OUT</constant></member>
     <member><constant>CURLINFO_DATA_IN</constant></member>
     <member><constant>CURLINFO_DATA_OUT</constant></member>
     <member><constant>CURLINFO_SSL_DATA_IN</constant></member>
     <member><constant>CURLINFO_SSL_DATA_OUT</constant></member>
    </simplelist>
-   Once this option is set, <constant>CURLINFO_HEADER_OUT</constant>
+   Once this option is set, <constant linkend="constant.curlinfo-header-out">CURLINFO_HEADER_OUT</constant>
    must not be set because it uses the same libcurl functionality.
   </para>
 

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -174,7 +174,7 @@
     </listitem>
     <listitem>
      <simpara>
-      "request_header" (This is only set if the <constant>CURLINFO_HEADER_OUT</constant>
+      "request_header" (This is only set if the <constant linkend="constant.curlinfo-header-out">CURLINFO_HEADER_OUT</constant>
       is set by a previous call to <function>curl_setopt</function>)
      </simpara>
     </listitem>


### PR DESCRIPTION
Fixes #4085

Add linkend attributes to disambiguate between the two CURLINFO_HEADER_OUT constant definitions.