### PR TITLE
Update ob_get_status and ob_start documentation

### DIFF
--- a/reference/outcontrol/functions/ob-get-status.xml
+++ b/reference/outcontrol/functions/ob-get-status.xml
@@ -107,7 +107,14 @@
     <seglistitem>
      <seg>buffer_size</seg>
      <seg>
-      Output buffer size in bytes
+      Currently allocated size of the output buffer in bytes.
+      It starts at <literal>16384</literal> bytes with the default
+      <parameter>chunk_size</parameter>, or at
+      <parameter>chunk_size</parameter> rounded up to the next multiple of
+      <literal>4096</literal> when one is given, and grows in multiples of
+      <literal>4096</literal> as more output is buffered.
+      This is not the amount of data in the buffer (see
+      <literal>buffer_used</literal>).
      </seg>
     </seglistitem>
     <seglistitem>

--- a/reference/outcontrol/functions/ob-start.xml
+++ b/reference/outcontrol/functions/ob-start.xml
@@ -111,15 +111,22 @@
     <varlistentry>
      <term><parameter>chunk_size</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        If the optional parameter <parameter>chunk_size</parameter> is passed,
        the buffer will be flushed after any block of code resulting in output
        that causes the buffer's length to equal
        or exceed <parameter>chunk_size</parameter>.
        The default value <literal>0</literal> means
        that all output is buffered until the buffer is turned off.
+       A value of <literal>1</literal> means the buffer will be flushed
+       after every output operation, effectively disabling buffering.
+       <parameter>chunk_size</parameter> also determines the initial size of
+       the buffer reported by <function>ob_get_status</function>:
+       <literal>16384</literal> bytes when it is <literal>0</literal>, and
+       <parameter>chunk_size</parameter> rounded up to the next multiple of
+       <literal>4096</literal> otherwise.
        See <xref linkend="outcontrol.buffer-size"/> for more details.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
`ob_get_status()` documents `buffer_size` as "Output buffer size in bytes", which says nothing about what the number means or why it moves. The linked issue also asks why `chunk_size` of `0` and `1` produce different `buffer_size` values.

The allocation rule is in `main/php_output.h`:

```c
#define PHP_OUTPUT_HANDLER_INITBUF_SIZE(s) \
( ((s) > 0) ? ZEND_MM_ALIGNED_SIZE_EX(s, PHP_OUTPUT_HANDLER_ALIGNTO_SIZE) \
            : PHP_OUTPUT_HANDLER_DEFAULT_SIZE )
#define PHP_OUTPUT_HANDLER_ALIGNTO_SIZE   0x1000   //  4096
#define PHP_OUTPUT_HANDLER_DEFAULT_SIZE   0x4000   // 16384
```

Measured on PHP 8.5.4:

```
chunk_size=0      -> buffer_size=16384
chunk_size=1      -> buffer_size=4096
chunk_size=100    -> buffer_size=4096
chunk_size=4096   -> buffer_size=4096
chunk_size=10000  -> buffer_size=12288

growth with the default chunk_size:
  16000 bytes written -> 16384       16384 -> 32768
  40000 bytes written -> 40960      100000 -> 102400
```

So the initial size is 16384 with the default `chunk_size`, not one memory page, and any explicit `chunk_size` is rounded up to the next multiple of 4096. Both pages now state that.

The flush behaviour of `chunk_size = 1` is documented as well, verified with an output callback: `echo "A"; echo "B"; echo "C";` reaches the callback as three separate chunks with `chunk_size = 1`, as a single `"ABC"` with `0`, and as `"AB"`, `"CD"` with `2`.

Fixes: #3816
