### PR TITLE
Add DOMException mention to DOM error sections

### DIFF
--- a/reference/dom/domcharacterdata/deletedata.xml
+++ b/reference/dom/domcharacterdata/deletedata.xml
@@ -52,6 +52,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domcharacterdata/insertdata.xml
+++ b/reference/dom/domcharacterdata/insertdata.xml
@@ -49,6 +49,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domcharacterdata/replacedata.xml
+++ b/reference/dom/domcharacterdata/replacedata.xml
@@ -61,6 +61,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domcharacterdata/substringdata.xml
+++ b/reference/dom/domcharacterdata/substringdata.xml
@@ -51,6 +51,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domdocument/adoptnode.xml
+++ b/reference/dom/domdocument/adoptnode.xml
@@ -41,6 +41,10 @@
 
  <refsect1 role="errors">
    &reftitle.errors;
+   <simpara>
+    May throw a <exceptionname>DOMException</exceptionname> with the
+    following error codes:
+   </simpara>
    <variablelist>
     <varlistentry>
      <term><constant>DOM_NOT_SUPPORTED_ERR</constant></term>

--- a/reference/dom/domdocument/createattribute.xml
+++ b/reference/dom/domdocument/createattribute.xml
@@ -39,6 +39,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domdocument/createattributens.xml
+++ b/reference/dom/domdocument/createattributens.xml
@@ -50,6 +50,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domdocument/createelement.xml
+++ b/reference/dom/domdocument/createelement.xml
@@ -56,6 +56,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domdocument/createelementns.xml
+++ b/reference/dom/domdocument/createelementns.xml
@@ -60,6 +60,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domdocument/createentityreference.xml
+++ b/reference/dom/domdocument/createentityreference.xml
@@ -42,6 +42,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domdocument/createprocessinginstruction.xml
+++ b/reference/dom/domdocument/createprocessinginstruction.xml
@@ -48,6 +48,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domdocument/savexml.xml
+++ b/reference/dom/domdocument/savexml.xml
@@ -51,6 +51,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domelement/removeattribute.xml
+++ b/reference/dom/domelement/removeattribute.xml
@@ -38,6 +38,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domelement/removeattributenode.xml
+++ b/reference/dom/domelement/removeattributenode.xml
@@ -38,6 +38,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domelement/removeattributens.xml
+++ b/reference/dom/domelement/removeattributens.xml
@@ -47,6 +47,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domelement/setattribute.xml
+++ b/reference/dom/domelement/setattribute.xml
@@ -48,6 +48,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domelement/setattributenode.xml
+++ b/reference/dom/domelement/setattributenode.xml
@@ -40,6 +40,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domelement/setattributenodens.xml
+++ b/reference/dom/domelement/setattributenodens.xml
@@ -40,6 +40,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domelement/setattributens.xml
+++ b/reference/dom/domelement/setattributens.xml
@@ -58,6 +58,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domelement/setidattribute.xml
+++ b/reference/dom/domelement/setidattribute.xml
@@ -50,6 +50,10 @@
  
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domelement/setidattributenode.xml
+++ b/reference/dom/domelement/setidattributenode.xml
@@ -51,6 +51,10 @@
  
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domelement/setidattributens.xml
+++ b/reference/dom/domelement/setidattributens.xml
@@ -60,6 +60,10 @@
  
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domimplementation/createdocument.xml
+++ b/reference/dom/domimplementation/createdocument.xml
@@ -63,6 +63,10 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domimplementation/createdocumenttype.xml
+++ b/reference/dom/domimplementation/createdocumenttype.xml
@@ -61,6 +61,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domnode/appendchild.xml
+++ b/reference/dom/domnode/appendchild.xml
@@ -47,6 +47,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domnode/insertbefore.xml
+++ b/reference/dom/domnode/insertbefore.xml
@@ -55,6 +55,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domnode/removechild.xml
+++ b/reference/dom/domnode/removechild.xml
@@ -40,6 +40,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>

--- a/reference/dom/domnode/replacechild.xml
+++ b/reference/dom/domnode/replacechild.xml
@@ -54,6 +54,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   May throw a <exceptionname>DOMException</exceptionname> with the
+   following error codes:
+  </simpara>
   <para>
    <variablelist>
     <varlistentry>


### PR DESCRIPTION
Fixes #4225

Add an introductory sentence mentioning DOMException to error sections that list error codes without context.

Happy to adjust if needed.