### PR TITLE
Document proc_open Windows /s /c change in PHP 8.0.0

### DIFF
--- a/reference/exec/functions/proc-open.xml
+++ b/reference/exec/functions/proc-open.xml
@@ -55,13 +55,14 @@
         On <emphasis>Windows</emphasis>, unless <literal>bypass_shell</literal> is set to &true; in
         <parameter>options</parameter>, the <parameter>command</parameter> is
         passed to <command>cmd.exe</command> (actually, <literal>%ComSpec%</literal>)
-        with the <literal>/c</literal> flag as <emphasis>unquoted</emphasis> string
-        (i.e. exactly as has been given to <function>proc_open</function>).
-        This can cause <command>cmd.exe</command> to remove enclosing quotes from
-        <parameter>command</parameter> (for details see the <command>cmd.exe</command> documentation),
-        resulting in unexpected, and potentially even dangerous behavior, because
-        <command>cmd.exe</command> error messages may contain (parts of) the passed
-        <parameter>command</parameter> (see example below).
+        with the <literal>/s /c</literal> flags as
+        <command>%ComSpec% /s /c "$command"</command>, which has the same
+        effect as executing <parameter>command</parameter> directly (without
+        additional quotes).
+        Prior to PHP 8.0.0, the <literal>/c</literal> flag was used without
+        <literal>/s</literal>, which could cause <command>cmd.exe</command> to
+        remove enclosing quotes from <parameter>command</parameter>
+        (see example below).
        </simpara>
       </note>
       <para>
@@ -214,6 +215,16 @@
         A <exceptionname>ValueError</exceptionname> will be thrown if
         <parameter>command</parameter> is an array without at least one
         non-empty element.
+       </entry>
+      </row>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        On Windows, the string <parameter>command</parameter> is now
+        executed via <command>%ComSpec% /s /c "$command"</command> instead
+        of the previous <command>%ComSpec% /c $command</command>, which
+        has the same effect as executing <parameter>command</parameter>
+        directly.
        </entry>
       </row>
       <row>


### PR DESCRIPTION
Update the Windows note in proc_open() for the PHP 8.0.0 change from %ComSpec% /c to %ComSpec% /s /c.