### PR TITLE
Add security warning about publicly exposed PHP-FPM

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -251,6 +251,15 @@
         'ip.add.re.ss:port', 'port', '/path/to/unix/socket'. This option is
         mandatory for each pool.
        </para>
+       <warning>
+        <simpara>
+         Prefer Unix sockets over TCP sockets when the web server runs on
+         the same host. If a TCP socket must be used, ensure it is not
+         exposed to untrusted networks and restrict access using
+         <link linkend="listen-allowed-clients">listen.allowed_clients</link>.
+         An exposed FastCGI endpoint allows arbitrary code execution.
+        </simpara>
+       </warning>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="listen-backlog">

--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -253,11 +253,19 @@
        </para>
        <warning>
         <simpara>
-         Prefer Unix sockets over TCP sockets when the web server runs on
-         the same host. If a TCP socket must be used, ensure it is not
-         exposed to untrusted networks and restrict access using
-         <link linkend="listen-allowed-clients">listen.allowed_clients</link>.
          An exposed FastCGI endpoint allows arbitrary code execution.
+         When the web server runs on the same host, a Unix socket should be
+         preferred; on Linux its access is then controlled by
+         <link linkend="listen-owner">listen.owner</link>,
+         <literal>listen.group</literal> and <literal>listen.mode</literal>,
+         although many BSD-derived systems accept connections regardless of
+         those permissions.
+         When a TCP socket is used, the addresses allowed to connect must be
+         listed in
+         <link linkend="listen-allowed-clients">listen.allowed_clients</link>,
+         which is unset by default and then accepts any address.
+         In container setups, the FPM service should not publish its port on
+         the host; containers on the same network reach each other directly.
         </simpara>
        </warning>
       </listitem>

--- a/install/fpm/index.xml
+++ b/install/fpm/index.xml
@@ -3,21 +3,6 @@
   <chapter xml:id="install.fpm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
    <title>FastCGI Process Manager (FPM)</title>
    &fpm.intro;
-   <warning>
-    <simpara>
-     PHP-FPM must not be publicly exposed to the network. A FastCGI
-     endpoint that is accessible from untrusted sources allows
-     <emphasis>arbitrary code execution</emphasis>. When using TCP
-     sockets, restrict access using the
-     <link linkend="listen-allowed-clients">listen.allowed_clients</link>
-     directive to allow connections from the web server only. Prefer
-     Unix sockets over TCP sockets when the web server runs on the same
-     host, as they can be protected with filesystem permissions. When
-     using Docker or similar container setups, do not expose PHP-FPM
-     ports to the host or external networks; communicate between
-     containers using an internal network instead.
-    </simpara>
-   </warning>
    <para>
     These features include:
     <itemizedlist>
@@ -57,9 +42,8 @@
      </listitem>
      <listitem>
       <simpara>
-       <function>fastcgi_finish_request</function> and
-       <function>fastcgi_abort_request</function> - special functions to finish
-       or abort a request and flush all data while continuing to do something
+       <function>fastcgi_finish_request</function> - special function to finish
+       request and flush all data while continuing to do something
        time-consuming (video converting, stats processing etc.);
       </simpara>
      </listitem>
@@ -82,6 +66,20 @@
     </itemizedlist>
    </para>
    
+   <warning>
+    <simpara>
+     php-fpm must not be reachable from an untrusted network.
+     A client that can open a FastCGI connection controls the
+     configuration used for the request, including
+     <link linkend="ini.auto-prepend-file">auto_prepend_file</link>,
+     and can therefore execute arbitrary code.
+     Access is restricted through the
+     <link linkend="listen">listen</link> and
+     <link linkend="listen-allowed-clients">listen.allowed_clients</link>
+     directives.
+    </simpara>
+   </warning>
+
    &install.fpm.install;
    &install.fpm.configuration;
   </chapter>

--- a/install/fpm/index.xml
+++ b/install/fpm/index.xml
@@ -57,8 +57,9 @@
      </listitem>
      <listitem>
       <para>
-       <function>fastcgi_finish_request</function> - special function to finish
-       request and flush all data while continuing to do something
+       <function>fastcgi_finish_request</function> and
+       <function>fastcgi_abort_request</function> - special functions to finish
+       or abort a request and flush all data while continuing to do something
        time-consuming (video converting, stats processing etc.);
       </para>
      </listitem>

--- a/install/fpm/index.xml
+++ b/install/fpm/index.xml
@@ -3,6 +3,21 @@
   <chapter xml:id="install.fpm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
    <title>FastCGI Process Manager (FPM)</title>
    &fpm.intro;
+   <warning>
+    <simpara>
+     PHP-FPM must not be publicly exposed to the network. A FastCGI
+     endpoint that is accessible from untrusted sources allows
+     <emphasis>arbitrary code execution</emphasis>. When using TCP
+     sockets, restrict access using the
+     <link linkend="listen-allowed-clients">listen.allowed_clients</link>
+     directive to allow connections from the web server only. Prefer
+     Unix sockets over TCP sockets when the web server runs on the same
+     host, as they can be protected with filesystem permissions. When
+     using Docker or similar container setups, do not expose PHP-FPM
+     ports to the host or external networks; communicate between
+     containers using an internal network instead.
+    </simpara>
+   </warning>
    <para>
     These features include:
     <itemizedlist>

--- a/install/fpm/index.xml
+++ b/install/fpm/index.xml
@@ -56,12 +56,12 @@
       </para>
      </listitem>
      <listitem>
-      <para>
+      <simpara>
        <function>fastcgi_finish_request</function> and
        <function>fastcgi_abort_request</function> - special functions to finish
        or abort a request and flush all data while continuing to do something
        time-consuming (video converting, stats processing etc.);
-      </para>
+      </simpara>
      </listitem>
      <listitem>
       <para>


### PR DESCRIPTION
## Summary

  - Add a prominent `<warning>` block to the FPM main page (`install/fpm/index.xml`) about the
  risk of exposing PHP-FPM to untrusted networks (arbitrary code execution)
  - Cover Unix sockets vs TCP sockets, `listen.allowed_clients`, and Docker/container best
  practices
  - Add a matching warning on the `listen` directive in `install/fpm/configuration.xml`

  Fixes #3984