### PR TITLE
Fix rand() range constraint to use abs() for reversed parameters

### DIFF
--- a/reference/random/functions/rand.xml
+++ b/reference/random/functions/rand.xml
@@ -132,8 +132,9 @@ echo rand(5, 15), "\n";
   <warning>
    <para>
     <parameter>min</parameter> <parameter>max</parameter> range must
-    be within the range <function>getrandmax</function>. i.e. (<parameter>max</parameter> -
-    <parameter>min</parameter>) &lt;= <function>getrandmax</function>
+    be within the range <function>getrandmax</function>. i.e.
+    abs(<parameter>max</parameter> - <parameter>min</parameter>) &lt;=
+    <function>getrandmax</function>.
     Otherwise, <function>rand</function> may return poor-quality random numbers.
    </para>
   </warning>


### PR DESCRIPTION
## Summary

  - Fix the range constraint in `rand()` notes from `(max - min) <= getrandmax()` to `abs(max -
  min) <= getrandmax()`
  - Since `rand()` accepts `max` smaller than `min` (unlike `mt_rand()`), the absolute value is
  required

  Fixes #3890