### PR TITLE
Improve gmp_export() documentation

### DIFF
--- a/reference/gmp/functions/gmp-export.xml
+++ b/reference/gmp/functions/gmp-export.xml
@@ -14,9 +14,16 @@
    <methodparam choice="opt"><type>int</type><parameter>word_size</parameter><initializer>1</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>GMP_MSW_FIRST | GMP_NATIVE_ENDIAN</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Export a GMP number to a binary string
-  </para>
+  <simpara>
+   Exports a GMP number to a binary string. This function can handle
+   arbitrarily large numbers beyond the range of PHP's native integer
+   type, with configurable word size and byte order, similar in spirit
+   to <function>pack</function>.
+  </simpara>
+  <simpara>
+   The sign of the number is ignored; exporting a negative number
+   produces the same result as exporting its absolute value.
+  </simpara>
  </refsect1>
  
  <refsect1 role="parameters">
@@ -26,25 +33,35 @@
     <varlistentry>
      <term><parameter>num</parameter></term>
      <listitem>
-      <para>
-       The GMP number being exported
-      </para>
+      <simpara>
+       The GMP number to export.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>word_size</parameter></term>
      <listitem>
-      <para>
-       Default value is 1. The number of bytes in each chunk of binary data. This is mainly used in conjunction with the options parameter.
-      </para>
+      <simpara>
+       The number of bytes per word in the output. The total length of
+       the returned string will be a multiple of this value.
+       Default value: <literal>1</literal>.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
-       Default value is <constant>GMP_MSW_FIRST</constant> | <constant>GMP_NATIVE_ENDIAN</constant>.
-      </para>
+      <simpara>
+       A bitmask controlling word order and byte order. Word order:
+       <constant>GMP_MSW_FIRST</constant> (most significant word first,
+       default) or <constant>GMP_LSW_FIRST</constant> (least significant
+       word first). Byte order within each word:
+       <constant>GMP_NATIVE_ENDIAN</constant> (default),
+       <constant>GMP_BIG_ENDIAN</constant>, or
+       <constant>GMP_LITTLE_ENDIAN</constant>.
+       Default value:
+       <constant>GMP_MSW_FIRST</constant> | <constant>GMP_NATIVE_ENDIAN</constant>.
+      </simpara>
      </listitem>
     </varlistentry>   
    </variablelist>
@@ -53,9 +70,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Returns a string.
-  </para>
+  <simpara>
+   Returns a string containing the binary representation of the
+   GMP number. The string is empty if the number is zero.
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">


### PR DESCRIPTION
## Summary
  - Improved `gmp_export()` description with pack() analogy and sign handling note
  - Enhanced parameter descriptions (word_size, flags with all GMP_* constants documented)
  - Improved return value description

  Fixes #3865