### PR TITLE
Fix OPENSSL_RAW_DATA description for encrypt/decrypt

### DIFF
--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -779,10 +779,10 @@
       </term>
       <listitem>
         <simpara>
-         If <constant>OPENSSL_RAW_DATA</constant> is set in the
-         <function>openssl_encrypt</function> or <function>openssl_decrypt</function>,
-         the returned data is returned as-is.
-         When it is not specified, Base64 encoded data is returned to the caller.
+         Used with <function>openssl_encrypt</function> and
+         <function>openssl_decrypt</function> to indicate that data
+         should be in raw binary format rather than base64-encoded.
+         See the respective function descriptions for details.
         </simpara>
       </listitem>
     </varlistentry>

--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -855,10 +855,10 @@
       </term>
       <listitem>
         <simpara>
-         If <constant>OPENSSL_RAW_DATA</constant> is set in the
-         <function>openssl_encrypt</function> or <function>openssl_decrypt</function>,
-         the returned data is returned as-is.
-         When it is not specified, Base64 encoded data is returned to the caller.
+         Used with <function>openssl_encrypt</function> and
+         <function>openssl_decrypt</function> to indicate that data
+         should be in raw binary format rather than base64-encoded.
+         See the respective function descriptions for details.
         </simpara>
       </listitem>
     </varlistentry>

--- a/reference/openssl/functions/openssl-decrypt.xml
+++ b/reference/openssl/functions/openssl-decrypt.xml
@@ -66,10 +66,16 @@
       <term><parameter>options</parameter></term>
       <listitem>
        <para>
-        <parameter>options</parameter> can be one of
+        <parameter>options</parameter> is a bitwise disjunction of the flags
         <constant>OPENSSL_RAW_DATA</constant>,
-        <constant>OPENSSL_ZERO_PADDING</constant>
-        or <constant>OPENSSL_DONT_ZERO_PAD_KEY</constant>.
+        <constant>OPENSSL_ZERO_PADDING</constant>,
+        and <constant>OPENSSL_DONT_ZERO_PAD_KEY</constant>.
+       </para>
+       <para>
+        When <constant>OPENSSL_RAW_DATA</constant> is set,
+        <parameter>data</parameter> is expected to be raw binary
+        ciphertext. When it is not set, <parameter>data</parameter>
+        is expected to be base64-encoded.
        </para>
       </listitem>
     </varlistentry>

--- a/reference/openssl/functions/openssl-decrypt.xml
+++ b/reference/openssl/functions/openssl-decrypt.xml
@@ -65,18 +65,18 @@
     <varlistentry>
       <term><parameter>options</parameter></term>
       <listitem>
-       <para>
+       <simpara>
         <parameter>options</parameter> is a bitwise disjunction of the flags
         <constant>OPENSSL_RAW_DATA</constant>,
         <constant>OPENSSL_ZERO_PADDING</constant>,
         and <constant>OPENSSL_DONT_ZERO_PAD_KEY</constant>.
-       </para>
-       <para>
+       </simpara>
+       <simpara>
         When <constant>OPENSSL_RAW_DATA</constant> is set,
         <parameter>data</parameter> is expected to be raw binary
         ciphertext. When it is not set, <parameter>data</parameter>
         is expected to be base64-encoded.
-       </para>
+       </simpara>
       </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/openssl/functions/openssl-encrypt.xml
+++ b/reference/openssl/functions/openssl-encrypt.xml
@@ -67,9 +67,14 @@
       <listitem>
         <para>
           <parameter>options</parameter> is a bitwise disjunction of the flags
-          <constant>OPENSSL_RAW_DATA</constant>, and
-          <constant>OPENSSL_ZERO_PADDING</constant>
-          or <constant>OPENSSL_DONT_ZERO_PAD_KEY</constant>.
+          <constant>OPENSSL_RAW_DATA</constant>,
+          <constant>OPENSSL_ZERO_PADDING</constant>,
+          and <constant>OPENSSL_DONT_ZERO_PAD_KEY</constant>.
+         </para>
+         <para>
+          When <constant>OPENSSL_RAW_DATA</constant> is set, the
+          encrypted output is returned as raw binary data. When it
+          is not set, the return value is base64-encoded.
         </para>
       </listitem>
     </varlistentry>

--- a/reference/openssl/functions/openssl-encrypt.xml
+++ b/reference/openssl/functions/openssl-encrypt.xml
@@ -65,17 +65,17 @@
     <varlistentry>
       <term><parameter>options</parameter></term>
       <listitem>
-        <para>
+        <simpara>
           <parameter>options</parameter> is a bitwise disjunction of the flags
           <constant>OPENSSL_RAW_DATA</constant>,
           <constant>OPENSSL_ZERO_PADDING</constant>,
           and <constant>OPENSSL_DONT_ZERO_PAD_KEY</constant>.
-         </para>
-         <para>
+         </simpara>
+         <simpara>
           When <constant>OPENSSL_RAW_DATA</constant> is set, the
           encrypted output is returned as raw binary data. When it
           is not set, the return value is base64-encoded.
-        </para>
+        </simpara>
       </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
Fixes #3826

Fix OPENSSL_RAW_DATA constant description to distinguish behavior between openssl_encrypt() and openssl_decrypt().