### PR TITLE
Document --enable-zend-max-execution-timers configure option

### DIFF
--- a/appendices/configure/misc.xml
+++ b/appendices/configure/misc.xml
@@ -46,6 +46,27 @@
     </listitem>
    </varlistentry>
 
+   <varlistentry xml:id="configure.enable-zend-max-execution-timers">
+    <term>
+     <option role="configure">--enable-zend-max-execution-timers</option>
+    </term>
+    <listitem>
+     <simpara>
+      Use POSIX per-thread timers for
+      <link linkend="ini.max-execution-time">max_execution_time</link>
+      tracking instead of the process-wide
+      <literal>setitimer()</literal>. These timers measure elapsed time
+      (<literal>CLOCK_BOOTTIME</literal>, or
+      <literal>CLOCK_MONOTONIC</literal> on FreeBSD), whereas the default
+      <literal>setitimer(ITIMER_PROF)</literal> measures CPU time, so time
+      spent sleeping or waiting on I/O counts towards the limit.
+      Requires <literal>timer_create()</literal> support: available on
+      Linux, and on FreeBSD as of PHP 8.4.0.
+      Available since PHP 8.1.0. Enabled by default for ZTS builds since
+      PHP 8.3.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="configure.enable-sigchild">
     <term>
      <option role="configure">--enable-sigchild</option>

--- a/reference/info/ini.xml
+++ b/reference/info/ini.xml
@@ -251,6 +251,15 @@
       <function>set_time_limit</function> function for more
       details.
      </para>
+     <simpara>
+      When PHP is compiled with
+      <link linkend="configure.enable-zend-max-execution-timers">--enable-zend-max-execution-timers</link>
+      (the default for ZTS builds since PHP 8.3.0), the limit is tracked
+      with POSIX per-thread timers that measure elapsed time, so time
+      spent sleeping or waiting on I/O counts towards it. The default
+      <literal>setitimer(ITIMER_PROF)</literal> based tracking measures
+      CPU time instead.
+     </simpara>
      <para>
       Your web server can have other timeout configurations that may 
       also interrupt PHP execution. Apache has a 


### PR DESCRIPTION
`--enable-zend-max-execution-timers` is not documented. This adds it to the configure options and cross-references it from the `max_execution_time` directive.

What the option changes, verified by running the same script under both builds with `max_execution_time=1` and a `sleep(3)`, which consumes no CPU:

```
php:8.5-cli         (default, setitimer)   no timeout, script ends after 3.0s
php:8.5-zts         (timers enabled)       timeout raised after 1.0s
php:8.5-zts-alpine  (timers enabled)       timeout raised after 1.0s
```

So the option is not a matter of precision, it changes what is measured: the timers track elapsed time, the default tracks CPU time.

Sources:

- `Zend/zend_max_execution_timer.c`: `timer_create()` on `CLOCK_BOOTTIME`, or `CLOCK_MONOTONIC` on FreeBSD, with `sigev_notify_thread_id` so each thread gets its own timer.
- `Zend/zend_execute_API.c`: the generic path is `setitimer(ITIMER_PROF)` with `SIGPROF`; `ITIMER_REAL` is only used on Cygwin, PASE and Apple Silicon, where `ITIMER_PROF` is broken.
- `Zend/Zend.m4`: the option exists since PHP 8.1.0, defaults to `$ZEND_ZTS` since PHP 8.3.0 (it was `no` in 8.1 and 8.2), and accepts `*linux*|*freebsd*` as of PHP 8.4.0 (Linux only before).

Fixes: #3767
