### PR TITLE
Fix hash functions changelog to mention E_WARNING

### DIFF
--- a/reference/hash/functions/hash-hmac-file.xml
+++ b/reference/hash/functions/hash-hmac-file.xml
@@ -98,7 +98,8 @@
        <entry>
         Now throws a <classname>ValueError</classname> exception if
         <parameter>algo</parameter> is unknown or is a non-cryptographic hash
-        function; previously, &false; was returned instead.
+        function; previously, &false; was returned
+        and an <constant>E_WARNING</constant> message was emitted.
        </entry>
       </row>
       <row>

--- a/reference/hash/functions/hash-hmac.xml
+++ b/reference/hash/functions/hash-hmac.xml
@@ -98,7 +98,8 @@
        <entry>
         Now throws a <classname>ValueError</classname> exception if
         <parameter>algo</parameter> is unknown or is a
-        non-cryptographic hash function; previously, &false; was returned instead.
+        non-cryptographic hash function; previously, &false; was returned
+        and an <constant>E_WARNING</constant> message was emitted.
        </entry>
       </row>
       <row>

--- a/reference/hash/functions/hash.xml
+++ b/reference/hash/functions/hash.xml
@@ -89,7 +89,8 @@
        <entry>8.0.0</entry>
        <entry>
         <function>hash</function> now throws a <classname>ValueError</classname> exception
-        if <parameter>algo</parameter> is unknown; previously, &false; was returned instead.
+        if <parameter>algo</parameter> is unknown; previously, &false; was returned
+        and an <constant>E_WARNING</constant> message was emitted.
        </entry>
       </row>
      </tbody>

--- a/reference/hash/functions/hash.xml
+++ b/reference/hash/functions/hash.xml
@@ -71,10 +71,10 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws a <classname>ValueError</classname> exception if
    <parameter>algo</parameter> is unknown.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/hash/functions/hash.xml
+++ b/reference/hash/functions/hash.xml
@@ -69,6 +69,14 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Throws a <classname>ValueError</classname> exception if
+   <parameter>algo</parameter> is unknown.
+  </para>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -88,7 +96,7 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        <function>hash</function> now throws a <classname>ValueError</classname> exception
+        Now throws a <classname>ValueError</classname> exception
         if <parameter>algo</parameter> is unknown; previously, &false; was returned
         and an <constant>E_WARNING</constant> message was emitted.
        </entry>

--- a/reference/hash/functions/hash.xml
+++ b/reference/hash/functions/hash.xml
@@ -72,7 +72,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <simpara>
-   Throws a <classname>ValueError</classname> exception if
+   Throws a <exceptionname>ValueError</exceptionname> exception if
    <parameter>algo</parameter> is unknown.
   </simpara>
  </refsect1>

--- a/reference/hash/functions/hash.xml
+++ b/reference/hash/functions/hash.xml
@@ -96,7 +96,7 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        Now throws a <classname>ValueError</classname> exception
+        Now throws a <exceptionname>ValueError</exceptionname> exception
         if <parameter>algo</parameter> is unknown; previously, &false; was returned
         and an <constant>E_WARNING</constant> message was emitted.
        </entry>


### PR DESCRIPTION
Fixes #3480

Add missing E_WARNING mention to changelog entries for hash(), hash_hmac(), and hash_hmac_file().