### PR TITLE
pcre: describe PREG_UNMATCHED_AS_NULL for trailing groups

### DIFF
--- a/reference/pcre/constants.xml
+++ b/reference/pcre/constants.xml
@@ -94,8 +94,10 @@
      <entry>
       This flag tells <function>preg_match</function> and
       <function>preg_match_all</function> to include unmatched subpatterns in
-      <varname>$matches</varname> as &null; values. Without this flag, unmatched
-      subpatterns are reported as empty strings, as if they were empty matches.
+      <varname>$matches</varname> as &null; values, including trailing
+      unmatched subpatterns. Without this flag, non-trailing unmatched
+      subpatterns are reported as empty strings, while trailing unmatched
+      subpatterns are omitted from the results entirely.
       Setting this flag allows to distinguish between these two cases.
      </entry>
      <entry>7.2.0</entry>

--- a/reference/pcre/constants.xml
+++ b/reference/pcre/constants.xml
@@ -97,6 +97,10 @@
       <varname>$matches</varname> as &null; values. Without this flag, unmatched
       subpatterns are reported as empty strings, as if they were empty matches.
       Setting this flag allows to distinguish between these two cases.
+      With <function>preg_match</function>, trailing unmatched subpatterns are
+      omitted from <varname>$matches</varname> entirely unless this flag is
+      used; as of PHP 7.4.0 the flag reports them as &null;, so that
+      <varname>$matches</varname> always has the same size.
      </entry>
      <entry>7.2.0</entry>
     </row>

--- a/reference/pcre/functions/preg-match-all.xml
+++ b/reference/pcre/functions/preg-match-all.xml
@@ -243,8 +243,12 @@ Array
          <term><constant>PREG_UNMATCHED_AS_NULL</constant></term>
          <listitem>
           <para>
-           If this flag is passed, unmatched subpatterns are reported as &null;;
-           otherwise they are reported as an empty <type>string</type>.
+           If this flag is passed, unmatched subpatterns are reported as &null;
+           and are always included in the results (including trailing ones).
+           Without this flag, unmatched subpatterns that are followed by a
+           matched subpattern are reported as an empty <type>string</type>,
+           while trailing unmatched subpatterns are omitted from the results
+           entirely.
           </para>
          </listitem>
         </varlistentry>  

--- a/reference/pcre/functions/preg-match-all.xml
+++ b/reference/pcre/functions/preg-match-all.xml
@@ -306,6 +306,14 @@ Array
      </thead>
      <tbody>
       <row>
+       <entry>7.4.0</entry>
+       <entry>
+        When the <constant>PREG_UNMATCHED_AS_NULL</constant> flag is used,
+        trailing unmatched capturing groups are now also included in the
+        result with the value &null;. Previously, they were omitted.
+       </entry>
+      </row>
+      <row>
        <entry>7.2.0</entry>
        <entry>
         The <constant>PREG_UNMATCHED_AS_NULL</constant> is now supported for the

--- a/reference/pcre/functions/preg-match-all.xml
+++ b/reference/pcre/functions/preg-match-all.xml
@@ -242,14 +242,14 @@ Array
         <varlistentry>
          <term><constant>PREG_UNMATCHED_AS_NULL</constant></term>
          <listitem>
-          <para>
+          <simpara>
            If this flag is passed, unmatched subpatterns are reported as &null;
            and are always included in the results (including trailing ones).
            Without this flag, unmatched subpatterns that are followed by a
            matched subpattern are reported as an empty <type>string</type>,
            while trailing unmatched subpatterns are omitted from the results
            entirely.
-          </para>
+          </simpara>
          </listitem>
         </varlistentry>  
        </variablelist>

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -119,8 +119,12 @@ Array
          <term><constant>PREG_UNMATCHED_AS_NULL</constant></term>
          <listitem>
           <para>
-           If this flag is passed, unmatched subpatterns are reported as &null;;
-           otherwise they are reported as an empty <type>string</type>.
+           If this flag is passed, unmatched subpatterns are reported as &null;
+           and are always included in the results (including trailing ones).
+           Without this flag, unmatched subpatterns that are followed by a
+           matched subpattern are reported as an empty <type>string</type>,
+           while trailing unmatched subpatterns are omitted from the results
+           entirely.
            <informalexample>
             <programlisting role="php">
 <![CDATA[
@@ -128,6 +132,12 @@ Array
 preg_match('/(a)(b)*(c)/', 'ac', $matches);
 var_dump($matches);
 preg_match('/(a)(b)*(c)/', 'ac', $matches, PREG_UNMATCHED_AS_NULL);
+var_dump($matches);
+
+// Trailing unmatched subpatterns:
+preg_match('/(a)(b)?(c)?/', 'a', $matches);
+var_dump($matches);
+preg_match('/(a)(b)?(c)?/', 'a', $matches, PREG_UNMATCHED_AS_NULL);
 var_dump($matches);
 ?>
 ]]>
@@ -154,6 +164,22 @@ array(4) {
   NULL
   [3]=>
   string(1) "c"
+}
+array(2) {
+  [0]=>
+  string(1) "a"
+  [1]=>
+  string(1) "a"
+}
+array(4) {
+  [0]=>
+  string(1) "a"
+  [1]=>
+  string(1) "a"
+  [2]=>
+  NULL
+  [3]=>
+  NULL
 }
 ]]>
             </screen>

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -297,6 +297,14 @@ Array
      </thead>
      <tbody>
       <row>
+       <entry>7.4.0</entry>
+       <entry>
+        When the <constant>PREG_UNMATCHED_AS_NULL</constant> flag is used,
+        trailing unmatched capturing groups are now also included in the
+        result with the value &null;. Previously, they were omitted.
+       </entry>
+      </row>
+      <row>
        <entry>7.2.0</entry>
        <entry>
         The <constant>PREG_UNMATCHED_AS_NULL</constant> is now supported for the

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -119,8 +119,12 @@ Array
          <term><constant>PREG_UNMATCHED_AS_NULL</constant></term>
          <listitem>
           <para>
-           If this flag is passed, unmatched subpatterns are reported as &null;;
-           otherwise they are reported as an empty <type>string</type>.
+           If this flag is passed, unmatched subpatterns are reported as &null;
+           and are always included in the results (including trailing ones).
+           Without this flag, unmatched subpatterns that are followed by a
+           matched subpattern are reported as an empty <type>string</type>,
+           while trailing unmatched subpatterns are omitted from the results
+           entirely.
            <informalexample>
             <programlisting role="php">
 <![CDATA[
@@ -128,6 +132,12 @@ Array
 preg_match('/(a)(b)*(c)/', 'ac', $matches);
 var_dump($matches);
 preg_match('/(a)(b)*(c)/', 'ac', $matches, PREG_UNMATCHED_AS_NULL);
+var_dump($matches);
+
+// Trailing unmatched subpatterns:
+preg_match('/(a)(b)?(c)?/', 'a', $matches);
+var_dump($matches);
+preg_match('/(a)(b)?(c)?/', 'a', $matches, PREG_UNMATCHED_AS_NULL);
 var_dump($matches);
 ?>
 ]]>
@@ -154,6 +164,22 @@ array(4) {
   NULL
   [3]=>
   string(1) "c"
+}
+array(2) {
+  [0]=>
+  string(1) "a"
+  [1]=>
+  string(1) "a"
+}
+array(4) {
+  [0]=>
+  string(1) "a"
+  [1]=>
+  string(1) "a"
+  [2]=>
+  NULL
+  [3]=>
+  NULL
 }
 ]]>
             </screen>
@@ -270,6 +296,17 @@ Array
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>7.4.0</entry>
+       <entry>
+        When the <constant>PREG_UNMATCHED_AS_NULL</constant> flag is used,
+        trailing unmatched capturing groups are now also included in the
+        result with the value &null; (or <literal>[null, -1]</literal> when
+        <constant>PREG_OFFSET_CAPTURE</constant> is also used), so that
+        <varname>$matches</varname> always has the same size. Previously,
+        they were omitted.
+       </entry>
+      </row>
       <row>
        <entry>7.2.0</entry>
        <entry>


### PR DESCRIPTION
`PREG_UNMATCHED_AS_NULL` is described as:

> If this flag is passed, unmatched subpatterns are reported as null; otherwise they are reported as an empty string.

That is incomplete for `preg_match()`: without the flag, an unmatched subpattern is only reported as an empty string when a later subpattern matched. Trailing unmatched subpatterns are dropped from `$matches` entirely.

```php
preg_match('/(a)(b)?(c)?/', 'a', $m);                            // array(2): 0, 1
preg_match('/(a)(b)?(c)?/', 'a', $m, PREG_UNMATCHED_AS_NULL);    // array(4): 2 and 3 are null
```

Measured behaviour of the second call:

| Version | Result |
| --- | --- |
| 7.2.34, 7.3.33 | `[0 => "a", 1 => "a"]` |
| 7.4.33 to 8.5.8 | `[0 => "a", 1 => "a", 2 => null, 3 => null]` |

Hence the 7.4.0 changelog entry, which follows `UPGRADING` for PHP 7.4:

> When PREG_UNMATCHED_AS_NULL mode is used, trailing unmatched capturing groups will now also be set to null (or [null, -1] if offset capture is enabled). This means that the size of the $matches will always be the same.

The `[null, -1]` form is confirmed too: on 7.4.33 and 8.5.8, `PREG_UNMATCHED_AS_NULL|PREG_OFFSET_CAPTURE` yields `2 => [null, -1]`, while 7.3.33 omits the entry.

`preg_match_all()` is deliberately left untouched: it never had this behaviour. In `PREG_PATTERN_ORDER` the array is indexed by group, so trailing groups are always present — as empty strings without the flag and as null with it, on 7.2.34 as on 8.5.8. Nothing changed there in 7.4.

Fixes: #3483
