### PR TITLE
Add algorithm categorization note to hash_algos()

### DIFF
--- a/reference/hash/functions/hash-algos.xml
+++ b/reference/hash/functions/hash-algos.xml
@@ -24,6 +24,14 @@
    Returns a numerically indexed array containing the list of supported
    hashing algorithms.
   </para>
+  <note>
+   <simpara>
+    Not all algorithms are suitable for every use case.
+    See the <link linkend="intro.hash">Hash extension introduction</link>
+    for a description of the different categories (checksum,
+    non-cryptographic, and cryptographic).
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="changelog">


### PR DESCRIPTION
Fixes #3616

Add a note to hash_algos() referencing the algorithm categorization in the Hash extension introduction.