### PR TITLE
Clarify ldap_connect/ldap_bind/ldap_set_option behavior

### DIFF
--- a/reference/ldap/functions/ldap-bind.xml
+++ b/reference/ldap/functions/ldap-bind.xml
@@ -17,6 +17,15 @@
   <para>
    Binds to the LDAP directory with specified RDN and password.
   </para>
+  <note>
+   <simpara>
+    This function establishes the actual network connection to the
+    LDAP server (since <function>ldap_connect</function> only
+    initializes connection parameters). Any options that affect the
+    connection, such as <constant>LDAP_OPT_PROTOCOL_VERSION</constant>
+    or TLS-related options, must be set before calling this function.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/ldap/functions/ldap-bind.xml
+++ b/reference/ldap/functions/ldap-bind.xml
@@ -14,9 +14,9 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>dn</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>string</type><type>null</type></type><parameter>password</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Binds to the LDAP directory with specified RDN and password.
-  </para>
+  </simpara>
   <note>
    <simpara>
     This function establishes the actual network connection to the

--- a/reference/ldap/functions/ldap-connect.xml
+++ b/reference/ldap/functions/ldap-connect.xml
@@ -23,14 +23,26 @@
    <methodparam choice="opt"><type>int</type><parameter>port</parameter><initializer>389</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Creates an <classname>LDAP\Connection</classname> connection and checks whether the given
-   <parameter>uri</parameter> is plausible.
+   Creates an <classname>LDAP\Connection</classname> instance and checks
+   whether the given <parameter>uri</parameter> is plausible.
   </para>
   <note>
    <simpara>
-    This function does <emphasis>not</emphasis> open a connection.
-    It checks whether the given parameters are plausible and can be used
-    to open a connection as soon as one is needed.
+    This function does <emphasis>not</emphasis> open a network connection.
+    It only validates the URI syntax and initializes connection parameters.
+    The actual TCP connection is established when
+    <function>ldap_bind</function> is called.
+   </simpara>
+  </note>
+  <note>
+   <simpara>
+    Options that affect the connection setup, such as
+    <constant>LDAP_OPT_PROTOCOL_VERSION</constant> and TLS-related
+    options (<constant>LDAP_OPT_X_TLS_*</constant>), must be set
+    using <function>ldap_set_option</function> after calling this
+    function and before calling <function>ldap_bind</function>.
+    TLS-related options must be set globally (by passing &null; as
+    the first argument to <function>ldap_set_option</function>).
    </simpara>
   </note>
  </refsect1>

--- a/reference/ldap/functions/ldap-connect.xml
+++ b/reference/ldap/functions/ldap-connect.xml
@@ -22,10 +22,10 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>host</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>port</parameter><initializer>389</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Creates an <classname>LDAP\Connection</classname> instance and checks
    whether the given <parameter>uri</parameter> is plausible.
-  </para>
+  </simpara>
   <note>
    <simpara>
     This function does <emphasis>not</emphasis> open a network connection.

--- a/reference/ldap/functions/ldap-connect.xml
+++ b/reference/ldap/functions/ldap-connect.xml
@@ -38,7 +38,7 @@
    <simpara>
     Options that affect the connection setup, such as
     <constant>LDAP_OPT_PROTOCOL_VERSION</constant> and TLS-related
-    options (<constant>LDAP_OPT_X_TLS_*</constant>), must be set
+    options (<literal>LDAP_OPT_X_TLS_*</literal>), must be set
     using <function>ldap_set_option</function> after calling this
     function and before calling <function>ldap_bind</function>.
     TLS-related options must be set globally (by passing &null; as

--- a/reference/ldap/functions/ldap-set-option.xml
+++ b/reference/ldap/functions/ldap-set-option.xml
@@ -17,6 +17,15 @@
   <para>
    Sets the value of the specified option to be <parameter>value</parameter>.
   </para>
+  <note>
+   <simpara>
+    TLS-related options (<constant>LDAP_OPT_X_TLS_*</constant>) must be
+    set globally by passing &null; as <parameter>ldap</parameter>,
+    because the TLS context is initialized before the per-connection
+    state is available. These options must also be set before calling
+    <function>ldap_bind</function>.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/ldap/functions/ldap-set-option.xml
+++ b/reference/ldap/functions/ldap-set-option.xml
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
    <methodparam><type class="union"><type>array</type><type>string</type><type>int</type><type>bool</type></type><parameter>value</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Sets the value of the specified option to be <parameter>value</parameter>.
-  </para>
+  </simpara>
   <note>
    <simpara>
     TLS-related options (<constant>LDAP_OPT_X_TLS_*</constant>) must be

--- a/reference/ldap/functions/ldap-set-option.xml
+++ b/reference/ldap/functions/ldap-set-option.xml
@@ -19,7 +19,7 @@
   </simpara>
   <note>
    <simpara>
-    TLS-related options (<constant>LDAP_OPT_X_TLS_*</constant>) must be
+    TLS-related options (<literal>LDAP_OPT_X_TLS_*</literal>) must be
     set globally by passing &null; as <parameter>ldap</parameter>,
     because the TLS context is initialized before the per-connection
     state is available. These options must also be set before calling


### PR DESCRIPTION
Clarifies that `ldap_connect()` only validates the URI and initializes parameters, while `ldap_bind()` establishes the actual TCP connection. Documents that TLS options must be set globally with `null` before bind.

Fixes #3526