### PR TITLE
Modernize PDO installation documentation

### DIFF
--- a/reference/pdo/configure.xml
+++ b/reference/pdo/configure.xml
@@ -47,11 +47,11 @@ extension=pdo
   <step>
    <para>
     PDO is enabled by default.
-    Choose the other database-specific DLL files and either use 
-    <function>dl</function> to load them at runtime, or enable them in
-    &php.ini;. For example, this loads the
+    Enable the database-specific drivers in &php.ini; as needed.
+    For example, this loads the
     <link linkend="ref.pdo-sqlite">PDO_SQLITE</link> driver but
-    leaves the <link linkend="ref.pdo-odbc">PDO_ODBC</link> driver commented out:
+    leaves the <link linkend="ref.pdo-odbc">PDO_ODBC</link> driver
+    commented out:
     <screen>
 <![CDATA[
 ;extension=pdo_odbc
@@ -59,10 +59,10 @@ extension=pdo_sqlite
 ]]>
     </screen>
    </para>
-   <para>
-    These DLLs should exist in the system's 
+   <simpara>
+    The corresponding extension files should exist in the
     <link linkend="ini.extension-dir">extension_dir</link>.
-   </para>
+   </simpara>
   </step>
  </procedure>
  <note>


### PR DESCRIPTION
 ## Summary
  - Remove outdated `dl()` reference from Windows PDO installation section
  - Replace "DLL files" with generic "extension files" wording
  - The main issue (`.so`/`.dll` extensions and `php_` prefix in examples) was already fixed in
  a previous update

  Fixes #3377