### PR TITLE
writeable -> writable

### DIFF
--- a/reference/spl/splfileinfo/iswritable.xml
+++ b/reference/spl/splfileinfo/iswritable.xml
@@ -33,13 +33,13 @@
   &reftitle.examples;
   <para>
    <example>
-    <title><methodname>SplFileInfo::isWriteable</methodname> example</title>
+    <title><methodname>SplFileInfo::isWritable</methodname> example</title>
     <programlisting role="php">
 <![CDATA[
 <?php
 $info = new SplFileInfo('locked.jpg');
-if (!$info->isWriteable()) {
-    echo $info->getFilename() . ' is not writeable';
+if (!$info->isWritable()) {
+    echo $info->getFilename() . ' is not writable';
 }
 ?>
 ]]>
@@ -47,7 +47,7 @@ if (!$info->isWriteable()) {
     &example.outputs.similar;
     <screen>
 <![CDATA[
-locked.jpg is not writeable
+locked.jpg is not writable
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
Sometimes the spelling used is "writeable", sometimes it's "writable". Both are valid in English, but the SplFileInfo method is `isWritable()`.

The "ea" variant is sometimes used elsewhere (the `is_writeable()` function most notably), so being fully consistent would require php/src changes, not just tidying the docs.

