### PR TITLE
Document IntlDateFormatter::parseToCalendar and Spoofchecker::setAllowedChars (PHP 8.4)

### DIFF
--- a/reference/intl/dateformatter/parsetocalendar.xml
+++ b/reference/intl/dateformatter/parsetocalendar.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="intldateformatter.parsetocalendar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlDateFormatter::parseToCalendar</refname>
+  <refpurpose>Parse a string into a timestamp, updating an open calendar</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="IntlDateFormatter">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>float</type><type>false</type></type><methodname>IntlDateFormatter::parseToCalendar</methodname>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter role="reference">offset</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Converts <parameter>string</parameter> to an incremental time value, starting at
+   <parameter>offset</parameter> and consuming as much of the input value as possible.
+  </simpara>
+  <simpara>
+   This method behaves like <methodname>IntlDateFormatter::parse</methodname>, except
+   that the time zone of the formatter is updated according to the time zone information
+   contained in the parsed <parameter>string</parameter>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>string</parameter></term>
+    <listitem>
+     <simpara>
+      The string to convert to a time.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>offset</parameter></term>
+    <listitem>
+     <simpara>
+      Position at which to start the parsing in <parameter>string</parameter> (zero-based).
+      If no error occurs before <parameter>string</parameter> is consumed,
+      <parameter>offset</parameter> will contain -1, otherwise it will contain the position
+      at which parsing ended (and the error occurred).
+      This variable will contain the end position if the parse fails.
+      If <parameter>offset</parameter> &gt; <code>strlen($string)</code>, the parse fails immediately.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Timestamp of parsed value, or &false; if value cannot be parsed.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>IntlDateFormatter::parseToCalendar</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$fmt = new IntlDateFormatter(
+    'en_US',
+    IntlDateFormatter::FULL,
+    IntlDateFormatter::FULL,
+    'America/Los_Angeles',
+    IntlDateFormatter::GREGORIAN
+);
+echo $fmt->parseToCalendar('Wednesday, December 20, 1989 at 4:00:00 PM Pacific Standard Time');
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+630201600
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>IntlDateFormatter::parse</methodname></member>
+   <member><methodname>IntlDateFormatter::format</methodname></member>
+   <member><methodname>IntlDateFormatter::getErrorCode</methodname></member>
+   <member><methodname>IntlDateFormatter::getErrorMessage</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/spoofchecker/setallowedchars.xml
+++ b/reference/intl/spoofchecker/setallowedchars.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="spoofchecker.setallowedchars" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Spoofchecker::setAllowedChars</refname>
+  <refpurpose>Set the set of characters allowed when running checks</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Spoofchecker">
+   <modifier>public</modifier> <type>void</type><methodname>Spoofchecker::setAllowedChars</methodname>
+   <methodparam><type>string</type><parameter>pattern</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>patternOptions</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Restricts the characters that are considered acceptable by subsequent checks to the
+   set described by <parameter>pattern</parameter>. Any character outside of this set
+   causes <methodname>Spoofchecker::isSuspicious</methodname> to report a result.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>pattern</parameter></term>
+    <listitem>
+     <simpara>
+      A character set described as a <literal>UnicodeSet</literal> pattern, that is a
+      regular-expression style character class. It must begin with <literal>[</literal>
+      and end with <literal>]</literal>, for example <literal>[a-z0-9]</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>patternOptions</parameter></term>
+    <listitem>
+     <simpara>
+      A bitmask controlling how <parameter>pattern</parameter> is interpreted. It must be
+      <literal>0</literal>, or <constant>Spoofchecker::IGNORE_SPACE</constant> on its own
+      or combined with exactly one of <constant>Spoofchecker::CASE_INSENSITIVE</constant>,
+      <constant>Spoofchecker::ADD_CASE_MAPPINGS</constant>, or
+      <constant>Spoofchecker::SIMPLE_CASE_INSENSITIVE</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   No value is returned.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Throws a <exceptionname>ValueError</exceptionname> if <parameter>pattern</parameter> is
+   not a valid character set pattern, or if <parameter>patternOptions</parameter> is not
+   a valid combination of options.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Spoofchecker::setAllowedChars</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$checker = new Spoofchecker();
+$checker->setAllowedChars('[a-z0-9]');
+
+var_dump($checker->isSuspicious('hello'));
+var_dump($checker->isSuspicious('héllo'));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(false)
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Spoofchecker::setAllowedLocales</methodname></member>
+   <member><methodname>Spoofchecker::isSuspicious</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/versions.xml
+++ b/reference/intl/versions.xml
@@ -180,6 +180,7 @@
  <function name="intldateformatter::format" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
  <function name="intldateformatter::formatobject" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL intl &gt;= 3.0.0"/>
  <function name="intldateformatter::parse" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
+ <function name="intldateformatter::parsetocalendar" from="PHP 8 &gt;= 8.4.0"/>
  <function name="intldateformatter::localtime" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
  <function name="intldateformatter::geterrorcode" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
  <function name="intldateformatter::geterrormessage" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
@@ -311,6 +312,7 @@
  <function name="spoofchecker::areconfusable" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
  <function name="spoofchecker::construct" from="PHP 5 &gt;= 5.4.0, PHP 7, PECL intl &gt;= 2.0.0"/>
  <function name="spoofchecker::issuspicious" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
+ <function name="spoofchecker::setallowedchars" from="PHP 8 &gt;= 8.4.0"/>
  <function name="spoofchecker::setallowedlocales" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
  <function name="spoofchecker::setchecks" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8, PECL intl &gt;= 2.0.0"/>
  <function name="spoofchecker::setRestrictionLevel" from="PHP 7 &gt;= 7.3.0, PHP 8"/>


### PR DESCRIPTION
Documents two PHP 8.4 intl methods that were missing from the manual:

- `IntlDateFormatter::parseToCalendar()`
- `Spoofchecker::setAllowedChars()`

Adds the matching `reference/intl/versions.xml` entries so the version banner is shown. Part of #3872.