### PR TITLE
Fix imagecharup return type: bool -> true

### DIFF
--- a/reference/image/functions/imagecharup.xml
+++ b/reference/image/functions/imagecharup.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecharup</methodname>
+   <type>true</type><methodname>imagecharup</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
@@ -65,7 +65,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -80,6 +80,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.gdfont-instance;
      &gd.changelog.image-param;
     </tbody>


### PR DESCRIPTION
Since PHP 8.2, `imagecharup()` always returns `true` instead of `bool`.

Changes:
- Update `<type>bool</type>` to `<type>true</type>` in methodsynopsis
- Update return value description to `&return.true.always;`
- Add `&return.type.true;` changelog entry for 8.2.0

**Reference:** [`ext/gd/gd.stub.php` line 691](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/gd/gd.stub.php#L691)

```php
function imagecharup(GdImage $image, GdFont|int $font, int $x, int $y, string $char, int $color): true {}
```