### PR TITLE
Fix imagecolormatch return type: bool -> true

### DIFF
--- a/reference/image/functions/imagecolormatch.xml
+++ b/reference/image/functions/imagecolormatch.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecolormatch</methodname>
+   <type>true</type><methodname>imagecolormatch</methodname>
    <methodparam><type>GdImage</type><parameter>image1</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>image2</parameter></methodparam>
   </methodsynopsis>
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -58,6 +58,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      <row>
       <entry>8.0.0</entry>
       <entry>


### PR DESCRIPTION
Since PHP 8.2, `imagecolormatch()` always returns `true` instead of `bool`.

Changes:
- Update `<type>bool</type>` to `<type>true</type>` in methodsynopsis
- Update return value description to `&return.true.always;`
- Add `&return.type.true;` changelog entry for 8.2.0

**Reference:** [`ext/gd/gd.stub.php` line 493](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/gd/gd.stub.php#L493)

```php
function imagecolormatch(GdImage $image1, GdImage $image2): true {}
```