### PR TITLE
Fix imagecopymergegray return type: bool -> true

### DIFF
--- a/reference/image/functions/imagecopymergegray.xml
+++ b/reference/image/functions/imagecopymergegray.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecopymergegray</methodname>
+   <type>true</type><methodname>imagecopymergegray</methodname>
    <methodparam><type>GdImage</type><parameter>dst_image</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>src_image</parameter></methodparam>
    <methodparam><type>int</type><parameter>dst_x</parameter></methodparam>
@@ -113,7 +113,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -128,6 +128,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      <row>
       <entry>8.0.0</entry>
       <entry>


### PR DESCRIPTION
Since PHP 8.2, `imagecopymergegray()` always returns `true` instead of `bool`.

Changes:
- Update `<type>bool</type>` to `<type>true</type>` in methodsynopsis
- Update return value description to `&return.true.always;`
- Add `&return.type.true;` changelog entry for 8.2.0

**Reference:** [`ext/gd/gd.stub.php` line 701](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/gd/gd.stub.php#L701)

```php
function imagecopymergegray(GdImage $dst_image, GdImage $src_image, int $dst_x, int $dst_y, int $src_x, int $src_y, int $src_width, int $src_height, int $pct): true {}
```