### PR TITLE
Add missing 8.5.0 changelog entry for imagecopyresampled return type

### DIFF
--- a/reference/image/functions/imagecopyresampled.xml
+++ b/reference/image/functions/imagecopyresampled.xml
@@ -142,7 +142,12 @@
      </row>
     </thead>
     <tbody>
-     &return.type.true;
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       The return type is &true; now; previously, it was <type>bool</type>.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/image/functions/imagecopyresampled.xml
+++ b/reference/image/functions/imagecopyresampled.xml
@@ -142,6 +142,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      <row>
       <entry>8.0.0</entry>
       <entry>


### PR DESCRIPTION
Add missing `&return.type.true;` changelog entry for 8.5.0.

Fixes https://github.com/php/doc-en/issues/5426