### PR TITLE
Fix imagedestroy return type: bool -> true

### DIFF
--- a/reference/image/functions/imagedestroy.xml
+++ b/reference/image/functions/imagedestroy.xml
@@ -12,7 +12,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier role="attribute">#[\Deprecated]</modifier>
-   <type>bool</type><methodname>imagedestroy</methodname>
+   <type>true</type><methodname>imagedestroy</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
   </methodsynopsis>
   &note.resource-migration-8.0-dead-function;
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -49,6 +49,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      <row>
       <entry>8.5.0</entry>
       <entry>


### PR DESCRIPTION
Since PHP 8.2, `imagedestroy()` always returns `true` instead of `bool`.

Changes:
- Update `<type>bool</type>` to `<type>true</type>` in methodsynopsis
- Update return value description to `&return.true.always;`
- Add `&return.type.true;` changelog entry for 8.2.0

**Reference:** [`ext/gd/gd.stub.php` line 627](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/gd/gd.stub.php#L627)

```php
function imagedestroy(GdImage $image): true {}
```