### PR TITLE
Fix imagefilledellipse return type: bool -> true

### DIFF
--- a/reference/image/functions/imagefilledellipse.xml
+++ b/reference/image/functions/imagefilledellipse.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagefilledellipse</methodname>
+   <type>true</type><methodname>imagefilledellipse</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>center_x</parameter></methodparam>
    <methodparam><type>int</type><parameter>center_y</parameter></methodparam>
@@ -72,7 +72,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -87,6 +87,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>


### PR DESCRIPTION
Since PHP 8.2, `imagefilledellipse()` always returns `true` instead of `bool`.

Changes:
- Update `<type>bool</type>` to `<type>true</type>` in methodsynopsis
- Update return value description to `&return.true.always;`
- Add `&return.type.true;` changelog entry for 8.2.0

**Reference:** [`ext/gd/gd.stub.php` line 497](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/gd/gd.stub.php#L497)

```php
function imagefilledellipse(GdImage $image, int $center_x, int $center_y, int $width, int $height, int $color): true {}
```