### PR TITLE
Fix imagefilledrectangle return type: bool -> true

### DIFF
--- a/reference/image/functions/imagefilledrectangle.xml
+++ b/reference/image/functions/imagefilledrectangle.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagefilledrectangle</methodname>
+   <type>true</type><methodname>imagefilledrectangle</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x1</parameter></methodparam>
    <methodparam><type>int</type><parameter>y1</parameter></methodparam>
@@ -73,7 +73,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -88,6 +88,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>


### PR DESCRIPTION
Since PHP 8.2, `imagefilledrectangle()` always returns `true` instead of `bool`.

Changes:
- Update `<type>bool</type>` to `<type>true</type>` in methodsynopsis
- Update return value description to `&return.true.always;`
- Add `&return.type.true;` changelog entry for 8.2.0

**Reference:** [`ext/gd/gd.stub.php` line 663](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/gd/gd.stub.php#L663)

```php
function imagefilledrectangle(GdImage $image, int $x1, int $y1, int $x2, int $y2, int $color): true {}
```