### PR TITLE
Fix imageflip return type: bool -> true

### DIFF
--- a/reference/image/functions/imageflip.xml
+++ b/reference/image/functions/imageflip.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imageflip</methodname>
+   <type>true</type><methodname>imageflip</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>mode</parameter></methodparam>
   </methodsynopsis>
@@ -40,6 +40,7 @@
           </row>
          </thead>
          <tbody>
+     &return.type.true;
           <row>
            <entry><constant>IMG_FLIP_HORIZONTAL</constant></entry>
            <entry>
@@ -71,7 +72,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 


### PR DESCRIPTION
Since PHP 8.2, `imageflip()` always returns `true` instead of `bool`.

Changes:
- Update `<type>bool</type>` to `<type>true</type>` in methodsynopsis
- Update return value description to `&return.true.always;`
- Add `&return.type.true;` changelog entry for 8.2.0

**Reference:** [`ext/gd/gd.stub.php` line 748](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/gd/gd.stub.php#L748)

```php
function imageflip(GdImage $image, int $mode): true {}
```