### PR TITLE
Fix imagegammacorrect return type: bool -> true

### DIFF
--- a/reference/image/functions/imagegammacorrect.xml
+++ b/reference/image/functions/imagegammacorrect.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagegammacorrect</methodname>
+   <type>true</type><methodname>imagegammacorrect</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>float</type><parameter>input_gamma</parameter></methodparam>
    <methodparam><type>float</type><parameter>output_gamma</parameter></methodparam>
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -60,6 +60,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>


### PR DESCRIPTION
Since PHP 8.2, `imagegammacorrect()` always returns `true` instead of `bool`.

Changes:
- Update `<type>bool</type>` to `<type>true</type>` in methodsynopsis
- Update return value description to `&return.true.always;`
- Add `&return.type.true;` changelog entry for 8.2.0

**Reference:** [`ext/gd/gd.stub.php` line 653](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/gd/gd.stub.php#L653)

```php
function imagegammacorrect(GdImage $image, float $input_gamma, float $output_gamma): true {}
```