### PR TITLE
Fix imagelayereffect return type: bool -> true

### DIFF
--- a/reference/image/functions/imagelayereffect.xml
+++ b/reference/image/functions/imagelayereffect.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagelayereffect</methodname>
+   <type>true</type><methodname>imagelayereffect</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>effect</parameter></methodparam>
   </methodsynopsis>
@@ -81,7 +81,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -96,6 +96,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
      <row>
       <entry>7.2.0</entry>


### PR DESCRIPTION
Since PHP 8.2, `imagelayereffect()` always returns `true` instead of `bool`.

Changes:
- Update `<type>bool</type>` to `<type>true</type>` in methodsynopsis
- Update return value description to `&return.true.always;`
- Add `&return.type.true;` changelog entry for 8.2.0

**Reference:** [`ext/gd/gd.stub.php` line 505](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/gd/gd.stub.php#L505)

```php
function imagelayereffect(GdImage $image, int $effect): true {}
```