### PR TITLE
Fix imagesavealpha return type: bool -> true

### DIFF
--- a/reference/image/functions/imagesavealpha.xml
+++ b/reference/image/functions/imagesavealpha.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagesavealpha</methodname>
+   <type>true</type><methodname>imagesavealpha</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>bool</type><parameter>enable</parameter></methodparam>
   </methodsynopsis>
@@ -56,7 +56,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -71,6 +71,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>


### PR DESCRIPTION
Since PHP 8.2, `imagesavealpha()` always returns `true` instead of `bool`.

Changes:
- Update `<type>bool</type>` to `<type>true</type>` in methodsynopsis
- Update return value description to `&return.true.always;`
- Add `&return.type.true;` changelog entry for 8.2.0

**Reference:** [`ext/gd/gd.stub.php` line 503](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/gd/gd.stub.php#L503)

```php
function imagesavealpha(GdImage $image, bool $enable): true {}
```