### PR TITLE
Fix imagesetbrush return type: bool -> true

### DIFF
--- a/reference/image/functions/imagesetbrush.xml
+++ b/reference/image/functions/imagesetbrush.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagesetbrush</methodname>
+   <type>true</type><methodname>imagesetbrush</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>brush</parameter></methodparam>
   </methodsynopsis>
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -63,6 +63,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      <row>
       <entry>8.0.0</entry>
       <entry>


### PR DESCRIPTION
Since PHP 8.2, `imagesetbrush()` always returns `true` instead of `bool`.

Changes:
- Update `<type>bool</type>` to `<type>true</type>` in methodsynopsis
- Update return value description to `&return.true.always;`
- Add `&return.type.true;` changelog entry for 8.2.0

**Reference:** [`ext/gd/gd.stub.php` line 532](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/gd/gd.stub.php#L532)

```php
function imagesetbrush(GdImage $image, GdImage $brush): true {}
```