### PR TITLE
Fix imagesettile return type: bool -> true

### DIFF
--- a/reference/image/functions/imagesettile.xml
+++ b/reference/image/functions/imagesettile.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagesettile</methodname>
+   <type>true</type><methodname>imagesettile</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>tile</parameter></methodparam>
   </methodsynopsis>
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -66,6 +66,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      <row>
       <entry>8.0.0</entry>
       <entry>


### PR DESCRIPTION
Since PHP 8.2, `imagesettile()` always returns `true` instead of `bool`.

Changes:
- Update `<type>bool</type>` to `<type>true</type>` in methodsynopsis
- Update return value description to `&return.true.always;`
- Add `&return.type.true;` changelog entry for 8.2.0

**Reference:** [`ext/gd/gd.stub.php` line 530](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/gd/gd.stub.php#L530)

```php
function imagesettile(GdImage $image, GdImage $tile): true {}
```