### PR TITLE
Fix finfo_close return type: bool -> true

### DIFF
--- a/reference/fileinfo/functions/finfo-close.xml
+++ b/reference/fileinfo/functions/finfo-close.xml
@@ -13,7 +13,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier role="attribute">#[\Deprecated]</modifier>
-   <type>bool</type><methodname>finfo_close</methodname>
+   <type>true</type><methodname>finfo_close</methodname>
    <methodparam><type>finfo</type><parameter>finfo</parameter></methodparam>
   </methodsynopsis>
 
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   &return.success;
+   &return.true.always;
   </simpara>
  </refsect1>
 
@@ -51,6 +51,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &fileinfo.changelog.finfo-object;
     </tbody>
    </tgroup>


### PR DESCRIPTION
Since PHP 8.2, `finfo_close()` always returns `true` instead of `bool`.

Changes:
- Update `<type>bool</type>` to `<type>true</type>` in methodsynopsis
- Update return value description to `&return.true.always;`
- Add `&return.type.true;` changelog entry for 8.2.0

**Reference:** [`ext/fileinfo/fileinfo.stub.php` line 96](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/fileinfo/fileinfo.stub.php#L96)

```php
function finfo_close(finfo $finfo): true {}
```