### PR TITLE
Fix ftp_set_option return type: bool -> true

### DIFF
--- a/reference/ftp/functions/ftp-set-option.xml
+++ b/reference/ftp/functions/ftp-set-option.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>ftp_set_option</methodname>
+   <type>true</type><methodname>ftp_set_option</methodname>
    <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
    <methodparam><type class="union"><type>int</type><type>bool</type></type><parameter>value</parameter></methodparam>
@@ -36,6 +36,7 @@
         <title>Supported runtime FTP options</title>
         <tgroup cols="2">
          <tbody>
+     &return.type.true;
           <row>
            <entry><constant>FTP_TIMEOUT_SEC</constant></entry>
            <entry>


### PR DESCRIPTION
Since PHP 8.2, `ftp_set_option()` always returns `true` instead of `bool`.

Changes:
- Update `<type>bool</type>` to `<type>true</type>` in methodsynopsis
- Update return value description to `&return.true.always;`
- Add `&return.type.true;` changelog entry for 8.2.0

**Reference:** [`ext/ftp/ftp.stub.php` line 135](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/ftp/ftp.stub.php#L135)

```php
function ftp_set_option(FTP\Connection $ftp, int $option, $value): true {}
```