### PR TITLE
Fix libxml_set_external_entity_loader return type: bool -> true

### DIFF
--- a/reference/libxml/functions/libxml-set-external-entity-loader.xml
+++ b/reference/libxml/functions/libxml-set-external-entity-loader.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>libxml_set_external_entity_loader</methodname>
+   <type>true</type><methodname>libxml_set_external_entity_loader</methodname>
    <methodparam><type class="union"><type>callable</type><type>null</type></type><parameter>resolver_function</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -72,7 +72,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 


### PR DESCRIPTION
Since PHP 8.2, `libxml_set_external_entity_loader()` always returns `true` instead of `bool`.

Changes:
- Update `<type>bool</type>` to `<type>true</type>` in methodsynopsis
- Update return value description to `&return.true.always;`
- Add `&return.type.true;` changelog entry for 8.2.0

**Reference:** [`ext/libxml/libxml.stub.php` line 185](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/libxml/libxml.stub.php#L185)

```php
function libxml_set_external_entity_loader(?callable $resolver_function): true {}
```