### PR TITLE
Fix shm_detach return type: bool -> true

### DIFF
--- a/reference/sem/functions/shm-detach.xml
+++ b/reference/sem/functions/shm-detach.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>shm_detach</methodname>
+   <type>true</type><methodname>shm_detach</methodname>
    <methodparam><type>SysvSharedMemory</type><parameter>shm</parameter></methodparam>
   </methodsynopsis>
   <simpara>
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   &return.success;
+   &return.true.always;
   </simpara>
  </refsect1>
 
@@ -52,6 +52,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      <row>
       <entry>8.0.0</entry>
       <entry>


### PR DESCRIPTION
Since PHP 8.2, `shm_detach()` always returns `true` instead of `bool`.

Changes:
- Update `<type>bool</type>` to `<type>true</type>` in methodsynopsis
- Update return value description to `&return.true.always;`
- Add `&return.type.true;` changelog entry for 8.2.0

**Reference:** [`ext/sysvshm/sysvshm.stub.php` line 15](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/sysvshm/sysvshm.stub.php#L15)

```php
function shm_detach(SysvSharedMemory $shm): true {}
```