### PR TITLE
Fix array_multisort return type: bool -> true

### DIFF
--- a/reference/array/functions/array-multisort.xml
+++ b/reference/array/functions/array-multisort.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>array_multisort</methodname>
+   <type>true</type><methodname>array_multisort</methodname>
    <methodparam><type>array</type><parameter role="reference">array1</parameter></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>array1_sort_order</parameter><initializer>SORT_ASC</initializer></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>array1_sort_flags</parameter><initializer>SORT_REGULAR</initializer></methodparam>
@@ -118,7 +118,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 


### PR DESCRIPTION
Since PHP 8.2, `array_multisort()` always returns `true` instead of `bool`.

Changes:
- Update `<type>bool</type>` to `<type>true</type>` in methodsynopsis
- Update return value description to `&return.true.always;`
- Add `&return.type.true;` changelog entry for 8.2.0

**Reference:** [`ext/standard/basic_functions.stub.php` line 1857](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/standard/basic_functions.stub.php#L1857)

```php
function array_multisort(&$array, &...$rest): true {}
```