### PR TITLE
Fix pcntl_exec return type: bool -> false

### DIFF
--- a/reference/pcntl/functions/pcntl-exec.xml
+++ b/reference/pcntl/functions/pcntl-exec.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>pcntl_exec</methodname>
+   <type>false</type><methodname>pcntl_exec</methodname>
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>args</parameter><initializer>[]</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>env_vars</parameter><initializer>[]</initializer></methodparam>


### PR DESCRIPTION
`pcntl_exec()` either replaces the current process (never returns) or returns `false` on failure.

The return type in the methodsynopsis should be `false`, not `bool`, to match php-src.

**Reference:** [`ext/pcntl/pcntl.stub.php` line 1061](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pcntl/pcntl.stub.php#L1061)

```php
function pcntl_exec(string $path, array $args = [], array $env_vars = []): false {}
```