### PR TITLE
Fix pg_escape_identifier signature to match php-src

### DIFF
--- a/reference/pgsql/functions/pg-escape-identifier.xml
+++ b/reference/pgsql/functions/pg-escape-identifier.xml
@@ -12,9 +12,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>pg_escape_identifier</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>pg_escape_identifier</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_escape_identifier</function> escapes a identifier
@@ -48,7 +48,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>data</parameter></term>
+     <term><parameter>string</parameter></term>
      <listitem>
       <para>
        A <type>string</type> containing text to be escaped.
@@ -62,7 +62,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   A <type>string</type> containing the escaped data.
+   A <type>string</type> containing the escaped data, or &false; on failure.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Sync `pg_escape_identifier()` documentation with php-src stub:

- Return type: `string` -> `string|false` (can return false on failure)
- Parameter name: `$data` -> `$string` (matches php-src pgsql.stub.php)

**Reference:** [`ext/pgsql/pgsql.stub.php` line 880](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pgsql/pgsql.stub.php#L880)

```php
function pg_escape_identifier($connection, string $string = UNKNOWN): string|false {}
```