### PR TITLE
Fix pg_escape_bytea parameter name: $data -> $string

### DIFF
--- a/reference/pgsql/functions/pg-escape-bytea.xml
+++ b/reference/pgsql/functions/pg-escape-bytea.xml
@@ -14,7 +14,7 @@
   <methodsynopsis>
    <type>string</type><methodname>pg_escape_bytea</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_escape_bytea</function> escapes string for
@@ -49,7 +49,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>data</parameter></term>
+     <term><parameter>string</parameter></term>
      <listitem>
       <para>
        A <type>string</type> containing text or binary data to be inserted into a bytea


### PR DESCRIPTION
Sync `pg_escape_bytea()` parameter name `$data` -> `$string` to match php-src pgsql.stub.php.

**Reference:** [`ext/pgsql/pgsql.stub.php` line 865](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pgsql/pgsql.stub.php#L865)

```php
function pg_escape_bytea($connection, string $string = UNKNOWN): string {}
```