### PR TITLE
Fix pg_escape_string parameter name: $data -> $string

### DIFF
--- a/reference/pgsql/functions/pg-escape-string.xml
+++ b/reference/pgsql/functions/pg-escape-string.xml
@@ -14,7 +14,7 @@
   <methodsynopsis>
    <type>string</type><methodname>pg_escape_string</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_escape_string</function> escapes a string for querying
@@ -45,7 +45,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>data</parameter></term>
+     <term><parameter>string</parameter></term>
      <listitem>
       <para>
        A <type>string</type> containing text to be escaped.


### PR DESCRIPTION
Sync `pg_escape_string()` parameter name `$data` -> `$string` to match php-src pgsql.stub.php.

**Reference:** [`ext/pgsql/pgsql.stub.php` line 859](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pgsql/pgsql.stub.php#L859)

```php
function pg_escape_string($connection, string $string = UNKNOWN): string {}
```