### PR TITLE
Fix pg_execute parameter name: $stmtname -> $statement_name

### DIFF
--- a/reference/pgsql/functions/pg-execute.xml
+++ b/reference/pgsql/functions/pg-execute.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <type class="union"><type>PgSql\Result</type><type>false</type></type><methodname>pg_execute</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>stmtname</parameter></methodparam>
+   <methodparam><type>string</type><parameter>statement_name</parameter></methodparam>
    <methodparam><type>array</type><parameter>params</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -46,7 +46,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>stmtname</parameter></term>
+     <term><parameter>statement_name</parameter></term>
      <listitem>
       <para>
        The name of the prepared statement to execute.  if


### PR DESCRIPTION
Sync `pg_execute()` parameter name `$stmtname` -> `$statement_name` to match php-src pgsql.stub.php.

**Reference:** [`ext/pgsql/pgsql.stub.php` line 552](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pgsql/pgsql.stub.php#L552)

```php
function pg_execute($connection, $statement_name, array $params = UNKNOWN): PgSql\Result|false {}
```