### PR TITLE
Fix pg_prepare parameter name: $stmtname -> $statement_name

### DIFF
--- a/reference/pgsql/functions/pg-prepare.xml
+++ b/reference/pgsql/functions/pg-prepare.xml
@@ -15,7 +15,7 @@
   <methodsynopsis>
    <type class="union"><type>PgSql\Result</type><type>false</type></type><methodname>pg_prepare</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>stmtname</parameter></methodparam>
+   <methodparam><type>string</type><parameter>statement_name</parameter></methodparam>
    <methodparam><type>string</type><parameter>query</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -27,8 +27,8 @@
    higher connections; it will fail when using earlier versions.
   </para>
   <para>
-   The function creates a prepared statement named <parameter>stmtname</parameter> from the <parameter>query</parameter>
-   string, which must contain a single SQL command. <parameter>stmtname</parameter> may be <literal>""</literal> to
+   The function creates a prepared statement named <parameter>statement_name</parameter> from the <parameter>query</parameter>
+   string, which must contain a single SQL command. <parameter>statement_name</parameter> may be <literal>""</literal> to
    create an unnamed statement, in which case any pre-existing unnamed
    statement is automatically replaced; otherwise it is an error if the
    statement name is already defined in the current session. If any parameters
@@ -55,7 +55,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>stmtname</parameter></term>
+     <term><parameter>statement_name</parameter></term>
      <listitem>
       <para>
        The name to give the prepared statement.  Must be unique per-connection.  If


### PR DESCRIPTION
Sync `pg_prepare()` parameter name `$stmtname` -> `$statement_name` to match php-src pgsql.stub.php.

**Reference:** [`ext/pgsql/pgsql.stub.php` line 545](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pgsql/pgsql.stub.php#L545)

```php
function pg_prepare($connection, string $statement_name, string $query = UNKNOWN): PgSql\Result|false {}
```