### PR TITLE
Fix pg_lo_export parameter name: $pathname -> $filename

### DIFF
--- a/reference/pgsql/functions/pg-lo-export.xml
+++ b/reference/pgsql/functions/pg-lo-export.xml
@@ -13,7 +13,7 @@
    <type>bool</type><methodname>pg_lo_export</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
    <methodparam><type>int</type><parameter>oid</parameter></methodparam>
-   <methodparam><type>string</type><parameter>pathname</parameter></methodparam>
+   <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_lo_export</function> takes a large object in a
@@ -50,7 +50,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>pathname</parameter></term>
+     <term><parameter>filename</parameter></term>
      <listitem>
       <para>
        The full path and file name of the file in which to write the


### PR DESCRIPTION
Sync `pg_lo_export()` parameter name `$pathname` -> `$filename` to match php-src.

**Reference:** [`ext/pgsql/pgsql.stub.php` line 804](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pgsql/pgsql.stub.php#L804)

```php
function pg_lo_export($connection, $oid = UNKNOWN, $filename = UNKNOWN): bool {}
```