### PR TITLE
Fix pg_lo_import parameter names to match php-src

### DIFF
--- a/reference/pgsql/functions/pg-lo-import.xml
+++ b/reference/pgsql/functions/pg-lo-import.xml
@@ -12,8 +12,8 @@
   <methodsynopsis>
    <type>int|string|false</type><methodname>pg_lo_import</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>pathname</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>object_id</parameter></methodparam>
+   <methodparam><type>string</type><parameter>filename</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>oid</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_lo_import</function> creates a new large object
@@ -42,7 +42,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>pathname</parameter></term>
+     <term><parameter>filename</parameter></term>
      <listitem>
       <para>
        The full path and file name of the file on the client
@@ -51,10 +51,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>object_id</parameter></term>
+     <term><parameter>oid</parameter></term>
      <listitem>
       <para>
-       If an <parameter>object_id</parameter> is given the function
+       If an <parameter>oid</parameter> is given the function
        will try to create a large object with this id, else a free
        object id is assigned by the server. The parameter
        relies on functionality that first


### PR DESCRIPTION
Sync `pg_lo_import()` parameter names with php-src:

- `$pathname` -> `$filename`
- `$object_id` -> `$oid`

**Reference:** [`ext/pgsql/pgsql.stub.php` line 788](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pgsql/pgsql.stub.php#L788)

```php
function pg_lo_import($connection, $filename = UNKNOWN, $oid = UNKNOWN): string|int|false {}
```