### PR TITLE
Fix pg_parameter_status signature to match php-src

### DIFF
--- a/reference/pgsql/functions/pg-parameter-status.xml
+++ b/reference/pgsql/functions/pg-parameter-status.xml
@@ -9,9 +9,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>pg_parameter_status</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>pg_parameter_status</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>param_name</parameter></methodparam>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
   <para>
     Looks up a current parameter setting of the server.
@@ -60,10 +60,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>param_name</parameter></term>
+     <term><parameter>name</parameter></term>
      <listitem>
         <para>
-         Possible <parameter>param_name</parameter> values include <literal>server_version</literal>, 
+         Possible <parameter>name</parameter> values include <literal>server_version</literal>, 
         <literal>server_encoding</literal>, <literal>client_encoding</literal>, 
         <literal>is_superuser</literal>, <literal>session_authorization</literal>, 
         <literal>DateStyle</literal>, <literal>TimeZone</literal>, and 
@@ -78,7 +78,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>A <type>string</type> containing the value of the parameter, &false; on failure or invalid
-  <parameter>param_name</parameter>.</para>
+  <parameter>name</parameter>.</para>
  </refsect1>
 
  <refsect1 role="changelog">


### PR DESCRIPTION
Sync `pg_parameter_status()` with php-src:

- Return type: `string` -> `string|false`
- Parameter name: `$param_name` -> `$name`

**Reference:** [`ext/pgsql/pgsql.stub.php` line 518](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pgsql/pgsql.stub.php#L518)

```php
function pg_parameter_status($connection, string $name = UNKNOWN): string|false {}
```