### PR TITLE
Fix pg_set_error_verbosity return type: int -> int|false

### DIFF
--- a/reference/pgsql/functions/pg-set-error-verbosity.xml
+++ b/reference/pgsql/functions/pg-set-error-verbosity.xml
@@ -13,7 +13,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>int</type><methodname>pg_set_error_verbosity</methodname>
+   <type class="union"><type>int</type><type>false</type></type><methodname>pg_set_error_verbosity</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
    <methodparam><type>int</type><parameter>verbosity</parameter></methodparam>
   </methodsynopsis>


### PR DESCRIPTION
Sync `pg_set_error_verbosity()` return type with php-src: `int` -> `int|false`.

**Reference:** [`ext/pgsql/pgsql.stub.php` line 822](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pgsql/pgsql.stub.php#L822)

```php
function pg_set_error_verbosity($connection, int $verbosity = UNKNOWN): int|false {}
```