### PR TITLE
Fix pg_put_line parameter name: $data -> $query

### DIFF
--- a/reference/pgsql/functions/pg-put-line.xml
+++ b/reference/pgsql/functions/pg-put-line.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>pg_put_line</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>query</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_put_line</function> sends a NULL-terminated string
@@ -57,7 +57,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>data</parameter></term>
+     <term><parameter>query</parameter></term>
      <listitem>
       <para>
        A line of text to be sent directly to the PostgreSQL backend.  A <literal>NULL</literal>


### PR DESCRIPTION
Sync `pg_put_line()` parameter name with php-src: `$data` -> `$query`.

**Reference:** [`ext/pgsql/pgsql.stub.php` line 845](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pgsql/pgsql.stub.php#L845)

```php
function pg_put_line($connection, string $query = UNKNOWN): bool {}
```