### PR TITLE
Fix ldap_exop signature to match php-src

### DIFF
--- a/reference/ldap/functions/ldap-exop.xml
+++ b/reference/ldap/functions/ldap-exop.xml
@@ -10,11 +10,11 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>mixed</type><methodname>ldap_exop</methodname>
+   <type class="union"><type>LDAP\Result</type><type>bool</type></type><methodname>ldap_exop</methodname>
    <methodparam><type>LDAP\Connection</type><parameter>ldap</parameter></methodparam>
    <methodparam><type>string</type><parameter>request_oid</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>request_data</parameter><initializer>&null;</initializer></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>controls</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>request_data</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>controls</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter role="reference">response_data</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter role="reference">response_oid</parameter></methodparam>
   </methodsynopsis>


### PR DESCRIPTION
Sync `ldap_exop()` signature with php-src:

- Return type: `mixed` -> `LDAP\Result|bool`
- `$request_data` type: `string` -> `?string` (nullable, default is null)
- `$controls` type: `array` -> `?array` (nullable, default is null)

**Reference:** [`ext/ldap/ldap.stub.php` line 798](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/ldap/ldap.stub.php#L798)

```php
function ldap_exop(LDAP\Connection $ldap, string $request_oid, ?string $request_data = null, ?array $controls = null, &$response_data = UNKNOWN, &$response_oid = null): LDAP\Result|bool {}
```