### PR TITLE
Fix stream_filter_append parameter names to match php-src

### DIFF
--- a/reference/stream/functions/stream-filter-append.xml
+++ b/reference/stream/functions/stream-filter-append.xml
@@ -10,12 +10,12 @@
   <methodsynopsis>
    <type>resource</type><methodname>stream_filter_append</methodname>
    <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
-   <methodparam><type>string</type><parameter>filtername</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>read_write</parameter></methodparam>
+   <methodparam><type>string</type><parameter>filter_name</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>mode</parameter></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>params</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Adds <parameter>filtername</parameter> to the list of filters
+   Adds <parameter>filter_name</parameter> to the list of filters
    attached to <parameter>stream</parameter>.  
   </para>
  </refsect1>
@@ -33,7 +33,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>filtername</parameter></term>
+     <term><parameter>filter_name</parameter></term>
      <listitem>
       <para>
        The filter name.
@@ -41,7 +41,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>read_write</parameter></term>
+     <term><parameter>mode</parameter></term>
      <listitem>
       <para>
        By default, <function>stream_filter_append</function> will
@@ -54,7 +54,7 @@
        <constant>STREAM_FILTER_READ</constant>,
        <constant>STREAM_FILTER_WRITE</constant>, and/or
        <constant>STREAM_FILTER_ALL</constant> can also be passed to the
-       <parameter>read_write</parameter> parameter to override this behavior.
+       <parameter>mode</parameter> parameter to override this behavior.
       </para>
      </listitem>
     </varlistentry>
@@ -84,7 +84,7 @@
 
   <para>
    &false; is returned if <parameter>stream</parameter> is not a resource or
-   if <parameter>filtername</parameter> cannot be located.
+   if <parameter>filter_name</parameter> cannot be located.
   </para>
  </refsect1>
 
@@ -139,7 +139,7 @@ Guvf vf n grfg
    <title>When using custom (user) filters</title>
    <simpara>
     <function>stream_filter_register</function> must be called first
-    in order to register the desired user filter to <parameter>filtername</parameter>.
+    in order to register the desired user filter to <parameter>filter_name</parameter>.
    </simpara>
   </note>
   <note>


### PR DESCRIPTION
Sync `stream_filter_append()` parameter names with php-src:

- \`\$filtername\` -> \`\$filter_name\`
- \`\$read_write\` -> \`\$mode\`

**Reference:** [\`ext/standard/basic_functions.stub.php\` line 3422](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/standard/basic_functions.stub.php#L3422)

\`\`\`php
function stream_filter_append(\$stream, string \$filter_name, int \$mode = 0, mixed \$params = UNKNOWN) {}
\`\`\`