### PR TITLE
Document missing PHP 8.4 constants (ldap, openssl)

### DIFF
--- a/reference/ldap/constants.xml
+++ b/reference/ldap/constants.xml
@@ -384,7 +384,7 @@
    </term>
    <listitem>
     <simpara>
-     Specifies the maximum protocol version.
+     Specifies the maximum protocol version. This can be one of: <constant>LDAP_OPT_X_TLS_PROTOCOL_SSL2</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_SSL3</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_0</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_1</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_2</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_3</constant>.
      Available as of PHP 8.4.0.
     </simpara>
    </listitem>

--- a/reference/ldap/functions/ldap-get-option.xml
+++ b/reference/ldap/functions/ldap-get-option.xml
@@ -199,6 +199,11 @@
            <entry>7.1</entry>
           </row>
           <row>
+           <entry><constant>LDAP_OPT_X_TLS_PROTOCOL_MAX</constant></entry>
+           <entry><type>int</type></entry>
+           <entry>8.4</entry>
+          </row>
+          <row>
            <entry><constant>LDAP_OPT_X_TLS_RANDOM_FILE</constant></entry>
            <entry><type>string</type></entry>
            <entry>7.1</entry>

--- a/reference/ldap/functions/ldap-set-option.xml
+++ b/reference/ldap/functions/ldap-set-option.xml
@@ -179,6 +179,11 @@
            <entry>PHP 7.1.0</entry>
           </row>
           <row>
+           <entry><constant>LDAP_OPT_X_TLS_PROTOCOL_MAX</constant></entry>
+           <entry><type>int</type></entry>
+           <entry>PHP 8.4.0</entry>
+          </row>
+          <row>
            <entry><constant>LDAP_OPT_X_TLS_RANDOM_FILE</constant></entry>
            <entry><type>string</type></entry>
            <entry>PHP 7.1.0</entry>

--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -90,6 +90,7 @@
      </term>
      <listitem>
       <simpara>
+       Verify the certificate for use as an OCSP responder helper.
        Available as of PHP 8.4.0.
       </simpara>
      </listitem>
@@ -101,6 +102,7 @@
      </term>
      <listitem>
       <simpara>
+       Verify the certificate for use as a trusted time stamp signer.
        Available as of PHP 8.4.0.
       </simpara>
      </listitem>


### PR DESCRIPTION
Documents four PHP 8.4 constants that were listed in the migration appendix but missing from their extension constants pages:

- `LDAP_OPT_X_TLS_PROTOCOL_MAX`, `LDAP_OPT_X_TLS_PROTOCOL_TLS1_3` (ldap)
- `X509_PURPOSE_OCSP_HELPER`, `X509_PURPOSE_TIMESTAMP_SIGN` (openssl)

Part of #3872.