### PR TITLE
Fix PDOStatement::setFetchMode return type: bool -> true

### DIFF
--- a/reference/pdo/pdostatement/setfetchmode.xml
+++ b/reference/pdo/pdostatement/setfetchmode.xml
@@ -11,25 +11,25 @@
   &reftitle.description;
 
   <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter></methodparam>
   </methodsynopsis>
 
   <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter><initializer>PDO::FETCH_COLUMN</initializer></methodparam>
    <methodparam><type>int</type><parameter>colno</parameter></methodparam>
   </methodsynopsis>
 
   <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter><initializer>PDO::FETCH_CLASS</initializer></methodparam>
    <methodparam><type>string</type><parameter>class</parameter></methodparam>
    <methodparam><type class="union"><type>array</type><type>null</type></type><parameter>constructorArgs</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
   <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter><initializer>PDO::FETCH_INTO</initializer></methodparam>
    <methodparam><type>object</type><parameter>object</parameter></methodparam>
   </methodsynopsis>
@@ -88,8 +88,25 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Since PHP 8.2, `PDOStatement::setFetchMode()` always returns `true` instead of `bool`.

Changes:
- Update `<type>bool</type>` to `<type>true</type>` in all 4 methodsynopsis variants
- Update return value description to `&return.true.always;`
- Add `&return.type.true;` changelog entry for 8.2.0

**Reference:** [`ext/pdo/pdo_stmt.stub.php` line 65](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pdo/pdo_stmt.stub.php#L65)

```php
public function setFetchMode(int $mode, mixed ...$args): true {}
```