### PR TITLE
Fix IntlBreakIterator::getPartsIterator $type parameter type

### DIFF
--- a/reference/intl/intlbreakiterator/getpartsiterator.xml
+++ b/reference/intl/intlbreakiterator/getpartsiterator.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis role="IntlBreakIterator">
    <modifier>public</modifier> <type>IntlPartsIterator</type><methodname>IntlBreakIterator::getPartsIterator</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>type</parameter><initializer><constant>IntlPartsIterator::KEY_SEQUENTIAL</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer><constant>IntlPartsIterator::KEY_SEQUENTIAL</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
 


### PR DESCRIPTION
The `$type` parameter of `IntlBreakIterator::getPartsIterator()` is documented as `string` but the stub declares it as `int`:
https://github.com/php/php-src/blob/master/ext/intl/breakiterator/breakiterator.stub.php

```php
public function getPartsIterator(int $type = IntlPartsIterator::KEY_SEQUENTIAL): IntlPartsIterator {}
```

(Scope reduced to this single fix: the other signature fixes from the original PR have since landed on master.)