### PR TITLE
Add documentation for pcntl_wifcontinued

### DIFF
--- a/reference/pcntl/functions/pcntl-wifcontinued.xml
+++ b/reference/pcntl/functions/pcntl-wifcontinued.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pcntl-wifcontinued" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_wifcontinued</refname>
+  <refpurpose>Checks if the child process was resumed by delivery of <constant>SIGCONT</constant></refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>pcntl_wifcontinued</methodname>
+   <methodparam><type>int</type><parameter>status</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Checks whether the child process which caused the return of
+   <function>pcntl_waitpid</function> was resumed by delivery of
+   <constant>SIGCONT</constant>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>status</parameter></term>
+     <listitem>
+      &pcntl.parameter.status;
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns &true; if the child process was resumed by delivery of
+   <constant>SIGCONT</constant>, &false; otherwise.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pcntl_waitpid</function></member>
+    <member><function>pcntl_wifexited</function></member>
+    <member><function>pcntl_wifstopped</function></member>
+    <member><function>pcntl_wifsignaled</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
## Summary

Add missing documentation for `pcntl_wifcontinued()` which checks if a child process was resumed by delivery of `SIGCONT`.

This function has been available since PHP 8.4 but was missing a documentation page.

- [php-src: ext/pcntl/pcntl.stub.php L1050](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pcntl/pcntl.stub.php#L1050)