### PR TITLE
Add documentation for pcntl_getcpu

### DIFF
--- a/reference/pcntl/functions/pcntl-getcpu.xml
+++ b/reference/pcntl/functions/pcntl-getcpu.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pcntl-getcpu" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_getcpu</refname>
+  <refpurpose>Get the number of the CPU on which the calling process is currently running</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pcntl_getcpu</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Returns the number of the CPU on which the calling process is currently
+   running, using the <function>sched_getcpu</function> system call.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the CPU number as an &integer;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pcntl_getcpuaffinity</function></member>
+    <member><function>pcntl_setcpuaffinity</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
## Summary

Add missing documentation for `pcntl_getcpu()` which returns the CPU number on which the calling process is currently running.

Available since PHP 8.4. Requires `sched_getcpu` support (Linux).

- [php-src: ext/pcntl/pcntl.stub.php L1104](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pcntl/pcntl.stub.php#L1104)