### PR TITLE
Add documentation for pcntl_forkx

### DIFF
--- a/reference/pcntl/functions/pcntl-forkx.xml
+++ b/reference/pcntl/functions/pcntl-forkx.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pcntl-forkx" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_forkx</refname>
+  <refpurpose>Create a child process using forkx(2)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pcntl_forkx</methodname>
+   <methodparam><type>int</type><parameter>flags</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   The <function>pcntl_forkx</function> function creates a child process
+   using the <literal>forkx(2)</literal> system call, which is available
+   on illumos and Solaris systems.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>flags</parameter></term>
+     <listitem>
+      <para>
+       The <parameter>flags</parameter> parameter controls the behavior
+       of the fork. Pass <literal>0</literal> for default behavior or
+       <constant>FORK_NOSIGCHLD</constant> to prevent the
+       <constant>SIGCHLD</constant> signal from being sent to the parent
+       when the child terminates.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   On success, the PID of the child process is returned in the
+   parent's thread of execution, and a <literal>0</literal> is returned
+   in the child's thread of execution. On failure, a <literal>-1</literal>
+   will be returned in the parent's context, no child process will be
+   created, and a PHP error is raised.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pcntl_fork</function></member>
+    <member><function>pcntl_rfork</function></member>
+    <member><function>pcntl_waitpid</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
## Summary

Create a child process using forkx(2) (illumos/Solaris).

This function has been available since PHP 8.4 but was missing a documentation page.

- [php-src: ext/pcntl/pcntl.stub.php L1091](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pcntl/pcntl.stub.php#L1091)