### PR TITLE
Add documentation for pcntl_setns

### DIFF
--- a/reference/pcntl/functions/pcntl-setns.xml
+++ b/reference/pcntl/functions/pcntl-setns.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pcntl-setns" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_setns</refname>
+  <refpurpose>Reassociate the calling process with a namespace of another process</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>pcntl_setns</methodname>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>process_id</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>nstype</parameter><initializer><constant>CLONE_NEWNET</constant></initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Reassociates the calling process with a Linux namespace of the process
+   specified by <parameter>process_id</parameter>, using a pidfd obtained
+   via <literal>pidfd_open(2)</literal> and <literal>setns(2)</literal>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>process_id</parameter></term>
+     <listitem>
+      <para>
+       The process ID of the target process whose namespace to join.
+       If &null;, the calling process's own PID is used.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>nstype</parameter></term>
+     <listitem>
+      <para>
+       The namespace type to reassociate with. Defaults to
+       <constant>CLONE_NEWNET</constant> (network namespace).
+       Possible values include <constant>CLONE_NEWNET</constant>,
+       <constant>CLONE_NEWIPC</constant>,
+       <constant>CLONE_NEWUTS</constant>, and others.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pcntl_unshare</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
## Summary

Reassociate the calling process with a namespace of another process (Linux).

This function has been available since PHP 8.4 but was missing a documentation page.

- [php-src: ext/pcntl/pcntl.stub.php L1095](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pcntl/pcntl.stub.php#L1095)