### PR TITLE
Add documentation for pcntl_setqos_class

### DIFF
--- a/reference/pcntl/functions/pcntl-setqos-class.xml
+++ b/reference/pcntl/functions/pcntl-setqos-class.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pcntl-setqos-class" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_setqos_class</refname>
+  <refpurpose>Set the Quality of Service class of the process</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>pcntl_setqos_class</methodname>
+   <methodparam choice="opt"><type>Pcntl\QosClass</type><parameter>qos_class</parameter><initializer>Pcntl\QosClass::Default</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Sets the Quality of Service (QoS) class of the calling process.
+   This function is only available on macOS, which uses QoS classes to
+   manage energy efficiency and performance.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>qos_class</parameter></term>
+     <listitem>
+      <para>
+       The QoS class to set. Must be one of the
+       <classname>Pcntl\QosClass</classname> enum values:
+       <simplelist>
+        <member><literal>Pcntl\QosClass::UserInteractive</literal></member>
+        <member><literal>Pcntl\QosClass::UserInitiated</literal></member>
+        <member><literal>Pcntl\QosClass::Default</literal></member>
+        <member><literal>Pcntl\QosClass::Utility</literal></member>
+        <member><literal>Pcntl\QosClass::Background</literal></member>
+       </simplelist>
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pcntl_getqos_class</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
## Summary

Set the QoS class of the process (macOS).

This function has been available since PHP 8.4 but was missing a documentation page.

- [php-src: ext/pcntl/pcntl.stub.php L1108](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pcntl/pcntl.stub.php#L1108)