### PR TITLE
Add documentation for intltz_get_iana_id

### DIFF
--- a/reference/intl/functions/intltz-get-iana-id.xml
+++ b/reference/intl/functions/intltz-get-iana-id.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.intltz-get-iana-id" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>intltz_get_iana_id</refname>
+  <refpurpose>Get the IANA identifier for a given timezone</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>intltz_get_iana_id</methodname>
+   <methodparam><type>string</type><parameter>timezoneId</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Translates a timezone identifier to its IANA equivalent. For example,
+   <literal>"GMT"</literal> returns <literal>"Etc/GMT"</literal>, and
+   <literal>"US/Eastern"</literal> returns <literal>"America/New_York"</literal>.
+  </para>
+  <note>
+   <para>
+    This function requires ICU 74 or later.
+   </para>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>timezoneId</parameter></term>
+     <listitem>
+      <para>
+       The timezone identifier to translate.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the IANA timezone identifier as a &string;, or &false; on failure.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>intltz_get_id_for_windows_id</function></member>
+    <member><function>intltz_get_windows_id</function></member>
+    <member><function>intltz_create_time_zone</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
## Summary

Get the IANA identifier for a given timezone. Requires ICU >= 74.

This function has been available since PHP 8.4 but was missing a documentation page.

- [php-src: ext/intl/php_intl.stub.php L620](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/intl/php_intl.stub.php#L620)