### PR TITLE
Add documentation for openssl_password_hash

### DIFF
--- a/reference/openssl/functions/openssl-password-hash.xml
+++ b/reference/openssl/functions/openssl-password-hash.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.openssl-password-hash" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>openssl_password_hash</refname>
+  <refpurpose>Create a password hash using OpenSSL's Argon2 implementation</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>openssl_password_hash</methodname>
+   <methodparam><type>string</type><parameter>algo</parameter></methodparam>
+   <methodparam><type>string</type><parameter>password</parameter></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>[]</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Creates a password hash using OpenSSL's Argon2 implementation. This is an
+   alternative to <function>password_hash</function> that uses OpenSSL as
+   the backend, which may offer hardware acceleration on some platforms.
+  </para>
+  <note>
+   <para>
+    This function is only available when PHP is compiled with OpenSSL
+    support that includes Argon2 (<literal>HAVE_OPENSSL_ARGON2</literal>).
+   </para>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>algo</parameter></term>
+     <listitem>
+      <para>
+       The password hashing algorithm. Supported values:
+       <literal>"argon2id"</literal> and <literal>"argon2i"</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>password</parameter></term>
+     <listitem>
+      <para>
+       The user's password.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>options</parameter></term>
+     <listitem>
+      <para>
+       An associative &array; of options. Supported keys:
+       <simplelist>
+        <member>
+         <literal>memory_cost</literal> - Maximum memory (in KiB) that may
+         be used to compute the hash
+        </member>
+        <member>
+         <literal>time_cost</literal> - Maximum amount of time it may take
+         to compute the hash
+        </member>
+        <member>
+         <literal>threads</literal> - Number of threads to use for
+         computing the hash
+        </member>
+       </simplelist>
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the password hash as a &string;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>openssl_password_verify</function></member>
+    <member><function>password_hash</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
## Summary

Create a password hash using OpenSSL Argon2 implementation.

This function has been available since PHP 8.4 but was missing a documentation page.

- [php-src: ext/openssl/openssl.stub.php L699](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/openssl/openssl.stub.php#L699)