### PR TITLE
Add documentation for pg_change_password

### DIFF
--- a/reference/pgsql/functions/pg-change-password.xml
+++ b/reference/pgsql/functions/pg-change-password.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pg-change-password" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_change_password</refname>
+  <refpurpose>Change a PostgreSQL user's password</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>pg_change_password</methodname>
+   <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
+   <methodparam><type>string</type><parameter>user</parameter></methodparam>
+   <methodparam><type>string</type><parameter>password</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>pg_change_password</function> changes the password of a
+   PostgreSQL user. This function uses the
+   <literal>PQchangePassword</literal> libpq function which handles
+   password encryption automatically based on the server's settings.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>connection</parameter></term>
+     <listitem>
+      &pgsql.parameter.connection;
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>user</parameter></term>
+     <listitem>
+      <para>
+       The name of the PostgreSQL user whose password to change.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>password</parameter></term>
+     <listitem>
+      <para>
+       The new password.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pg_connect</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
## Summary

Change a PostgreSQL user password.

This function has been available since PHP 8.4 but was missing a documentation page.

- [php-src: ext/pgsql/pgsql.stub.php L963](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pgsql/pgsql.stub.php#L963)