### PR TITLE
Add documentation for pg_put_copy_data

### DIFF
--- a/reference/pgsql/functions/pg-put-copy-data.xml
+++ b/reference/pgsql/functions/pg-put-copy-data.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pg-put-copy-data" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_put_copy_data</refname>
+  <refpurpose>Send data to the server during a COPY operation</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pg_put_copy_data</methodname>
+   <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
+   <methodparam><type>string</type><parameter>cmd</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Sends data to the server during a <literal>COPY FROM STDIN</literal>
+   operation. A <literal>COPY</literal> command must have been issued
+   via <function>pg_query</function> before calling this function.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>connection</parameter></term>
+     <listitem>
+      &pgsql.parameter.connection;
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>cmd</parameter></term>
+     <listitem>
+      <para>
+       The data to send to the server. A final newline is automatically
+       added if not present. The data must be formatted according to
+       the <literal>COPY</literal> command's format.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns <literal>1</literal> on success, <literal>0</literal> if the
+   data could not be queued (only in non-blocking mode), or
+   <literal>-1</literal> on error.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pg_put_copy_end</function></member>
+    <member><function>pg_query</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
## Summary

Send data to the server during a COPY operation.

This function has been available since PHP 8.4 but was missing a documentation page.

- [php-src: ext/pgsql/pgsql.stub.php L965](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pgsql/pgsql.stub.php#L965)