### PR TITLE
Add documentation for pg_socket_poll

### DIFF
--- a/reference/pgsql/functions/pg-socket-poll.xml
+++ b/reference/pgsql/functions/pg-socket-poll.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pg-socket-poll" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_socket_poll</refname>
+  <refpurpose>Poll a PostgreSQL connection socket for read/write readiness</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pg_socket_poll</methodname>
+   <methodparam><type>resource</type><parameter>socket</parameter></methodparam>
+   <methodparam><type>int</type><parameter>read</parameter></methodparam>
+   <methodparam><type>int</type><parameter>write</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>timeout</parameter><initializer>-1</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Polls a PostgreSQL connection socket for read and/or write readiness.
+   The socket can be obtained using <function>pg_socket</function>.
+   This function is useful for implementing non-blocking, asynchronous
+   query workflows.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>socket</parameter></term>
+     <listitem>
+      <para>
+       A socket resource obtained from <function>pg_socket</function>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>read</parameter></term>
+     <listitem>
+      <para>
+       Whether to check for read readiness. Pass <literal>1</literal>
+       to check, <literal>0</literal> to skip.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>write</parameter></term>
+     <listitem>
+      <para>
+       Whether to check for write readiness. Pass <literal>1</literal>
+       to check, <literal>0</literal> to skip.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>timeout</parameter></term>
+     <listitem>
+      <para>
+       The maximum number of milliseconds to wait. Pass
+       <literal>-1</literal> to wait indefinitely, or
+       <literal>0</literal> to not wait at all.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns a positive value if the socket is ready, <literal>0</literal>
+   if the timeout was reached, or <literal>-1</literal> on error.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pg_socket</function></member>
+    <member><function>pg_consume_input</function></member>
+    <member><function>pg_send_query</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
## Summary

Poll a PostgreSQL connection socket for read/write readiness.

This function has been available since PHP 8.4 but was missing a documentation page.

- [php-src: ext/pgsql/pgsql.stub.php L971](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pgsql/pgsql.stub.php#L971)