### PR TITLE
Add documentation for 6 new pcntl functions (PHP 8.4)

### DIFF
--- a/reference/pcntl/functions/pcntl-forkx.xml
+++ b/reference/pcntl/functions/pcntl-forkx.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pcntl-forkx" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_forkx</refname>
+  <refpurpose>Create a child process using forkx(2)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pcntl_forkx</methodname>
+   <methodparam><type>int</type><parameter>flags</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   The <function>pcntl_forkx</function> function creates a child process
+   using the <literal>forkx(2)</literal> system call, which is available
+   on illumos and Solaris systems.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>flags</parameter></term>
+     <listitem>
+      <para>
+       The <parameter>flags</parameter> parameter controls the behavior
+       of the fork. Pass <literal>0</literal> for default behavior or
+       <constant>FORK_NOSIGCHLD</constant> to prevent the
+       <constant>SIGCHLD</constant> signal from being sent to the parent
+       when the child terminates.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   On success, the PID of the child process is returned in the
+   parent's thread of execution, and a <literal>0</literal> is returned
+   in the child's thread of execution. On failure, a <literal>-1</literal>
+   will be returned in the parent's context, no child process will be
+   created, and a PHP error is raised.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pcntl_fork</function></member>
+    <member><function>pcntl_rfork</function></member>
+    <member><function>pcntl_waitpid</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-forkx.xml
+++ b/reference/pcntl/functions/pcntl-forkx.xml
@@ -20,22 +20,20 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>flags</parameter></term>
-     <listitem>
-      <simpara>
-       The <parameter>flags</parameter> parameter controls the behavior
-       of the fork. Pass <literal>0</literal> for default behavior or
-       <constant>FORK_NOSIGCHLD</constant> to prevent the
-       <constant>SIGCHLD</constant> signal from being sent to the parent
-       when the child terminates.
-      </simpara>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>flags</parameter></term>
+    <listitem>
+     <simpara>
+      The <parameter>flags</parameter> parameter controls the behavior
+      of the fork. Pass <literal>0</literal> for default behavior or
+      <constant>FORK_NOSIGCHLD</constant> to prevent the
+      <constant>SIGCHLD</constant> signal from being sent to the parent
+      when the child terminates.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
@@ -51,13 +49,11 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>pcntl_fork</function></member>
-    <member><function>pcntl_rfork</function></member>
-    <member><function>pcntl_waitpid</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>pcntl_fork</function></member>
+   <member><function>pcntl_rfork</function></member>
+   <member><function>pcntl_waitpid</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-forkx.xml
+++ b/reference/pcntl/functions/pcntl-forkx.xml
@@ -11,11 +11,11 @@
    <type>int</type><methodname>pcntl_forkx</methodname>
    <methodparam><type>int</type><parameter>flags</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    The <function>pcntl_forkx</function> function creates a child process
    using the <literal>forkx(2)</literal> system call, which is available
    on illumos and Solaris systems.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,13 +25,13 @@
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The <parameter>flags</parameter> parameter controls the behavior
        of the fork. Pass <literal>0</literal> for default behavior or
        <constant>FORK_NOSIGCHLD</constant> to prevent the
        <constant>SIGCHLD</constant> signal from being sent to the parent
        when the child terminates.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -40,13 +40,13 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    On success, the PID of the child process is returned in the
    parent's thread of execution, and a <literal>0</literal> is returned
    in the child's thread of execution. On failure, a <literal>-1</literal>
    will be returned in the parent's context, no child process will be
    created, and a PHP error is raised.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/pcntl/functions/pcntl-getcpu.xml
+++ b/reference/pcntl/functions/pcntl-getcpu.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pcntl-getcpu" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_getcpu</refname>
+  <refpurpose>Get the CPU number on which the calling process last executed</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pcntl_getcpu</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   <function>pcntl_getcpu</function> returns the number of the CPU on which
+   the calling process was last executed. This function uses the
+   <literal>sched_getcpu(3)</literal> system call available on Linux.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the CPU number as an &integer;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pcntl_getcpuaffinity</function></member>
+    <member><function>pcntl_setcpuaffinity</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-getcpu.xml
+++ b/reference/pcntl/functions/pcntl-getcpu.xml
@@ -11,11 +11,11 @@
    <type>int</type><methodname>pcntl_getcpu</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>pcntl_getcpu</function> returns the number of the CPU on which
    the calling process was last executed. This function uses the
    <literal>sched_getcpu(3)</literal> system call available on Linux.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the CPU number as an &integer;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/pcntl/functions/pcntl-getcpu.xml
+++ b/reference/pcntl/functions/pcntl-getcpu.xml
@@ -32,12 +32,10 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>pcntl_getcpuaffinity</function></member>
-    <member><function>pcntl_setcpuaffinity</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>pcntl_getcpuaffinity</function></member>
+   <member><function>pcntl_setcpuaffinity</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-getqos-class.xml
+++ b/reference/pcntl/functions/pcntl-getqos-class.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pcntl-getqos-class" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_getqos_class</refname>
+  <refpurpose>Get the current Quality of Service class of the process</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>Pcntl\QosClass</type><methodname>pcntl_getqos_class</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Returns the current Quality of Service (QoS) class of the calling process.
+   This function is only available on macOS, which uses QoS classes to
+   manage energy efficiency and performance.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns a <classname>Pcntl\QosClass</classname> enum value representing
+   the current QoS class.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pcntl_setqos_class</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-getqos-class.xml
+++ b/reference/pcntl/functions/pcntl-getqos-class.xml
@@ -33,11 +33,9 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>pcntl_setqos_class</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>pcntl_setqos_class</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-getqos-class.xml
+++ b/reference/pcntl/functions/pcntl-getqos-class.xml
@@ -11,11 +11,11 @@
    <type>Pcntl\QosClass</type><methodname>pcntl_getqos_class</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Returns the current Quality of Service (QoS) class of the calling process.
    This function is only available on macOS, which uses QoS classes to
    manage energy efficiency and performance.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,10 +25,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns a <classname>Pcntl\QosClass</classname> enum value representing
    the current QoS class.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/pcntl/functions/pcntl-getqos-class.xml
+++ b/reference/pcntl/functions/pcntl-getqos-class.xml
@@ -12,8 +12,8 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   Returns the current Quality of Service (QoS) class of the calling process.
-   This function is only available on macOS, which uses QoS classes to
+   Returns the current Quality of Service (<acronym>QoS</acronym>) class of the calling process.
+   This function is only available on macOS, which uses <acronym>QoS</acronym> classes to
    manage energy efficiency and performance.
   </simpara>
  </refsect1>
@@ -27,7 +27,7 @@
   &reftitle.returnvalues;
   <simpara>
    Returns a <classname>Pcntl\QosClass</classname> enum value representing
-   the current QoS class.
+   the current <acronym>QoS</acronym> class.
   </simpara>
  </refsect1>
 

--- a/reference/pcntl/functions/pcntl-setns.xml
+++ b/reference/pcntl/functions/pcntl-setns.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pcntl-setns" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_setns</refname>
+  <refpurpose>Reassociate the calling process with a namespace of another process</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>pcntl_setns</methodname>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>process_id</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>nstype</parameter><initializer><constant>CLONE_NEWNET</constant></initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Reassociates the calling process with a Linux namespace of the process
+   specified by <parameter>process_id</parameter>, using a pidfd obtained
+   via <literal>pidfd_open(2)</literal> and <literal>setns(2)</literal>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>process_id</parameter></term>
+     <listitem>
+      <para>
+       The process ID of the target process whose namespace to join.
+       If &null;, the calling process's own PID is used.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>nstype</parameter></term>
+     <listitem>
+      <para>
+       The namespace type to reassociate with. Defaults to
+       <constant>CLONE_NEWNET</constant> (network namespace).
+       Possible values include <constant>CLONE_NEWNET</constant>,
+       <constant>CLONE_NEWIPC</constant>,
+       <constant>CLONE_NEWUTS</constant>, and others.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pcntl_unshare</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-setns.xml
+++ b/reference/pcntl/functions/pcntl-setns.xml
@@ -21,31 +21,29 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>process_id</parameter></term>
-     <listitem>
-      <simpara>
-       The process ID of the target process whose namespace to join.
-       If &null;, the calling process's own PID is used.
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>nstype</parameter></term>
-     <listitem>
-      <simpara>
-       The namespace type to reassociate with. Defaults to
-       <constant>CLONE_NEWNET</constant> (network namespace).
-       Possible values include <constant>CLONE_NEWNET</constant>,
-       <constant>CLONE_NEWIPC</constant>,
-       <constant>CLONE_NEWUTS</constant>, and others.
-      </simpara>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>process_id</parameter></term>
+    <listitem>
+     <simpara>
+      The process ID of the target process whose namespace to join.
+      If &null;, the calling process's own PID is used.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>nstype</parameter></term>
+    <listitem>
+     <simpara>
+      The namespace type to reassociate with. Defaults to
+      <constant>CLONE_NEWNET</constant> (network namespace).
+      Possible values include <constant>CLONE_NEWNET</constant>,
+      <constant>CLONE_NEWIPC</constant>,
+      <constant>CLONE_NEWUTS</constant>, and others.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
@@ -57,11 +55,9 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>pcntl_unshare</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>pcntl_unshare</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-setns.xml
+++ b/reference/pcntl/functions/pcntl-setns.xml
@@ -12,11 +12,11 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>process_id</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>nstype</parameter><initializer><constant>CLONE_NEWNET</constant></initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Reassociates the calling process with a Linux namespace of the process
    specified by <parameter>process_id</parameter>, using a pidfd obtained
    via <literal>pidfd_open(2)</literal> and <literal>setns(2)</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,22 +26,22 @@
     <varlistentry>
      <term><parameter>process_id</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The process ID of the target process whose namespace to join.
        If &null;, the calling process's own PID is used.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>nstype</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The namespace type to reassociate with. Defaults to
        <constant>CLONE_NEWNET</constant> (network namespace).
        Possible values include <constant>CLONE_NEWNET</constant>,
        <constant>CLONE_NEWIPC</constant>,
        <constant>CLONE_NEWUTS</constant>, and others.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -50,9 +50,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/pcntl/functions/pcntl-setqos-class.xml
+++ b/reference/pcntl/functions/pcntl-setqos-class.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pcntl-setqos-class" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_setqos_class</refname>
+  <refpurpose>Set the Quality of Service class of the process</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>pcntl_setqos_class</methodname>
+   <methodparam choice="opt"><type>Pcntl\QosClass</type><parameter>qos_class</parameter><initializer>Pcntl\QosClass::Default</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Sets the Quality of Service (QoS) class of the calling process.
+   This function is only available on macOS, which uses QoS classes to
+   manage energy efficiency and performance.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>qos_class</parameter></term>
+     <listitem>
+      <para>
+       The QoS class to set. Must be one of the
+       <classname>Pcntl\QosClass</classname> enum values:
+       <simplelist>
+        <member><literal>Pcntl\QosClass::UserInteractive</literal></member>
+        <member><literal>Pcntl\QosClass::UserInitiated</literal></member>
+        <member><literal>Pcntl\QosClass::Default</literal></member>
+        <member><literal>Pcntl\QosClass::Utility</literal></member>
+        <member><literal>Pcntl\QosClass::Background</literal></member>
+       </simplelist>
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pcntl_getqos_class</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-setqos-class.xml
+++ b/reference/pcntl/functions/pcntl-setqos-class.xml
@@ -11,11 +11,11 @@
    <type>void</type><methodname>pcntl_setqos_class</methodname>
    <methodparam choice="opt"><type>Pcntl\QosClass</type><parameter>qos_class</parameter><initializer>Pcntl\QosClass::Default</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Sets the Quality of Service (QoS) class of the calling process.
    This function is only available on macOS, which uses QoS classes to
    manage energy efficiency and performance.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -44,9 +44,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/pcntl/functions/pcntl-setqos-class.xml
+++ b/reference/pcntl/functions/pcntl-setqos-class.xml
@@ -12,8 +12,8 @@
    <methodparam choice="opt"><type>Pcntl\QosClass</type><parameter>qos_class</parameter><initializer>Pcntl\QosClass::Default</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Sets the Quality of Service (QoS) class of the calling process.
-   This function is only available on macOS, which uses QoS classes to
+   Sets the Quality of Service (<acronym>QoS</acronym>) class of the calling process.
+   This function is only available on macOS, which uses <acronym>QoS</acronym> classes to
    manage energy efficiency and performance.
   </simpara>
  </refsect1>
@@ -25,7 +25,7 @@
     <term><parameter>qos_class</parameter></term>
     <listitem>
      <simpara>
-      The QoS class to set. Must be one of the
+      The <acronym>QoS</acronym> class to set. Must be one of the
       <classname>Pcntl\QosClass</classname> enum values:
      </simpara>
      <simplelist>

--- a/reference/pcntl/functions/pcntl-setqos-class.xml
+++ b/reference/pcntl/functions/pcntl-setqos-class.xml
@@ -20,26 +20,24 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>qos_class</parameter></term>
-     <listitem>
-      <para>
-       The QoS class to set. Must be one of the
-       <classname>Pcntl\QosClass</classname> enum values:
-       <simplelist>
-        <member><literal>Pcntl\QosClass::UserInteractive</literal></member>
-        <member><literal>Pcntl\QosClass::UserInitiated</literal></member>
-        <member><literal>Pcntl\QosClass::Default</literal></member>
-        <member><literal>Pcntl\QosClass::Utility</literal></member>
-        <member><literal>Pcntl\QosClass::Background</literal></member>
-       </simplelist>
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>qos_class</parameter></term>
+    <listitem>
+     <simpara>
+      The QoS class to set. Must be one of the
+      <classname>Pcntl\QosClass</classname> enum values:
+     </simpara>
+     <simplelist>
+      <member><literal>Pcntl\QosClass::UserInteractive</literal></member>
+      <member><literal>Pcntl\QosClass::UserInitiated</literal></member>
+      <member><literal>Pcntl\QosClass::Default</literal></member>
+      <member><literal>Pcntl\QosClass::Utility</literal></member>
+      <member><literal>Pcntl\QosClass::Background</literal></member>
+     </simplelist>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
@@ -51,11 +49,9 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>pcntl_getqos_class</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>pcntl_getqos_class</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-wifcontinued.xml
+++ b/reference/pcntl/functions/pcntl-wifcontinued.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pcntl-wifcontinued" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_wifcontinued</refname>
+  <refpurpose>Checks whether the child process has continued from a job control stop</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>pcntl_wifcontinued</methodname>
+   <methodparam><type>int</type><parameter>status</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Checks whether the child process which caused the return of
+   <function>pcntl_waitpid</function> has continued from a job control stop.
+   This function is only useful if the call to
+   <function>pcntl_waitpid</function> was done using the
+   <constant>WCONTINUED</constant> option.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>status</parameter></term>
+     <listitem>
+      &pcntl.parameter.status;
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns &true; if the child process which caused the return of
+   <function>pcntl_waitpid</function> has continued from a job control stop,
+   &false; otherwise.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pcntl_waitpid</function></member>
+    <member><function>pcntl_wifstopped</function></member>
+    <member><function>pcntl_wifexited</function></member>
+    <member><function>pcntl_wifsignaled</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-wifcontinued.xml
+++ b/reference/pcntl/functions/pcntl-wifcontinued.xml
@@ -11,13 +11,13 @@
    <type>bool</type><methodname>pcntl_wifcontinued</methodname>
    <methodparam><type>int</type><parameter>status</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Checks whether the child process which caused the return of
    <function>pcntl_waitpid</function> has continued from a job control stop.
    This function is only useful if the call to
    <function>pcntl_waitpid</function> was done using the
    <constant>WCONTINUED</constant> option.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -36,11 +36,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns &true; if the child process which caused the return of
    <function>pcntl_waitpid</function> has continued from a job control stop,
    &false; otherwise.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/pcntl/functions/pcntl-wifcontinued.xml
+++ b/reference/pcntl/functions/pcntl-wifcontinued.xml
@@ -22,16 +22,14 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>status</parameter></term>
-     <listitem>
-      &pcntl.parameter.status;
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>status</parameter></term>
+    <listitem>
+     &pcntl.parameter.status;
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
@@ -45,14 +43,12 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>pcntl_waitpid</function></member>
-    <member><function>pcntl_wifstopped</function></member>
-    <member><function>pcntl_wifexited</function></member>
-    <member><function>pcntl_wifsignaled</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>pcntl_waitpid</function></member>
+   <member><function>pcntl_wifstopped</function></member>
+   <member><function>pcntl_wifexited</function></member>
+   <member><function>pcntl_wifsignaled</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Add documentation for 6 new pcntl functions available since PHP 8.4: `pcntl_wifcontinued`, `pcntl_getcpu`, `pcntl_forkx`, `pcntl_setns`, `pcntl_getqos_class`, and `pcntl_setqos_class`.