### PR TITLE
Add documentation for 5 new pgsql functions (PHP 8.4)

### DIFF
--- a/reference/pgsql/functions/pg-change-password.xml
+++ b/reference/pgsql/functions/pg-change-password.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pg-change-password" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_change_password</refname>
+  <refpurpose>Change a PostgreSQL user's password</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>pg_change_password</methodname>
+   <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
+   <methodparam><type>string</type><parameter>user</parameter></methodparam>
+   <methodparam><type>string</type><parameter>password</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>pg_change_password</function> changes the password of a
+   PostgreSQL user. This function uses the
+   <literal>PQchangePassword</literal> libpq function which handles
+   password encryption automatically based on the server's settings.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>user</parameter></term>
+    <listitem>
+     <simpara>
+      The name of the PostgreSQL user whose password to change.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>password</parameter></term>
+    <listitem>
+     <simpara>
+      The new password.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_connect</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-jit.xml
+++ b/reference/pgsql/functions/pg-jit.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pg-jit" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_jit</refname>
+  <refpurpose>Returns the JIT information of the server</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>array</type><methodname>pg_jit</methodname>
+   <methodparam choice="opt"><type class="union"><type>PgSql\Connection</type><type>null</type></type><parameter>connection</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>pg_jit</function> returns an array with the JIT (Just-In-Time
+   compilation) information of the PostgreSQL server.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection-with-nullable-default;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns an &array; containing the JIT information of the server.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_version</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-put-copy-data.xml
+++ b/reference/pgsql/functions/pg-put-copy-data.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pg-put-copy-data" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_put_copy_data</refname>
+  <refpurpose>Send data to the server during a COPY operation</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pg_put_copy_data</methodname>
+   <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
+   <methodparam><type>string</type><parameter>cmd</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Sends data to the server during a <literal>COPY FROM STDIN</literal>
+   operation. A <literal>COPY</literal> command must have been issued
+   via <function>pg_query</function> before calling this function.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>cmd</parameter></term>
+    <listitem>
+     <simpara>
+      The data to send to the server. A final newline is automatically
+      added if not present. The data must be formatted according to
+      the <literal>COPY</literal> command's format.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns <literal>1</literal> on success, <literal>0</literal> if the
+   data could not be queued (only in non-blocking mode), or
+   <literal>-1</literal> on error.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_put_copy_end</function></member>
+   <member><function>pg_query</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-put-copy-end.xml
+++ b/reference/pgsql/functions/pg-put-copy-end.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pg-put-copy-end" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_put_copy_end</refname>
+  <refpurpose>Signal the completion of a COPY operation to the server</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pg_put_copy_end</methodname>
+   <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>error</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Sends an end-of-data indication to the server during a
+   <literal>COPY FROM STDIN</literal> operation.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>error</parameter></term>
+    <listitem>
+     <simpara>
+      If not &null;, the <literal>COPY</literal> operation is forced to
+      fail with the given error message.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns <literal>1</literal> on success, <literal>0</literal> if the
+   data could not be queued (only in non-blocking mode), or
+   <literal>-1</literal> on error.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_put_copy_data</function></member>
+   <member><function>pg_query</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-socket-poll.xml
+++ b/reference/pgsql/functions/pg-socket-poll.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.pg-socket-poll" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_socket_poll</refname>
+  <refpurpose>Poll a PostgreSQL connection socket for read/write readiness</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pg_socket_poll</methodname>
+   <methodparam><type>resource</type><parameter>socket</parameter></methodparam>
+   <methodparam><type>int</type><parameter>read</parameter></methodparam>
+   <methodparam><type>int</type><parameter>write</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>timeout</parameter><initializer>-1</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Polls a PostgreSQL connection socket for read and/or write readiness.
+   The socket can be obtained using <function>pg_socket</function>.
+   This function is useful for implementing non-blocking, asynchronous
+   query workflows.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>socket</parameter></term>
+    <listitem>
+     <simpara>
+      A socket resource obtained from <function>pg_socket</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>read</parameter></term>
+    <listitem>
+     <simpara>
+      Whether to check for read readiness. Pass <literal>1</literal>
+      to check, <literal>0</literal> to skip.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>write</parameter></term>
+    <listitem>
+     <simpara>
+      Whether to check for write readiness. Pass <literal>1</literal>
+      to check, <literal>0</literal> to skip.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>timeout</parameter></term>
+    <listitem>
+     <simpara>
+      The maximum number of milliseconds to wait. Pass
+      <literal>-1</literal> to wait indefinitely, or
+      <literal>0</literal> to not wait at all.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns a positive value if the socket is ready, <literal>0</literal>
+   if the timeout was reached, or <literal>-1</literal> on error.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_socket</function></member>
+   <member><function>pg_consume_input</function></member>
+   <member><function>pg_send_query</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/versions.xml
+++ b/reference/pgsql/versions.xml
@@ -6,6 +6,7 @@
 <versions>
  <function name="pg_affected_rows" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pg_cancel_query" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_change_password" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pg_client_encoding" from="PHP 4 &gt;= 4.0.3, PHP 5, PHP 7, PHP 8"/>
  <function name="pg_close" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="pg_connect" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
@@ -48,6 +49,7 @@
  <function name="pg_get_result" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pg_host" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="pg_insert" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_jit" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pg_last_error" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pg_last_notice" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
  <function name="pg_last_oid" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
@@ -72,6 +74,8 @@
  <function name="pg_ping" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pg_port" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="pg_prepare" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
+ <function name="pg_put_copy_data" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="pg_put_copy_end" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pg_put_line" from="PHP 4 &gt;= 4.0.3, PHP 5, PHP 7, PHP 8"/>
  <function name="pg_query" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pg_query_params" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
@@ -90,6 +94,7 @@
  <function name="pg_set_error_verbosity" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
  <function name="pg_set_chunked_rows_size" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pg_socket" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
+ <function name="pg_socket_poll" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pg_trace" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>
  <function name="pg_transaction_status" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
  <function name="pg_tty" from="PHP 4, PHP 5, PHP 7, PHP 8"/>


### PR DESCRIPTION
Add documentation for 5 new `pgsql` functions available since PHP 8.4: `pg_jit`, `pg_change_password`, `pg_put_copy_data`, `pg_put_copy_end`, and `pg_socket_poll`.