### PR TITLE
Add documentation for intltz_get_iana_id (PHP 8.4)

### DIFF
--- a/reference/intl/functions/intltz-get-iana-id.xml
+++ b/reference/intl/functions/intltz-get-iana-id.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="function.intltz-get-iana-id" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>intltz_get_iana_id</refname>
+  <refpurpose>Get the IANA identifier for a given timezone</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>intltz_get_iana_id</methodname>
+   <methodparam><type>string</type><parameter>timezoneId</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Translates a timezone identifier to its IANA equivalent. For example,
+   <literal>"GMT"</literal> returns <literal>"Etc/GMT"</literal>, and
+   <literal>"US/Eastern"</literal> returns <literal>"America/New_York"</literal>.
+  </para>
+  <note>
+   <para>
+    This function requires ICU 74 or later.
+   </para>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>timezoneId</parameter></term>
+     <listitem>
+      <para>
+       The timezone identifier to translate.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the IANA timezone identifier as a &string;, or &false; on failure.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>intltz_get_id_for_windows_id</function></member>
+    <member><function>intltz_get_windows_id</function></member>
+    <member><function>intltz_create_time_zone</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/functions/intltz-get-iana-id.xml
+++ b/reference/intl/functions/intltz-get-iana-id.xml
@@ -17,9 +17,9 @@
    <literal>"US/Eastern"</literal> returns <literal>"America/New_York"</literal>.
   </para>
   <note>
-   <para>
+   <simpara>
     This function requires ICU 74 or later.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 
@@ -30,9 +30,9 @@
     <varlistentry>
      <term><parameter>timezoneId</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The timezone identifier to translate.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -41,9 +41,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the IANA timezone identifier as a &string;, or &false; on failure.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/intl/intltimezone/getianaid.xml
+++ b/reference/intl/intltimezone/getianaid.xml
@@ -8,7 +8,7 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>&style.oop; (method):</para>
+  <simpara>&style.oop; (method):</simpara>
   <methodsynopsis role="IntlTimeZone">
    <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>IntlTimeZone::getIanaID</methodname>
    <methodparam><type>string</type><parameter>timezoneId</parameter></methodparam>

--- a/reference/intl/intltimezone/getianaid.xml
+++ b/reference/intl/intltimezone/getianaid.xml
@@ -32,18 +32,16 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>timezoneId</parameter></term>
-     <listitem>
-      <simpara>
-       The timezone identifier to translate.
-      </simpara>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+ <variablelist>
+  <varlistentry>
+   <term><parameter>timezoneId</parameter></term>
+   <listitem>
+    <simpara>
+     The timezone identifier to translate.
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/intl/intltimezone/getianaid.xml
+++ b/reference/intl/intltimezone/getianaid.xml
@@ -55,13 +55,11 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>intltz_get_id_for_windows_id</function></member>
-    <member><function>intltz_get_windows_id</function></member>
-    <member><function>intltz_create_time_zone</function></member>
-   </simplelist>
-  </para>
+ <simplelist>
+  <member><function>intltz_get_id_for_windows_id</function></member>
+  <member><function>intltz_get_windows_id</function></member>
+  <member><function>intltz_create_time_zone</function></member>
+ </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/intl/intltimezone/getianaid.xml
+++ b/reference/intl/intltimezone/getianaid.xml
@@ -1,12 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<refentry xml:id="function.intltz-get-iana-id" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="intltimezone.getianaid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
+  <refname>IntlTimeZone::getIanaID</refname>
   <refname>intltz_get_iana_id</refname>
-  <refpurpose>Get the IANA identifier for a given timezone</refpurpose>
+  <refpurpose>Translate a timezone identifier to its IANA equivalent</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
+  <para>&style.oop; (method):</para>
+  <methodsynopsis role="IntlTimeZone">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>IntlTimeZone::getIanaID</methodname>
+   <methodparam><type>string</type><parameter>timezoneId</parameter></methodparam>
+  </methodsynopsis>
+  <para>&style.procedural;:</para>
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>intltz_get_iana_id</methodname>
    <methodparam><type>string</type><parameter>timezoneId</parameter></methodparam>
@@ -18,7 +25,7 @@
   </para>
   <note>
    <simpara>
-    This function requires ICU 74 or later.
+    This function requires ICU version &gt;= 74.
    </simpara>
   </note>
  </refsect1>

--- a/reference/intl/intltimezone/getianaid.xml
+++ b/reference/intl/intltimezone/getianaid.xml
@@ -18,11 +18,11 @@
    <type class="union"><type>string</type><type>false</type></type><methodname>intltz_get_iana_id</methodname>
    <methodparam><type>string</type><parameter>timezoneId</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Translates a timezone identifier to its IANA equivalent. For example,
    <literal>"GMT"</literal> returns <literal>"Etc/GMT"</literal>, and
    <literal>"US/Eastern"</literal> returns <literal>"America/New_York"</literal>.
-  </para>
+  </simpara>
   <note>
    <simpara>
     This function requires ICU version &gt;= 74.

--- a/reference/intl/intltimezone/getianaid.xml
+++ b/reference/intl/intltimezone/getianaid.xml
@@ -13,7 +13,7 @@
    <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>IntlTimeZone::getIanaID</methodname>
    <methodparam><type>string</type><parameter>timezoneId</parameter></methodparam>
   </methodsynopsis>
-  <para>&style.procedural;:</para>
+  <simpara>&style.procedural;:</simpara>
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>intltz_get_iana_id</methodname>
    <methodparam><type>string</type><parameter>timezoneId</parameter></methodparam>

--- a/reference/intl/versions.xml
+++ b/reference/intl/versions.xml
@@ -159,6 +159,7 @@
  <function name="intltimezone::geterrorcode" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
  <function name="intltimezone::geterrormessage" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL &gt;= 3.0.0a1"/>
  <function name="intltimezone::getwindowsid" from="PHP 7 &gt;= 7.1.0, PHP 8"/>
+ <function name="intltimezone::getianaid" from="PHP 8 &gt;= 8.4.0"/>
 
  <function name="intldateformatter" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
  <function name="intldateformatter::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>


### PR DESCRIPTION
Add documentation for `intltz_get_iana_id()`, available since PHP 8.4.