### PR TITLE
Fix return type for 33 GD image functions: bool -> true

### DIFF
--- a/reference/image/functions/imagealphablending.xml
+++ b/reference/image/functions/imagealphablending.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagealphablending</methodname>
+   <type>true</type><methodname>imagealphablending</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>bool</type><parameter>enable</parameter></methodparam>
   </methodsynopsis>
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -60,6 +60,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imageantialias.xml
+++ b/reference/image/functions/imageantialias.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imageantialias</methodname>
+   <type>true</type><methodname>imageantialias</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>bool</type><parameter>enable</parameter></methodparam>
   </methodsynopsis>
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -61,6 +61,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
      <row>
       <entry>7.2.0</entry>

--- a/reference/image/functions/imagearc.xml
+++ b/reference/image/functions/imagearc.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagearc</methodname>
+   <type>true</type><methodname>imagearc</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>center_x</parameter></methodparam>
    <methodparam><type>int</type><parameter>center_y</parameter></methodparam>
@@ -92,7 +92,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -107,6 +107,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imagechar.xml
+++ b/reference/image/functions/imagechar.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagechar</methodname>
+   <type>true</type><methodname>imagechar</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
@@ -68,7 +68,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -83,6 +83,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.gdfont-instance;
      &gd.changelog.image-param;
     </tbody>

--- a/reference/image/functions/imagecharup.xml
+++ b/reference/image/functions/imagecharup.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecharup</methodname>
+   <type>true</type><methodname>imagecharup</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
@@ -65,7 +65,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -80,6 +80,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.gdfont-instance;
      &gd.changelog.image-param;
     </tbody>

--- a/reference/image/functions/imagecolordeallocate.xml
+++ b/reference/image/functions/imagecolordeallocate.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecolordeallocate</methodname>
+   <type>true</type><methodname>imagecolordeallocate</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>color</parameter></methodparam>
   </methodsynopsis>
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -52,6 +52,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imagecolormatch.xml
+++ b/reference/image/functions/imagecolormatch.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecolormatch</methodname>
+   <type>true</type><methodname>imagecolormatch</methodname>
    <methodparam><type>GdImage</type><parameter>image1</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>image2</parameter></methodparam>
   </methodsynopsis>
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -58,6 +58,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/image/functions/imagecopy.xml
+++ b/reference/image/functions/imagecopy.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecopy</methodname>
+   <type>true</type><methodname>imagecopy</methodname>
    <methodparam><type>GdImage</type><parameter>dst_image</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>src_image</parameter></methodparam>
    <methodparam><type>int</type><parameter>dst_x</parameter></methodparam>
@@ -94,7 +94,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -109,6 +109,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/image/functions/imagecopymerge.xml
+++ b/reference/image/functions/imagecopymerge.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecopymerge</methodname>
+   <type>true</type><methodname>imagecopymerge</methodname>
    <methodparam><type>GdImage</type><parameter>dst_image</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>src_image</parameter></methodparam>
    <methodparam><type>int</type><parameter>dst_x</parameter></methodparam>
@@ -108,7 +108,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -123,6 +123,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/image/functions/imagecopymergegray.xml
+++ b/reference/image/functions/imagecopymergegray.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecopymergegray</methodname>
+   <type>true</type><methodname>imagecopymergegray</methodname>
    <methodparam><type>GdImage</type><parameter>dst_image</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>src_image</parameter></methodparam>
    <methodparam><type>int</type><parameter>dst_x</parameter></methodparam>
@@ -113,7 +113,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -128,6 +128,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/image/functions/imagecopyresampled.xml
+++ b/reference/image/functions/imagecopyresampled.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecopyresampled</methodname>
+   <type>true</type><methodname>imagecopyresampled</methodname>
    <methodparam><type>GdImage</type><parameter>dst_image</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>src_image</parameter></methodparam>
    <methodparam><type>int</type><parameter>dst_x</parameter></methodparam>
@@ -127,7 +127,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -142,6 +142,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/image/functions/imagecopyresized.xml
+++ b/reference/image/functions/imagecopyresized.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecopyresized</methodname>
+   <type>true</type><methodname>imagecopyresized</methodname>
    <methodparam><type>GdImage</type><parameter>dst_image</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>src_image</parameter></methodparam>
    <methodparam><type>int</type><parameter>dst_x</parameter></methodparam>
@@ -127,7 +127,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -142,6 +142,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/image/functions/imagedashedline.xml
+++ b/reference/image/functions/imagedashedline.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagedashedline</methodname>
+   <type>true</type><methodname>imagedashedline</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x1</parameter></methodparam>
    <methodparam><type>int</type><parameter>y1</parameter></methodparam>
@@ -73,7 +73,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -88,6 +88,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imagedestroy.xml
+++ b/reference/image/functions/imagedestroy.xml
@@ -12,7 +12,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier role="attribute">#[\Deprecated]</modifier>
-   <type>bool</type><methodname>imagedestroy</methodname>
+   <type>true</type><methodname>imagedestroy</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
   </methodsynopsis>
   &note.resource-migration-8.0-dead-function;
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -49,6 +49,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      <row>
       <entry>8.5.0</entry>
       <entry>

--- a/reference/image/functions/imageellipse.xml
+++ b/reference/image/functions/imageellipse.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imageellipse</methodname>
+   <type>true</type><methodname>imageellipse</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>center_x</parameter></methodparam>
    <methodparam><type>int</type><parameter>center_y</parameter></methodparam>
@@ -71,7 +71,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -86,6 +86,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imagefill.xml
+++ b/reference/image/functions/imagefill.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagefill</methodname>
+   <type>true</type><methodname>imagefill</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
    <methodparam><type>int</type><parameter>y</parameter></methodparam>
@@ -55,7 +55,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -70,6 +70,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imagefilledarc.xml
+++ b/reference/image/functions/imagefilledarc.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagefilledarc</methodname>
+   <type>true</type><methodname>imagefilledarc</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>center_x</parameter></methodparam>
    <methodparam><type>int</type><parameter>center_y</parameter></methodparam>
@@ -116,7 +116,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -131,6 +131,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imagefilledellipse.xml
+++ b/reference/image/functions/imagefilledellipse.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagefilledellipse</methodname>
+   <type>true</type><methodname>imagefilledellipse</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>center_x</parameter></methodparam>
    <methodparam><type>int</type><parameter>center_y</parameter></methodparam>
@@ -72,7 +72,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -87,6 +87,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imagefilledrectangle.xml
+++ b/reference/image/functions/imagefilledrectangle.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagefilledrectangle</methodname>
+   <type>true</type><methodname>imagefilledrectangle</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x1</parameter></methodparam>
    <methodparam><type>int</type><parameter>y1</parameter></methodparam>
@@ -73,7 +73,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -88,6 +88,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imagefilltoborder.xml
+++ b/reference/image/functions/imagefilltoborder.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagefilltoborder</methodname>
+   <type>true</type><methodname>imagefilltoborder</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
    <methodparam><type>int</type><parameter>y</parameter></methodparam>
@@ -66,7 +66,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -81,6 +81,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imageflip.xml
+++ b/reference/image/functions/imageflip.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imageflip</methodname>
+   <type>true</type><methodname>imageflip</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>mode</parameter></methodparam>
   </methodsynopsis>
@@ -40,6 +40,7 @@
           </row>
          </thead>
          <tbody>
+     &return.type.true;
           <row>
            <entry><constant>IMG_FLIP_HORIZONTAL</constant></entry>
            <entry>
@@ -71,7 +72,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagegammacorrect.xml
+++ b/reference/image/functions/imagegammacorrect.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagegammacorrect</methodname>
+   <type>true</type><methodname>imagegammacorrect</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>float</type><parameter>input_gamma</parameter></methodparam>
    <methodparam><type>float</type><parameter>output_gamma</parameter></methodparam>
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -60,6 +60,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imagelayereffect.xml
+++ b/reference/image/functions/imagelayereffect.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagelayereffect</methodname>
+   <type>true</type><methodname>imagelayereffect</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>effect</parameter></methodparam>
   </methodsynopsis>
@@ -81,7 +81,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -96,6 +96,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
      <row>
       <entry>7.2.0</entry>

--- a/reference/image/functions/imageline.xml
+++ b/reference/image/functions/imageline.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imageline</methodname>
+   <type>true</type><methodname>imageline</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x1</parameter></methodparam>
    <methodparam><type>int</type><parameter>y1</parameter></methodparam>
@@ -71,7 +71,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -86,6 +86,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imagerectangle.xml
+++ b/reference/image/functions/imagerectangle.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagerectangle</methodname>
+   <type>true</type><methodname>imagerectangle</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x1</parameter></methodparam>
    <methodparam><type>int</type><parameter>y1</parameter></methodparam>
@@ -73,7 +73,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -88,6 +88,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imagesavealpha.xml
+++ b/reference/image/functions/imagesavealpha.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagesavealpha</methodname>
+   <type>true</type><methodname>imagesavealpha</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>bool</type><parameter>enable</parameter></methodparam>
   </methodsynopsis>
@@ -56,7 +56,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -71,6 +71,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imagesetbrush.xml
+++ b/reference/image/functions/imagesetbrush.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagesetbrush</methodname>
+   <type>true</type><methodname>imagesetbrush</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>brush</parameter></methodparam>
   </methodsynopsis>
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -63,6 +63,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/image/functions/imagesetclip.xml
+++ b/reference/image/functions/imagesetclip.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagesetclip</methodname>
+   <type>true</type><methodname>imagesetclip</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x1</parameter></methodparam>
    <methodparam><type>int</type><parameter>y1</parameter></methodparam>
@@ -64,7 +64,7 @@
  <refsect1 role="returnvalues"><!-- {{{ -->
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1><!-- }}} -->
 
@@ -79,6 +79,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imagesetpixel.xml
+++ b/reference/image/functions/imagesetpixel.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagesetpixel</methodname>
+   <type>true</type><methodname>imagesetpixel</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
    <methodparam><type>int</type><parameter>y</parameter></methodparam>
@@ -54,7 +54,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -69,6 +69,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imagesetthickness.xml
+++ b/reference/image/functions/imagesetthickness.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagesetthickness</methodname>
+   <type>true</type><methodname>imagesetthickness</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>thickness</parameter></methodparam>
   </methodsynopsis>
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -52,6 +52,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.image-param;
     </tbody>
    </tgroup>

--- a/reference/image/functions/imagesettile.xml
+++ b/reference/image/functions/imagesettile.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagesettile</methodname>
+   <type>true</type><methodname>imagesettile</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>tile</parameter></methodparam>
   </methodsynopsis>
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -66,6 +66,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/image/functions/imagestring.xml
+++ b/reference/image/functions/imagestring.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagestring</methodname>
+   <type>true</type><methodname>imagestring</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
@@ -64,7 +64,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -79,6 +79,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.gdfont-instance;
      &gd.changelog.image-param;
     </tbody>

--- a/reference/image/functions/imagestringup.xml
+++ b/reference/image/functions/imagestringup.xml
@@ -8,7 +8,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagestringup</methodname>
+   <type>true</type><methodname>imagestringup</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
@@ -65,7 +65,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 
@@ -80,6 +80,7 @@
      </row>
     </thead>
     <tbody>
+     &return.type.true;
      &gd.changelog.gdfont-instance;
      &gd.changelog.image-param;
     </tbody>


### PR DESCRIPTION
## Summary

Update return type from `bool` to `true` for 33 GD image functions. These functions always return `true` (or throw on error) since PHP 8.0+.

Changes per file:
- `<type>bool</type>` → `<type>true</type>` in methodsynopsis
- Return values description updated to use `&return.true.always;`
- Added changelog entry for PHP 8.2.0 with `&return.type.true;`

### Functions updated (33)

imagealphablending, imageantialias, imagearc, imagechar, imagecharup, imagecolordeallocate, imagecolormatch, imagecopy, imagecopymerge, imagecopymergegray, imagecopyresampled, imagecopyresized, imagedashedline, imagedestroy, imageellipse, imagefill, imagefilledarc, imagefilledellipse, imagefilledrectangle, imagefilltoborder, imageflip, imagegammacorrect, imagelayereffect, imageline, imagerectangle, imagesavealpha, imagesetbrush, imagesetclip, imagesetpixel, imagesetthickness, imagesettile, imagestring, imagestringup

### Reference

- [php-src ext/gd/gd.stub.php](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/gd/gd.stub.php)