### PR TITLE
Fix stream_filter_append/prepend parameter names to match php-src

### DIFF
--- a/reference/stream/functions/stream-filter-append.xml
+++ b/reference/stream/functions/stream-filter-append.xml
@@ -10,12 +10,12 @@
   <methodsynopsis>
    <type>resource</type><methodname>stream_filter_append</methodname>
    <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
-   <methodparam><type>string</type><parameter>filtername</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>read_write</parameter></methodparam>
+   <methodparam><type>string</type><parameter>filter_name</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>mode</parameter></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>params</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Adds <parameter>filtername</parameter> to the list of filters
+   Adds <parameter>filter_name</parameter> to the list of filters
    attached to <parameter>stream</parameter>.  
   </para>
  </refsect1>
@@ -33,7 +33,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>filtername</parameter></term>
+     <term><parameter>filter_name</parameter></term>
      <listitem>
       <para>
        The filter name.
@@ -41,7 +41,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>read_write</parameter></term>
+     <term><parameter>mode</parameter></term>
      <listitem>
       <para>
        By default, <function>stream_filter_append</function> will
@@ -54,7 +54,7 @@
        <constant>STREAM_FILTER_READ</constant>,
        <constant>STREAM_FILTER_WRITE</constant>, and/or
        <constant>STREAM_FILTER_ALL</constant> can also be passed to the
-       <parameter>read_write</parameter> parameter to override this behavior.
+       <parameter>mode</parameter> parameter to override this behavior.
       </para>
      </listitem>
     </varlistentry>
@@ -84,7 +84,7 @@
 
   <para>
    &false; is returned if <parameter>stream</parameter> is not a resource or
-   if <parameter>filtername</parameter> cannot be located.
+   if <parameter>filter_name</parameter> cannot be located.
   </para>
  </refsect1>
 
@@ -139,7 +139,7 @@ Guvf vf n grfg
    <title>When using custom (user) filters</title>
    <simpara>
     <function>stream_filter_register</function> must be called first
-    in order to register the desired user filter to <parameter>filtername</parameter>.
+    in order to register the desired user filter to <parameter>filter_name</parameter>.
    </simpara>
   </note>
   <note>

--- a/reference/stream/functions/stream-filter-prepend.xml
+++ b/reference/stream/functions/stream-filter-prepend.xml
@@ -10,12 +10,12 @@
   <methodsynopsis>
    <type>resource</type><methodname>stream_filter_prepend</methodname>
    <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
-   <methodparam><type>string</type><parameter>filtername</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>read_write</parameter></methodparam>
+   <methodparam><type>string</type><parameter>filter_name</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>mode</parameter></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>params</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Adds <parameter>filtername</parameter> to the list of filters
+   Adds <parameter>filter_name</parameter> to the list of filters
    attached to <parameter>stream</parameter>.
   </para>
  </refsect1>
@@ -33,7 +33,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>filtername</parameter></term>
+     <term><parameter>filter_name</parameter></term>
      <listitem>
       <para>
        The filter name.
@@ -41,7 +41,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>read_write</parameter></term>
+     <term><parameter>mode</parameter></term>
      <listitem>
       <para>
        By default, <function>stream_filter_prepend</function> will
@@ -54,7 +54,7 @@
        <constant>STREAM_FILTER_READ</constant>,
        <constant>STREAM_FILTER_WRITE</constant>, and/or
        <constant>STREAM_FILTER_ALL</constant> can also be passed to the
-       <parameter>read_write</parameter> parameter to override this behavior.
+       <parameter>mode</parameter> parameter to override this behavior.
        See <function>stream_filter_append</function> for an example of
        using this parameter.
       </para>
@@ -85,7 +85,7 @@
 
   <para>
    &false; is returned if <parameter>stream</parameter> is not a resource or
-   if <parameter>filtername</parameter> cannot be located.
+   if <parameter>filter_name</parameter> cannot be located.
   </para>
  </refsect1>
 
@@ -95,7 +95,7 @@
    <title>When using custom (user) filters</title>
    <simpara>
     <function>stream_filter_register</function> must be called first
-    in order to register the desired user filter to <parameter>filtername</parameter>.
+    in order to register the desired user filter to <parameter>filter_name</parameter>.
    </simpara>
   </note>
   <note>


### PR DESCRIPTION
Fix parameter names for stream_filter_append and stream_filter_prepend to match php-src stubs.

Happy to adjust if needed.