### PR TITLE
Fix return type for 5 misc functions: bool -> true

### DIFF
--- a/reference/array/functions/array-multisort.xml
+++ b/reference/array/functions/array-multisort.xml
@@ -133,7 +133,12 @@
      </row>
     </thead>
     <tbody>
-     &return.type.true;
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       The return type is &true; now; previously, it was <type>bool</type>.
+      </entry>
+     </row>
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/fileinfo/functions/finfo-close.xml
+++ b/reference/fileinfo/functions/finfo-close.xml
@@ -57,7 +57,12 @@
        This function has been deprecated.
       </entry>
      </row>
-     &return.type.true;
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       The return type is &true; now; previously, it was <type>bool</type>.
+      </entry>
+     </row>
      <row>
       <entry>8.1.0</entry>
       <entry>

--- a/reference/ftp/functions/ftp-set-option.xml
+++ b/reference/ftp/functions/ftp-set-option.xml
@@ -96,7 +96,12 @@
      </row>
     </thead>
     <tbody>
-     &return.type.true;
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       The return type is &true; now; previously, it was <type>bool</type>.
+      </entry>
+     </row>
      &ftp.changelog.ftp-param;
     </tbody>
    </tgroup>

--- a/reference/libxml/functions/libxml-set-external-entity-loader.xml
+++ b/reference/libxml/functions/libxml-set-external-entity-loader.xml
@@ -87,7 +87,12 @@
      </row>
     </thead>
     <tbody>
-     &return.type.true;
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       The return type is &true; now; previously, it was <type>bool</type>.
+      </entry>
+     </row>
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/sem/functions/shm-detach.xml
+++ b/reference/sem/functions/shm-detach.xml
@@ -52,7 +52,12 @@
      </row>
     </thead>
     <tbody>
-     &return.type.true;
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       The return type is &true; now; previously, it was <type>bool</type>.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>


### PR DESCRIPTION
Fix return type from `bool` to `true` for finfo_close, ftp_set_option, libxml_set_external_entity_loader, shm_detach, and array_multisort to match php-src stubs.

Happy to adjust if needed.