### PR TITLE
Fix pcntl_exec return type: bool -> false

### DIFF
--- a/reference/pcntl/functions/pcntl-exec.xml
+++ b/reference/pcntl/functions/pcntl-exec.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>pcntl_exec</methodname>
+   <type>false</type><methodname>pcntl_exec</methodname>
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>args</parameter><initializer>[]</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>env_vars</parameter><initializer>[]</initializer></methodparam>


### PR DESCRIPTION
## Summary

Fix return type for `pcntl_exec` from `bool` to `false`. This function never returns on success (replaces the current process). On failure it returns `false`.

### Reference

- [php-src ext/pcntl/pcntl.stub.php L1040](https://github.com/php/php-src/blob/7fed075ba6b0431195795a7f3cc9a114a102a2e8/ext/pcntl/pcntl.stub.php#L1040)