### PR TITLE
Document HashContext::__debugInfo (PHP 8.4)

### DIFF
--- a/reference/hash/hashcontext/debuginfo.xml
+++ b/reference/hash/hashcontext/debuginfo.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="hashcontext.debuginfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>HashContext::__debugInfo</refname>
+  <refpurpose>Returns debugging information about the hashing context</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="HashContext">
+   <modifier>public</modifier> <type>array</type><methodname>HashContext::__debugInfo</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   This method is not meant to be called directly; it is invoked by
+   <function>var_dump</function> and related functions when inspecting a
+   <classname>HashContext</classname> instance.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns an associative array of debugging information. It contains an
+   <literal>algo</literal> key holding the name of the hashing algorithm
+   in use by the context.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>HashContext::__debugInfo</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$ctx = hash_init('sha256');
+var_dump($ctx);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(HashContext)#1 (1) {
+  ["algo"]=>
+  string(6) "sha256"
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>hash_init</function></member>
+   <member><function>var_dump</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/hash/versions.xml
+++ b/reference/hash/versions.xml
@@ -6,6 +6,7 @@
 <versions> 
  <function name="HashContext" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
  <function name="HashContext::__construct" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
+ <function name="HashContext::__debugInfo" from="PHP 8 &gt;= 8.4.0"/>
  <function name="HashContext::__serialize" from="PHP 8"/>
  <function name="HashContext::__unserialize" from="PHP 8"/>
  


### PR DESCRIPTION
Documents the `HashContext::__debugInfo()` magic method (PHP 8.4), which exposes the hashing algorithm when a `HashContext` is inspected with `var_dump()`.

Adds the matching `reference/hash/versions.xml` entry. Part of #3872.