### PR TITLE
Add PHP 8.4.0 changelog entries for PGSQL and PDO pages

### DIFF
--- a/reference/pdo/pdo/getattribute.xml
+++ b/reference/pdo/pdo/getattribute.xml
@@ -79,6 +79,29 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       It is now possible to fetch the value of the
+       <constant>PDO::ATTR_STRINGIFY_FETCHES</constant> attribute.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/pgsql/functions/pg-fetch-result.xml
+++ b/reference/pgsql/functions/pg-fetch-result.xml
@@ -91,6 +91,17 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.4.0</entry>
+      <entry>
+       The two argument signature of
+       <function>pg_fetch_result</function>
+       (<parameter>result</parameter>,
+       <parameter>field</parameter>) is now deprecated.
+       Use the three argument signature with
+       <parameter>row</parameter> set to &null; instead.
+      </entry>
+     </row>
+     <row>
       <entry>8.3.0</entry>
       <entry>
        <parameter>row</parameter> is now nullable.

--- a/reference/pgsql/functions/pg-field-is-null.xml
+++ b/reference/pgsql/functions/pg-field-is-null.xml
@@ -83,6 +83,17 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.4.0</entry>
+      <entry>
+       The two argument signature of
+       <function>pg_field_is_null</function>
+       (<parameter>result</parameter>,
+       <parameter>field</parameter>) is now deprecated.
+       Use the three argument signature with
+       <parameter>row</parameter> set to &null; instead.
+      </entry>
+     </row>
+     <row>
       <entry>8.3.0</entry>
       <entry>
        <parameter>row</parameter> is now nullable.

--- a/reference/pgsql/functions/pg-field-prtlen.xml
+++ b/reference/pgsql/functions/pg-field-prtlen.xml
@@ -84,6 +84,17 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.4.0</entry>
+      <entry>
+       The two argument signature of
+       <function>pg_field_prtlen</function>
+       (<parameter>result</parameter>,
+       <parameter>field_name_or_number</parameter>) is now deprecated.
+       Use the three argument signature with
+       <parameter>row</parameter> set to &null; instead.
+      </entry>
+     </row>
+     <row>
       <entry>8.3.0</entry>
       <entry>
        <parameter>row</parameter> is now nullable.


### PR DESCRIPTION
Relates to #3872

Add missing 8.4.0 changelog entries for pg_fetch_result, pg_field_prtlen, pg_field_is_null, and PDO::getAttribute.