### PR TITLE
Add PHP 8.4.0 changelog entries for Intl and MBString pages

### DIFF
--- a/reference/intl/idn/idn-to-ascii.xml
+++ b/reference/intl/idn/idn-to-ascii.xml
@@ -91,6 +91,21 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Now throws a <exceptionname>ValueError</exceptionname>
+        if the <parameter>domain</parameter> name is empty.
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Now throws a <exceptionname>ValueError</exceptionname>
+        if the <parameter>variant</parameter> parameter is not
+        <constant>INTL_IDNA_VARIANT_UTS46</constant>.
+       </entry>
+      </row>
+      <row>
        <entry>7.4.0</entry>
        <entry>
         The default value of <parameter>variant</parameter> is now

--- a/reference/intl/idn/idn-to-ascii.xml
+++ b/reference/intl/idn/idn-to-ascii.xml
@@ -94,7 +94,7 @@
        <entry>8.4.0</entry>
        <entry>
         Now throws a <exceptionname>ValueError</exceptionname>
-        if the <parameter>domain</parameter> name is empty.
+        if the <parameter>domain</parameter> parameter is empty.
        </entry>
       </row>
       <row>

--- a/reference/intl/idn/idn-to-utf8.xml
+++ b/reference/intl/idn/idn-to-utf8.xml
@@ -91,6 +91,21 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Now throws a <exceptionname>ValueError</exceptionname>
+        if the <parameter>domain</parameter> name is empty.
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Now throws a <exceptionname>ValueError</exceptionname>
+        if the <parameter>variant</parameter> parameter is not
+        <constant>INTL_IDNA_VARIANT_UTS46</constant>.
+       </entry>
+      </row>
+      <row>
        <entry>7.4.0</entry>
        <entry>
         The default value of <parameter>variant</parameter> is now

--- a/reference/intl/idn/idn-to-utf8.xml
+++ b/reference/intl/idn/idn-to-utf8.xml
@@ -94,7 +94,7 @@
        <entry>8.4.0</entry>
        <entry>
         Now throws a <exceptionname>ValueError</exceptionname>
-        if the <parameter>domain</parameter> name is empty.
+        if the <parameter>domain</parameter> parameter is empty.
        </entry>
       </row>
       <row>

--- a/reference/mbstring/functions/mb-strcut.xml
+++ b/reference/mbstring/functions/mb-strcut.xml
@@ -107,6 +107,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       The behavior of <function>mb_strcut</function> is more
+       consistent now on invalid UTF-8 and UTF-16 strings.
+      </entry>
+     </row>
      &mbstring.changelog.encoding-nullable;
     </tbody>
    </tgroup>

--- a/reference/mbstring/functions/mb-strcut.xml
+++ b/reference/mbstring/functions/mb-strcut.xml
@@ -110,8 +110,7 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       The behavior of <function>mb_strcut</function> is more
-       consistent now on invalid UTF-8 and UTF-16 strings.
+       The behavior is more consistent now on invalid <literal>UTF-8</literal> and <literal>UTF-16</literal> strings.
       </entry>
      </row>
      &mbstring.changelog.encoding-nullable;

--- a/reference/mbstring/functions/mb-substr.xml
+++ b/reference/mbstring/functions/mb-substr.xml
@@ -97,6 +97,17 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       On invalid strings (those with encoding errors),
+       <function>mb_substr</function> now interprets character
+       indices in the same manner as most other mbstring functions.
+       This means that character indices returned by
+       <function>mb_strpos</function> can be passed to
+       <function>mb_substr</function>.
+      </entry>
+     </row>
      &mbstring.changelog.encoding-nullable;
     </tbody>
    </tgroup>

--- a/reference/mbstring/functions/mb-substr.xml
+++ b/reference/mbstring/functions/mb-substr.xml
@@ -101,11 +101,9 @@
       <entry>8.4.0</entry>
       <entry>
        On invalid strings (those with encoding errors),
-       <function>mb_substr</function> now interprets character
-       indices in the same manner as most other mbstring functions.
-       This means that character indices returned by
-       <function>mb_strpos</function> can be passed to
-       <function>mb_substr</function>.
+       character indices are now interpreted in the same manner as most
+       other mbstring functions. This means that character indices returned
+       by <function>mb_strpos</function> can be passed directly.
       </entry>
      </row>
      &mbstring.changelog.encoding-nullable;


### PR DESCRIPTION
Relates to #3872

Add missing 8.4.0 changelog entries for mb_substr, mb_strcut, idn_to_ascii, and idn_to_utf8.