### PR TITLE
Add PHP 8.4.0 changelog entries for Session and LDAP pages

### DIFF
--- a/reference/ldap/functions/ldap-connect.xml
+++ b/reference/ldap/functions/ldap-connect.xml
@@ -104,6 +104,14 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Calling <function>ldap_connect</function> with more than
+       two arguments is now deprecated.
+       Use <function>ldap_connect_wallet</function> instead.
+      </entry>
+     </row>
+     <row>
       <entry>8.3.0</entry>
       <entry>
        Calling <function>ldap_connect</function> with separate

--- a/reference/ldap/functions/ldap-connect.xml
+++ b/reference/ldap/functions/ldap-connect.xml
@@ -108,7 +108,6 @@
       <entry>
        Calling <function>ldap_connect</function> with more than
        two arguments is now deprecated.
-       Use <function>ldap_connect_wallet</function> instead.
       </entry>
      </row>
      <row>

--- a/reference/session/functions/session-set-save-handler.xml
+++ b/reference/session/functions/session-set-save-handler.xml
@@ -271,6 +271,30 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Calling <function>session_set_save_handler</function> with more
+       than two arguments is now deprecated.
+       Use the two argument signature instead.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>


### PR DESCRIPTION
Relates to #3872

Add missing 8.4.0 changelog entries for session_set_save_handler and ldap_connect.