### PR TITLE
Add PHP 8.4.0 changelog entries for SPL, Standard, and Filesystem pages

### DIFF
--- a/reference/filesystem/functions/tempnam.xml
+++ b/reference/filesystem/functions/tempnam.xml
@@ -71,6 +71,14 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.4.0</entry>
+      <entry>
+       The name of files created by <function>tempnam</function> are
+       now 13 bytes longer. The total length is still
+       platform-dependent.
+      </entry>
+     </row>
+     <row>
       <entry>7.1.0</entry>
       <entry>
        <function>tempnam</function> now emits a notice when falling back to the

--- a/reference/spl/splfixedarray.xml
+++ b/reference/spl/splfixedarray.xml
@@ -68,6 +68,17 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Out of bounds accesses in <classname>SplFixedArray</classname> now throw
+        exceptions of type <exceptionname>OutOfBoundsException</exceptionname>
+        instead of <exceptionname>RuntimeException</exceptionname>.
+        Because <exceptionname>OutOfBoundsException</exceptionname> is a child
+        class of <exceptionname>RuntimeException</exceptionname> no behavioural
+        changes are exhibited when attempting to catch those exceptions.
+       </entry>
+      </row>
+      <row>
        <entry>8.2.0</entry>
        <entry>
         The <methodname>SplFixedArray::__serialize</methodname> and

--- a/reference/var/functions/debug-zval-dump.xml
+++ b/reference/var/functions/debug-zval-dump.xml
@@ -47,6 +47,30 @@
    &return.void;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <function>debug_zval_dump</function> now indicates whether an
+       array is packed.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -173,6 +173,13 @@
        </entry>
       </row>
       <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Unserializing strings using the uppercase <literal>S</literal> tag
+        is now deprecated.
+       </entry>
+      </row>
+      <row>
        <entry>8.3.0</entry>
        <entry>
         Now emits <constant>E_WARNING</constant> when the input string has unconsumed data.

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -175,8 +175,8 @@
       <row>
        <entry>8.4.0</entry>
        <entry>
-        Unserializing strings using the uppercase <literal>S</literal> tag
-        is now deprecated.
+        Unserializing strings using the uppercase <literal>"S"</literal> tag
+        is now deprecated; use the lowercase <literal>"s"</literal> tag instead.
        </entry>
       </row>
       <row>


### PR DESCRIPTION
Helps with #3872

Add missing 8.4.0 changelog entries for SplFixedArray, debug_zval_dump, tempnam, and unserialize.