### PR TITLE
Document missing PHP 8.4.0 constants and deprecations

### DIFF
--- a/reference/ldap/constants.xml
+++ b/reference/ldap/constants.xml
@@ -373,7 +373,19 @@
    </term>
    <listitem>
     <simpara>
-     Specifies the minimum protocol version. This can be one of: <constant>LDAP_OPT_X_TLS_PROTOCOL_SSL2</constant>,<constant>LDAP_OPT_X_TLS_PROTOCOL_SSL3</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_0</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_1</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_2</constant>
+     Specifies the minimum protocol version. This can be one of: <constant>LDAP_OPT_X_TLS_PROTOCOL_SSL2</constant>,<constant>LDAP_OPT_X_TLS_PROTOCOL_SSL3</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_0</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_1</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_2</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_3</constant>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-tls-protocol-max">
+   <term>
+    <constant>LDAP_OPT_X_TLS_PROTOCOL_MAX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Specifies the maximum protocol version.
+     Available as of PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1152,6 +1164,18 @@
    <listitem>
     <simpara>
      The TLS 1.2 protocol.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-tls-protocol-tls1-3">
+   <term>
+    <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_3</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The TLS 1.3 protocol.
+     Available as of PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -83,6 +83,28 @@
       </simpara>
      </listitem>
     </varlistentry>
+    <varlistentry xml:id="constant.x509-purpose-ocsp-helper">
+     <term>
+      <constant>X509_PURPOSE_OCSP_HELPER</constant>
+      (<type>int</type>)
+     </term>
+     <listitem>
+      <simpara>
+       Available as of PHP 8.4.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="constant.x509-purpose-timestamp-sign">
+     <term>
+      <constant>X509_PURPOSE_TIMESTAMP_SIGN</constant>
+      (<type>int</type>)
+     </term>
+     <listitem>
+      <simpara>
+       Available as of PHP 8.4.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </section>
 

--- a/reference/session/constants.xml
+++ b/reference/session/constants.xml
@@ -16,6 +16,11 @@
      if session ID was set in an appropriate session cookie. This is
      the same id as the one returned by <function>session_id</function>.
     </simpara>
+    <warning>
+     <simpara>
+      This constant has been deprecated as of PHP 8.4.0.
+     </simpara>
+    </warning>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.php-session-disabled">

--- a/reference/soap/constants.xml
+++ b/reference/soap/constants.xml
@@ -60,7 +60,9 @@
       (<type>int</type>)
      </entry>
      <entry>999</entry>
-     <entry/>
+     <entry>
+      Deprecated as of PHP 8.4.0.
+     </entry>
     </row>
     <row xml:id="constant.soap-encoded">
      <entry>


### PR DESCRIPTION
Helps with #3872

Document missing PHP 8.4.0 constants (LDAP, OpenSSL) and deprecations (Session `SID`, SOAP `SOAP_FUNCTIONS_ALL`).