### PR TITLE
Since PHP 8.5 semicolon is deprecated to terminate case in switch

### DIFF
--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -269,7 +269,7 @@ endswitch;
   </informalexample>
  </para>
  <para>
-  It's possible to use a semicolon instead of a colon after a case like:
+  Deprecated in 8.5: It's possible to use a semicolon instead of a colon after a case like:
   <informalexample>
    <programlisting role="php">
 <![CDATA[


### PR DESCRIPTION
According to https://www.php.net/releases/8.5/en.php#features: Terminating case statements with a semicolon instead of a colon has been deprecated.