### PR TITLE
Memcached::__construct: Document callback and connection_str parameters

### DIFF
--- a/reference/memcached/memcached/construct.xml
+++ b/reference/memcached/memcached/construct.xml
@@ -18,7 +18,6 @@
    Creates a Memcached instance representing the connection to the memcache
    servers.
   </para>
-  &warn.undocumented.func;
  </refsect1>
 
  <refsect1 role="parameters">
@@ -41,7 +40,13 @@
      <term><parameter>callback</parameter></term>
      <listitem>
       <para>
-       <!-- TODO Document constructor params -->
+       An optional callback function that is invoked when a new persistent
+       connection is created. This can be used to perform initialization tasks
+       such as configuring options or adding servers.
+      </para>
+      <para>
+       The callback is only executed when a new persistent instance is created,
+       not when an existing persistent instance is reused.
       </para>
      </listitem>
     </varlistentry>
@@ -49,7 +54,10 @@
      <term><parameter>connection_str</parameter></term>
      <listitem>
       <para>
-       <!-- TODO Document constructor params -->
+       An optional connection string used to configure the Memcached instance.
+       The format of the connection string depends on the underlying libmemcached
+       library and may be used to define servers and connection options in a
+       single string.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
This PR documents the previously undocumented `callback` and `connection_str` parameters for Memcached::__construct.

It also removes the undocumented function warning as the constructor is now fully documented.