### PR TITLE
FAQ: Mention named arguments and discourage manual escaping

### DIFF
--- a/faq/using.xml
+++ b/faq/using.xml
@@ -30,8 +30,7 @@
      </para>
      <para>
       As of PHP 8.0, <link linkend="functions.named-arguments">named arguments</link>
-      allow passing arguments by parameter name, which makes the parameter order
-      less important when it improves readability.
+      allow passing arguments by parameter name, making parameter order less of a concern.
      </para>
     </answer>
    </qandaentry>


### PR DESCRIPTION
Updates the FAQ:

- Mentions named arguments in the parameter order entry.
- Adds a note discouraging manual escaping in the addslashes entry, recommending prepared statements and parameter binding instead.