### PR TITLE
Remove whitespace inside <methodname> tags

### DIFF
--- a/reference/imagick/imagick/setprogressmonitor.xml
+++ b/reference/imagick/imagick/setprogressmonitor.xml
@@ -33,9 +33,7 @@
      
      <methodsynopsis xmlns="http://docbook.org/ns/docbook">
       <type>bool</type>
-      <methodname>
-       <replaceable>callback</replaceable>
-      </methodname>
+      <methodname><replaceable>callback</replaceable></methodname>
       <methodparam>
        <type>mixed</type><parameter>offset</parameter>
       </methodparam>

--- a/reference/outcontrol/user-level-output-buffers.xml
+++ b/reference/outcontrol/user-level-output-buffers.xml
@@ -342,9 +342,7 @@
   <para>
    <methodsynopsis>
     <type>string</type>
-    <methodname>
-     <replaceable>handler</replaceable>
-    </methodname>
+    <methodname><replaceable>handler</replaceable></methodname>
     <methodparam>
      <type>string</type>
      <parameter>buffer</parameter>


### PR DESCRIPTION
Fix whitespace inside `<methodname>` tags flagged by `qaxml-ws.php` in two files.

Context: php/phd#237 and php/phd#80

Happy to adjust if needed.