### PR TITLE
Fix filter_input() return value documentation

### DIFF
--- a/reference/filter/functions/filter-input.xml
+++ b/reference/filter/functions/filter-input.xml
@@ -57,11 +57,12 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   On success returns the filtered variable.
-   If the variable is not set &false; is returned.
-   On failure &false; is returned,
-   unless the <constant>FILTER_NULL_ON_FAILURE</constant> flag is used,
-   in which case &null; is returned.
+   Value of the requested variable on success,
+   &false; if the filter fails,
+   or &null; if the <parameter>var_name</parameter> variable is not set.
+   If the flag <constant>FILTER_NULL_ON_FAILURE</constant> is used,
+   it returns &false; if the variable is not set
+   and &null; if the filter fails.
   </simpara>
  </refsect1>
 


### PR DESCRIPTION
Fixes #4361

`filter_input()` returns `null` when the variable is not set, not `false`. Also clarifies the `FILTER_NULL_ON_FAILURE` inverted behavior.

Happy to adjust if needed.