### PR TITLE
Document ValueError thrown by settype() since PHP 8.0

### DIFF
--- a/reference/var/functions/settype.xml
+++ b/reference/var/functions/settype.xml
@@ -87,6 +87,41 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Throws a <exceptionname>ValueError</exceptionname> if the value of
+   <parameter>type</parameter> is not a valid type, as of PHP 8.0.0.
+   Prior to PHP 8.0.0, a <constant>E_WARNING</constant> was emitted
+   and &false; was returned.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       Now throws a <exceptionname>ValueError</exceptionname> when an invalid
+       type is passed to <parameter>type</parameter>. Previously, a
+       <constant>E_WARNING</constant> was emitted and the function returned
+       &false;.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>


### PR DESCRIPTION
Fixes #3431

Adds Errors/Exceptions section and changelog entry for the ValueError thrown when an invalid type is passed, since PHP 8.0.

Happy to adjust if needed.