### PR TITLE
DATE_ATOM: refer to RFC 3339, not 3399

### DIFF
--- a/reference/datetime/constants.xml
+++ b/reference/datetime/constants.xml
@@ -68,7 +68,7 @@
    </term>
    <listitem>
     <simpara>
-     Atom (example: <literal>2005-08-15T15:52:01+00:00</literal>); compatible with ISO-8601, RFC 3399, and XML Schema
+     Atom (example: <literal>2005-08-15T15:52:01+00:00</literal>); compatible with ISO-8601, RFC 3339, and XML Schema
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
Fixes #5386