### PR TITLE
grapheme-str-split.xml: Remove erroneous locale changelog entry

### DIFF
--- a/reference/intl/grapheme/grapheme-str-split.xml
+++ b/reference/intl/grapheme/grapheme-str-split.xml
@@ -60,23 +60,6 @@
   </simpara>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <informaltable>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>&Version;</entry>
-      <entry>&Description;</entry>
-     </row>
-    </thead>
-    <tbody>
-     &intl.changelog.grapheme.locale;
-    </tbody>
-   </tgroup>
-  </informaltable>
- </refsect1>
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>


### PR DESCRIPTION
Remove erroneous `locale` changelog entry from `grapheme_str_split()`

The `locale` parameter description was correctly removed in #5182,
but the changelog entry (`&intl.changelog.grapheme.locale;`) remained.
