### PR TITLE
Fix duplicated constant name in IntlChar 8.4.0 changelog

### DIFF
--- a/reference/intl/intlchar.xml
+++ b/reference/intl/intlchar.xml
@@ -10721,7 +10721,7 @@
         <entry>8.4.0</entry>
         <entry>
          Added <constant>IntlChar::PROPERTY_IDS_UNARY_OPERATOR</constant>, <constant>IntlChar::PROPERTY_ID_COMPAT_MATH_START</constant>,
-         <constant>IntlChar::PROPERTY_ID_COMPAT_MATH_START</constant>.
+         <constant>IntlChar::PROPERTY_ID_COMPAT_MATH_CONTINUE</constant>.
         </entry>
        </row>
        <row>


### PR DESCRIPTION
The changelog entry lists PROPERTY_ID_COMPAT_MATH_START twice.
The second should be PROPERTY_ID_COMPAT_MATH_CONTINUE.

See https://www.php.net/manual/en/migration84.constants.php