### PR TITLE
Fix wrong varname for SoapFault::$lang property

### DIFF
--- a/reference/soap/soapfault.xml
+++ b/reference/soap/soapfault.xml
@@ -153,7 +153,7 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="soapfault.props.lang">
-     <term><varname>headerfault</varname></term>
+     <term><varname>lang</varname></term>
      <listitem>
       <simpara>
        Soap 1.2 Reason Text xml:lang attribute.


### PR DESCRIPTION
Under xml:id="soapfault.props.lang", the <varname> says "headerfault"
instead of "lang" (copy-paste error).

See https://www.php.net/manual/en/class.soapfault.php
(the rendered page shows "headerfault" twice, "lang" is missing)