### PR TITLE
ext/pgsql: Update outdated PostgreSQL version requirements

### DIFF
--- a/reference/pgsql/functions/pg-affected-rows.xml
+++ b/reference/pgsql/functions/pg-affected-rows.xml
@@ -20,8 +20,7 @@
    queries. 
   </para>
   <para>
-   Since PostgreSQL 9.0 and above, the server returns the number of 
-   SELECTed rows. Older PostgreSQL return 0 for SELECT.
+   The server also returns the number of SELECTed rows.
   </para>
   <note>
    <para>

--- a/reference/pgsql/functions/pg-client-encoding.xml
+++ b/reference/pgsql/functions/pg-client-encoding.xml
@@ -24,8 +24,7 @@
   </para>
   <note>
    <para>
-    This function requires PostgreSQL 7.0 or
-    higher. If libpq is compiled without multibyte encoding support,
+    If libpq is compiled without multibyte encoding support,
     <function>pg_client_encoding</function> always returns
     <literal>SQL_ASCII</literal>. Supported encoding depends on PostgreSQL
     version.  Refer to the PostgreSQL Documentation supported encodings.

--- a/reference/pgsql/functions/pg-escape-identifier.xml
+++ b/reference/pgsql/functions/pg-escape-identifier.xml
@@ -29,12 +29,6 @@
    type fields, <function>pg_escape_bytea</function> must be used
    instead.
   </para>
-  <note>
-   <para>
-    This function has internal escape code and can also be used with
-    PostgreSQL 8.4 or less.
-    </para>
-  </note>
  </refsect1>
 
 <refsect1 role="parameters">

--- a/reference/pgsql/functions/pg-escape-literal.xml
+++ b/reference/pgsql/functions/pg-escape-literal.xml
@@ -27,12 +27,6 @@
    instead. For escaping identifiers (e.g. table, field
    names), <function>pg_escape_identifier</function> must be used.
   </para>
-  <note>
-   <para>
-    This function has internal escape code and can also be used with
-    PostgreSQL 8.4 or less.
-    </para>
-  </note>
  </refsect1>
 
 <refsect1 role="parameters">

--- a/reference/pgsql/functions/pg-escape-string.xml
+++ b/reference/pgsql/functions/pg-escape-string.xml
@@ -27,11 +27,6 @@
    instead. <function>pg_escape_identifier</function> must be used to
    escape identifiers (e.g. table names, field names)
   </para>
-  <note>
-   <para>
-    This function requires PostgreSQL 7.2 or later.
-    </para>
-  </note>
  </refsect1>
 
 <refsect1 role="parameters">

--- a/reference/pgsql/functions/pg-execute.xml
+++ b/reference/pgsql/functions/pg-execute.xml
@@ -26,8 +26,6 @@
     query string. This feature allows commands that will be used repeatedly to 
     be parsed and planned just once, rather than each time they are executed. 
     The statement must have been prepared previously in the current session. 
-    <function>pg_execute</function> is supported only against PostgreSQL 7.4 or
-    higher connections; it will fail when using earlier versions.
   </para>
   <para>
     The parameters are identical to <function>pg_query_params</function>, except that the name of a 

--- a/reference/pgsql/functions/pg-lo-create.xml
+++ b/reference/pgsql/functions/pg-lo-create.xml
@@ -22,11 +22,9 @@
    <function>pg_lo_create</function> creates a large
    object and returns the <varname>OID</varname> of the large
    object.  PostgreSQL access modes
-   <constant>INV_READ</constant>, <constant>INV_WRITE</constant>, and 
-   <constant>INV_ARCHIVE</constant> are not supported, the
-   object is created always with both read and write
-   access. <constant>INV_ARCHIVE</constant> has been removed from PostgreSQL itself
-   (version 6.3 and above).
+   <constant>INV_READ</constant> and <constant>INV_WRITE</constant>
+   are not supported, the object is created always with both read and write
+   access.
   </para>
   <para>
    To use the large object interface, it is necessary to
@@ -60,9 +58,7 @@
       <para>
        If an <parameter>object_id</parameter> is given the function
        will try to create a large object with this id, else a free
-       object id is assigned by the server. The parameter
-       relies on functionality that first
-       appeared in PostgreSQL 8.1.
+       object id is assigned by the server.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/pgsql/functions/pg-parameter-status.xml
+++ b/reference/pgsql/functions/pg-parameter-status.xml
@@ -23,30 +23,14 @@
     parameter if known, or &false; if the parameter is not known.
   </para>
   <para>
-    Parameters reported as of PostgreSQL 8.0 include <literal>server_version</literal>, 
-    <literal>server_encoding</literal>, <literal>client_encoding</literal>, 
-    <literal>is_superuser</literal>, <literal>session_authorization</literal>, 
+    Parameters reported by the server include <literal>server_version</literal>,
+    <literal>server_encoding</literal>, <literal>client_encoding</literal>,
+    <literal>is_superuser</literal>, <literal>session_authorization</literal>,
     <literal>DateStyle</literal>, <literal>TimeZone</literal>, and <literal>integer_datetimes</literal>.
-    (<literal>server_encoding</literal>, <literal>TimeZone</literal>, and 
-    <literal>integer_datetimes</literal> were not reported by releases before 8.0.) Note that 
-    <literal>server_version</literal>, <literal>server_encoding</literal> and <literal>integer_datetimes</literal> 
+    Note that
+    <literal>server_version</literal>, <literal>server_encoding</literal> and <literal>integer_datetimes</literal>
     cannot change after PostgreSQL startup.
   </para>
-  <para>
-    PostgreSQL 7.3 or lower servers do not report parameter settings,
-    <function>pg_parameter_status</function>
-    includes logic to obtain values for <literal>server_version</literal> and 
-    <literal>client_encoding</literal>
-    anyway. Applications are encouraged to use <function>pg_parameter_status</function> rather than ad 
-    hoc code to determine these values.
-  </para>
-  <caution>
-    <para>
-      On a pre-7.4
-      PostgreSQL server, changing <literal>client_encoding</literal> via <literal>SET</literal> after connection startup will 
-      not be reflected by <function>pg_parameter_status</function>.
-     </para>
-  </caution>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/pgsql/functions/pg-prepare.xml
+++ b/reference/pgsql/functions/pg-prepare.xml
@@ -23,8 +23,6 @@
    <function>pg_execute</function> or <function>pg_send_execute</function>.
    This feature allows commands that will be used repeatedly to
    be parsed and planned just once, rather than each time they are executed.
-   <function>pg_prepare</function> is supported only against PostgreSQL 7.4 or
-   higher connections; it will fail when using earlier versions.
   </para>
   <para>
    The function creates a prepared statement named <parameter>stmtname</parameter> from the <parameter>query</parameter>

--- a/reference/pgsql/functions/pg-query-params.xml
+++ b/reference/pgsql/functions/pg-query-params.xml
@@ -23,8 +23,6 @@
     <function>pg_query_params</function> is like <function>pg_query</function>, 
     but offers additional functionality: parameter 
     values can be specified separately from the command string proper. 
-    <function>pg_query_params</function> is supported only against PostgreSQL 7.4 or
-    higher connections; it will fail when using earlier versions.
   </para>
   <para>
     If parameters are used, they are referred to in the

--- a/reference/pgsql/functions/pg-result-error-field.xml
+++ b/reference/pgsql/functions/pg-result-error-field.xml
@@ -16,8 +16,7 @@
   </methodsynopsis>
   <para>
    <function>pg_result_error_field</function> returns one of the detailed error message
-   fields associated with <parameter>result</parameter> instance. It is only available
-   against a PostgreSQL 7.4 or above server.  The error field is specified by
+   fields associated with <parameter>result</parameter> instance. The error field is specified by
    the <parameter>field_code</parameter>.
   </para>
   <para>
@@ -50,8 +49,8 @@
          <constant>PGSQL_DIAG_SQLSTATE</constant>, <constant>PGSQL_DIAG_MESSAGE_PRIMARY</constant>,
          <constant>PGSQL_DIAG_MESSAGE_DETAIL</constant>,
          <constant>PGSQL_DIAG_MESSAGE_HINT</constant>, <constant>PGSQL_DIAG_STATEMENT_POSITION</constant>,
-         <constant>PGSQL_DIAG_INTERNAL_POSITION</constant> (PostgreSQL 8.0+ only),
-         <constant>PGSQL_DIAG_INTERNAL_QUERY</constant> (PostgreSQL 8.0+ only),
+         <constant>PGSQL_DIAG_INTERNAL_POSITION</constant>,
+         <constant>PGSQL_DIAG_INTERNAL_QUERY</constant>,
          <constant>PGSQL_DIAG_CONTEXT</constant>, <constant>PGSQL_DIAG_SOURCE_FILE</constant>,
          <constant>PGSQL_DIAG_SOURCE_LINE</constant> or
          <constant>PGSQL_DIAG_SOURCE_FUNCTION</constant>.

--- a/reference/pgsql/functions/pg-unescape-bytea.xml
+++ b/reference/pgsql/functions/pg-unescape-bytea.xml
@@ -25,15 +25,6 @@
     prefixed with '\' (e.g. \032). Users are supposed to convert back to
     binary format manually.
    </para>
-   <para>
-    This function requires PostgreSQL 7.2 or later. With PostgreSQL
-    7.2.0 and 7.2.1, bytea values must be cast when you enable
-    multi-byte support. i.e. <literal>INSERT INTO test_table (image)
-    VALUES ('$image_escaped'::bytea);</literal> PostgreSQL 7.2.2 or
-    later does not need a cast. The exception is when the client and backend
-    character encoding does not match, and there may be multi-byte
-    stream error. User must then cast to bytea to avoid this error.
-   </para>
   </note>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-version.xml
+++ b/reference/pgsql/functions/pg-version.xml
@@ -16,8 +16,7 @@
   </methodsynopsis>
   <para>
    <function>pg_version</function> returns an array with the client, protocol
-   and server version. Protocol and server versions are only available if PHP
-   was compiled with PostgreSQL 7.4 or later.
+   and server version.
   </para>
   <para>
    For more detailed server information, use <function>pg_parameter_status</function>.

--- a/reference/pgsql/reference.xml
+++ b/reference/pgsql/reference.xml
@@ -34,8 +34,7 @@
     <para>
      PostgreSQL does not have special commands for fetching database schema
      information (eg. all the tables in the current database).  Instead, there
-     is a standard schema named <literal>information_schema</literal> in
-     PostgreSQL 7.4 and above containing
+     is a standard schema named <literal>information_schema</literal> containing
      system views with all the necessary information, in an easily
      queryable form.  See the <link xlink:href="&url.pgsql.manual;">PostgreSQL Documentation</link>
      for full details.  

--- a/reference/pgsql/setup.xml
+++ b/reference/pgsql/setup.xml
@@ -8,9 +8,11 @@
  <section xml:id="pgsql.requirements">
   &reftitle.required;
   <para>
-   To use PostgreSQL support, you need PostgreSQL 6.5 or
-   later, PostgreSQL 8.0 or later to enable all PostgreSQL module
-   features. PostgreSQL supports many character encodings including
+   To use PostgreSQL support, you need libpq (the PostgreSQL C client
+   library).
+   As of PHP 8.0.0, libpq 9.1 or later is required.
+   As of PHP 8.4.0, libpq 10.0 or later is required.
+   PostgreSQL supports many character encodings including
    multibyte character encoding. The current version and more
    information about PostgreSQL is available at 
    <link xlink:href="&url.pgsql;">&url.pgsql;</link> and


### PR DESCRIPTION
## Summary

The pgsql extension documentation references PostgreSQL versions that have been outdated for years. The requirements page (`reference/pgsql/setup.xml`) states:

https://www.php.net/manual/en/pgsql.requirements.php

> To use PostgreSQL support, you need PostgreSQL 6.5 or later,
> PostgreSQL 8.0 or later to enable all PostgreSQL module features.

However, the actual minimum libpq versions enforced by php-src are:

| PHP version | Minimum libpq | Commit |
|---|---|---|
| PHP 8.0+ | libpq 9.1 | php/php-src@ce668c0ec6 |
| PHP 8.4+ | libpq 10.0 | php/php-src#14628 |

The "PostgreSQL 6.5" requirement has been incorrect since at least PHP 8.0.0 (released 2020-11-26), which requires libpq 9.1 via `PQlibVersion` check in `ext/pgsql/config.m4`. As of PHP 8.4, the minimum was further raised to libpq 10.0 via `PQencryptPasswordConn` check in `build/php.m4`.

## Changes

- **setup.xml**: Update requirements to match php-src, following the same pattern used by ext/curl and ext/openssl (per-PHP-version listing).
- **14 function pages**: Remove notes referencing PostgreSQL versions 6.3–9.0 that are no longer relevant given the libpq 10.0 minimum. These include version-gated notes for `pg_prepare`, `pg_query_params`, `pg_execute`, `pg_escape_string`, `pg_escape_identifier`, `pg_escape_literal`, `pg_client_encoding`, `pg_unescape_bytea`, `pg_result_error_field`, `pg_parameter_status`, `pg_lo_create`, `pg_version`, `pg_affected_rows`, and the general `reference.xml`.