### PR TITLE
Fix IntlDateFormatter::PATTERN changelog version: 8.5.0 -> 8.4.0

### DIFF
--- a/reference/intl/dateformatter.xml
+++ b/reference/intl/dateformatter.xml
@@ -129,7 +129,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>8.5.0</entry>
+       <entry>8.4.0</entry>
        <entry>
         Added <constant>IntlDateFormatter::PATTERN</constant>.
        </entry>


### PR DESCRIPTION
The changelog says PATTERN was added in 8.5.0, but the constants description on the same page says "Available as of PHP 8.4.0".

See also https://www.php.net/manual/en/migration84.constants.php