### PR TITLE
Fix gh-5270: Clarify request_parse_body behavior with consumed body

### DIFF
--- a/reference/network/functions/request-parse-body.xml
+++ b/reference/network/functions/request-parse-body.xml
@@ -38,7 +38,8 @@
   <caution>
    <simpara>
     <function>request_parse_body</function> consumes the request body without
-    buffering it to the <literal>php://input</literal> stream.
+    buffering it to the <literal>php://input</literal> stream. If the body was
+    already consumed earlier, the raw input stream may no longer be available.
    </simpara>
   </caution>
  </refsect1>


### PR DESCRIPTION
Fixes #5270