### PR TITLE
Fix GH-5403: document missing SSL context options

### DIFF
--- a/language/context/ssl.xml
+++ b/language/context/ssl.xml
@@ -204,6 +204,43 @@
      </simpara>
     </listitem>
    </varlistentry>
+   <varlistentry xml:id="context.ssl.sni-server-certs">
+    <term>
+     <parameter>SNI_server_certs</parameter>
+     <type>array</type>
+    </term>
+    <listitem>
+     <simpara>
+      An array of server names and their corresponding certificates to be used
+      for SNI. The keys are the server names and the values are the paths to
+      the certificate files on the local filesystem. The certificate files must
+      be <acronym>PEM</acronym> encoded and contain both the certificate and private key.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.alpn-protocols">
+    <term>
+     <parameter>alpn_protocols</parameter>
+     <type>array</type>
+    </term>
+    <listitem>
+     <simpara>
+      An array of application layer protocol names to be used for ALPN (Application-Layer Protocol Negotiation).
+      The values are the protocol names as strings (e.g. "http/1.1", "h2").
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.no-ticket">
+    <term>
+     <parameter>no_ticket</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      If set, disable TLS session tickets. This can help to enhance security by providing Perfect Forward Secrecy (PFS).
+     </simpara>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="context.ssl.disable-compression">
     <term>
      <parameter>disable_compression</parameter>
@@ -249,6 +286,38 @@
      </simpara>
      <simpara>
       Available as of PHP 7.2.0 and OpenSSL 1.1.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.min-proto-version">
+    <term>
+     <parameter>min_proto_version</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <simpara>
+      Sets the minimum protocol version allowed. If not specified the library default
+      minimum protocol version is used. The protocol versions are described in
+      <link xlink:href="&url.openssl.protocol-versions;">SSL_CTX_set_min_proto_version(3)</link>.
+     </simpara>
+     <simpara>
+      Available as of PHP 8.0.0 and OpenSSL 1.1.1.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.max-proto-version">
+    <term>
+     <parameter>max_proto_version</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <simpara>
+      Sets the maximum protocol version allowed. If not specified the library default
+      maximum protocol version is used. The protocol versions are described in
+      <link xlink:href="&url.openssl.protocol-versions;">SSL_CTX_set_min_proto_version(3)</link>.
+     </simpara>
+     <simpara>
+      Available as of PHP 8.0.0 and OpenSSL 1.1.1.
      </simpara>
     </listitem>
    </varlistentry>

--- a/language/context/ssl.xml
+++ b/language/context/ssl.xml
@@ -228,6 +228,9 @@
       An array of application layer protocol names to be used for ALPN (Application-Layer Protocol Negotiation).
       The values are the protocol names as strings (e.g. "http/1.1", "h2").
      </simpara>
+     <simpara>
+      Available as of PHP 7.0.0 and OpenSSL 1.0.2.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="context.ssl.no-ticket">
@@ -301,7 +304,7 @@
       <link xlink:href="&url.openssl.protocol-versions;">SSL_CTX_set_min_proto_version(3)</link>.
      </simpara>
      <simpara>
-      Available as of PHP 8.0.0 and OpenSSL 1.1.1.
+      Available as of PHP 7.3.0 and OpenSSL 1.1.1.
      </simpara>
     </listitem>
    </varlistentry>
@@ -317,7 +320,7 @@
       <link xlink:href="&url.openssl.protocol-versions;">SSL_CTX_set_min_proto_version(3)</link>.
      </simpara>
      <simpara>
-      Available as of PHP 8.0.0 and OpenSSL 1.1.1.
+      Available as of PHP 7.3.0 and OpenSSL 1.1.1.
      </simpara>
     </listitem>
    </varlistentry>

--- a/language/context/ssl.xml
+++ b/language/context/ssl.xml
@@ -216,9 +216,12 @@
       the certificate files on the local filesystem. The certificate files must
       be <acronym>PEM</acronym> encoded and contain both the certificate and private key.
      </simpara>
+     <simpara>
+      Available as of PHP 5.6.0.
+     </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="context.alpn-protocols">
+   <varlistentry xml:id="context.ssl.alpn-protocols">
     <term>
      <parameter>alpn_protocols</parameter>
      <type>array</type>
@@ -241,6 +244,9 @@
     <listitem>
      <simpara>
       If set, disable TLS session tickets. This can help to enhance security by providing Perfect Forward Secrecy (PFS).
+     </simpara>
+     <simpara>
+      Available as of PHP 5.3.6.
      </simpara>
     </listitem>
    </varlistentry>
@@ -292,7 +298,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="context.min-proto-version">
+   <varlistentry xml:id="context.ssl.min-proto-version">
     <term>
      <parameter>min_proto_version</parameter>
      <type>int</type>
@@ -304,11 +310,11 @@
       <link xlink:href="&url.openssl.protocol-versions;">SSL_CTX_set_min_proto_version(3)</link>.
      </simpara>
      <simpara>
-      Available as of PHP 7.3.0 and OpenSSL 1.1.1.
+      Available as of PHP 7.3.0 and OpenSSL 1.1.0.
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="context.max-proto-version">
+   <varlistentry xml:id="context.ssl.max-proto-version">
     <term>
      <parameter>max_proto_version</parameter>
      <type>int</type>
@@ -317,10 +323,10 @@
      <simpara>
       Sets the maximum protocol version allowed. If not specified the library default
       maximum protocol version is used. The protocol versions are described in
-      <link xlink:href="&url.openssl.protocol-versions;">SSL_CTX_set_min_proto_version(3)</link>.
+      <link xlink:href="&url.openssl.protocol-versions;">SSL_CTX_set_max_proto_version(3)</link>.
      </simpara>
      <simpara>
-      Available as of PHP 7.3.0 and OpenSSL 1.1.1.
+      Available as of PHP 7.3.0 and OpenSSL 1.1.0.
      </simpara>
     </listitem>
    </varlistentry>
@@ -339,9 +345,34 @@
     </thead>
     <tbody>
      <row>
+      <entry>7.3.0</entry>
+      <entry>
+       Added <parameter>min_proto_version</parameter> and
+       <parameter>max_proto_version</parameter>. Requires OpenSSL &gt;= 1.1.0.
+      </entry>
+     </row>
+     <row>
       <entry>7.2.0</entry>
       <entry>
        Added <parameter>security_level</parameter>. Requires OpenSSL &gt;= 1.1.0.
+      </entry>
+     </row>
+     <row>
+      <entry>7.0.0</entry>
+      <entry>
+       Added <parameter>alpn_protocols</parameter>. Requires OpenSSL &gt;= 1.0.2.
+      </entry>
+     </row>
+     <row>
+      <entry>5.6.0</entry>
+      <entry>
+       Added <parameter>SNI_server_certs</parameter>.
+      </entry>
+     </row>
+     <row>
+      <entry>5.3.6</entry>
+      <entry>
+       Added <parameter>no_ticket</parameter>.
       </entry>
      </row>
     </tbody>

--- a/language/context/ssl.xml
+++ b/language/context/ssl.xml
@@ -9,276 +9,272 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>
+  <simpara>
    Context options for <literal>ssl://</literal> and <literal>tls://</literal>
    transports.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="options">
   &reftitle.options;
-  <para>
-   <variablelist>
-    <varlistentry xml:id="context.ssl.peer-name">
-     <term>
-      <parameter>peer_name</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Peer name to be used. If this value is not set, then the name is guessed
-       based on the hostname used when opening the stream.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.verify-peer">
-     <term>
-      <parameter>verify_peer</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       Require verification of SSL certificate used.
-      </para>
-      <para>
-       Defaults to &true;.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.verify-peer-name">
-     <term>
-      <parameter>verify_peer_name</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       Require verification of peer name.
-      </para>
-      <para>
-       Defaults to &true;.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.allow-self-signed">
-     <term>
-      <parameter>allow_self_signed</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       Allow self-signed certificates. Requires
-       <link linkend="context.ssl.verify-peer"><parameter>verify_peer</parameter></link>.
-      </para>
-      <para>
-       Defaults to &false;
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.cafile">
-     <term>
-      <parameter>cafile</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Location of Certificate Authority file on local filesystem
-       which should be used with the <literal>verify_peer</literal>
-       context option to authenticate the identity of the remote peer.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.capath">
-     <term>
-      <parameter>capath</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       If <literal>cafile</literal> is not specified or if the certificate
-       is not found there, the directory pointed to by <literal>capath</literal>
-       is searched for a suitable certificate.  <literal>capath</literal>
-       must be a correctly hashed certificate directory.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.local-cert">
-     <term>
-      <parameter>local_cert</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Path to local certificate file on filesystem.  It must be a
-       <acronym>PEM</acronym> encoded file which contains your certificate and
-       private key. It can optionally contain the certificate chain of issuers.
-       The private key also may be contained in a separate file specified
-       by <literal>local_pk</literal>.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.local-pk">
-     <term>
-      <parameter>local_pk</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Path to local private key file on filesystem in case of separate
-       files for certificate (<literal>local_cert</literal>) and private key.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.passphrase">
-     <term>
-      <parameter>passphrase</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Passphrase with which your <literal>local_cert</literal> file
-       was encoded.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.verify-depth">
-     <term>
-      <parameter>verify_depth</parameter>
-      <type>int</type>
-     </term>
-     <listitem>
-      <para>
-       Abort if the certificate chain is too deep.
-      </para>
-      <para>
-       Defaults to no verification.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.ciphers">
-     <term>
-      <parameter>ciphers</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Sets the list of available ciphers. The format of the string is described
-       in <link xlink:href="&url.openssl.ciphers;">ciphers(1)</link>.
-      </para>
-      <para>
-       Defaults to <literal>DEFAULT</literal>.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.capture-peer-cert">
-     <term>
-      <parameter>capture_peer_cert</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       If set to &true; a <literal>peer_certificate</literal> context option
-       will be created containing the peer certificate.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.capture-peer-cert-chain">
-     <term>
-      <parameter>capture_peer_cert_chain</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       If set to &true; a <literal>peer_certificate_chain</literal> context
-       option will be created containing the certificate chain.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.sni-enabled">
-     <term>
-      <parameter>SNI_enabled</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       If set to &true; server name indication will be enabled. Enabling SNI
-       allows multiple certificates on the same IP address.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.disable-compression">
-     <term>
-      <parameter>disable_compression</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       If set, disable TLS compression. This can help mitigate the CRIME attack
-       vector.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.peer-fingerprint">
-     <term>
-      <parameter>peer_fingerprint</parameter>
-      <type>string</type> | <type>array</type>
-     </term>
-     <listitem>
-      <para>
-       Aborts when the remote certificate digest doesn't match the specified
-       hash.
-      </para>
-      <para>
-       When a <type>string</type> is used, the length will determine which hashing algorithm
-       is applied, either "md5" (32) or "sha1" (40).
-      </para>
-      <para>
-       When an <type>array</type> is used, the keys indicate the hashing algorithm name
-       and each corresponding value is the expected digest.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.security-level">
-     <term>
-      <parameter>security_level</parameter>
-      <type>int</type>
-     </term>
-     <listitem>
-      <para>
-       Sets the security level. If not specified the library default security level is used.
-       The security levels are described in
-       <link xlink:href="&url.openssl.security-level;">SSL_CTX_get_security_level(3)</link>.
-      </para>
-      <para>
-       Available as of PHP 7.2.0 and OpenSSL 1.1.0.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry xml:id="context.ssl.peer-name">
+    <term>
+     <parameter>peer_name</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Peer name to be used. If this value is not set, then the name is guessed
+      based on the hostname used when opening the stream.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.verify-peer">
+    <term>
+     <parameter>verify_peer</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Require verification of SSL certificate used.
+     </simpara>
+     <simpara>
+      Defaults to &true;.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.verify-peer-name">
+    <term>
+     <parameter>verify_peer_name</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Require verification of peer name.
+     </simpara>
+     <simpara>
+      Defaults to &true;.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.allow-self-signed">
+    <term>
+     <parameter>allow_self_signed</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Allow self-signed certificates. Requires
+      <link linkend="context.ssl.verify-peer"><parameter>verify_peer</parameter></link>.
+     </simpara>
+     <simpara>
+      Defaults to &false;
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.cafile">
+    <term>
+     <parameter>cafile</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Location of Certificate Authority file on local filesystem
+      which should be used with the <literal>verify_peer</literal>
+      context option to authenticate the identity of the remote peer.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.capath">
+    <term>
+     <parameter>capath</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      If <literal>cafile</literal> is not specified or if the certificate
+      is not found there, the directory pointed to by <literal>capath</literal>
+      is searched for a suitable certificate.  <literal>capath</literal>
+      must be a correctly hashed certificate directory.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.local-cert">
+    <term>
+     <parameter>local_cert</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Path to local certificate file on filesystem.  It must be a
+      <acronym>PEM</acronym> encoded file which contains your certificate and
+      private key. It can optionally contain the certificate chain of issuers.
+      The private key also may be contained in a separate file specified
+      by <literal>local_pk</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.local-pk">
+    <term>
+     <parameter>local_pk</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Path to local private key file on filesystem in case of separate
+      files for certificate (<literal>local_cert</literal>) and private key.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.passphrase">
+    <term>
+     <parameter>passphrase</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Passphrase with which your <literal>local_cert</literal> file
+      was encoded.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.verify-depth">
+    <term>
+     <parameter>verify_depth</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <simpara>
+      Abort if the certificate chain is too deep.
+     </simpara>
+     <simpara>
+      Defaults to no verification.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.ciphers">
+    <term>
+     <parameter>ciphers</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Sets the list of available ciphers. The format of the string is described
+      in <link xlink:href="&url.openssl.ciphers;">ciphers(1)</link>.
+     </simpara>
+     <simpara>
+      Defaults to <literal>DEFAULT</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.capture-peer-cert">
+    <term>
+     <parameter>capture_peer_cert</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      If set to &true; a <literal>peer_certificate</literal> context option
+      will be created containing the peer certificate.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.capture-peer-cert-chain">
+    <term>
+     <parameter>capture_peer_cert_chain</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      If set to &true; a <literal>peer_certificate_chain</literal> context
+      option will be created containing the certificate chain.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.sni-enabled">
+    <term>
+     <parameter>SNI_enabled</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      If set to &true; server name indication will be enabled. Enabling SNI
+      allows multiple certificates on the same IP address.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.disable-compression">
+    <term>
+     <parameter>disable_compression</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      If set, disable TLS compression. This can help mitigate the CRIME attack
+      vector.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.peer-fingerprint">
+    <term>
+     <parameter>peer_fingerprint</parameter>
+     <type>string</type> | <type>array</type>
+    </term>
+    <listitem>
+     <simpara>
+      Aborts when the remote certificate digest doesn't match the specified
+      hash.
+     </simpara>
+     <simpara>
+      When a <type>string</type> is used, the length will determine which hashing algorithm
+      is applied, either "md5" (32) or "sha1" (40).
+     </simpara>
+     <simpara>
+      When an <type>array</type> is used, the keys indicate the hashing algorithm name
+      and each corresponding value is the expected digest.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.security-level">
+    <term>
+     <parameter>security_level</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <simpara>
+      Sets the security level. If not specified the library default security level is used.
+      The security levels are described in
+      <link xlink:href="&url.openssl.security-level;">SSL_CTX_get_security_level(3)</link>.
+     </simpara>
+     <simpara>
+      Available as of PHP 7.2.0 and OpenSSL 1.1.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>7.2.0</entry>
-       <entry>
-        Added <parameter>security_level</parameter>. Requires OpenSSL &gt;= 1.1.0.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>7.2.0</entry>
+      <entry>
+       Added <parameter>security_level</parameter>. Requires OpenSSL &gt;= 1.1.0.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="notes">
@@ -304,11 +300,9 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><xref linkend="context.socket" /></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><xref linkend="context.socket" /></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/openssl/functions/openssl-x509-verify.xml
+++ b/reference/openssl/functions/openssl-x509-verify.xml
@@ -97,7 +97,7 @@ $ssloptions = array(
     "CN_match" => $hostname,
     "verify_peer" => true,
     "SNI_enabled" => true,
-    "SNI_server_name" => $hostname,
+    "peer_name" => $hostname,
 );
  
 $ctx = stream_context_create( array("ssl" => $ssloptions) );


### PR DESCRIPTION
It is likely better to review commits one by one since it also migrates `para` to `simpara`.

Companion: https://github.com/php/doc-base/pull/279 (that's why test fail).

Fixes #5403 
Fixes #5402 
Fixes #5401