### PR TITLE
Add a warning about the subtle global state in legacy random functions

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -31,6 +31,19 @@ highly discouraged.</simpara></warning>'>
  </para>
 </caution>'>
 
+<!ENTITY caution.mt19937-global-state '<caution xmlns="http://docbook.org/ns/docbook">
+ <simpara>
+    This function uses the global Mt19937 (“Mersenne Twister”) instance as the source of randomness and thus shares its state with all other functions using the global Mt19937.
+    Using any of these functions advances the sequence for <emphasis>all</emphasis> the other functions, regardless of scope.
+  </simpara>
+  <simpara>
+    Generating repeatable sequences by seeding <function>mt_srand</function> or <function>srand</function> with a known value will also yield repeatable output from this function.
+  </simpara>
+  <simpara>
+    Prefer using <classname>Random\Randomizer</classname> methods in all newly written code.
+ </simpara>
+</caution>'>
+
 <!ENTITY caution.mt19937-tiny-seed '<caution xmlns="http://docbook.org/ns/docbook">
  <para>
   Because the Mt19937 (“Mersenne Twister”) engine accepts only a single 32 bit integer as the

--- a/reference/array/functions/array-rand.xml
+++ b/reference/array/functions/array-rand.xml
@@ -17,6 +17,7 @@
    key (or keys) of the random entries.
   </para>
   &caution.cryptographically-insecure;
+  &caution.mt19937-global-state;
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/array/functions/shuffle.xml
+++ b/reference/array/functions/shuffle.xml
@@ -15,6 +15,7 @@
    This function shuffles (randomizes the order of the elements in) an array.
   </para>
   &caution.cryptographically-insecure;
+  &caution.mt19937-global-state;
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/random/functions/mt-rand.xml
+++ b/reference/random/functions/mt-rand.xml
@@ -35,6 +35,7 @@
    15)</literal>.
   </simpara>
   &caution.cryptographically-insecure;
+  &caution.mt19937-global-state;
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/random/functions/rand.xml
+++ b/reference/random/functions/rand.xml
@@ -25,6 +25,7 @@
    15)</literal>.
   </simpara>
   &caution.cryptographically-insecure;
+  &caution.mt19937-global-state;
   <note>
    <simpara>
     Prior to PHP 7.1.0, <function>getrandmax</function> was only 32767 on some

--- a/reference/strings/functions/str-shuffle.xml
+++ b/reference/strings/functions/str-shuffle.xml
@@ -17,6 +17,7 @@
    of all possible is created.
   </simpara>
   &caution.cryptographically-insecure;
+  &caution.mt19937-global-state;
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Fixes https://github.com/php/php-src/issues/21351
Replaces https://github.com/php/php-src/pull/21352