### PR TITLE
Fix GH-1132: Document mb_strlen invalid encoding behavior change in P…

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1200,6 +1200,22 @@ encoding value will be used.</simpara>'>
  </entry>
 </row>'>
 
+<!ENTITY mbstring.errors.encoding-invalid '<para xmlns="http://docbook.org/ns/docbook">
+ As of PHP 8.0.0, a <exceptionname>ValueError</exceptionname> is thrown if
+ <parameter>encoding</parameter> is an invalid encoding.
+ Prior to PHP 8.0.0, an <constant>E_WARNING</constant> was emitted instead.
+</para>'>
+
+<!ENTITY mbstring.changelog.encoding-invalid '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.0.0</entry>
+ <entry>
+  Now throws a <exceptionname>ValueError</exceptionname> if
+  <parameter>encoding</parameter> is an invalid encoding.
+  Previously, an <constant>E_WARNING</constant> was emitted
+  and &false; was returned.
+ </entry>
+</row>'>
+
 <!-- mcrypt notes -->
 
 <!ENTITY mcrypt.parameter.cipher '<simpara xmlns="http://docbook.org/ns/docbook">One of the <constant>MCRYPT_ciphername</constant> constants, or the name of the algorithm as string.</simpara>'>

--- a/reference/mbstring/functions/mb-encoding-aliases.xml
+++ b/reference/mbstring/functions/mb-encoding-aliases.xml
@@ -40,10 +40,7 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
-   Throws a <classname>ValueError</classname> if
-   <parameter>encoding</parameter> is unknown.
-  </para>
+  &mbstring.errors.encoding-invalid;
  </refsect1>
 
  <refsect1 role="changelog">
@@ -57,14 +54,7 @@
      </row>
     </thead>
     <tbody>
-     <row>
-      <entry>8.0.0</entry>
-      <entry>
-       If the <parameter>encoding</parameter> is unknown, a <classname>ValueError</classname>
-       is now thrown; previously an <constant>E_WARNING</constant> was emitted,
-       and the function returned &false;.
-      </entry>
-     </row>
+     &mbstring.changelog.encoding-invalid;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/mbstring/functions/mb-internal-encoding.xml
+++ b/reference/mbstring/functions/mb-internal-encoding.xml
@@ -50,11 +50,7 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
-   As of PHP 8.0.0, a <classname>ValueError</classname> is thrown if the
-   value of <parameter>encoding</parameter> is an invalid encoding.
-   Prior to PHP 8.0.0, a <constant>E_WARNING</constant> was emitted instead.
-  </para>
+  &mbstring.errors.encoding-invalid;
  </refsect1>
 
  <refsect1 role="changelog">
@@ -69,14 +65,7 @@
     </thead>
     <tbody>
      &mbstring.changelog.encoding-nullable;
-     <row>
-      <entry>8.0.0</entry>
-      <entry>
-       Now throws a <classname>ValueError</classname> if
-       <parameter>encoding</parameter> is an invalid encoding.
-       Previously a <constant>E_WARNING</constant> was emitted instead.
-      </entry>
-     </row>
+     &mbstring.changelog.encoding-invalid;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/mbstring/functions/mb-strlen.xml
+++ b/reference/mbstring/functions/mb-strlen.xml
@@ -70,6 +70,14 @@
     </thead>
     <tbody>
      &mbstring.changelog.encoding-nullable;
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       Passing an invalid encoding now throws a
+       <classname>ValueError</classname>. Previously, the return value was
+       undefined (could return &false;).
+      </entry>
+     </row>
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/mbstring/functions/mb-strlen.xml
+++ b/reference/mbstring/functions/mb-strlen.xml
@@ -74,8 +74,8 @@
       <entry>8.0.0</entry>
       <entry>
        Passing an invalid encoding now throws a
-       <classname>ValueError</classname>. Previously, the return value was
-       undefined (could return &false;).
+       <exceptionname>ValueError</exceptionname>. Previously, &false; was
+       returned.
       </entry>
      </row>
     </tbody>

--- a/reference/mbstring/functions/mb-strlen.xml
+++ b/reference/mbstring/functions/mb-strlen.xml
@@ -52,10 +52,7 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
-   If the encoding is unknown, an error of level
-   <constant>E_WARNING</constant> is generated.
-  </para>
+  &mbstring.errors.encoding-invalid;
  </refsect1>
 
  <refsect1 role="changelog">
@@ -70,6 +67,7 @@
     </thead>
     <tbody>
      &mbstring.changelog.encoding-nullable;
+     &mbstring.changelog.encoding-invalid;
     </tbody>
    </tgroup>
   </informaltable>


### PR DESCRIPTION
Fixes #1132

Documents that passing an invalid encoding to `mb_strlen()` had undefined behavior before PHP 8.0 (could return `false`) and that as of PHP 8.0 a `ValueError` is thrown instead, as suggested in the issue discussion.