### PR TITLE
Document PHP 8.5.0 ini directive deprecations and removals

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -60,7 +60,7 @@
         <entry><link linkend="ini.disable-classes">disable_classes</link></entry>
         <entry>""</entry>
         <entry>&php.ini; only</entry>
-        <entry></entry>
+        <entry>Removed as of PHP 8.5.0</entry>
        </row>
        <row>
         <entry><link linkend="ini.exit-on-timeout">exit_on_timeout</link></entry>
@@ -235,15 +235,15 @@
        <type>string</type>
       </term>
       <listitem>
-       <para>
+       <simpara>
         This directive allows certain classes to be disabled.
         It takes a comma-delimited list of class names.
         Disabling a class just prevents the class's instantiation.
-       </para>
-       <para>
+       </simpara>
+       <simpara>
         Only internal classes can be disabled using this directive.
         User-defined classes are unaffected.
-       </para>
+       </simpara>
        <simpara>
         This directive must be set in &php.ini;.
         It cannot be set in &httpd.conf;.
@@ -252,6 +252,11 @@
         <simpara>
          This directive can be circumvented and should not be considered a
          sufficient security measure for shared hosting environments.
+        </simpara>
+       </warning>
+       <warning>
+        <simpara>
+         This directive has been <emphasis>REMOVED</emphasis> as of PHP 8.5.0.
         </simpara>
        </warning>
       </listitem>
@@ -599,7 +604,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         <entry><link linkend="ini.register-argc-argv">register_argc_argv</link></entry>
         <entry>"1"</entry>
         <entry><constant>INI_PERDIR</constant></entry>
-        <entry></entry>
+        <entry>Deprecated as of PHP 8.5.0 and will be removed in the future</entry>
        </row>
        <row>
         <entry><link linkend="ini.enable-post-data-reading">enable_post_data_reading</link></entry>
@@ -789,6 +794,14 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        <simpara>
         See also <link linkend="features.commandline">command line</link>.
        </simpara>
+       <warning>
+        <simpara>
+         This directive has been <emphasis>DEPRECATED</emphasis> as of PHP 8.5.0 and will be removed in the future.
+         Configure <literal>register_argc_argv=0</literal> and switch to either <varname>$_GET</varname>
+         or <varname>$_SERVER['QUERY_STRING']</varname> to access the information,
+         after verifying that the usage is safe.
+        </simpara>
+       </warning>
       </listitem>
      </varlistentry>
      

--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -254,11 +254,7 @@
          sufficient security measure for shared hosting environments.
         </simpara>
        </warning>
-       <warning>
-        <simpara>
-         This directive has been <emphasis>REMOVED</emphasis> as of PHP 8.5.0.
-        </simpara>
-       </warning>
+       &warn.removed.feature-8-5-0;
       </listitem>
      </varlistentry>
 
@@ -794,14 +790,14 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        <simpara>
         See also <link linkend="features.commandline">command line</link>.
        </simpara>
-       <warning>
+       &warn.deprecated.feature-8-5-0;
+       <note>
         <simpara>
-         This directive has been <emphasis>DEPRECATED</emphasis> as of PHP 8.5.0 and will be removed in the future.
          Configure <literal>register_argc_argv=0</literal> and switch to either <varname>$_GET</varname>
          or <varname>$_SERVER['QUERY_STRING']</varname> to access the information,
          after verifying that the usage is safe.
         </simpara>
-       </warning>
+       </note>
       </listitem>
      </varlistentry>
      

--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -600,7 +600,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         <entry><link linkend="ini.register-argc-argv">register_argc_argv</link></entry>
         <entry>"1"</entry>
         <entry><constant>INI_PERDIR</constant></entry>
-        <entry>Deprecated as of PHP 8.5.0 and will be removed in the future</entry>
+        <entry>Deprecated as of PHP 8.5.0</entry>
        </row>
        <row>
         <entry><link linkend="ini.enable-post-data-reading">enable_post_data_reading</link></entry>

--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -793,9 +793,11 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        &warn.deprecated.feature-8-5-0;
        <note>
         <simpara>
-         Configure <literal>register_argc_argv=0</literal> and switch to either <varname>$_GET</varname>
-         or <varname>$_SERVER['QUERY_STRING']</varname> to access the information,
-         after verifying that the usage is safe.
+         Deriving <code>$_SERVER['argc']</code> and <code>$_SERVER['argv']</code>
+         from the query string for non-CLI SAPIs has been deprecated.
+         Configure <literal>register_argc_argv=0</literal> and switch to either
+         <varname>$_GET</varname> or <code>$_SERVER['QUERY_STRING']</code>
+         to access the information, after verifying that the usage is safe.
         </simpara>
        </note>
       </listitem>

--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -207,7 +207,7 @@
        <entry><link linkend="ini.disable-classes">disable_classes</link></entry>
        <entry><literal>""</literal></entry>
        <entry>&php.ini; only</entry>
-       <entry></entry>
+       <entry>Removed as of PHP 8.5.0</entry>
       </row>
       <row>
        <entry><link linkend="ini.disable-functions">disable_functions</link></entry>
@@ -551,13 +551,13 @@
        <entry><link linkend="ini.register-argc-argv">register_argc_argv</link></entry>
        <entry><literal>"1"</literal></entry>
        <entry><constant>INI_PERDIR</constant></entry>
-       <entry></entry>
+       <entry>Deprecated as of PHP 8.5.0 and will be removed in the future</entry>
       </row>
       <row>
        <entry><link linkend="ini.report-memleaks">report_memleaks</link></entry>
        <entry><literal>"1"</literal></entry>
        <entry><constant>INI_ALL</constant></entry>
-       <entry></entry>
+       <entry>Deprecated as of PHP 8.5.0 and will be removed in the future</entry>
       </row>
       <row>
        <entry>report_zend_debug</entry>

--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -551,13 +551,13 @@
        <entry><link linkend="ini.register-argc-argv">register_argc_argv</link></entry>
        <entry><literal>"1"</literal></entry>
        <entry><constant>INI_PERDIR</constant></entry>
-       <entry>Deprecated as of PHP 8.5.0 and will be removed in the future</entry>
+       <entry>Deprecated as of PHP 8.5.0</entry>
       </row>
       <row>
        <entry><link linkend="ini.report-memleaks">report_memleaks</link></entry>
        <entry><literal>"1"</literal></entry>
        <entry><constant>INI_ALL</constant></entry>
-       <entry>Deprecated as of PHP 8.5.0 and will be removed in the future</entry>
+       <entry>Deprecated as of PHP 8.5.0</entry>
       </row>
       <row>
        <entry>report_zend_debug</entry>

--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -203,6 +203,11 @@ if (php_sapi_name() === 'cli') {
             </informalexample>
            </para>
           </warning>
+          <warning>
+           <simpara>
+            This directive has been <emphasis>DEPRECATED</emphasis> as of PHP 8.5.0 and will be removed in the future.
+           </simpara>
+          </warning>
           </entry>
          </row>
          <row>

--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -203,11 +203,7 @@ if (php_sapi_name() === 'cli') {
             </informalexample>
            </para>
           </warning>
-          <warning>
-           <simpara>
-            This feature has been <emphasis>DEPRECATED</emphasis> as of PHP 8.5.0.
-           </simpara>
-          </warning>
+          &warn.deprecated.feature-8-5-0;
           </entry>
          </row>
          <row>

--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -205,7 +205,7 @@ if (php_sapi_name() === 'cli') {
           </warning>
           <warning>
            <simpara>
-            This directive has been <emphasis>DEPRECATED</emphasis> as of PHP 8.5.0 and will be removed in the future.
+            This feature has been <emphasis>DEPRECATED</emphasis> as of PHP 8.5.0.
            </simpara>
           </warning>
           </entry>

--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -1027,8 +1027,7 @@ php_admin_value[memory_limit] = 32M
      PHP settings passed with <literal>php_value</literal> or
      <literal>php_flag</literal> will overwrite their previous value.
      Please note that defining
-     <link linkend="ini.disable-functions">disable_functions</link> or
-     <link linkend="ini.disable-classes">disable_classes</link> will
+     <link linkend="ini.disable-functions">disable_functions</link> will
      not overwrite previously defined <filename>php.ini</filename> values,
      but will append the new value instead.
     </para>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -462,6 +462,10 @@ xmlns="http://docbook.org/ns/docbook"><simpara>This function was
 <!ENTITY warn.removed.alias-8-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>This alias is
 <emphasis>REMOVED</emphasis> as of PHP 8.0.0.</simpara></warning>'>
 
+<!ENTITY warn.removed.feature-8-5-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara>This feature has been
+<emphasis>REMOVED</emphasis> as of PHP 8.5.0.</simpara></warning>'>
+
 <!ENTITY warn.experimental.func '<warning xmlns="http://docbook.org/ns/docbook"><simpara>This function is
 <emphasis>EXPERIMENTAL</emphasis>. The behaviour of this function, its name, and
 surrounding documentation may change without notice in a future release of PHP.

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -328,11 +328,7 @@
       error_reporting includes <constant>E_WARNING</constant> in the allowed
       list.
      </simpara>
-     <warning>
-      <simpara>
-       This feature has been <emphasis>DEPRECATED</emphasis> as of PHP 8.5.0.
-      </simpara>
-     </warning>
+     &warn.deprecated.feature-8-5-0;
     </listitem>
    </varlistentry>
 

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -64,7 +64,7 @@
      <entry><link linkend="ini.report-memleaks">report_memleaks</link></entry>
      <entry>"1"</entry>
      <entry><constant>INI_ALL</constant></entry>
-     <entry></entry>
+     <entry>Deprecated as of PHP 8.5.0 and will be removed in the future</entry>
     </row>
     <row>
      <entry><link linkend="ini.track-errors">track_errors</link></entry>
@@ -318,7 +318,7 @@
      <type>bool</type>
     </term>
     <listitem>
-     <para>
+     <simpara>
       If this parameter is set to On (the default), this parameter will show a
       report of memory leaks detected by the Zend memory manager. This report
       will be sent to stderr on Posix platforms. On Windows, it will be sent
@@ -327,7 +327,12 @@
       This parameter only has effect in a debug build and if
       error_reporting includes <constant>E_WARNING</constant> in the allowed
       list.
-     </para>
+     </simpara>
+     <warning>
+      <simpara>
+       This directive has been <emphasis>DEPRECATED</emphasis> as of PHP 8.5.0 and will be removed in the future.
+      </simpara>
+     </warning>
     </listitem>
    </varlistentry>
 

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -64,7 +64,7 @@
      <entry><link linkend="ini.report-memleaks">report_memleaks</link></entry>
      <entry>"1"</entry>
      <entry><constant>INI_ALL</constant></entry>
-     <entry>Deprecated as of PHP 8.5.0 and will be removed in the future</entry>
+     <entry>Deprecated as of PHP 8.5.0</entry>
     </row>
     <row>
      <entry><link linkend="ini.track-errors">track_errors</link></entry>
@@ -330,7 +330,7 @@
      </simpara>
      <warning>
       <simpara>
-       This directive has been <emphasis>DEPRECATED</emphasis> as of PHP 8.5.0 and will be removed in the future.
+       This feature has been <emphasis>DEPRECATED</emphasis> as of PHP 8.5.0.
       </simpara>
      </warning>
     </listitem>


### PR DESCRIPTION
The report_memleaks INI directive has been deprecated. 
RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_report_memleaks_ini_directive

The disable_classes INI setting has been removed as it causes various engine assumptions to be broken. 
RFC: https://wiki.php.net/rfc/deprecations_php_8_5#remove_disable_classes_ini_setting

Deriving $_SERVER['argc'] and $_SERVER['argv'] from the query string for non-CLI SAPIs has been deprecated. Configure register_argc_argv=0 and switch to either $_GET or $_SERVER['QUERY_STRING'] to access the information, after verifying that the usage is safe. 
RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_register_argc_argv_ini_directive