### PR TITLE
openssl_sign()'s new $padding parameter needs to be OPENSSL_PKCS1_PSS_PADDING for PSS padding to work

### DIFF
--- a/reference/openssl/functions/openssl-sign.xml
+++ b/reference/openssl/functions/openssl-sign.xml
@@ -71,7 +71,10 @@
     <varlistentry>
      <term><parameter>padding</parameter></term>
      <listitem>
-      <simpara>RSA PSS padding to use.</simpara>
+      <para>
+       <parameter>padding</parameter> only supports one option:
+       <constant>OPENSSL_PKCS1_PSS_PADDING</constant>.
+      </para>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Per https://www.php.net/manual/en/function.openssl-sign.php PHP 8.5.0 saw the addition of a new parameter to `openssl_sign()` - `$padding`. The documentation says, simply, "_RSA PSS padding to use_". From that one might think simply setting `$padding` to 1 would be sufficient but it isn't - it needs to be `OPENSSL_PKCS1_PSS_PADDING` for PSS signatures to work.

That said, `OPENSSL_PKCS1_PSS_PADDING` does not appear to be mentioned anywhere else. https://www.php.net/manual/en/openssl.padding.php doesn't seem appropriate because that's "Padding flags for asymmetric encryption". For that I suppose there are two things that could be done. Either that could be renamed "Padding flags" or a whole new page - "Padding flags for signatures" - could be created. I suppose a third option would be to add `OPENSSL_PKCS1_PSS_PADDING` to https://www.php.net/manual/en/openssl.constants.other.php . That page already has `OPENSSL_ZERO_PADDING` after all... 