### PR TITLE
Fix PGSQL_TRACE_SUPPRESS_TIMESTAMPS version: 8.3.0 → 8.4.20

### DIFF
--- a/reference/pgsql/constants.xml
+++ b/reference/pgsql/constants.xml
@@ -951,7 +951,7 @@
     <simpara>
      To be used with <function>pg_trace</function>,
      the timestamp is not included in the trace's messages.
-     Available as of PHP 8.3.0.
+     Available as of PHP 8.4.20.
     </simpara>
    </listitem>
    </varlistentry>


### PR DESCRIPTION
Due to a preprocessor guard typo in pgsql.stub.php (`PQTRACE_SUPPPRESS_TIMESTAMPS` — triple P), this constant was never registered. Fixed in php-src and will be available from PHP 8.4.20.

php-src fix: https://github.com/php/php-src/pull/21386

For patch-version notation precedent, see MYSQLI_REFRESH_REPLICA (Available as of PHP 8.1.2, doc-en PR #1006).