### PR TITLE
Fix typo: RFC 3399 -> RFC 3339 in DateTimeInterface::ATOM

### DIFF
--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -158,7 +158,7 @@
      <term><constant>DATE_ATOM</constant></term>
      <listitem>
       <simpara>
-       Atom (example: 2005-08-15T15:52:01+00:00); compatible with ISO-8601, RFC 3399, and XML Schema
+       Atom (example: 2005-08-15T15:52:01+00:00); compatible with ISO-8601, RFC 3339, and XML Schema
       </simpara>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
The `DATE_ATOM` constant description incorrectly references "RFC 3399" instead of "RFC 3339" (Date and Time on the Internet: Timestamps).