### PR TITLE
Move __sleep()/__wakeup() after __serialize()/unserialize()

### DIFF
--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -170,7 +170,7 @@ class Connection
    <link linkend="object.sleep">__sleep()</link> and
    <link linkend="object.wakeup">__wakeup()</link>
   </title>
-  
+
   <warning>
    <simpara>
     This serialization mechanism is soft-deprecated as of PHP 8.5.0.
@@ -239,7 +239,7 @@ class Connection
 {
     protected $link;
     private $dsn, $username, $password;
-    
+
     public function __construct($dsn, $username, $password)
     {
         $this->dsn = $dsn;
@@ -247,17 +247,17 @@ class Connection
         $this->password = $password;
         $this->connect();
     }
-    
+
     private function connect()
     {
         $this->link = new PDO($this->dsn, $this->username, $this->password);
     }
-    
+
     public function __sleep()
     {
         return array('dsn', 'username', 'password');
     }
-    
+
     public function __wakeup()
     {
         $this->connect();


### PR DESCRIPTION
This is part of https://wiki.php.net/rfc/soft-deprecate-sleep-wakeup