### PR TITLE
stream_select: Fix explanation of the microseconds behavior

### DIFF
--- a/reference/stream/functions/stream-select.xml
+++ b/reference/stream/functions/stream-select.xml
@@ -77,7 +77,7 @@
        The <parameter>timeout</parameter> is an upper bound on the amount of time
        that <function>stream_select</function> will wait before it returns.
        If <parameter>seconds</parameter> is set to <literal>0</literal> and
-       <parameter>microseconds</parameter> is omitted, <literal>0</literal>, or &null;,
+       <parameter>microseconds</parameter> is <literal>0</literal> or &null;,
        <function>stream_select</function> will not wait for data - instead it will return immediately,
        indicating the current status of the streams.
       </para>


### PR DESCRIPTION
it can be 0 or null or unspecified without blocking.