### PR TITLE
Remove description about preg `e` modifier

### DIFF
--- a/reference/pcre/functions/preg-replace.xml
+++ b/reference/pcre/functions/preg-replace.xml
@@ -85,16 +85,6 @@
        <literal>$1</literal> backreference, leaving the <literal>1</literal>
        as a literal.
       </para>
-      <para>
-       When using the deprecated <literal>e</literal> modifier, this function escapes
-       some characters (namely <literal>'</literal>, <literal>"</literal>,
-       <literal>\</literal> and NULL) in the strings that replace the
-       backreferences. This is done to ensure that no syntax errors arise
-       from backreference usage with either single or double quotes (e.g.
-       <literal>'strlen(\'$1\')+strlen("$2")'</literal>). Make sure you are
-       aware of PHP's <link linkend="language.types.string">string
-       syntax</link> to know exactly how the interpreted string will look.
-      </para>
      </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
`e` modifier was removed in PHP 7.0.
It has already been removed from `pattern.modifiers.xml`: bcb7074498301e4712576a18849821f99f0fbaea