### PR TITLE
Document each global ext/dom constant on its own row

### DIFF
--- a/reference/dom/constants.xml
+++ b/reference/dom/constants.xml
@@ -251,7 +251,7 @@
      </row>
     </thead>
     <tbody>
-     <row xml:id="constant.dom-html-no-default-ns">
+     <row xml:id="constant.-dom-html-no-default-ns">
       <entry>
        <constant>Dom\HTML_NO_DEFAULT_NS</constant>
        (<type>int</type>)
@@ -287,7 +287,7 @@
      </row>
     </thead>
     <tbody>
-     <row xml:id="constant.dom-php-err">
+     <row xml:id="constant.-dom-php-err">
       <entry>
        <constant>DOM_PHP_ERR</constant>
        (<type>int</type>)
@@ -300,9 +300,19 @@
        out-of-memory situations.
       </entry>
      </row>
+     <row xml:id="constant.-dom-index-size-err">
+      <entry>
+       <constant>DOM_INDEX_SIZE_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>1</entry>
+      <entry>
+       If index or size is negative, or greater than the allowed value.
+      </entry>
+     </row>
      <row xml:id="constant.dom-index-size-err">
       <entry>
-       <constant>DOM_INDEX_SIZE_ERR</constant> / <constant>Dom\INDEX_SIZE_ERR</constant>
+       <constant>Dom\INDEX_SIZE_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>1</entry>
@@ -312,7 +322,7 @@
      </row>
      <row xml:id="constant.domstring-size-err">
       <entry>
-       <constant>DOMSTRING_SIZE_ERR</constant> / <constant>Dom\STRING_SIZE_ERR</constant>
+       <constant>DOMSTRING_SIZE_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>2</entry>
@@ -321,17 +331,36 @@
        <type>string</type>.
       </entry>
      </row>
-     <row xml:id="constant.dom-hierarchy-request-err">
+     <row xml:id="constant.-dom-string-size-err">
       <entry>
-       <constant>DOM_HIERARCHY_REQUEST_ERR</constant> / <constant>Dom\HIERARCHY_REQUEST_ERR</constant>
+       <constant>Dom\STRING_SIZE_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>2</entry>
+      <entry>
+       If the specified range of text does not fit into a
+       <type>string</type>.
+      </entry>
+     </row>
+     <row xml:id="constant.-dom-hierarchy-request-err">
+      <entry>
+       <constant>DOM_HIERARCHY_REQUEST_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>3</entry>
       <entry>If any node is inserted somewhere it doesn't belong</entry>
      </row>
-     <row xml:id="constant.dom-wrong-document-err">
+     <row xml:id="constant.dom-hierarchy-request-err">
       <entry>
-       <constant>DOM_WRONG_DOCUMENT_ERR</constant> / <constant>Dom\WRONG_DOCUMENT_ERR</constant>
+       <constant>Dom\HIERARCHY_REQUEST_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>3</entry>
+      <entry>If any node is inserted somewhere it doesn't belong</entry>
+     </row>
+     <row xml:id="constant.-dom-wrong-document-err">
+      <entry>
+       <constant>DOM_WRONG_DOCUMENT_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>4</entry>
@@ -339,9 +368,19 @@
        If a node is used in a different document than the one that created it.
       </entry>
      </row>
-     <row xml:id="constant.dom-invalid-character-err">
+     <row xml:id="constant.dom-wrong-document-err">
       <entry>
-       <constant>DOM_INVALID_CHARACTER_ERR</constant> / <constant>Dom\INVALID_CHARACTER_ERR</constant>
+       <constant>Dom\WRONG_DOCUMENT_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>4</entry>
+      <entry>
+       If a node is used in a different document than the one that created it.
+      </entry>
+     </row>
+     <row xml:id="constant.-dom-invalid-character-err">
+      <entry>
+       <constant>DOM_INVALID_CHARACTER_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>5</entry>
@@ -349,9 +388,19 @@
        If an invalid or illegal character is specified, such as in a name.
       </entry>
      </row>
-     <row xml:id="constant.dom-no-data-allowed-err">
+     <row xml:id="constant.dom-invalid-character-err">
       <entry>
-       <constant>DOM_NO_DATA_ALLOWED_ERR</constant> / <constant>Dom\NO_DATA_ALLOWED_ERR</constant>
+       <constant>Dom\INVALID_CHARACTER_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>5</entry>
+      <entry>
+       If an invalid or illegal character is specified, such as in a name.
+      </entry>
+     </row>
+     <row xml:id="constant.-dom-no-data-allowed-err">
+      <entry>
+       <constant>DOM_NO_DATA_ALLOWED_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>6</entry>
@@ -359,9 +408,19 @@
        If data is specified for a node which does not support data.
       </entry>
      </row>
-     <row xml:id="constant.dom-no-modification-allowed-err">
+     <row xml:id="constant.dom-no-data-allowed-err">
       <entry>
-       <constant>DOM_NO_MODIFICATION_ALLOWED_ERR</constant> / <constant>Dom\NO_MODIFICATION_ALLOWED_ERR</constant>
+       <constant>Dom\NO_DATA_ALLOWED_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>6</entry>
+      <entry>
+       If data is specified for a node which does not support data.
+      </entry>
+     </row>
+     <row xml:id="constant.-dom-no-modification-allowed-err">
+      <entry>
+       <constant>DOM_NO_MODIFICATION_ALLOWED_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>7</entry>
@@ -369,9 +428,19 @@
        If an attempt is made to modify an object where modifications are not allowed.
       </entry>
      </row>
-     <row xml:id="constant.dom-not-found-err">
+     <row xml:id="constant.dom-no-modification-allowed-err">
       <entry>
-       <constant>DOM_NOT_FOUND_ERR</constant> / <constant>Dom\NOT_FOUND_ERR</constant>
+       <constant>Dom\NO_MODIFICATION_ALLOWED_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>7</entry>
+      <entry>
+       If an attempt is made to modify an object where modifications are not allowed.
+      </entry>
+     </row>
+     <row xml:id="constant.-dom-not-found-err">
+      <entry>
+       <constant>DOM_NOT_FOUND_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>8</entry>
@@ -379,9 +448,19 @@
        If an attempt is made to reference a node in a context where it does not exist.
       </entry>
      </row>
-     <row xml:id="constant.dom-not-supported-err">
+     <row xml:id="constant.dom-not-found-err">
       <entry>
-       <constant>DOM_NOT_SUPPORTED_ERR</constant> / <constant>Dom\NOT_SUPPORTED_ERR</constant>
+       <constant>Dom\NOT_FOUND_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>8</entry>
+      <entry>
+       If an attempt is made to reference a node in a context where it does not exist.
+      </entry>
+     </row>
+     <row xml:id="constant.-dom-not-supported-err">
+      <entry>
+       <constant>DOM_NOT_SUPPORTED_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>9</entry>
@@ -389,9 +468,19 @@
        If the implementation does not support the requested type of object or operation.
       </entry>
      </row>
-     <row xml:id="constant.dom-inuse-attribute-err">
+     <row xml:id="constant.dom-not-supported-err">
       <entry>
-       <constant>DOM_INUSE_ATTRIBUTE_ERR</constant> / <constant>Dom\INUSE_ATTRIBUTE_ERR</constant>
+       <constant>Dom\NOT_SUPPORTED_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>9</entry>
+      <entry>
+       If the implementation does not support the requested type of object or operation.
+      </entry>
+     </row>
+     <row xml:id="constant.-dom-inuse-attribute-err">
+      <entry>
+       <constant>DOM_INUSE_ATTRIBUTE_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>10</entry>
@@ -399,9 +488,19 @@
        If an attempt is made to add an attribute that is already in use elsewhere.
       </entry>
      </row>
-     <row xml:id="constant.dom-invalid-state-err">
+     <row xml:id="constant.dom-inuse-attribute-err">
       <entry>
-       <constant>DOM_INVALID_STATE_ERR</constant> / <constant>Dom\INVALID_STATE_ERR</constant>
+       <constant>Dom\INUSE_ATTRIBUTE_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>10</entry>
+      <entry>
+       If an attempt is made to add an attribute that is already in use elsewhere.
+      </entry>
+     </row>
+     <row xml:id="constant.-dom-invalid-state-err">
+      <entry>
+       <constant>DOM_INVALID_STATE_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>11</entry>
@@ -409,25 +508,51 @@
        If an attempt is made to use an object that is not, or is no longer, usable.
       </entry>
      </row>
-     <row xml:id="constant.dom-syntax-err">
+     <row xml:id="constant.dom-invalid-state-err">
       <entry>
-       <constant>DOM_SYNTAX_ERR</constant> / <constant>Dom\SYNTAX_ERR</constant>
+       <constant>Dom\INVALID_STATE_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>11</entry>
+      <entry>
+       If an attempt is made to use an object that is not, or is no longer, usable.
+      </entry>
+     </row>
+     <row xml:id="constant.-dom-syntax-err">
+      <entry>
+       <constant>DOM_SYNTAX_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>12</entry>
       <entry>If an invalid or illegal string is specified.</entry>
      </row>
-     <row xml:id="constant.dom-invalid-modification-err">
+     <row xml:id="constant.dom-syntax-err">
       <entry>
-       <constant>DOM_INVALID_MODIFICATION_ERR</constant> / <constant>Dom\INVALID_MODIFICATION_ERR</constant>
+       <constant>Dom\SYNTAX_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>12</entry>
+      <entry>If an invalid or illegal string is specified.</entry>
+     </row>
+     <row xml:id="constant.-dom-invalid-modification-err">
+      <entry>
+       <constant>DOM_INVALID_MODIFICATION_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>13</entry>
       <entry>If an attempt is made to modify the type of the underlying object.</entry>
      </row>
-     <row xml:id="constant.dom-namespace-err">
+     <row xml:id="constant.dom-invalid-modification-err">
       <entry>
-       <constant>DOM_NAMESPACE_ERR</constant> / <constant>Dom\NAMESPACE_ERR</constant>
+       <constant>Dom\INVALID_MODIFICATION_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>13</entry>
+      <entry>If an attempt is made to modify the type of the underlying object.</entry>
+     </row>
+     <row xml:id="constant.-dom-namespace-err">
+      <entry>
+       <constant>DOM_NAMESPACE_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>14</entry>
@@ -436,9 +561,20 @@
        incorrect with regard to namespaces.
       </entry>
      </row>
-     <row xml:id="constant.dom-invalid-access-err">
+     <row xml:id="constant.dom-namespace-err">
       <entry>
-       <constant>DOM_INVALID_ACCESS_ERR</constant> / <constant>Dom\INVALID_ACCESS_ERR</constant>
+       <constant>Dom\NAMESPACE_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>14</entry>
+      <entry>
+       If an attempt is made to create or change an object in a way which is
+       incorrect with regard to namespaces.
+      </entry>
+     </row>
+     <row xml:id="constant.-dom-invalid-access-err">
+      <entry>
+       <constant>DOM_INVALID_ACCESS_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>15</entry>
@@ -446,9 +582,32 @@
        If a parameter or an operation is not supported by the underlying object.
       </entry>
      </row>
+     <row xml:id="constant.dom-invalid-access-err">
+      <entry>
+       <constant>Dom\INVALID_ACCESS_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>15</entry>
+      <entry>
+       If a parameter or an operation is not supported by the underlying object.
+      </entry>
+     </row>
+     <row xml:id="constant.-dom-validation-err">
+      <entry>
+       <constant>DOM_VALIDATION_ERR</constant>
+       (<type>int</type>)
+      </entry>
+      <entry>16</entry>
+      <entry>
+       If a call to a method such as insertBefore or removeChild would make the Node
+       invalid with respect to "partial validity", this exception would be raised and
+       the operation would not be done.
+      </entry>
+     </row>
+
      <row xml:id="constant.dom-validation-err">
       <entry>
-       <constant>DOM_VALIDATION_ERR</constant> / <constant>Dom\VALIDATION_ERR</constant>
+       <constant>Dom\VALIDATION_ERR</constant>
        (<type>int</type>)
       </entry>
       <entry>16</entry>


### PR DESCRIPTION
Before these changes, the `gen_stub.php --verify-manual` command used to fail with an exception due to ext/DOM constants being wrongly formatted: the old and new constant counterparts were documented in the same row (e.g. `DOM_VALIDATION_ERR` / `Dom\VALIDATION_ERR`) which format cannot be recognized by gen_stub.php. Instead, let's document each constant on its own row.

Related to https://github.com/php/php-src/pull/21484