### PR TITLE
PHP 8.5 | Migration guide: sort constants sections alphabetically

### DIFF
--- a/appendices/migration85/constants.xml
+++ b/appendices/migration85/constants.xml
@@ -144,6 +144,17 @@
   </simplelist>
  </sect2>
 
+ <sect2 xml:id="migration85.constants.standard">
+  <title>Standard</title>
+
+  <simplelist>
+   <member>
+    <constant>IMAGETYPE_SVG</constant>
+    when libxml is loaded.
+   </member>
+  </simplelist>
+ </sect2>
+
  <sect2 xml:id="migration85.constants.tokenizer">
   <title>Tokenizer</title>
   <simplelist>
@@ -152,17 +163,6 @@
    </member>
    <member>
     <constant>T_PIPE</constant>
-   </member>
-  </simplelist>
- </sect2>
-
- <sect2 xml:id="migration85.constants.standard">
-  <title>Standard</title>
-
-  <simplelist>
-   <member>
-    <constant>IMAGETYPE_SVG</constant>
-    when libxml is loaded.
    </member>
   </simplelist>
  </sect2>


### PR DESCRIPTION
Sort the sections in the PHP 8.5 migration guide constants page alphabetically. The Standard section was incorrectly placed after Tokenizer instead of before it.

Refs:
* #5043