### PR TITLE
Correctly format predefined constant pages

### DIFF
--- a/appendices/reserved.constants.core.xml
+++ b/appendices/reserved.constants.core.xml
@@ -649,7 +649,7 @@
    <listitem>
     <simpara>
      A Windows
-     <keycombo action='simul'>
+     <keycombo action="simul">
       <keycap>CTRL</keycap>
       <keycap>C</keycap>
      </keycombo>
@@ -666,7 +666,7 @@
    <listitem>
     <simpara>
      A Windows
-     <keycombo action='simul'>
+     <keycombo action="simul">
       <keycap>CTRL</keycap>
       <keycap>BREAK</keycap>
      </keycombo>

--- a/appendices/tokens.xml
+++ b/appendices/tokens.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
 <appendix xml:id="tokens" xmlns="http://docbook.org/ns/docbook">
  <title>List of Parser Tokens</title>
  <para>
@@ -52,124 +51,189 @@ defined('T_FN') || define('T_FN', 10001);
    </thead>
    <tbody>
     <row xml:id="constant.t-abstract">
-     <entry><constant>T_ABSTRACT</constant></entry>
+     <entry>
+      <constant>T_ABSTRACT</constant>
+      (<type>int</type>)
+     </entry>
      <entry>abstract</entry>
      <entry><xref linkend="language.oop5.abstract"/></entry>
     </row>
     <row xml:id="constant.t-ampersand-followed-by-var-or-vararg">
-     <entry><constant>T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG</constant></entry>
+     <entry>
+      <constant>T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG</constant>
+      (<type>int</type>)
+     </entry>
      <entry>&amp;</entry>
      <entry><xref linkend="language.types.declarations"/> (available as of PHP 8.1.0)</entry>
     </row>
     <row xml:id="constant.t-ampersand-not-followed-by-var-or-vararg">
-     <entry><constant>T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG</constant></entry>
+     <entry>
+      <constant>T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG</constant>
+      (<type>int</type>)
+     </entry>
      <entry>&amp;</entry>
      <entry><xref linkend="language.types.declarations"/> (available as of PHP 8.1.0)</entry>
     </row>
     <row xml:id="constant.t-and-equal">
-     <entry><constant>T_AND_EQUAL</constant></entry>
+     <entry>
+      <constant>T_AND_EQUAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>&amp;=</entry>
      <entry><link linkend="language.operators.assignment">assignment
      operators</link></entry>
     </row>
     <row xml:id="constant.t-array">
-     <entry><constant>T_ARRAY</constant></entry>
+     <entry>
+      <constant>T_ARRAY</constant>
+      (<type>int</type>)
+     </entry>
      <entry>array()</entry>
-     <entry><function>array</function>, <link
-     linkend="language.types.array.syntax">array syntax</link></entry>
+     <entry><function>array</function>, <link linkend="language.types.array.syntax">array syntax</link></entry>
     </row>
     <row xml:id="constant.t-array-cast">
-     <entry><constant>T_ARRAY_CAST</constant></entry>
+     <entry>
+      <constant>T_ARRAY_CAST</constant>
+      (<type>int</type>)
+     </entry>
      <entry>(array)</entry>
      <entry><link linkend="language.types.typecasting">type-casting</link></entry>
     </row>
     <row xml:id="constant.t-as">
-     <entry><constant>T_AS</constant></entry>
+     <entry>
+      <constant>T_AS</constant>
+      (<type>int</type>)
+     </entry>
      <entry>as</entry>
      <entry>&foreach;</entry>
     </row>
     <row xml:id="constant.t-attribute">
-     <entry><constant>T_ATTRIBUTE</constant></entry>
+     <entry>
+      <constant>T_ATTRIBUTE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>#[</entry>
      <entry><link linkend="language.attributes">attributes</link> (available as of PHP 8.0.0)</entry>
     </row>
     <row xml:id="constant.t-bad-character">
-     <entry><constant>T_BAD_CHARACTER</constant></entry>
-     <entry></entry>
+     <entry>
+      <constant>T_BAD_CHARACTER</constant>
+      (<type>int</type>)
+     </entry>
+     <entry/>
      <entry>
       anything below ASCII 32 except \t (0x09), \n (0x0a) and \r (0x0d)
       (available as of PHP 7.4.0)
      </entry>
     </row>
     <row xml:id="constant.t-boolean-and">
-     <entry><constant>T_BOOLEAN_AND</constant></entry>
+     <entry>
+      <constant>T_BOOLEAN_AND</constant>
+      (<type>int</type>)
+     </entry>
      <entry>&amp;&amp;</entry>
      <entry><link linkend="language.operators.logical">logical operators</link></entry>
     </row>
     <row xml:id="constant.t-boolean-or">
-     <entry><constant>T_BOOLEAN_OR</constant></entry>
+     <entry>
+      <constant>T_BOOLEAN_OR</constant>
+      (<type>int</type>)
+     </entry>
      <entry>||</entry>
      <entry><link linkend="language.operators.logical">logical operators</link></entry>
     </row>
     <row xml:id="constant.t-bool-cast">
-     <entry><constant>T_BOOL_CAST</constant></entry>
+     <entry>
+      <constant>T_BOOL_CAST</constant>
+      (<type>int</type>)
+     </entry>
      <entry>(bool) or (boolean)</entry>
      <entry><link linkend="language.types.typecasting">type-casting</link></entry>
     </row>
     <row xml:id="constant.t-break">
-     <entry><constant>T_BREAK</constant></entry>
+     <entry>
+      <constant>T_BREAK</constant>
+      (<type>int</type>)
+     </entry>
      <entry>break</entry>
      <entry><link linkend="control-structures.break">break</link></entry>
     </row>
     <row xml:id="constant.t-callable">
-     <entry><constant>T_CALLABLE</constant></entry>
+     <entry>
+      <constant>T_CALLABLE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>callable</entry>
      <entry><link linkend="language.types.callable">callable</link></entry>
     </row>
     <row xml:id="constant.t-case">
-     <entry><constant>T_CASE</constant></entry>
+     <entry>
+      <constant>T_CASE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>case</entry>
      <entry><link linkend="control-structures.switch">switch</link></entry>
     </row>
     <row xml:id="constant.t-catch">
-     <entry><constant>T_CATCH</constant></entry>
+     <entry>
+      <constant>T_CATCH</constant>
+      (<type>int</type>)
+     </entry>
      <entry>catch</entry>
      <entry><xref linkend="language.exceptions"/></entry>
     </row>
     <row xml:id="constant.t-class">
-     <entry><constant>T_CLASS</constant></entry>
+     <entry>
+      <constant>T_CLASS</constant>
+      (<type>int</type>)
+     </entry>
      <entry>class</entry>
      <entry><link linkend="language.oop5">classes and objects</link></entry>
     </row>
     <row xml:id="constant.t-class-c">
-     <entry><constant>T_CLASS_C</constant></entry>
+     <entry>
+      <constant>T_CLASS_C</constant>
+      (<type>int</type>)
+     </entry>
      <entry>__CLASS__</entry>
      <entry>
       <link linkend="language.constants.magic">magic constants</link>
      </entry>
     </row>
     <row xml:id="constant.t-clone">
-     <entry><constant>T_CLONE</constant></entry>
+     <entry>
+      <constant>T_CLONE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>clone</entry>
      <entry>
       <link linkend="language.oop5">classes and objects</link>
      </entry>
     </row>
     <row xml:id="constant.t-close-tag">
-     <entry><constant>T_CLOSE_TAG</constant></entry>
+     <entry>
+      <constant>T_CLOSE_TAG</constant>
+      (<type>int</type>)
+     </entry>
      <entry>?&gt; or %&gt;</entry>
      <entry><link linkend="language.basic-syntax.phpmode">escaping
      from HTML</link></entry>
     </row>
     <row xml:id="constant.t-coalesce">
-     <entry><constant>T_COALESCE</constant></entry>
+     <entry>
+      <constant>T_COALESCE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>??</entry>
      <entry>
       <link linkend="language.operators.comparison.coalesce">comparison operators</link>
      </entry>
     </row>
     <row xml:id="constant.t-coalesce-equal">
-     <entry><constant>T_COALESCE_EQUAL</constant></entry>
+     <entry>
+      <constant>T_COALESCE_EQUAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>??=</entry>
      <entry>
       <link linkend="language.operators.assignment">assignment operators</link>
@@ -177,33 +241,51 @@ defined('T_FN') || define('T_FN', 10001);
      </entry>
     </row>
     <row xml:id="constant.t-comment">
-     <entry><constant>T_COMMENT</constant></entry>
+     <entry>
+      <constant>T_COMMENT</constant>
+      (<type>int</type>)
+     </entry>
      <entry>// or #, and /* */</entry>
      <entry><link linkend="language.basic-syntax.comments">comments</link></entry>
     </row>
     <row xml:id="constant.t-concat-equal">
-     <entry><constant>T_CONCAT_EQUAL</constant></entry>
+     <entry>
+      <constant>T_CONCAT_EQUAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>.=</entry>
      <entry><link linkend="language.operators.assignment">assignment
      operators</link></entry>
     </row>
     <row xml:id="constant.t-const">
-     <entry><constant>T_CONST</constant></entry>
+     <entry>
+      <constant>T_CONST</constant>
+      (<type>int</type>)
+     </entry>
      <entry>const</entry>
      <entry><link linkend="language.constants">class constants</link></entry>
     </row>
     <row xml:id="constant.t-constant-encapsed-string">
-     <entry><constant>T_CONSTANT_ENCAPSED_STRING</constant></entry>
+     <entry>
+      <constant>T_CONSTANT_ENCAPSED_STRING</constant>
+      (<type>int</type>)
+     </entry>
      <entry>"foo" or 'bar'</entry>
      <entry><link linkend="language.types.string.syntax">string syntax</link></entry>
     </row>
     <row xml:id="constant.t-continue">
-     <entry><constant>T_CONTINUE</constant></entry>
+     <entry>
+      <constant>T_CONTINUE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>continue</entry>
      <entry><link linkend="control-structures.continue">continue</link></entry>
     </row>
     <row xml:id="constant.t-curly-open">
-     <entry><constant>T_CURLY_OPEN</constant></entry>
+     <entry>
+      <constant>T_CURLY_OPEN</constant>
+      (<type>int</type>)
+     </entry>
      <entry>{$</entry>
      <entry>
       <link linkend="language.types.string.parsing.advanced">advanced</link>
@@ -211,52 +293,78 @@ defined('T_FN') || define('T_FN', 10001);
      </entry>
     </row>
     <row xml:id="constant.t-dec">
-     <entry><constant>T_DEC</constant></entry>
+     <entry>
+      <constant>T_DEC</constant>
+      (<type>int</type>)
+     </entry>
      <entry>--</entry>
-     <entry><link
-     linkend="language.operators.increment">incrementing/decrementing
+     <entry><link linkend="language.operators.increment">incrementing/decrementing
      operators</link></entry>
     </row>
     <row xml:id="constant.t-declare">
-     <entry><constant>T_DECLARE</constant></entry>
+     <entry>
+      <constant>T_DECLARE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>declare</entry>
      <entry><link linkend="control-structures.declare">declare</link></entry>
     </row>
     <row xml:id="constant.t-default">
-     <entry><constant>T_DEFAULT</constant></entry>
+     <entry>
+      <constant>T_DEFAULT</constant>
+      (<type>int</type>)
+     </entry>
      <entry>default</entry>
      <entry><link linkend="control-structures.switch">switch</link></entry>
     </row>
     <row xml:id="constant.t-dir">
-     <entry><constant>T_DIR</constant></entry>
+     <entry>
+      <constant>T_DIR</constant>
+      (<type>int</type>)
+     </entry>
      <entry>__DIR__</entry>
      <entry><link linkend="language.constants.magic">magic constants</link></entry>
     </row>
     <row xml:id="constant.t-div-equal">
-     <entry><constant>T_DIV_EQUAL</constant></entry>
+     <entry>
+      <constant>T_DIV_EQUAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>/=</entry>
      <entry><link linkend="language.operators.assignment">assignment
      operators</link></entry>
     </row>
     <row xml:id="constant.t-dnumber">
-     <entry><constant>T_DNUMBER</constant></entry>
+     <entry>
+      <constant>T_DNUMBER</constant>
+      (<type>int</type>)
+     </entry>
      <entry>0.12, etc.</entry>
      <entry><link linkend="language.types.float">floating point numbers</link></entry>
     </row>
     <row xml:id="constant.t-do">
-     <entry><constant>T_DO</constant></entry>
+     <entry>
+      <constant>T_DO</constant>
+      (<type>int</type>)
+     </entry>
      <entry>do</entry>
      <entry><link linkend="control-structures.do.while">do..while</link></entry>
     </row>
     <row xml:id="constant.t-doc-comment">
-     <entry><constant>T_DOC_COMMENT</constant></entry>
+     <entry>
+      <constant>T_DOC_COMMENT</constant>
+      (<type>int</type>)
+     </entry>
      <entry>/** */</entry>
      <entry>
       <link linkend="language.basic-syntax.comments">PHPDoc style comments</link>
      </entry>
     </row>
     <row xml:id="constant.t-dollar-open-curly-braces">
-     <entry><constant>T_DOLLAR_OPEN_CURLY_BRACES</constant></entry>
+     <entry>
+      <constant>T_DOLLAR_OPEN_CURLY_BRACES</constant>
+      (<type>int</type>)
+     </entry>
      <entry>${</entry>
      <entry>
       <link linkend="language.types.string.parsing.basic">basic</link>
@@ -264,133 +372,198 @@ defined('T_FN') || define('T_FN', 10001);
      </entry>
     </row>
     <row xml:id="constant.t-double-arrow">
-     <entry><constant>T_DOUBLE_ARROW</constant></entry>
+     <entry>
+      <constant>T_DOUBLE_ARROW</constant>
+      (<type>int</type>)
+     </entry>
      <entry>=&gt;</entry>
      <entry><link linkend="language.types.array.syntax">array syntax</link></entry>
     </row>
     <row xml:id="constant.t-double-cast">
-     <entry><constant>T_DOUBLE_CAST</constant></entry>
+     <entry>
+      <constant>T_DOUBLE_CAST</constant>
+      (<type>int</type>)
+     </entry>
      <entry>(real), (double) or (float)</entry>
      <entry><link linkend="language.types.typecasting">type-casting</link></entry>
     </row>
     <row xml:id="constant.t-double-colon">
-     <entry><constant>T_DOUBLE_COLON</constant></entry>
+     <entry>
+      <constant>T_DOUBLE_COLON</constant>
+      (<type>int</type>)
+     </entry>
      <entry>::</entry>
      <entry>see <constant>T_PAAMAYIM_NEKUDOTAYIM</constant> below</entry>
     </row>
     <row xml:id="constant.t-echo">
-     <entry><constant>T_ECHO</constant></entry>
+     <entry>
+      <constant>T_ECHO</constant>
+      (<type>int</type>)
+     </entry>
      <entry>echo</entry>
      <entry><function>echo</function></entry>
     </row>
     <row xml:id="constant.t-ellipsis">
-     <entry><constant>T_ELLIPSIS</constant></entry>
+     <entry>
+      <constant>T_ELLIPSIS</constant>
+      (<type>int</type>)
+     </entry>
      <entry>...</entry>
      <entry>
       <link linkend="functions.variable-arg-list">function arguments</link>
      </entry>
     </row>
     <row xml:id="constant.t-else">
-     <entry><constant>T_ELSE</constant></entry>
+     <entry>
+      <constant>T_ELSE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>else</entry>
      <entry><link linkend="control-structures.else">else</link></entry>
     </row>
     <row xml:id="constant.t-elseif">
-     <entry><constant>T_ELSEIF</constant></entry>
+     <entry>
+      <constant>T_ELSEIF</constant>
+      (<type>int</type>)
+     </entry>
      <entry>elseif</entry>
      <entry><link linkend="control-structures.elseif">elseif</link></entry>
     </row>
     <row xml:id="constant.t-empty">
-     <entry><constant>T_EMPTY</constant></entry>
+     <entry>
+      <constant>T_EMPTY</constant>
+      (<type>int</type>)
+     </entry>
      <entry>empty</entry>
      <entry><function>empty</function></entry>
     </row>
     <row xml:id="constant.t-encapsed-and-whitespace">
-     <entry><constant>T_ENCAPSED_AND_WHITESPACE</constant></entry>
+     <entry>
+      <constant>T_ENCAPSED_AND_WHITESPACE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>" $a"</entry>
      <entry><link linkend="language.types.string.parsing">constant part of
      string with variables</link></entry>
     </row>
     <row xml:id="constant.t-enddeclare">
-     <entry><constant>T_ENDDECLARE</constant></entry>
+     <entry>
+      <constant>T_ENDDECLARE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>enddeclare</entry>
-     <entry><link linkend="control-structures.declare">declare</link>, <link
-     linkend="control-structures.alternative-syntax">alternative syntax</link></entry>
+     <entry><link linkend="control-structures.declare">declare</link>, <link linkend="control-structures.alternative-syntax">alternative syntax</link></entry>
     </row>
     <row xml:id="constant.t-endfor">
-     <entry><constant>T_ENDFOR</constant></entry>
+     <entry>
+      <constant>T_ENDFOR</constant>
+      (<type>int</type>)
+     </entry>
      <entry>endfor</entry>
-     <entry><link linkend="control-structures.for">for</link>, <link
-     linkend="control-structures.alternative-syntax">alternative syntax</link></entry>
+     <entry><link linkend="control-structures.for">for</link>, <link linkend="control-structures.alternative-syntax">alternative syntax</link></entry>
     </row>
     <row xml:id="constant.t-endforeach">
-     <entry><constant>T_ENDFOREACH</constant></entry>
+     <entry>
+      <constant>T_ENDFOREACH</constant>
+      (<type>int</type>)
+     </entry>
      <entry>endforeach</entry>
-     <entry>&foreach;, <link
-     linkend="control-structures.alternative-syntax">alternative syntax</link></entry>
+     <entry>&foreach;, <link linkend="control-structures.alternative-syntax">alternative syntax</link></entry>
     </row>
     <row xml:id="constant.t-endif">
-     <entry><constant>T_ENDIF</constant></entry>
+     <entry>
+      <constant>T_ENDIF</constant>
+      (<type>int</type>)
+     </entry>
      <entry>endif</entry>
-     <entry><link linkend="control-structures.if">if</link>, <link
-     linkend="control-structures.alternative-syntax">alternative syntax</link></entry>
+     <entry><link linkend="control-structures.if">if</link>, <link linkend="control-structures.alternative-syntax">alternative syntax</link></entry>
     </row>
     <row xml:id="constant.t-endswitch">
-     <entry><constant>T_ENDSWITCH</constant></entry>
+     <entry>
+      <constant>T_ENDSWITCH</constant>
+      (<type>int</type>)
+     </entry>
      <entry>endswitch</entry>
-     <entry><link linkend="control-structures.switch">switch</link>, <link
-     linkend="control-structures.alternative-syntax">alternative syntax</link></entry>
+     <entry><link linkend="control-structures.switch">switch</link>, <link linkend="control-structures.alternative-syntax">alternative syntax</link></entry>
     </row>
     <row xml:id="constant.t-endwhile">
-     <entry><constant>T_ENDWHILE</constant></entry>
+     <entry>
+      <constant>T_ENDWHILE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>endwhile</entry>
-     <entry><link linkend="control-structures.while">while</link>, <link
-     linkend="control-structures.alternative-syntax">alternative syntax</link></entry>
+     <entry><link linkend="control-structures.while">while</link>, <link linkend="control-structures.alternative-syntax">alternative syntax</link></entry>
     </row>
     <row xml:id="constant.t-enum">
-     <entry><constant>T_ENUM</constant></entry>
+     <entry>
+      <constant>T_ENUM</constant>
+      (<type>int</type>)
+     </entry>
      <entry>enum</entry>
      <entry><link linkend="language.types.enumerations">Enumerations</link> (available as of PHP 8.1.0)</entry>
     </row>
     <row xml:id="constant.t-end-heredoc">
-     <entry><constant>T_END_HEREDOC</constant></entry>
-     <entry></entry>
+     <entry>
+      <constant>T_END_HEREDOC</constant>
+      (<type>int</type>)
+     </entry>
+     <entry/>
      <entry><link linkend="language.types.string.syntax.heredoc">heredoc
      syntax</link></entry>
     </row>
     <row xml:id="constant.t-eval">
-     <entry><constant>T_EVAL</constant></entry>
+     <entry>
+      <constant>T_EVAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>eval()</entry>
      <entry><function>eval</function></entry>
     </row>
     <row xml:id="constant.t-exit">
-     <entry><constant>T_EXIT</constant></entry>
+     <entry>
+      <constant>T_EXIT</constant>
+      (<type>int</type>)
+     </entry>
      <entry>exit or die</entry>
      <entry><function>exit</function>, <function>die</function></entry>
     </row>
     <row xml:id="constant.t-extends">
-     <entry><constant>T_EXTENDS</constant></entry>
+     <entry>
+      <constant>T_EXTENDS</constant>
+      (<type>int</type>)
+     </entry>
      <entry>extends</entry>
-     <entry><link linkend="language.oop5.basic.extends">extends</link>, <link
-     linkend="language.oop5">classes and objects</link></entry>
+     <entry><link linkend="language.oop5.basic.extends">extends</link>, <link linkend="language.oop5">classes and objects</link></entry>
     </row>
     <row xml:id="constant.t-file">
-     <entry><constant>T_FILE</constant></entry>
+     <entry>
+      <constant>T_FILE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>__FILE__</entry>
      <entry><link linkend="language.constants.magic">magic constants</link></entry>
     </row>
     <row xml:id="constant.t-final">
-     <entry><constant>T_FINAL</constant></entry>
+     <entry>
+      <constant>T_FINAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>final</entry>
      <entry><xref linkend="language.oop5.final"/></entry>
     </row>
     <row xml:id="constant.t-finally">
-     <entry><constant>T_FINALLY</constant></entry>
+     <entry>
+      <constant>T_FINALLY</constant>
+      (<type>int</type>)
+     </entry>
      <entry>finally</entry>
      <entry><xref linkend="language.exceptions"/></entry>
     </row>
     <row xml:id="constant.t-fn">
-     <entry><constant>T_FN</constant></entry>
+     <entry>
+      <constant>T_FN</constant>
+      (<type>int</type>)
+     </entry>
      <entry>fn</entry>
      <entry>
       <link linkend="functions.arrow">arrow functions</link>
@@ -398,425 +571,643 @@ defined('T_FN') || define('T_FN', 10001);
      </entry>
     </row>
     <row xml:id="constant.t-for">
-     <entry><constant>T_FOR</constant></entry>
+     <entry>
+      <constant>T_FOR</constant>
+      (<type>int</type>)
+     </entry>
      <entry>for</entry>
      <entry><link linkend="control-structures.for">for</link></entry>
     </row>
     <row xml:id="constant.t-foreach">
-     <entry><constant>T_FOREACH</constant></entry>
+     <entry>
+      <constant>T_FOREACH</constant>
+      (<type>int</type>)
+     </entry>
      <entry>foreach</entry>
      <entry>&foreach;</entry>
     </row>
     <row xml:id="constant.t-function">
-     <entry><constant>T_FUNCTION</constant></entry>
+     <entry>
+      <constant>T_FUNCTION</constant>
+      (<type>int</type>)
+     </entry>
      <entry>function</entry>
      <entry><link linkend="language.functions">functions</link></entry>
     </row>
     <row xml:id="constant.t-func-c">
-     <entry><constant>T_FUNC_C</constant></entry>
+     <entry>
+      <constant>T_FUNC_C</constant>
+      (<type>int</type>)
+     </entry>
      <entry>__FUNCTION__</entry>
      <entry>
       <link linkend="language.constants.magic">magic constants</link>
      </entry>
     </row>
     <row xml:id="constant.t-global">
-     <entry><constant>T_GLOBAL</constant></entry>
+     <entry>
+      <constant>T_GLOBAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>global</entry>
      <entry><link linkend="language.variables.scope">variable scope</link></entry>
     </row>
     <row xml:id="constant.t-goto">
-     <entry><constant>T_GOTO</constant></entry>
+     <entry>
+      <constant>T_GOTO</constant>
+      (<type>int</type>)
+     </entry>
      <entry>goto</entry>
      <entry><link linkend="control-structures.goto">goto</link></entry>
     </row>
     <row xml:id="constant.t-halt-compiler">
-     <entry><constant>T_HALT_COMPILER</constant></entry>
+     <entry>
+      <constant>T_HALT_COMPILER</constant>
+      (<type>int</type>)
+     </entry>
      <entry>__halt_compiler()</entry>
      <entry><xref linkend="function.halt-compiler"/></entry>
     </row>
     <row xml:id="constant.t-if">
-     <entry><constant>T_IF</constant></entry>
+     <entry>
+      <constant>T_IF</constant>
+      (<type>int</type>)
+     </entry>
      <entry>if</entry>
      <entry><link linkend="control-structures.if">if</link></entry>
     </row>
     <row xml:id="constant.t-implements">
-     <entry><constant>T_IMPLEMENTS</constant></entry>
+     <entry>
+      <constant>T_IMPLEMENTS</constant>
+      (<type>int</type>)
+     </entry>
      <entry>implements</entry>
      <entry><xref linkend="language.oop5.interfaces"/></entry>
     </row>
     <row xml:id="constant.t-inc">
-     <entry><constant>T_INC</constant></entry>
+     <entry>
+      <constant>T_INC</constant>
+      (<type>int</type>)
+     </entry>
      <entry>++</entry>
-     <entry><link
-     linkend="language.operators.increment">incrementing/decrementing
+     <entry><link linkend="language.operators.increment">incrementing/decrementing
      operators</link></entry>
     </row>
     <row xml:id="constant.t-include">
-     <entry><constant>T_INCLUDE</constant></entry>
+     <entry>
+      <constant>T_INCLUDE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>include</entry>
      <entry><function>include</function></entry>
     </row>
     <row xml:id="constant.t-include-once">
-     <entry><constant>T_INCLUDE_ONCE</constant></entry>
+     <entry>
+      <constant>T_INCLUDE_ONCE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>include_once</entry>
      <entry><function>include_once</function></entry>
     </row>
     <row xml:id="constant.t-inline-html">
-     <entry><constant>T_INLINE_HTML</constant></entry>
-     <entry></entry>
+     <entry>
+      <constant>T_INLINE_HTML</constant>
+      (<type>int</type>)
+     </entry>
+     <entry/>
      <entry><link linkend="language.basic-syntax.phpmode">text outside PHP</link></entry>
     </row>
     <row xml:id="constant.t-instanceof">
-     <entry><constant>T_INSTANCEOF</constant></entry>
+     <entry>
+      <constant>T_INSTANCEOF</constant>
+      (<type>int</type>)
+     </entry>
      <entry>instanceof</entry>
      <entry>
       <link linkend="language.operators.type">type operators</link>
      </entry>
     </row>
     <row xml:id="constant.t-insteadof">
-     <entry><constant>T_INSTEADOF</constant></entry>
+     <entry>
+      <constant>T_INSTEADOF</constant>
+      (<type>int</type>)
+     </entry>
      <entry>insteadof</entry>
      <entry><xref linkend="language.oop5.traits"/></entry>
     </row>
     <row xml:id="constant.t-interface">
-     <entry><constant>T_INTERFACE</constant></entry>
+     <entry>
+      <constant>T_INTERFACE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>interface</entry>
      <entry><xref linkend="language.oop5.interfaces"/></entry>
     </row>
     <row xml:id="constant.t-int-cast">
-     <entry><constant>T_INT_CAST</constant></entry>
+     <entry>
+      <constant>T_INT_CAST</constant>
+      (<type>int</type>)
+     </entry>
      <entry>(int) or (integer)</entry>
      <entry><link linkend="language.types.typecasting">type-casting</link></entry>
     </row>
     <row xml:id="constant.t-isset">
-     <entry><constant>T_ISSET</constant></entry>
+     <entry>
+      <constant>T_ISSET</constant>
+      (<type>int</type>)
+     </entry>
      <entry>isset()</entry>
      <entry><function>isset</function></entry>
     </row>
     <row xml:id="constant.t-is-equal">
-     <entry><constant>T_IS_EQUAL</constant></entry>
+     <entry>
+      <constant>T_IS_EQUAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>==</entry>
      <entry><link linkend="language.operators.comparison">comparison operators</link></entry>
     </row>
     <row xml:id="constant.t-is-greater-or-equal">
-     <entry><constant>T_IS_GREATER_OR_EQUAL</constant></entry>
+     <entry>
+      <constant>T_IS_GREATER_OR_EQUAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>&gt;=</entry>
      <entry><link linkend="language.operators.comparison">comparison operators</link></entry>
     </row>
     <row xml:id="constant.t-is-identical">
-     <entry><constant>T_IS_IDENTICAL</constant></entry>
+     <entry>
+      <constant>T_IS_IDENTICAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>===</entry>
      <entry><link linkend="language.operators.comparison">comparison operators</link></entry>
     </row>
     <row xml:id="constant.t-is-not-equal">
-     <entry><constant>T_IS_NOT_EQUAL</constant></entry>
+     <entry>
+      <constant>T_IS_NOT_EQUAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>!= or &lt;&gt;</entry>
      <entry><link linkend="language.operators.comparison">comparison operators</link></entry>
     </row>
     <row xml:id="constant.t-is-not-identical">
-     <entry><constant>T_IS_NOT_IDENTICAL</constant></entry>
+     <entry>
+      <constant>T_IS_NOT_IDENTICAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>!==</entry>
      <entry><link linkend="language.operators.comparison">comparison operators</link></entry>
     </row>
     <row xml:id="constant.t-is-smaller-or-equal">
-     <entry><constant>T_IS_SMALLER_OR_EQUAL</constant></entry>
+     <entry>
+      <constant>T_IS_SMALLER_OR_EQUAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>&lt;=</entry>
      <entry><link linkend="language.operators.comparison">comparison operators</link></entry>
     </row>
     <row xml:id="constant.t-line">
-     <entry><constant>T_LINE</constant></entry>
+     <entry>
+      <constant>T_LINE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>__LINE__</entry>
      <entry><link linkend="language.constants.magic">magic constants</link></entry>
     </row>
     <row xml:id="constant.t-list">
-     <entry><constant>T_LIST</constant></entry>
+     <entry>
+      <constant>T_LIST</constant>
+      (<type>int</type>)
+     </entry>
      <entry>list()</entry>
      <entry><function>list</function></entry>
     </row>
     <row xml:id="constant.t-lnumber">
-     <entry><constant>T_LNUMBER</constant></entry>
+     <entry>
+      <constant>T_LNUMBER</constant>
+      (<type>int</type>)
+     </entry>
      <entry>123, 012, 0x1ac, etc.</entry>
      <entry><link linkend="language.types.integer">integers</link></entry>
     </row>
     <row xml:id="constant.t-logical-and">
-     <entry><constant>T_LOGICAL_AND</constant></entry>
+     <entry>
+      <constant>T_LOGICAL_AND</constant>
+      (<type>int</type>)
+     </entry>
      <entry>and</entry>
      <entry><link linkend="language.operators.logical">logical operators</link></entry>
     </row>
     <row xml:id="constant.t-logical-or">
-     <entry><constant>T_LOGICAL_OR</constant></entry>
+     <entry>
+      <constant>T_LOGICAL_OR</constant>
+      (<type>int</type>)
+     </entry>
      <entry>or</entry>
      <entry><link linkend="language.operators.logical">logical operators</link></entry>
     </row>
     <row xml:id="constant.t-logical-xor">
-     <entry><constant>T_LOGICAL_XOR</constant></entry>
+     <entry>
+      <constant>T_LOGICAL_XOR</constant>
+      (<type>int</type>)
+     </entry>
      <entry>xor</entry>
      <entry><link linkend="language.operators.logical">logical operators</link></entry>
     </row>
     <row xml:id="constant.t-match">
-     <entry><constant>T_MATCH</constant></entry>
+     <entry>
+      <constant>T_MATCH</constant>
+      (<type>int</type>)
+     </entry>
      <entry>match</entry>
      <entry>
       &match; (available as of PHP 8.0.0)
      </entry>
     </row>
     <row xml:id="constant.t-method-c">
-     <entry><constant>T_METHOD_C</constant></entry>
+     <entry>
+      <constant>T_METHOD_C</constant>
+      (<type>int</type>)
+     </entry>
      <entry>__METHOD__</entry>
      <entry>
       <link linkend="language.constants.magic">magic constants</link>
      </entry>
     </row>
     <row xml:id="constant.t-minus-equal">
-     <entry><constant>T_MINUS_EQUAL</constant></entry>
+     <entry>
+      <constant>T_MINUS_EQUAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>-=</entry>
      <entry><link linkend="language.operators.assignment">assignment
      operators</link></entry>
     </row>
     <row xml:id="constant.t-mod-equal">
-     <entry><constant>T_MOD_EQUAL</constant></entry>
+     <entry>
+      <constant>T_MOD_EQUAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>%=</entry>
      <entry><link linkend="language.operators.assignment">assignment
      operators</link></entry>
     </row>
     <row xml:id="constant.t-mul-equal">
-     <entry><constant>T_MUL_EQUAL</constant></entry>
+     <entry>
+      <constant>T_MUL_EQUAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>*=</entry>
      <entry><link linkend="language.operators.assignment">assignment
      operators</link></entry>
     </row>
     <row xml:id="constant.t-namespace">
-     <entry><constant>T_NAMESPACE</constant></entry>
+     <entry>
+      <constant>T_NAMESPACE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>namespace</entry>
      <entry>
       <link linkend="language.namespaces">namespaces</link>
      </entry>
     </row>
     <row xml:id="constant.t-name-fully-qualified">
-     <entry><constant>T_NAME_FULLY_QUALIFIED</constant></entry>
+     <entry>
+      <constant>T_NAME_FULLY_QUALIFIED</constant>
+      (<type>int</type>)
+     </entry>
      <entry>\App\Namespace</entry>
      <entry>
       <link linkend="language.namespaces">namespaces</link> (available as of PHP 8.0.0)
      </entry>
     </row>
     <row xml:id="constant.t-name-qualified">
-     <entry><constant>T_NAME_QUALIFIED</constant></entry>
+     <entry>
+      <constant>T_NAME_QUALIFIED</constant>
+      (<type>int</type>)
+     </entry>
      <entry>App\Namespace</entry>
      <entry>
       <link linkend="language.namespaces">namespaces</link> (available as of PHP 8.0.0)
      </entry>
     </row>
     <row xml:id="constant.t-name-relative">
-     <entry><constant>T_NAME_RELATIVE</constant></entry>
+     <entry>
+      <constant>T_NAME_RELATIVE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>namespace\Namespace</entry>
      <entry>
       <link linkend="language.namespaces">namespaces</link> (available as of PHP 8.0.0)
      </entry>
     </row>
     <row xml:id="constant.t-new">
-     <entry><constant>T_NEW</constant></entry>
+     <entry>
+      <constant>T_NEW</constant>
+      (<type>int</type>)
+     </entry>
      <entry>new</entry>
      <entry><link linkend="language.oop5">classes and objects</link></entry>
     </row>
     <row xml:id="constant.t-ns-c">
-     <entry><constant>T_NS_C</constant></entry>
+     <entry>
+      <constant>T_NS_C</constant>
+      (<type>int</type>)
+     </entry>
      <entry>__NAMESPACE__</entry>
      <entry>
       <link linkend="language.namespaces">namespaces</link>
      </entry>
     </row>
     <row xml:id="constant.t-ns-separator">
-     <entry><constant>T_NS_SEPARATOR</constant></entry>
+     <entry>
+      <constant>T_NS_SEPARATOR</constant>
+      (<type>int</type>)
+     </entry>
      <entry>\</entry>
      <entry>
       <link linkend="language.namespaces">namespaces</link>
      </entry>
     </row>
     <row xml:id="constant.t-num-string">
-     <entry><constant>T_NUM_STRING</constant></entry>
+     <entry>
+      <constant>T_NUM_STRING</constant>
+      (<type>int</type>)
+     </entry>
      <entry>"$a[0]"</entry>
      <entry><link linkend="language.types.string.parsing">numeric array index
      inside string</link></entry>
     </row>
     <row xml:id="constant.t-object-cast">
-     <entry><constant>T_OBJECT_CAST</constant></entry>
+     <entry>
+      <constant>T_OBJECT_CAST</constant>
+      (<type>int</type>)
+     </entry>
      <entry>(object)</entry>
      <entry><link linkend="language.types.typecasting">type-casting</link></entry>
     </row>
     <row xml:id="constant.t-object-operator">
-     <entry><constant>T_OBJECT_OPERATOR</constant></entry>
+     <entry>
+      <constant>T_OBJECT_OPERATOR</constant>
+      (<type>int</type>)
+     </entry>
      <entry>-&gt;</entry>
      <entry><link linkend="language.oop5">classes and objects</link></entry>
     </row>
     <row xml:id="constant.t-nullsafe-object-operator">
-     <entry><constant>T_NULLSAFE_OBJECT_OPERATOR</constant></entry>
+     <entry>
+      <constant>T_NULLSAFE_OBJECT_OPERATOR</constant>
+      (<type>int</type>)
+     </entry>
      <entry>?-&gt;</entry>
      <entry><link linkend="language.oop5">classes and objects</link></entry>
     </row>
     <row xml:id="constant.t-open-tag">
-     <entry><constant>T_OPEN_TAG</constant></entry>
+     <entry>
+      <constant>T_OPEN_TAG</constant>
+      (<type>int</type>)
+     </entry>
      <entry>&lt;?php, &lt;? or &lt;%</entry>
      <entry><link linkend="language.basic-syntax.phpmode">escaping
      from HTML</link></entry>
     </row>
     <row xml:id="constant.t-open-tag-with-echo">
-     <entry><constant>T_OPEN_TAG_WITH_ECHO</constant></entry>
+     <entry>
+      <constant>T_OPEN_TAG_WITH_ECHO</constant>
+      (<type>int</type>)
+     </entry>
      <entry>&lt;?= or &lt;%=</entry>
      <entry><link linkend="language.basic-syntax.phpmode">escaping
      from HTML</link></entry>
     </row>
     <row xml:id="constant.t-or-equal">
-     <entry><constant>T_OR_EQUAL</constant></entry>
+     <entry>
+      <constant>T_OR_EQUAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>|=</entry>
      <entry><link linkend="language.operators.assignment">assignment
      operators</link></entry>
     </row>
     <row xml:id="constant.t-paamayim-nekudotayim">
-     <entry><constant>T_PAAMAYIM_NEKUDOTAYIM</constant></entry>
+     <entry>
+      <constant>T_PAAMAYIM_NEKUDOTAYIM</constant>
+      (<type>int</type>)
+     </entry>
      <entry>::</entry>
      <entry><link linkend="language.oop5.paamayim-nekudotayim">scope resolution</link>. Also defined as
       <constant>T_DOUBLE_COLON</constant>.</entry>
     </row>
     <row xml:id="constant.t-plus-equal">
-     <entry><constant>T_PLUS_EQUAL</constant></entry>
+     <entry>
+      <constant>T_PLUS_EQUAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>+=</entry>
      <entry><link linkend="language.operators.assignment">assignment
      operators</link></entry>
     </row>
     <row xml:id="constant.t-pow">
-     <entry><constant>T_POW</constant></entry>
+     <entry>
+      <constant>T_POW</constant>
+      (<type>int</type>)
+     </entry>
      <entry>**</entry>
      <entry>
       <link linkend="language.operators.arithmetic">arithmetic operators</link>
      </entry>
     </row>
     <row xml:id="constant.t-pow-equal">
-     <entry><constant>T_POW_EQUAL</constant></entry>
+     <entry>
+      <constant>T_POW_EQUAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>**=</entry>
      <entry>
       <link linkend="language.operators.assignment">assignment operators</link>
      </entry>
     </row>
     <row xml:id="constant.t-print">
-     <entry><constant>T_PRINT</constant></entry>
+     <entry>
+      <constant>T_PRINT</constant>
+      (<type>int</type>)
+     </entry>
      <entry>print</entry>
      <entry><function>print</function></entry>
     </row>
     <row xml:id="constant.t-private">
-     <entry><constant>T_PRIVATE</constant></entry>
+     <entry>
+      <constant>T_PRIVATE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>private</entry>
      <entry>
       <link linkend="language.oop5">classes and objects</link>
      </entry>
     </row>
     <row xml:id="constant.t-private-set">
-     <entry><constant>T_PRIVATE_SET</constant></entry>
+     <entry>
+      <constant>T_PRIVATE_SET</constant>
+      (<type>int</type>)
+     </entry>
      <entry>private(set)</entry>
      <entry>
       property hooks (available as of PHP 8.4.0)
      </entry>
     </row>
     <row xml:id="constant.t-property-c">
-     <entry><constant>T_PROPERTY_C</constant></entry>
+     <entry>
+      <constant>T_PROPERTY_C</constant>
+      (<type>int</type>)
+     </entry>
      <entry>__PROPERTY__</entry>
      <entry>
       <link linkend="language.constants.magic">magic constants</link>
      </entry>
     </row>
     <row xml:id="constant.t-protected">
-     <entry><constant>T_PROTECTED</constant></entry>
+     <entry>
+      <constant>T_PROTECTED</constant>
+      (<type>int</type>)
+     </entry>
      <entry>protected</entry>
      <entry>
       <link linkend="language.oop5">classes and objects</link>
      </entry>
     </row>
     <row xml:id="constant.t-protected-set">
-     <entry><constant>T_PROTECTED_SET</constant></entry>
+     <entry>
+      <constant>T_PROTECTED_SET</constant>
+      (<type>int</type>)
+     </entry>
      <entry>protected(set)</entry>
      <entry>
       property hooks (available as of PHP 8.4.0)
      </entry>
     </row>
     <row xml:id="constant.t-public">
-     <entry><constant>T_PUBLIC</constant></entry>
+     <entry>
+      <constant>T_PUBLIC</constant>
+      (<type>int</type>)
+     </entry>
      <entry>public</entry>
      <entry>
       <link linkend="language.oop5">classes and objects</link>
      </entry>
     </row>
     <row xml:id="constant.t-public-set">
-     <entry><constant>T_PUBLIC_SET</constant></entry>
+     <entry>
+      <constant>T_PUBLIC_SET</constant>
+      (<type>int</type>)
+     </entry>
      <entry>public(set)</entry>
      <entry>
       property hooks (available as of PHP 8.4.0)
      </entry>
     </row>
     <row xml:id="constant.t-readonly">
-     <entry><constant>T_READONLY</constant></entry>
+     <entry>
+      <constant>T_READONLY</constant>
+      (<type>int</type>)
+     </entry>
      <entry>readonly</entry>
      <entry>
       <link linkend="language.oop5">classes and objects</link> (available as of PHP 8.1.0)
      </entry>
     </row>
     <row xml:id="constant.t-require">
-     <entry><constant>T_REQUIRE</constant></entry>
+     <entry>
+      <constant>T_REQUIRE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>require</entry>
      <entry><function>require</function></entry>
     </row>
     <row xml:id="constant.t-require-once">
-     <entry><constant>T_REQUIRE_ONCE</constant></entry>
+     <entry>
+      <constant>T_REQUIRE_ONCE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>require_once</entry>
      <entry><function>require_once</function></entry>
     </row>
     <row xml:id="constant.t-return">
-     <entry><constant>T_RETURN</constant></entry>
+     <entry>
+      <constant>T_RETURN</constant>
+      (<type>int</type>)
+     </entry>
      <entry>return</entry>
      <entry><link linkend="functions.returning-values">returning values</link></entry>
     </row>
     <row xml:id="constant.t-sl">
-     <entry><constant>T_SL</constant></entry>
+     <entry>
+      <constant>T_SL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>&lt;&lt;</entry>
      <entry><link linkend="language.operators.bitwise">bitwise
      operators</link></entry>
     </row>
     <row xml:id="constant.t-sl-equal">
-     <entry><constant>T_SL_EQUAL</constant></entry>
+     <entry>
+      <constant>T_SL_EQUAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>&lt;&lt;=</entry>
      <entry><link linkend="language.operators.assignment">assignment
      operators</link></entry>
     </row>
     <row xml:id="constant.t-spaceship">
-     <entry><constant>T_SPACESHIP</constant></entry>
+     <entry>
+      <constant>T_SPACESHIP</constant>
+      (<type>int</type>)
+     </entry>
      <entry>&lt;=&gt;</entry>
      <entry>
       <link linkend="language.operators.comparison">comparison operators</link>
      </entry>
     </row>
     <row xml:id="constant.t-sr">
-     <entry><constant>T_SR</constant></entry>
+     <entry>
+      <constant>T_SR</constant>
+      (<type>int</type>)
+     </entry>
      <entry>&gt;&gt;</entry>
      <entry><link linkend="language.operators.bitwise">bitwise
      operators</link></entry>
     </row>
     <row xml:id="constant.t-sr-equal">
-     <entry><constant>T_SR_EQUAL</constant></entry>
+     <entry>
+      <constant>T_SR_EQUAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>&gt;&gt;=</entry>
      <entry><link linkend="language.operators.assignment">assignment
      operators</link></entry>
     </row>
     <row xml:id="constant.t-start-heredoc">
-     <entry><constant>T_START_HEREDOC</constant></entry>
+     <entry>
+      <constant>T_START_HEREDOC</constant>
+      (<type>int</type>)
+     </entry>
      <entry>&lt;&lt;&lt;</entry>
      <entry><link linkend="language.types.string.syntax.heredoc">heredoc
      syntax</link></entry>
     </row>
     <row xml:id="constant.t-static">
-     <entry><constant>T_STATIC</constant></entry>
+     <entry>
+      <constant>T_STATIC</constant>
+      (<type>int</type>)
+     </entry>
      <entry>static</entry>
      <entry><link linkend="language.variables.scope">variable scope</link></entry>
     </row>
     <row xml:id="constant.t-string">
-     <entry><constant>T_STRING</constant></entry>
+     <entry>
+      <constant>T_STRING</constant>
+      (<type>int</type>)
+     </entry>
      <entry>parent, self, etc.</entry>
      <entry>
       identifiers, e.g. keywords like <literal>parent</literal> and <literal>self</literal>,
@@ -825,12 +1216,18 @@ defined('T_FN') || define('T_FN', 10001);
      </entry>
     </row>
     <row xml:id="constant.t-string-cast">
-     <entry><constant>T_STRING_CAST</constant></entry>
+     <entry>
+      <constant>T_STRING_CAST</constant>
+      (<type>int</type>)
+     </entry>
      <entry>(string)</entry>
      <entry><link linkend="language.types.typecasting">type-casting</link></entry>
     </row>
     <row xml:id="constant.t-string-varname">
-     <entry><constant>T_STRING_VARNAME</constant></entry>
+     <entry>
+      <constant>T_STRING_VARNAME</constant>
+      (<type>int</type>)
+     </entry>
      <entry>"${a</entry>
      <entry>
       <link linkend="language.variables.variable">variable variables</link>
@@ -838,79 +1235,123 @@ defined('T_FN') || define('T_FN', 10001);
      </entry>
     </row>
     <row xml:id="constant.t-switch">
-     <entry><constant>T_SWITCH</constant></entry>
+     <entry>
+      <constant>T_SWITCH</constant>
+      (<type>int</type>)
+     </entry>
      <entry>switch</entry>
      <entry><link linkend="control-structures.switch">switch</link></entry>
     </row>
     <row xml:id="constant.t-throw">
-     <entry><constant>T_THROW</constant></entry>
+     <entry>
+      <constant>T_THROW</constant>
+      (<type>int</type>)
+     </entry>
      <entry>throw</entry>
      <entry><xref linkend="language.exceptions"/></entry>
     </row>
     <row xml:id="constant.t-trait">
-     <entry><constant>T_TRAIT</constant></entry>
+     <entry>
+      <constant>T_TRAIT</constant>
+      (<type>int</type>)
+     </entry>
      <entry>trait</entry>
      <entry><xref linkend="language.oop5.traits"/></entry>
     </row>
     <row xml:id="constant.t-trait-c">
-     <entry><constant>T_TRAIT_C</constant></entry>
+     <entry>
+      <constant>T_TRAIT_C</constant>
+      (<type>int</type>)
+     </entry>
      <entry>__TRAIT__</entry>
      <entry><constant>__TRAIT__</constant></entry>
     </row>
     <row xml:id="constant.t-try">
-     <entry><constant>T_TRY</constant></entry>
+     <entry>
+      <constant>T_TRY</constant>
+      (<type>int</type>)
+     </entry>
      <entry>try</entry>
      <entry><xref linkend="language.exceptions"/></entry>
     </row>
     <row xml:id="constant.t-unset">
-     <entry><constant>T_UNSET</constant></entry>
+     <entry>
+      <constant>T_UNSET</constant>
+      (<type>int</type>)
+     </entry>
      <entry>unset()</entry>
      <entry><function>unset</function></entry>
     </row>
     <row xml:id="constant.t-unset-cast">
-     <entry><constant>T_UNSET_CAST</constant></entry>
+     <entry>
+      <constant>T_UNSET_CAST</constant>
+      (<type>int</type>)
+     </entry>
      <entry>(unset)</entry>
      <entry><link linkend="language.types.typecasting">type-casting</link></entry>
     </row>
     <row xml:id="constant.t-use">
-     <entry><constant>T_USE</constant></entry>
+     <entry>
+      <constant>T_USE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>use</entry>
      <entry><link linkend="language.namespaces">namespaces</link></entry>
     </row>
     <row xml:id="constant.t-var">
-     <entry><constant>T_VAR</constant></entry>
+     <entry>
+      <constant>T_VAR</constant>
+      (<type>int</type>)
+     </entry>
      <entry>var</entry>
      <entry><link linkend="language.oop5">classes and objects</link></entry>
     </row>
     <row xml:id="constant.t-variable">
-     <entry><constant>T_VARIABLE</constant></entry>
+     <entry>
+      <constant>T_VARIABLE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>$foo</entry>
      <entry><link linkend="language.variables">variables</link></entry>
     </row>
     <row xml:id="constant.t-while">
-     <entry><constant>T_WHILE</constant></entry>
+     <entry>
+      <constant>T_WHILE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>while</entry>
-     <entry><link linkend="control-structures.while">while</link>, <link
-     linkend="control-structures.do.while">do..while</link></entry>
+     <entry><link linkend="control-structures.while">while</link>, <link linkend="control-structures.do.while">do..while</link></entry>
     </row>
     <row xml:id="constant.t-whitespace">
-     <entry><constant>T_WHITESPACE</constant></entry>
+     <entry>
+      <constant>T_WHITESPACE</constant>
+      (<type>int</type>)
+     </entry>
      <entry>\t \r\n</entry>
-     <entry></entry>
+     <entry/>
     </row>
     <row xml:id="constant.t-xor-equal">
-     <entry><constant>T_XOR_EQUAL</constant></entry>
+     <entry>
+      <constant>T_XOR_EQUAL</constant>
+      (<type>int</type>)
+     </entry>
      <entry>^=</entry>
      <entry><link linkend="language.operators.assignment">assignment
      operators</link></entry>
     </row>
     <row xml:id="constant.t-yield">
-     <entry><constant>T_YIELD</constant></entry>
+     <entry>
+      <constant>T_YIELD</constant>
+      (<type>int</type>)
+     </entry>
      <entry>yield</entry>
      <entry><link linkend="control-structures.yield">generators</link></entry>
     </row>
     <row xml:id="constant.t-yield-from">
-     <entry><constant>T_YIELD_FROM</constant></entry>
+     <entry>
+      <constant>T_YIELD_FROM</constant>
+      (<type>int</type>)
+     </entry>
      <entry>yield from</entry>
      <entry><link linkend="control-structures.yield.from">generators</link></entry>
     </row>
@@ -921,7 +1362,6 @@ defined('T_FN') || define('T_FN', 10001);
   See also <function>token_name</function>.
  </para>
 </appendix>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/dir/constants.xml
+++ b/reference/dir/constants.xml
@@ -6,7 +6,7 @@
   <varlistentry xml:id="constant.directory-separator">
    <term>
     <constant>DIRECTORY_SEPARATOR</constant>
-     (<type>string</type>)
+    (<type>string</type>)
    </term>
    <listitem>
     <simpara>
@@ -17,7 +17,7 @@
   <varlistentry xml:id="constant.path-separator">
    <term>
     <constant>PATH_SEPARATOR</constant>
-     (<type>string</type>)
+    (<type>string</type>)
    </term>
    <listitem>
     <simpara>
@@ -28,7 +28,7 @@
   <varlistentry xml:id="constant.scandir-sort-ascending">
    <term>
     <constant>SCANDIR_SORT_ASCENDING</constant>
-     (<type>int</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -39,7 +39,7 @@
   <varlistentry xml:id="constant.scandir-sort-descending">
    <term>
     <constant>SCANDIR_SORT_DESCENDING</constant>
-     (<type>int</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -50,7 +50,7 @@
   <varlistentry xml:id="constant.scandir-sort-none">
    <term>
     <constant>SCANDIR_SORT_NONE</constant>
-     (<type>int</type>)
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
@@ -60,7 +60,6 @@
   </varlistentry>
  </variablelist>
 </appendix>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/iconv/constants.xml
+++ b/reference/iconv/constants.xml
@@ -17,12 +17,18 @@
     </thead>
     <tbody>
      <row xml:id="constant.iconv-impl">
-      <entry><constant>ICONV_IMPL</constant></entry>
+      <entry>
+       <constant>ICONV_IMPL</constant>
+       (<type>string</type>)
+      </entry>
       <entry><type>string</type></entry>
       <entry>The implementation name</entry>
      </row>
      <row xml:id="constant.iconv-version">
-      <entry><constant>ICONV_VERSION</constant></entry>
+      <entry>
+       <constant>ICONV_VERSION</constant>
+       (<type>string</type>)
+      </entry>
       <entry><type>string</type></entry>
       <entry>The implementation version</entry>
      </row>
@@ -51,12 +57,18 @@
     </thead>
     <tbody>
      <row xml:id="constant.iconv-mime-decode-strict">
-      <entry><constant>ICONV_MIME_DECODE_STRICT</constant></entry>
+      <entry>
+       <constant>ICONV_MIME_DECODE_STRICT</constant>
+       (<type>int</type>)
+      </entry>
       <entry><type>int</type></entry>
       <entry>A bitmask used for <function>iconv_mime_decode</function></entry>
      </row>
      <row xml:id="constant.iconv-mime-decode-continue-on-error">
-      <entry><constant>ICONV_MIME_DECODE_CONTINUE_ON_ERROR</constant></entry>
+      <entry>
+       <constant>ICONV_MIME_DECODE_CONTINUE_ON_ERROR</constant>
+       (<type>int</type>)
+      </entry>
       <entry><type>int</type></entry>
       <entry>A bitmask used for <function>iconv_mime_decode</function></entry>
      </row>
@@ -65,7 +77,6 @@
   </table>
  </para>
 </appendix>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
@@ -83,4 +94,3 @@ sgml-local-catalogs:nil
 sgml-local-ecat-files:nil
 End:
 -->
-

--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -144,7 +144,7 @@
    <varlistentry xml:id="constant.mysqli-client-can-handle-expired-passwords">
     <term>
      <constant>MYSQLI_CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS</constant>
-    (<type>int</type>)
+     (<type>int</type>)
     </term>
     <listitem>
      <simpara>
@@ -157,7 +157,7 @@
    <varlistentry xml:id="constant.mysqli-client-found-rows">
     <term>
      <constant>MYSQLI_CLIENT_FOUND_ROWS</constant>
-    (<type>int</type>)
+     (<type>int</type>)
     </term>
     <listitem>
      <simpara>
@@ -168,7 +168,7 @@
    <varlistentry xml:id="constant.mysqli-client-ssl-verify-server-cert">
     <term>
      <constant>MYSQLI_CLIENT_SSL_VERIFY_SERVER_CERT</constant>
-    (<type>int</type>)
+     (<type>int</type>)
     </term>
     <listitem>
      <simpara>

--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -163,8 +163,8 @@
     </varlistentry>
     <varlistentry xml:id="constant.openssl-keytype-dh">
      <term>
-    <constant>OPENSSL_KEYTYPE_DH</constant>
-    (<type>int</type>)
+      <constant>OPENSSL_KEYTYPE_DH</constant>
+      (<type>int</type>)
      </term>
    <listitem>
     <simpara>


### PR DESCRIPTION
These were generated by the `./gen_stub.php --replace-predefined-constants ./ ../doc-en` command. Since there was no change in the actual translated content, the commit should be marked as such (but I forgot what kind of marker I should use, so please remind me).