### PR TITLE
Document missing RFTSIGZMB and RFTHREAD flags in pcntl_rfork()

### DIFF
--- a/reference/pcntl/functions/pcntl-rfork.xml
+++ b/reference/pcntl/functions/pcntl-rfork.xml
@@ -69,11 +69,11 @@
     <varlistentry>
      <term><parameter>signal</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The signal number to deliver to the parent when the child exits.
        This is only used when the <constant>RFTSIGZMB</constant> flag is set.
        Specifying <literal>0</literal> disables signal delivery upon the child exit.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/pcntl/functions/pcntl-rfork.xml
+++ b/reference/pcntl/functions/pcntl-rfork.xml
@@ -51,6 +51,17 @@
          <constant>RFLINUXTHPN</constant>: If set, the kernel will return SIGUSR1 instead of SIGCHILD upon thread exit for the child.
          This is intended to do Linux clone exit parent notification.
         </member>
+        <member>
+         <constant>RFTSIGZMB</constant>: If set, the kernel will deliver the signal specified
+         by the <parameter>signal</parameter> parameter to the parent upon the child exit,
+         instead of the default SIGCHLD. Specifying signal number 0 disables signal
+         delivery upon the child exit.
+        </member>
+        <member>
+         <constant>RFTHREAD</constant>: If set, the new process shares file descriptor
+         to process leaders table with its parent. Only applies when neither
+         <constant>RFFDG</constant> nor <constant>RFCFDG</constant> are set.
+        </member>
        </simplelist>
       </para>
      </listitem>
@@ -59,7 +70,9 @@
      <term><parameter>signal</parameter></term>
      <listitem>
       <para>
-       The signal number.
+       The signal number to deliver to the parent when the child exits.
+       This is only used when the <constant>RFTSIGZMB</constant> flag is set.
+       Specifying <literal>0</literal> disables signal delivery upon the child exit.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/pcntl/functions/pcntl-rfork.xml
+++ b/reference/pcntl/functions/pcntl-rfork.xml
@@ -48,7 +48,7 @@
          Is mutually exclusive with <constant>RFFDG</constant>.
         </member>
         <member>
-         <constant>RFLINUXTHPN</constant>: If set, the kernel will return SIGUSR1 instead of SIGCHILD upon thread exit for the child.
+         <constant>RFLINUXTHPN</constant>: If set, the kernel will return SIGUSR1 instead of SIGCHLD upon thread exit for the child.
          This is intended to do Linux clone exit parent notification.
         </member>
         <member>


### PR DESCRIPTION
Fixes https://github.com/php/doc-en/issues/5435

Add missing RFTSIGZMB and RFTHREAD flags to the parameters section and improve the signal parameter description.