### PR TITLE
ini.fatal-error-backtraces

### DIFF
--- a/appendices/migration85/other-changes.xml
+++ b/appendices/migration85/other-changes.xml
@@ -401,8 +401,9 @@
    <title>Core</title>
 
    <simpara>
-    Added fatal_error_backtraces to control whether fatal errors should include
-    a backtrace.
+    Added <link
+    linkend="ini.fatal-error-backtraces">fatal_error_backtraces</link> to
+    control whether fatal errors should include a backtrace.
     <!-- RFC: https://wiki.php.net/rfc/error_backtraces_v2 -->
    </simpara>
 

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -23,6 +23,14 @@
      <entry></entry>
     </row>
     <row>
+     <entry><link linkend="ini.fatal-error-backtraces">fatal_error_backtraces</link></entry>
+     <entry>"1"</entry>
+     <entry><constant>INI_ALL</constant></entry>
+     <entry>
+      Available as of PHP 8.5.0
+     </entry>
+    </row>
+    <row>
      <entry><link linkend="ini.display-errors">display_errors</link></entry>
      <entry>"1"</entry>
      <entry><constant>INI_ALL</constant></entry>
@@ -195,6 +203,23 @@
        <constant>E_ALL</constant>).
       </para>
      </note>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="ini.fatal-error-backtraces">
+    <term>
+     <parameter>fatal_error_backtraces</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Controls whether fatal errors should include a backtrace.
+      Fatal errors are <constant>E_ERROR</constant>,
+      <constant>E_CORE_ERROR</constant>, <constant>E_COMPILE_ERROR</constant>,
+      <constant>E_USER_ERROR</constant>,
+      <constant>E_RECOVERABLE_ERROR</constant>, and
+      <constant>E_PARSE</constant>.
+     </simpara>
     </listitem>
    </varlistentry>
 

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -23,6 +23,14 @@
      <entry></entry>
     </row>
     <row>
+     <entry><link linkend="ini.fatal-error-backtraces">fatal_error_backtraces</link></entry>
+     <entry>"1"</entry>
+     <entry><constant>INI_ALL</constant></entry>
+     <entry>
+      Available as of PHP 8.5.0
+     </entry>
+    </row>
+    <row>
      <entry><link linkend="ini.display-errors">display_errors</link></entry>
      <entry>"1"</entry>
      <entry><constant>INI_ALL</constant></entry>
@@ -197,6 +205,24 @@
      </note>
     </listitem>
    </varlistentry>
+
+   <varlistentry xml:id="ini.fatal-error-backtraces">
+    <term>
+     <parameter>fatal_error_backtraces</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Controls whether fatal errors should include a backtrace.
+      Fatal errors are <constant>E_ERROR</constant>,
+      <constant>E_CORE_ERROR</constant>, <constant>E_COMPILE_ERROR</constant>,
+      <constant>E_USER_ERROR</constant>,
+      <constant>E_RECOVERABLE_ERROR</constant>, and
+      <constant>E_PARSE</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
    <varlistentry xml:id="ini.display-errors">
     <term>
      <parameter>display_errors</parameter>


### PR DESCRIPTION
The ini setting so far was only mentioned in the migration guide (new in 8.5).

refs https://github.com/php/doc-en/issues/4886