### PR TITLE
Enable runnable (WASM) examples for language sections: constants, exceptions, expressions

### DIFF
--- a/language/constants.xml
+++ b/language/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
- <chapter xml:id="language.constants" xmlns="http://docbook.org/ns/docbook">
+ <chapter xml:id="language.constants" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
   <title>Constants</title>
 
   <simpara>
@@ -36,7 +36,7 @@
 <!-- TODO Move into syntax section? -->
    <example>
     <title>Valid and invalid constant names</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -52,8 +52,6 @@ define("2FOO",    "something");
 // PHP may one day provide a magical constant
 // that will break your script
 define("__FOO__", "something"); 
-
-?>
 ]]>
     </programlisting>
    </example>
@@ -178,7 +176,6 @@ define("CONSTANT", "Hello world.");
 echo CONSTANT; // outputs "Hello world."
 echo Constant; // Emits an Error: Undefined constant "Constant"
                // Prior to PHP 8.0.0, outputs "Constant" and issues a warning.
-?>
 ]]>
      </programlisting>
     </example>
@@ -193,23 +190,22 @@ echo Constant; // Emits an Error: Undefined constant "Constant"
 // Simple scalar value
 const CONSTANT = 'Hello World';
 
-echo CONSTANT;
+echo CONSTANT . "\n";
 
 // Scalar expression
-const ANOTHER_CONST = CONSTANT.'; Goodbye World';
-echo ANOTHER_CONST;
+const ANOTHER_CONST = CONSTANT . '; Goodbye World';
+echo ANOTHER_CONST . "\n";
 
 const ANIMALS = array('dog', 'cat', 'bird');
-echo ANIMALS[1]; // outputs "cat"
+echo ANIMALS[1] . "\n"; // outputs "cat"
 
 // Constant arrays
-define('ANIMALS', array(
+define('ANIMALS_DEF', array(
     'dog',
     'cat',
     'bird'
 ));
-echo ANIMALS[1]; // outputs "cat"
-?>
+echo ANIMALS_DEF[1] . "\n"; // outputs "cat"
 ]]>
      </programlisting>
     </example>

--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<chapter xml:id="language.exceptions" xmlns="http://docbook.org/ns/docbook">
+<chapter xml:id="language.exceptions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Exceptions</title>
+ <note>
+  <simpara>See also the <classname>Exception</classname> class</simpara>
+ </note>
  <para>
   PHP has an exception model similar to that of other programming
   languages. An exception can be &throw;n, and caught ("&catch;ed") within
@@ -112,7 +115,7 @@
     </para>
     <example>
      <title>Converting error reporting to exceptions</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function exceptions_error_handler($severity, $message, $filename, $lineno) {
@@ -120,7 +123,6 @@ function exceptions_error_handler($severity, $message, $filename, $lineno) {
 }
 
 set_error_handler('exceptions_error_handler');
-?>
 ]]>
      </programlisting>
     </example>
@@ -158,7 +160,6 @@ try {
 
 // Continue execution
 echo "Hello World\n";
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -200,7 +201,6 @@ try {
 
 // Continue execution
 echo "Hello World\n";
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -231,7 +231,6 @@ function test() {
 }
 
 echo test();
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -266,8 +265,6 @@ class Test {
 
 $foo = new Test;
 $foo->testing();
-
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -299,8 +296,6 @@ class Test {
 
 $foo = new Test;
 $foo->testing();
-
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -328,7 +323,6 @@ try {
 } catch (SpecificException) {
     print "A SpecificException was thrown, but we don't care about the details.";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -358,7 +352,6 @@ try {
 } catch (Exception $e) {
     print $e->getMessage();
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -406,12 +399,12 @@ string(6) "Fourth"
   <title>Extending Exceptions</title>
   <para>
    A User defined Exception class can be defined by extending the built-in
-   Exception class. The members and properties below, show what is accessible
+   <classname>Exception</classname> class. The members and properties below, show what is accessible
    within the child class that derives from the built-in Exception class.
   </para>
   <example>
    <title>The Built in Exception class</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
     <![CDATA[
 <?php
 class Exception implements Throwable
@@ -439,12 +432,11 @@ class Exception implements Throwable
     // Overrideable
     public function __toString();               // formatted string for display
 }
-?>
 ]]>
    </programlisting>
   </example>
   <para>
-   If a class extends the built-in Exception class and re-defines the <link
+   If a class extends the built-in <classname>Exception</classname> class and re-defines the <link
    linkend="language.oop5.decon">constructor</link>, it is highly recommended
    that it also call <link
    linkend="language.oop5.paamayim-nekudotayim">parent::__construct()</link>
@@ -521,7 +513,7 @@ class TestException
 }
 
 
-// Example 1
+echo "# Example 1\n";
 try {
     $o = new TestException(TestException::THROW_CUSTOM);
 } catch (MyException $e) {      // Will be caught
@@ -533,10 +525,9 @@ try {
 
 // Continue execution
 var_dump($o); // Null
-echo "\n\n";
 
 
-// Example 2
+echo "\n\n# Example 2\n";
 try {
     $o = new TestException(TestException::THROW_DEFAULT);
 } catch (MyException $e) {      // Doesn't match this type
@@ -548,10 +539,9 @@ try {
 
 // Continue execution
 var_dump($o); // Null
-echo "\n\n";
 
 
-// Example 3
+echo "\n\n# Example 3\n";
 try {
     $o = new TestException(TestException::THROW_CUSTOM);
 } catch (Exception $e) {        // Will be caught
@@ -560,10 +550,9 @@ try {
 
 // Continue execution
 var_dump($o); // Null
-echo "\n\n";
 
 
-// Example 4
+echo "\n\n# Example 4\n";
 try {
     $o = new TestException();
 } catch (Exception $e) {        // Skipped, no exception
@@ -572,8 +561,6 @@ try {
 
 // Continue execution
 var_dump($o); // TestException
-echo "\n\n";
-?>
 ]]>
    </programlisting>
   </example>

--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -3,7 +3,7 @@
 <chapter xml:id="language.exceptions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Exceptions</title>
  <note>
-  <simpara>See also the <classname>Exception</classname> class</simpara>
+  <simpara>See also the <exceptionname>Exception</exceptionname> class</simpara>
  </note>
  <para>
   PHP has an exception model similar to that of other programming
@@ -399,7 +399,7 @@ string(6) "Fourth"
   <title>Extending Exceptions</title>
   <para>
    A User defined Exception class can be defined by extending the built-in
-   <classname>Exception</classname> class. The members and properties below, show what is accessible
+   <exceptionname>Exception</exceptionname> class. The members and properties below, show what is accessible
    within the child class that derives from the built-in Exception class.
   </para>
   <example>
@@ -436,7 +436,7 @@ class Exception implements Throwable
    </programlisting>
   </example>
   <para>
-   If a class extends the built-in <classname>Exception</classname> class and re-defines the <link
+   If a class extends the built-in <exceptionname>Exception</exceptionname> class and re-defines the <link
    linkend="language.oop5.decon">constructor</link>, it is highly recommended
    that it also call <link
    linkend="language.oop5.paamayim-nekudotayim">parent::__construct()</link>

--- a/language/expressions.xml
+++ b/language/expressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
- <chapter xml:id="language.expressions" xmlns="http://docbook.org/ns/docbook">
+ <chapter xml:id="language.expressions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
    <title>Expressions</title>
    <simpara>
     Expressions are the most important building blocks of PHP. In PHP,
@@ -26,7 +26,7 @@
     Slightly more complex examples for expressions are functions. For
     instance, consider the following function:
     <informalexample>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function foo ()
@@ -135,7 +135,7 @@ function foo ()
    </para>
    <para>
     <informalexample>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $first ? $second : $third
@@ -161,24 +161,33 @@ $first ? $second : $third
 <?php
 function double($i)
 {
-    return $i*2;
+    return $i * 2;
 }
+
 $b = $a = 5;        /* assign the value five into the variable $a and $b */
 $c = $a++;          /* post-increment, assign original value of $a 
                        (5) to $c */
+print "a = {$a}; b = {$b}; c = {$c}" . PHP_EOL;
+
 $e = $d = ++$b;     /* pre-increment, assign the incremented value of 
                        $b (6) to $d and $e */
+print "b = {$b}; d = {$d}; e = {$e}" . PHP_EOL;
 
 /* at this point, both $d and $e are equal to 6 */
 
 $f = double($d++);  /* assign twice the value of $d before
                        the increment, 2*6 = 12 to $f */
+print "d = {$d}; f = {$f}" . PHP_EOL;
+
 $g = double(++$e);  /* assign twice the value of $e after
                        the increment, 2*7 = 14 to $g */
+print "e = {$e}; g = {$g}" . PHP_EOL;
+
 $h = $g += 10;      /* first, $g is incremented by 10 and ends with the 
                        value of 24. the value of the assignment (24) is 
                        then assigned into $h, and $h ends with the value 
                        of 24 as well. */
+print "g = {$g}; h = {$h}" . PHP_EOL;
 ?>
 ]]>
      </programlisting>

--- a/language/fibers.xml
+++ b/language/fibers.xml
@@ -57,7 +57,6 @@ $value = $fiber->start();
 echo "Value from fiber suspending: ", $value, PHP_EOL;
 
 $fiber->resume('test');
-?>
 ]]>
    </programlisting>
    &example.outputs;

--- a/language/fibers.xml
+++ b/language/fibers.xml
@@ -57,6 +57,7 @@ $value = $fiber->start();
 echo "Value from fiber suspending: ", $value, PHP_EOL;
 
 $fiber->resume('test');
+?>
 ]]>
    </programlisting>
    &example.outputs;


### PR DESCRIPTION
Related: #4799 

These sections are all basically one page so I decided to tackle them all in one PR.

Additionally:

* Removed unnecessary `?>`
* Added some links to Exceptions section help people who are looking for the Exception class definition page

I looked at the Fibers section, but attempting to run the example causes an (browser console) error apparently from wasm regarding a missing getcontext function. This error also happens when trying to run the same code on 3v4l.org's live preview.