### PR TITLE
Add missing 8.0.0 changelog for datetime functions no longer returning false

### DIFF
--- a/reference/datetime/functions/date-parse-from-format.xml
+++ b/reference/datetime/functions/date-parse-from-format.xml
@@ -124,6 +124,13 @@
       </entry>
      </row>
      <row>
+      <entry>8.0.0</entry>
+      <entry>
+       This function no longer returns &false; on failure, but throws a
+       <exceptionname>TypeError</exceptionname> instead.
+      </entry>
+     </row>
+     <row>
       <entry>7.2.0</entry>
       <entry>
        The <literal>zone</literal> element of the returned array represents

--- a/reference/datetime/functions/date-parse.xml
+++ b/reference/datetime/functions/date-parse.xml
@@ -125,6 +125,13 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.0.0</entry>
+      <entry>
+       This function no longer returns &false; on failure, but throws a
+       <exceptionname>TypeError</exceptionname> instead.
+      </entry>
+     </row>
+     <row>
       <entry>7.2.0</entry>
       <entry>
        The <literal>zone</literal> element of the returned array represents

--- a/reference/datetime/functions/date-sun-info.xml
+++ b/reference/datetime/functions/date-sun-info.xml
@@ -155,6 +155,13 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.0.0</entry>
+       <entry>
+        This function no longer returns &false; on failure, but throws a
+        <exceptionname>TypeError</exceptionname> instead.
+       </entry>
+      </row>
+      <row>
        <entry>7.2.0</entry>
        <entry>
         The calculation was fixed with regards to local midnight instead of

--- a/reference/datetime/functions/date.xml
+++ b/reference/datetime/functions/date.xml
@@ -84,6 +84,13 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
+        This function no longer returns &false; on failure, but throws a
+        <exceptionname>TypeError</exceptionname> instead.
+       </entry>
+      </row>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
         <parameter>timestamp</parameter> is nullable now.
        </entry>
       </row>

--- a/reference/datetime/functions/getdate.xml
+++ b/reference/datetime/functions/getdate.xml
@@ -131,6 +131,13 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
+        This function no longer returns &false; on failure, but throws a
+        <exceptionname>TypeError</exceptionname> instead.
+       </entry>
+      </row>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
         <parameter>timestamp</parameter> is nullable now.
        </entry>
       </row>

--- a/reference/datetime/functions/gmdate.xml
+++ b/reference/datetime/functions/gmdate.xml
@@ -61,6 +61,13 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
+        This function no longer returns &false; on failure, but throws a
+        <exceptionname>TypeError</exceptionname> instead.
+       </entry>
+      </row>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
         <parameter>timestamp</parameter> is nullable now.
        </entry>
       </row>

--- a/reference/datetime/functions/localtime.xml
+++ b/reference/datetime/functions/localtime.xml
@@ -127,6 +127,13 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
+        This function no longer returns &false; on failure, but throws a
+        <exceptionname>TypeError</exceptionname> instead.
+       </entry>
+      </row>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
         <parameter>timestamp</parameter> is nullable now.
        </entry>
       </row>


### PR DESCRIPTION
In PHP 7.x, several datetime functions returned `false` on parameter parsing failure. PHP 8.0 changed this to throw `TypeError` instead (per RFC: Consistent type errors for internal functions).

This changelog entry was already documented for
`DateTimeZone::listIdentifiers`/`timezone_identifiers_list`, but was missing from the following functions:

- `date()`
- `gmdate()`
- `localtime()`
- `getdate()`
- `date_parse()`
- `date_parse_from_format()`
- `date_sun_info()`

Functions that still return `false` from their own logic (e.g. `strtotime()`, `mktime()`, `date_create()`) are not included, as the parameter parsing change is not observable in their return types.

The issue also requests reverting the return value description to mention `false`, but the old text was inaccurate (non-numeric strings were coerced to `0`, not rejected) and was intentionally removed in #2130.

Closes #5460