### PR TITLE
uri: Unify example URL for RFC 3986 getters

### DIFF
--- a/reference/uri/uri/rfc3986/uri/getfragment.xml
+++ b/reference/uri/uri/rfc3986/uri/getfragment.xml
@@ -35,16 +35,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://example.com#foo=bar");
 
-echo $uri->getFragment();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->getFragment());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-foo=bar
+string(8) "book.uri"
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/gethost.xml
+++ b/reference/uri/uri/rfc3986/uri/gethost.xml
@@ -35,16 +35,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://example.com");
 
-echo $uri->getHost();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->getHost());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-example.com
+string(11) "www.php.net"
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/getpassword.xml
+++ b/reference/uri/uri/rfc3986/uri/getpassword.xml
@@ -38,16 +38,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
 
-echo $uri->getPassword();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->getPassword());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-password
+string(9) "elephpant"
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/getpath.xml
+++ b/reference/uri/uri/rfc3986/uri/getpath.xml
@@ -35,16 +35,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar");
 
-echo $uri->getPath();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->getPath());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-/foo/bar
+string(18) "/manual/change.php"
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/getport.xml
+++ b/reference/uri/uri/rfc3986/uri/getport.xml
@@ -35,16 +35,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://example.com:443");
 
-echo $uri->getPort();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->getPort());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-443
+int(443)
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/getquery.xml
+++ b/reference/uri/uri/rfc3986/uri/getquery.xml
@@ -35,16 +35,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://example.com?foo=bar");
 
-echo $uri->getQuery();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->getQuery());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-foo=bar
+string(20) "page=en/book.uri.php"
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/getrawfragment.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawfragment.xml
@@ -35,16 +35,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://example.com#foo=bar");
 
-echo $uri->getRawFragment();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->getRawFragment());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-foo=bar
+string(10) "%62ook.uri"
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/getrawhost.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawhost.xml
@@ -35,16 +35,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://example.com");
 
-echo $uri->getRawHost();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->getRawHost());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-example.com
+string(11) "WWW.PHP.NET"
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/getrawpassword.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawpassword.xml
@@ -38,16 +38,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
 
-echo $uri->getRawPassword();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->getRawPassword());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-password
+string(11) "elephp%61nt"
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/getrawpath.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawpath.xml
@@ -35,16 +35,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar");
 
-echo $uri->getRawPath();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->getRawPath());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-/foo/bar
+string(20) "/manual/ch%61nge.php"
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/getrawquery.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawquery.xml
@@ -35,16 +35,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://example.com?foo=bar");
 
-echo $uri->getRawQuery();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->getRawQuery());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-foo=bar
+string(22) "p%61ge=en/book.uri.php"
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/getrawscheme.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawscheme.xml
@@ -35,16 +35,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://example.com");
 
-echo $uri->getRawScheme();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->getRawScheme());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-https
+string(5) "HTTPS"
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/getrawuserinfo.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawuserinfo.xml
@@ -35,16 +35,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
 
-echo $uri->getRawUserInfo();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->getRawUserinfo());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-user:password
+string(17) "p%68p:elephp%61nt"
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/getrawuserinfo.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawuserinfo.xml
@@ -38,7 +38,7 @@
 
 $uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
 
-var_dump($uri->getRawUserinfo());
+var_dump($uri->getRawUserInfo());
 
 ?>
 ]]>

--- a/reference/uri/uri/rfc3986/uri/getrawusername.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawusername.xml
@@ -36,16 +36,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
 
-echo $uri->getRawUsername();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->getRawUsername());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-user
+string(5) "p%68p"
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/getscheme.xml
+++ b/reference/uri/uri/rfc3986/uri/getscheme.xml
@@ -35,16 +35,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://example.com");
 
-echo $uri->getScheme();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->getScheme());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-https
+string(5) "https"
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/getuserinfo.xml
+++ b/reference/uri/uri/rfc3986/uri/getuserinfo.xml
@@ -35,16 +35,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
 
-echo $uri->getUserInfo();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->getUserinfo());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-user:password
+string(13) "php:elephpant"
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/getuserinfo.xml
+++ b/reference/uri/uri/rfc3986/uri/getuserinfo.xml
@@ -38,7 +38,7 @@
 
 $uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
 
-var_dump($uri->getUserinfo());
+var_dump($uri->getUserInfo());
 
 ?>
 ]]>

--- a/reference/uri/uri/rfc3986/uri/getusername.xml
+++ b/reference/uri/uri/rfc3986/uri/getusername.xml
@@ -36,16 +36,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
 
-echo $uri->getUsername();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->getUsername());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-user
+string(3) "php"
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/torawstring.xml
+++ b/reference/uri/uri/rfc3986/uri/torawstring.xml
@@ -35,16 +35,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar?baz");
 
-echo $uri->toRawString();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->toRawString());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-https://example.com/foo/bar?baz
+string(95) "HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri"
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/rfc3986/uri/tostring.xml
+++ b/reference/uri/uri/rfc3986/uri/tostring.xml
@@ -35,16 +35,18 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar?baz");
 
-echo $uri->toString();
+$uri = new \Uri\Rfc3986\Uri('HTTPS://p%68p:elephp%61nt@WWW.PHP.NET:443/manual/ch%61nge.php?p%61ge=en/book.uri.php#%62ook.uri');
+
+var_dump($uri->toString());
+
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-https://example.com/foo/bar?baz
+string(85) "https://php:elephpant@www.php.net:443/manual/change.php?page=en/book.uri.php#book.uri"
 ]]>
    </screen>
   </example>


### PR DESCRIPTION
This new example URL includes all possible components and each of the component includes a meaningful difference between the “normalized” and “raw” version to make it easy for a reader to see what each of the getters refers to and what kind of normalization to expect.