### PR TITLE
Enable runnable (WASM) examples for language.namespaces section

### DIFF
--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <chapter xml:id="language.namespaces" xmlns="http://docbook.org/ns/docbook"
- version="1.1">
+ version="1.1" annotations="interactive">
  <title>Namespaces</title>
 
  <sect1 xml:id="language.namespaces.rationale">
@@ -58,16 +58,19 @@ function myfunction() {}
 const MYCONST = 1;
 
 $a = new MyClass;
+print $a::class . "\n";
 $c = new \my\name\MyClass; // see "Global Space" section
+print $c::class . "\n";
 
 $a = strlen('hi'); // see "Using namespaces: fallback to global
                    // function/constant" section
+print $a . "\n";
 
 $d = namespace\MYCONST; // see "namespace operator and __NAMESPACE__
                         // constant" section
+print $d . "\n";
 $d = __NAMESPACE__ . '\MYCONST';
 echo constant($d); // see "Namespaces and dynamic language features" section
-?>
     ]]>
    </programlisting>
   </example>
@@ -101,7 +104,7 @@ echo constant($d); // see "Namespaces and dynamic language features" section
    <xref linkend="control-structures.declare" /> keyword.
    <example>
     <title>Declaring a single namespace</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace MyProject;
@@ -109,8 +112,6 @@ namespace MyProject;
 const CONNECT_OK = 1;
 class Connection { /* ... */ }
 function connect() { /* ... */ }
-
-?>
 ]]>
     </programlisting>
    </example>
@@ -125,12 +126,11 @@ function connect() { /* ... */ }
    no non-PHP code may precede a namespace declaration, including extra whitespace:
    <example>
     <title>Declaring a single namespace</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <html>
 <?php
 namespace MyProject; // fatal error - namespace must be the first statement in the script
-?>
 ]]>
     </programlisting>
    </example>
@@ -150,7 +150,7 @@ namespace MyProject; // fatal error - namespace must be the first statement in t
    sub-levels:
    <example>
     <title>Declaring a single namespace with hierarchy</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace MyProject\Sub\Level;
@@ -158,8 +158,6 @@ namespace MyProject\Sub\Level;
 const CONNECT_OK = 1;
 class Connection { /* ... */ }
 function connect() { /* ... */  }
-
-?>
 ]]>
     </programlisting>
    </example>
@@ -179,7 +177,7 @@ function connect() { /* ... */  }
   <para>
    <example>
     <title>Declaring multiple namespaces, simple combination syntax</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace MyProject;
@@ -193,7 +191,6 @@ namespace AnotherProject;
 const CONNECT_OK = 1;
 class Connection { /* ... */ }
 function connect() { /* ... */  }
-?>
 ]]>
     </programlisting>
    </example>
@@ -205,7 +202,7 @@ function connect() { /* ... */  }
   <para>
    <example>
     <title>Declaring multiple namespaces, bracketed syntax</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace MyProject {
@@ -221,7 +218,6 @@ const CONNECT_OK = 1;
 class Connection { /* ... */ }
 function connect() { /* ... */  }
 }
-?>
 ]]>
     </programlisting>
    </example>
@@ -243,16 +239,22 @@ function connect() { /* ... */  }
 namespace MyProject {
 
 const CONNECT_OK = 1;
-class Connection { /* ... */ }
-function connect() { /* ... */  }
+class Connection { 
+    public static function start() {
+        print __METHOD__ . "\n";
+    }
+}
+
+function connect() {
+    print __FUNCTION__ . "\n";
+}
 }
 
 namespace { // global code
-session_start();
-$a = MyProject\connect();
-echo MyProject\Connection::start();
+print strlen("hi") . "\n";
+MyProject\connect();
+MyProject\Connection::start();
 }
-?>
 ]]>
     </programlisting>
    </example>
@@ -265,20 +267,26 @@ echo MyProject\Connection::start();
     <programlisting role="php">
      <![CDATA[
 <?php
-declare(encoding='UTF-8');
+declare(strict_types=1);
 namespace MyProject {
 
 const CONNECT_OK = 1;
-class Connection { /* ... */ }
-function connect() { /* ... */  }
+class Connection { 
+    public static function start() {
+        print __METHOD__ . "\n";
+    }
+}
+
+function connect() {
+    print __FUNCTION__ . "\n";
+}
 }
 
 namespace { // global code
-session_start();
-$a = MyProject\connect();
-echo MyProject\Connection::start();
+print strlen("hi") . "\n";
+MyProject\connect();
+MyProject\Connection::start();
 }
-?>
 ]]>
     </programlisting>
    </example>
@@ -358,7 +366,7 @@ echo MyProject\Connection::start();
    Here is an example of the three kinds of syntax in actual code:
    <informalexample>
     <simpara>file1.php</simpara>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace Foo\Bar\subnamespace;
@@ -369,11 +377,10 @@ class foo
 {
     static function staticmethod() {}
 }
-?>
      ]]>
     </programlisting>
     <simpara>file2.php</simpara>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace Foo\Bar;
@@ -401,7 +408,6 @@ echo subnamespace\FOO; // resolves to constant Foo\Bar\subnamespace\FOO
 \Foo\Bar\foo(); // resolves to function Foo\Bar\foo
 \Foo\Bar\foo::staticmethod(); // resolves to class Foo\Bar\foo, method staticmethod
 echo \Foo\Bar\FOO; // resolves to constant Foo\Bar\FOO
-?>
      ]]>
     </programlisting>
    </informalexample>
@@ -422,10 +428,10 @@ function strlen() {}
 const INI_ALL = 3;
 class Exception {}
 
-$a = \strlen('hi'); // calls global function strlen
-$b = \INI_ALL; // accesses global constant INI_ALL
+print \strlen('hi') . "\n"; // calls global function strlen
+print \INI_ALL . "\n"; // accesses global constant INI_ALL
 $c = new \Exception('error'); // instantiates global class Exception
-?>
+print $c::class . "\n";
      ]]>
     </programlisting>
    </example>
@@ -462,7 +468,6 @@ $obj = new $a; // prints classname::__construct
 $b = 'funcname';
 $b(); // prints funcname
 echo constant('constname'), "\n"; // prints global
-?>
     ]]>
     </programlisting>
    </example>
@@ -500,7 +505,6 @@ $b = '\namespacename\funcname';
 $b(); // also prints namespacename\funcname
 echo constant('\namespacename\constname'), "\n"; // prints namespaced
 echo constant('namespacename\constname'), "\n"; // also prints namespaced
-?>
     ]]>
     </programlisting>
    </example>
@@ -530,7 +534,6 @@ echo constant('namespacename\constname'), "\n"; // also prints namespaced
 namespace MyProject;
 
 echo '"', __NAMESPACE__, '"'; // outputs "MyProject"
-?>
 ]]>
     </programlisting>
    </example>
@@ -539,9 +542,7 @@ echo '"', __NAMESPACE__, '"'; // outputs "MyProject"
     <programlisting role="php">
      <![CDATA[
 <?php
-
 echo '"', __NAMESPACE__, '"'; // outputs ""
-?>
 ]]>
     </programlisting>
    </example>
@@ -549,7 +550,7 @@ echo '"', __NAMESPACE__, '"'; // outputs ""
    names, for instance:
    <example>
     <title>using __NAMESPACE__ for dynamic name construction</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace MyProject;
@@ -559,7 +560,6 @@ function get($classname)
     $a = __NAMESPACE__ . '\\' . $classname;
     return new $a;
 }
-?>
 ]]>
     </programlisting>
    </example>
@@ -570,7 +570,7 @@ function get($classname)
    equivalent of the <literal>self</literal> operator for classes.
    <example>
     <title>the namespace operator, inside a namespace</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace MyProject;
@@ -585,13 +585,12 @@ namespace\sub\func(); // calls function MyProject\sub\func()
 namespace\cname::method(); // calls static method "method" of class MyProject\cname
 $a = new namespace\sub\cname(); // instantiates object of class MyProject\sub\cname
 $b = namespace\CONSTANT; // assigns value of constant MyProject\CONSTANT to $b
-?>
 ]]>
     </programlisting>
    </example>
    <example>
     <title>the namespace operator, in global code</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 
@@ -600,7 +599,6 @@ namespace\sub\func(); // calls function sub\func()
 namespace\cname::method(); // calls static method "method" of class cname
 $a = new namespace\sub\cname(); // instantiates object of class sub\cname
 $b = namespace\CONSTANT; // assigns value of constant CONSTANT to $b
-?>
 ]]>
     </programlisting>
    </example>
@@ -624,7 +622,7 @@ $b = namespace\CONSTANT; // assigns value of constant CONSTANT to $b
    Here is an example showing all 5 kinds of importing:
    <example>
     <title>importing/aliasing with the use operator</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace foo;
@@ -652,7 +650,6 @@ $a = new ArrayObject(array(1)); // instantiates object of class ArrayObject
 // without the "use ArrayObject" we would instantiate an object of class foo\ArrayObject
 func(); // calls function My\Full\functionName
 echo CONSTANT; // echoes the value of My\Full\CONSTANT
-?>
 ]]>
     </programlisting>
    </example>
@@ -667,14 +664,13 @@ echo CONSTANT; // echoes the value of My\Full\CONSTANT
    on the same line
    <example>
     <title>importing/aliasing with the use operator, multiple use statements combined</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 use My\Full\Classname as Another, My\Full\NSname;
 
 $obj = new Another; // instantiates object of class My\Full\Classname
 NSname\subns\func(); // calls function My\Full\NSname\subns\func
-?>
 ]]>
     </programlisting>
    </example>
@@ -684,7 +680,7 @@ NSname\subns\func(); // calls function My\Full\NSname\subns\func
    or constant names.
    <example>
     <title>Importing and dynamic names</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 use My\Full\Classname as Another, My\Full\NSname;
@@ -692,7 +688,6 @@ use My\Full\Classname as Another, My\Full\NSname;
 $obj = new Another; // instantiates object of class My\Full\Classname
 $a = 'Another';
 $obj = new $a;      // instantiates object of class Another
-?>
 ]]>
     </programlisting>
    </example>
@@ -702,7 +697,7 @@ $obj = new $a;      // instantiates object of class Another
    names are absolute, and unaffected by imports.
    <example>
     <title>Importing and fully qualified names</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 use My\Full\Classname as Another, My\Full\NSname;
@@ -711,7 +706,6 @@ $obj = new Another; // instantiates object of class My\Full\Classname
 $obj = new \Another; // instantiates object of class Another
 $obj = new Another\thing; // instantiates object of class My\Full\Classname\thing
 $obj = new \Another\thing; // instantiates object of class Another\thing
-?>
 ]]>
     </programlisting>
    </example>
@@ -740,7 +734,6 @@ function toGreenlandic()
 
     // ...
 }
-?>
 ]]>
      </programlisting>
     </example>
@@ -760,7 +753,7 @@ function toGreenlandic()
     statement.
    </para>
    <informalexample>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -797,7 +790,7 @@ use const some\namespace\{ConstA, ConstB, ConstC};
    namespace.
    <example>
     <title>Using global space specification</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace A\B\C;
@@ -808,7 +801,6 @@ function fopen() {
      $f = \fopen(...); // call global fopen
      return $f;
 }
-?>
     ]]>
     </programlisting>
    </example>
@@ -832,10 +824,11 @@ namespace A\B\C;
 class Exception extends \Exception {}
 
 $a = new Exception('hi'); // $a is an object of class A\B\C\Exception
+var_dump($a::class);
 $b = new \Exception('hi'); // $b is an object of class Exception
+var_dump($b::class);
 
 $c = new ArrayObject; // fatal error, class A\B\C\ArrayObject not found
-?>
     ]]>
     </programlisting>
    </example>
@@ -865,7 +858,6 @@ if (is_array('hi')) { // prints "is not array"
 } else {
     echo "is not array\n";
 }
-?>
     ]]>
     </programlisting>
    </example>
@@ -994,7 +986,7 @@ if (is_array('hi')) { // prints "is not array"
   </para>
   <example>
    <title>Name resolutions illustrated</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 namespace A;
@@ -1054,7 +1046,6 @@ A\B::foo();   // calls method "foo" of class "B" from namespace "A\A"
 
 \A\B::foo();  // calls method "foo" of class "B" from namespace "A"
               // if class "A\B" not found, it tries to autoload class "A\B"
-?>
 ]]>
    </programlisting>
   </example>
@@ -1167,7 +1158,7 @@ A\B::foo();   // calls method "foo" of class "B" from namespace "A\A"
 <![CDATA[
 <?php
 $a = new \stdClass;
-?>
+print $a::class;
 ]]>
      </programlisting>
     </example>
@@ -1182,7 +1173,7 @@ $a = new \stdClass;
 <![CDATA[
 <?php
 $a = new stdClass;
-?>
+print $a::class;
 ]]>
      </programlisting>
     </example>
@@ -1198,14 +1189,16 @@ $a = new stdClass;
 <?php
 namespace foo;
 $a = new \stdClass;
+print $a::class . "\n";
 
-function test(\ArrayObject $parameter_type_example = null) {}
+function test(?\ArrayObject $parameter_type_example = null) {}
 
-$a = \DirectoryIterator::CURRENT_AS_FILEINFO;
+$a = \FilesystemIterator::CURRENT_AS_FILEINFO;
+print $a . "\n";
 
 // extending an internal or global class
 class MyException extends \Exception {}
-?>
+print MyException::class . "\n";
 ]]>
      </programlisting>
     </example>
@@ -1227,19 +1220,21 @@ namespace foo;
 class MyClass {}
 
 // using a class from the current namespace as a parameter type
-function test(MyClass $parameter_type_example = null) {}
+function test(?MyClass $parameter_type_example = null) {}
 // another way to use a class from the current namespace as a parameter type
-function test(\foo\MyClass $parameter_type_example = null) {}
+function test2(?\foo\MyClass $parameter_type_example = null) {}
 
 // extending a class from the current namespace
 class Extended extends MyClass {}
+print Extended::class . "\n";
 
 // accessing a global function
-$a = \globalfunc();
+$a = \strlen("test");
+print $a . "\n";
 
 // accessing a global constant
 $b = \INI_ALL;
-?>
+print $b . "\n";
 ]]>
      </programlisting>
     </example>
@@ -1256,14 +1251,13 @@ $b = \INI_ALL;
     and <literal>\Exception</literal> is <literal>Exception</literal>.
     <example>
      <title>Fully Qualified names</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 namespace foo;
 $a = new \my\name(); // instantiates "my\name" class
 echo \strlen('hi'); // calls function "strlen"
 $a = \INI_ALL; // $a is set to the value of constant "INI_ALL"
-?>
 ]]>
      </programlisting>
     </example>
@@ -1286,7 +1280,7 @@ $a = \INI_ALL; // $a is set to the value of constant "INI_ALL"
    <para>
     <example>
      <title>Qualified names</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 namespace foo;
@@ -1296,7 +1290,6 @@ $a = new my\name(); // instantiates "foo\my\name" class
 foo\bar::name(); // calls static method "name" in class "blah\blah\bar"
 my\bar(); // calls function "foo\my\bar"
 $a = my\BAR; // sets $a to the value of constant "foo\my\BAR"
-?>
 ]]>
      </programlisting>
     </example>
@@ -1319,7 +1312,7 @@ $a = my\BAR; // sets $a to the value of constant "foo\my\BAR"
    <para>
     <example>
      <title>Unqualified class names</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 namespace foo;
@@ -1327,7 +1320,6 @@ use blah\blah as foo;
 
 $a = new name(); // instantiates "foo\name" class
 foo::name(); // calls static method "name" in class "blah\blah"
-?>
 ]]>
      </programlisting>
     </example>
@@ -1361,8 +1353,12 @@ use blah\blah as foo;
 
 const FOO = 1;
 
-function my() {}
-function foo() {}
+function my() {
+    print __FUNCTION__ . "\n";
+}
+function foo() {
+    print __FUNCTION__ . "\n";
+}
 function sort(&$a)
 {
     \sort($a); // calls the global function "sort"
@@ -1371,14 +1367,16 @@ function sort(&$a)
 }
 
 my(); // calls "foo\my"
-$a = strlen('hi'); // calls global function "strlen" because "foo\strlen" does not exist
+print strlen('hi') . "\n"; // calls global function "strlen" because "foo\strlen" does not exist
 $arr = array(1,3,2);
 $b = sort($arr); // calls function "foo\sort"
-$c = foo(); // calls function "foo\foo" - import is not applied
+var_dump($b);
+foo(); // calls function "foo\foo" - import is not applied
 
 $a = FOO; // sets $a to value of constant "foo\FOO" - import is not applied
+print $a;
 $b = INI_ALL; // sets $b to value of global constant "INI_ALL"
-?>
+print $b;
 ]]>
      </programlisting>
     </example>
@@ -1390,25 +1388,23 @@ $b = INI_ALL; // sets $b to value of global constant "INI_ALL"
     The following script combinations are legal:
     <informalexample>
      <simpara>file1.php</simpara>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace my\stuff;
 class MyClass {}
-?>
      ]]>
      </programlisting>
      <simpara>another.php</simpara>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace another;
 class thing {}
-?>
      ]]>
      </programlisting>
      <simpara>file2.php</simpara>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace my\stuff;
@@ -1417,7 +1413,6 @@ include 'another.php';
 
 use another\thing as MyClass;
 $a = new MyClass; // instantiates class "thing" from namespace another
-?>
      ]]>
      </programlisting>
     </informalexample>
@@ -1428,14 +1423,13 @@ $a = new MyClass; // instantiates class "thing" from namespace another
     in a separate file. However, the next example causes a fatal error on name conflict
     because MyClass is defined in the same file as the use statement.
     <informalexample>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace my\stuff;
 use another\thing as MyClass;
 class MyClass {} // fatal error: MyClass conflicts with import statement
 $a = new MyClass;
-?>
      ]]>
      </programlisting>
     </informalexample>
@@ -1454,7 +1448,6 @@ namespace my\stuff {
         class foo {}
     }
 }
-?>
      ]]>
      </programlisting>
     </informalexample>
@@ -1466,7 +1459,6 @@ namespace my\stuff {
 namespace my\stuff\nested {
     class foo {}
 }
-?>
      ]]>
      </programlisting>
     </informalexample>
@@ -1481,7 +1473,7 @@ namespace my\stuff\nested {
     there is a risk of unintended consequences:
     <example>
      <title>Dangers of using namespaced names inside a double-quoted string</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
       <![CDATA[
 <?php
 $a = "dangerous\name"; // \n is a newline inside double quoted strings!
@@ -1489,7 +1481,6 @@ $obj = new $a;
 
 $a = 'not\at\all\dangerous'; // no problems here.
 $obj = new $a;
-?>
       ]]>
      </programlisting>
     </example>
@@ -1506,7 +1497,7 @@ $obj = new $a;
     backslash will produce a fatal error if not found.
     <example>
      <title>Undefined constants</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
       <![CDATA[
 <?php
 namespace bar;
@@ -1514,7 +1505,6 @@ $a = FOO; // produces notice - undefined constants "FOO" assumed "FOO";
 $a = \FOO; // fatal error, undefined namespace constant FOO
 $a = Bar\FOO; // fatal error, undefined namespace constant bar\Bar\FOO
 $a = \Bar\FOO; // fatal error, undefined namespace constant Bar\FOO
-?>
       ]]>
      </programlisting>
     </example>
@@ -1534,7 +1524,6 @@ namespace bar;
 const NULL = 0; // fatal error;
 const true = 'stupid'; // also fatal error;
 // etc.
-?>
       ]]>
      </programlisting>
     </example>

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -239,7 +239,7 @@ function connect() { /* ... */  }
 namespace MyProject {
 
 const CONNECT_OK = 1;
-class Connection { 
+class Connection {
     public static function start() {
         print __METHOD__ . "\n";
     }
@@ -271,7 +271,7 @@ declare(strict_types=1);
 namespace MyProject {
 
 const CONNECT_OK = 1;
-class Connection { 
+class Connection {
     public static function start() {
         print __METHOD__ . "\n";
     }


### PR DESCRIPTION
Related: #4799 
