### PR TITLE
Fix ImagickDraw::getTextInterlineSpacing description typo

### DIFF
--- a/reference/imagick/imagickdraw/gettextinterlinespacing.xml
+++ b/reference/imagick/imagickdraw/gettextinterlinespacing.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="imagickdraw.gettextinterlinespacing" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ImagickDraw::getTextInterlineSpacing</refname>
-  <refpurpose>Gets the text interword spacing</refpurpose>
+  <refpurpose>Gets the text interline spacing</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Gets the text interword spacing.
+   Gets the text interline spacing.
   </para>
  </refsect1>
 


### PR DESCRIPTION
The description incorrectly said "interword spacing" instead of "interline spacing". This appears to be a copy-paste error from the getTextInterwordSpacing page. The ImageMagick C API (DrawGetTextInterlineSpacing) describes this function as "Gets the spacing between lines in text."