### PR TITLE
proc_close: "waits", not "closes". Also grammar fix in Returns.

### DIFF
--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -4,7 +4,7 @@
 <refentry xml:id='function.proc-close' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>proc_close</refname>
-  <refpurpose>Close a process opened by <function>proc_open</function> and return the exit code of that process</refpurpose>
+  <refpurpose>Wait for a process opened by <function>proc_open</function> to close and return the exit code of that process</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -46,7 +46,7 @@
   &reftitle.returnvalues;
   <para>
    Returns the termination status of the process that was run. In case of 
-   an error then <literal>-1</literal> is returned.
+   an error <literal>-1</literal> is returned.
   </para>
   &note.sigchild;
  </refsect1>

--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -4,7 +4,7 @@
 <refentry xml:id='function.proc-close' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>proc_close</refname>
-  <refpurpose>Wait for a process opened by <function>proc_open</function> to close and return the exit code of that process</refpurpose>
+  <refpurpose>Close pipes to a process opened by <function>proc_open</function>, wait for it to terminate, and return its exit code</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -44,10 +44,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the termination status of the process that was run. In case of 
-   an error <literal>-1</literal> is returned.
-  </para>
+   an error, <literal>-1</literal> is returned.
+  </simpara>
   &note.sigchild;
  </refsect1>
 


### PR DESCRIPTION
The function waits (waitpid) for a process to terminate, it does not do any closing. The description is a little misleading.