### PR TITLE
proc_close: clarify termination status in regard to proc_get_status

### DIFF
--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -50,7 +50,29 @@
   </para>
   &note.sigchild;
  </refsect1>
-
+  <refsect1 role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.3.0</entry>
+       <entry>
+        <function>proc_close</function> now returns the correct exit code
+        even after <function>proc_get_status</function> was called first.
+        Previously, <literal>-1</literal> was returned in that case.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </refsect1>
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -49,9 +49,9 @@
    an error then <literal>-1</literal> is returned.
   </para>
   <para>
-   If <function>proc_get_status</function> is called before <function>proc_close</function>,
-   and finds the process not in "running" state anymore, and retrieves the exit code, then
-   <function>proc_close</function> will also return <literal>-1</literal>.
+   Prior to PHP 8.3.0, if <function>proc_get_status</function> is called before
+   <function>proc_close</function> and retrieves the exit code, then
+   <function>proc_close</function> will return <literal>-1</literal>.
   </para>
   &note.sigchild;
  </refsect1>

--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -48,11 +48,6 @@
    Returns the termination status of the process that was run. In case of 
    an error then <literal>-1</literal> is returned.
   </para>
-  <para>
-   Prior to PHP 8.3.0, if <function>proc_get_status</function> is called before
-   <function>proc_close</function> and retrieves the exit code, then
-   <function>proc_close</function> will return <literal>-1</literal>.
-  </para>
   &note.sigchild;
  </refsect1>
 

--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -48,6 +48,11 @@
    Returns the termination status of the process that was run. In case of 
    an error then <literal>-1</literal> is returned.
   </para>
+  <para>
+   If <function>proc_get_status</function> is called before <function>proc_close</function>,
+   and finds the process not in "running" state anymore, and retrieves the exit code, then
+   <function>proc_close</function> will also return <literal>-1</literal>.
+  </para>
   &note.sigchild;
  </refsect1>
 


### PR DESCRIPTION
Explain how proc_get_status may interfere with proc_close return value.