### PR TITLE
Enable runnable (WASM) examples for Predefined Interfaces & Classes (language/predefined)

### DIFF
--- a/language/predefined/arrayaccess.xml
+++ b/language/predefined/arrayaccess.xml
@@ -81,7 +81,6 @@ $obj[] = 'Append 1';
 $obj[] = 'Append 2';
 $obj[] = 'Append 3';
 print_r($obj);
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;
@@ -91,9 +90,9 @@ bool(true)
 int(2)
 bool(false)
 string(7) "A value"
-obj Object
+Obj Object
 (
-    [container:obj:private] => Array
+    [container] => Array
         (
             [one] => 1
             [three] => 3

--- a/language/predefined/fiber.xml
+++ b/language/predefined/fiber.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<reference xml:id="class.fiber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.fiber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude"
+ annotations="non-interactive">
  <title>The Fiber class</title>
  <titleabbrev>Fiber</titleabbrev>
 

--- a/language/predefined/fibererror.xml
+++ b/language/predefined/fibererror.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<reference xml:id="class.fibererror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.fibererror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude"
+ annotations="non-interactive">
  <title>FiberError</title>
  <titleabbrev>FiberError</titleabbrev>
 

--- a/language/predefined/interfaces.xml
+++ b/language/predefined/interfaces.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<part xml:id="reserved.interfaces" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<part xml:id="reserved.interfaces" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+ annotations="interactive">
  <title>Predefined Interfaces and Classes</title>
 
  <partintro>

--- a/language/predefined/iteratoraggregate.xml
+++ b/language/predefined/iteratoraggregate.xml
@@ -49,19 +49,13 @@
 
 class myData implements IteratorAggregate
 {
-    public $property1 = "Public property one";
-    public $property2 = "Public property two";
-    public $property3 = "Public property three";
-    public $property4 = "";
-
-    public function __construct()
-    {
-        $this->property4 = "last property";
-    }
-
     public function getIterator(): Traversable
     {
-        return new ArrayIterator($this);
+        return new ArrayIterator([
+            "key one" => "item one",
+            "key two" => "item two",
+            "key three" => "item three"
+        ]);
     }
 }
 
@@ -71,24 +65,19 @@ foreach ($obj as $key => $value) {
     var_dump($key, $value);
     echo "\n";
 }
-
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;
     <screen>
 <![CDATA[
-string(9) "property1"
-string(19) "Public property one"
+string(7) "key one"
+string(8) "item one"
 
-string(9) "property2"
-string(19) "Public property two"
+string(7) "key two"
+string(8) "item two"
 
-string(9) "property3"
-string(21) "Public property three"
-
-string(9) "property4"
-string(13) "last property"
+string(9) "key three"
+string(10) "item three"
 
 ]]>
     </screen>

--- a/language/predefined/serializable.xml
+++ b/language/predefined/serializable.xml
@@ -88,6 +88,7 @@ var_dump($newobj->getData());
     &example.outputs.similar;
     <screen>
 <![CDATA[
+Deprecated: obj implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in script on line 2
 string(38) "C:3:"obj":23:{s:15:"My private data";}"
 string(15) "My private data"
 ]]>

--- a/language/predefined/unitenum/cases.xml
+++ b/language/predefined/unitenum/cases.xml
@@ -48,21 +48,20 @@ enum Suit
 }
 
 var_dump(Suit::cases());
-?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
 array(4) {
-    [0]=>
-    enum(Suit::Hearts)
-    [1]=>
-    enum(Suit::Diamonds)
-    [2]=>
-    enum(Suit::Clubs)
-    [3]=>
-    enum(Suit::Spades)
+  [0]=>
+  enum(Suit::Hearts)
+  [1]=>
+  enum(Suit::Diamonds)
+  [2]=>
+  enum(Suit::Clubs)
+  [3]=>
+  enum(Suit::Spades)
 }
 ]]>
    </screen>


### PR DESCRIPTION
Related: #4799 

The IteratorAggregate example was replaced as the existing example showed deprecated usage or ArrayIterator.

While there are no current examples on the affected pages, I have explicitly disabled interactive examples on the Fiber classes due to https://github.com/php/web-php/issues/1878