### PR TITLE
fix: change INSERT to be DROP in implicit commit example 1

### DIFF
--- a/reference/pdo/transactions.xml
+++ b/reference/pdo/transactions.xml
@@ -72,7 +72,7 @@
 $pdo->beginTransaction();
 $pdo->exec("INSERT INTO users (name) VALUES ('Rasmus')");
 $pdo->exec("CREATE TABLE test (id INT PRIMARY KEY)"); // Implicit COMMIT occurs here
-$pdo->rollBack(); // This will NOT undo the INSERT/CREATE for MySQL or Oracle
+$pdo->rollBack(); // This will NOT undo the DROP/CREATE for MySQL or Oracle
 ?>
 ]]>
    </programlisting>


### PR DESCRIPTION
Issue link => https://github.com/php/doc-en/issues/5488

From manual page: https://php.net/pdo.transactions

---

in the Example 1 Implicit Commit Example 
```php
<?php
$pdo->beginTransaction();
$pdo->exec("INSERT INTO users (name) VALUES ('Rasmus')");
$pdo->exec("CREATE TABLE test (id INT PRIMARY KEY)"); // Implicit COMMIT occurs here
$pdo->rollBack(); // This will NOT undo the INSERT/CREATE for MySQL or Oracle
?>
```
The comment in the last line `$pdo->rollback();` explains that we cannot undo the INSERT and this is wrong.
we can undo the INSERT but we cannot undo the create or drop (DDL) statements, So it should be like this 

```php
<?php
$pdo->beginTransaction();
$pdo->exec("INSERT INTO users (name) VALUES ('Rasmus')");
$pdo->exec("CREATE TABLE test (id INT PRIMARY KEY)"); // Implicit COMMIT occurs here
$pdo->rollBack(); // This will NOT undo the DROP/CREATE for MySQL or Oracle
?>
```