### PR TITLE
Document warning emitted by openssl_x509_read

### DIFF
--- a/reference/openssl/functions/openssl-x509-read.xml
+++ b/reference/openssl/functions/openssl-x509-read.xml
@@ -45,9 +45,9 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    An <constant>E_WARNING</constant> is emitted if the X.509 certificate cannot be retrieved.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/openssl/functions/openssl-x509-read.xml
+++ b/reference/openssl/functions/openssl-x509-read.xml
@@ -43,6 +43,13 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   An <constant>E_WARNING</constant> is emitted if the X.509 certificate cannot be retrieved.
+  </para>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>


### PR DESCRIPTION
An error is emitted when the certificate is not found:

```php
<?php
openssl_x509_read('qsdfqsdfqsdf');
// PHP Warning:  openssl_x509_read(): X.509 Certificate cannot be retrieved in...
```