### PR TITLE
MongoDB: document readonly properties and IWM URI options

### DIFF
--- a/reference/mongodb/mongodb/driver/exception/bulkwriteexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwriteexception.xml
@@ -42,7 +42,8 @@
 <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
-     <modifier>protected</modifier>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>MongoDB\Driver\WriteResult</type>
      <varname linkend="mongodb-driver-exception-bulkwriteexception.props.writeresult">writeResult</varname>
     </fieldsynopsis>
@@ -95,6 +96,13 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        The <varname>writeResult</varname> property is now
+        <modifier>public</modifier> <modifier>readonly</modifier>.
+       </entry>
+      </row>
       <row>
        <entry>PECL mongodb 2.0.0</entry>
        <entry>

--- a/reference/mongodb/mongodb/driver/exception/bulkwriteexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwriteexception.xml
@@ -42,7 +42,8 @@
 <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
-     <modifier>protected</modifier>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>MongoDB\Driver\WriteResult</type>
      <varname linkend="mongodb-driver-exception-bulkwriteexception.props.writeresult">writeResult</varname>
     </fieldsynopsis>
@@ -96,6 +97,13 @@
        </row>
       </thead>
       <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         The <varname>writeResult</varname> property is now
+         <modifier>public</modifier> <modifier>readonly</modifier>.
+        </entry>
+       </row>
        <row>
         <entry>PECL mongodb 2.0.0</entry>
         <entry>

--- a/reference/mongodb/mongodb/driver/exception/commandexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/commandexception.xml
@@ -42,7 +42,8 @@
 <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
-     <modifier>protected</modifier>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>object</type>
      <varname linkend="mongodb-driver-exception-commandexception.props.resultdocument">resultDocument</varname>
     </fieldsynopsis>
@@ -83,6 +84,29 @@
    </variablelist>
   </section>
 <!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        The <varname>resultDocument</varname> property is now
+        <modifier>public</modifier> <modifier>readonly</modifier>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/mongodb/mongodb/driver/exception/commandexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/commandexception.xml
@@ -42,7 +42,8 @@
 <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
-     <modifier>protected</modifier>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>object</type>
      <varname linkend="mongodb-driver-exception-commandexception.props.resultdocument">resultDocument</varname>
     </fieldsynopsis>
@@ -83,6 +84,31 @@
    </variablelist>
   </section>
 <!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         The <varname>resultDocument</varname> property is now
+         <modifier>public</modifier> <modifier>readonly</modifier>.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
 
  </partintro>
 

--- a/reference/mongodb/mongodb/driver/manager/construct.xml
+++ b/reference/mongodb/mongodb/driver/manager/construct.xml
@@ -208,6 +208,16 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
           </entry>
          </row>
          <row>
+          <entry>enableOverloadRetargeting</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <simpara>
+            When set to &true; it forces server selection after a
+            <literal>SystemOverloadedError</literal>. Defaults to &false;.
+           </simpara>
+          </entry>
+         </row>
+         <row>
           <entry>heartbeatFrequencyMS</entry>
           <entry><type>int</type></entry>
           <entry>
@@ -259,6 +269,17 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
             The size in milliseconds of the latency window for selecting among
             multiple suitable MongoDB instances while resolving a read
             preference. Defaults to 15 milliseconds.
+           </simpara>
+          </entry>
+         </row>
+         <row>
+          <entry>maxAdaptiveRetries</entry>
+          <entry><type>int</type></entry>
+          <entry>
+           <simpara>
+            This option can be used to change the maximum number of retries
+            when a <literal>SystemOverloadedError</literal> occurs. Must be a
+            positive integer; defaults to <literal>2</literal>.
            </simpara>
           </entry>
          </row>

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent.xml
@@ -34,11 +34,194 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.commandname">commandName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.databasename">databaseName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.duration">duration</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Exception</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.error">error</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>object</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.reply">reply</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.operationid">operationId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.requestid">requestId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>MongoDB\BSON\ObjectId</type><type>null</type></type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.serviceid">serviceId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.serverconnectionid">serverConnectionId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-commandfailedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\CommandFailedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-commandfailedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <simpara>The hostname of the server that executed the command.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <simpara>The port of the server that executed the command.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.commandname">
+     <term><varname>commandName</varname></term>
+     <listitem>
+      <simpara>The command name.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.databasename">
+     <term><varname>databaseName</varname></term>
+     <listitem>
+      <simpara>The database name.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.duration">
+     <term><varname>duration</varname></term>
+     <listitem>
+      <simpara>
+       The duration of the command in microseconds. The duration is a
+       calculated value that includes the time to send the message and
+       receive the response from the server.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.error">
+     <term><varname>error</varname></term>
+     <listitem>
+      <simpara>The exception that was thrown when the command failed.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.reply">
+     <term><varname>reply</varname></term>
+     <listitem>
+      <simpara>The failure reply document returned by the server.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.operationid">
+     <term><varname>operationId</varname></term>
+     <listitem>
+      <simpara>
+       The operation ID. This may be used to link events together such as
+       bulk writes, which may dispatch multiple commands.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.requestid">
+     <term><varname>requestId</varname></term>
+     <listitem>
+      <simpara>
+       The request ID. This may be used to associate this
+       <classname>MongoDB\Driver\Monitoring\CommandFailedEvent</classname>
+       with a corresponding
+       <classname>MongoDB\Driver\Monitoring\CommandStartedEvent</classname>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.serviceid">
+     <term><varname>serviceId</varname></term>
+     <listitem>
+      <simpara>
+       The service ID, or &null; if the server does not support it (i.e.
+       not using load-balanced mode).
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.serverconnectionid">
+     <term><varname>serverConnectionId</varname></term>
+     <listitem>
+      <simpara>
+       The server connection ID, or &null; if not available.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Added public <modifier>readonly</modifier> properties. The
+        <varname>duration</varname> property replaces the
+        <methodname>getDurationMicros</methodname> method.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent.xml
@@ -33,12 +33,197 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.commandname">commandName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.databasename">databaseName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.duration">duration</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Exception</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.error">error</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>object</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.reply">reply</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.operationid">operationId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.requestid">requestId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>MongoDB\BSON\ObjectId</type><type>null</type></type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.serviceid">serviceId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.serverconnectionid">serverConnectionId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-commandfailedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\CommandFailedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-commandfailedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <para>The hostname of the server that executed the command.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <para>The port of the server that executed the command.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.commandname">
+     <term><varname>commandName</varname></term>
+     <listitem>
+      <para>The command name.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.databasename">
+     <term><varname>databaseName</varname></term>
+     <listitem>
+      <para>The database name.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.duration">
+     <term><varname>duration</varname></term>
+     <listitem>
+      <para>
+       The duration of the command in microseconds. The duration is a
+       calculated value that includes the time to send the message and
+       receive the response from the server.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.error">
+     <term><varname>error</varname></term>
+     <listitem>
+      <para>The exception that was thrown when the command failed.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.reply">
+     <term><varname>reply</varname></term>
+     <listitem>
+      <para>The failure reply document returned by the server.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.operationid">
+     <term><varname>operationId</varname></term>
+     <listitem>
+      <para>
+       The operation ID. This may be used to link events together such as
+       bulk writes, which may dispatch multiple commands.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.requestid">
+     <term><varname>requestId</varname></term>
+     <listitem>
+      <para>
+       The request ID. This may be used to associate this
+       <classname>MongoDB\Driver\Monitoring\CommandFailedEvent</classname>
+       with a corresponding
+       <classname>MongoDB\Driver\Monitoring\CommandStartedEvent</classname>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.serviceid">
+     <term><varname>serviceId</varname></term>
+     <listitem>
+      <para>
+       The service ID, or &null; if the server does not support it (i.e.
+       not using load-balanced mode).
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.serverconnectionid">
+     <term><varname>serverConnectionId</varname></term>
+     <listitem>
+      <para>
+       The server connection ID, or &null; if not available.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Added public <modifier>readonly</modifier> properties. The
+         <varname>duration</varname> property replaces the
+         <methodname>getDurationMicros</methodname> method.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent.xml
@@ -34,11 +34,164 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.commandname">commandName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.databasename">databaseName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>object</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.command">command</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.operationid">operationId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.requestid">requestId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>MongoDB\BSON\ObjectId</type><type>null</type></type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.serviceid">serviceId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.serverconnectionid">serverConnectionId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-commandstartedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\CommandStartedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-commandstartedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <simpara>The hostname of the server that executed the command.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <simpara>The port of the server that executed the command.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.commandname">
+     <term><varname>commandName</varname></term>
+     <listitem>
+      <simpara>The command name.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.databasename">
+     <term><varname>databaseName</varname></term>
+     <listitem>
+      <simpara>The database name.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.command">
+     <term><varname>command</varname></term>
+     <listitem>
+      <simpara>The command document.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.operationid">
+     <term><varname>operationId</varname></term>
+     <listitem>
+      <simpara>
+       The operation ID. This may be used to link events together such as
+       bulk writes, which may dispatch multiple commands.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.requestid">
+     <term><varname>requestId</varname></term>
+     <listitem>
+      <simpara>
+       The request ID. This may be used to associate this
+       <classname>MongoDB\Driver\Monitoring\CommandStartedEvent</classname>
+       with a corresponding
+       <classname>MongoDB\Driver\Monitoring\CommandSucceededEvent</classname>
+       or
+       <classname>MongoDB\Driver\Monitoring\CommandFailedEvent</classname>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.serviceid">
+     <term><varname>serviceId</varname></term>
+     <listitem>
+      <simpara>
+       The service ID, or &null; if the server does not support it (i.e.
+       not using load-balanced mode).
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.serverconnectionid">
+     <term><varname>serverConnectionId</varname></term>
+     <listitem>
+      <simpara>The server connection ID, or &null; if not available.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Added public <modifier>readonly</modifier> properties.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent.xml
@@ -33,12 +33,167 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.commandname">commandName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.databasename">databaseName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>object</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.command">command</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.operationid">operationId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.requestid">requestId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>MongoDB\BSON\ObjectId</type><type>null</type></type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.serviceid">serviceId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.serverconnectionid">serverConnectionId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-commandstartedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\CommandStartedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-commandstartedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <para>The hostname of the server that executed the command.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <para>The port of the server that executed the command.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.commandname">
+     <term><varname>commandName</varname></term>
+     <listitem>
+      <para>The command name.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.databasename">
+     <term><varname>databaseName</varname></term>
+     <listitem>
+      <para>The database name.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.command">
+     <term><varname>command</varname></term>
+     <listitem>
+      <para>The command document.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.operationid">
+     <term><varname>operationId</varname></term>
+     <listitem>
+      <para>
+       The operation ID. This may be used to link events together such as
+       bulk writes, which may dispatch multiple commands.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.requestid">
+     <term><varname>requestId</varname></term>
+     <listitem>
+      <para>
+       The request ID. This may be used to associate this
+       <classname>MongoDB\Driver\Monitoring\CommandStartedEvent</classname>
+       with a corresponding
+       <classname>MongoDB\Driver\Monitoring\CommandSucceededEvent</classname>
+       or
+       <classname>MongoDB\Driver\Monitoring\CommandFailedEvent</classname>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.serviceid">
+     <term><varname>serviceId</varname></term>
+     <listitem>
+      <para>
+       The service ID, or &null; if the server does not support it (i.e.
+       not using load-balanced mode).
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.serverconnectionid">
+     <term><varname>serverConnectionId</varname></term>
+     <listitem>
+      <para>The server connection ID, or &null; if not available.</para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Added public <modifier>readonly</modifier> properties.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent.xml
@@ -34,11 +34,180 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.commandname">commandName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.databasename">databaseName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.duration">duration</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>object</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.reply">reply</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.operationid">operationId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.requestid">requestId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>MongoDB\BSON\ObjectId</type><type>null</type></type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.serviceid">serviceId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.serverconnectionid">serverConnectionId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-commandsucceededevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\CommandSucceededEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-commandsucceededevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <simpara>The hostname of the server that executed the command.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <simpara>The port of the server that executed the command.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.commandname">
+     <term><varname>commandName</varname></term>
+     <listitem>
+      <simpara>The command name.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.databasename">
+     <term><varname>databaseName</varname></term>
+     <listitem>
+      <simpara>The database name.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.duration">
+     <term><varname>duration</varname></term>
+     <listitem>
+      <simpara>
+       The duration of the command in microseconds. The duration is a
+       calculated value that includes the time to send the message and
+       receive the response from the server.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.reply">
+     <term><varname>reply</varname></term>
+     <listitem>
+      <simpara>The reply document returned by the server.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.operationid">
+     <term><varname>operationId</varname></term>
+     <listitem>
+      <simpara>
+       The operation ID. This may be used to link events together such as
+       bulk writes, which may dispatch multiple commands.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.requestid">
+     <term><varname>requestId</varname></term>
+     <listitem>
+      <simpara>
+       The request ID. This may be used to associate this
+       <classname>MongoDB\Driver\Monitoring\CommandSucceededEvent</classname>
+       with a corresponding
+       <classname>MongoDB\Driver\Monitoring\CommandStartedEvent</classname>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.serviceid">
+     <term><varname>serviceId</varname></term>
+     <listitem>
+      <simpara>
+       The service ID, or &null; if the server does not support it (i.e.
+       not using load-balanced mode).
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.serverconnectionid">
+     <term><varname>serverConnectionId</varname></term>
+     <listitem>
+      <simpara>The server connection ID, or &null; if not available.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Added public <modifier>readonly</modifier> properties. The
+        <varname>duration</varname> property replaces the
+        <methodname>getDurationMicros</methodname> method.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent.xml
@@ -33,12 +33,183 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.commandname">commandName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.databasename">databaseName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.duration">duration</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>object</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.reply">reply</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.operationid">operationId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.requestid">requestId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>MongoDB\BSON\ObjectId</type><type>null</type></type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.serviceid">serviceId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.serverconnectionid">serverConnectionId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-commandsucceededevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\CommandSucceededEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-commandsucceededevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <para>The hostname of the server that executed the command.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <para>The port of the server that executed the command.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.commandname">
+     <term><varname>commandName</varname></term>
+     <listitem>
+      <para>The command name.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.databasename">
+     <term><varname>databaseName</varname></term>
+     <listitem>
+      <para>The database name.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.duration">
+     <term><varname>duration</varname></term>
+     <listitem>
+      <para>
+       The duration of the command in microseconds. The duration is a
+       calculated value that includes the time to send the message and
+       receive the response from the server.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.reply">
+     <term><varname>reply</varname></term>
+     <listitem>
+      <para>The reply document returned by the server.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.operationid">
+     <term><varname>operationId</varname></term>
+     <listitem>
+      <para>
+       The operation ID. This may be used to link events together such as
+       bulk writes, which may dispatch multiple commands.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.requestid">
+     <term><varname>requestId</varname></term>
+     <listitem>
+      <para>
+       The request ID. This may be used to associate this
+       <classname>MongoDB\Driver\Monitoring\CommandSucceededEvent</classname>
+       with a corresponding
+       <classname>MongoDB\Driver\Monitoring\CommandStartedEvent</classname>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.serviceid">
+     <term><varname>serviceId</varname></term>
+     <listitem>
+      <para>
+       The service ID, or &null; if the server does not support it (i.e.
+       not using load-balanced mode).
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.serverconnectionid">
+     <term><varname>serverConnectionId</varname></term>
+     <listitem>
+      <para>The server connection ID, or &null; if not available.</para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Added public <modifier>readonly</modifier> properties. The
+         <varname>duration</varname> property replaces the
+         <methodname>getDurationMicros</methodname> method.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serverchangedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverchangedevent.xml
@@ -36,11 +36,103 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-serverchangedevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverchangedevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\BSON\ObjectId</type>
+     <varname linkend="mongodb-driver-monitoring-serverchangedevent.props.topologyid">topologyId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\Driver\ServerDescription</type>
+     <varname linkend="mongodb-driver-monitoring-serverchangedevent.props.newdescription">newDescription</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\Driver\ServerDescription</type>
+     <varname linkend="mongodb-driver-monitoring-serverchangedevent.props.previousdescription">previousDescription</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-serverchangedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\ServerChangedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-serverchangedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverchangedevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <simpara>The hostname of the server.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverchangedevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <simpara>The port of the server.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverchangedevent.props.topologyid">
+     <term><varname>topologyId</varname></term>
+     <listitem>
+      <simpara>The topology ID.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverchangedevent.props.newdescription">
+     <term><varname>newDescription</varname></term>
+     <listitem>
+      <simpara>The new server description.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverchangedevent.props.previousdescription">
+     <term><varname>previousDescription</varname></term>
+     <listitem>
+      <simpara>The previous server description.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Added public <modifier>readonly</modifier> properties.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serverchangedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverchangedevent.xml
@@ -35,12 +35,106 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-serverchangedevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverchangedevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\BSON\ObjectId</type>
+     <varname linkend="mongodb-driver-monitoring-serverchangedevent.props.topologyid">topologyId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\Driver\ServerDescription</type>
+     <varname linkend="mongodb-driver-monitoring-serverchangedevent.props.newdescription">newDescription</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\Driver\ServerDescription</type>
+     <varname linkend="mongodb-driver-monitoring-serverchangedevent.props.previousdescription">previousDescription</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-serverchangedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\ServerChangedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-serverchangedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverchangedevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <para>The hostname of the server.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverchangedevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <para>The port of the server.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverchangedevent.props.topologyid">
+     <term><varname>topologyId</varname></term>
+     <listitem>
+      <para>The topology ID.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverchangedevent.props.newdescription">
+     <term><varname>newDescription</varname></term>
+     <listitem>
+      <para>The new server description.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverchangedevent.props.previousdescription">
+     <term><varname>previousDescription</varname></term>
+     <listitem>
+      <para>The previous server description.</para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Added public <modifier>readonly</modifier> properties.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serverclosedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverclosedevent.xml
@@ -35,11 +35,79 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-serverclosedevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverclosedevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\BSON\ObjectId</type>
+     <varname linkend="mongodb-driver-monitoring-serverclosedevent.props.topologyid">topologyId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-serverclosedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\ServerClosedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-serverclosedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverclosedevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <simpara>The hostname of the server.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverclosedevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <simpara>The port of the server.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverclosedevent.props.topologyid">
+     <term><varname>topologyId</varname></term>
+     <listitem>
+      <simpara>The topology ID.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Added public <modifier>readonly</modifier> properties.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serverclosedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverclosedevent.xml
@@ -34,12 +34,82 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-serverclosedevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverclosedevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\BSON\ObjectId</type>
+     <varname linkend="mongodb-driver-monitoring-serverclosedevent.props.topologyid">topologyId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-serverclosedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\ServerClosedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-serverclosedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverclosedevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <para>The hostname of the server.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverclosedevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <para>The port of the server.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverclosedevent.props.topologyid">
+     <term><varname>topologyId</varname></term>
+     <listitem>
+      <para>The topology ID.</para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Added public <modifier>readonly</modifier> properties.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent.xml
@@ -37,11 +37,113 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatfailedevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatfailedevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>bool</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatfailedevent.props.awaited">awaited</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatfailedevent.props.duration">duration</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Exception</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatfailedevent.props.error">error</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-serverheartbeatfailedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <simpara>The hostname of the server.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <simpara>The port of the server.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.props.awaited">
+     <term><varname>awaited</varname></term>
+     <listitem>
+      <simpara>
+       Whether the heartbeat used a streaming protocol. The extension does
+       not use the streaming protocol for monitoring, so this method will always
+       return &false;.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.props.duration">
+     <term><varname>duration</varname></term>
+     <listitem>
+      <simpara>
+       The duration of the heartbeat in microseconds. The duration is a
+       calculated value that includes the time to send the message and
+       receive the response from the server.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.props.error">
+     <term><varname>error</varname></term>
+     <listitem>
+      <simpara>The exception that was thrown when the heartbeat failed.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Added public <modifier>readonly</modifier> properties. The
+        <varname>duration</varname> property replaces the
+        <methodname>getDurationMicros</methodname> method.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <reference xml:id="class.mongodb-driver-monitoring-serverheartbeatfailedevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -36,12 +36,116 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatfailedevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatfailedevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>bool</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatfailedevent.props.awaited">awaited</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatfailedevent.props.duration">duration</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Exception</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatfailedevent.props.error">error</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-serverheartbeatfailedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <para>The hostname of the server.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <para>The port of the server.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.props.awaited">
+     <term><varname>awaited</varname></term>
+     <listitem>
+      <para>
+       Whether the heartbeat used a streaming protocol. The extension does
+       not use the streaming protocol for monitoring, so this method will always
+       return &false;.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.props.duration">
+     <term><varname>duration</varname></term>
+     <listitem>
+      <para>
+       The duration of the heartbeat in microseconds. The duration is a
+       calculated value that includes the time to send the message and
+       receive the response from the server.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.props.error">
+     <term><varname>error</varname></term>
+     <listitem>
+      <para>The exception that was thrown when the heartbeat failed.</para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Added public <modifier>readonly</modifier> properties. The
+         <varname>duration</varname> property replaces the
+         <methodname>getDurationMicros</methodname> method.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent.xml
@@ -37,11 +37,83 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatstartedevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatstartedevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>bool</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatstartedevent.props.awaited">awaited</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-serverheartbeatstartedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <simpara>The hostname of the server.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <simpara>The port of the server.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.props.awaited">
+     <term><varname>awaited</varname></term>
+     <listitem>
+      <simpara>
+       Whether the heartbeat used a streaming protocol. The extension does
+       not use the streaming protocol for monitoring, so this method will always
+       return &false;.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Added public <modifier>readonly</modifier> properties.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <reference xml:id="class.mongodb-driver-monitoring-serverheartbeatstartedevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -36,12 +36,86 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatstartedevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatstartedevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>bool</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatstartedevent.props.awaited">awaited</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-serverheartbeatstartedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <para>The hostname of the server.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <para>The port of the server.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.props.awaited">
+     <term><varname>awaited</varname></term>
+     <listitem>
+      <para>
+       Whether the heartbeat used a streaming protocol. The extension does
+       not use the streaming protocol for monitoring, so this method will always
+       return &false;.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Added public <modifier>readonly</modifier> properties.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent.xml
@@ -37,11 +37,113 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>bool</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.awaited">awaited</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.duration">duration</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>object</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.reply">reply</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-serverheartbeatsucceededevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <simpara>The hostname of the server.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <simpara>The port of the server.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.awaited">
+     <term><varname>awaited</varname></term>
+     <listitem>
+      <simpara>
+       Whether the heartbeat used a streaming protocol. The extension does
+       not use the streaming protocol for monitoring, so this method will always
+       return &false;.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.duration">
+     <term><varname>duration</varname></term>
+     <listitem>
+      <simpara>
+       The duration of the heartbeat in microseconds. The duration is a
+       calculated value that includes the time to send the message and
+       receive the response from the server.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.reply">
+     <term><varname>reply</varname></term>
+     <listitem>
+      <simpara>The reply document returned by the server.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Added public <modifier>readonly</modifier> properties. The
+        <varname>duration</varname> property replaces the
+        <methodname>getDurationMicros</methodname> method.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <reference xml:id="class.mongodb-driver-monitoring-serverheartbeatsucceededevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -36,12 +36,116 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>bool</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.awaited">awaited</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.duration">duration</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>object</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.reply">reply</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-serverheartbeatsucceededevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <para>The hostname of the server.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <para>The port of the server.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.awaited">
+     <term><varname>awaited</varname></term>
+     <listitem>
+      <para>
+       Whether the heartbeat used a streaming protocol. The extension does
+       not use the streaming protocol for monitoring, so this method will always
+       return &false;.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.duration">
+     <term><varname>duration</varname></term>
+     <listitem>
+      <para>
+       The duration of the heartbeat in microseconds. The duration is a
+       calculated value that includes the time to send the message and
+       receive the response from the server.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.reply">
+     <term><varname>reply</varname></term>
+     <listitem>
+      <para>The reply document returned by the server.</para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Added public <modifier>readonly</modifier> properties. The
+         <varname>duration</varname> property replaces the
+         <methodname>getDurationMicros</methodname> method.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serveropeningevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serveropeningevent.xml
@@ -35,11 +35,79 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-serveropeningevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serveropeningevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\BSON\ObjectId</type>
+     <varname linkend="mongodb-driver-monitoring-serveropeningevent.props.topologyid">topologyId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-serveropeningevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\ServerOpeningEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-serveropeningevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-serveropeningevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <simpara>The hostname of the server.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serveropeningevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <simpara>The port of the server.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serveropeningevent.props.topologyid">
+     <term><varname>topologyId</varname></term>
+     <listitem>
+      <simpara>The topology ID.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Added public <modifier>readonly</modifier> properties.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serveropeningevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serveropeningevent.xml
@@ -34,12 +34,82 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-serveropeningevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serveropeningevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\BSON\ObjectId</type>
+     <varname linkend="mongodb-driver-monitoring-serveropeningevent.props.topologyid">topologyId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-serveropeningevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\ServerOpeningEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-serveropeningevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-serveropeningevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <para>The hostname of the server.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serveropeningevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <para>The port of the server.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serveropeningevent.props.topologyid">
+     <term><varname>topologyId</varname></term>
+     <listitem>
+      <para>The topology ID.</para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Added public <modifier>readonly</modifier> properties.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/topologychangedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologychangedevent.xml
@@ -36,11 +36,79 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\BSON\ObjectId</type>
+     <varname linkend="mongodb-driver-monitoring-topologychangedevent.props.topologyid">topologyId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\Driver\TopologyDescription</type>
+     <varname linkend="mongodb-driver-monitoring-topologychangedevent.props.newdescription">newDescription</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\Driver\TopologyDescription</type>
+     <varname linkend="mongodb-driver-monitoring-topologychangedevent.props.previousdescription">previousDescription</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-topologychangedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\TopologyChangedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-topologychangedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-topologychangedevent.props.topologyid">
+     <term><varname>topologyId</varname></term>
+     <listitem>
+      <simpara>The topology ID.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-topologychangedevent.props.newdescription">
+     <term><varname>newDescription</varname></term>
+     <listitem>
+      <simpara>The new topology description.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-topologychangedevent.props.previousdescription">
+     <term><varname>previousDescription</varname></term>
+     <listitem>
+      <simpara>The previous topology description.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Added public <modifier>readonly</modifier> properties.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/topologychangedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologychangedevent.xml
@@ -35,12 +35,82 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\BSON\ObjectId</type>
+     <varname linkend="mongodb-driver-monitoring-topologychangedevent.props.topologyid">topologyId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\Driver\TopologyDescription</type>
+     <varname linkend="mongodb-driver-monitoring-topologychangedevent.props.newdescription">newDescription</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\Driver\TopologyDescription</type>
+     <varname linkend="mongodb-driver-monitoring-topologychangedevent.props.previousdescription">previousDescription</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-topologychangedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\TopologyChangedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-topologychangedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-topologychangedevent.props.topologyid">
+     <term><varname>topologyId</varname></term>
+     <listitem>
+      <para>The topology ID.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-topologychangedevent.props.newdescription">
+     <term><varname>newDescription</varname></term>
+     <listitem>
+      <para>The new topology description.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-topologychangedevent.props.previousdescription">
+     <term><varname>previousDescription</varname></term>
+     <listitem>
+      <para>The previous topology description.</para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Added public <modifier>readonly</modifier> properties.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/topologyclosedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologyclosedevent.xml
@@ -44,11 +44,55 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\BSON\ObjectId</type>
+     <varname linkend="mongodb-driver-monitoring-topologyclosedevent.props.topologyid">topologyId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-topologyclosedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\TopologyClosedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-topologyclosedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-topologyclosedevent.props.topologyid">
+     <term><varname>topologyId</varname></term>
+     <listitem>
+      <simpara>The topology ID.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Added public <modifier>readonly</modifier> properties.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/topologyclosedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologyclosedevent.xml
@@ -43,12 +43,58 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\BSON\ObjectId</type>
+     <varname linkend="mongodb-driver-monitoring-topologyclosedevent.props.topologyid">topologyId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-topologyclosedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\TopologyClosedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-topologyclosedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-topologyclosedevent.props.topologyid">
+     <term><varname>topologyId</varname></term>
+     <listitem>
+      <para>The topology ID.</para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Added public <modifier>readonly</modifier> properties.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/topologyopeningevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologyopeningevent.xml
@@ -43,11 +43,55 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\BSON\ObjectId</type>
+     <varname linkend="mongodb-driver-monitoring-topologyopeningevent.props.topologyid">topologyId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-topologyopeningevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\TopologyOpeningEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-topologyopeningevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-topologyopeningevent.props.topologyid">
+     <term><varname>topologyId</varname></term>
+     <listitem>
+      <simpara>The topology ID.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Added public <modifier>readonly</modifier> properties.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/topologyopeningevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologyopeningevent.xml
@@ -42,12 +42,58 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\BSON\ObjectId</type>
+     <varname linkend="mongodb-driver-monitoring-topologyopeningevent.props.topologyid">topologyId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-topologyopeningevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\TopologyOpeningEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-topologyopeningevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-topologyopeningevent.props.topologyid">
+     <term><varname>topologyId</varname></term>
+     <listitem>
+      <para>The topology ID.</para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Added public <modifier>readonly</modifier> properties.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/readconcern.xml
+++ b/reference/mongodb/mongodb/driver/readconcern.xml
@@ -42,6 +42,14 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="mongodb-driver-readconcern.props.level">level</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
@@ -80,6 +88,22 @@
 <!-- }}} -->
 
   </section>
+
+<!-- {{{ MongoDB\Driver\ReadConcern properties -->
+  <section xml:id="mongodb-driver-readconcern.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-readconcern.props.level">
+     <term><varname>level</varname></term>
+     <listitem>
+      <simpara>
+       The read concern level. &null; if no level was specified.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
 
 <!-- {{{ MongoDB\Driver\ReadConcern constants -->
   <section xml:id="mongodb-driver-readconcern.constants">
@@ -236,6 +260,12 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Added public <modifier>readonly</modifier> properties.
+       </entry>
+      </row>
       <row>
        <entry>PECL mongodb 1.11.0</entry>
        <entry>

--- a/reference/mongodb/mongodb/driver/readconcern.xml
+++ b/reference/mongodb/mongodb/driver/readconcern.xml
@@ -42,6 +42,14 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="mongodb-driver-readconcern.props.level">level</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
@@ -80,6 +88,22 @@
 <!-- }}} -->
 
   </section>
+
+<!-- {{{ MongoDB\Driver\ReadConcern properties -->
+  <section xml:id="mongodb-driver-readconcern.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-readconcern.props.level">
+     <term><varname>level</varname></term>
+     <listitem>
+      <para>
+       The read concern level. &null; if no level was specified.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
 
 <!-- {{{ MongoDB\Driver\ReadConcern constants -->
   <section xml:id="mongodb-driver-readconcern.constants">
@@ -237,6 +261,12 @@
        </row>
       </thead>
       <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Added public <modifier>readonly</modifier> properties.
+        </entry>
+       </row>
        <row>
         <entry>PECL mongodb 1.11.0</entry>
         <entry>

--- a/reference/mongodb/mongodb/driver/readpreference.xml
+++ b/reference/mongodb/mongodb/driver/readpreference.xml
@@ -40,6 +40,32 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-readpreference.props.mode">mode</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>array</type><type>null</type></type>
+     <varname linkend="mongodb-driver-readpreference.props.tags">tags</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-readpreference.props.maxstaleness">maxStalenessSeconds</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>object</type><type>null</type></type>
+     <varname linkend="mongodb-driver-readpreference.props.hedge">hedge</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
@@ -90,6 +116,57 @@
 <!-- }}} -->
 
   </section>
+
+<!-- {{{ MongoDB\Driver\ReadPreference properties -->
+  <section xml:id="mongodb-driver-readpreference.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-readpreference.props.mode">
+     <term><varname>mode</varname></term>
+     <listitem>
+      <simpara>
+       The read preference mode as a string (e.g.
+       <literal>"primary"</literal>, <literal>"secondary"</literal>).
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-readpreference.props.tags">
+     <term><varname>tags</varname></term>
+     <listitem>
+      <simpara>
+       The tag set list used by the read preference, or &null; if no tag
+       sets were specified.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-readpreference.props.maxstaleness">
+     <term><varname>maxStalenessSeconds</varname></term>
+     <listitem>
+      <simpara>
+       The maximum staleness in seconds for reads, or
+       <constant>MongoDB\Driver\ReadPreference::NO_MAX_STALENESS</constant>
+       if no maximum staleness was specified.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-readpreference.props.hedge">
+     <term><varname>hedge</varname></term>
+     <listitem>
+      <simpara>
+       A document specifying the hedge options for the read preference, or
+       &null; if no hedge options were specified.
+      </simpara>
+      <warning>
+       <simpara>
+        This property is deprecated as hedged reads are deprecated in
+        MongoDB 8.0.
+       </simpara>
+      </warning>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
 
 <!-- {{{ MongoDB\Driver\ReadPreference constants -->
   <section xml:id="mongodb-driver-readpreference.constants">
@@ -186,6 +263,12 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Added public <modifier>readonly</modifier> properties.
+       </entry>
+      </row>
       <row>
        <entry>PECL mongodb 2.0.0</entry>
        <entry>

--- a/reference/mongodb/mongodb/driver/readpreference.xml
+++ b/reference/mongodb/mongodb/driver/readpreference.xml
@@ -40,6 +40,32 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-readpreference.props.mode">mode</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>array</type><type>null</type></type>
+     <varname linkend="mongodb-driver-readpreference.props.tags">tags</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-readpreference.props.maxstaleness">maxStalenessSeconds</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>object</type><type>null</type></type>
+     <varname linkend="mongodb-driver-readpreference.props.hedge">hedge</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
@@ -90,6 +116,57 @@
 <!-- }}} -->
 
   </section>
+
+<!-- {{{ MongoDB\Driver\ReadPreference properties -->
+  <section xml:id="mongodb-driver-readpreference.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-readpreference.props.mode">
+     <term><varname>mode</varname></term>
+     <listitem>
+      <para>
+       The read preference mode as a string (e.g.
+       <literal>"primary"</literal>, <literal>"secondary"</literal>).
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-readpreference.props.tags">
+     <term><varname>tags</varname></term>
+     <listitem>
+      <para>
+       The tag set list used by the read preference, or &null; if no tag
+       sets were specified.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-readpreference.props.maxstaleness">
+     <term><varname>maxStalenessSeconds</varname></term>
+     <listitem>
+      <para>
+       The maximum staleness in seconds for reads, or
+       <constant>MongoDB\Driver\ReadPreference::NO_MAX_STALENESS</constant>
+       if no maximum staleness was specified.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-readpreference.props.hedge">
+     <term><varname>hedge</varname></term>
+     <listitem>
+      <para>
+       A document specifying the hedge options for the read preference, or
+       &null; if no hedge options were specified.
+      </para>
+      <warning>
+       <simpara>
+        This property is deprecated as hedged reads are deprecated in
+        MongoDB 8.0.
+       </simpara>
+      </warning>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
 
 <!-- {{{ MongoDB\Driver\ReadPreference constants -->
   <section xml:id="mongodb-driver-readpreference.constants">
@@ -187,6 +264,12 @@
        </row>
       </thead>
       <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Added public <modifier>readonly</modifier> properties.
+        </entry>
+       </row>
        <row>
         <entry>PECL mongodb 2.0.0</entry>
         <entry>

--- a/reference/mongodb/mongodb/driver/writeconcern.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern.xml
@@ -52,12 +52,68 @@
      <initializer>"majority"</initializer>
     </fieldsynopsis>
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeconcern.props.w">w</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>bool</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeconcern.props.j">j</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-writeconcern.props.wtimeout">wtimeout</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-writeconcern')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
   </section>
+
+<!-- {{{ MongoDB\Driver\WriteConcern properties -->
+  <section xml:id="mongodb-driver-writeconcern.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-writeconcern.props.w">
+     <term><varname>w</varname></term>
+     <listitem>
+      <simpara>
+       The write concern value (integer number of nodes, the string
+       <literal>"majority"</literal>, or a custom write concern tag name),
+       or &null; if not set.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeconcern.props.j">
+     <term><varname>j</varname></term>
+     <listitem>
+      <simpara>
+       Whether write operations must be committed to the journal before
+       acknowledged, or &null; if not specified.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeconcern.props.wtimeout">
+     <term><varname>wtimeout</varname></term>
+     <listitem>
+      <simpara>
+       The timeout in milliseconds to wait for write concern acknowledgement.
+       A value of <literal>0</literal> means to wait indefinitely.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
 
 <!-- {{{ MongoDB\Driver\WriteConcern constants -->
   <section xml:id="mongodb-driver-writeconcern.constants">
@@ -90,6 +146,12 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Added public <modifier>readonly</modifier> properties.
+       </entry>
+      </row>
       <row>
        <entry>PECL mongodb 1.7.0</entry>
        <entry>

--- a/reference/mongodb/mongodb/driver/writeconcern.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern.xml
@@ -52,12 +52,68 @@
      <initializer>"majority"</initializer>
     </fieldsynopsis>
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeconcern.props.w">w</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>bool</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeconcern.props.j">j</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-writeconcern.props.wtimeout">wtimeout</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-writeconcern')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
   </section>
+
+<!-- {{{ MongoDB\Driver\WriteConcern properties -->
+  <section xml:id="mongodb-driver-writeconcern.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-writeconcern.props.w">
+     <term><varname>w</varname></term>
+     <listitem>
+      <para>
+       The write concern value (integer number of nodes, the string
+       <literal>"majority"</literal>, or a custom write concern tag name),
+       or &null; if not set.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeconcern.props.j">
+     <term><varname>j</varname></term>
+     <listitem>
+      <para>
+       Whether write operations must be committed to the journal before
+       acknowledged, or &null; if not specified.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeconcern.props.wtimeout">
+     <term><varname>wtimeout</varname></term>
+     <listitem>
+      <para>
+       The timeout in milliseconds to wait for write concern acknowledgement.
+       A value of <literal>0</literal> means to wait indefinitely.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
 
 <!-- {{{ MongoDB\Driver\WriteConcern constants -->
   <section xml:id="mongodb-driver-writeconcern.constants">
@@ -91,6 +147,12 @@
        </row>
       </thead>
       <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Added public <modifier>readonly</modifier> properties.
+        </entry>
+       </row>
        <row>
         <entry>PECL mongodb 1.7.0</entry>
         <entry>

--- a/reference/mongodb/mongodb/driver/writeconcernerror.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror.xml
@@ -35,11 +35,81 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-writeconcernerror.props.message">message</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-writeconcernerror.props.code">code</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>object</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeconcernerror.props.info">info</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-writeconcernerror')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\WriteConcernError properties -->
+  <section xml:id="mongodb-driver-writeconcernerror.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-writeconcernerror.props.message">
+     <term><varname>message</varname></term>
+     <listitem>
+      <simpara>The error message.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeconcernerror.props.code">
+     <term><varname>code</varname></term>
+     <listitem>
+      <simpara>The error code.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeconcernerror.props.info">
+     <term><varname>info</varname></term>
+     <listitem>
+      <simpara>
+       Additional information for the error, or &null; if not available.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Added public <modifier>readonly</modifier> properties.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/writeconcernerror.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror.xml
@@ -34,12 +34,84 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-writeconcernerror.props.message">message</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-writeconcernerror.props.code">code</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>object</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeconcernerror.props.info">info</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-writeconcernerror')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\WriteConcernError properties -->
+  <section xml:id="mongodb-driver-writeconcernerror.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-writeconcernerror.props.message">
+     <term><varname>message</varname></term>
+     <listitem>
+      <para>The error message.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeconcernerror.props.code">
+     <term><varname>code</varname></term>
+     <listitem>
+      <para>The error code.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeconcernerror.props.info">
+     <term><varname>info</varname></term>
+     <listitem>
+      <para>
+       Additional information for the error, or &null; if not available.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Added public <modifier>readonly</modifier> properties.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/writeerror.xml
+++ b/reference/mongodb/mongodb/driver/writeerror.xml
@@ -35,11 +35,96 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-writeerror.props.message">message</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-writeerror.props.code">code</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-writeerror.props.index">index</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>object</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeerror.props.info">info</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-writeerror')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\WriteError properties -->
+  <section xml:id="mongodb-driver-writeerror.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-writeerror.props.message">
+     <term><varname>message</varname></term>
+     <listitem>
+      <simpara>The error message.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeerror.props.code">
+     <term><varname>code</varname></term>
+     <listitem>
+      <simpara>The error code.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeerror.props.index">
+     <term><varname>index</varname></term>
+     <listitem>
+      <simpara>
+       The index of the write operation within the
+       <classname>MongoDB\Driver\BulkWrite</classname> that caused the error.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeerror.props.info">
+     <term><varname>info</varname></term>
+     <listitem>
+      <simpara>
+       Additional information for the error, or &null; if not available.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Added public <modifier>readonly</modifier> properties.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/writeerror.xml
+++ b/reference/mongodb/mongodb/driver/writeerror.xml
@@ -34,12 +34,99 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-writeerror.props.message">message</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-writeerror.props.code">code</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-writeerror.props.index">index</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>object</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeerror.props.info">info</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-writeerror')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\WriteError properties -->
+  <section xml:id="mongodb-driver-writeerror.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-writeerror.props.message">
+     <term><varname>message</varname></term>
+     <listitem>
+      <para>The error message.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeerror.props.code">
+     <term><varname>code</varname></term>
+     <listitem>
+      <para>The error code.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeerror.props.index">
+     <term><varname>index</varname></term>
+     <listitem>
+      <para>
+       The index of the write operation within the
+       <classname>MongoDB\Driver\BulkWrite</classname> that caused the error.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeerror.props.info">
+     <term><varname>info</varname></term>
+     <listitem>
+      <para>
+       Additional information for the error, or &null; if not available.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Added public <modifier>readonly</modifier> properties.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/writeresult.xml
+++ b/reference/mongodb/mongodb/driver/writeresult.xml
@@ -37,11 +37,208 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.insertedcount">insertedCount</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.matchedcount">matchedCount</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.modifiedcount">modifiedCount</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.deletedcount">deletedCount</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.upsertedcount">upsertedCount</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\Driver\Server</type>
+     <varname linkend="mongodb-driver-writeresult.props.server">server</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>array</type>
+     <varname linkend="mongodb-driver-writeresult.props.upsertedids">upsertedIds</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>array</type>
+     <varname linkend="mongodb-driver-writeresult.props.writeerrors">writeErrors</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>MongoDB\Driver\WriteConcernError</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.writeconcernerror">writeConcernError</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>MongoDB\Driver\WriteConcern</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.writeconcern">writeConcern</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>array</type>
+     <varname linkend="mongodb-driver-writeresult.props.errorreplies">errorReplies</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-writeresult')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\WriteResult properties -->
+  <section xml:id="mongodb-driver-writeresult.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.insertedcount">
+     <term><varname>insertedCount</varname></term>
+     <listitem>
+      <simpara>
+       The number of documents inserted (excluding upserts), or &null; if
+       the write concern did not request acknowledgement.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.matchedcount">
+     <term><varname>matchedCount</varname></term>
+     <listitem>
+      <simpara>
+       The number of documents matched by update and replace operations, or
+       &null; if the write concern did not request acknowledgement.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.modifiedcount">
+     <term><varname>modifiedCount</varname></term>
+     <listitem>
+      <simpara>
+       The number of documents modified by update and replace operations, or
+       &null; if the write concern did not request acknowledgement or if the
+       server did not report this information.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.deletedcount">
+     <term><varname>deletedCount</varname></term>
+     <listitem>
+      <simpara>
+       The number of documents deleted, or &null; if the write concern did
+       not request acknowledgement.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.upsertedcount">
+     <term><varname>upsertedCount</varname></term>
+     <listitem>
+      <simpara>
+       The number of documents upserted, or &null; if the write concern did
+       not request acknowledgement.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.server">
+     <term><varname>server</varname></term>
+     <listitem>
+      <simpara>
+       The server that executed the bulk write.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.upsertedids">
+     <term><varname>upsertedIds</varname></term>
+     <listitem>
+      <simpara>
+       An array of <literal>_id</literal> values for upserted documents.
+       Array keys will correspond to the index of the write operation from
+       <classname>MongoDB\Driver\BulkWrite</classname>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.writeerrors">
+     <term><varname>writeErrors</varname></term>
+     <listitem>
+      <simpara>
+       An array of <classname>MongoDB\Driver\WriteError</classname>s for any
+       write errors that occurred during execution.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.writeconcernerror">
+     <term><varname>writeConcernError</varname></term>
+     <listitem>
+      <simpara>
+       The <classname>MongoDB\Driver\WriteConcernError</classname> that
+       occurred, or &null; if no write concern error occurred.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.writeconcern">
+     <term><varname>writeConcern</varname></term>
+     <listitem>
+      <simpara>
+       The <classname>MongoDB\Driver\WriteConcern</classname> used for the
+       bulk write, or &null; if not available.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.errorreplies">
+     <term><varname>errorReplies</varname></term>
+     <listitem>
+      <simpara>
+       An array of error reply documents from the server.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Added public <modifier>readonly</modifier> properties.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/writeresult.xml
+++ b/reference/mongodb/mongodb/driver/writeresult.xml
@@ -36,12 +36,211 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.insertedcount">insertedCount</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.matchedcount">matchedCount</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.modifiedcount">modifiedCount</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.deletedcount">deletedCount</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.upsertedcount">upsertedCount</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\Driver\Server</type>
+     <varname linkend="mongodb-driver-writeresult.props.server">server</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>array</type>
+     <varname linkend="mongodb-driver-writeresult.props.upsertedids">upsertedIds</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>array</type>
+     <varname linkend="mongodb-driver-writeresult.props.writeerrors">writeErrors</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>MongoDB\Driver\WriteConcernError</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.writeconcernerror">writeConcernError</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>MongoDB\Driver\WriteConcern</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.writeconcern">writeConcern</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>array</type>
+     <varname linkend="mongodb-driver-writeresult.props.errorreplies">errorReplies</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-writeresult')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\WriteResult properties -->
+  <section xml:id="mongodb-driver-writeresult.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.insertedcount">
+     <term><varname>insertedCount</varname></term>
+     <listitem>
+      <para>
+       The number of documents inserted (excluding upserts), or &null; if
+       the write concern did not request acknowledgement.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.matchedcount">
+     <term><varname>matchedCount</varname></term>
+     <listitem>
+      <para>
+       The number of documents matched by update and replace operations, or
+       &null; if the write concern did not request acknowledgement.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.modifiedcount">
+     <term><varname>modifiedCount</varname></term>
+     <listitem>
+      <para>
+       The number of documents modified by update and replace operations, or
+       &null; if the write concern did not request acknowledgement or if the
+       server did not report this information.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.deletedcount">
+     <term><varname>deletedCount</varname></term>
+     <listitem>
+      <para>
+       The number of documents deleted, or &null; if the write concern did
+       not request acknowledgement.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.upsertedcount">
+     <term><varname>upsertedCount</varname></term>
+     <listitem>
+      <para>
+       The number of documents upserted, or &null; if the write concern did
+       not request acknowledgement.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.server">
+     <term><varname>server</varname></term>
+     <listitem>
+      <para>
+       The server that executed the bulk write.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.upsertedids">
+     <term><varname>upsertedIds</varname></term>
+     <listitem>
+      <para>
+       An array of <literal>_id</literal> values for upserted documents.
+       Array keys will correspond to the index of the write operation from
+       <classname>MongoDB\Driver\BulkWrite</classname>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.writeerrors">
+     <term><varname>writeErrors</varname></term>
+     <listitem>
+      <para>
+       An array of <classname>MongoDB\Driver\WriteError</classname>s for any
+       write errors that occurred during execution.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.writeconcernerror">
+     <term><varname>writeConcernError</varname></term>
+     <listitem>
+      <para>
+       The <classname>MongoDB\Driver\WriteConcernError</classname> that
+       occurred, or &null; if no write concern error occurred.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.writeconcern">
+     <term><varname>writeConcern</varname></term>
+     <listitem>
+      <para>
+       The <classname>MongoDB\Driver\WriteConcern</classname> used for the
+       bulk write, or &null; if not available.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.errorreplies">
+     <term><varname>errorReplies</varname></term>
+     <listitem>
+      <para>
+       An array of error reply documents from the server.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Added public <modifier>readonly</modifier> properties.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>


### PR DESCRIPTION
This PR adds documentation for `public readonly` properties being added in ext-mongodb 2.3.0 as well as the new URI options for Intelligent Workload Management.