### PR TITLE
Add new bpftrace section for DTrace document

### DIFF
--- a/features/dtrace.xml
+++ b/features/dtrace.xml
@@ -552,6 +552,194 @@ probe process("sapi/cli/php").provider("php").mark("request__startup") {
    </para>
   </sect2>
  </sect1>
+ <sect1 xml:id="features.dtrace.bpftrace">
+  <title>Using bpftrace with PHP DTrace Static Probes</title>
+    <para>
+     On Linux distributions with a kernel that supports eBPF, the
+     bpftrace utility can attach to PHP's DTrace USDT probes directly,
+     without requiring SystemTap.
+    </para>
+  <sect2 xml:id="features.dtrace.bpftrace-install">
+   <title>Installing bpftrace</title>
+   <para>
+    Install bpftrace using the distribution's package manager. For
+    example, on Oracle Linux, RHEL, or Fedora:
+    <informalexample>
+     <programlisting role="shell">
+<![CDATA[
+# dnf install bpftrace
+]]>
+     </programlisting>
+    </informalexample>
+    Or, on Debian or Ubuntu:
+    <informalexample>
+     <programlisting role="shell">
+<![CDATA[
+# apt install bpftrace
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+   <para>
+    The examples below assume the target PHP binary is installed at
+    <filename>/usr/bin/php</filename>.
+   </para>
+   <para>The same USDT probes are also
+    exposed by other SAPIs built from the same source tree, so the
+    probe target may instead be the Apache module
+    (<filename>libphp.so</filename>) or the FastCGI Process Manager
+    binary (<filename>php-fpm</filename>); substitute the appropriate
+    path or attach by PID with <literal>-p</literal> as needed.
+   </para>
+   <para>
+    Make sure target binary is built with DTrace and configured environment properly.
+    <link linkend="features.dtrace.install">Configuring PHP for DTrace Static Probes</link> for details.
+    </para>
+   <para>
+    The static probes in PHP can be listed using
+    <filename>bpftrace</filename>:
+    <informalexample>
+     <programlisting>
+<![CDATA[
+# bpftrace -l 'usdt:/usr/bin/php:php:*'
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+
+   <para>
+    This outputs:
+    <informalexample>
+     <programlisting>
+<![CDATA[
+usdt:/usr/bin/php:php:compile__file__entry
+usdt:/usr/bin/php:php:compile__file__return
+usdt:/usr/bin/php:php:error
+usdt:/usr/bin/php:php:exception__caught
+usdt:/usr/bin/php:php:exception__thrown
+usdt:/usr/bin/php:php:execute__entry
+usdt:/usr/bin/php:php:execute__return
+usdt:/usr/bin/php:php:function__entry
+usdt:/usr/bin/php:php:function__return
+usdt:/usr/bin/php:php:request__shutdown
+usdt:/usr/bin/php:php:request__startup
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+
+   <para>
+    <example>
+     <title><filename>all_probes.bt</filename> for tracing all PHP Static Probes with bpftrace</title>
+     <programlisting role="shell">
+<![CDATA[
+#!/usr/bin/env bpftrace
+
+usdt:/usr/bin/php:php:compile__file__entry
+{
+    printf("Probe compile__file__entry\n");
+    printf("  compile_file %s\n", str(arg0));
+    printf("  compile_file_translated %s\n", str(arg1));
+}
+usdt:/usr/bin/php:php:compile__file__return
+{
+    printf("Probe compile__file__return\n");
+    printf("  compile_file %s\n", str(arg0));
+    printf("  compile_file_translated %s\n", str(arg1));
+}
+usdt:/usr/bin/php:php:error
+{
+    printf("Probe error\n");
+    printf("  errormsg %s\n", str(arg0));
+    printf("  request_file %s\n", str(arg1));
+    printf("  lineno %d\n", (int32)arg2);
+}
+usdt:/usr/bin/php:php:exception__caught
+{
+    printf("Probe exception__caught\n");
+    printf("  classname %s\n", str(arg0));
+}
+usdt:/usr/bin/php:php:exception__thrown
+{
+    printf("Probe exception__thrown\n");
+    printf("  classname %s\n", str(arg0));
+}
+usdt:/usr/bin/php:php:execute__entry
+{
+    printf("Probe execute__entry\n");
+    printf("  request_file %s\n", str(arg0));
+    printf("  lineno %d\n", (int32)arg1);
+}
+usdt:/usr/bin/php:php:execute__return
+{
+    printf("Probe execute__return\n");
+    printf("  request_file %s\n", str(arg0));
+    printf("  lineno %d\n", (int32)arg1);
+}
+usdt:/usr/bin/php:php:function__entry
+{
+    printf("Probe function__entry\n");
+    printf("  function_name %s\n", str(arg0));
+    printf("  request_file %s\n", str(arg1));
+    printf("  lineno %d\n", (int32)arg2);
+    printf("  classname %s\n", str(arg3));
+    printf("  scope %s\n", str(arg4));
+}
+usdt:/usr/bin/php:php:function__return
+{
+    printf("Probe function__return\n");
+    printf("  function_name %s\n", str(arg0));
+    printf("  request_file %s\n", str(arg1));
+    printf("  lineno %d\n", (int32)arg2);
+    printf("  classname %s\n", str(arg3));
+    printf("  scope %s\n", str(arg4));
+}
+usdt:/usr/bin/php:php:request__shutdown
+{
+    printf("Probe request__shutdown\n");
+    printf("  file %s\n", str(arg0));
+    printf("  request_uri %s\n", str(arg1));
+    printf("  request_method %s\n", str(arg2));
+}
+usdt:/usr/bin/php:php:request__startup
+{
+    printf("Probe request__startup\n");
+    printf("  file %s\n", str(arg0));
+    printf("  request_uri %s\n", str(arg1));
+    printf("  request_method %s\n", str(arg2));
+}
+]]>
+     </programlisting>
+    </example>
+   </para>
+
+   <para>
+    The above script will trace all core PHP static probe points
+    throughout the duration of a running PHP script. bpftrace requires
+    root privileges:
+    <informalexample>
+     <programlisting>
+<![CDATA[
+# USE_ZEND_DTRACE=1 bpftrace -c '/usr/bin/php test.php' all_probes.bt
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+
+   <para>
+    To trace an already-running PHP process (for instance, a
+    <filename>php-fpm</filename> worker or an Apache process loading
+    <filename>libphp.so</filename>), attach by PID:
+    <informalexample>
+     <programlisting>
+<![CDATA[
+# bpftrace -p $PID all_probes.bt
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+  </sect2>
+ </sect1>
 </chapter>
 
 <!-- Keep this comment at the end of the file

--- a/features/dtrace.xml
+++ b/features/dtrace.xml
@@ -554,11 +554,11 @@ probe process("sapi/cli/php").provider("php").mark("request__startup") {
  </sect1>
  <sect1 xml:id="features.dtrace.bpftrace">
   <title>Using bpftrace with PHP DTrace Static Probes</title>
-    <para>
+    <simpara>
      On Linux distributions with a kernel that supports eBPF, the
      bpftrace utility can attach to PHP's DTrace USDT probes directly,
      without requiring SystemTap.
-    </para>
+    </simpara>
   <sect2 xml:id="features.dtrace.bpftrace-install">
    <title>Installing bpftrace</title>
    <para>
@@ -591,10 +591,10 @@ probe process("sapi/cli/php").provider("php").mark("request__startup") {
     binary (<filename>php-fpm</filename>); substitute the appropriate
     path or attach by PID with <literal>-p</literal> as needed.
    </para>
-   <para>
-    Make sure target binary is built with DTrace and configured environment properly.
+   <simpara>
+    Make sure the target binary is built with DTrace and that the environment is configured properly. See 
     <link linkend="features.dtrace.install">Configuring PHP for DTrace Static Probes</link> for details.
-    </para>
+   </simpara>
    <para>
     The static probes in PHP can be listed using
     <filename>bpftrace</filename>:

--- a/features/dtrace.xml
+++ b/features/dtrace.xml
@@ -554,11 +554,11 @@ probe process("sapi/cli/php").provider("php").mark("request__startup") {
  </sect1>
  <sect1 xml:id="features.dtrace.bpftrace">
   <title>Using bpftrace with PHP DTrace Static Probes</title>
-    <simpara>
-     On Linux distributions with a kernel that supports eBPF, the
-     bpftrace utility can attach to PHP's DTrace USDT probes directly,
-     without requiring SystemTap.
-    </simpara>
+  <simpara>
+   On Linux distributions with a kernel that supports eBPF, the
+   bpftrace utility can attach to PHP's DTrace USDT probes directly,
+   without requiring SystemTap.
+  </simpara>
   <sect2 xml:id="features.dtrace.bpftrace-install">
    <title>Installing bpftrace</title>
    <para>

--- a/features/dtrace.xml
+++ b/features/dtrace.xml
@@ -584,16 +584,16 @@ probe process("sapi/cli/php").provider("php").mark("request__startup") {
     The examples below assume the target PHP binary is installed at
     <filename>/usr/bin/php</filename>.
    </para>
-   <para>The same USDT probes are also
-    exposed by other SAPIs built from the same source tree, so the
+   <para>
+    The same USDT probes are also exposed by other SAPIs built from the same source tree, so the
     probe target may instead be the Apache module
     (<filename>libphp.so</filename>) or the FastCGI Process Manager
     binary (<filename>php-fpm</filename>); substitute the appropriate
     path or attach by PID with <literal>-p</literal> as needed.
    </para>
    <simpara>
-    Make sure the target binary is built with DTrace and that the environment is configured properly. See 
-    <link linkend="features.dtrace.install">Configuring PHP for DTrace Static Probes</link> for details.
+    Make sure the target binary is built with DTrace and that the environment is configured properly.
+    See <link linkend="features.dtrace.install">Configuring PHP for DTrace Static Probes</link> for details.
    </simpara>
    <para>
     The static probes in PHP can be listed using

--- a/features/dtrace.xml
+++ b/features/dtrace.xml
@@ -580,17 +580,17 @@ probe process("sapi/cli/php").provider("php").mark("request__startup") {
      </programlisting>
     </informalexample>
    </para>
-   <para>
+   <simpara>
     The examples below assume the target PHP binary is installed at
     <filename>/usr/bin/php</filename>.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     The same USDT probes are also exposed by other SAPIs built from the same source tree, so the
     probe target may instead be the Apache module
     (<filename>libphp.so</filename>) or the FastCGI Process Manager
     binary (<filename>php-fpm</filename>); substitute the appropriate
     path or attach by PID with <literal>-p</literal> as needed.
-   </para>
+   </simpara>
    <simpara>
     Make sure the target binary is built with DTrace and that the environment is configured properly.
     See <link linkend="features.dtrace.install">Configuring PHP for DTrace Static Probes</link> for details.

--- a/features/dtrace.xml
+++ b/features/dtrace.xml
@@ -737,11 +737,10 @@ usdt:/usr/bin/php:php:request__startup
 ]]>
      </programlisting>
     </informalexample>
-</informalexample>
-The <literal>usdt:</literal> target path in the script must match the binary of
-the running process; adjust <literal>usdt:/usr/bin/php</literal> to the
-<filename>php-fpm</filename> binary or <filename>libphp.so</filename> as appropriate.
-</para>
+    The <literal>usdt:</literal> target path in the script must match the binary of
+    the running process; adjust <literal>usdt:/usr/bin/php</literal> to the
+    <filename>php-fpm</filename> binary or <filename>libphp.so</filename> as appropriate.
+  </para>
   </sect2>
  </sect1>
 </chapter>

--- a/features/dtrace.xml
+++ b/features/dtrace.xml
@@ -597,7 +597,7 @@ probe process("sapi/cli/php").provider("php").mark("request__startup") {
    </simpara>
    <para>
     The static probes in PHP can be listed using
-    <filename>bpftrace</filename>:
+    <command>bpftrace</command>:
     <informalexample>
      <programlisting>
 <![CDATA[
@@ -737,7 +737,11 @@ usdt:/usr/bin/php:php:request__startup
 ]]>
      </programlisting>
     </informalexample>
-   </para>
+</informalexample>
+The <literal>usdt:</literal> target path in the script must match the binary of
+the running process; adjust <literal>usdt:/usr/bin/php</literal> to the
+<filename>php-fpm</filename> binary or <filename>libphp.so</filename> as appropriate.
+</para>
   </sect2>
  </sect1>
 </chapter>


### PR DESCRIPTION
This PR adds new section which explains how to use DTrace with bpdtrace command, related to my previous PR #4456 .

Since this PR adds completely new section, I want to explain why it should be added, why it is useful for PHP users. Hoping it could be merged.

##  Background / Motivation

To encourage PHP users to use useful, stable DTrace  based tracepoints easier way.

DTrace is basically an option, though most of PHP packages provided by Linux distributions(aside from Debian) are enabled in reality.

Ubuntu 24.04 Noble is also disabled because of build error from upstream, though enabled again from next version. Here are related issues:
	
- https://bugs.launchpad.net/ubuntu/+source/php8.3/+bug/2088977
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1110885

Although the existing SystemTap section requires users to install SystemTap which is  a bit difficult on modern Linux distributions.

For instance, I have installed SytemTap( And gcc-12 because of the missing dependency) with Ubuntu 22.04 Jammy. I got bunch of errors like below.

Systemtap version 4.6/0.186
https://gist.github.com/egmc/1667b12fcf58eb4fdfbddce256f35084

It may be fixed, though it could be hard for users who tried the functionality for first time.

In contrast, eBPF is now supported natively in mainline Linux kernels, and bpftrace (a high-level eBPF tracing frontend) is available as a standard package on
major distributions (Fedora, RHEL, Oracle Linux, Debian, Ubuntu). The examples in the new section work reliably out of the box with a simple package install,
making them a more practical starting point for users who want to trace PHP on Linux.

bpftrace v0.21.2
https://gist.github.com/egmc/467678a1b6b845bd0a5605dcf3aaa906

So adding bpftrace version would provide more straightforward, easy way to uses.

Notes

- The new section is placed after the existing SystemTap section
- Probe names and arguments match the existing DTrace/SystemTap documentation
- The all_probes.bt script mirrors the existing all_probes.stp example for consistency