### PR TITLE
request_parse_body: Clarify behavior when body already consumed

### DIFF
--- a/reference/network/functions/request-parse-body.xml
+++ b/reference/network/functions/request-parse-body.xml
@@ -37,8 +37,12 @@
 
   <caution>
    <simpara>
+    The request body can only be consumed once.
     <function>request_parse_body</function> consumes the request body without
     buffering it to the <literal>php://input</literal> stream.
+    Conversely, if the body has already been read (e.g. via
+    <literal>php://input</literal>), <function>request_parse_body</function>
+    will return empty data.
    </simpara>
   </caution>
  </refsect1>


### PR DESCRIPTION
Alternative to #5412. When the body has already been read (e.g. via php://input), request_parse_body() deterministically returns empty data rather than "may no longer be available".

Fixes #5270 @kamil-tekiela 