### PR TITLE
DATE_RFC7231 constant has been deprecated in PHP 8.5

### DIFF
--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -366,6 +366,13 @@
       </thead>
       <tbody>
        <row>
+        <entry>8.5.0</entry>
+        <entry>
+         The <constant>DATE_RFC7231</constant> and
+         <constant>DateTimeInterface::RFC7231</constant> constants have been deprecated.
+        </entry>
+       </row>
+       <row>
         <entry>8.4.0</entry>
         <entry>The class constants are now typed.</entry>
        </row>


### PR DESCRIPTION
I updated the DateTimeInterface changelog since the DATE_RFC721 constant has been deprecated.

Source: <https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.date>