### PR TITLE
Fix several issues in versions.xml files

### DIFF
--- a/appendices/aliases.xml
+++ b/appendices/aliases.xml
@@ -592,6 +592,11 @@
       <entry><link linkend="ref.pgsql">PostgreSQL</link></entry>
      </row>
      <row>
+      <entry>pg_exec</entry>
+      <entry><function>pg_query</function></entry>
+      <entry><link linkend="ref.pgsql">PostgreSQL</link></entry>
+     </row>
+     <row>
       <entry>pos</entry>
       <entry><function>current</function></entry>
       <entry>Base syntax</entry>

--- a/appendices/aliases.xml
+++ b/appendices/aliases.xml
@@ -132,16 +132,6 @@
       <entry><link linkend="ref.imap">IMAP</link></entry>
      </row>
      <row>
-      <entry>imap_getmailboxes</entry>
-      <entry><function>imap_list_full</function></entry>
-      <entry><link linkend="ref.imap">IMAP</link></entry>
-     </row>
-     <row>
-      <entry>imap_getsubscribed</entry>
-      <entry><function>imap_lsub_full</function></entry>
-      <entry><link linkend="ref.imap">IMAP</link></entry>
-     </row>
-     <row>
       <entry>imap_header</entry>
       <entry><function>imap_headerinfo</function></entry>
       <entry><link linkend="ref.imap">IMAP</link></entry>

--- a/language/predefined/versions.xml
+++ b/language/predefined/versions.xml
@@ -103,8 +103,6 @@
 
  <function name="closedgeneratorexception" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
 
- <function name="requstparsebodyexception" from="PHP 8 &gt;= 8.4.0"/>
-
  <function name="fiber" from="PHP 8 &gt;= 8.1.0"/>
  <function name="fiber::__construct" from="PHP 8 &gt;= 8.1.0"/>
  <function name="fiber::start" from="PHP 8 &gt;= 8.1.0"/>

--- a/reference/apcu/versions.xml
+++ b/reference/apcu/versions.xml
@@ -17,6 +17,7 @@
  <function name='apcu_inc' from='PECL apcu &gt;= 4.0.0'/>
  <function name='apcu_sma_info' from='PECL apcu &gt;= 4.0.0'/>
  <function name='apcu_store' from='PECL apcu &gt;= 4.0.0'/>
+ <function name='apcu_key_info' from='PECL apcu &gt;= 4.0.2'/>
 
  <function name='APCUIterator' from='PECL apcu &gt;= 5.0.0'/>
  <function name='APCUIterator::__construct' from='PECL apcu &gt;= 5.0.0'/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -188,6 +188,7 @@
  <function name="domtext" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domtext::__construct" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domtext::iswhitespaceinelementcontent" from="PHP 5, PHP 7, PHP 8"/>
+ <function name="domtext::iselementcontentwhitespace" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
  <function name="domtext::replacewholetext" from="PHP 5, PHP 7"/>
  <function name="domtext::splittext" from="PHP 5, PHP 7, PHP 8"/>
 

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -58,7 +58,6 @@
  <function name="domdocument::prepend" from="PHP 8"/>
  <function name="domdocument::relaxngvalidate" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domdocument::relaxngvalidatesource" from="PHP 5, PHP 7, PHP 8"/>
- <function name="domdocument::renamenode" from="PHP 5, PHP 7"/>
  <function name="domdocument::replacechildren" from="PHP 8 &gt;= 8.3.0"/>
  <function name="domdocument::save" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domdocument::savehtml" from="PHP 5, PHP 7, PHP 8"/>
@@ -121,11 +120,7 @@
  <function name="domimplementation::__construct" from="PHP 5, PHP 7"/>
  <function name="domimplementation::createdocument" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domimplementation::createdocumenttype" from="PHP 5, PHP 7, PHP 8"/>
- <function name="domimplementation::getfeature" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domimplementation::hasfeature" from="PHP 5, PHP 7, PHP 8"/>
- <function name="domimplementation::listitem" from="PHP 5, PHP 7"/>
- <function name="domimplementation::source_get_domimplementation" from="PHP 5, PHP 7"/>
- <function name="domimplementation::source_get_domimplementations" from="PHP 5, PHP 7"/>
 
  <function name="domnamednodemap" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domnamednodemap::count" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
@@ -133,10 +128,6 @@
  <function name="domnamednodemap::getnameditem" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domnamednodemap::getnameditemns" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domnamednodemap::item" from="PHP 5, PHP 7, PHP 8"/>
- <function name="domnamednodemap::removenameditem" from="PHP 5, PHP 7"/>
- <function name="domnamednodemap::removenameditemns" from="PHP 5, PHP 7"/>
- <function name="domnamednodemap::setnameditem" from="PHP 5, PHP 7"/>
- <function name="domnamednodemap::setnameditemns" from="PHP 5, PHP 7"/>
 
  <function name="domnamespacenode" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domnamespacenode::__sleep" from="PHP 8 &gt;= 8.1.25"/>
@@ -149,10 +140,8 @@
  <function name="domnode::clonenode" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domnode::comparedocumentposition" from="PHP 8 &gt;= 8.4.0"/>
  <function name="domnode::contains" from="PHP 8 &gt;= 8.3.0"/>
- <function name="domnode::getfeature" from="PHP 5, PHP 7"/>
  <function name="domnode::getlineno" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="domnode::getnodepath" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
- <function name="domnode::getuserdata" from="PHP 5, PHP 7"/>
  <function name="domnode::getrootnode" from="PHP 8 &gt;= 8.3.0"/>
  <function name="domnode::hasattributes" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domnode::haschildnodes" from="PHP 5, PHP 7, PHP 8"/>
@@ -166,7 +155,6 @@
  <function name="domnode::normalize" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domnode::removechild" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domnode::replacechild" from="PHP 5, PHP 7, PHP 8"/>
- <function name="domnode::setuserdata" from="PHP 5, PHP 7"/>
  <function name="domnode::__sleep" from="PHP 8 &gt;= 8.1.25"/>
  <function name="domnode::__wakeup" from="PHP 8 PHP 8 &gt;= 8.1.25"/>
 
@@ -189,7 +177,6 @@
  <function name="domtext::__construct" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domtext::iswhitespaceinelementcontent" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domtext::iselementcontentwhitespace" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
- <function name="domtext::replacewholetext" from="PHP 5, PHP 7"/>
  <function name="domtext::splittext" from="PHP 5, PHP 7, PHP 8"/>
 
  <function name="domxpath" from="PHP 5, PHP 7, PHP 8"/>

--- a/reference/imap/versions.xml
+++ b/reference/imap/versions.xml
@@ -39,11 +39,9 @@
  <function name="imap_last_error" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="imap_list" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="imap_listscan" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
- <function name="imap_list_full" from="PHP 5, PHP 7"/>
  <function name="imap_listmailbox" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="imap_listsubscribed" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="imap_lsub" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
- <function name="imap_lsub_full" from="PHP 5, PHP 7"/>
  <function name="imap_mail" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="imap_mail_compose" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="imap_mail_copy" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
@@ -56,7 +54,6 @@
  <function name="imap_num_recent" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="imap_open" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="imap_ping" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
- <function name="imap_popen" from="PHP 5, PHP 7"/>
  <function name="imap_qprint" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="imap_rename" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="imap_renamemailbox" from="PHP 4, PHP 5, PHP 7, PHP 8"/>

--- a/reference/openssl/versions.xml
+++ b/reference/openssl/versions.xml
@@ -68,6 +68,8 @@
  <function name="openssl_x509_read" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PHP 8"/>
  <function name="openssl_x509_fingerprint" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
  <function name="openssl_x509_verify" from="PHP 7 &gt;= 7.4.0, PHP 8"/>
+ <function name="openssl_password_hash" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="openssl_password_verify" from="PHP 8 &gt;= 8.4.0"/>
 
  <function name="opensslcertificate" from="PHP 8"/>
  <function name="opensslcertificatesigningrequest" from="PHP 8"/>

--- a/reference/pdo/versions.xml
+++ b/reference/pdo/versions.xml
@@ -42,11 +42,6 @@
 
  <function name="pdo_drivers" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.9.0"/>
 
- <function name="pdo_user" from="PECL pdo_user &gt;= 0.2.0"/>
- <function name="pdo_user::parsesql" from="PECL pdo_user &gt;= 0.2.0"/>
- <function name="pdo_user::tokenizesql" from="PECL pdo_user &gt;= 0.2.0"/>
- <function name="pdo_user::tokenname" from="PECL pdo_user &gt;= 0.2.0"/>
-
  <function name="pdorow" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 1.0.0"/>
 
  <function name="pdostatement" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 1.0.0"/>

--- a/reference/pdo/versions.xml
+++ b/reference/pdo/versions.xml
@@ -60,7 +60,6 @@
  <function name="pdostatement::fetchall" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
  <function name="pdostatement::fetchcolumn" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.9.0"/>
  <function name="pdostatement::fetchobject" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.2.4"/>
- <function name="pdostatement::fetchsingle" from="PECL pdo 0.1-0.3"/>
  <function name="pdostatement::getattribute" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.2.0"/>
  <function name="pdostatement::getcolumnmeta" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.2.0"/>
  <function name="pdostatement::getiterator" from="PHP 8"/>

--- a/reference/pdo/versions.xml
+++ b/reference/pdo/versions.xml
@@ -9,8 +9,6 @@
 <versions>
  <function name="pdo" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
  <function name="pdo::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
- <function name="pdo::__sleep" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 1.0.0"/>
- <function name="pdo::__wakeup" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 1.0.0"/>
  <function name="pdo::begintransaction" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
  <function name="pdo::commit" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
  <function name="pdo::connect" from="PHP 8 &gt;= 8.4.0"/>
@@ -45,8 +43,6 @@
  <function name="pdorow" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 1.0.0"/>
 
  <function name="pdostatement" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 1.0.0"/>
- <function name="pdostatement::__sleep" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 1.0.0"/>
- <function name="pdostatement::__wakeup" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 1.0.0"/>
  <function name="pdostatement::bindcolumn" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
  <function name="pdostatement::bindparam" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
  <function name="pdostatement::bindvalue" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 1.0.0"/>

--- a/reference/phar/versions.xml
+++ b/reference/phar/versions.xml
@@ -19,9 +19,6 @@
  <function name="phar::compress" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
  <function name="phar::compressfiles" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
  <function name="phar::converttodata" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
- <function name="phar::converttotar" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
- <function name="phar::converttozip" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
- <function name="phar::converttophar" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
  <function name="phar::converttoexecutable" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
  <function name="phar::copy" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
  <function name="phar::count" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
@@ -43,9 +40,6 @@
  <function name="phar::hasmetadata" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.2.0"/>
  <function name="phar::interceptfilefuncs" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
  <function name="phar::iscompressed" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
- <function name="phar::isphar" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
- <function name="phar::istar" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
- <function name="phar::iszip" from="PHP 5 &gt;= 5.3.0, PHP 7, PECL phar &gt;= 2.0.0"/>
  <function name="phar::isfileformat" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
  <function name="phar::iswritable" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 2.0.0"/>
  <function name="phar::isbuffering" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>

--- a/reference/reflection/versions.xml
+++ b/reference/reflection/versions.xml
@@ -421,6 +421,7 @@
  <function name="reflectiongenerator::isclosed" from="PHP 8 &gt;= 8.4.0"/>
 
  <function name="reflectionreference" from="PHP 7 &gt;= 7.4.0, PHP 8"/>
+ <function name="reflectionreference::__construct" from="PHP 7 &gt;= 7.4.0, PHP 8"/>
  <function name="reflectionreference::fromarrayelement" from="PHP 7 &gt;= 7.4.0, PHP 8"/>
  <function name="reflectionreference::getid" from="PHP 7 &gt;= 7.4.0, PHP 8"/>
 

--- a/reference/simplexml/versions.xml
+++ b/reference/simplexml/versions.xml
@@ -24,7 +24,8 @@
  <function name="simplexmlelement::savexml" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="simplexmlelement::xpath" from="PHP 5, PHP 7, PHP 8"/>
 
- <function name="simplexmlelement" from="PHP 8"/>
+ <function name="simplexmliterator" from="PHP 5, PHP 7, PHP 8"/>
+
  <function name="simplexmlelement::count" from="PHP 8"/>
  <function name="simplexmlelement::current" from="PHP 8"/>
  <function name="simplexmlelement::getchildren" from="PHP 8"/>

--- a/reference/simplexml/versions.xml
+++ b/reference/simplexml/versions.xml
@@ -33,7 +33,14 @@
  <function name="simplexmlelement::key" from="PHP 8"/>
  <function name="simplexmlelement::next" from="PHP 8"/>
  <function name="simplexmlelement::rewind" from="PHP 8"/>
- <function name="simplexmlelement::valid" from="PHP 8"/>
+<function name="simplexmliterator::count" from="PHP 8"/>
+<function name="simplexmliterator::current" from="PHP 8"/>
+<function name="simplexmliterator::getchildren" from="PHP 8"/>
+<function name="simplexmliterator::haschildren" from="PHP 8"/>
+<function name="simplexmliterator::key" from="PHP 8"/>
+<function name="simplexmliterator::next" from="PHP 8"/>
+<function name="simplexmliterator::rewind" from="PHP 8"/>
+<function name="simplexmliterator::valid" from="PHP 8"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/soap/versions.xml
+++ b/reference/soap/versions.xml
@@ -24,12 +24,10 @@
  <function name="soapclient::__setcookie" from="PHP 5 &gt;= 5.0.4, PHP 7, PHP 8"/>
  <function name="soapclient::__setlocation" from="PHP 5 &gt;= 5.0.4, PHP 7, PHP 8"/>
  <function name="soapclient::__setsoapheaders" from="PHP 5 &gt;= 5.0.5, PHP 7, PHP 8"/>
- <function name="soapclient::soapclient" from="PHP 5, PHP 7"/>
 
  <function name="soapserver" from="PHP 5, PHP 7, PHP 8"/>
  <function name="soapserver::__construct" from="PHP 5, PHP 7, PHP 8"/>
  <function name="soapserver::__getlastresponse" from="PHP 8 &gt;= 8.4"/>
- <function name="soapserver::soapserver" from="PHP 5, PHP 7"/>
  <function name="soapserver::setpersistence" from="PHP 5, PHP 7, PHP 8"/>
  <function name="soapserver::setclass" from="PHP 5, PHP 7, PHP 8"/>
  <function name="soapserver::setobject" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
@@ -40,7 +38,6 @@
  <function name="soapserver::addsoapheader" from="PHP 5 &gt;= 5.1.3, PHP 7, PHP 8"/>
 
  <function name="soapfault" from="PHP 5, PHP 7, PHP 8"/>
- <function name="soapfault::soapfault" from="PHP 5, PHP 7"/>
  <function name="soapfault::__tostring" from="PHP 5, PHP 7, PHP 8"/>
  <function name="soapfault::__clone" from="PHP 5, PHP 7, PHP 8"/>
  <function name="soapfault::__construct" from="PHP 5, PHP 7, PHP 8"/>
@@ -54,15 +51,12 @@
 
  <function name="soapparam" from="PHP 5, PHP 7, PHP 8"/>
  <function name="soapparam::__construct" from="PHP 5, PHP 7, PHP 8"/>
- <function name="soapparam::soapparam" from="PHP 5, PHP 7"/>
 
  <function name="soapheader" from="PHP 5, PHP 7, PHP 8"/>
  <function name="soapheader::__construct" from="PHP 5, PHP 7, PHP 8"/>
- <function name="soapheader::soapheader" from="PHP 5, PHP 7"/>
 
  <function name="soapvar" from="PHP 5, PHP 7, PHP 8"/>
  <function name="soapvar::__construct" from="PHP 5, PHP 7, PHP 8"/>
- <function name="soapvar::soapvar" from="PHP 5, PHP 7"/>
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/sqlite3/versions.xml
+++ b/reference/sqlite3/versions.xml
@@ -32,6 +32,7 @@
  <function name="SQLite3Exception" from="PHP 8 &gt;= 8.3.0"/>
 
  <function name="SQLite3Stmt" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="SQLite3Stmt::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3Stmt::bindParam" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3Stmt::bindValue" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3Stmt::clear" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
@@ -43,6 +44,7 @@
  <function name="SQLite3Stmt::reset" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
  <function name="SQLite3Result" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="SQLite3Result::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3Result::columnName" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3Result::columnType" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3Result::fetchArray" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>

--- a/reference/zip/versions.xml
+++ b/reference/zip/versions.xml
@@ -34,7 +34,6 @@
  <function name="ZipArchive::isEncryptionMethodSupported" from="PHP &gt;= 8.0.0, PECL zip &gt;= 1.19.0"/>
  <function name="ZipArchive::locateName" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.5.0"/>
  <function name="ZipArchive::open" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.1.0"/>
- <function name="ZipArchive::rename" from="PHP 5 &gt;= 5.2.0, PHP 7, PECL zip &lt; 1.5.0"/>
  <function name="ZipArchive::renameIndex" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.5.0"/>
  <function name="ZipArchive::renameName" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.5.0"/>
  <function name="ZipArchive::replaceFile" from="PHP &gt;= 8.0.0, PECL zip &gt;= 1.18.0"/>


### PR DESCRIPTION
These files are manually maintained, and so they suffer from several issues: missing entries, unnecessary entries, typos, etc. 

- The first few commits fix typos and add a few missing entries that I was able to verify
- The rest removes entries that are definitely no longer useful to anyone

However, this is just a small patch. The number of missing entries is much larger. There are also hundreds of entries that don't serve any purpose. They can be grouped mostly into two types: inherited but not overridden methods, and aliases. None of them have a matching page in the documentation, which means that these entries aren't used by PHP manual at least. However, I was cautious about removing them as they can still offer some insight into other tools or human eyes. 