### PR TITLE
Add openssl_password_hash/verify entries to versions.xml

### DIFF
--- a/reference/openssl/versions.xml
+++ b/reference/openssl/versions.xml
@@ -30,6 +30,8 @@
  <function name="openssl_get_privatekey" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
  <function name="openssl_get_publickey" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
  <function name="openssl_open" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
+ <function name="openssl_password_hash" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="openssl_password_verify" from="PHP 8 &gt;= 8.4.0"/>
  <function name="openssl_pbkdf2" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="openssl_pkcs12_export" from="PHP 5 &gt;= 5.2.2, PHP 7, PHP 8"/>
  <function name="openssl_pkcs12_export_to_file" from="PHP 5 &gt;= 5.2.2, PHP 7, PHP 8"/>


### PR DESCRIPTION
Follow-up to #5352: the two functions were documented but their entries in `reference/openssl/versions.xml` were missing, so the PHP version availability bar was not rendered on php.net.