### PR TITLE
Clarify with enable_post_data_reading=0 body can also be consumed via request_parse_body()

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -800,11 +800,12 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
       <listitem>
        <simpara>
         Disabling this option causes <varname>$_POST</varname> and
-        <varname>$_FILES</varname> <emphasis>not</emphasis> to be populated.
-        The only way to read postdata will then be through the
-        <link linkend="wrappers.php">php://input</link> stream wrapper.
-        This can be useful to proxy requests or to process
-        the POST data in a memory efficient fashion.
+        <varname>$_FILES</varname> <emphasis>not</emphasis> to be populated. The
+        request body remains unconsumed in
+        <link linkend="wrappers.php">php://input</link> and can be read manually
+        or parsed via <link linkend="wrappers.php">request_parse_body</link>.
+        This can be useful to proxy requests or to process the POST data in a
+        memory efficient fashion.
        </simpara>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
Disclosure: I didn't test locally. Not sure if it looks good.