### PR TITLE
[idea] Merge constant aliases by using multiple term tags for a varlistentry

### DIFF
--- a/appendices/reserved.constants.core.xml
+++ b/appendices/reserved.constants.core.xml
@@ -108,45 +108,29 @@
     </note>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.zend-thread-safe">
-   <term>
+  <varlistentry>
+   <term xml:id="constant.zend-thread-safe">
     <constant>ZEND_THREAD_SAFE</constant>
     (<type>bool</type>)
    </term>
+   <term xml:id="constant.php-zts">
+    <constant>PHP_ZTS</constant>
+    (<type>bool</type>)
+   </term>
    <listitem>
     <simpara>
      Indicates whether the current build of PHP is thread safe.
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.zend-debug-build">
-   <term>
+  <varlistentry>
+   <term xml:id="constant.zend-debug-build">
     <constant>ZEND_DEBUG_BUILD</constant>
     (<type>bool</type>)
    </term>
-   <listitem>
-    <simpara>
-     Indicates whether the current build of PHP is a debug build.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.php-zts">
-   <term>
-    <constant>PHP_ZTS</constant>
-    (<type>bool</type>)
-    &Alias; <constant>ZEND_THREAD_SAFE</constant>
-   </term>
-   <listitem>
-    <simpara>
-     Indicates whether the current build of PHP is thread safe.
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.php-debug">
-   <term>
+   <term xml:id="constant.php-debug">
     <constant>PHP_DEBUG</constant>
     (<type>bool</type>)
-    &Alias; <constant>ZEND_DEBUG_BUILD</constant>
    </term>
    <listitem>
     <simpara>


### PR DESCRIPTION
As a reply to https://github.com/php/doc-en/pull/5434#issuecomment-4142370139 I think improving the markup of aliased constants to something like this probably makes the most sense, as we don't duplicate wording nor need to specify X is an alias of Y. :)