### PR TITLE
Clarify in_array() strict comparison behavior for PHP 8.0+

### DIFF
--- a/reference/array/functions/in-array.xml
+++ b/reference/array/functions/in-array.xml
@@ -55,12 +55,16 @@
       </para>
       <note>
        <para>
-        Prior to PHP 8.0.0, a <literal>string</literal> <parameter>needle</parameter> will match an array
-        value of <literal>0</literal> in non-strict mode, and vice versa.  That may lead to undesireable
-        results.  Similar edge cases exist for other types, as well.  If not absolutely certain of the
-        types of values involved, always use the <parameter>strict</parameter> flag to avoid unexpected behavior.
-       </para>
-      </note>
+        Prior to PHP 8.0.0, a <literal>string</literal> <parameter>needle</parameter> would loosely match
+        a numeric <parameter>haystack</parameter> value of <literal>0</literal>, and vice versa.
+        As of PHP 8.0.0, this behavior is restricted to numeric strings. However, non-strict mode
+        still employs loose comparison (<literal>==</literal>), which allows for matches across
+        unrelated types. For example, a boolean <constant>&true;</constant> value in the
+        <parameter>haystack</parameter> will match any non-empty <literal>string</literal>
+        <parameter>needle</parameter>. It is recommended to use the <parameter>strict</parameter>
+        flag to ensure type-safe results.
+        </para>
+       </note>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/array/functions/in-array.xml
+++ b/reference/array/functions/in-array.xml
@@ -55,12 +55,16 @@
       </para>
       <note>
        <para>
-        Prior to PHP 8.0.0, a <literal>string</literal> <parameter>needle</parameter> will match an array
-        value of <literal>0</literal> in non-strict mode, and vice versa.  That may lead to undesireable
-        results.  Similar edge cases exist for other types, as well.  If not absolutely certain of the
-        types of values involved, always use the <parameter>strict</parameter> flag to avoid unexpected behavior.
-       </para>
-      </note>
+        Prior to PHP 8.0.0, a <literal>string</literal> <parameter>needle</parameter> would loosely match 
+        a numeric <parameter>haystack</parameter> value of <literal>0</literal>, and vice versa. 
+        As of PHP 8.0.0, this behavior is restricted to numeric strings. However, non-strict mode 
+        still employs loose comparison (<literal>==</literal>), which allows for matches across 
+        unrelated types. For example, a boolean <constant>&true;</constant> value in the 
+        <parameter>haystack</parameter> will match any non-empty <literal>string</literal> 
+        <parameter>needle</parameter>. It is recommended to use the <parameter>strict</parameter> 
+        flag to ensure type-safe results 
+        </para>
+       </note>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/array/functions/in-array.xml
+++ b/reference/array/functions/in-array.xml
@@ -55,14 +55,14 @@
       </para>
       <note>
        <para>
-        Prior to PHP 8.0.0, a <literal>string</literal> <parameter>needle</parameter> would loosely match 
-        a numeric <parameter>haystack</parameter> value of <literal>0</literal>, and vice versa. 
-        As of PHP 8.0.0, this behavior is restricted to numeric strings. However, non-strict mode 
-        still employs loose comparison (<literal>==</literal>), which allows for matches across 
-        unrelated types. For example, a boolean <constant>&true;</constant> value in the 
-        <parameter>haystack</parameter> will match any non-empty <literal>string</literal> 
-        <parameter>needle</parameter>. It is recommended to use the <parameter>strict</parameter> 
-        flag to ensure type-safe results 
+        Prior to PHP 8.0.0, a <literal>string</literal> <parameter>needle</parameter> would loosely match
+        a numeric <parameter>haystack</parameter> value of <literal>0</literal>, and vice versa.
+        As of PHP 8.0.0, this behavior is restricted to numeric strings. However, non-strict mode
+        still employs loose comparison (<literal>==</literal>), which allows for matches across
+        unrelated types. For example, a boolean <constant>&true;</constant> value in the
+        <parameter>haystack</parameter> will match any non-empty <literal>string</literal>
+        <parameter>needle</parameter>. It is recommended to use the <parameter>strict</parameter>
+        flag to ensure type-safe results.
         </para>
        </note>
      </listitem>

--- a/reference/array/functions/in-array.xml
+++ b/reference/array/functions/in-array.xml
@@ -54,17 +54,24 @@
        <parameter>needle</parameter> in the <parameter>haystack</parameter>.
       </para>
       <note>
-       <para>
-        Prior to PHP 8.0.0, a <literal>string</literal> <parameter>needle</parameter> would loosely match
-        a numeric <parameter>haystack</parameter> value of <literal>0</literal>, and vice versa.
-        As of PHP 8.0.0, this behavior is restricted to numeric strings. However, non-strict mode
-        still employs loose comparison (<literal>==</literal>), which allows for matches across
-        unrelated types. For example, a boolean <constant>&true;</constant> value in the
-        <parameter>haystack</parameter> will match any non-empty <literal>string</literal>
-        <parameter>needle</parameter>. It is recommended to use the <parameter>strict</parameter>
-        flag to ensure type-safe results.
-        </para>
-       </note>
+       <simpara>
+        Prior to PHP 8.0.0, a non-numeric <type>string</type>
+        <parameter>needle</parameter> would loosely match a
+        <parameter>haystack</parameter> value of <literal>0</literal>, and
+        vice versa. As of PHP 8.0.0, the number is converted to a
+        <type>string</type> and the two are compared as strings, so only a
+        numeric <type>string</type> of the same value still matches.
+       </simpara>
+       <simpara>
+        Non-strict mode nonetheless uses
+        <link linkend="types.comparisions-loose">loose comparison</link>, so
+        values of different types can still compare as equal: &true; matches
+        any truthy <type>string</type>, and &false; matches both
+        <literal>""</literal> and <literal>"0"</literal>. Unless the types of
+        all values involved are known with certainty, always pass
+        <parameter>strict</parameter> to force an identity comparison.
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
The current note for the `strict` parameter focuses primarily on a legacy string-to-integer comparison bug that was partially resolved in PHP 8.0.0. This can give users the false impression that non-strict mode is now "safe" in modern versions.

This PR updates the documentation to:
1. Clarify the specific change introduced in PHP 8.0.0 (restriction to numeric strings).
2. Explicitly mention the persistent "truthy" trap where boolean `true` loosely matches any non-empty string.
3. Strongly reinforce the recommendation for strict comparison to ensure type safety.
