### PR TITLE
Fix exception name in createFromDateString documentation

### DIFF
--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -62,7 +62,7 @@
   &reftitle.errors;
   <para>
    Object Oriented API only: If an invalid Date/Time string is passed,
-   <exceptionname>DateMalformedStringException</exceptionname> is thrown.
+   <exceptionname>DateMalformedIntervalStringException</exceptionname> is thrown.
   </para>
  </refsect1>
 
@@ -81,7 +81,7 @@
       <entry>8.3.0</entry>
       <entry>
        <methodname>DateInterval::createFromDateString</methodname> now throws
-       <exceptionname>DateMalformedStringException</exceptionname> if an
+       <exceptionname>DateMalformedIntervalStringException</exceptionname> if an
        invalid string is passed.  Previously, it returned <literal>false</literal>,
        and a warning was emitted.
        <function>date_interval_create_from_date_string</function> has not been


### PR DESCRIPTION
Refs:
- https://github.com/php/php-src/blob/master/ext/date/tests/DateInterval_createFromDateString_broken.phpt
- https://3v4l.org/EF631