### PR TITLE
Change <para> to <simpara> in language-snippets.

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -75,8 +75,8 @@ binary-safe.</simpara></note>'>
 function are cached. See <function>clearstatcache</function> for
 more details.</simpara></note>'>
 
-<!ENTITY note.context-support '<para xmlns="http://docbook.org/ns/docbook">A <link linkend="stream.contexts">context stream</link>
-<type>resource</type>.</para>'>
+<!ENTITY note.context-support '<simpara xmlns="http://docbook.org/ns/docbook">A <link linkend="stream.contexts">context stream</link>
+<type>resource</type>.</simpara>'>
 
 <!ENTITY note.exec-bg '<note xmlns="http://docbook.org/ns/docbook"><simpara>If a program is started with this function,
 in order for it to continue running in the background, the output of the
@@ -1629,9 +1629,9 @@ It is strongly recommended to avoid timezone abbreviations.
 Every call to a date/time function will generate a <constant>E_WARNING</constant>
 if the time zone is not valid. See also <function>date_default_timezone_set</function></simpara>'>
 
-<!ENTITY date.timezone.errors.changelog '<row xmlns="http://docbook.org/ns/docbook"><entry>5.1.0</entry><entry><para>
+<!ENTITY date.timezone.errors.changelog '<row xmlns="http://docbook.org/ns/docbook"><entry>5.1.0</entry><entry><simpara>
 Now issues the <constant>E_STRICT</constant> and <constant>E_NOTICE</constant>
-time zone errors.</para></entry></row>'>
+time zone errors.</simpara></entry></row>'>
 
 <!ENTITY date.timestamp.description '
 <varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>timestamp</parameter></term><listitem><simpara>
@@ -2969,7 +2969,7 @@ system call.</simpara></listitem>
 </para>
 '>
 
-<!ENTITY eio.request.pri.values '<para
+<!ENTITY eio.request.pri.values '<simpara
 xmlns="http://docbook.org/ns/docbook">The request priority: <constant
 xmlns="http://docbook.org/ns/docbook">EIO_PRI_DEFAULT</constant>, <constant
 xmlns="http://docbook.org/ns/docbook">EIO_PRI_MIN</constant>, <constant
@@ -2977,7 +2977,7 @@ xmlns="http://docbook.org/ns/docbook">EIO_PRI_MAX</constant>, or &null;.
 If &null; passed, <parameter
 xmlns="http://docbook.org/ns/docbook">pri</parameter> internally is set to
 <constant xmlns="http://docbook.org/ns/docbook">EIO_PRI_DEFAULT</constant>.
-</para>
+</simpara>
 '>
 
 <!ENTITY eio.warn.relpath '<warning
@@ -3799,34 +3799,34 @@ local: {
 '>
 
 <!-- Radius -->
-<!ENTITY radius.request.required '<note xmlns="http://docbook.org/ns/docbook"><para>A request must be created via <function>radius_create_request</function> before this function can be called.</para></note>'>
-<!ENTITY radius.parameter.attribute-type '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>type</parameter></term><listitem><para>The attribute type.</para></listitem></varlistentry>'>
-<!ENTITY radius.parameter.handle '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>radius_handle</parameter></term><listitem><para>The RADIUS resource.</para></listitem></varlistentry>'>
-<!ENTITY radius.parameter.options '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>options</parameter></term><listitem><para>A bitmask of the attribute options. The available options include <link linkend="constant.radius-option-tagged"><constant>RADIUS_OPTION_TAGGED</constant></link> and <link linkend="constant.radius-option-salt"><constant>RADIUS_OPTION_SALT</constant></link>.</para></listitem></varlistentry>'>
-<!ENTITY radius.parameter.tag '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>tag</parameter></term><listitem><para>The attribute tag. This parameter is ignored unless the <link linkend="constant.radius-option-tagged"><constant>RADIUS_OPTION_TAGGED</constant></link> option is set.</para></listitem></varlistentry>'>
-<!ENTITY radius.parameter.vendor '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>vendor</parameter></term><listitem><para>The vendor ID.</para></listitem></varlistentry>'>
+<!ENTITY radius.request.required '<note xmlns="http://docbook.org/ns/docbook"><simpara>A request must be created via <function>radius_create_request</function> before this function can be called.</simpara></note>'>
+<!ENTITY radius.parameter.attribute-type '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>type</parameter></term><listitem><simpara>The attribute type.</simpara></listitem></varlistentry>'>
+<!ENTITY radius.parameter.handle '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>radius_handle</parameter></term><listitem><simpara>The RADIUS resource.</simpara></listitem></varlistentry>'>
+<!ENTITY radius.parameter.options '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>options</parameter></term><listitem><simpara>A bitmask of the attribute options. The available options include <link linkend="constant.radius-option-tagged"><constant>RADIUS_OPTION_TAGGED</constant></link> and <link linkend="constant.radius-option-salt"><constant>RADIUS_OPTION_SALT</constant></link>.</simpara></listitem></varlistentry>'>
+<!ENTITY radius.parameter.tag '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>tag</parameter></term><listitem><simpara>The attribute tag. This parameter is ignored unless the <link linkend="constant.radius-option-tagged"><constant>RADIUS_OPTION_TAGGED</constant></link> option is set.</simpara></listitem></varlistentry>'>
+<!ENTITY radius.parameter.vendor '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>vendor</parameter></term><listitem><simpara>The vendor ID.</simpara></listitem></varlistentry>'>
 
 <!-- posix snippets -->
 <!ENTITY posix.parameter.fd '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>file_descriptor</parameter></term>
  <listitem>
-  <para>
+  <simpara>
    The file descriptor, which is expected to be either a file
    <type>resource</type> or an <type>int</type>. An <type>int</type>
    will be assumed to be a file descriptor that can be passed directly to
    the underlying system call.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
 <!ENTITY posix.rlimits '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
   Each resource has an associated soft and hard limit.  The soft
   limit is the value that the kernel enforces for the corresponding
   resource.  The hard limit acts as a ceiling for the soft limit.
   An unprivileged process may only set its soft limit to a value
   from 0 to the hard limit, and irreversibly lower its hard limit.
-</para>
+</simpara>
 '>
 
 <!-- strings snippets -->
@@ -4029,40 +4029,40 @@ local: {
 '>
 
 <!ENTITY strings.parameter.encoding '
- <para xmlns="http://docbook.org/ns/docbook">
+ <simpara xmlns="http://docbook.org/ns/docbook">
   An optional argument defining the encoding used when converting characters.
- </para>
+ </simpara>
 
- <para xmlns="http://docbook.org/ns/docbook">
+ <simpara xmlns="http://docbook.org/ns/docbook">
   If omitted, <parameter>encoding</parameter> defaults to the value of the
   <link linkend="ini.default-charset">default_charset</link> configuration
   option.
- </para>
+ </simpara>
 
- <para xmlns="http://docbook.org/ns/docbook">
+ <simpara xmlns="http://docbook.org/ns/docbook">
   Although this argument is technically optional, you are highly encouraged to
   specify the correct value for your code
   if the <link linkend="ini.default-charset">default_charset</link>
   configuration option may be set incorrectly for the given input.
- </para>
+ </simpara>
 '>
 
 <!ENTITY strings.parameter.format '
 <varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>format</parameter></term>
  <listitem>
-  <para>
+  <simpara>
    The format string is composed of zero or more directives:
    ordinary characters (excluding <literal>&#37;</literal>) that are
    copied directly to the result and <emphasis>conversion
    specifications</emphasis>, each of which results in fetching its
    own parameter.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    A conversion specification follows this prototype:
    <literal>&#37;[argnum$][flags][width][.precision]specifier</literal>.
-  </para>
+  </simpara>
 
   <formalpara>
    <title>Argnum</title>
@@ -4246,18 +4246,18 @@ local: {
       <row>
        <entry><literal>g</literal></entry>
        <entry>
-        <para>
+        <simpara>
          General format.
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Let P equal the precision if nonzero, 6 if the precision is omitted,
          or 1 if the precision is zero.
          Then, if a conversion with style E would have an exponent of X:
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          If P > X ≥ −4, the conversion is with style f and precision P − (X + 1).
          Otherwise, the conversion is with style e and precision P − 1.
-        </para>
+        </simpara>
        </entry>
       </row>
       <row>
@@ -4321,15 +4321,15 @@ local: {
   </para>
 
   <warning>
-   <para>
+   <simpara>
     The <literal>c</literal> type specifier ignores padding and width.
-   </para>
+   </simpara>
   </warning>
 
   <warning>
-   <para>
+   <simpara>
     Attempting to use a combination of the string and width specifiers with character sets that require more than one byte per character may result in unexpected results.
-   </para>
+   </simpara>
   </warning>
 
   <para>
@@ -4420,14 +4420,14 @@ local: {
 '>
 
 <!ENTITY strings.parameter.needle.non-string '
- <para xmlns="http://docbook.org/ns/docbook">
+ <simpara xmlns="http://docbook.org/ns/docbook">
   Prior to PHP 8.0.0, if <parameter>needle</parameter> is not a string, it is converted
   to an integer and applied as the ordinal value of a character.
   This behavior is deprecated as of PHP 7.3.0, and relying on it is highly
   discouraged. Depending on the intended behavior, the
   <parameter>needle</parameter> should either be explicitly cast to string,
   or an explicit call to <function>chr</function> should be performed.
- </para>
+ </simpara>
 '>
 
 <!ENTITY strings.changelog.needle-empty '<row xmlns="http://docbook.org/ns/docbook">
@@ -4569,41 +4569,41 @@ local: {
 '>
 
 <!ENTITY strings.errors.sprintf '
-  <para xmlns="http://docbook.org/ns/docbook">
+  <simpara xmlns="http://docbook.org/ns/docbook">
    As of PHP 8.0.0, a <classname>ValueError</classname> is thrown if the number of arguments is zero.
    Prior to PHP 8.0.0, a <constant>E_WARNING</constant> was emitted instead.
-  </para>
-  <para xmlns="http://docbook.org/ns/docbook">
+  </simpara>
+  <simpara xmlns="http://docbook.org/ns/docbook">
    As of PHP 8.0.0, a <classname>ValueError</classname> is thrown if <literal>[width]</literal> is less than zero or bigger than <constant>PHP_INT_MAX</constant>.
    Prior to PHP 8.0.0, a <constant>E_WARNING</constant> was emitted instead.
-  </para>
-  <para xmlns="http://docbook.org/ns/docbook">
+  </simpara>
+  <simpara xmlns="http://docbook.org/ns/docbook">
    As of PHP 8.0.0, a <classname>ValueError</classname> is thrown if <literal>[precision]</literal> is less than zero or bigger than <constant>PHP_INT_MAX</constant>.
    Prior to PHP 8.0.0, a <constant>E_WARNING</constant> was emitted instead.
-  </para>
-  <para xmlns="http://docbook.org/ns/docbook">
+  </simpara>
+  <simpara xmlns="http://docbook.org/ns/docbook">
    As of PHP 8.0.0, a <classname>ArgumentCountError</classname> is thrown when less arguments are given than required.
    Prior to PHP 8.0.0, &false; was returned and a <constant>E_WARNING</constant> emitted instead.
-  </para>
+  </simpara>
 '>
 
 <!ENTITY strings.errors.vsprintf '
-  <para xmlns="http://docbook.org/ns/docbook">
+  <simpara xmlns="http://docbook.org/ns/docbook">
    As of PHP 8.0.0, a <classname>ValueError</classname> is thrown if the number of arguments is zero.
    Prior to PHP 8.0.0, a <constant>E_WARNING</constant> was emitted instead.
-  </para>
-  <para xmlns="http://docbook.org/ns/docbook">
+  </simpara>
+  <simpara xmlns="http://docbook.org/ns/docbook">
    As of PHP 8.0.0, a <classname>ValueError</classname> is thrown if <literal>[width]</literal> is less than zero or bigger than <constant>PHP_INT_MAX</constant>.
    Prior to PHP 8.0.0, a <constant>E_WARNING</constant> was emitted instead.
-  </para>
-  <para xmlns="http://docbook.org/ns/docbook">
+  </simpara>
+  <simpara xmlns="http://docbook.org/ns/docbook">
    As of PHP 8.0.0, a <classname>ValueError</classname> is thrown if <literal>[precision]</literal> is less than zero or bigger than <constant>PHP_INT_MAX</constant>.
    Prior to PHP 8.0.0, a <constant>E_WARNING</constant> was emitted instead.
-  </para>
-  <para xmlns="http://docbook.org/ns/docbook">
+  </simpara>
+  <simpara xmlns="http://docbook.org/ns/docbook">
    As of PHP 8.0.0, a <classname>ValueError</classname> is thrown when less arguments are given than required.
    Prior to PHP 8.0.0, &false; was returned and a <constant>E_WARNING</constant> emitted instead.
-  </para>
+  </simpara>
 '>
 
 <!ENTITY strings.comparison.return '
@@ -4624,7 +4624,7 @@ local: {
  <varlistentry xmlns="http://docbook.org/ns/docbook">
   <term><parameter>filter</parameter></term>
   <listitem>
-   <para>
+   <simpara>
     The filter to apply.
     Can be a validation filter by using one of the
     <constant>FILTER_VALIDATE_<replaceable>*</replaceable></constant>
@@ -4632,67 +4632,67 @@ local: {
     <constant>FILTER_SANITIZE_<replaceable>*</replaceable></constant>
     or <constant>FILTER_UNSAFE_RAW</constant>, or a custom filter by using
     <constant>FILTER_CALLBACK</constant>.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     The default is <constant>FILTER_DEFAULT</constant>,
     which is an alias of <constant>FILTER_UNSAFE_RAW</constant>.
     This will result in no filtering taking place by default.
-   </para>
+   </simpara>
   </listitem>
  </varlistentry>
 '>
 
 <!-- csprng snippets -->
 <!ENTITY csprng.sources '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  The sources of randomness in the order of priority are as follows:
-</para>
+</simpara>
 <itemizedlist xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <listitem>
-  <para>
+  <simpara>
    Linux: <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    FreeBSD &gt;= 12 (PHP &gt;= 7.3): <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    Windows (PHP &gt;= 7.2): <link xlink:href="&url.csprng.cng-api;">CNG-API</link>
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Windows: <link xlink:href="&url.csprng.crypt-gen-random;">CryptGenRandom</link>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    macOS (PHP &gt;= 8.2; &gt;= 8.1.9; &gt;= 8.0.22 if CCRandomGenerateBytes is available at compile time): CCRandomGenerateBytes()
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    macOS (PHP &gt;= 8.1; &gt;= 8.0.2): arc4random_buf(), <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    NetBSD &gt;= 7 (PHP &gt;= 7.1; &gt;= 7.0.1): arc4random_buf(), <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    OpenBSD &gt;= 5.5 (PHP &gt;= 7.1; &gt;= 7.0.1): arc4random_buf(), <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    DragonflyBSD (PHP &gt;= 8.1): <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    Solaris (PHP &gt;= 8.1): <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
   <simpara>
@@ -4759,9 +4759,9 @@ xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
 <!ENTITY xml.parser.param '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>parser</parameter></term>
  <listitem>
-  <para>
+  <simpara>
    The XML parser.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
@@ -4774,10 +4774,10 @@ xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
   </simpara>
  </warning>
 </para>
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  If <parameter>handler</parameter> is a <type>callable</type>,
  the callable is set as the handler.
-</para>
+</simpara>
 <para xmlns="http://docbook.org/ns/docbook">
  If <parameter>handler</parameter> is a <type>string</type>,
  it can be the name of a method of an object set with
@@ -4835,31 +4835,31 @@ xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
 
 <!-- Migration Guide snippets -->
 <!ENTITY migration56.openssl.peer-verification '
-   <para xmlns="http://docbook.org/ns/docbook">
+   <simpara xmlns="http://docbook.org/ns/docbook">
     All encrypted client streams now enable peer verification by default. By
     default, this will use OpenSSL&apos;s default CA bundle to verify the peer
     certificate. In most cases, no changes will need to be made to communicate
     with servers with valid SSL certificates, as distributors generally
     configure OpenSSL to use known good CA bundles.
-   </para>
+   </simpara>
 
-   <para xmlns="http://docbook.org/ns/docbook">
+   <simpara xmlns="http://docbook.org/ns/docbook">
     The default CA bundle may be overridden on a global basis by setting
     either the openssl.cafile or openssl.capath configuration setting, or on a
     per request basis by using the
     <link linkend="context.ssl.cafile"><parameter>cafile</parameter></link> or
     <link linkend="context.ssl.capath"><parameter>capath</parameter></link>
     context options.
-   </para>
+   </simpara>
 
-   <para xmlns="http://docbook.org/ns/docbook">
+   <simpara xmlns="http://docbook.org/ns/docbook">
     While not recommended in general, it is possible to disable peer
     certificate verification for a request by setting the
     <link linkend="context.ssl.verify-peer"><parameter>verify_peer</parameter></link>
     context option to &false;, and to disable peer name validation by setting
     the <link linkend="context.ssl.verify-peer-name"><parameter>verify_peer_name</parameter></link>
     context option to &false;.
-   </para>
+   </simpara>
 '>
 
 <!-- Keep this comment at the end of the file

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2101,54 +2101,54 @@ may be <literal>On</literal> or <literal>Off</literal>.
 security reasons.
 </simpara>'>
 
-<!ENTITY oci.datatypes '<para xmlns="http://docbook.org/ns/docbook">For details on the data type mapping performed by
+<!ENTITY oci.datatypes '<simpara xmlns="http://docbook.org/ns/docbook">For details on the data type mapping performed by
 the OCI8 extension, see the <link linkend="oci8.datatypes">datatypes
-supported by the driver</link></para>'>
+supported by the driver</link></simpara>'>
 
-<!ENTITY oci.parameter.connection '<para xmlns="http://docbook.org/ns/docbook">An Oracle connection identifier,
+<!ENTITY oci.parameter.connection '<simpara xmlns="http://docbook.org/ns/docbook">An Oracle connection identifier,
 returned by <function>oci_connect</function>, <function>oci_pconnect</function>,
-or <function>oci_new_connect</function>.</para>'>
+or <function>oci_new_connect</function>.</simpara>'>
 
 <!ENTITY oci.availability.note.10g '<note xmlns="http://docbook.org/ns/docbook"><title>Oracle version requirement</title>
-<para>This function is available when PHP is linked with Oracle Database
-libraries from version 10<emphasis>g</emphasis> onwards.</para></note>'>
+<simpara>This function is available when PHP is linked with Oracle Database
+libraries from version 10<emphasis>g</emphasis> onwards.</simpara></note>'>
 
-<!ENTITY oci.clientinfo.tip '<tip xmlns="http://docbook.org/ns/docbook"><title>Performance</title><para>With older versions of
+<!ENTITY oci.clientinfo.tip '<tip xmlns="http://docbook.org/ns/docbook"><title>Performance</title><simpara>With older versions of
 OCI8 or the Oracle Database, the client information can be set using the Oracle
 <literal>DBMS_APPLICATION_INFO</literal> package. This is less efficient than
-using <function>oci_set_client_info</function>.</para></tip>'>
+using <function>oci_set_client_info</function>.</simpara></tip>'>
 
 <!ENTITY oci.roundtrip.caution '<caution xmlns="http://docbook.org/ns/docbook"><title>Round-trip Gotcha</title>
-<para>Some but not all OCI8 functions cause round-trips.  Round-trips to the
+<simpara>Some but not all OCI8 functions cause round-trips.  Round-trips to the
 database may not occur with queries when result caching is enabled.
-</para></caution>'>
+</simpara></caution>'>
 
-<!ENTITY oci.use.setprefetch '<para xmlns="http://docbook.org/ns/docbook">For
+<!ENTITY oci.use.setprefetch '<simpara xmlns="http://docbook.org/ns/docbook">For
 queries returning a large number of rows, performance can be
 significantly improved by
 increasing <link linkend="ini.oci8.default-prefetch">oci8.default_prefetch</link>
 or using <function>oci_set_prefetch</function>.
-</para>'>
+</simpara>'>
 
 
 <!ENTITY oci.arg.statement.id
-"<para xmlns='http://docbook.org/ns/docbook'>A valid OCI8 statement
+"<simpara xmlns='http://docbook.org/ns/docbook'>A valid OCI8 statement
 identifier created by <function>oci_parse</function> and executed
 by <function>oci_execute</function>, or a <literal>REF
-CURSOR</literal> statement identifier.</para>">
+CURSOR</literal> statement identifier.</simpara>">
 
 <!-- PCNTL Notes -->
-<!ENTITY pcntl.parameter.status '<para xmlns="http://docbook.org/ns/docbook">The <parameter>status</parameter>
+<!ENTITY pcntl.parameter.status '<simpara xmlns="http://docbook.org/ns/docbook">The <parameter>status</parameter>
 parameter is the status parameter supplied to a successful
-call to <function>pcntl_waitpid</function>.</para>'>
+call to <function>pcntl_waitpid</function>.</simpara>'>
 
 <!-- PS Notes -->
-<!ENTITY ps.note.visible '<para xmlns="http://docbook.org/ns/docbook">The note will not be visible if the document
+<!ENTITY ps.note.visible '<simpara xmlns="http://docbook.org/ns/docbook">The note will not be visible if the document
 is printed or viewed but it will show up if the document is converted to
-pdf by either Acrobat Distiller™ or Ghostview.</para>'>
+pdf by either Acrobat Distiller™ or Ghostview.</simpara>'>
 
-<!ENTITY note.open-basedir.func '<note xmlns="http://docbook.org/ns/docbook"><para>This function is affected by <link
-linkend="ini.open-basedir">open_basedir</link>.</para></note>'>
+<!ENTITY note.open-basedir.func '<note xmlns="http://docbook.org/ns/docbook"><simpara>This function is affected by <link
+linkend="ini.open-basedir">open_basedir</link>.</simpara></note>'>
 
 
 <!ENTITY note.language-construct '<note xmlns="http://docbook.org/ns/docbook"><simpara>Because this is a
@@ -2158,16 +2158,16 @@ or <link linkend="functions.named-arguments">named arguments</link>.</simpara>
 </note>'>
 
 <!-- Common pieces in partintro-sections -->
-<!ENTITY no.config '<para xmlns="http://docbook.org/ns/docbook">This extension has no configuration directives defined in &php.ini;.</para>'>
-<!ENTITY no.resource '<para xmlns="http://docbook.org/ns/docbook">This extension has no resource types defined.</para>'>
-<!ENTITY no.constants '<para xmlns="http://docbook.org/ns/docbook">This extension has no constants defined.</para>'>
-<!ENTITY no.requirement '<para xmlns="http://docbook.org/ns/docbook">No external libraries are needed to build this extension.</para>'>
-<!ENTITY no.install '<para xmlns="http://docbook.org/ns/docbook">There is no installation needed to use these
-functions; they are part of the PHP core.</para>'>
+<!ENTITY no.config '<simpara xmlns="http://docbook.org/ns/docbook">This extension has no configuration directives defined in &php.ini;.</simpara>'>
+<!ENTITY no.resource '<simpara xmlns="http://docbook.org/ns/docbook">This extension has no resource types defined.</simpara>'>
+<!ENTITY no.constants '<simpara xmlns="http://docbook.org/ns/docbook">This extension has no constants defined.</simpara>'>
+<!ENTITY no.requirement '<simpara xmlns="http://docbook.org/ns/docbook">No external libraries are needed to build this extension.</simpara>'>
+<!ENTITY no.install '<simpara xmlns="http://docbook.org/ns/docbook">There is no installation needed to use these
+functions; they are part of the PHP core.</simpara>'>
 
 <!-- Used in every chapter that has directive descriptions -->
-<!ENTITY ini.descriptions.title '<para xmlns="http://docbook.org/ns/docbook">Here&apos;s a short explanation of
-the configuration directives.</para>'>
+<!ENTITY ini.descriptions.title '<simpara xmlns="http://docbook.org/ns/docbook">Here&apos;s a short explanation of
+the configuration directives.</simpara>'>
 
 <!-- Common pieces for reference part BEGIN-->
 
@@ -2212,14 +2212,14 @@ driver, if your code can run against multiple drivers.</simpara>'>
 
 <!-- PDO errors -->
 
-<!ENTITY pdo.errors '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pdo.errors '<simpara xmlns="http://docbook.org/ns/docbook">
 Emits an error with level <constant>E_WARNING</constant> if the attribute <constant>PDO::ATTR_ERRMODE</constant> is set
 to <constant>PDO::ERRMODE_WARNING</constant>.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
 Throws a <classname>PDOException</classname> if the attribute <constant>PDO::ATTR_ERRMODE</constant>
 is set to <constant>PDO::ERRMODE_EXCEPTION</constant>.
-</para>'>
+</simpara>'>
 
 <!-- PECL entities -->
 <!ENTITY pecl.moved 'This &link.pecl; extension is not bundled with PHP.'>
@@ -2267,7 +2267,7 @@ repository and is no longer bundled with PHP as of PHP '>
 
 <!-- PGSQL entities -->
 
-<!ENTITY pgsql.parameter.connection '<para xmlns="http://docbook.org/ns/docbook">An <classname>PgSql\Connection</classname> instance.</para>'>
+<!ENTITY pgsql.parameter.connection '<simpara xmlns="http://docbook.org/ns/docbook">An <classname>PgSql\Connection</classname> instance.</simpara>'>
 
 <!ENTITY pgsql.parameter.connection-with-unspecified-default '<para xmlns="http://docbook.org/ns/docbook">An <classname>PgSql\Connection</classname> instance.
 When <parameter>connection</parameter> is unspecified, the default connection is used.
@@ -2281,18 +2281,18 @@ The default connection is the last connection made by <function>pg_connect</func
 or <function>pg_pconnect</function>.
 <warning><simpara>As of PHP 8.1.0, using the default connection is deprecated.</simpara></warning></para>'>
 
-<!ENTITY pgsql.parameter.result '<para xmlns="http://docbook.org/ns/docbook">An <classname>PgSql\Result</classname> instance, returned by <function>pg_query</function>,
-<function>pg_query_params</function> or <function>pg_execute</function>(among others).</para>'>
+<!ENTITY pgsql.parameter.result '<simpara xmlns="http://docbook.org/ns/docbook">An <classname>PgSql\Result</classname> instance, returned by <function>pg_query</function>,
+<function>pg_query_params</function> or <function>pg_execute</function>(among others).</simpara>'>
 
-<!ENTITY pgsql.parameter.lob '<para xmlns="http://docbook.org/ns/docbook">An <classname>PgSql\Lob</classname> instance, returned by <function>pg_lo_open</function>.</para>'>
+<!ENTITY pgsql.parameter.lob '<simpara xmlns="http://docbook.org/ns/docbook">An <classname>PgSql\Lob</classname> instance, returned by <function>pg_lo_open</function>.</simpara>'>
 
-<!ENTITY pgsql.parameter.mode '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pgsql.parameter.mode '<simpara xmlns="http://docbook.org/ns/docbook">
 An optional parameter that controls how the returned <type>array</type> is indexed.
 <parameter>mode</parameter> is a constant and can take the following values:
 <constant>PGSQL_ASSOC</constant>, <constant>PGSQL_NUM</constant> and <constant>PGSQL_BOTH</constant>.
 Using <constant>PGSQL_NUM</constant>, the function will return an array with numerical indices,
 using <constant>PGSQL_ASSOC</constant> it will return only associative indices
-while <constant>PGSQL_BOTH</constant> will return both numerical and associative indices.</para>'>
+while <constant>PGSQL_BOTH</constant> will return both numerical and associative indices.</simpara>'>
 
 <!ENTITY pgsql.changelog.connection-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
@@ -2339,17 +2339,17 @@ extensions in order to use these functions.</simpara>'>
 <!ENTITY sqlsafemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.sql.safe-mode">SQL safe mode</link>'>
 
 <!-- CTYPE Notes -->
-<!ENTITY note.ctype.parameter.integer '<note xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY note.ctype.parameter.integer '<note xmlns="http://docbook.org/ns/docbook"><simpara>
 If an <type>int</type> between -128 and 255 inclusive is provided, it is interpreted as
 the ASCII value of a single character (negative values have 256 added in order to allow
 characters in the Extended ASCII range). Any other integer is interpreted as a string
-containing the decimal digits of the integer.</para></note>'>
+containing the decimal digits of the integer.</simpara></note>'>
 
-<!ENTITY note.ctype.parameter.non-string '<warning xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY note.ctype.parameter.non-string '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
 As of PHP 8.1.0, passing a non-string argument is deprecated.
 In the future, the argument will be interpreted as a string instead of an ASCII codepoint.
 Depending on the intended behavior, the argument should either be cast to &string;
-or an explicit call to <function>chr</function> should be made.</para></warning>'>
+or an explicit call to <function>chr</function> should be made.</simpara></warning>'>
 
 <!ENTITY ctype.result.empty-string 'When called with an empty string the result will always be &false;.'>
 
@@ -2361,55 +2361,55 @@ or an explicit call to <function>chr</function> should be made.</para></warning>
   instance now; previously, a &resource; was expected.
  </entry>
 </row>'>
-<!ENTITY ftp.parameter.ftp '<para xmlns="http://docbook.org/ns/docbook">An <classname>FTP\Connection</classname> instance.</para>'>
+<!ENTITY ftp.parameter.ftp '<simpara xmlns="http://docbook.org/ns/docbook">An <classname>FTP\Connection</classname> instance.</simpara>'>
 
 <!-- GMP Notes -->
 <!ENTITY gmp.return 'A <classname xmlns="http://docbook.org/ns/docbook">GMP</classname> object.'>
-<!ENTITY gmp.parameter '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY gmp.parameter '<simpara xmlns="http://docbook.org/ns/docbook">
  A <classname>GMP</classname> object, an &integer;,
  or a &string; that can be interpreted as a number following the same logic
  as if the string was used in <function>gmp_init</function> with automatic
  base detection (i.e. when <parameter>base</parameter> is equal to 0).
-</para>'>
+</simpara>'>
 
 <!-- MySQLi Notes -->
 <!ENTITY mysqli.result.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>result</parameter></term><listitem><para>Procedural style only: A <classname>mysqli_result</classname>
+<parameter>result</parameter></term><listitem><simpara>Procedural style only: A <classname>mysqli_result</classname>
 object returned by <function>mysqli_query</function>, <function>mysqli_store_result</function>,
-<function>mysqli_use_result</function> or <function>mysqli_stmt_get_result</function>.</para></listitem></varlistentry>'>
+<function>mysqli_use_result</function> or <function>mysqli_stmt_get_result</function>.</simpara></listitem></varlistentry>'>
 <!ENTITY mysqli.link.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>mysql</parameter></term><listitem><para>Procedural style only: A <classname>mysqli</classname> object
+<parameter>mysql</parameter></term><listitem><simpara>Procedural style only: A <classname>mysqli</classname> object
 returned by <function>mysqli_connect</function> or <function>mysqli_init</function>
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 <!ENTITY mysqli.stmt.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>statement</parameter></term><listitem><para>Procedural style only: A <classname>mysqli_stmt</classname> object
-returned by <function>mysqli_stmt_init</function>.</para></listitem></varlistentry>'>
+<parameter>statement</parameter></term><listitem><simpara>Procedural style only: A <classname>mysqli_stmt</classname> object
+returned by <function>mysqli_stmt_init</function>.</simpara></listitem></varlistentry>'>
 <!ENTITY mysqli.available.mysqlnd 'Available only with <link xmlns="http://docbook.org/ns/docbook"
 linkend="book.mysqlnd">mysqlnd</link>.'>
 <!ENTITY mysqli.charset.note '<note xmlns="http://docbook.org/ns/docbook">
-<para>MySQLnd always assumes the server default charset. This charset is sent during connection
-hand-shake/authentication, which mysqlnd will use.</para><para>Libmysqlclient uses the default charset set in the
+<simpara>MySQLnd always assumes the server default charset. This charset is sent during connection
+hand-shake/authentication, which mysqlnd will use.</simpara><simpara>Libmysqlclient uses the default charset set in the
 <filename>my.cnf</filename> or by an explicit call to <function>mysqli_options</function> prior to
-calling <function>mysqli_real_connect</function>, but after <function>mysqli_init</function>.</para></note>'>
+calling <function>mysqli_real_connect</function>, but after <function>mysqli_init</function>.</simpara></note>'>
 <!ENTITY mysqli.integer.overflow.as.string.note '<note xmlns="http://docbook.org/ns/docbook">
-<para>If the number of rows is greater than <constant>PHP_INT_MAX</constant>,
-the number will be returned as a &string;.</para></note>'>
+<simpara>If the number of rows is greater than <constant>PHP_INT_MAX</constant>,
+the number will be returned as a &string;.</simpara></note>'>
 <!ENTITY mysqli.sqlinjection.warning '<warning xmlns="http://docbook.org/ns/docbook">
-<title>Security warning: SQL injection</title><para>If the query contains any variable
+<title>Security warning: SQL injection</title><simpara>If the query contains any variable
 input then <link linkend="mysqli.quickstart.prepared-statements">parameterized
 prepared statements</link> should be used instead. Alternatively, the
 data must be properly formatted and all strings must be escaped using
 the <function>mysqli_real_escape_string</function>
-function.</para></warning>'>
-<!ENTITY mysqli.conditionalexception '<para xmlns="http://docbook.org/ns/docbook">
+function.</simpara></warning>'>
+<!ENTITY mysqli.conditionalexception '<simpara xmlns="http://docbook.org/ns/docbook">
 If mysqli error reporting is enabled (<constant>MYSQLI_REPORT_ERROR</constant>) and the requested operation fails,
 a warning is generated. If, in addition, the mode is set to <constant>MYSQLI_REPORT_STRICT</constant>,
-a <classname>mysqli_sql_exception</classname> is thrown instead.</para>'>
+a <classname>mysqli_sql_exception</classname> is thrown instead.</simpara>'>
 
 <!-- Notes for PCRE -->
-<!ENTITY pcre.pattern.warning '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pcre.pattern.warning '<simpara xmlns="http://docbook.org/ns/docbook">
 If the regex pattern passed does not compile to a valid regex, an <constant>E_WARNING</constant> is emitted.
-</para>'>
+</simpara>'>
 
 <!-- Notes for SAPI/Apache -->
 <!ENTITY apache.req.module '<simpara xmlns="http://docbook.org/ns/docbook">This function is supported when PHP
@@ -2417,9 +2417,9 @@ is installed as an Apache module webserver.
 </simpara>'>
 
 <!-- Notes for SAPI/FPM -->
-<!ENTITY fpm.intro '<para xmlns="http://docbook.org/ns/docbook">FPM (FastCGI Process Manager) is
+<!ENTITY fpm.intro '<simpara xmlns="http://docbook.org/ns/docbook">FPM (FastCGI Process Manager) is
 a primary PHP FastCGI implementation containing some features (mostly) useful for heavy-loaded sites.
-</para>'>
+</simpara>'>
 
 <!-- SimpleXML Notes -->
 <!ENTITY simplexml.iteration '<note xmlns="http://docbook.org/ns/docbook"><simpara>SimpleXML has made a rule of adding
@@ -2427,34 +2427,34 @@ iterative properties to most methods. They cannot be viewed using <function>var_
 or anything else which can examine objects.</simpara></note>'>
 
 <!-- SQLite Notes -->
-<!ENTITY sqlite.case-fold '<para xmlns="http://docbook.org/ns/docbook">The column names returned by
+<!ENTITY sqlite.case-fold '<simpara xmlns="http://docbook.org/ns/docbook">The column names returned by
 <constant>SQLITE_ASSOC</constant> and <constant>SQLITE_BOTH</constant> will be
 case-folded according to the value of the
 <link linkend="ini.sqlite.assoc-case">sqlite.assoc_case</link> configuration
-option.</para>'>
+option.</simpara>'>
 
-<!ENTITY sqlite.decode-bin '<para xmlns="http://docbook.org/ns/docbook">When the <parameter>decode_binary</parameter>
+<!ENTITY sqlite.decode-bin '<simpara xmlns="http://docbook.org/ns/docbook">When the <parameter>decode_binary</parameter>
 parameter is set to &true; (the default), PHP will decode the binary encoding
 it applied to the data if it was encoded using the
 <function>sqlite_escape_string</function>.  You should normally leave this
 value at its default, unless you are interoperating with databases created by
-other sqlite capable applications.</para>'>
+other sqlite capable applications.</simpara>'>
 
-<!ENTITY sqlite.no-unbuffered '<note xmlns="http://docbook.org/ns/docbook"><para>This function cannot be used with
-unbuffered result handles.</para></note>'>
+<!ENTITY sqlite.no-unbuffered '<note xmlns="http://docbook.org/ns/docbook"><simpara>This function cannot be used with
+unbuffered result handles.</simpara></note>'>
 
 <!ENTITY sqlite.param-compat '<note xmlns="http://docbook.org/ns/docbook"><simpara>Two alternative syntaxes are
 supported for compatibility with other database extensions (such as MySQL).
 The preferred form is the first, where the <parameter>dbhandle</parameter>
 parameter is the first parameter to the function.</simpara></note>'>
 
-<!ENTITY sqlite.result-type '<para xmlns="http://docbook.org/ns/docbook">The optional <parameter>result_type</parameter>
+<!ENTITY sqlite.result-type '<simpara xmlns="http://docbook.org/ns/docbook">The optional <parameter>result_type</parameter>
 parameter accepts a constant and determines how the returned array will be
 indexed. Using <constant>SQLITE_ASSOC</constant> will return only associative
 indices (named fields) while <constant>SQLITE_NUM</constant> will return
 only numerical indices (ordinal field numbers). <constant>SQLITE_BOTH</constant>
 will return both associative and numerical indices.
-<constant>SQLITE_BOTH</constant> is the default for this function.</para>'>
+<constant>SQLITE_BOTH</constant> is the default for this function.</simpara>'>
 
 <!-- Database Notes -->
 <!ENTITY database.field-case '<note xmlns="http://docbook.org/ns/docbook"><simpara>Field names returned by this function
@@ -2466,76 +2466,76 @@ the PHP &null; value.</simpara></note>'>
 <!-- MySQL Notes -->
 <!-- The mysql.*.description entities are used in the parameters refsect1 -->
 <!ENTITY mysql.linkid.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>link_identifier</parameter></term><listitem><para>The MySQL connection. If the
+<parameter>link_identifier</parameter></term><listitem><simpara>The MySQL connection. If the
 link identifier is not specified, the last link opened by
 <function>mysql_connect</function> is assumed. If no such link is found, it
 will try to create one as if <function>mysql_connect</function> had been called
 with no arguments. If no connection is found or established, an
-<constant>E_WARNING</constant> level error is generated.</para></listitem>
+<constant>E_WARNING</constant> level error is generated.</simpara></listitem>
 </varlistentry>'>
 
 <!ENTITY mysql.linkid-noreopen.description '<varlistentry
 xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>link_identifier</parameter></term><listitem><para>The MySQL connection. If the
+<parameter>link_identifier</parameter></term><listitem><simpara>The MySQL connection. If the
 link identifier is not specified, the last link opened by
 <function>mysql_connect</function> is assumed. If no connection is found or
 established, an <constant>E_WARNING</constant> level error is
-generated.</para></listitem></varlistentry>'>
+generated.</simpara></listitem></varlistentry>'>
 
 <!ENTITY mysql.result.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>result</parameter></term><listitem><para>The result <type>resource</type> that
+<parameter>result</parameter></term><listitem><simpara>The result <type>resource</type> that
 is being evaluated. This result comes from a call to
-<function>mysql_query</function>.</para></listitem></varlistentry>'>
+<function>mysql_query</function>.</simpara></listitem></varlistentry>'>
 
 <!ENTITY mysql.field-offset.req.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>field_offset</parameter></term><listitem><para>The numerical field offset. The
+<parameter>field_offset</parameter></term><listitem><simpara>The numerical field offset. The
 <parameter>field_offset</parameter> starts at <literal>0</literal>. If
 <parameter>field_offset</parameter> does not exist, an error of level
-<constant>E_WARNING</constant> is also issued.</para></listitem></varlistentry>'>
+<constant>E_WARNING</constant> is also issued.</simpara></listitem></varlistentry>'>
 
-<!ENTITY mysql.alternative.note '<para xmlns="http://docbook.org/ns/docbook">This extension was deprecated in PHP 5.5.0, and it was removed in PHP 7.0.0.
+<!ENTITY mysql.alternative.note '<simpara xmlns="http://docbook.org/ns/docbook">This extension was deprecated in PHP 5.5.0, and it was removed in PHP 7.0.0.
 Instead, the <link linkend="book.mysqli">MySQLi</link> or <link linkend="ref.pdo-mysql">PDO_MySQL</link> extension should be used.
 See also <link linkend="mysqlinfo.api.choosing">MySQL: choosing an API</link> guide.
-Alternatives to this function include:</para>'>
+Alternatives to this function include:</simpara>'>
 
-<!ENTITY mysql.alternative.note.4-3-0 '<para xmlns="http://docbook.org/ns/docbook">This function was deprecated in PHP 4.3.0, and it
+<!ENTITY mysql.alternative.note.4-3-0 '<simpara xmlns="http://docbook.org/ns/docbook">This function was deprecated in PHP 4.3.0, and it
 and the entire <link linkend="book.mysql">original MySQL extension</link> was removed in PHP 7.0.0.
 Instead, use either the actively developed <link linkend="book.mysqli">MySQLi</link> or <link linkend="ref.pdo-mysql">PDO_MySQL</link> extensions.
 See also the <link linkend="mysqlinfo.api.choosing">MySQL: choosing an API</link> guide.
-Alternatives to this function include:</para>'>
+Alternatives to this function include:</simpara>'>
 
-<!ENTITY mysql.alternative.note.5-3-0 '<para xmlns="http://docbook.org/ns/docbook">This function was deprecated in PHP 5.3.0, and it
+<!ENTITY mysql.alternative.note.5-3-0 '<simpara xmlns="http://docbook.org/ns/docbook">This function was deprecated in PHP 5.3.0, and it
 and the entire <link linkend="book.mysql">original MySQL extension</link> was removed in PHP 7.0.0.
 Instead, use either the actively developed <link linkend="book.mysqli">MySQLi</link> or <link linkend="ref.pdo-mysql">PDO_MySQL</link> extensions.
 See also the <link linkend="mysqlinfo.api.choosing">MySQL: choosing an API</link> guide.
-Alternatives to this function include:</para>'>
+Alternatives to this function include:</simpara>'>
 
-<!ENTITY mysql.alternative.note.5-4-0 '<para xmlns="http://docbook.org/ns/docbook">This function was deprecated in PHP 5.4.0, and it
+<!ENTITY mysql.alternative.note.5-4-0 '<simpara xmlns="http://docbook.org/ns/docbook">This function was deprecated in PHP 5.4.0, and it
 and the entire <link linkend="book.mysql">original MySQL extension</link> was removed in PHP 7.0.0.
 Instead, use either the actively developed <link linkend="book.mysqli">MySQLi</link> or <link linkend="ref.pdo-mysql">PDO_MySQL</link> extensions.
 See also the <link linkend="mysqlinfo.api.choosing">MySQL: choosing an API</link> guide.
-Alternatives to this function include:</para>'>
+Alternatives to this function include:</simpara>'>
 
-<!ENTITY mysql.alternative.note.5-5-0 '<para xmlns="http://docbook.org/ns/docbook">This function was deprecated in PHP 5.5.0, and it
+<!ENTITY mysql.alternative.note.5-5-0 '<simpara xmlns="http://docbook.org/ns/docbook">This function was deprecated in PHP 5.5.0, and it
 and the entire <link linkend="book.mysql">original MySQL extension</link> was removed in PHP 7.0.0.
 Instead, use either the actively developed <link linkend="book.mysqli">MySQLi</link> or <link linkend="ref.pdo-mysql">PDO_MySQL</link> extensions.
 See also the <link linkend="mysqlinfo.api.choosing">MySQL: choosing an API</link> guide.
-Alternatives to this function include:</para>'>
+Alternatives to this function include:</simpara>'>
 
-<!ENTITY mysql.close.connections.result.sets '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY mysql.close.connections.result.sets '<simpara xmlns="http://docbook.org/ns/docbook">
 Open non-persistent MySQL connections and result sets are automatically destroyed when a
 PHP script finishes its execution. So, while explicitly closing open
 connections and freeing result sets is optional, doing so is recommended.
 This will immediately return resources to PHP and MySQL, which can
 improve performance. For related information, see
-<link linkend="language.types.resource.self-destruct">freeing resources</link></para>'>
+<link linkend="language.types.resource.self-destruct">freeing resources</link></simpara>'>
 
 <!-- Xattr entities -->
-<!ENTITY xattr.namespace '<para xmlns="http://docbook.org/ns/docbook">Extended attributes have two different namespaces: user
+<!ENTITY xattr.namespace '<simpara xmlns="http://docbook.org/ns/docbook">Extended attributes have two different namespaces: user
 and root. The user namespace is available to all users, while the root namespace
 is available only to users with root privileges. xattr operates on the user
 namespace  by default, but this can be changed with the
-<parameter>flags</parameter> parameter.</para>'>
+<parameter>flags</parameter> parameter.</simpara>'>
 
 <!-- Notes for IPv6 -->
 <!ENTITY ipv6.brackets '<note xmlns="http://docbook.org/ns/docbook"><simpara>When specifying a numerical IPv6 address
@@ -2545,12 +2545,12 @@ brackets—for example, <literal>tcp://[fe80::1]:80</literal>.</simpara></note>'
 <!-- Notes for tidy -->
 <!ENTITY tidy.object 'The <classname xmlns="http://docbook.org/ns/docbook">Tidy</classname> object.'>
 
-<!ENTITY tidy.conf-enc '<para xmlns="http://docbook.org/ns/docbook">The <parameter>config</parameter> parameter
+<!ENTITY tidy.conf-enc '<simpara xmlns="http://docbook.org/ns/docbook">The <parameter>config</parameter> parameter
 can be passed either as an array or as a string. If a string is passed,
 it is interpreted as the name of the configuration file, otherwise, it is
 interpreted as the options themselves. Check
 <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.tidy.conf;">&url.tidy.conf;</link>
-for an explanation about each option.</para><para>The
+for an explanation about each option.</simpara><simpara>The
 <parameter>encoding</parameter> parameter sets the encoding for input/output
 documents. The possible values for <parameter>encoding</parameter> are:
 <literal>ascii</literal>, <literal>latin0</literal>, <literal>latin1</literal>,
@@ -2558,22 +2558,22 @@ documents. The possible values for <parameter>encoding</parameter> are:
 <literal>mac</literal>, <literal>win1252</literal>, <literal>ibm858</literal>,
 <literal>utf16</literal>, <literal>utf16le</literal>,
 <literal>utf16be</literal>, <literal>big5</literal> and
-<literal>shiftjis</literal>.</para>'>
+<literal>shiftjis</literal>.</simpara>'>
 
 <!-- Snippets for the installation section -->
-<!ENTITY warn.apache2.compat '<warning xmlns="http://docbook.org/ns/docbook"><para>We do not recommend using a
+<!ENTITY warn.apache2.compat '<warning xmlns="http://docbook.org/ns/docbook"><simpara>We do not recommend using a
 threaded MPM in production with Apache 2. Use the prefork MPM, which is
 the default MPM with Apache 2.0 and 2.2.
 For information on why, read the related FAQ entry on using
-<link linkend="faq.installation.apache2">Apache2 with a threaded MPM</link></para></warning>'>
+<link linkend="faq.installation.apache2">Apache2 with a threaded MPM</link></simpara></warning>'>
 <!ENTITY warn.install.third-party-support '<warning xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <para>
+ <simpara>
   Builds from third-parties are considered unofficial and not directly
   supported by the PHP project. Any bugs encountered should be reported to the
   provider of those unofficial builds unless they can be reproduced using the
   builds from <link xlink:href="&url.php.downloads;">the official download
   area</link>.
- </para>
+ </simpara>
 </warning>'>
 
 <!ENTITY note.apache.slashes '<note xmlns="http://docbook.org/ns/docbook"><simpara>Remember that when adding

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -3049,10 +3049,10 @@ paths</simpara></warning>
        <row xmlns="http://docbook.org/ns/docbook">
         <entry>PECL mongodb 2.0.0</entry>
         <entry>
-         <para>
+         <simpara>
           This class no longer implements the
           <interfacename>Serializable</interfacename> interface.
-         </para>
+         </simpara>
         </entry>
        </row>
 '>
@@ -3082,9 +3082,9 @@ paths</simpara></warning>
        <row xmlns="http://docbook.org/ns/docbook">
         <entry>PECL mongodb 2.0.0</entry>
         <entry>
-         <para>
+         <simpara>
           This method now throws an exception when called for an unacknowledged write instead of returning &null;.
-         </para>
+         </simpara>
         </entry>
        </row>
 '>
@@ -3094,15 +3094,15 @@ paths</simpara></warning>
           <entry>collation</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             <link xlink:href="&url.mongodb.docs.collation;" xmlns:xlink="http://www.w3.org/1999/xlink">Collation</link> allows users to specify language-specific rules for string comparison, such as rules for lettercase and accent marks. When specifying collation, the <literal>"locale"</literal> field is mandatory; all other collation fields are optional. For descriptions of the fields, see <link xlink:href="&url.mongodb.docs.collation;#collation-document" xmlns:xlink="http://www.w3.org/1999/xlink">Collation Document</link>.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             If the collation is unspecified but the collection has a default collation, the operation uses the collation specified for the collection. If no collation is specified for the collection or for the operation, MongoDB uses the simple binary comparison used in prior versions for string comparisons.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             This option is available in MongoDB 3.4+ and will result in an exception at execution time if specified for an older server version.
-           </para>
+           </simpara>
           </entry>
          </row>
 '>
@@ -3111,12 +3111,12 @@ paths</simpara></warning>
           <entry>let</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Map of parameter names and values. Values must be constant or closed expressions that do not reference document fields. Parameters can then be accessed as variables in an aggregate expression context (e.g. <literal>$$var</literal>).
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             This option is available in MongoDB 5.0+ and will result in an exception at execution time if specified for an older server version.
-           </para>
+           </simpara>
           </entry>
          </row>
 '>
@@ -3139,18 +3139,18 @@ paths</simpara></warning>
           <entry>kmsProviders</entry>
           <entry><type>array</type></entry>
           <entry>
-           <para>
+           <simpara>
             A document containing the configuration for one or more KMS providers, which are used to encrypt data keys. Supported providers include <literal>"aws"</literal>, <literal>"azure"</literal>, <literal>"gcp"</literal>, <literal>"kmip"</literal>, and <literal>"local"</literal> and at least one must be specified.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             If an empty document is specified for <literal>"aws"</literal>,
             <literal>"azure"</literal>, or <literal>"gcp"</literal>, the driver
             will attempt to configure the provider using
             <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Automatic Credentials</link>.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             The format for <literal>"aws"</literal> is as follows:
-           </para>
+           </simpara>
            <programlisting role="javascript">
 <![CDATA[
 aws: {
@@ -3160,9 +3160,9 @@ aws: {
 }
 ]]>
            </programlisting>
-           <para>
+           <simpara>
             The format for <literal>"azure"</literal> is as follows:
-           </para>
+           </simpara>
            <programlisting role="javascript">
 <![CDATA[
 azure: {
@@ -3173,9 +3173,9 @@ azure: {
 }
 ]]>
            </programlisting>
-           <para>
+           <simpara>
             The format for <literal>"gcp"</literal> is as follows:
-           </para>
+           </simpara>
            <programlisting role="javascript">
 <![CDATA[
 gcp: {
@@ -3185,9 +3185,9 @@ gcp: {
 }
 ]]>
            </programlisting>
-           <para>
+           <simpara>
             The format for <literal>"kmip"</literal> is as follows:
-           </para>
+           </simpara>
            <programlisting role="javascript">
 <![CDATA[
 kmip: {
@@ -3195,9 +3195,9 @@ kmip: {
 }
 ]]>
            </programlisting>
-           <para>
+           <simpara>
             The format for <literal>"local"</literal> is as follows:
-           </para>
+           </simpara>
            <programlisting role="javascript">
 <![CDATA[
 local: {
@@ -3355,9 +3355,9 @@ local: {
           <entry>tlsOptions</entry>
           <entry><type>array</type></entry>
           <entry>
-           <para>
+           <simpara>
             A document containing the TLS configuration for one or more KMS providers. Supported providers include <literal>"aws"</literal>, <literal>"azure"</literal>, <literal>"gcp"</literal>, and <literal>"kmip"</literal>. All providers support the following options:
-           </para>
+           </simpara>
            <programlisting role="javascript">
 <![CDATA[
 <provider>: {
@@ -3376,14 +3376,14 @@ local: {
           <entry>maxCommitTimeMS</entry>
           <entry>integer</entry>
           <entry>
-           <para>
+           <simpara>
             The maximum amount of time in milliseconds to allow a single
             <literal>commitTransaction</literal> command to run.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             If specified, <literal>maxCommitTimeMS</literal> must be a signed
             32-bit integer greater than or equal to zero.
-           </para>
+           </simpara>
           </entry>
          </row>
 '>
@@ -3392,14 +3392,14 @@ local: {
           <entry>readConcern</entry>
           <entry><classname>MongoDB\Driver\ReadConcern</classname></entry>
           <entry>
-           <para>
+           <simpara>
             A read concern to apply to the operation.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             This option is available in MongoDB 3.2+ and will result in an
             exception at execution time if specified for an older server
             version.
-           </para>
+           </simpara>
           </entry>
          </row>
 '>
@@ -3408,9 +3408,9 @@ local: {
           <entry>readPreference</entry>
           <entry><classname>MongoDB\Driver\ReadPreference</classname></entry>
           <entry>
-           <para>
+           <simpara>
             A read preference to use for selecting a server for the operation.
-           </para>
+           </simpara>
           </entry>
          </row>
 '>
@@ -3419,15 +3419,15 @@ local: {
           <entry>session</entry>
           <entry><classname>MongoDB\Driver\Session</classname></entry>
           <entry>
-           <para>
+           <simpara>
             A session to associate with the operation.
-           </para>
+           </simpara>
           </entry>
          </row>
 '>
 <!ENTITY mongodb.option.transactionReadWriteConcern '
      <warning xmlns="http://docbook.org/ns/docbook">
-      <para>
+      <simpara>
        If you are using a <literal>"session"</literal> which has a transaction
        in progress, you cannot specify a <literal>"readConcern"</literal> or
        <literal>"writeConcern"</literal> option. This will result in an
@@ -3435,7 +3435,7 @@ local: {
        being thrown. Instead, you should set these two options when you create
        the transaction with
        <methodname>MongoDB\Driver\Session::startTransaction</methodname>.
-      </para>
+      </simpara>
      </warning>
 '>
 <!ENTITY mongodb.option.writeConcern '
@@ -3443,9 +3443,9 @@ local: {
           <entry>writeConcern</entry>
           <entry><classname>MongoDB\Driver\WriteConcern</classname></entry>
           <entry>
-           <para>
+           <simpara>
             A write concern to apply to the operation.
-           </para>
+           </simpara>
           </entry>
          </row>
 '>
@@ -3453,9 +3453,9 @@ local: {
    <varlistentry xmlns="http://docbook.org/ns/docbook">
     <term><parameter>namespace</parameter> (<type>string</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       A fully qualified namespace (e.g. <literal>"databaseName.collectionName"</literal>).
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 '>
@@ -3463,9 +3463,9 @@ local: {
    <varlistentry xmlns="http://docbook.org/ns/docbook">
     <term><parameter>db</parameter> (<type>string</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       The name of the database on which to execute the command.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 '>
@@ -3473,9 +3473,9 @@ local: {
    <varlistentry xmlns="http://docbook.org/ns/docbook">
     <term><parameter>bulk</parameter> (<classname>MongoDB\Driver\BulkWrite</classname>)</term>
     <listitem>
-     <para>
+     <simpara>
       The write(s) to execute.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 '>
@@ -3483,9 +3483,9 @@ local: {
    <varlistentry xmlns="http://docbook.org/ns/docbook">
     <term><parameter>bulk</parameter> (<classname>MongoDB\Driver\BulkWriteCommand</classname>)</term>
     <listitem>
-     <para>
+     <simpara>
       The write(s) to execute.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 '>
@@ -3493,9 +3493,9 @@ local: {
    <varlistentry xmlns="http://docbook.org/ns/docbook">
     <term><parameter>command</parameter> (<classname>MongoDB\Driver\Command</classname>)</term>
     <listitem>
-     <para>
+     <simpara>
       The command to execute.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 '>
@@ -3519,11 +3519,11 @@ local: {
           <entry>algorithm</entry>
           <entry><type>string</type></entry>
           <entry>
-           <para>
+           <simpara>
             The encryption algorithm to be used. This option is required.
             Specify one of the following
             <link linkend="mongodb-driver-clientencryption.constants">ClientEncryption constants</link>:
-           </para>
+           </simpara>
            <simplelist>
             <member><constant>MongoDB\Driver\ClientEncryption::AEAD_AES_256_CBC_HMAC_SHA_512_DETERMINISTIC</constant></member>
             <member><constant>MongoDB\Driver\ClientEncryption::AEAD_AES_256_CBC_HMAC_SHA_512_RANDOM</constant></member>
@@ -3537,74 +3537,74 @@ local: {
           <entry>contentionFactor</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             The contention factor for evaluating queries with indexed, encrypted
             payloads.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             This option only applies and may only be specified when
             <literal>algorithm</literal> is
             <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant>
             or
             <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant>.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>keyAltName</entry>
           <entry><type>string</type></entry>
           <entry>
-           <para>
+           <simpara>
             Identifies a key vault collection document by
             <literal>keyAltName</literal>. This option is mutually exclusive
             with <literal>keyId</literal> and exactly one is required.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>keyId</entry>
           <entry><classname>MongoDB\BSON\Binary</classname></entry>
           <entry>
-           <para>
+           <simpara>
             Identifies a data key by <literal>_id</literal>. The value is a UUID
             (binary subtype 4). This option is mutually exclusive with
             <literal>keyAltName</literal> and exactly one is required.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>queryType</entry>
           <entry><type>string</type></entry>
           <entry>
-           <para>
+           <simpara>
             The query type for evaluating queries with indexed, encrypted
             payloads. Specify one of the following
             <link linkend="mongodb-driver-clientencryption.constants">ClientEncryption constants</link>:
-           </para>
+           </simpara>
            <simplelist>
             <member><constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_EQUALITY</constant></member>
             <member><constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE</constant></member>
            </simplelist>
-           <para>
+           <simpara>
             This option only applies and may only be specified when
             <literal>algorithm</literal> is
             <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant>
             or <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant>.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>rangeOpts</entry>
           <entry><type>array</type></entry>
           <entry>
-           <para>
+           <simpara>
             Index options for a queryable encryption field supporting "range"
             queries. The options below must match the values set in the
             <literal>encryptedFields</literal> of the target collection. For
             double and decimal128 BSON field types, <literal>min</literal>,
             <literal>max</literal>, and <literal>precision</literal> must all be
             set, or all be unset.
-           </para>
+           </simpara>
            <para>
             <table>
              <title>Range index options</title>
@@ -3669,9 +3669,9 @@ local: {
    <varlistentry xmlns="http://docbook.org/ns/docbook">
     <term><parameter>query</parameter> (<classname>MongoDB\Driver\Query</classname>)</term>
     <listitem>
-     <para>
+     <simpara>
       The query to execute.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 '>
@@ -3679,9 +3679,9 @@ local: {
    <varlistentry xmlns="http://docbook.org/ns/docbook">
     <term><parameter>typeMap</parameter> (<type>array</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       <link linkend="mongodb.persistence.typemaps">Type map configuration</link>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 '>
@@ -3689,10 +3689,10 @@ local: {
    <varlistentry xmlns="http://docbook.org/ns/docbook">
     <term><parameter>filter</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
     <listitem>
-     <para>
+     <simpara>
       The <link xlink:href="&url.mongodb.docs;tutorial/query-documents/" xmlns:xlink="http://www.w3.org/1999/xlink">query predicate</link>.
       An empty predicate will match all documents in the collection.
-     </para>
+     </simpara>
      <note>
       <simpara>
        When evaluating query criteria, MongoDB compares types and values according to its own <link xlink:href="&url.mongodb.docs;reference/bson-type-comparison-order/" xmlns:xlink="http://www.w3.org/1999/xlink">comparison rules for BSON types</link>, which differs from PHP&apos;s <link linkend="types.comparisons">comparison</link> and <link linkend="language.types.type-juggling">type juggling</link> rules. When matching a special BSON type the query criteria should use the respective <link linkend="mongodb.bson">BSON class</link> (e.g. use <classname>MongoDB\BSON\ObjectId</classname> to match an <link xlink:href="&url.mongodb.docs.objectid;" xmlns:xlink="http://www.w3.org/1999/xlink">ObjectId</link>).
@@ -3701,9 +3701,9 @@ local: {
     </listitem>
    </varlistentry>
 '>
-<!ENTITY mongodb.returns.cursor '<para xmlns="http://docbook.org/ns/docbook">Returns <classname>MongoDB\Driver\Cursor</classname> on success.</para>'>
-<!ENTITY mongodb.returns.writeresult '<para xmlns="http://docbook.org/ns/docbook">Returns <classname>MongoDB\Driver\WriteResult</classname> on success.</para>'>
-<!ENTITY mongodb.returns.bulkwritecommandresult '<para xmlns="http://docbook.org/ns/docbook">Returns <classname>MongoDB\Driver\BulkWriteCommandResult</classname> on success.</para>'>
+<!ENTITY mongodb.returns.cursor '<simpara xmlns="http://docbook.org/ns/docbook">Returns <classname>MongoDB\Driver\Cursor</classname> on success.</simpara>'>
+<!ENTITY mongodb.returns.writeresult '<simpara xmlns="http://docbook.org/ns/docbook">Returns <classname>MongoDB\Driver\WriteResult</classname> on success.</simpara>'>
+<!ENTITY mongodb.returns.bulkwritecommandresult '<simpara xmlns="http://docbook.org/ns/docbook">Returns <classname>MongoDB\Driver\BulkWriteCommandResult</classname> on success.</simpara>'>
 <!ENTITY mongodb.throws.std '&mongodb.throws.argumentparsing;&mongodb.throws.connection;&mongodb.throws.authentication;'>
 <!ENTITY mongodb.throws.session-readwriteconcern '<member xmlns="http://docbook.org/ns/docbook">Throws <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> if the <literal>"session"</literal> option is used with an associated transaction in combination with a <literal>"readConcern"</literal> or <literal>"writeConcern"</literal> option.</member>'>
 <!ENTITY mongodb.throws.session-unacknowledged '<member xmlns="http://docbook.org/ns/docbook">Throws <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> if the <literal>"session"</literal> option is used in combination with an unacknowledged write concern.</member>'>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2585,13 +2585,13 @@ slash may also be necessary for directories.</simpara></note>'>
 <!-- Snippets and titles for the contributors section -->
 <!ENTITY Credit.Authors.and.Contributors 'Authors and Contributors'>
 
-<!ENTITY Credit.Introduction '<para xmlns="http://docbook.org/ns/docbook"> There is a large number of contributors who
+<!ENTITY Credit.Introduction '<simpara xmlns="http://docbook.org/ns/docbook"> There is a large number of contributors who
 currently help in our work or have provided a great amount of help to the project
 in the past. There are also a lot of unnamed people who help out with user
 notes on manual pages, which continually get included in the references, the
 work of whom we are also very thankful for. All of the lists provided below are in
 alphabetical order.
-</para>'>
+</simpara>'>
 
 <!ENTITY Credit.Authors.and.Editors 'Authors and Editors'>
 
@@ -2634,8 +2634,8 @@ using public key authentication, use the
 
 <!-- XMLWriter Notes -->
 <!ENTITY xmlwriter.xmlwriter.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>writer</parameter></term><listitem><para>Only for procedural calls.
-The <classname>XMLWriter</classname> instance that is being modified. This object is returned from a call to <function>xmlwriter_open_uri</function> or <function>xmlwriter_open_memory</function>.</para></listitem></varlistentry>'>
+<parameter>writer</parameter></term><listitem><simpara>Only for procedural calls.
+The <classname>XMLWriter</classname> instance that is being modified. This object is returned from a call to <function>xmlwriter_open_uri</function> or <function>xmlwriter_open_memory</function>.</simpara></listitem></varlistentry>'>
 
 <!ENTITY xmlwriter.changelog.writer-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
@@ -2646,12 +2646,12 @@ The <classname>XMLWriter</classname> instance that is being modified. This objec
 </row>'>
 
 <!-- SOAP notes -->
-<!ENTITY soap.wsdl.mode.only "<note xmlns='http://docbook.org/ns/docbook'><para>This function only works in WSDL mode.</para></note>">
+<!ENTITY soap.wsdl.mode.only "<note xmlns='http://docbook.org/ns/docbook'><simpara>This function only works in WSDL mode.</simpara></note>">
 
 <!-- Stomp notes -->
-<!ENTITY stomp.param.link "<varlistentry xmlns='http://docbook.org/ns/docbook'><term><parameter>link</parameter></term><listitem><para>Procedural style only: The stomp link identifier returned by <function>stomp_connect</function>.</para></listitem></varlistentry>">
-<!ENTITY stomp.param.headers "<varlistentry xmlns='http://docbook.org/ns/docbook'><term><parameter>headers</parameter></term><listitem><para>Associative array containing the additional headers (example: receipt).</para></listitem></varlistentry>">
-<!ENTITY stomp.note.transaction "<note xmlns='http://docbook.org/ns/docbook'><para>A transaction header may be specified, indicating that the message acknowledgment should be part of the named transaction.</para></note>">
+<!ENTITY stomp.param.link "<varlistentry xmlns='http://docbook.org/ns/docbook'><term><parameter>link</parameter></term><listitem><simpara>Procedural style only: The stomp link identifier returned by <function>stomp_connect</function>.</simpara></listitem></varlistentry>">
+<!ENTITY stomp.param.headers "<varlistentry xmlns='http://docbook.org/ns/docbook'><term><parameter>headers</parameter></term><listitem><simpara>Associative array containing the additional headers (example: receipt).</simpara></listitem></varlistentry>">
+<!ENTITY stomp.note.transaction "<note xmlns='http://docbook.org/ns/docbook'><simpara>A transaction header may be specified, indicating that the message acknowledgment should be part of the named transaction.</simpara></note>">
 <!ENTITY stomp.note.sync "<tip xmlns='http://docbook.org/ns/docbook'><simpara>Stomp is inherently asynchronous. Synchronous communication can be implemented adding a receipt header. This will cause methods to not return anything until the server has acknowledged receipt of the message or until read timeout was reached.</simpara></tip>">
 
 <!-- SVN notes -->
@@ -2660,14 +2660,14 @@ The <classname>XMLWriter</classname> instance that is being modified. This objec
 <!ENTITY svn.referto.type 'Refer to <link xmlns="http://docbook.org/ns/docbook" linkend="svn.constants.type">type constants</link> for possible values.'>
 
 <!-- FANN notes -->
-<!ENTITY fann.ann.description '<para xmlns="http://docbook.org/ns/docbook">Neural network <type>resource</type>.</para>'>
-<!ENTITY fann.train.description '<para xmlns="http://docbook.org/ns/docbook">Neural network training data <type>resource</type>.</para>'>
-<!ENTITY fann.errdat.description '<para xmlns="http://docbook.org/ns/docbook">Either neural network <type>resource</type> or neural network trainining data <type>resource</type>.</para>'>
-<!ENTITY fann.return.void '<para xmlns="http://docbook.org/ns/docbook">No value is returned.</para>'>
-<!ENTITY fann.return.bool '<para xmlns="http://docbook.org/ns/docbook">Returns &true; on success, or &false; otherwise.</para>'>
-<!ENTITY fann.return.ann '<para xmlns="http://docbook.org/ns/docbook"> Returns a neural network <type>resource</type> on success, or &false; on error.</para>'>
-<!ENTITY fann.return.train '<para xmlns="http://docbook.org/ns/docbook"> Returns a train data <type>resource</type> on success, or &false; on error.</para>'>
-<!ENTITY fann.note.function.fann-2.2 '<note xmlns="http://docbook.org/ns/docbook"><para>This function is only available if the fann extension has been build against libfann &gt;= 2.2.</para></note>'>
+<!ENTITY fann.ann.description '<simpara xmlns="http://docbook.org/ns/docbook">Neural network <type>resource</type>.</simpara>'>
+<!ENTITY fann.train.description '<simpara xmlns="http://docbook.org/ns/docbook">Neural network training data <type>resource</type>.</simpara>'>
+<!ENTITY fann.errdat.description '<simpara xmlns="http://docbook.org/ns/docbook">Either neural network <type>resource</type> or neural network trainining data <type>resource</type>.</simpara>'>
+<!ENTITY fann.return.void '<simpara xmlns="http://docbook.org/ns/docbook">No value is returned.</simpara>'>
+<!ENTITY fann.return.bool '<simpara xmlns="http://docbook.org/ns/docbook">Returns &true; on success, or &false; otherwise.</simpara>'>
+<!ENTITY fann.return.ann '<simpara xmlns="http://docbook.org/ns/docbook"> Returns a neural network <type>resource</type> on success, or &false; on error.</simpara>'>
+<!ENTITY fann.return.train '<simpara xmlns="http://docbook.org/ns/docbook"> Returns a train data <type>resource</type> on success, or &false; on error.</simpara>'>
+<!ENTITY fann.note.function.fann-2.2 '<note xmlns="http://docbook.org/ns/docbook"><simpara>This function is only available if the fann extension has been build against libfann &gt;= 2.2.</simpara></note>'>
 
 <!-- Imagick generic return types -->
 <!ENTITY imagick.return.success 'Returns &true; on success.'>
@@ -2734,38 +2734,38 @@ The <classname>XMLWriter</classname> instance that is being modified. This objec
   section</link> for more information.
  </simpara>
 </note>'>
-<!ENTITY note.openssl.param-notext '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY note.openssl.param-notext '<simpara xmlns="http://docbook.org/ns/docbook">
  The optional parameter <parameter>notext</parameter> affects
  the verbosity of the output; if it is &false;, then additional human-readable
  information is included in the output. The default value of
  <parameter>notext</parameter> is &true;.
-</para>'>
+</simpara>'>
 
 <!-- COM/Dotnet -->
 <!ENTITY com.variant-arith '<note xmlns="http://docbook.org/ns/docbook">
-<para>
+<simpara>
  As with all the variant arithmetic functions, the parameters for this function
  can be either a PHP native type (integer, string, floating point, boolean or
  &null;), or an instance of a COM, VARIANT or DOTNET class.  PHP native types
  will be converted to variants using the same rules as found in the constructor
  for the <xref linkend="class.variant"/> class.  COM and DOTNET objects
  will have the value of their default property taken and used as the variant value.
-</para>
-<para>
+</simpara>
+<simpara>
  The variant arithmetic functions are wrappers around the similarly named
  functions in the COM library; for more information on these functions, consult
  the MSDN library.  The PHP functions are named slightly differently; for example
  <function>variant_add</function> in PHP corresponds to <literal>VarAdd()
  </literal> in the MSDN documentation.
-</para>
+</simpara>
 </note>
 '>
 
 <!-- phar -->
-<!ENTITY phar.write '<note xmlns="http://docbook.org/ns/docbook"><para>This
+<!ENTITY phar.write '<note xmlns="http://docbook.org/ns/docbook"><simpara>This
 method requires the &php.ini; setting <literal>phar.readonly</literal> to be
 set to <literal>0</literal> in order to work for <classname>Phar</classname>
-objects.  Otherwise, a <classname>PharException</classname> will be thrown.</para></note>'>
+objects.  Otherwise, a <classname>PharException</classname> will be thrown.</simpara></note>'>
 
 <!ENTITY phar.note.performance '<note xmlns="http://docbook.org/ns/docbook">
  <simpara>
@@ -2786,28 +2786,28 @@ objects.  Otherwise, a <classname>PharException</classname> will be thrown.</par
 </note>'>
 
 <!-- XML -->
-<!ENTITY libxml.required '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY libxml.required '<simpara xmlns="http://docbook.org/ns/docbook">
  This extension requires the <link linkend="book.libxml">libxml</link> PHP extension.
  This means passing the <option role="configure">--with-libxml</option>,
  or prior to PHP 7.4 the <option role="configure">--enable-libxml</option>,
  configuration flag, although this is implicitly accomplished because libxml
  is enabled by default.
-</para>'>
+</simpara>'>
 
 <!-- XMLReader -->
-<!ENTITY xmlreader.libxml20620.note '<caution xmlns="http://docbook.org/ns/docbook"><para>This function is only available when PHP is compiled against libxml 20620 or later.</para></caution>'>
+<!ENTITY xmlreader.libxml20620.note '<caution xmlns="http://docbook.org/ns/docbook"><simpara>This function is only available when PHP is compiled against libxml 20620 or later.</simpara></caution>'>
 
 <!-- inotify -->
 <!ENTITY inotify.instance.description 'Resource returned by
 <function xmlns="http://docbook.org/ns/docbook">inotify_init</function>'>
 
 <!-- User streams -->
-<!ENTITY userstream.not.implemented.warning '<para xmlns="http://docbook.org/ns/docbook">Emits
+<!ENTITY userstream.not.implemented.warning '<simpara xmlns="http://docbook.org/ns/docbook">Emits
 <constant>E_WARNING</constant> if call to this method fails
-(i.e. not implemented).</para>'>
-<!ENTITY userstream.updates.context '<note xmlns="http://docbook.org/ns/docbook"><para>The
+(i.e. not implemented).</simpara>'>
+<!ENTITY userstream.updates.context '<note xmlns="http://docbook.org/ns/docbook"><simpara>The
 <varname linkend="streamwrapper.props.context">streamWrapper::$context</varname>
-property is updated if a valid context is passed to the caller function.</para></note>'>
+property is updated if a valid context is passed to the caller function.</simpara></note>'>
 
 <!ENTITY stream.bucket.param '<parameter>bucket</parameter> expects a <classname>StreamBucket</classname> instance now; previously, an <classname>stdClass</classname> was expected.'>
 <!ENTITY stream.bucket.return 'This function returns a <classname>StreamBucket</classname> instance now; previously, an <classname>stdClass</classname> was returned.'>
@@ -2833,28 +2833,28 @@ to be references, then they must be references in the passed argument list.'>
 <!ENTITY reflection.getattributes.param.name '<varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>name</parameter></term>
 <listitem>
- <para>
+ <simpara>
   Filter the results to include only <classname>ReflectionAttribute</classname>
   instances for attributes matching this class name.
- </para>
+ </simpara>
 </listitem>
 </varlistentry>'>
 
 <!ENTITY reflection.getattributes.param.flags '<varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>flags</parameter></term>
 <listitem>
- <para>
+ <simpara>
   Flags for determining how to filter the results, if <parameter>name</parameter>
   is provided.
- </para>
- <para>
+ </simpara>
+ <simpara>
   Default is <literal>0</literal> which will only return results for attributes that
   are of the class <parameter>name</parameter>.
- </para>
- <para>
+ </simpara>
+ <simpara>
   The only other option available, is to use <constant>ReflectionAttribute::IS_INSTANCEOF</constant>,
   which will instead use <literal>instanceof</literal> for filtering.
- </para>
+ </simpara>
 </listitem>
 </varlistentry>'>
 
@@ -2867,9 +2867,9 @@ to be references, then they must be references in the passed argument list.'>
 <!ENTITY win32service.noerror.false.error 'returned <constant xmlns="http://docbook.org/ns/docbook">WIN32_NO_ERROR</constant> on success&win32service.false.error;'>
 
 <!-- SNMP -->
-<!ENTITY snmp.set.type.values '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY snmp.set.type.values '<simpara xmlns="http://docbook.org/ns/docbook">
  The <acronym>MIB</acronym> defines the type of each object id. It has to be specified as a single character from the below list.
-</para>
+</simpara>
 <table xmlns="http://docbook.org/ns/docbook">
  <title>types</title>
  <tgroup cols="2">
@@ -2888,9 +2888,9 @@ to be references, then they must be references in the passed argument list.'>
   </tbody>
  </tgroup>
 </table>
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  If <constant>OPAQUE_SPECIAL_TYPES</constant> was defined while compiling the <acronym>SNMP</acronym> library, the following are also valid:
-</para>
+</simpara>
 <table xmlns="http://docbook.org/ns/docbook">
  <title>types</title>
  <tgroup cols="2">
@@ -2903,20 +2903,20 @@ to be references, then they must be references in the passed argument list.'>
  </tgroup>
 </table>
 '>
-<!ENTITY snmp.set.type.values.asn.mapping '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY snmp.set.type.values.asn.mapping '<simpara xmlns="http://docbook.org/ns/docbook">
  Most of these will use the obvious corresponding ASN.1 type.  &apos;s&apos;, &apos;x&apos;, &apos;d&apos; and &apos;b&apos; are all different ways of specifying an OCTET STRING value, and
  the &apos;u&apos; unsigned type is also used for handling Gauge32 values.
-</para>
+</simpara>
 '>
-<!ENTITY snmp.set.type.values.equal.note '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY snmp.set.type.values.equal.note '<simpara xmlns="http://docbook.org/ns/docbook">
  If the MIB-Files are loaded by into the MIB Tree with "snmp_read_mib" or by specifying it in the libsnmp config, &apos;=&apos; may be used as
  the <parameter>type</parameter> parameter for all object ids as the type can then be automatically read from the MIB.
-</para>
+</simpara>
 '>
-<!ENTITY snmp.set.type.values.bitset.note '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY snmp.set.type.values.bitset.note '<simpara xmlns="http://docbook.org/ns/docbook">
  Note that there are two ways to set a variable of the type BITS like e.g.
  "SYNTAX    BITS {telnet(0), ftp(1), http(2), icmp(3), snmp(4), ssh(5), https(6)}":
-</para>
+</simpara>
 <itemizedlist xmlns="http://docbook.org/ns/docbook">
  <listitem>
   <simpara>
@@ -2929,19 +2929,19 @@ to be references, then they must be references in the passed argument list.'>
   </simpara>
  </listitem>
 </itemizedlist>
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  See examples section for more details.
-</para>
+</simpara>
 '>
 <!ENTITY snmp.methods.exceptions_enable.refsect '<refsect1 role="errors" xmlns="http://docbook.org/ns/docbook">
 &reftitle.errors;
-<para>
+<simpara>
  This method does not throw any exceptions by default.
  To enable throwing an SNMPException exception when some of library errors occur
  the SNMP class parameter <parameter>exceptions_enabled</parameter>
  should be set to a corresponding value. See <link linkend="snmp.props.exceptions-enabled">
  <parameter>SNMP::$exceptions_enabled</parameter> explanation</link> for more details.
-</para>
+</simpara>
 </refsect1>
 '>
 
@@ -2954,16 +2954,16 @@ void callback(mixed $data, int $result[, resource $req]);
 <variablelist xmlns="http://docbook.org/ns/docbook">
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>data</parameter></term>
-<listitem><para>is custom data passed to the request.</para></listitem>
+<listitem><simpara>is custom data passed to the request.</simpara></listitem>
 </varlistentry>
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>result</parameter></term>
-<listitem><para>request-specific result value; basically, the value returned by corresponding
-system call.</para></listitem>
+<listitem><simpara>request-specific result value; basically, the value returned by corresponding
+system call.</simpara></listitem>
 </varlistentry>
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>req</parameter></term>
-<listitem><para>is optional request resource which can be used with functions like <function>eio_get_last_error</function>.</para></listitem>
+<listitem><simpara>is optional request resource which can be used with functions like <function>eio_get_last_error</function>.</simpara></listitem>
 </varlistentry>
 </variablelist>
 </para>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -715,10 +715,10 @@ use.</simpara></note>'>
 <!ENTITY sort.flags.parameter '<varlistentry xmlns="http://docbook.org/ns/docbook">
   <term><parameter>flags</parameter></term>
   <listitem>
-   <para>
+   <simpara>
     The optional second parameter <parameter>flags</parameter>
     may be used to modify the sorting behavior using these values:
-   </para>
+   </simpara>
    <para>
     Sorting type flags:
     <itemizedlist>
@@ -759,18 +759,18 @@ use.</simpara></note>'>
  </varlistentry>
 '>
 
-<!ENTITY sort.callback.description '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY sort.callback.description '<simpara xmlns="http://docbook.org/ns/docbook">
  &return.callbacksort;
-</para>
+</simpara>
 &callback.cmp;
 <caution xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   Returning <emphasis>non-integer</emphasis> values from the comparison
   function, such as <type>float</type>, will result in an internal cast to
   <type>int</type> of the callback&apos;s return value. So values such as
   <literal>0.99</literal> and <literal>0.1</literal> will both be cast to an
   integer value of <literal>0</literal>, which will compare such values as equal.
- </para>
+ </simpara>
 </caution>'>
 
 <!ENTITY sort.callback.description.presort '<caution xmlns="http://docbook.org/ns/docbook">
@@ -898,7 +898,7 @@ function.</simpara></warning>'>
 '>
 
 <!-- FileInfo -->
-<!ENTITY fileinfo.parameters.finfo '<para xmlns="http://docbook.org/ns/docbook">An <classname>finfo</classname> instance, returned by <function>finfo_open</function>.</para>'>
+<!ENTITY fileinfo.parameters.finfo '<simpara xmlns="http://docbook.org/ns/docbook">An <classname>finfo</classname> instance, returned by <function>finfo_open</function>.</simpara>'>
 <!ENTITY fileinfo.changelog.finfo-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
@@ -911,27 +911,27 @@ function.</simpara></warning>'>
 <!ENTITY openssl.param.x509 '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>certificate</parameter></term>
  <listitem>
-  <para>
+  <simpara>
    See <link linkend="openssl.certparams">Key/Certificate parameters</link> for a list of valid values.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
 <!ENTITY openssl.param.csr '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>csr</parameter></term>
  <listitem>
-  <para>
+  <simpara>
    See <link linkend="openssl.certparams">CSR parameters</link> for a list of valid values.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
 <!ENTITY openssl.param.key '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>key</parameter></term>
  <listitem>
-  <para>
+  <simpara>
    See <link linkend="openssl.certparams">Public/Private Key parameters</link> for a list of valid values.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
@@ -944,18 +944,18 @@ if PHP is compiled using <option role="configure">--with-t1lib[=DIR]</option>.
 PHP is compiled with freetype support (<option role="configure">--with-freetype-dir=DIR</option>)
 </simpara></note>'>
 
-<!ENTITY note.gd.notrequired '<note xmlns="http://docbook.org/ns/docbook"><para>This function does not require the GD image library.</para></note>'>
+<!ENTITY note.gd.notrequired '<note xmlns="http://docbook.org/ns/docbook"><simpara>This function does not require the GD image library.</simpara></note>'>
 
-<!ENTITY note.gd.interpolation '<note xmlns="http://docbook.org/ns/docbook"><para>This function is affected by the interpolation method set by <function>imagesetinterpolation</function>.</para></note>'>
+<!ENTITY note.gd.interpolation '<note xmlns="http://docbook.org/ns/docbook"><simpara>This function is affected by the interpolation method set by <function>imagesetinterpolation</function>.</simpara></note>'>
 
 <!ENTITY gd.image.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>image</parameter></term><listitem><para>A <classname>GdImage</classname> object, returned by one of the image creation functions,
-such as <function>imagecreatetruecolor</function>.</para></listitem></varlistentry>'>
+<parameter>image</parameter></term><listitem><simpara>A <classname>GdImage</classname> object, returned by one of the image creation functions,
+such as <function>imagecreatetruecolor</function>.</simpara></listitem></varlistentry>'>
 
 <!ENTITY gd.font.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>font</parameter></term><listitem><para>Can be 1, 2, 3, 4, 5 for built-in
+<parameter>font</parameter></term><listitem><simpara>Can be 1, 2, 3, 4, 5 for built-in
 fonts in latin2 encoding (where higher numbers corresponding to larger fonts) or <classname>GdFont</classname> instance,
-returned by <function>imageloadfont</function>.</para></listitem></varlistentry>'>
+returned by <function>imageloadfont</function>.</simpara></listitem></varlistentry>'>
 
 <!ENTITY gd.changelog.gdfont-instance '<row xmlns="http://docbook.org/ns/docbook">
   <entry>8.1.0</entry>
@@ -969,23 +969,23 @@ returned by <function>imageloadfont</function>.</para></listitem></varlistentry>
     <varlistentry xmlns='http://docbook.org/ns/docbook'>
      <term><parameter>fontfile</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The path to the TrueType font you wish to use.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        Depending on which version of the GD library PHP is using, <emphasis>when
        <parameter>fontfile</parameter> does not begin with a leading
        <literal>/</literal> then <literal>.ttf</literal> will be appended</emphasis>
        to the filename and the library will attempt to search for that
        filename along a library-defined font path.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        When using versions of the GD library lower than 2.0.18, a <literal>space</literal> character,
        rather than a semicolon, was used as the 'path separator' for different font files.
        Unintentional use of this feature will result in the warning message:
        <literal>Warning: Could not find/open font</literal>. For these affected versions, the
        only solution is moving the font to a path which does not contain spaces.
-      </para>
+      </simpara>
       <para>
        In many cases where a font resides in the same directory as the script using it
        the following trick will alleviate any include problems.
@@ -1002,10 +1002,10 @@ $font = 'SomeFont';
        </programlisting>
       </para>
       <note>
-       <para>
+       <simpara>
         Note that <link linkend='ini.open-basedir'>open_basedir</link> does
         <emphasis>not</emphasis> apply to <parameter>fontfile</parameter>.
-       </para>
+       </simpara>
       </note>
      </listitem>
     </varlistentry>
@@ -1118,33 +1118,33 @@ purposes.</simpara></warning>'>
 <!-- DBM notes -->
 
 <!ENTITY dbm.dbm-identifier.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>dbm_identifier</parameter></term><listitem><para>The DBM link identifier,
-returned by <function>dbmopen</function>.</para></listitem></varlistentry>'>
+<parameter>dbm_identifier</parameter></term><listitem><simpara>The DBM link identifier,
+returned by <function>dbmopen</function>.</simpara></listitem></varlistentry>'>
 
 <!-- JSON notes -->
 
 <!ENTITY json.implementation.superset '
  <note xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <para>
+  <simpara>
    PHP implements a superset of JSON as specified in the original
    <link xlink:href="&url.rfc;7159">RFC 7159</link>.
-  </para>
+  </simpara>
  </note>
 '>
 
 <!-- cURL notes -->
 
 <!ENTITY curl.ch.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>handle</parameter>
-</term><listitem><para>A cURL handle returned by
-<function>curl_init</function>.</para></listitem></varlistentry>'>
+</term><listitem><simpara>A cURL handle returned by
+<function>curl_init</function>.</simpara></listitem></varlistentry>'>
 
 <!ENTITY curl.mh.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>multi_handle</parameter>
-</term><listitem><para>A cURL multi handle returned by
-<function>curl_multi_init</function>.</para></listitem></varlistentry>'>
+</term><listitem><simpara>A cURL multi handle returned by
+<function>curl_multi_init</function>.</simpara></listitem></varlistentry>'>
 
 <!ENTITY curl.sh.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>share_handle</parameter>
-</term><listitem><para>A cURL share handle returned by
-<function>curl_share_init</function>.</para></listitem></varlistentry>'>
+</term><listitem><simpara>A cURL share handle returned by
+<function>curl_share_init</function>.</simpara></listitem></varlistentry>'>
 
 <!ENTITY curl.changelog.handle-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
@@ -1216,19 +1216,19 @@ returned by <function>dbmopen</function>.</para></listitem></varlistentry>'>
 <!ENTITY enchant.param.broker '<varlistentry xmlns="http://docbook.org/ns/docbook">
      <term><parameter>broker</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        An Enchant broker returned by <function>enchant_broker_init</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>'>
 
 <!ENTITY enchant.param.dictionary '<varlistentry xmlns="http://docbook.org/ns/docbook">
      <term><parameter>dictionary</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        An Enchant dictionary returned by <function>enchant_broker_request_dict</function>
        or <function>enchant_broker_request_pwl_dict</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>'>
 
@@ -1259,15 +1259,15 @@ returned by <function>dbmopen</function>.</para></listitem></varlistentry>'>
 </row>'>
 
 <!ENTITY imap.imap-parameter.imap '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>imap</parameter></term><listitem><para>An <classname>IMAP\Connection</classname> instance.</para></listitem></varlistentry>'>
+<parameter>imap</parameter></term><listitem><simpara>An <classname>IMAP\Connection</classname> instance.</simpara></listitem></varlistentry>'>
 
 <!-- Deprecated -->
 <!ENTITY imap.imap-stream.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>imap</parameter></term><listitem><para>An IMAP stream returned by
-<function>imap_open</function>.</para></listitem></varlistentry>'>
+<parameter>imap</parameter></term><listitem><simpara>An IMAP stream returned by
+<function>imap_open</function>.</simpara></listitem></varlistentry>'>
 
-<!ENTITY imap.pattern '<para xmlns="http://docbook.org/ns/docbook">Specifies where in the mailbox hierarchy
-to start searching.</para><para xmlns="http://docbook.org/ns/docbook">There are two special characters you can
+<!ENTITY imap.pattern '<simpara xmlns="http://docbook.org/ns/docbook">Specifies where in the mailbox hierarchy
+to start searching.</simpara><simpara xmlns="http://docbook.org/ns/docbook">There are two special characters you can
 pass as part of the <parameter>pattern</parameter>:
 &apos;<literal>*</literal>&apos; and &apos;<literal>&#37;</literal>&apos;.
 &apos;<literal>*</literal>&apos; means to return all mailboxes. If you pass
@@ -1277,7 +1277,7 @@ get a list of the entire mailbox hierarchy.
 means to return the current level only.
 &apos;<literal>&#37;</literal>&apos; as the <parameter>pattern</parameter>
 parameter will return only the top level
-mailboxes; &apos;<literal>~/mail/&#37;</literal>&apos; on <literal>UW_IMAPD</literal> will return every mailbox in the <filename>~/mail</filename> directory, but none in subfolders of that directory.</para>'>
+mailboxes; &apos;<literal>~/mail/&#37;</literal>&apos; on <literal>UW_IMAPD</literal> will return every mailbox in the <filename>~/mail</filename> directory, but none in subfolders of that directory.</simpara>'>
 
 <!ENTITY imap.mailboxname.insecure '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
 Passing untrusted data to this parameter is <emphasis>insecure</emphasis>, unless
@@ -1286,19 +1286,19 @@ Passing untrusted data to this parameter is <emphasis>insecure</emphasis>, unles
 
 <!-- intl notes -->
 
-<!ENTITY intl.parameter.intl-calendar '<para xmlns="http://docbook.org/ns/docbook">An <classname>IntlCalendar</classname> instance.</para>'>
+<!ENTITY intl.parameter.intl-calendar '<simpara xmlns="http://docbook.org/ns/docbook">An <classname>IntlCalendar</classname> instance.</simpara>'>
 
-<!ENTITY intl.error.intl-calendar '<para xmlns="http://docbook.org/ns/docbook">On failure &false; is also returned. To detect error conditions use <function>intl_get_error_code</function>, or set up Intl to throw <link linkend="ini.intl.use-exceptions">exceptions</link>.</para>'>
+<!ENTITY intl.error.intl-calendar '<simpara xmlns="http://docbook.org/ns/docbook">On failure &false; is also returned. To detect error conditions use <function>intl_get_error_code</function>, or set up Intl to throw <link linkend="ini.intl.use-exceptions">exceptions</link>.</simpara>'>
 
-<!ENTITY intl.codepoint.parameter '<para xmlns="http://docbook.org/ns/docbook">The <type>int</type> codepoint value (e.g. <literal>0x2603</literal> for <emphasis>U+2603 SNOWMAN</emphasis>), or the character encoded as a UTF-8 <type>string</type> (e.g. <literal>"\u{2603}"</literal>)</para>'>
+<!ENTITY intl.codepoint.parameter '<simpara xmlns="http://docbook.org/ns/docbook">The <type>int</type> codepoint value (e.g. <literal>0x2603</literal> for <emphasis>U+2603 SNOWMAN</emphasis>), or the character encoded as a UTF-8 <type>string</type> (e.g. <literal>"\u{2603}"</literal>)</simpara>'>
 
-<!ENTITY intl.codepoint.return '<para xmlns="http://docbook.org/ns/docbook">The return type is <type>int</type> unless the code point was passed as a UTF-8 <type>string</type>, in which case a <type>string</type> is returned. Returns &null; on failure.</para>'>
+<!ENTITY intl.codepoint.return '<simpara xmlns="http://docbook.org/ns/docbook">The return type is <type>int</type> unless the code point was passed as a UTF-8 <type>string</type>, in which case a <type>string</type> is returned. Returns &null; on failure.</simpara>'>
 
 <!ENTITY intl.codepoint.example 'Testing different code points'>
 
-<!ENTITY intl.locale-len.return '<para xmlns="http://docbook.org/ns/docbook">Returns &null; when the length of <parameter>locale</parameter> exceeds <constant>INTL_MAX_LOCALE_LEN</constant>.</para>'>
+<!ENTITY intl.locale-len.return '<simpara xmlns="http://docbook.org/ns/docbook">Returns &null; when the length of <parameter>locale</parameter> exceeds <constant>INTL_MAX_LOCALE_LEN</constant>.</simpara>'>
 
-<!ENTITY intl.property.parameter '<para xmlns="http://docbook.org/ns/docbook">The Unicode property to lookup (see the <literal>IntlChar::PROPERTY_*</literal> constants).</para>'>
+<!ENTITY intl.property.parameter '<simpara xmlns="http://docbook.org/ns/docbook">The Unicode property to lookup (see the <literal>IntlChar::PROPERTY_*</literal> constants).</simpara>'>
 
 <!ENTITY intl.property.example 'Testing different properties'>
 
@@ -1377,28 +1377,28 @@ Passing untrusted data to this parameter is <emphasis>insecure</emphasis>, unles
 <!ENTITY ldap.return-result 'Returns an <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instance,&return.falseforfailure;.'>
 <!ENTITY ldap.return-result-array 'Returns an <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instance, an array of <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instances,&return.falseforfailure;.'>
 
-<!ENTITY ldap.return-result-array-info '<para xmlns="http://docbook.org/ns/docbook">It is also possible to perform parallel searches. In this case, the first argument should be an array of
+<!ENTITY ldap.return-result-array-info '<simpara xmlns="http://docbook.org/ns/docbook">It is also possible to perform parallel searches. In this case, the first argument should be an array of
 <classname>LDAP\Connection</classname> instances, rather than a single one.
 If the searches should not all use the same base DN and filter, an array of base DNs and/or an array of filters can be passed as arguments instead.
 These arrays must be of the same size as the <classname>LDAP\Connection</classname> instances array,
 since the first entries of the arrays are used for one search, the second entries are used for another, and so on.
-When doing parallel searches an array of <classname>LDAP\Result</classname> instances is returned, except in case of error, when the return value will be &false;.</para>'>
+When doing parallel searches an array of <classname>LDAP\Result</classname> instances is returned, except in case of error, when the return value will be &false;.</simpara>'>
 
 <!-- mbstring notes -->
 
-<!ENTITY note.mbstring.encoding.internal '<note xmlns="http://docbook.org/ns/docbook"><para>The internal encoding or the
+<!ENTITY note.mbstring.encoding.internal '<note xmlns="http://docbook.org/ns/docbook"><simpara>The internal encoding or the
 character encoding specified by <function>mb_regex_encoding</function>
-will be used as the character encoding for this function.</para></note>'>
+will be used as the character encoding for this function.</simpara></note>'>
 
-<!ENTITY note.mbstring.encoding.current '<note xmlns="http://docbook.org/ns/docbook"><para>The
+<!ENTITY note.mbstring.encoding.current '<note xmlns="http://docbook.org/ns/docbook"><simpara>The
 character encoding specified by <function>mb_regex_encoding</function>
-will be used as the character encoding for this function by default.</para></note>'>
+will be used as the character encoding for this function by default.</simpara></note>'>
 
-<!ENTITY mbstring.encoding.parameter '<para xmlns="http://docbook.org/ns/docbook">The <parameter>encoding</parameter>
+<!ENTITY mbstring.encoding.parameter '<simpara xmlns="http://docbook.org/ns/docbook">The <parameter>encoding</parameter>
 parameter is the character encoding. If it is omitted or &null;, the internal character
-encoding value will be used.</para>'>
+encoding value will be used.</simpara>'>
 
-<!ENTITY mbstring.warning.e-modifier '<warning xmlns="http://docbook.org/ns/docbook"><para>Never use the <literal>e</literal> modifier when working on untrusted input. No automatic escaping will happen (as known from <function>preg_replace</function>). Not taking care of this will most likely create remote code execution vulnerabilities in your application.</para></warning>'>
+<!ENTITY mbstring.warning.e-modifier '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Never use the <literal>e</literal> modifier when working on untrusted input. No automatic escaping will happen (as known from <function>preg_replace</function>). Not taking care of this will most likely create remote code execution vulnerabilities in your application.</simpara></warning>'>
 
 <!ENTITY mbstring.changelog.encoding-nullable '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
@@ -1416,19 +1416,19 @@ encoding value will be used.</para>'>
 
 <!-- mcrypt notes -->
 
-<!ENTITY mcrypt.parameter.cipher '<para xmlns="http://docbook.org/ns/docbook">One of the <constant>MCRYPT_ciphername</constant> constants, or the name of the algorithm as string.</para>'>
+<!ENTITY mcrypt.parameter.cipher '<simpara xmlns="http://docbook.org/ns/docbook">One of the <constant>MCRYPT_ciphername</constant> constants, or the name of the algorithm as string.</simpara>'>
 
-<!ENTITY mcrypt.parameter.iv '<para xmlns="http://docbook.org/ns/docbook">Used for the initialization in CBC, CFB, OFB modes, and in some algorithms in STREAM mode. If you do not supply an IV, while it is needed for an algorithm, the function issues a warning and uses an IV with all its bytes set to "<literal>\0</literal>".</para>'>
+<!ENTITY mcrypt.parameter.iv '<simpara xmlns="http://docbook.org/ns/docbook">Used for the initialization in CBC, CFB, OFB modes, and in some algorithms in STREAM mode. If you do not supply an IV, while it is needed for an algorithm, the function issues a warning and uses an IV with all its bytes set to "<literal>\0</literal>".</simpara>'>
 
-<!ENTITY mcrypt.parameter.iv.strict '<para xmlns="http://docbook.org/ns/docbook">Used for the initialization in CBC, CFB, OFB modes, and in some algorithms in STREAM mode. If the provided IV size is not supported by the chaining mode or no IV was provided, but the chaining mode requires one, the function will emit a warning and return &false;.</para>'>
+<!ENTITY mcrypt.parameter.iv.strict '<simpara xmlns="http://docbook.org/ns/docbook">Used for the initialization in CBC, CFB, OFB modes, and in some algorithms in STREAM mode. If the provided IV size is not supported by the chaining mode or no IV was provided, but the chaining mode requires one, the function will emit a warning and return &false;.</simpara>'>
 
-<!ENTITY mcrypt.parameter.mode '<para xmlns="http://docbook.org/ns/docbook">One of the <constant>MCRYPT_MODE_modename</constant> constants, or one of the following strings: "ecb", "cbc", "cfb", "ofb", "nofb" or "stream".</para>'>
+<!ENTITY mcrypt.parameter.mode '<simpara xmlns="http://docbook.org/ns/docbook">One of the <constant>MCRYPT_MODE_modename</constant> constants, or one of the following strings: "ecb", "cbc", "cfb", "ofb", "nofb" or "stream".</simpara>'>
 
  <!-- MCVE notes -->
 
 <!ENTITY mcve.conn.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>conn</parameter></term><listitem><para>An MCVE_CONN resource returned by
-<function>m_initengine</function>.</para></listitem></varlistentry>'>
+<parameter>conn</parameter></term><listitem><simpara>An MCVE_CONN resource returned by
+<function>m_initengine</function>.</simpara></listitem></varlistentry>'>
 
 <!-- memcached notes -->
 
@@ -1453,17 +1453,17 @@ encoding value will be used.</para>'>
 
 <!ENTITY memcached.result.getresultcode 'Use <methodname xmlns="http://docbook.org/ns/docbook">Memcached::getResultCode</methodname> if necessary.'>
 
-<!ENTITY memcached.result.delete-multi '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY memcached.result.delete-multi '<simpara xmlns="http://docbook.org/ns/docbook">
    Returns an array indexed by <parameter>keys</parameter>. Each element
    is &true; if the corresponding key was deleted, or one of the
    <constant>Memcached::RES_<replaceable>*</replaceable></constant> constants if the corresponding deletion
    failed.
-   </para>
-  <para xmlns="http://docbook.org/ns/docbook">
+   </simpara>
+  <simpara xmlns="http://docbook.org/ns/docbook">
    The <methodname>Memcached::getResultCode</methodname> will return
    the result code for the last executed delete operation, that is, the delete
    operation for the last element of <parameter>keys</parameter>.
-  </para>
+  </simpara>
 '>
 
 <!-- password notes -->
@@ -1494,9 +1494,9 @@ encoding value will be used.</para>'>
  </entry>
 </row>'>
 
-<!ENTITY pspell.parameter.pspell-dictionary '<para xmlns="http://docbook.org/ns/docbook">An <classname>PSpell\Dictionary</classname> instance.</para>'>
+<!ENTITY pspell.parameter.pspell-dictionary '<simpara xmlns="http://docbook.org/ns/docbook">An <classname>PSpell\Dictionary</classname> instance.</simpara>'>
 
-<!ENTITY pspell.parameter.pspell-config '<para xmlns="http://docbook.org/ns/docbook">An <classname>PSpell\Config</classname> instance.</para>'>
+<!ENTITY pspell.parameter.pspell-config '<simpara xmlns="http://docbook.org/ns/docbook">An <classname>PSpell\Config</classname> instance.</simpara>'>
 
 <!-- RNP -->
 
@@ -1545,13 +1545,13 @@ encoding value will be used.</para>'>
 <!ENTITY gearman.parameter.callback '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>callback</parameter></term>
  <listitem>
-  <para>
+  <simpara>
    A function or method to call.
    It should return a valid <link linkend="gearman.constants">Gearman return value</link>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    If no return statement is present, it defaults to <constant>GEARMAN_SUCCESS</constant>.
-  </para>
+  </simpara>
   <methodsynopsis>
    <type>int</type><methodname><replaceable>callback</replaceable></methodname>
    <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
@@ -1561,17 +1561,17 @@ encoding value will be used.</para>'>
    <varlistentry>
     <term><parameter>task</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       The task this callback is called for.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>context</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Whatever has been passed to <methodname>GearmanClient::addTask</methodname> (or equivalent method) as <parameter>context</parameter>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -1579,10 +1579,10 @@ encoding value will be used.</para>'>
 </varlistentry>'>
 
 <!ENTITY gearman.note.callback '<note xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   The callback will only be triggered for tasks that are added (e.g. by calling <methodname>GearmanClient::addTask</methodname>)
   after calling this method.
- </para>
+ </simpara>
 </note>'>
 
 <!-- Date and time entities -->

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -19,16 +19,16 @@ highly discouraged.</simpara></warning>'>
 
 <!-- Cautions -->
 <!ENTITY caution.cryptographically-insecure '<caution xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   This function does not generate cryptographically secure values, and <emphasis>must not</emphasis>
   be used for cryptographic purposes, or purposes that require returned values to be unguessable.
- </para>
- <para>
+ </simpara>
+ <simpara>
   If cryptographically secure randomness is required, the <classname>Random\Randomizer</classname> may be
   used with the <classname>Random\Engine\Secure</classname> engine. For simple use cases, the <function>random_int</function>
   and <function>random_bytes</function> functions provide a convenient and secure <acronym>API</acronym> that is backed by
   the operating system’s <acronym>CSPRNG</acronym>.
- </para>
+ </simpara>
 </caution>'>
 
 <!ENTITY caution.mt19937-global-state '<caution xmlns="http://docbook.org/ns/docbook">
@@ -45,25 +45,25 @@ highly discouraged.</simpara></warning>'>
 </caution>'>
 
 <!ENTITY caution.mt19937-tiny-seed '<caution xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   Because the Mt19937 (“Mersenne Twister”) engine accepts only a single 32 bit integer as the
   seed, the number of possible random sequences is limited to just 2<superscript>32</superscript>
   (i.e. 4,294,967,296), despite Mt19937’s huge period of 2<superscript>19937</superscript>-1.
- </para>
- <para>
+ </simpara>
+ <simpara>
   When relying on either implicit or explicit random seeding, duplications will appear
   much earlier. Duplicated seeds are expected with 50&#37; probability after less than
   80,000 randomly generated seeds according to the birthday problem. A 10&#37; probability
   of a duplicated seed happens after randomly generating roughly 30,000 seeds.
- </para>
- <para>
+ </simpara>
+ <simpara>
   This makes Mt19937 unsuitable for applications where duplicated sequences must not happen with
   more than a negligible probability. If reproducible seeding is required, both the
   <classname>Random\Engine\Xoshiro256StarStar</classname> and <classname>Random\Engine\PcgOneseq128XslRr64</classname>
   engines support much larger seeds that are unlikely to collide randomly. If reproducibility
   is not required, the <classname>Random\Engine\Secure</classname> engine provides cryptographically
   secure randomness.
- </para>
+ </simpara>
 </caution>'>
 
 <!-- Notes -->
@@ -78,43 +78,43 @@ more details.</simpara></note>'>
 <!ENTITY note.context-support '<para xmlns="http://docbook.org/ns/docbook">A <link linkend="stream.contexts">context stream</link>
 <type>resource</type>.</para>'>
 
-<!ENTITY note.exec-bg '<note xmlns="http://docbook.org/ns/docbook"><para>If a program is started with this function,
+<!ENTITY note.exec-bg '<note xmlns="http://docbook.org/ns/docbook"><simpara>If a program is started with this function,
 in order for it to continue running in the background, the output of the
 program must be redirected to a file or another output stream. Failing to do so
-will cause PHP to hang until the execution of the program ends.</para></note>'>
+will cause PHP to hang until the execution of the program ends.</simpara></note>'>
 
-<!ENTITY note.exec-bypass-shell '<note xmlns="http://docbook.org/ns/docbook"><para>On Windows <function>exec</function>
+<!ENTITY note.exec-bypass-shell '<note xmlns="http://docbook.org/ns/docbook"><simpara>On Windows <function>exec</function>
 will first start cmd.exe to launch the command. If you want to start an external program without starting cmd.exe
-use <function>proc_open</function> with the <parameter>bypass_shell</parameter> option set.</para></note>'>
+use <function>proc_open</function> with the <parameter>bypass_shell</parameter> option set.</simpara></note>'>
 
-<!ENTITY note.extractto-windows '<note xmlns="http://docbook.org/ns/docbook"><para>Windows NTFS file systems
+<!ENTITY note.extractto-windows '<note xmlns="http://docbook.org/ns/docbook"><simpara>Windows NTFS file systems
 do not support some characters in filenames, namely <literal>&lt;|&gt;*?":</literal>. Filenames with a trailing dot
 are not supported either. Contrary to some extraction tools, this method does not replace these characters with
-an underscore, but instead fails to extract such files.</para></note>'>
+an underscore, but instead fails to extract such files.</simpara></note>'>
 
 <!ENTITY note.func-callback '<note xmlns="http://docbook.org/ns/docbook"><simpara>Instead of a function name, an
 array containing an object reference and a method name can also be
 supplied.</simpara></note>'>
 
-<!ENTITY note.func-callback-exceptions '<note xmlns="http://docbook.org/ns/docbook"><para>Callbacks registered
+<!ENTITY note.func-callback-exceptions '<note xmlns="http://docbook.org/ns/docbook"><simpara>Callbacks registered
 with functions such as <function>call_user_func</function> and <function>call_user_func_array</function> will not be
-called if there is an uncaught exception thrown in a previous callback.</para></note>'>
+called if there is an uncaught exception thrown in a previous callback.</simpara></note>'>
 
-<!ENTITY note.funcbyref '<note xmlns="http://docbook.org/ns/docbook"><para>If the arguments are passed by reference,
+<!ENTITY note.funcbyref '<note xmlns="http://docbook.org/ns/docbook"><simpara>If the arguments are passed by reference,
 any changes to the arguments will be reflected in the values returned by this function. As of PHP 7
-the current values will also be returned if the arguments are passed by value.</para></note>'>
+the current values will also be returned if the arguments are passed by value.</simpara></note>'>
 
-<!ENTITY note.funcnoparam '<note xmlns="http://docbook.org/ns/docbook"><para>Because this function depends on the
+<!ENTITY note.funcnoparam '<note xmlns="http://docbook.org/ns/docbook"><simpara>Because this function depends on the
 current scope to determine parameter details, it cannot be used as a
 function parameter in versions prior to 5.3.0. If this value must be passed, the results should be assigned
-to a variable, and that variable should be passed.</para></note>'>
+to a variable, and that variable should be passed.</simpara></note>'>
 
-<!ENTITY note.func-named-params '<note xmlns="http://docbook.org/ns/docbook"><para>As of PHP 8.0.0, the func_*() family of
+<!ENTITY note.func-named-params '<note xmlns="http://docbook.org/ns/docbook"><simpara>As of PHP 8.0.0, the func_*() family of
 functions is intended to be mostly transparent with regard to named arguments,
 by treating the arguments as if they were all passed positionally,
 and missing arguments are replaced with their defaults.
 This function ignores the collection of unknown named variadic arguments.
-Unknown named arguments which are collected can only be accessed through the variadic parameter.</para></note>'>
+Unknown named arguments which are collected can only be accessed through the variadic parameter.</simpara></note>'>
 
 <!ENTITY note.line-endings '<note xmlns="http://docbook.org/ns/docbook"><simpara>If PHP is not properly recognizing
 the line endings when reading files either on or created by a Macintosh
@@ -148,61 +148,61 @@ to seed the random number generator with <function>srand</function> or
 <function>mt_srand</function> as this is done automatically.
 </simpara></note>'>
 
-<!ENTITY note.is-superglobal "<note xmlns='http://docbook.org/ns/docbook'><para>This is a 'superglobal', or
+<!ENTITY note.is-superglobal "<note xmlns='http://docbook.org/ns/docbook'><simpara>This is a 'superglobal', or
 automatic global, variable. This simply means that it is available in
 all scopes throughout a script. There is no need to do
 <command>global $variable;</command> to access it within functions or methods.
-</para></note>">
+</simpara></note>">
 
-<!ENTITY note.uses-ob '<note xmlns="http://docbook.org/ns/docbook"><para>When the <parameter>return</parameter> parameter
+<!ENTITY note.uses-ob '<note xmlns="http://docbook.org/ns/docbook"><simpara>When the <parameter>return</parameter> parameter
 is used, this function uses internal output buffering so it cannot be used inside an
-<function>ob_start</function> callback function.</para></note>'>
+<function>ob_start</function> callback function.</simpara></note>'>
 
-<!ENTITY note.uses-ob-php70 '<note xmlns="http://docbook.org/ns/docbook"><para>When the <parameter>return</parameter> parameter
+<!ENTITY note.uses-ob-php70 '<note xmlns="http://docbook.org/ns/docbook"><simpara>When the <parameter>return</parameter> parameter
 is used, this function uses internal output buffering prior to PHP 7.1.0, so it cannot be used inside an
-<function>ob_start</function> callback function.</para></note>'>
+<function>ob_start</function> callback function.</simpara></note>'>
 
-<!ENTITY note.filesystem-time-res '<note xmlns="http://docbook.org/ns/docbook"><para>Note that time resolution may differ
-from one file system to another.</para></note>'>
+<!ENTITY note.filesystem-time-res '<note xmlns="http://docbook.org/ns/docbook"><simpara>Note that time resolution may differ
+from one file system to another.</simpara></note>'>
 
 <!ENTITY note.uses-autoload '<note xmlns="http://docbook.org/ns/docbook">
-<para>Using this function will use any registered
-<link linkend="language.oop5.autoload">autoloaders</link> if the class is not already known.</para></note>'>
+<simpara>Using this function will use any registered
+<link linkend="language.oop5.autoload">autoloaders</link> if the class is not already known.</simpara></note>'>
 
 <!ENTITY note.network.header.sapi '<note xmlns="http://docbook.org/ns/docbook">
-   <para>
+   <simpara>
     Headers will only be accessible and output when a SAPI that supports them
     is in use.
-   </para>
+   </simpara>
   </note>
 '>
 
 <!ENTITY note.sigchild '<note xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   If PHP has been compiled with --enable-sigchild, the return value of this function is undefined.
- </para>
+ </simpara>
 </note>
 '>
 
 <!ENTITY note.sort-unstable '<note xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   If two members compare as equal, they retain their original order.
   Prior to PHP 8.0.0, their relative order in the sorted array was undefined.
- </para>
+ </simpara>
 </note>
 '>
 
 <!ENTITY note.reset-index "<note xmlns='http://docbook.org/ns/docbook'>
- <para>
+ <simpara>
     Resets array's internal pointer to the first element.
- </para>
+ </simpara>
 </note>
 ">
 
 <!ENTITY note.resource-migration-8.0-dead-function '<note xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   This function has no effect. Prior to PHP 8.0.0, this function was used to close the resource.
- </para>
+ </simpara>
 </note>
 '>
 
@@ -234,11 +234,11 @@ the output of this function, and save it in a
 
 <!-- Warnings -->
 
-<!ENTITY warn.escapeshell '<warning xmlns="http://docbook.org/ns/docbook"><para>When allowing user-supplied data to be
+<!ENTITY warn.escapeshell '<warning xmlns="http://docbook.org/ns/docbook"><simpara>When allowing user-supplied data to be
 passed to this function, use
 <function>escapeshellarg</function> or <function>escapeshellcmd</function>
 to ensure that users cannot trick the system into executing arbitrary
-commands.</para></warning>'>
+commands.</simpara></warning>'>
 
 <!ENTITY warn.experimental '<warning xmlns="http://docbook.org/ns/docbook"><simpara>This extension is
 <emphasis>EXPERIMENTAL</emphasis>. The behaviour of this extension including
@@ -487,23 +487,23 @@ linkend="book.imap">IMAP</link>, <link linkend="book.recode">recode</link> and
 extensions cannot be used in conjunction, because they
 share the same internal symbols. Note: Yaz 2.0 and above does not suffer from this problem.</simpara></warning>'>
 
-<!ENTITY warn.install.cgi '<warning xmlns="http://docbook.org/ns/docbook"><para>A server deployed in CGI mode is open
+<!ENTITY warn.install.cgi '<warning xmlns="http://docbook.org/ns/docbook"><simpara>A server deployed in CGI mode is open
 to several possible vulnerabilities. Please read our
 <link linkend="security.cgi-bin">CGI security section</link> to learn how to
-defend yourself from such attacks.</para></warning>'>
+defend yourself from such attacks.</simpara></warning>'>
 
 <!ENTITY warn.passwordhashing '
 <warning xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   It is not recommended to use this function to secure passwords,
   due to the fast nature of this hashing algorithm. See the
   <link linkend="faq.passwords.fasthash">Password Hashing FAQ</link>
   for details and best practices.
- </para>
+ </simpara>
 </warning>
 '>
 
-<!ENTITY warn.ssl-non-standard '<warning xmlns="http://docbook.org/ns/docbook"><para>When using SSL, Microsoft IIS
+<!ENTITY warn.ssl-non-standard '<warning xmlns="http://docbook.org/ns/docbook"><simpara>When using SSL, Microsoft IIS
 will violate the protocol by closing the connection without sending a
 <literal>close_notify</literal> indicator. PHP will report this as "SSL: Fatal
 Protocol Error" when you reach the end of the data. To work around this, the
@@ -513,7 +513,7 @@ PHP can detect buggy IIS server software when you open
 the stream using the <literal>https://</literal> wrapper and will suppress the
 warning. When using <function>fsockopen</function> to create an
 <literal>ssl://</literal> socket, the developer is responsible for detecting
-and suppressing this warning.</para></warning>'>
+and suppressing this warning.</simpara></warning>'>
 
 <!ENTITY warn.undocumented.class '
 <warning xmlns="http://docbook.org/ns/docbook">
@@ -534,90 +534,90 @@ currently not documented; only its argument list is available.
      en/reference/regex/reference.xml for examples of these in action. -->
 
 <!ENTITY warn.deprecated.function.4-1-0.removed.7-0-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  This function was <emphasis>DEPRECATED</emphasis> in PHP 4.1.0, and
  <emphasis>REMOVED</emphasis> in PHP 7.0.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Alternatives to this function include:
-</para>
+</simpara>
 '>
 
 <!ENTITY warn.deprecated.feature.5-3-0.removed.7-0-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  This feature was <emphasis>DEPRECATED</emphasis> in PHP 5.3.0, and
  <emphasis>REMOVED</emphasis> in PHP 7.0.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Alternatives to this feature include:
-</para>
+</simpara>
 '>
 
 <!ENTITY warn.deprecated.function.5-3-0.removed.7-0-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  This function was <emphasis>DEPRECATED</emphasis> in PHP 5.3.0, and
  <emphasis>REMOVED</emphasis> in PHP 7.0.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Alternatives to this function include:
-</para>
+</simpara>
 '>
 
 <!ENTITY warn.deprecated.function.5-5-0.removed.7-0-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  This function was <emphasis>DEPRECATED</emphasis> in PHP 5.5.0, and
  <emphasis>REMOVED</emphasis> in PHP 7.0.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Alternatives to this function include:
-</para>
+</simpara>
 '>
 
 <!ENTITY warn.removed.feature.7-0-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  This feature was <emphasis>REMOVED</emphasis> in PHP 7.0.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Alternatives to this feature include:
-</para>
+</simpara>
 '>
 
 <!ENTITY warn.removed.function.7-0-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  This function was <emphasis>REMOVED</emphasis> in PHP 7.0.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Alternatives to this function include:
-</para>
+</simpara>
 '>
 
 <!ENTITY warn.deprecated.feature.7-1-0.removed.7-2-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  This feature was <emphasis>DEPRECATED</emphasis> in PHP 7.1.0, and
  <emphasis>REMOVED</emphasis> in PHP 7.2.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Alternatives to this feature include:
-</para>
+</simpara>
 '>
 
 <!ENTITY warn.deprecated.function.7-1-0.removed.7-2-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  This function was <emphasis>DEPRECATED</emphasis> in PHP 7.1.0, and
  <emphasis>REMOVED</emphasis> in PHP 7.2.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Alternatives to this function include:
-</para>
+</simpara>
 '>
 
 <!ENTITY warn.deprecated.function-8-1-0.alternatives '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
 <emphasis>DEPRECATED</emphasis> as of PHP 8.1.0. Relying on this function
 is highly discouraged.</simpara></warning>
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Alternatives to this function include:
-</para>
+</simpara>
 '>
 
 <!-- Misc -->
@@ -626,69 +626,69 @@ is highly discouraged.</simpara></warning>
 
 <!ENTITY version.trunk.changelog 'Future'>
 
-<!ENTITY no.function.parameters '<para xmlns="http://docbook.org/ns/docbook">This function has no parameters.</para>'>
+<!ENTITY no.function.parameters '<simpara xmlns="http://docbook.org/ns/docbook">This function has no parameters.</simpara>'>
 
-<!ENTITY example.outputs '<para xmlns="http://docbook.org/ns/docbook">The above example will output:</para>'>
+<!ENTITY example.outputs '<simpara xmlns="http://docbook.org/ns/docbook">The above example will output:</simpara>'>
 
-<!ENTITY example.outputs.5 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 5:</para>'>
+<!ENTITY example.outputs.5 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 5:</simpara>'>
 
-<!ENTITY example.outputs.53 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 5.3:</para>'>
+<!ENTITY example.outputs.53 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 5.3:</simpara>'>
 
-<!ENTITY example.outputs.54 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 5.4:</para>'>
+<!ENTITY example.outputs.54 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 5.4:</simpara>'>
 
-<!ENTITY example.outputs.55 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 5.5:</para>'>
+<!ENTITY example.outputs.55 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 5.5:</simpara>'>
 
-<!ENTITY example.outputs.56 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 5.6:</para>'>
+<!ENTITY example.outputs.56 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 5.6:</simpara>'>
 
-<!ENTITY example.outputs.7 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 7:</para>'>
+<!ENTITY example.outputs.7 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 7:</simpara>'>
 
-<!ENTITY example.outputs.70 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 7.0:</para>'>
+<!ENTITY example.outputs.70 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 7.0:</simpara>'>
 
-<!ENTITY example.outputs.71 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 7.1:</para>'>
+<!ENTITY example.outputs.71 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 7.1:</simpara>'>
 
-<!ENTITY example.outputs.72 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 7.2:</para>'>
+<!ENTITY example.outputs.72 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 7.2:</simpara>'>
 
-<!ENTITY example.outputs.73 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 7.3:</para>'>
+<!ENTITY example.outputs.73 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 7.3:</simpara>'>
 
-<!ENTITY example.outputs.8 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8:</para>'>
+<!ENTITY example.outputs.8 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8:</simpara>'>
 
-<!ENTITY example.outputs.8.similar '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8 is similar to:</para>'>
+<!ENTITY example.outputs.8.similar '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8 is similar to:</simpara>'>
 
-<!ENTITY example.outputs.80 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.0:</para>'>
+<!ENTITY example.outputs.80 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.0:</simpara>'>
 
-<!ENTITY example.outputs.81 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.1:</para>'>
+<!ENTITY example.outputs.81 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.1:</simpara>'>
 
-<!ENTITY example.outputs.82 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.2:</para>'>
+<!ENTITY example.outputs.82 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.2:</simpara>'>
 
-<!ENTITY example.outputs.82.similar '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.2 is similar to:</para>'>
+<!ENTITY example.outputs.82.similar '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.2 is similar to:</simpara>'>
 
-<!ENTITY example.outputs.83 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.3:</para>'>
+<!ENTITY example.outputs.83 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.3:</simpara>'>
 
-<!ENTITY example.outputs.83.similar '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.3 is similar to:</para>'>
+<!ENTITY example.outputs.83.similar '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.3 is similar to:</simpara>'>
 
-<!ENTITY example.outputs.84 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.4:</para>'>
+<!ENTITY example.outputs.84 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.4:</simpara>'>
 
-<!ENTITY example.outputs.84.similar '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.4 is similar to:</para>'>
+<!ENTITY example.outputs.84.similar '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.4 is similar to:</simpara>'>
 
-<!ENTITY example.outputs.85 '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.5:</para>'>
+<!ENTITY example.outputs.85 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.5:</simpara>'>
 
-<!ENTITY example.outputs.85.similar '<para xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.5 is similar to:</para>'>
+<!ENTITY example.outputs.85.similar '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.5 is similar to:</simpara>'>
 
-<!ENTITY example.outputs.32bit '<para xmlns="http://docbook.org/ns/docbook">Output of the above example on 32 bit machines:</para>'>
+<!ENTITY example.outputs.32bit '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example on 32 bit machines:</simpara>'>
 
-<!ENTITY example.outputs.64bit '<para xmlns="http://docbook.org/ns/docbook">Output of the above example on 64 bit machines:</para>'>
+<!ENTITY example.outputs.64bit '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example on 64 bit machines:</simpara>'>
 
-<!ENTITY example.outputs.similar '<para xmlns="http://docbook.org/ns/docbook">The above example will output
-something similar to:</para>'>
+<!ENTITY example.outputs.similar '<simpara xmlns="http://docbook.org/ns/docbook">The above example will output
+something similar to:</simpara>'>
 
-<!ENTITY examples.outputs '<para xmlns="http://docbook.org/ns/docbook">The above examples will output:</para>'>
+<!ENTITY examples.outputs '<simpara xmlns="http://docbook.org/ns/docbook">The above examples will output:</simpara>'>
 
-<!ENTITY examples.outputs.32bit '<para xmlns="http://docbook.org/ns/docbook">Output of the above examples on 32 bit machines:</para>'>
+<!ENTITY examples.outputs.32bit '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above examples on 32 bit machines:</simpara>'>
 
-<!ENTITY examples.outputs.64bit '<para xmlns="http://docbook.org/ns/docbook">Output of the above examples on 64 bit machines:</para>'>
+<!ENTITY examples.outputs.64bit '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above examples on 64 bit machines:</simpara>'>
 
-<!ENTITY examples.outputs.similar '<para xmlns="http://docbook.org/ns/docbook">The above examples will output
-something similar to:</para>'>
+<!ENTITY examples.outputs.similar '<simpara xmlns="http://docbook.org/ns/docbook">The above examples will output
+something similar to:</simpara>'>
 
 <!ENTITY array.resetspointer '<note xmlns="http://docbook.org/ns/docbook"><simpara>This function will
 <function>reset</function> the <type>array</type> pointer of the input array after

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1625,34 +1625,34 @@ might be different for each timezonedb release, and should not be relied upon.
 It is strongly recommended to avoid timezone abbreviations.
 </simpara>'>
 
-<!ENTITY date.timezone.errors.description '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY date.timezone.errors.description '<simpara xmlns="http://docbook.org/ns/docbook">
 Every call to a date/time function will generate a <constant>E_WARNING</constant>
-if the time zone is not valid. See also <function>date_default_timezone_set</function></para>'>
+if the time zone is not valid. See also <function>date_default_timezone_set</function></simpara>'>
 
 <!ENTITY date.timezone.errors.changelog '<row xmlns="http://docbook.org/ns/docbook"><entry>5.1.0</entry><entry><para>
 Now issues the <constant>E_STRICT</constant> and <constant>E_NOTICE</constant>
 time zone errors.</para></entry></row>'>
 
 <!ENTITY date.timestamp.description '
-<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>timestamp</parameter></term><listitem><para>
+<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>timestamp</parameter></term><listitem><simpara>
 The optional <parameter>timestamp</parameter> parameter is an
 <type>int</type> Unix timestamp that defaults to the current
 local time if <parameter>timestamp</parameter> is omitted or &null;. In other
 words, it defaults to the value of <function>time</function>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
 <!ENTITY date.datetime.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>object</parameter></term>
-<listitem><para>Procedural style only: A <classname>DateTime</classname> object
-returned by <function>date_create</function></para></listitem></varlistentry>'>
+<listitem><simpara>Procedural style only: A <classname>DateTime</classname> object
+returned by <function>date_create</function></simpara></listitem></varlistentry>'>
 
 <!ENTITY date.datetime.description.modified '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>object</parameter></term>
-<listitem><para>Procedural style only: A <classname>DateTime</classname> object
+<listitem><simpara>Procedural style only: A <classname>DateTime</classname> object
 returned by <function>date_create</function>.
-The function modifies this object.</para></listitem></varlistentry>'>
+The function modifies this object.</simpara></listitem></varlistentry>'>
 
 <!ENTITY date.datetimezone.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>object</parameter></term><listitem><para>Procedural style only: A <classname>DateTimeZone</classname> object
-returned by <function>timezone_open</function></para></listitem></varlistentry>'>
+<parameter>object</parameter></term><listitem><simpara>Procedural style only: A <classname>DateTimeZone</classname> object
+returned by <function>timezone_open</function></simpara></listitem></varlistentry>'>
 
 <!ENTITY date.datetime.return.modifiedobjectorfalseforfailure 'Returns the modified <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> object for method chaining&return.falseforfailure;.'>
 <!ENTITY date.datetime.return.modifiedobject 'Returns the modified <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> object for method chaining.'>
@@ -1681,15 +1681,15 @@ returned by <function>timezone_open</function></para></listitem></varlistentry>'
 <!ENTITY dom.node.inserted 'This node will not show up in the document unless
 it is inserted with (e.g.) <function xmlns="http://docbook.org/ns/docbook">DOMNode::appendChild</function>.'>
 
-<!ENTITY dom.malformederror '<para xmlns="http://docbook.org/ns/docbook">While malformed HTML should load successfully, this function may generate <constant>E_WARNING</constant> errors when it encounters bad markup. <link linkend="function.libxml-use-internal-errors">libxml&apos;s error handling functions</link> may be used to handle these errors.</para>'>
-<!ENTITY dom.note.utf8 '<note xmlns="http://docbook.org/ns/docbook"><para>The DOM extension uses UTF-8 encoding. Use <function>mb_convert_encoding</function>, <methodname>UConverter::transcode</methodname>, or <function>iconv</function> to handle other encodings.</para></note>'>
+<!ENTITY dom.malformederror '<simpara xmlns="http://docbook.org/ns/docbook">While malformed HTML should load successfully, this function may generate <constant>E_WARNING</constant> errors when it encounters bad markup. <link linkend="function.libxml-use-internal-errors">libxml&apos;s error handling functions</link> may be used to handle these errors.</simpara>'>
+<!ENTITY dom.note.utf8 '<note xmlns="http://docbook.org/ns/docbook"><simpara>The DOM extension uses UTF-8 encoding. Use <function>mb_convert_encoding</function>, <methodname>UConverter::transcode</methodname>, or <function>iconv</function> to handle other encodings.</simpara></note>'>
 <!ENTITY dom.note.modern.utf8 '<note xmlns="http://docbook.org/ns/docbook">
  <simpara>
   The DOM extension uses UTF-8 encoding when working with methods or properties.
   The parser methods auto-detect the encoding or allow the caller to specify an encoding.
  </simpara>
 </note>'>
-<!ENTITY dom.note.json '<note xmlns="http://docbook.org/ns/docbook"><para>When using <function>json_encode</function> on a <classname>DOMDocument</classname> object the result will be that of encoding an empty object.</para></note>'>
+<!ENTITY dom.note.json '<note xmlns="http://docbook.org/ns/docbook"><simpara>When using <function>json_encode</function> on a <classname>DOMDocument</classname> object the result will be that of encoding an empty object.</simpara></note>'>
 <!ENTITY dom.domdocument.html5 '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
   Use <classname>Dom\HTMLDocument</classname> to parse and process modern HTML
@@ -1743,7 +1743,7 @@ it is inserted with (e.g.) <function xmlns="http://docbook.org/ns/docbook">DOMNo
 
 
 <!-- Dom Examples -->
-<!ENTITY dom.book.example '<para xmlns="http://docbook.org/ns/docbook">The following examples use <filename>book.xml</filename> which contains the following:</para>
+<!ENTITY dom.book.example '<simpara xmlns="http://docbook.org/ns/docbook">The following examples use <filename>book.xml</filename> which contains the following:</simpara>
 <programlisting role="xml" xmlns="http://docbook.org/ns/docbook">
 <!-- Warning: The CDATA markup here is a little tricky. Please DO NOT BREAK it! -->
 <![CDATA[
@@ -1777,10 +1777,10 @@ it is inserted with (e.g.) <function xmlns="http://docbook.org/ns/docbook">DOMNo
 ]]></programlisting>'>
 
 <!-- Dom entities -->
-<!ENTITY dom.parameter.options '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY dom.parameter.options '<simpara xmlns="http://docbook.org/ns/docbook">
   <link linkend="language.operators.bitwise">Bitwise <literal>OR</literal></link>
   of the <link linkend="libxml.constants">libxml option constants</link>.
-</para>'>
+</simpara>'>
 
 <!ENTITY dom.parameter.compliant.options '&dom.parameter.options;
  <simpara xmlns="http://docbook.org/ns/docbook">
@@ -1807,11 +1807,11 @@ it is inserted with (e.g.) <function xmlns="http://docbook.org/ns/docbook">DOMNo
 <!ENTITY dom.parameters.register_node_ns '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>registerNodeNS</parameter></term>
  <listitem>
-  <para>
+  <simpara>
    Whether to automatically register the in-scope namespace prefixes of the context node to the <classname>DOMXPath</classname> object.
    This can be used to avoid needing to call <methodname>DOMXPath::registerNamespace</methodname> manually for each in-scope namespaces.
    When a namespace prefix conflict exists, only the nearest descendant namespace prefix is registered.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
@@ -1826,32 +1826,32 @@ it is inserted with (e.g.) <function xmlns="http://docbook.org/ns/docbook">DOMNo
 <!ENTITY dom.errors.hierarchy.parent '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><constant>DOM_HIERARCHY_REQUEST_ERR</constant></term>
   <listitem>
-  <para>
+  <simpara>
     Raised if the parent is of a type that does not allow children of the
     type of one of the passed <parameter>nodes</parameter>, or if the node to
     put in is one of this node&#39;s ancestors or this node itself.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
 <!ENTITY dom.errors.hierarchy.self '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><constant>DOM_HIERARCHY_REQUEST_ERR</constant></term>
   <listitem>
-  <para>
+  <simpara>
     Raised if this node is of a type that does not allow children of the
     type of one of the passed <parameter>nodes</parameter>, or if the node to
     put in is one of this node&#39;s ancestors or this node itself.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
 <!ENTITY dom.errors.wrong_document '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><constant>DOM_WRONG_DOCUMENT_ERR</constant></term>
   <listitem>
-  <para>
+  <simpara>
     Raised if one of the passed <parameter>nodes</parameter> was created from a different
     document than the one that created this node.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
@@ -1900,17 +1900,17 @@ it is inserted with (e.g.) <function xmlns="http://docbook.org/ns/docbook">DOMNo
  </listitem>'>
 
 <!-- FileSystem entities -->
-<!ENTITY fs.emits.warning.on.failure '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY fs.emits.warning.on.failure '<simpara xmlns="http://docbook.org/ns/docbook">
 Upon failure, an <constant>E_WARNING</constant> is emitted.
-</para>'>
+</simpara>'>
 
-<!ENTITY fs.validfp.all '<para xmlns="http://docbook.org/ns/docbook">The file pointer must be valid, and must point to
+<!ENTITY fs.validfp.all '<simpara xmlns="http://docbook.org/ns/docbook">The file pointer must be valid, and must point to
 a file successfully opened by <function>fopen</function> or
 <function>fsockopen</function> (and not yet closed by
-<function>fclose</function>).</para>'>
+<function>fclose</function>).</simpara>'>
 
-<!ENTITY fs.file.pointer '<para xmlns="http://docbook.org/ns/docbook">A file system pointer <type>resource</type>
-that is typically created using <function>fopen</function>.</para>'>
+<!ENTITY fs.file.pointer '<simpara xmlns="http://docbook.org/ns/docbook">A file system pointer <type>resource</type>
+that is typically created using <function>fopen</function>.</simpara>'>
 
 <!ENTITY fs.file.32bit '<note xmlns="http://docbook.org/ns/docbook"><simpara>
     Because PHP&apos;s integer type is signed and many platforms use 32bit integers,
@@ -1918,27 +1918,27 @@ that is typically created using <function>fopen</function>.</para>'>
     are larger than 2GB.
    </simpara></note>'>
 
-<!ENTITY ini.scanner.typed '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY ini.scanner.typed '<simpara xmlns="http://docbook.org/ns/docbook">
     As of PHP 5.6.1 can also be specified as <constant>INI_SCANNER_TYPED</constant>.
     In this mode boolean, null and integer types are preserved when possible.
     String values <literal>"true"</literal>, <literal>"on"</literal> and <literal>"yes"</literal>
     are converted to &true;. <literal>"false"</literal>, <literal>"off"</literal>, <literal>"no"</literal>
     and <literal>"none"</literal> are considered &false;. <literal>"null"</literal> is converted to &null;
     in typed mode. Also, all numeric strings are converted to integer type if it is possible.
-   </para>'>
+   </simpara>'>
 
 <!-- GNUPG -->
-<!ENTITY gnupg.identifier '<para xmlns="http://docbook.org/ns/docbook">The gnupg identifier, from a call to
-<function>gnupg_init</function> or <classname>gnupg</classname>.</para>'>
+<!ENTITY gnupg.identifier '<simpara xmlns="http://docbook.org/ns/docbook">The gnupg identifier, from a call to
+<function>gnupg_init</function> or <classname>gnupg</classname>.</simpara>'>
 
-<!ENTITY gnupg.fingerprint '<para xmlns="http://docbook.org/ns/docbook">The fingerprint key.</para>'>
+<!ENTITY gnupg.fingerprint '<simpara xmlns="http://docbook.org/ns/docbook">The fingerprint key.</simpara>'>
 
 <!-- HaruDoc -->
-<!ENTITY haru.error '<para xmlns="http://docbook.org/ns/docbook">Throws a <classname>HaruException</classname> on error.</para>'>
+<!ENTITY haru.error '<simpara xmlns="http://docbook.org/ns/docbook">Throws a <classname>HaruException</classname> on error.</simpara>'>
 
 <!-- ODBC -->
-<!ENTITY odbc.connection.id '<para xmlns="http://docbook.org/ns/docbook">The ODBC connection object,
-see <function>odbc_connect</function> for details.</para>'>
+<!ENTITY odbc.connection.id '<simpara xmlns="http://docbook.org/ns/docbook">The ODBC connection object,
+see <function>odbc_connect</function> for details.</simpara>'>
 
 <!ENTITY odbc.result.object 'The ODBC result object'>
 
@@ -2022,20 +2022,20 @@ error if the callback function cannot be called, or was not specified.'>
 <!ENTITY oauth.changelog.error.null 'Previously returned &null; on failure, instead of &false;.'>
 
 <!-- Oracle -->
-<!ENTITY oci.db "<para xmlns='http://docbook.org/ns/docbook' xmlns:xlink='http://www.w3.org/1999/xlink'>Contains
+<!ENTITY oci.db "<simpara xmlns='http://docbook.org/ns/docbook' xmlns:xlink='http://www.w3.org/1999/xlink'>Contains
 the <literal>Oracle instance</literal> to connect to. It can be
 an <link xlink:href='&url.oracle.oic.connect;'>Easy Connect
 string</link>, or a Connect Name from
 the <filename>tnsnames.ora</filename> file, or the name of a local
 Oracle instance.
-</para>
-<para xmlns='http://docbook.org/ns/docbook'>If not specified or &null;, PHP uses
+</simpara>
+<simpara xmlns='http://docbook.org/ns/docbook'>If not specified or &null;, PHP uses
 environment variables such as <constant>TWO_TASK</constant> (on Linux)
 or <constant>LOCAL</constant> (on Windows)
 and <constant>ORACLE_SID</constant> to determine the
 <literal>Oracle instance</literal> to connect to.
-</para>
-<para xmlns='http://docbook.org/ns/docbook'>
+</simpara>
+<simpara xmlns='http://docbook.org/ns/docbook'>
 To use the Easy Connect naming method, PHP must be linked with Oracle
 10<emphasis>g</emphasis> or greater Client libraries. The Easy Connect string for Oracle
 10<emphasis>g</emphasis> is of the form:
@@ -2046,32 +2046,32 @@ Further options were introduced with Oracle 19c, including timeout and keep-aliv
 settings.  Refer to Oracle documentation.  Service names can be found by running
 the Oracle utility <literal>lsnrctl status</literal> on the database server
 machine.
-</para>
-<para xmlns='http://docbook.org/ns/docbook'>
+</simpara>
+<simpara xmlns='http://docbook.org/ns/docbook'>
 The <filename>tnsnames.ora</filename> file can be in the Oracle Net search path,
 which
 includes <filename>/your/path/to/instantclient/network/admin</filename>, <filename>$ORACLE_HOME/network/admin</filename>
 and <filename>/etc</filename>.  Alternatively set <literal>TNS_ADMIN</literal>
 so that <filename>$TNS_ADMIN/tnsnames.ora</filename> is read.  Make sure the web
 daemon has read access to the file.
-</para>">
+</simpara>">
 
-<!ENTITY oci.charset "<para xmlns='http://docbook.org/ns/docbook'>Determines
+<!ENTITY oci.charset "<simpara xmlns='http://docbook.org/ns/docbook'>Determines
 the character set used by the Oracle Client libraries.  The character
 set does not need to match the character set used by the database.  If
 it doesn't match, Oracle will do its best to convert data to and from
 the database character set.  Depending on the character sets this may
 not give usable results.  Conversion also adds some time overhead.
-</para>
-<para xmlns='http://docbook.org/ns/docbook'>If not specified, the
+</simpara>
+<simpara xmlns='http://docbook.org/ns/docbook'>If not specified, the
 Oracle Client libraries determine a character set from
 the <constant>NLS_LANG</constant> environment variable.
-</para>
-<para xmlns='http://docbook.org/ns/docbook'>Passing this parameter can
+</simpara>
+<simpara xmlns='http://docbook.org/ns/docbook'>Passing this parameter can
 reduce the time taken to connect.
-</para>">
+</simpara>">
 
-<!ENTITY oci.sessionmode '<para xmlns="http://docbook.org/ns/docbook">This
+<!ENTITY oci.sessionmode '<simpara xmlns="http://docbook.org/ns/docbook">This
 parameter is available since version PHP 5 (PECL OCI8 1.1) and accepts the
 following values: <constant>OCI_DEFAULT</constant>,
 <constant>OCI_SYSOPER</constant> and <constant>OCI_SYSDBA</constant>.
@@ -2081,8 +2081,8 @@ to establish privileged connection using external credentials.
 Privileged connections are disabled by default. To enable them you
 need to set <link linkend="ini.oci8.privileged-connect">oci8.privileged_connect</link>
 to <literal>On</literal>.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
 PHP 5.3 (PECL OCI8 1.3.4) introduced the
 <constant>OCI_CRED_EXT</constant> mode value. This tells Oracle to use
 External or OS authentication, which must be configured in the
@@ -2090,16 +2090,16 @@ database.  The <constant>OCI_CRED_EXT</constant> flag can only be used
 with username of &quot;/&quot; and a empty password.
 <link linkend="ini.oci8.privileged-connect">oci8.privileged_connect</link>
 may be <literal>On</literal> or <literal>Off</literal>.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
 <constant>OCI_CRED_EXT</constant> may be combined with the
 <constant>OCI_SYSOPER</constant> or
 <constant>OCI_SYSDBA</constant> modes.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
 <constant>OCI_CRED_EXT</constant> is not supported on Windows for
 security reasons.
-</para>'>
+</simpara>'>
 
 <!ENTITY oci.datatypes '<para xmlns="http://docbook.org/ns/docbook">For details on the data type mapping performed by
 the OCI8 extension, see the <link linkend="oci8.datatypes">datatypes


### PR DESCRIPTION
It's best to check commits 1 by 1.

About 24 occurrences of `<para>` still remain. E.g because they are in a `formalpara` or have child elements.