### PR TITLE
Change 'Old adult' to 'Adult' in match.xml

### DIFF
--- a/language/control-structures/match.xml
+++ b/language/control-structures/match.xml
@@ -65,7 +65,7 @@ $output = match (true) {
     $age < 2 => "Baby",
     $age < 13 => "Child",
     $age <= 19 => "Teenager",
-    $age >= 40 => "Old adult",
+    $age >= 40 => "Adult",
     $age > 19 => "Young adult",
 };
 


### PR DESCRIPTION
Removes lightly irritating ageist language from match syntax documentation.