### PR TITLE
SNMP: add changelog for PHP 8.5 ValueError validation

### DIFF
--- a/reference/snmp/functions/snmp2-get.xml
+++ b/reference/snmp/functions/snmp2-get.xml
@@ -91,7 +91,7 @@
       <entry>8.5.0</entry>
       <entry>
        Now throws a <exceptionname>ValueError</exceptionname> when the hostname
-       is too large, contains any null byte, when the port is given but is
+   length is equal to or greater than 128 bytes, when the port is
        negative or greater than 65535, or when the timeout or retries values
        are lower than -1 or too large.
       </entry>

--- a/reference/snmp/functions/snmp2-get.xml
+++ b/reference/snmp/functions/snmp2-get.xml
@@ -76,6 +76,31 @@
   </simpara>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now throws a <exceptionname>ValueError</exceptionname> when the hostname
+       is too large, contains any null byte, when the port is given but is
+       negative or greater than 65535, or when the timeout or retries values
+       are lower than -1 or too large.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>

--- a/reference/snmp/functions/snmp2-set.xml
+++ b/reference/snmp/functions/snmp2-set.xml
@@ -114,7 +114,7 @@
       <entry>8.5.0</entry>
       <entry>
        Now throws a <exceptionname>ValueError</exceptionname> when the hostname
-       is too large, contains any null byte, when the port is given but is
+   length is equal to or greater than 128 bytes, when the port is
        negative or greater than 65535, or when the timeout or retries values
        are lower than -1 or too large.
       </entry>

--- a/reference/snmp/functions/snmp2-set.xml
+++ b/reference/snmp/functions/snmp2-set.xml
@@ -99,7 +99,30 @@
   </simpara>
  </refsect1>
 
-
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now throws a <exceptionname>ValueError</exceptionname> when the hostname
+       is too large, contains any null byte, when the port is given but is
+       negative or greater than 65535, or when the timeout or retries values
+       are lower than -1 or too large.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/snmp/functions/snmp3-get.xml
+++ b/reference/snmp/functions/snmp3-get.xml
@@ -134,6 +134,15 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now throws a <exceptionname>ValueError</exceptionname> when the hostname
+       is too large, contains any null byte, when the port is given but is
+       negative or greater than 65535, or when the timeout or retries values
+       are lower than -1 or too large.
+      </entry>
+     </row>
+     <row>
       <entry>8.1.0</entry>
       <entry>
        The <parameter>auth_protocol</parameter> now accepts <literal>"SHA256"</literal>

--- a/reference/snmp/functions/snmp3-get.xml
+++ b/reference/snmp/functions/snmp3-get.xml
@@ -137,7 +137,7 @@
       <entry>8.5.0</entry>
       <entry>
        Now throws a <exceptionname>ValueError</exceptionname> when the hostname
-       is too large, contains any null byte, when the port is given but is
+   length is equal to or greater than 128 bytes, when the port is
        negative or greater than 65535, or when the timeout or retries values
        are lower than -1 or too large.
       </entry>

--- a/reference/snmp/functions/snmp3-set.xml
+++ b/reference/snmp/functions/snmp3-set.xml
@@ -162,7 +162,7 @@
       <entry>8.5.0</entry>
       <entry>
        Now throws a <exceptionname>ValueError</exceptionname> when the hostname
-       is too large, contains any null byte, when the port is given but is
+   length is equal to or greater than 128 bytes, when the port is
        negative or greater than 65535, or when the timeout or retries values
        are lower than -1 or too large.
       </entry>

--- a/reference/snmp/functions/snmp3-set.xml
+++ b/reference/snmp/functions/snmp3-set.xml
@@ -147,6 +147,31 @@
   </simpara>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now throws a <exceptionname>ValueError</exceptionname> when the hostname
+       is too large, contains any null byte, when the port is given but is
+       negative or greater than 65535, or when the timeout or retries values
+       are lower than -1 or too large.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
    <example>

--- a/reference/snmp/functions/snmpget.xml
+++ b/reference/snmp/functions/snmpget.xml
@@ -91,7 +91,7 @@
       <entry>8.5.0</entry>
       <entry>
        Now throws a <exceptionname>ValueError</exceptionname> when the hostname
-       is too large, contains any null byte, when the port is given but is
+   length is equal to or greater than 128 bytes, when the port is
        negative or greater than 65535, or when the timeout or retries values
        are lower than -1 or too large.
       </entry>

--- a/reference/snmp/functions/snmpget.xml
+++ b/reference/snmp/functions/snmpget.xml
@@ -76,6 +76,31 @@
   </simpara>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now throws a <exceptionname>ValueError</exceptionname> when the hostname
+       is too large, contains any null byte, when the port is given but is
+       negative or greater than 65535, or when the timeout or retries values
+       are lower than -1 or too large.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>

--- a/reference/snmp/functions/snmpset.xml
+++ b/reference/snmp/functions/snmpset.xml
@@ -115,7 +115,7 @@
       <entry>8.5.0</entry>
       <entry>
        Now throws a <exceptionname>ValueError</exceptionname> when the hostname
-       is too large, contains any null byte, when the port is given but is
+   length is equal to or greater than 128 bytes, when the port is
        negative or greater than 65535, or when the timeout or retries values
        are lower than -1 or too large.
       </entry>

--- a/reference/snmp/functions/snmpset.xml
+++ b/reference/snmp/functions/snmpset.xml
@@ -100,6 +100,31 @@
   </simpara>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now throws a <exceptionname>ValueError</exceptionname> when the hostname
+       is too large, contains any null byte, when the port is given but is
+       negative or greater than 65535, or when the timeout or retries values
+       are lower than -1 or too large.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
    <example>


### PR DESCRIPTION
The SNMP fetch/set functions started throwing \`ValueError\` in PHP 8.5 on invalid
hostname / port / timeout / retries (already documented in
\`appendices/migration85/incompatible.xml\`), but the per-function changelog
entries were missing.

Adds the \`8.5.0\` row on:
- snmpget
- snmpset
- snmp2_get
- snmp2_set
- snmp3_get
- snmp3_set

Same spirit as #5528.