### PR TITLE
POSIX: add changelog entries for PHP 8.5 changes

### DIFF
--- a/reference/posix/functions/posix-fpathconf.xml
+++ b/reference/posix/functions/posix-fpathconf.xml
@@ -55,6 +55,30 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now sets <varname>last_error</varname> to <constant>EBADF</constant>
+       and raises an <constant>E_WARNING</constant> when an invalid file
+       descriptor is encountered.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="function.posix-fpathconf.example.basic">

--- a/reference/posix/functions/posix-isatty.xml
+++ b/reference/posix/functions/posix-isatty.xml
@@ -47,6 +47,13 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now raises an <constant>E_WARNING</constant> when an invalid
+       <parameter>file_descriptor</parameter> is encountered.
+      </entry>
+     </row>
+     <row>
       <entry>8.4.0</entry>
       <entry>
        Set errno (error number) to <constant>EBADF</constant> when the

--- a/reference/posix/functions/posix-kill.xml
+++ b/reference/posix/functions/posix-kill.xml
@@ -50,6 +50,31 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now throws a <exceptionname>ValueError</exceptionname> when the
+       <parameter>process_id</parameter> is lower than what the platform
+       supports or greater than what the platform supports (signed integer
+       or long range).
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/posix/functions/posix-kill.xml
+++ b/reference/posix/functions/posix-kill.xml
@@ -64,10 +64,9 @@
      <row>
       <entry>8.5.0</entry>
       <entry>
-       Now throws a <exceptionname>ValueError</exceptionname> when the
-       <parameter>process_id</parameter> is lower than what the platform
-       supports or greater than what the platform supports (signed integer
-       or long range).
+       Now throws a <exceptionname>ValueError</exceptionname> when
+       <parameter>process_id</parameter> is lower or greater than what
+       the platform supports (signed integer or long range).
       </entry>
      </row>
     </tbody>

--- a/reference/posix/functions/posix-setpgid.xml
+++ b/reference/posix/functions/posix-setpgid.xml
@@ -64,7 +64,7 @@
      <row>
       <entry>8.5.0</entry>
       <entry>
-       Now throws a <exceptionname>ValueError</exceptionname> when the
+       Now throws a <exceptionname>ValueError</exceptionname> when
        <parameter>process_id</parameter> or <parameter>process_group_id</parameter>
        is lower than zero or greater than what the platform supports.
       </entry>

--- a/reference/posix/functions/posix-setpgid.xml
+++ b/reference/posix/functions/posix-setpgid.xml
@@ -50,6 +50,30 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now throws a <exceptionname>ValueError</exceptionname> when the
+       <parameter>process_id</parameter> or <parameter>process_group_id</parameter>
+       is lower than zero or greater than what the platform supports.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/posix/functions/posix-setrlimit.xml
+++ b/reference/posix/functions/posix-setrlimit.xml
@@ -64,6 +64,31 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now throws a <exceptionname>ValueError</exceptionname> when
+       <parameter>hard_limit</parameter> or <parameter>soft_limit</parameter>
+       is lower than -1, or when <parameter>soft_limit</parameter> is greater
+       than <parameter>hard_limit</parameter>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/posix/functions/posix-ttyname.xml
+++ b/reference/posix/functions/posix-ttyname.xml
@@ -56,6 +56,13 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <varname>last_error</varname> is now set to <constant>EBADF</constant>
+       when an invalid <parameter>file_descriptor</parameter> is encountered.
+      </entry>
+     </row>
+     <row>
       <entry>8.3.0</entry>
       <entry>
        Type error <constant>E_WARNING</constant>s are now raised for integer


### PR DESCRIPTION
PHP 8.5 brings several POSIX changes already documented in
\`appendices/migration85\` but missing from the per-function changelogs.

- posix_kill: ValueError on out-of-range process_id
- posix_setpgid: ValueError on out-of-range process_id/process_group_id
- posix_setrlimit: ValueError on invalid hard_limit/soft_limit
- posix_ttyname: last_error EBADF on invalid file_descriptor
- posix_isatty: E_WARNING on invalid file_descriptor
- posix_fpathconf: last_error EBADF + E_WARNING on invalid file_descriptor

Same spirit as #5528.