### PR TITLE
Sockets: add changelog entries for PHP 8.5 changes

### DIFF
--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -44,7 +44,22 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (FreeBSD only)
+     Socket address family for the FreeBSD <literal>divert(4)</literal>
+     interface, used to receive packets diverted by the firewall.
+     Available as of PHP 8.3.0 (FreeBSD only).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.af-packet">
+   <term>
+    <constant>AF_PACKET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Socket address family for low-level packet sockets, used to send
+     and receive raw packets at the device-driver (OSI layer 2) level.
+     Available as of PHP 8.5.0 (Linux only).
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/sockets/functions/socket-addrinfo-lookup.xml
+++ b/reference/sockets/functions/socket-addrinfo-lookup.xml
@@ -74,6 +74,15 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now throws a <exceptionname>TypeError</exceptionname> if any value of
+       the <parameter>hints</parameter> array cannot be cast to int, and may
+       throw a <exceptionname>ValueError</exceptionname> if any of these
+       values overflow.
+      </entry>
+     </row>
+     <row>
       <entry>8.0.0</entry>
       <entry>
        On success, this function returns an array of <classname>AddressInfo</classname> instances now;

--- a/reference/sockets/functions/socket-bind.xml
+++ b/reference/sockets/functions/socket-bind.xml
@@ -86,6 +86,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now throws a <exceptionname>ValueError</exceptionname> when
+       <parameter>port</parameter> is lower than 0 or greater than 65535.
+      </entry>
+     </row>
      &sockets.changelog.socket-param;
     </tbody>
    </tgroup>

--- a/reference/sockets/functions/socket-create-listen.xml
+++ b/reference/sockets/functions/socket-create-listen.xml
@@ -75,6 +75,13 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now throws a <exceptionname>ValueError</exceptionname> when
+       <parameter>port</parameter> is lower than 0 or greater than 65535.
+      </entry>
+     </row>
+     <row>
       <entry>8.4.0</entry>
       <entry>
        The default value of is now <constant>SOMAXCONN</constant>.

--- a/reference/sockets/functions/socket-create.xml
+++ b/reference/sockets/functions/socket-create.xml
@@ -223,6 +223,12 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now supports creating <constant>AF_PACKET</constant> family sockets.
+      </entry>
+     </row>
+     <row>
       <entry>8.0.0</entry>
       <entry>
        On success, this function returns a <classname>Socket</classname> instance now;

--- a/reference/sockets/functions/socket-getsockname.xml
+++ b/reference/sockets/functions/socket-getsockname.xml
@@ -90,6 +90,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now retrieves the interface index and its string representation when
+       used on an <constant>AF_PACKET</constant> family socket.
+      </entry>
+     </row>
      &sockets.changelog.socket-param;
     </tbody>
    </tgroup>

--- a/reference/sockets/functions/socket-sendto.xml
+++ b/reference/sockets/functions/socket-sendto.xml
@@ -137,6 +137,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now throws a <exceptionname>ValueError</exceptionname> when
+       <parameter>port</parameter> is lower than 0 or greater than 65535.
+      </entry>
+     </row>
      &sockets.changelog.socket-param;
      <row>
       <entry>8.0.0</entry>

--- a/reference/sockets/functions/socket-set-option.xml
+++ b/reference/sockets/functions/socket-set-option.xml
@@ -90,6 +90,17 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now throws an exception when <constant>MCAST_LEAVE_GROUP</constant>
+       or <constant>MCAST_LEAVE_SOURCE_GROUP</constant> is used and the
+       value is not a valid object or array, and throws a
+       <exceptionname>ValueError</exceptionname> when a multicast option is
+       used on a socket that is not of <constant>AF_INET</constant> or
+       <constant>AF_INET6</constant> family.
+      </entry>
+     </row>
      &sockets.changelog.socket-param;
     </tbody>
    </tgroup>


### PR DESCRIPTION
PHP 8.5 brings several Sockets changes already documented in
\`appendices/migration85\` but missing from the per-function changelogs.

BC breaks:
- socket_bind, socket_create_listen, socket_sendto: ValueError on out-of-range port
- socket_addrinfo_lookup: TypeError/ValueError on hints array values
- socket_set_option: exception on multicast misuse + ValueError on non AF_INET/AF_INET6

New features:
- socket_create: AF_PACKET family support
- socket_getsockname: interface index for AF_PACKET sockets

Same spirit as #5528.