### PR TITLE
Change <para> to <simpara> in zip extension

### DIFF
--- a/reference/zip/book.xml
+++ b/reference/zip/book.xml
@@ -8,10 +8,10 @@
  <!-- {{{ preface -->
  <preface xml:id="intro.zip">
   &reftitle.intro;
-  <para>
+  <simpara>
    This extension enables you to transparently read or write ZIP compressed
    archives and the files inside them.
-  </para>
+  </simpara>
  </preface>
  <!-- }}} -->
  

--- a/reference/zip/configure.xml
+++ b/reference/zip/configure.xml
@@ -5,12 +5,12 @@
 
  <section xml:id="zip.installation.linux">
   <title>Linux systems</title>
-  <para>
+  <simpara>
    In order to use these functions PHP must be compiled with ZIP support
    by using the <option role="configure">--with-zip</option>
    configure option.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Prior to PHP 7.4.0, libzip was bundled with PHP,
    and to compile the extension one needed to use the
    <option role="configure">--enable-zip</option>
@@ -19,30 +19,30 @@
    but still possible by using the
    <option role="configure">--without-libzip</option>
    configure option.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    A <option role="configure">--with-libzip=DIR</option>
    configure option has been added to use a system libzip installation. libzip
    version 0.11 is required, with 0.11.2 or later recommended.
-  </para>
+  </simpara>
  </section>
   
  <section xml:id="zip.installation.new.windows">
   <title>Windows</title>
-  <para>
+  <simpara>
    As of PHP 8.2.0, <filename>php_zip.dll</filename> DLL must be
    <link linkend="install.pecl.windows.loading">enabled</link> in
    &php.ini;.
    Previously, this extension was built-in.
-  </para>
+  </simpara>
  </section>
 
  <section xml:id="zip.installation.pecl">
   <title>Installation via PECL</title>
-  <para>
+  <simpara>
    &pecl.info;
    <link xlink:href="&url.pecl.package;zip">&url.pecl.package;zip</link>.
-  </para>
+  </simpara>
  </section>
 
 </section>

--- a/reference/zip/constants.xml
+++ b/reference/zip/constants.xml
@@ -4,14 +4,14 @@
  &reftitle.constants;
  &extension.constants;
 
-  <para>
+  <simpara>
    <classname>ZipArchive</classname> uses class constants. 
    There are various types of constants, main are:
    Flags (prefixed with <literal>FL_</literal>),
    Global flags  (prefixed with <literal>AFL_</literal>),
    errors (prefixed with <literal>ER_</literal>) and
    mode (no prefix).
-  </para>
+  </simpara>
 
  <variablelist xml:id="ziparchive.constants.mode">
   <title>Archive open modes</title>

--- a/reference/zip/examples.xml
+++ b/reference/zip/examples.xml
@@ -78,13 +78,13 @@ print_r($odt_meta);
 ]]>
   </programlisting>
  </example>
- <para>
+ <simpara>
   This example uses the old API (PHP 4), it opens a ZIP file
   archive, reads each file in the archive and prints out its
   contents. The <filename>test2.zip</filename> archive used in this
   example is one of the test archives in the ZZIPlib source
   distribution.
- </para>
+ </simpara>
  <example>
   <title>Zip Usage Example</title>
   <programlisting role="php">

--- a/reference/zip/functions/zip-close.xml
+++ b/reference/zip/functions/zip-close.xml
@@ -18,9 +18,9 @@
    <type>void</type><methodname>zip_close</methodname>
    <methodparam><type>resource</type><parameter>zip</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Closes the given ZIP file archive.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -29,9 +29,9 @@
     <varlistentry>
      <term><parameter>zip</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        A ZIP file previously opened with <function>zip_open</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -39,9 +39,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-close.xml
+++ b/reference/zip/functions/zip-entry-close.xml
@@ -18,9 +18,9 @@
    <type>bool</type><methodname>zip_entry_close</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Closes the specified directory entry.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -29,9 +29,9 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        A directory entry previously opened <function>zip_entry_open</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -39,9 +39,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-compressedsize.xml
+++ b/reference/zip/functions/zip-entry-compressedsize.xml
@@ -18,9 +18,9 @@
    <type class="union"><type>int</type><type>false</type></type><methodname>zip_entry_compressedsize</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Returns the compressed size of the specified directory entry.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -29,9 +29,9 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        A directory entry returned by <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -39,9 +39,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The compressed size, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-compressionmethod.xml
+++ b/reference/zip/functions/zip-entry-compressionmethod.xml
@@ -18,10 +18,10 @@
    <type class="union"><type>string</type><type>false</type></type><methodname>zip_entry_compressionmethod</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Returns the compression method of the directory entry specified
    by <parameter>zip_entry</parameter>.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -30,9 +30,9 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        A directory entry returned by <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -40,9 +40,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The compression method, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-filesize.xml
+++ b/reference/zip/functions/zip-entry-filesize.xml
@@ -18,9 +18,9 @@
    <type class="union"><type>int</type><type>false</type></type><methodname>zip_entry_filesize</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Returns the actual size of the specified directory entry.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -29,9 +29,9 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        A directory entry returned by <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -39,9 +39,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The size of the directory entry, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-name.xml
+++ b/reference/zip/functions/zip-entry-name.xml
@@ -18,9 +18,9 @@
    <type class="union"><type>string</type><type>false</type></type><methodname>zip_entry_name</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Returns the name of the specified directory entry.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -29,9 +29,9 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        A directory entry returned by <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -39,9 +39,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The name of the directory entry, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-open.xml
+++ b/reference/zip/functions/zip-entry-open.xml
@@ -20,9 +20,9 @@
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>mode</parameter><initializer>"rb"</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Opens a directory entry in a zip file for reading.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -31,32 +31,32 @@
     <varlistentry>
      <term><parameter>zip_dp</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        A valid resource handle returned by <function>zip_open</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        A directory entry returned by <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>mode</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Any of the modes specified in the documentation of
        <function>fopen</function>.
-      </para>
+      </simpara>
       <note>
-       <para>
+       <simpara>
         Currently, <parameter>mode</parameter> is ignored and is always
         <literal>"rb"</literal>. This is due to the fact that zip support
         in PHP is read only access.
-       </para>
+       </simpara>
       </note>
      </listitem>
     </varlistentry>
@@ -65,16 +65,16 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
   <note>
-   <para>
+   <simpara>
     Unlike <function>fopen</function> and other similar functions,
     the return value of <function>zip_entry_open</function> only
     indicates the result of the operation and is not needed for
     reading or closing the directory entry.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/functions/zip-entry-read.xml
+++ b/reference/zip/functions/zip-entry-read.xml
@@ -19,9 +19,9 @@
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>len</parameter><initializer>1024</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Reads from an open directory entry.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -30,21 +30,21 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        A directory entry returned by <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>len</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The number of bytes to return.
-      </para>
+      </simpara>
       <note>
-       <para>
+       <simpara>
         This should be the uncompressed length you wish to read.
-       </para>
+       </simpara>
       </note>
      </listitem>
     </varlistentry>
@@ -53,9 +53,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the data read, empty string on end of a file, or &false; on error.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-open.xml
+++ b/reference/zip/functions/zip-open.xml
@@ -18,9 +18,9 @@
    <type class="union"><type>resource</type><type>int</type><type>false</type></type><methodname>zip_open</methodname>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Opens a new zip archive for reading. 
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -29,9 +29,9 @@
     <varlistentry>
      <term><parameter>filename</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The file name of the ZIP archive to open.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -39,12 +39,12 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns a resource handle for later use with
    <function>zip_read</function> and <function>zip_close</function>
    or returns either &false; or the number of error if <parameter>filename</parameter>
    does not exist or in case of other error.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-read.xml
+++ b/reference/zip/functions/zip-read.xml
@@ -18,9 +18,9 @@
    <type class="union"><type>resource</type><type>false</type></type><methodname>zip_read</methodname>
    <methodparam><type>resource</type><parameter>zip</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Reads the next entry in a zip file archive.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -29,9 +29,9 @@
     <varlistentry>
      <term><parameter>zip</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        A ZIP file previously opened with <function>zip_open</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -39,12 +39,12 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns a directory entry resource for later use with the
    <literal>zip_entry_...</literal> functions, or &false; if
    there are no more entries to read, or an error code if an error
    occurred.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/setup.xml
+++ b/reference/zip/setup.xml
@@ -7,12 +7,12 @@
  <!-- {{{ Requirements -->
  <section xml:id="zip.requirements">
   &reftitle.required;
-  <para>
+  <simpara>
    This extension requires <link xlink:href="&url.libzip;">libzip</link>. Version 1.1.2 was bundled in PHP until version 7.3.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Minimal supported version is 0.11, but higher is highly recommended.
-  </para>
+  </simpara>
   <para>
      <simplelist>
       <member>Version 1.2 required for encryption support, see <methodname>ZipArchive::setEncryptionIndex</methodname></member>
@@ -30,11 +30,11 @@
  <!-- {{{ Resources -->
  <section xml:id="zip.resources">
   &reftitle.resources;
-  <para>
+  <simpara>
    There are two resource types used in the Zip module. The first one
    is the Zip directory for the Zip archive, the second Zip Entry for
    the archive entries.
-  </para>
+  </simpara>
  </section>
  <!-- }}} -->
 

--- a/reference/zip/ziparchive.xml
+++ b/reference/zip/ziparchive.xml
@@ -9,9 +9,9 @@
 <!-- {{{ ZipArchive intro -->
   <section xml:id="ziparchive.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     A file archive, compressed with Zip.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
  
@@ -745,40 +745,40 @@
     <varlistentry xml:id="ziparchive.props.lastid">
      <term><varname>lastId</varname></term>
      <listitem>
-      <para>Index value of last added entry (file or directory).
-      Available as of PHP 8.0.0 and PECL zip 1.18.0.</para>
+      <simpara>Index value of last added entry (file or directory).
+      Available as of PHP 8.0.0 and PECL zip 1.18.0.</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.status">
      <term><varname>status</varname></term>
      <listitem>
-      <para>Status of the Zip Archive.
-      Available for closed archive, as of PHP 8.0.0 and PECL zip 1.18.0.</para>
+      <simpara>Status of the Zip Archive.
+      Available for closed archive, as of PHP 8.0.0 and PECL zip 1.18.0.</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.statussys">
      <term><varname>statusSys</varname></term>
      <listitem>
-      <para>System status of the Zip Archive.
-      Available for closed archive, as of PHP 8.0.0 and PECL zip 1.18.0.</para>
+      <simpara>System status of the Zip Archive.
+      Available for closed archive, as of PHP 8.0.0 and PECL zip 1.18.0.</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.numfiles">
      <term><varname>numFiles</varname></term>
      <listitem>
-      <para>Number of files in archive</para>
+      <simpara>Number of files in archive</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.filename">
      <term><varname>filename</varname></term>
      <listitem>
-      <para>File name in the file system</para>
+      <simpara>File name in the file system</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.comment">
      <term><varname>comment</varname></term>
      <listitem>
-      <para>Comment for the archive</para>
+      <simpara>Comment for the archive</simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/zip/ziparchive/addemptydir.xml
+++ b/reference/zip/ziparchive/addemptydir.xml
@@ -12,9 +12,9 @@
    <methodparam><type>string</type><parameter>dirname</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Adds an empty directory in the archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,22 +24,22 @@
     <varlistentry>
      <term><parameter>dirname</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The directory to add.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Bitmask consisting of
        <constant>ZipArchive::FL_ENC_GUESS</constant>,
        <constant>ZipArchive::FL_ENC_UTF_8</constant>,
        <constant>ZipArchive::FL_ENC_CP437</constant>.
        The behaviour of these constants is described on the
        <link linkend="zip.constants">ZIP constants</link> page.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -48,9 +48,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/ziparchive/addfile.xml
+++ b/reference/zip/ziparchive/addfile.xml
@@ -15,9 +15,9 @@
    <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer><constant>ZipArchive::LENGTH_TO_END</constant></initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>ZipArchive::FL_OVERWRITE</constant></initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Adds a file to a ZIP archive from a given path.
-  </para>
+  </simpara>
   &zip.filename.separator;
  </refsect1>
  <refsect1 role="parameters">
@@ -27,42 +27,42 @@
     <varlistentry>
      <term><parameter>filepath</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The path to the file to add.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>entryname</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        If supplied and not empty, this is the local name inside the ZIP archive that will override the <parameter>filepath</parameter>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>start</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        For partial copy, start position.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>length</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        For partial copy, length to be copied,
        if <constant>ZipArchive::LENGTH_TO_END</constant> (0) the file size is used,
        if <constant>ZipArchive::LENGTH_UNCHECKED</constant> the whole file is used
        (starting from <parameter>start</parameter>).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Bitmask consisting of
        <constant>ZipArchive::FL_OVERWRITE</constant>,
        <constant>ZipArchive::FL_ENC_GUESS</constant>,
@@ -71,7 +71,7 @@
        <constant>ZipArchive::FL_OPEN_FILE_NOW</constant>.
        The behaviour of these constants is described on the
        <link linkend="zip.constants">ZIP constants</link> page.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -80,9 +80,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -123,12 +123,12 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      This example opens a ZIP file archive
      <filename>test.zip</filename> and add
      the file <filename>/path/to/index.txt</filename>.
      as <filename>newname.txt</filename>.
-    </para>
+    </simpara>
     <example>
      <title>Open and add</title>
      <programlisting role="php">
@@ -151,14 +151,14 @@ if ($zip->open('test.zip') === TRUE) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     When a file is set to be added to the archive, PHP will lock the file. The
     lock is only released once the <classname>ZipArchive</classname> object
     has been closed, either via <methodname>ZipArchive::close</methodname> or
     the <classname>ZipArchive</classname> object being destroyed. This may
     prevent you from being able to delete the file being added until after the
     lock has been released.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/addfromstring.xml
+++ b/reference/zip/ziparchive/addfromstring.xml
@@ -13,9 +13,9 @@
    <methodparam><type>string</type><parameter>content</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>ZipArchive::FL_OVERWRITE</constant></initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Add a file to a ZIP archive using its contents.
-  </para>
+  </simpara>
   &zip.filename.separator;
  </refsect1>
  <refsect1 role="parameters">
@@ -25,24 +25,24 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The name of the entry to create.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>content</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The contents to use to create the entry. It is used in a binary
        safe mode.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Bitmask consisting of
        <constant>ZipArchive::FL_OVERWRITE</constant>,
        <constant>ZipArchive::FL_ENC_GUESS</constant>,
@@ -50,7 +50,7 @@
        <constant>ZipArchive::FL_ENC_CP437</constant>.
        The behaviour of these constants is described on the
        <link linkend="zip.constants">ZIP constants</link> page.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -58,9 +58,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/ziparchive/addglob.xml
+++ b/reference/zip/ziparchive/addglob.xml
@@ -14,9 +14,9 @@
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>[]</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Add files from a directory which match the glob <parameter>pattern</parameter>.
-  </para>
+  </simpara>
   &zip.filename.separator;
  </refsect1>
 
@@ -26,17 +26,17 @@
    <varlistentry>
     <term><parameter>pattern</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       A <function>glob</function> pattern against which files will be matched.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>flags</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       A bit mask of <literal>glob()</literal> flags.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -46,37 +46,37 @@
       An associative array of options. Available options are:
       <itemizedlist>
        <listitem>
-        <para>
+        <simpara>
          <literal>"add_path"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Prefix to prepend when translating to the local path of the file within
          the archive. This is applied after any remove operations defined by the
          <literal>"remove_path"</literal> or <literal>"remove_all_path"</literal>
          options.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"remove_path"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Prefix to remove from matching file paths before adding to the archive.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"remove_all_path"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          &true; to use the file name only and add to the root of the archive.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"flags"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Bitmask consisting of
          <constant>ZipArchive::FL_OVERWRITE</constant>,
          <constant>ZipArchive::FL_ENC_GUESS</constant>,
@@ -85,41 +85,41 @@
          <constant>ZipArchive::FL_OPEN_FILE_NOW</constant>.
          The behaviour of these constants is described on the
          <link linkend="zip.constants">ZIP constants</link> page.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"comp_method"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Compression method, one of the <constant>ZipArchive::CM_<replaceable>*</replaceable></constant>
          constants.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"comp_flags"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Compression level.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"enc_method"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Encryption method, one of the <constant>ZipArchive::EM_<replaceable>*</replaceable></constant>
          constants.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"enc_password"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Password used for encryption.
-        </para>
+        </simpara>
        </listitem>
       </itemizedlist>
      </para>
@@ -130,9 +130,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    An <type>array</type> of added files on success &return.falseforfailure;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -177,9 +177,9 @@
   &reftitle.examples;
   <example xml:id="ziparchive.addglob.example.basic">
    <title><methodname>ZipArchive::addGlob</methodname> example</title>
-   <para>
+   <simpara>
      Add all php scripts and text files from current working directory
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/zip/ziparchive/addpattern.xml
+++ b/reference/zip/ziparchive/addpattern.xml
@@ -14,10 +14,10 @@
    <methodparam choice="opt"><type>string</type><parameter>path</parameter><initializer>"."</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>[]</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Add files from a directory which match the regular expression <parameter>pattern</parameter>.
    The operation is not recursive. The pattern will be matched against the file name only.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,25 +26,25 @@
    <varlistentry>
     <term><parameter>pattern</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       A <link linkend="book.pcre">PCRE</link> pattern against which files will be matched.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>path</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       The directory that will be scanned. Defaults to the current working directory.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>options</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       An associative array of options accepted by <methodname>ZipArchive::addGlob</methodname>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -52,18 +52,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    An <type>array</type> of added files on success &return.falseforfailure;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="ziparchive.addpattern.example.basic">
    <title><methodname>ZipArchive::addPattern</methodname> example</title>
-   <para>
+   <simpara>
      Add all php scripts and text files from current directory
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/zip/ziparchive/clearerror.xml
+++ b/reference/zip/ziparchive/clearerror.xml
@@ -11,9 +11,9 @@
    <modifier>public</modifier> <type>void</type><methodname>ZipArchive::clearError</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Clear the status error message, system and/or zip messages.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -23,9 +23,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/zip/ziparchive/close.xml
+++ b/reference/zip/ziparchive/close.xml
@@ -11,16 +11,16 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::close</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Close opened or created archive and save changes. This method is
    automatically called at the end of the script.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    If the archive contains no files, the file is completely removed by default
    (no empty archive is written) according to the value of the
    <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
    global flag.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -30,9 +30,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/zip/ziparchive/count.xml
+++ b/reference/zip/ziparchive/count.xml
@@ -21,9 +21,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the number of files in the archive.
-  </para>
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/reference/zip/ziparchive/deleteindex.xml
+++ b/reference/zip/ziparchive/deleteindex.xml
@@ -11,9 +11,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::deleteIndex</methodname>
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Delete an entry in the archive using its index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -22,9 +22,9 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index of the entry to delete.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -32,9 +32,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/deletename.xml
+++ b/reference/zip/ziparchive/deletename.xml
@@ -11,9 +11,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::deleteName</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Delete an entry in the archive using its name.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -22,9 +22,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Name of the entry to delete.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -32,9 +32,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/extractto.xml
+++ b/reference/zip/ziparchive/extractto.xml
@@ -12,23 +12,23 @@
    <methodparam><type>string</type><parameter>pathto</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>string</type><type>null</type></type><parameter>files</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Extract the complete archive or the given files to the specified
    destination.
-  </para>
+  </simpara>
   <warning>
-   <para>
+   <simpara>
     The default permissions for extracted files and directories
     give the widest possible access. This can be restricted
     by setting the current umask, which can be changed using
     <function>umask</function>.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     For security reasons, the original permissions are not restored.
     For an example of how to restore them, see the
     <link linkend="ziparchive.getexternalattributesindex.examples.perms">code sample</link>
     on the <methodname>ZipArchive::getExternalAttributesIndex</methodname> page.
-   </para>
+   </simpara>
   </warning>
  </refsect1>
  <refsect1 role="parameters">
@@ -38,18 +38,18 @@
     <varlistentry>
      <term><parameter>pathto</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Location where to extract the files.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>files</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The entries to extract. It accepts either a single entry name or
        an array of names.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -57,9 +57,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getarchivecomment.xml
+++ b/reference/zip/ziparchive/getarchivecomment.xml
@@ -11,9 +11,9 @@
    <modifier>public</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>ZipArchive::getArchiveComment</methodname>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Returns the Zip archive comment.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -23,10 +23,10 @@
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        If flags is set to <constant>ZipArchive::FL_UNCHANGED</constant>, the original unchanged
        comment is returned.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the Zip archive comment&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/zip/ziparchive/getarchiveflag.xml
+++ b/reference/zip/ziparchive/getarchiveflag.xml
@@ -12,9 +12,9 @@
    <methodparam><type>int</type><parameter>flag</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Returns a Zip archive global flag value.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,24 +28,24 @@
        The global flag to retrieve, among <literal>AFL_*</literal> constants:
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_RDONLY</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_IS_TORRENTZIP</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_WANT_TORRENTZIP</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -54,10 +54,10 @@
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        If <parameter>flags</parameter> is set to <constant>ZipArchive::FL_UNCHANGED</constant>,
        the original unchanged flag is returned.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -66,9 +66,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns 1 if flag is set for archive, 0 if not, and -1 if an error occurred.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/zip/ziparchive/getcommentindex.xml
+++ b/reference/zip/ziparchive/getcommentindex.xml
@@ -12,9 +12,9 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Returns the comment of an entry using the entry index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,18 +23,18 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index of the entry
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        If flags is set to <constant>ZipArchive::FL_UNCHANGED</constant>, the original unchanged
        comment is returned.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,9 +42,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the comment on success&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getcommentname.xml
+++ b/reference/zip/ziparchive/getcommentname.xml
@@ -12,9 +12,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Returns the comment of an entry using the entry name.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,18 +23,18 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Name of the entry
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        If flags is set to <constant>ZipArchive::FL_UNCHANGED</constant>, the original unchanged
        comment is returned.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,9 +42,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the comment on success&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getexternalattributesindex.xml
+++ b/reference/zip/ziparchive/getexternalattributesindex.xml
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter role="reference">attr</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retrieve the external attributes of an entry defined by its index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,34 +25,34 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index of the entry.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>opsys</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        On success, receive the operating system code defined by one of the ZipArchive::OPSYS_ constants.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>attr</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        On success, receive the external attributes. Value depends on operating system.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        If flags is set to <constant>ZipArchive::FL_UNCHANGED</constant>, the original unchanged
        attributes are returned.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -60,17 +60,17 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
       This example extract all the entries of a ZIP
       archive <filename>test.zip</filename> and 
       set the Unix rights from external attributes.
-    </para>
+    </simpara>
     <example xml:id="ziparchive.getexternalattributesindex.examples.perms">
      <title>Extract all entries with Unix rights</title>
      <programlisting role="php">

--- a/reference/zip/ziparchive/getexternalattributesname.xml
+++ b/reference/zip/ziparchive/getexternalattributesname.xml
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter role="reference">attr</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retrieve the external attributes of an entry defined by its name.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,34 +25,34 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Name of the entry.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>opsys</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        On success, receive the operating system code defined by one of the ZipArchive::OPSYS_ constants.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>attr</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        On success, receive the external attributes. Value depends on operating system.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        If flags is set to <constant>ZipArchive::FL_UNCHANGED</constant>, the original unchanged
        attributes are returned.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -60,9 +60,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/getfromindex.xml
+++ b/reference/zip/ziparchive/getfromindex.xml
@@ -13,9 +13,9 @@
    <methodparam choice="opt"><type>int</type><parameter>len</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Returns the entry contents using its index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,18 +24,18 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index of the entry
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>len</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The length to be read from the entry. If <literal>0</literal>, then the
        entire entry is read.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -46,14 +46,14 @@
        be ORed to it.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_UNCHANGED</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_COMPRESSED</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -64,9 +64,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the contents of the entry on success&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getfromname.xml
+++ b/reference/zip/ziparchive/getfromname.xml
@@ -13,9 +13,9 @@
    <methodparam choice="opt"><type>int</type><parameter>len</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Returns the entry contents using its name.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,18 +24,18 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Name of the entry
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>len</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The length to be read from the entry. If <literal>0</literal>, then the
        entire entry is read.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -46,19 +46,19 @@
        be ORed.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_UNCHANGED</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_COMPRESSED</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NOCASE</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -69,9 +69,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the contents of the entry on success&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getnameindex.xml
+++ b/reference/zip/ziparchive/getnameindex.xml
@@ -12,9 +12,9 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Returns the name of an entry using its index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,18 +23,18 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index of the entry.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        If flags is set to <constant>ZipArchive::FL_UNCHANGED</constant>, the original unchanged
        name is returned.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,9 +42,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the name on success&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getstatusstring.xml
+++ b/reference/zip/ziparchive/getstatusstring.xml
@@ -11,9 +11,9 @@
    <modifier>public</modifier> <type>string</type><methodname>ZipArchive::getStatusString</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Returns the status error message, system and/or zip messages.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -23,9 +23,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns a <type>string</type> with the status message.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/ziparchive/getstream.xml
+++ b/reference/zip/ziparchive/getstream.xml
@@ -11,10 +11,10 @@
    <modifier>public</modifier> <type class="union"><type>resource</type><type>false</type></type><methodname>ZipArchive::getStream</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Get a file handler to the entry defined by its name. For now, it only
    supports read operations.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,9 +23,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The name of the entry to use.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -33,9 +33,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns a file pointer (resource) on success&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getstreamindex.xml
+++ b/reference/zip/ziparchive/getstreamindex.xml
@@ -12,10 +12,10 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Get a file handler to the entry defined by its index. For now, it only
    supports read operations.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,18 +24,18 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index of the entry
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        If flags is set to <constant>ZipArchive::FL_UNCHANGED</constant>, the original unchanged
        stream is returned.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -43,9 +43,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns a file pointer (resource) on success&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getstreamname.xml
+++ b/reference/zip/ziparchive/getstreamname.xml
@@ -12,10 +12,10 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Get a file handler to the entry defined by its name. For now, it only
    supports read operations.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,18 +24,18 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The name of the entry to use.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        If flags is set to <constant>ZipArchive::FL_UNCHANGED</constant>, the original unchanged
        stream is returned.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -43,9 +43,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns a file pointer (resource) on success&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/iscompressionmethoddupported.xml
+++ b/reference/zip/ziparchive/iscompressionmethoddupported.xml
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>enc</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Check if a compression method is supported by libzip.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,18 +25,18 @@
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The compression method, one of the
        <constant>ZipArchive::CM_<replaceable>*</replaceable></constant> constants.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>enc</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        If &true; check for compression, else check for decompression.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -45,17 +45,17 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     This function is only available if built against libzip ≥ 1.7.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/isencryptionmethoddupported.xml
+++ b/reference/zip/ziparchive/isencryptionmethoddupported.xml
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>enc</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Check if a compression method is supported by libzip.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,18 +25,18 @@
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The encryption method, one of the
        <constant>ZipArchive::EM_<replaceable>*</replaceable></constant> constants.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>enc</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        If &true; check for encryption, else check for decryption.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -45,17 +45,17 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     This function is only available if built against libzip ≥ 1.7.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/locatename.xml
+++ b/reference/zip/ziparchive/locatename.xml
@@ -12,9 +12,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Locates an entry using its name.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,9 +23,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The name of the entry to look up
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -36,14 +36,14 @@
        or 0 for none of them.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NOCASE</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NODIR</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -54,9 +54,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the index of the entry on success&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/open.xml
+++ b/reference/zip/ziparchive/open.xml
@@ -12,12 +12,12 @@
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Opens a new or existing zip archive for reading, writing or modifying.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Since libzip 1.6.0, an empty file is not a valid archive any longer.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -26,9 +26,9 @@
     <varlistentry>
      <term><parameter>filename</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The file name of the ZIP archive to open.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -38,29 +38,29 @@
        The mode to use to open the archive.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::OVERWRITE</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::CREATE</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::RDONLY</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::EXCL</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::CHECKCONS</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>

--- a/reference/zip/ziparchive/registercancelcallback.xml
+++ b/reference/zip/ziparchive/registercancelcallback.xml
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::registerCancelCallback</methodname>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Register a <parameter>callback</parameter> function to allow cancellation during archive close. 
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +24,9 @@
     <varlistentry>
      <term><parameter>callback</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        If this function return 0 operation will continue, other value it will be cancelled.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -35,18 +35,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      This example creates a ZIP file archive
      <filename>php.zip</filename> and cancel
      operation on some run condition.
-    </para>
+    </simpara>
     <example>
      <title>Archive a file</title>
      <programlisting role="php">
@@ -68,9 +68,9 @@ if ($zip->open('php.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     This function is only available if built against libzip ≥ 1.6.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/registerprogresscallback.xml
+++ b/reference/zip/ziparchive/registerprogresscallback.xml
@@ -13,9 +13,9 @@
    <methodparam><type>float</type><parameter>rate</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Register a <parameter>callback</parameter> function to provide updates during archive close. 
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,17 +25,17 @@
     <varlistentry>
      <term><parameter>rate</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Change between each call of the callback (from 0.0 to 1.0).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>callback</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        This function will receive the current <parameter>state</parameter> as a <type>float</type> (from 0.0 to 1.0).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -44,18 +44,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      This example creates a ZIP file archive
      <filename>php.zip</filename> and show
      progression.
-    </para>
+    </simpara>
     <example>
      <title>Archive a file</title>
      <programlisting role="php">
@@ -76,9 +76,9 @@ if ($zip->open('php.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     This function is only available if built against libzip ≥ 1.3.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/renameindex.xml
+++ b/reference/zip/ziparchive/renameindex.xml
@@ -12,9 +12,9 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam><type>string</type><parameter>new_name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Renames an entry defined by its index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,17 +23,17 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index of the entry to rename.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>new_name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        New name.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -41,9 +41,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/renamename.xml
+++ b/reference/zip/ziparchive/renamename.xml
@@ -12,9 +12,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam><type>string</type><parameter>new_name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Renames an entry defined by its name.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,17 +23,17 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Name of the entry to rename.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>new_name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        New name.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -41,9 +41,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/replacefile.xml
+++ b/reference/zip/ziparchive/replacefile.xml
@@ -15,9 +15,9 @@
    <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer><constant>ZipArchive::LENGTH_TO_END</constant></initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Replace file in ZIP archive with a given path.
-  </para>
+  </simpara>
   &zip.filename.separator;
  </refsect1>
  <refsect1 role="parameters">
@@ -27,42 +27,42 @@
     <varlistentry>
      <term><parameter>filepath</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The path to the file to add.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The index of the file to be replaced, its name is unchanged.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>start</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        For partial copy, start position.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>length</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        For partial copy, length to be copied,
        if <constant>ZipArchive::LENGTH_TO_END</constant> (0) the file size is used,
        if <constant>ZipArchive::LENGTH_UNCHECKED</constant> the whole file is used
        (starting from <parameter>start</parameter>).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Bitmask consisting of
        <constant>ZipArchive::FL_ENC_GUESS</constant>,
        <constant>ZipArchive::FL_ENC_UTF_8</constant>,
@@ -70,7 +70,7 @@
        <constant>ZipArchive::FL_OPEN_FILE_NOW</constant>.
        The behaviour of these constants is described on the
        <link linkend="zip.constants">ZIP constants</link> page.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -79,9 +79,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -116,11 +116,11 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      This example opens a ZIP file archive
      <filename>test.zip</filename> and replaces index 1 entry
      with <filename>/path/to/index.txt</filename>.
-    </para>
+    </simpara>
     <example>
      <title>Open and replace</title>
      <programlisting role="php">

--- a/reference/zip/ziparchive/setarchivecomment.xml
+++ b/reference/zip/ziparchive/setarchivecomment.xml
@@ -11,9 +11,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::setArchiveComment</methodname>
    <methodparam><type>string</type><parameter>comment</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Set the comment of a ZIP archive.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -22,9 +22,9 @@
     <varlistentry>
      <term><parameter>comment</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The contents of the comment.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -32,9 +32,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setarchiveflag.xml
+++ b/reference/zip/ziparchive/setarchiveflag.xml
@@ -12,9 +12,9 @@
    <methodparam><type>int</type><parameter>flag</parameter></methodparam>
    <methodparam><type>int</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Set a global flag of a ZIP archive.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -27,14 +27,14 @@
        The global flag to change, among <literal>AFL_*</literal> constants.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_WANT_TORRENTZIP</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -43,9 +43,9 @@
     <varlistentry>
      <term><parameter>value</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The new value of the flag.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -54,9 +54,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/zip/ziparchive/setcommentindex.xml
+++ b/reference/zip/ziparchive/setcommentindex.xml
@@ -12,9 +12,9 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam><type>string</type><parameter>comment</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Set the comment of an entry defined by its index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,17 +23,17 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index of the entry.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>comment</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The contents of the comment.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -41,9 +41,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setcommentname.xml
+++ b/reference/zip/ziparchive/setcommentname.xml
@@ -12,9 +12,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam><type>string</type><parameter>comment</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Set the comment of an entry defined by its name.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,17 +23,17 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Name of the entry.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>comment</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The contents of the comment.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -41,9 +41,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setcompressionindex.xml
+++ b/reference/zip/ziparchive/setcompressionindex.xml
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>compflags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Set the compression method of an entry defined by its index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,26 +24,26 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index of the entry.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The compression method, one of the
        <constant>ZipArchive::CM_<replaceable>*</replaceable></constant> constants.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>compflags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Compression level.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -51,9 +51,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setcompressionname.xml
+++ b/reference/zip/ziparchive/setcompressionname.xml
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>compflags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Set the compression method of an entry defined by its name.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,26 +24,26 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Name of the entry.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The compression method, one of the
        <constant>ZipArchive::CM_<replaceable>*</replaceable></constant> constants.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>compflags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Compression level.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -51,9 +51,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setencryptionindex.xml
+++ b/reference/zip/ziparchive/setencryptionindex.xml
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>string</type><type>null</type></type><parameter>password</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Set the encryption method of an entry defined by its index.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,25 +26,25 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index of the entry.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The encryption method defined by one of the ZipArchive::EM_ constants.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>password</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Optional password, default used when missing.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -53,9 +53,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -83,9 +83,9 @@
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     This function is only available if built against libzip ≥ 1.2.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/setencryptionname.xml
+++ b/reference/zip/ziparchive/setencryptionname.xml
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>string</type><type>null</type></type><parameter>password</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Set the encryption method of an entry defined by its name.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,25 +24,25 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Name of the entry.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The encryption method defined by one of the ZipArchive::EM_ constants.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>password</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Optional password, default used when missing.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -50,9 +50,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -79,12 +79,12 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      This example creates a ZIP file archive
      <filename>test.zip</filename> and add
      the file <filename>test.txt</filename>
      encrypted using the AES 256 method.
-    </para>
+    </simpara>
     <example>
      <title>Archive and encrypt a file</title>
      <programlisting role="php">
@@ -109,9 +109,9 @@ if ($zip->open('test.zip', ZipArchive::CREATE) === TRUE) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     This function is only available if built against libzip ≥ 1.2.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/setexternalattributesindex.xml
+++ b/reference/zip/ziparchive/setexternalattributesindex.xml
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>attr</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Set the external attributes of an entry defined by its index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,33 +25,33 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index of the entry.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>opsys</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The operating system code defined by one of the ZipArchive::OPSYS_ constants.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>attr</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The external attributes. Value depends on operating system.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Optional flags. Currently unused.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -59,9 +59,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/setexternalattributesname.xml
+++ b/reference/zip/ziparchive/setexternalattributesname.xml
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>attr</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Set the external attributes of an entry defined by its name.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,33 +25,33 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Name of the entry.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>opsys</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The operating system code defined by one of the ZipArchive::OPSYS_ constants.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>attr</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The external attributes. Value depends on operating system.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Optional flags. Currently unused.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -59,18 +59,18 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      This example opens a ZIP file archive
      <filename>test.zip</filename> and add
      the file <filename>test.txt</filename>
      with its Unix rights as external attributes.
-    </para>
+    </simpara>
     <example>
      <title>Archive a file, with its Unix rights</title>
      <programlisting role="php">

--- a/reference/zip/ziparchive/setmtimeindex.xml
+++ b/reference/zip/ziparchive/setmtimeindex.xml
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>timestamp</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Set the modification time of an entry defined by its index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,25 +24,25 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index of the entry.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>timestamp</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The modification time (unix timestamp) of the file.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Optional flags, unused for now.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -50,19 +50,19 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      This example creates a ZIP file archive
      <filename>test.zip</filename> and add
      the file <filename>test.txt</filename>
      with its modification date.
-    </para>
+    </simpara>
     <example>
      <title>Archive a file</title>
      <programlisting role="php">
@@ -86,9 +86,9 @@ if ($zip->open('test.zip', ZipArchive::CREATE) === TRUE) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     This function is only available if built against libzip ≥ 1.0.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/setmtimename.xml
+++ b/reference/zip/ziparchive/setmtimename.xml
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>timestamp</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Set the modification time of an entry defined by its name.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,25 +24,25 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Name of the entry.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>timestamp</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The modification time (unix timestamp) of the file.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Optional flags, unused for now.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -50,19 +50,19 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      This example creates a ZIP file archive
      <filename>test.zip</filename> and add
      the file <filename>test.txt</filename>
      with its modification date.
-    </para>
+    </simpara>
     <example>
      <title>Archive a file</title>
      <programlisting role="php">
@@ -86,9 +86,9 @@ if ($zip->open('test.zip', ZipArchive::CREATE) === TRUE) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     This function is only available if built against libzip ≥ 1.0.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/setpassword.xml
+++ b/reference/zip/ziparchive/setpassword.xml
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::setPassword</methodname>
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>password</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Sets the password for the active archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -23,9 +23,9 @@
    <varlistentry>
     <term><parameter>password</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       The password to be used for the archive.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -33,22 +33,22 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     As of PHP 7.2.0 and libzip 1.2.0 the password is used to decompress the archive,
     and is also the default password for <methodname>ZipArchive::setEncryptionName</methodname>
     and <methodname>ZipArchive::setEncryptionIndex</methodname>.
     Formerly, this function only set the password to be used to decompress the archive;
     it did not turn a non-password-protected <classname>ZipArchive</classname>
     into a password-protected <classname>ZipArchive</classname>.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/statindex.xml
+++ b/reference/zip/ziparchive/statindex.xml
@@ -12,10 +12,10 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     The  function  obtains  information  about the entry defined by its
     index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,19 +24,19 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index of the entry
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        <constant>ZipArchive::FL_UNCHANGED</constant> may be ORed to it to request
        information  about  the  original  file  in  the archive,
        ignoring any changes made.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -44,9 +44,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns an array containing the entry details&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/statname.xml
+++ b/reference/zip/ziparchive/statname.xml
@@ -12,10 +12,10 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     The function obtains information about the entry defined by its
     name.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,9 +24,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Name of the entry
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -39,19 +39,19 @@
        ignoring any changes made.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NOCASE</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NODIR</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_UNCHANGED</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -62,9 +62,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns an array containing the entry details &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/unchangeall.xml
+++ b/reference/zip/ziparchive/unchangeall.xml
@@ -11,9 +11,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::unchangeAll</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Undo all changes done in the archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -23,9 +23,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/unchangearchive.xml
+++ b/reference/zip/ziparchive/unchangearchive.xml
@@ -11,10 +11,10 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::unchangeArchive</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Revert all global changes to the archive.  For now, this
    only reverts archive comment changes.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +24,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/unchangeindex.xml
+++ b/reference/zip/ziparchive/unchangeindex.xml
@@ -11,9 +11,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::unchangeIndex</methodname>
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Revert all changes done to an entry at the given index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -22,9 +22,9 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index of the entry.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -32,9 +32,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/unchangename.xml
+++ b/reference/zip/ziparchive/unchangename.xml
@@ -11,9 +11,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::unchangeName</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Revert all changes done to an entry.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -22,9 +22,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Name of the entry.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -32,9 +32,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Same conversion as #5522 but on the `zip` extension. Replaces `<para>` with `<simpara>` everywhere the content is purely inline; the 112 remaining `<para>` are kept because they wrap block children (`<example>`, `<programlisting>`, `<itemizedlist>`, `<note>`, `<variablelist>`, etc.) which `<simpara>` cannot contain. Recursion into nested paras is handled, so inner paras inside a kept outer para are converted when eligible.

68 files touched, 318 conversions, no semantic change.