### PR TITLE
Use constants for int mask combinations of `debug_backtrace()`

### DIFF
--- a/reference/errorfunc/functions/debug-backtrace.xml
+++ b/reference/errorfunc/functions/debug-backtrace.xml
@@ -67,13 +67,13 @@
              <entry><code>debug_backtrace(1)</code></entry>
             </row>
             <row>
-             <entry><code>debug_backtrace(0)</code></entry>
+             <entry><code>debug_backtrace(~DEBUG_BACKTRACE_PROVIDE_OBJECT)</code></entry>
              <entry morerows="1" valign="middle">
               Omits index <literal>"object"</literal> and populates index <literal>"args"</literal>.
              </entry>
             </row>
             <row>
-             <entry><code>debug_backtrace(~DEBUG_BACKTRACE_PROVIDE_OBJECT)</code></entry>
+             <entry><code>debug_backtrace(0)</code></entry>
             </row>
             <row>
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
@@ -82,10 +82,10 @@
              </entry>
             </row>
             <row>
-             <entry><code>debug_backtrace(2)</code></entry>
+             <entry><code>debug_backtrace(~DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
             </row>
             <row>
-             <entry><code>debug_backtrace(~DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
+             <entry><code>debug_backtrace(2)</code></entry>
             </row>
             <row>
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT|DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>

--- a/reference/errorfunc/functions/debug-backtrace.xml
+++ b/reference/errorfunc/functions/debug-backtrace.xml
@@ -56,15 +56,12 @@
            <tbody>
             <row>
              <entry><code>debug_backtrace()</code></entry>
-             <entry morerows="2" valign="middle">
+             <entry morerows="1" valign="middle">
               Populates both indexes
              </entry>
             </row>
             <row>
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT)</code></entry>
-            </row>
-            <row>
-             <entry><code>debug_backtrace(1)</code></entry>
             </row>
             <row>
              <entry><code>debug_backtrace(~DEBUG_BACKTRACE_PROVIDE_OBJECT)</code></entry>
@@ -77,7 +74,7 @@
             </row>
             <row>
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
-             <entry morerows="2" valign="middle">
+             <entry morerows="1" valign="middle">
               Omits <emphasis>both</emphasis> index <literal>"object"</literal> <emphasis>and</emphasis> index <literal>"args"</literal>.
              </entry>
             </row>
@@ -85,16 +82,10 @@
              <entry><code>debug_backtrace(~DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
             </row>
             <row>
-             <entry><code>debug_backtrace(2)</code></entry>
-            </row>
-            <row>
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT|DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
-             <entry morerows="1" valign="middle">
+             <entry valign="middle">
               Populate index <literal>"object"</literal> <emphasis>and</emphasis> omit index <literal>"args"</literal>.
              </entry>
-            </row>
-            <row>
-             <entry><code>debug_backtrace(3)</code></entry>
             </row>
            </tbody>
           </tgroup>

--- a/reference/errorfunc/functions/debug-backtrace.xml
+++ b/reference/errorfunc/functions/debug-backtrace.xml
@@ -78,7 +78,7 @@
             <row>
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
              <entry morerows="2" valign="middle">
-              Omits both index <literal>"object"</literal> <emphasis>and</emphasis> index <literal>"args"</literal>.
+              Omits index <literal>"object"</literal> <emphasis>and</emphasis> index <literal>"args"</literal>.
              </entry>
             </row>
             <row>

--- a/reference/errorfunc/functions/debug-backtrace.xml
+++ b/reference/errorfunc/functions/debug-backtrace.xml
@@ -68,18 +68,24 @@
             </row>
             <row>
              <entry><code>debug_backtrace(0)</code></entry>
-             <entry valign="middle">
+             <entry morerows="1" valign="middle">
               Omits index <literal>"object"</literal> and populates index <literal>"args"</literal>.
              </entry>
             </row>
             <row>
+             <entry><code>debug_backtrace(~DEBUG_BACKTRACE_PROVIDE_OBJECT)</code></entry>
+            </row>
+            <row>
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
-             <entry morerows="1" valign="middle">
-              Omits index <literal>"object"</literal> <emphasis>and</emphasis> index <literal>"args"</literal>.
+             <entry morerows="2" valign="middle">
+              Omits both index <literal>"object"</literal> <emphasis>and</emphasis> index <literal>"args"</literal>.
              </entry>
             </row>
             <row>
              <entry><code>debug_backtrace(2)</code></entry>
+            </row>
+            <row>
+             <entry><code>debug_backtrace(~DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
             </row>
             <row>
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT|DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>


### PR DESCRIPTION
Follow-up to #1630

<img width="1000" height="516" alt="grafik" src="https://github.com/user-attachments/assets/887ec166-5fb4-4fbc-bfac-e27edc88292a" />
