### PR TITLE
Change <para> to <simpara> in phar extension

### DIFF
--- a/reference/phar/Phar.xml
+++ b/reference/phar/Phar.xml
@@ -9,10 +9,10 @@
 <!-- {{{ Phar intro -->
   <section xml:id="phar.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     The Phar class provides a high-level interface to accessing and creating
     phar archives.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
  

--- a/reference/phar/Phar/addEmptyDir.xml
+++ b/reference/phar/Phar/addEmptyDir.xml
@@ -13,10 +13,10 @@
   </methodsynopsis>
   &phar.write;
 
-  <para>
+  <simpara>
    With this method, an empty directory is created with path <literal>dirname</literal>.
    This method is similar to <function>ZipArchive::addEmptyDir</function>.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
     <varlistentry>
      <term><parameter>directory</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The name of the empty directory to create in the phar archive
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -37,9 +37,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    no return value, exception is thrown on failure.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/Phar/addFile.xml
+++ b/reference/phar/Phar/addFile.xml
@@ -14,14 +14,14 @@
   </methodsynopsis>
   &phar.write;
 
-  <para>
+  <simpara>
    With this method, any file or URL can be added to the phar archive.  If
    the optional second parameter <parameter>localName</parameter> is a &string;,
    the file will be stored in the archive with that name, otherwise the
    <literal>file</literal> parameter is used as the path to store within
    the archive.  URLs must have a localname or an exception is thrown.
    This method is similar to <function>ZipArchive::addFile</function>.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
@@ -31,18 +31,18 @@
     <varlistentry>
      <term><parameter>filename</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Full or relative path to a file on disk to be added
        to the phar archive.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>localName</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Path that the file will be stored in the archive.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -51,9 +51,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    no return value, exception is thrown on failure.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/phar/Phar/addFromString.xml
+++ b/reference/phar/Phar/addFromString.xml
@@ -14,11 +14,11 @@
   </methodsynopsis>
   &phar.write;
 
-  <para>
+  <simpara>
    With this method, any string can be added to the phar archive.
    The file will be stored in the archive with <literal>localname</literal> as its
    path.  This method is similar to <function>ZipArchive::addFromString</function>.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
@@ -28,17 +28,17 @@
     <varlistentry>
      <term><parameter>localName</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Path that the file will be stored in the archive.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>contents</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The file contents to store
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -47,9 +47,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    no return value, exception is thrown on failure.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/Phar/apiVersion.xml
+++ b/reference/phar/Phar/apiVersion.xml
@@ -12,24 +12,24 @@
    <void/>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Return the API version of the phar file format that will be
    used when creating phars.  The Phar extension supports reading API
    version 1.0.0 or newer.  API version 1.1.0 is required for SHA-256 and SHA-512
    hash, and API version 1.1.1 is required to store empty directories.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The API version string as in <literal>&quot;1.0.0&quot;</literal>.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/phar/Phar/buildFromDirectory.xml
+++ b/reference/phar/Phar/buildFromDirectory.xml
@@ -14,12 +14,12 @@
    <methodparam choice="opt"><type>string</type><parameter>pattern</parameter><initializer>""</initializer></methodparam>
   </methodsynopsis>
   &phar.write;
-  <para>
+  <simpara>
    Populate a phar archive from directory contents.  The optional second
    parameter is a regular expression (pcre) that is used to exclude files.
    Any filename that matches the regular expression will be included, all others will be
    excluded.  For more fine-grained control, use <function>Phar::buildFromIterator</function>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,20 +29,20 @@
     <varlistentry>
      <term><parameter>directory</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The full or relative path to the directory that contains all files
        to add to the archive.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>pattern</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        An optional pcre regular expression that is used to filter the
        list of files.  Only file paths matching the regular expression
        will be included in the archive.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -51,21 +51,21 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    <function>Phar::buildFromDirectory</function> returns an associative array
    mapping internal path of file to the full path of the file on the
    filesystem.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    This method throws <classname>BadMethodCallException</classname> when unable
    to instantiate the internal directory iterators,
    or a <classname>PharException</classname> if there were errors
    saving the phar archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -94,9 +94,9 @@
   &reftitle.examples;
   <example>
     <title>A <function>Phar::buildFromDirectory</function> example</title>
-  <para>
+  <simpara>
    
-  </para>
+  </simpara>
   <para>
    <programlisting role="php">
     <![CDATA[

--- a/reference/phar/Phar/buildFromIterator.xml
+++ b/reference/phar/Phar/buildFromIterator.xml
@@ -14,13 +14,13 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>baseDirectory</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   &phar.write;
-  <para>
+  <simpara>
    Populate a phar archive from an iterator.  Two styles of iterators are supported,
    iterators that map the filename within the phar to the name of a file on disk,
    and iterators like DirectoryIterator that return
    SplFileInfo objects.  For iterators that return SplFileInfo objects, the second
    parameter is required.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -30,19 +30,19 @@
     <varlistentry>
      <term><parameter>iterator</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Any iterator that either associatively maps phar file to location or
        returns SplFileInfo objects
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>baseDirectory</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        For iterators that return SplFileInfo objects, the portion of each
        file's full path to remove when adding to the phar archive
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -51,23 +51,23 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    <function>Phar::buildFromIterator</function> returns an associative array
    mapping internal path of file to the full path of the file on the
    filesystem.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    This method returns <classname>UnexpectedValueException</classname> when the
    iterator returns incorrect values, such as an integer key instead of a
    string, a <classname>BadMethodCallException</classname> when an
    SplFileInfo-based iterator is passed without a <parameter>baseDirectory</parameter>
    parameter, or a <classname>PharException</classname> if there were errors
    saving the phar archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -102,11 +102,11 @@
   &reftitle.examples;
    <example>
     <title>A <function>Phar::buildFromIterator</function> with SplFileInfo</title>
-  <para>
+  <simpara>
    For most phar archives, the archive will reflect an actual directory layout, and
    the second style is the most useful.  For instance, to create a phar archive
    containing the files in this sample directory layout:
-  </para>
+  </simpara>
   <para>
    <screen>
     <![CDATA[
@@ -126,9 +126,9 @@
     ]]>
    </screen>
   </para>
-  <para>
+  <simpara>
    This code could be used to add these files to the &quot;project.phar&quot; phar archive:
-  </para>
+  </simpara>
   <para>
    <programlisting role="php">
     <![CDATA[
@@ -144,16 +144,16 @@ $phar->setStub($phar->createDefaultStub('cli/index.php', 'www/index.php'));
     ]]>
    </programlisting>
   </para>
-  <para>
+  <simpara>
    The file project.phar can then be used immediately.  <function>Phar::buildFromIterator</function> does not
    set values such as compression, metadata, and this can be done after creating the
    phar archive.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    As an interesting note, <function>Phar::buildFromIterator</function> can also be used to
    copy the contents of an existing phar archive, as the Phar object descends
    from <classname>DirectoryIterator</classname>:
-  </para>
+  </simpara>
   <para>
    <programlisting role="php">
     <![CDATA[
@@ -172,10 +172,10 @@ $phar->setStub($phar->createDefaultStub('cli/index.php', 'www/index.php'));
   </example>
   <example>
     <title>A <function>Phar::buildFromIterator</function> with other iterators</title>
-  <para>
+  <simpara>
    The second form of the iterator can be used with any iterator that returns
    a key =&gt; value mapping, such as an <classname>ArrayIterator</classname>:
-  </para>
+  </simpara>
   <para>
    <programlisting role="php">
     <![CDATA[

--- a/reference/phar/Phar/canCompress.xml
+++ b/reference/phar/Phar/canCompress.xml
@@ -12,10 +12,10 @@
    <methodparam choice="opt"><type>int</type><parameter>compression</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    This should be used to test whether compression is possible prior to
    loading a phar archive containing compressed files.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,11 +25,11 @@
     <varlistentry>
      <term><parameter>compression</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Either <literal>Phar::GZ</literal> or <literal>Phar::BZ2</literal> can be
        used to test whether compression is possible with a specific compression
        algorithm (zlib or bzip2).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -37,9 +37,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &true; if compression/decompression is available, &false; if not.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/Phar/canWrite.xml
+++ b/reference/phar/Phar/canWrite.xml
@@ -12,23 +12,23 @@
    <void/>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    This static method determines whether write access has been disabled in
    the system php.ini via the <link linkend="ini.phar.readonly">phar.readonly</link>
    ini variable.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &true; if write access is enabled, &false; if it is disabled.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/Phar/compress.xml
+++ b/reference/phar/Phar/compress.xml
@@ -15,13 +15,13 @@
   </methodsynopsis>
  &phar.write;
 
-  <para>
+  <simpara>
    For tar-based and phar-based phar archives, this method compresses the entire archive using
    gzip compression or bzip2 compression.  The resulting file can be processed with the
    gunzip command/bunzip command, or accessed directly and transparently with the Phar
    extension.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    For Zip-based phar archives, this method fails with an exception.
    The <link linkend="ref.zlib">zlib</link> extension must be enabled to compress
    with gzip compression, the <link linkend="ref.bzip2">bzip2</link> extension must be
@@ -29,13 +29,13 @@
    As with all functionality that modifies the contents of a phar, the
    <link linkend="ini.phar.readonly">phar.readonly</link> INI variable must be off
    in order to succeed.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    In addition, this method automatically renames the archive, appending <literal>.gz</literal>,
    <literal>.bz2</literal> or removing the extension if passed <literal>Phar::NONE</literal> to
    remove compression.  Alternatively, a file extension may be specified with the second
    parameter.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -45,23 +45,23 @@
     <varlistentry>
      <term><parameter>compression</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Compression must be one of <literal>Phar::GZ</literal>,
        <literal>Phar::BZ2</literal> to add compression, or <literal>Phar::NONE</literal>
        to remove compression.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>extension</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        By default, the extension is <literal>.phar.gz</literal>
        or <literal>.phar.bz2</literal> for compressing phar archives, and
        <literal>.phar.tar.gz</literal> or <literal>.phar.tar.bz2</literal> for
        compressing tar archives.  For decompressing, the default file extensions
        are <literal>.phar</literal> and <literal>.phar.tar</literal>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -70,20 +70,20 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns a <classname>Phar</classname> object, or &null; on failure.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>BadMethodCallException</classname> if
    the <link linkend="ini.phar.readonly">phar.readonly</link>
    INI variable is on, the <link linkend="ref.zlib">zlib</link>
    extension is not available, or the <link linkend="ref.bzip2">bzip2</link> extension
    is not enabled.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/phar/Phar/compressFiles.xml
+++ b/reference/phar/Phar/compressFiles.xml
@@ -14,13 +14,13 @@
   </methodsynopsis>
   &phar.write;
 
-  <para>
+  <simpara>
    For tar-based phar archives, this method throws a
    <classname>BadMethodCallException</classname>, as compression of individual
    files within a tar archive is not supported by the file format.  Use
    <function>Phar::compress</function> to compress an entire tar-based phar archive.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    For Zip-based and phar-based phar archives, this method compresses all files in the
    Phar archive using the specified compression.
    The <link linkend="ref.zlib">zlib</link>  or <link linkend="ref.bzip2">bzip2</link>
@@ -30,7 +30,7 @@
    As with all functionality that modifies the contents of a phar, the
    <link linkend="ini.phar.readonly">phar.readonly</link> INI variable must be off
    in order to succeed.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -40,11 +40,11 @@
     <varlistentry>
      <term><parameter>compression</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Compression must be one of <literal>Phar::GZ</literal>,
        <literal>Phar::BZ2</literal> to add compression, or <literal>Phar::NONE</literal>
        to remove compression.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -54,21 +54,21 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>BadMethodCallException</classname> if
    the <link linkend="ini.phar.readonly">phar.readonly</link>
    INI variable is on, the <link linkend="ref.zlib">zlib</link>
    extension is not available, or if any files are compressed using
    bzip2 compression and the <link linkend="ref.bzip2">bzip2</link> extension
    is not enabled.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/Phar/construct.xml
+++ b/reference/phar/Phar/construct.xml
@@ -22,27 +22,27 @@
     <varlistentry>
      <term><parameter>filename</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Path to an existing Phar archive or to-be-created archive. The file name's
        extension must contain .phar.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Flags to pass to parent class <classname>RecursiveDirectoryIterator</classname>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>alias</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Alias with which this Phar archive should be referred to in calls to stream
        functionality.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -51,10 +51,10 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>BadMethodCallException</classname> if called twice, <classname>UnexpectedValueException</classname>
    if the phar archive can't be opened.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/phar/Phar/convertToData.xml
+++ b/reference/phar/Phar/convertToData.xml
@@ -16,21 +16,21 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>extension</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    This method is used to convert an executable phar archive to either a
    tar or zip file.  To make the tar or zip non-executable, the phar
    stub and phar alias files are removed from the newly created archive.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    If no changes are specified, this method throws a <classname>BadMethodCallException</classname>
    if the archive is in phar file format.  For archives in tar or zip file format,
    this method converts the archive to a non-executable archive.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    If successful, the method creates a new archive on disk and returns a <classname>PharData</classname>
    object.  The old archive is not removed from disk, and should be done manually after
    the process has finished.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -40,38 +40,38 @@
     <varlistentry>
      <term><parameter>format</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        This should be one of <literal>Phar::TAR</literal>
        or <literal>Phar::ZIP</literal>.  If set to &null;, the existing file format
        will be preserved.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>compression</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        This should be one of <literal>Phar::NONE</literal> for no whole-archive
        compression, <literal>Phar::GZ</literal> for zlib-based compression, and
        <literal>Phar::BZ2</literal> for bzip-based compression.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>extension</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        This parameter is used to override the default file extension for a
        converted archive.  Note that <literal>.phar</literal> cannot be used
        anywhere in the filename for a non-executable tar or zip archive.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        If converting to a tar-based phar archive, the
        default extensions are <literal>.tar</literal>, <literal>.tar.gz</literal>,
        and <literal>.tar.bz2</literal> depending on specified compression.
        For zip-based archives, the
        default extension is <literal>.zip</literal>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -80,22 +80,22 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The method returns a <classname>PharData</classname> object on success,
    or &null; on failure.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    This method throws <classname>BadMethodCallException</classname> when unable
    to compress, an unknown compression method has been specified, the requested
    archive is buffering with <function>Phar::startBuffering</function> and
    has not concluded with <function>Phar::stopBuffering</function>, 
    and a <classname>PharException</classname> if any problems are encountered
    during the phar creation process.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -125,9 +125,9 @@
   <para>
    <example>
     <title>A <function>Phar::convertToData</function> example</title>
-    <para>
+    <simpara>
      Using Phar::convertToData():
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/Phar/convertToExecutable.xml
+++ b/reference/phar/Phar/convertToExecutable.xml
@@ -16,21 +16,21 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>extension</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   &phar.write;
-  <para>
+  <simpara>
    This method is used to convert a phar archive to another file format.  For instance,
    it can be used to create a tar-based executable phar archive from a zip-based
    executable phar archive, or from an executable phar archive in the phar file format.  In
    addition, it can be used to apply whole-archive compression to a tar or phar-based
    archive.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    If no changes are specified, this method throws a <classname>BadMethodCallException</classname>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    If successful, the method creates a new archive on disk and returns a <classname>Phar</classname>
    object.  The old archive is not removed from disk, and should be done manually after
    the process has finished.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -40,40 +40,40 @@
     <varlistentry>
      <term><parameter>format</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        This should be one of <literal>Phar::PHAR</literal>, <literal>Phar::TAR</literal>,
        or <literal>Phar::ZIP</literal>.  If set to &null;, the existing file format
        will be preserved.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>compression</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        This should be one of <literal>Phar::NONE</literal> for no whole-archive
        compression, <literal>Phar::GZ</literal> for zlib-based compression, and
        <literal>Phar::BZ2</literal> for bzip-based compression.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>extension</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        This parameter is used to override the default file extension for a
        converted archive.  Note that all zip- and tar-based phar archives must contain
        <literal>.phar</literal> in their file extension in order to be processed as a
        phar archive.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        If converting to a phar-based archive, the default extensions are
        <literal>.phar</literal>, <literal>.phar.gz</literal>, or <literal>.phar.bz2</literal>
        depending on the specified compression.  For tar-based phar archives, the
        default extensions are <literal>.phar.tar</literal>, <literal>.phar.tar.gz</literal>,
        and <literal>.phar.tar.bz2</literal>.  For zip-based phar archives, the
        default extension is <literal>.phar.zip</literal>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -82,15 +82,15 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The method returns a <classname>Phar</classname> object on success,
    or &null; on failure.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    This method throws <classname>BadMethodCallException</classname> when unable
    to compress, an unknown compression method has been specified, the requested
    archive is buffering with <function>Phar::startBuffering</function> and
@@ -98,7 +98,7 @@
    <classname>UnexpectedValueException</classname> if write support is disabled,
    and a <classname>PharException</classname> if any problems are encountered
    during the phar creation process.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -128,9 +128,9 @@
   <para>
    <example>
     <title>A <function>Phar::convertToExecutable</function> example</title>
-    <para>
+    <simpara>
      Using Phar::convertToExecutable():
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/Phar/copy.xml
+++ b/reference/phar/Phar/copy.xml
@@ -15,11 +15,11 @@
   </methodsynopsis>
   &phar.write;
 
-  <para>
+  <simpara>
    Copy a file internal to the phar archive to another new file within the phar.
    This is an object-oriented alternative to using <function>copy</function> with
    the phar stream wrapper.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,15 +29,15 @@
     <varlistentry>
      <term><parameter>from</parameter></term>
      <listitem>
-      <para>
-      </para>
+      <simpara>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>to</parameter></term>
      <listitem>
-      <para>
-      </para>
+      <simpara>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -46,19 +46,19 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.true.always;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>UnexpectedValueException</classname> if the source file does not
    exist, the destination file already exists, write access is disabled, opening either
    file fails, reading the source file fails, or a <classname>PharException</classname>
    if writing the changes to the phar fails.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -66,12 +66,12 @@
   <para>
    <example>
     <title>A <function>Phar::copy</function> example</title>
-    <para>
+    <simpara>
      This example shows using <function>Phar::copy</function> and the
      equivalent stream wrapper performance of the same thing.  The primary
      difference between the two approaches is error handling.  All Phar methods
      throw exceptions, whereas the stream wrapper uses <function>trigger_error</function>.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/Phar/count.xml
+++ b/reference/phar/Phar/count.xml
@@ -12,8 +12,8 @@
    <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>COUNT_NORMAL</constant></initializer></methodparam>
   </methodsynopsis>
 
-  <para>
-  </para>
+  <simpara>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
@@ -22,23 +22,23 @@
    <varlistentry>
     <term><parameter>mode</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       <parameter>mode</parameter> is an integer value specifying the counting mode to be used.
       By default, it is set to <constant>COUNT_NORMAL</constant>,
       which counts only the number of items in the archive that have not been deleted or hidden.
       When set to <constant>COUNT_RECURSIVE</constant>, it counts all items in the archive,
       including those that have been deleted or hidden.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The number of files contained within this phar, or <literal>0</literal> (the number zero)
    if none.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -46,8 +46,8 @@
   <para>
    <example>
     <title>A <function>Phar::count</function> example</title>
-    <para>
-    </para>
+    <simpara>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/Phar/createDefaultStub.xml
+++ b/reference/phar/Phar/createDefaultStub.xml
@@ -13,10 +13,10 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>webIndex</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    This method is intended for creation of phar-file format-specific stubs, and is
    not intended for use with tar- or zip-based phar archives.
-  </para>
+  </simpara>
   <para>
    Phar archives contain a bootstrap loader, or <literal>stub</literal>
    written in PHP that is executed when the archive is executed in PHP either via
@@ -35,7 +35,7 @@ php myphar.phar
     ]]>
    </screen>
   </para>
-  <para>
+  <simpara>
    This method provides a simple and easy method to create a stub that will
    run a startup file from the phar archive.  In addition, different files can
    be specified for running the phar archive from the command line versus through
@@ -44,7 +44,7 @@ php myphar.phar
    phar extension is not present, the loader stub will extract the phar archive
    to a temporary directory and then operate on the files.  A shutdown function
    erases the temporary files on exit.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -55,17 +55,17 @@ php myphar.phar
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Relative path within the phar archive to run if accessed on the command-line
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>webIndex</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Relative path within the phar archive to run if accessed through a web browser
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -74,19 +74,19 @@ php myphar.phar
  
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns a string containing the contents of a customized bootstrap loader (stub)
    that allows the created Phar archive to work with or without the Phar extension
    enabled.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>UnexpectedValueException</classname> if either parameter is longer
    than 400 bytes.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/phar/Phar/decompress.xml
+++ b/reference/phar/Phar/decompress.xml
@@ -14,10 +14,10 @@
   </methodsynopsis>
  &phar.write;
 
-  <para>
+  <simpara>
    For tar-based and phar-based phar archives, this method decompresses the entire archive.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    For Zip-based phar archives, this method fails with an exception.
    The <link linkend="ref.zlib">zlib</link> extension must be enabled to decompress
    an archive compressed with gzip compression, and the
@@ -26,14 +26,14 @@
    As with all functionality that modifies the contents of a phar, the
    <link linkend="ini.phar.readonly">phar.readonly</link> INI variable must be off
    in order to succeed.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    In addition, this method automatically changes the file extension of the archive,
    <literal>.phar</literal>
    by default for phar archives, or <literal>.phar.tar</literal> for tar-based phar archives.
    Alternatively, a file extension may be specified with the second
    parameter.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -43,13 +43,13 @@
     <varlistentry>
      <term><parameter>extension</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        For decompressing, the default file extensions
        are <literal>.phar</literal> and <literal>.phar.tar</literal>.
        Use this parameter to specify another file extension.  Be aware
        that all executable phar archives must contain <literal>.phar</literal>
        in their filename.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -59,20 +59,20 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    A <classname>Phar</classname> object is returned on success, and &null; on failure.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>BadMethodCallException</classname> if
    the <link linkend="ini.phar.readonly">phar.readonly</link>
    INI variable is on, the <link linkend="ref.zlib">zlib</link>
    extension is not available, or the <link linkend="ref.bzip2">bzip2</link> extension
    is not enabled.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/phar/Phar/decompressFiles.xml
+++ b/reference/phar/Phar/decompressFiles.xml
@@ -14,13 +14,13 @@
   </methodsynopsis>
   &phar.write;
 
-  <para>
+  <simpara>
    For tar-based phar archives, this method throws a
    <classname>BadMethodCallException</classname>, as compression of individual
    files within a tar archive is not supported by the file format.  Use
    <function>Phar::compress</function> to compress an entire tar-based phar archive.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    For Zip-based and phar-based phar archives, this method decompresses all files in the
    Phar archive.
    The <link linkend="ref.zlib">zlib</link>  or <link linkend="ref.bzip2">bzip2</link>
@@ -29,7 +29,7 @@
    As with all functionality that modifies the contents of a phar, the
    <link linkend="ini.phar.readonly">phar.readonly</link> INI variable must be off
    in order to succeed.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -39,21 +39,21 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.true.always;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>BadMethodCallException</classname> if
    the <link linkend="ini.phar.readonly">phar.readonly</link>
    INI variable is on, the <link linkend="ref.zlib">zlib</link>
    extension is not available, or if any files are compressed using
    bzip2 compression and the <link linkend="ref.bzip2">bzip2</link> extension
    is not enabled.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/Phar/delMetadata.xml
+++ b/reference/phar/Phar/delMetadata.xml
@@ -14,30 +14,30 @@
   </methodsynopsis>
   &phar.write;
 
-  <para>
+  <simpara>
    Deletes the global metadata of the phar
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-  </para>
+  <simpara>
+  </simpara>
 
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.true.always;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>PharException</classname> if errors occur while flushing
    changes to disk.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/phar/Phar/delete.xml
+++ b/reference/phar/Phar/delete.xml
@@ -14,11 +14,11 @@
   </methodsynopsis>
   &phar.write;
 
-  <para>
+  <simpara>
    Delete a file within an archive.  This is the functional equivalent of
    calling <function>unlink</function> on the stream wrapper equivalent,
    as shown in the example below.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
     <varlistentry>
      <term><parameter>localName</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Path within an archive to the file to delete.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -39,17 +39,17 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.true.always;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>PharException</classname> if errors occur while flushing
    changes to disk.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/phar/Phar/extractTo.xml
+++ b/reference/phar/Phar/extractTo.xml
@@ -15,7 +15,7 @@
    <methodparam choice="opt"><type>bool</type><parameter>overwrite</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Extract all files within a phar archive to disk.  Extracted files and directories preserve
    permissions as stored in the archive.  The optional parameters allow optional control over
    which files are extracted, and whether existing files on disk can be overwritten.
@@ -24,7 +24,7 @@
    default, this method will not overwrite existing files, the third parameter can be
    set to true to enable overwriting of files.
    This method is similar to <function>ZipArchive::extractTo</function>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -34,26 +34,26 @@
     <varlistentry>
      <term><parameter>directory</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Path to extract the given <parameter>files</parameter> to
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>files</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The name of a file or directory to extract, or an array of files/directories to extract,
        &null; to skip this param
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>overwrite</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Set to &true; to enable overwriting existing files
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -62,18 +62,18 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    returns &true; on success, but it is better to check for thrown exception,
    and assume success if none is thrown.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>PharException</classname> if errors occur while flushing
    changes to disk.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/phar/Phar/getAlias.xml
+++ b/reference/phar/Phar/getAlias.xml
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Phar::getAlias</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
   &warn.undocumented.func;
 
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the alias or &null; if there's no alias.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/phar/Phar/getMetadata.xml
+++ b/reference/phar/Phar/getMetadata.xml
@@ -12,9 +12,9 @@
    <methodparam choice="opt"><type>array</type><parameter>unserializeOptions</parameter><initializer>[]</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Retrieve archive meta-data.  Meta-data can be any PHP variable that can be serialized.
-  </para>
+  </simpara>
 
   <caution>
    <simpara>
@@ -28,16 +28,16 @@
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
+  <simpara>
    No parameters.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Any PHP value that can be serialized and is stored as meta-data for the Phar archive,
    or &null; if no meta-data is stored.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -67,8 +67,8 @@
   <para>
    <example>
     <title>A <function>Phar::getMetadata</function> example</title>
-    <para>
-    </para>
+    <simpara>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/Phar/getModified.xml
+++ b/reference/phar/Phar/getModified.xml
@@ -12,24 +12,24 @@
    <void/>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    This method can be used to determine whether a phar has either
    had an internal file deleted, or contents of a file changed in
    some way.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
+  <simpara>
    No parameters.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &true; if the phar has been modified since opened, &false; if not.
-  </para>
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/reference/phar/Phar/getPath.xml
+++ b/reference/phar/Phar/getPath.xml
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>string</type><methodname>Phar::getPath</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
   &warn.undocumented.func;
 
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/phar/Phar/getSignature.xml
+++ b/reference/phar/Phar/getSignature.xml
@@ -12,19 +12,19 @@
    <void/>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Returns the verification signature of a phar archive in a hexadecimal string.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Array with the opened archive's signature in <literal>hash</literal> key and <literal>MD5</literal>,
    <literal>SHA-1</literal>,
    <literal>SHA-256</literal>, <literal>SHA-512</literal>, or <literal>OpenSSL</literal>
@@ -34,7 +34,7 @@
    <link linkend="ini.phar.require-hash">phar.require_hash</link> INI variable
    is set to true.
    If there is no signature, the function returns &false;.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/phar/Phar/getStub.xml
+++ b/reference/phar/Phar/getStub.xml
@@ -40,18 +40,18 @@ php myphar.phar
  
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns a string containing the contents of the bootstrap loader (stub) of
    the current Phar archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>RuntimeException</classname> if it is not possible to read
    the stub from the Phar archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/Phar/getSupportedCompression.xml
+++ b/reference/phar/Phar/getSupportedCompression.xml
@@ -12,25 +12,25 @@
    <modifier>final</modifier> <modifier>public</modifier> <modifier>static</modifier> <type>array</type><methodname>Phar::getSupportedCompression</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
+  <simpara>
    No parameters.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns an array containing any of <literal>Phar::GZ</literal> or
    <literal>Phar::BZ2</literal>, depending on the availability of
    the <link linkend="book.zlib">zlib</link> extension or the
    <link linkend="book.bzip2">bz2</link> extension.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/phar/Phar/getSupportedSignatures.xml
+++ b/reference/phar/Phar/getSupportedSignatures.xml
@@ -12,24 +12,24 @@
    <modifier>final</modifier> <modifier>public</modifier> <modifier>static</modifier> <type>array</type><methodname>Phar::getSupportedSignatures</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Return array of supported signature types
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
+  <simpara>
    No parameters.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns an array containing any of <literal>MD5</literal>, <literal>SHA-1</literal>,
    <literal>SHA-256</literal>, <literal>SHA-512</literal>, or <literal>OpenSSL</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/phar/Phar/getVersion.xml
+++ b/reference/phar/Phar/getVersion.xml
@@ -12,25 +12,25 @@
    <void/>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Returns the API version of an opened Phar archive.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The opened archive's API version.  This is not to be confused with
    the API version that the loaded phar extension will use to create
    new phars.  Each Phar archive has the API version hard-coded into
    its manifest.  See <link linkend="phar.fileformat">Phar file format</link>
    documentation for more information.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/phar/Phar/hasMetadata.xml
+++ b/reference/phar/Phar/hasMetadata.xml
@@ -12,23 +12,23 @@
    <modifier>public</modifier> <type>bool</type><methodname>Phar::hasMetadata</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Returns whether phar has global meta-data set.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
+  <simpara>
    No parameters.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns &true; if meta-data has been set, and &false; if not.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/Phar/interceptFileFuncs.xml
+++ b/reference/phar/Phar/interceptFileFuncs.xml
@@ -12,31 +12,31 @@
    <modifier>final</modifier> <modifier>public</modifier> <modifier>static</modifier> <type>void</type><methodname>Phar::interceptFileFuncs</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    instructs phar to intercept <function>fopen</function>, <function>readfile</function>,
    <function>file_get_contents</function>, <function>opendir</function>, and all of
    the stat-related functions.  If any of these functions is called from within
    a phar archive with a relative path, the call is modified to access a file
    within the phar archive.  Absolute paths are assumed to be attempts to load
    external files from the filesystem.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    This function makes it possible to run PHP applications designed to run off of
    a hard disk as a phar application.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
+  <simpara>
    No parameters.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
   <refsect1 role="examples">
@@ -54,11 +54,11 @@ include 'phar://' . __FILE__ . '/file.php';
     </programlisting>
    </example>
   </para>
-  <para>
+  <simpara>
    Assuming that this phar is at <literal>/path/to/myphar.phar</literal> and it
    contains <literal>file.php</literal> and
    <literal>file2.txt</literal>, if <literal>file.php</literal> contains this code:
-  </para>
+  </simpara>
   <para>
    <example>
     <title>A <function>Phar::interceptFileFuncs</function> example</title>
@@ -71,14 +71,14 @@ echo file_get_contents('file2.txt');
     </programlisting>
    </example>
   </para>
-  <para>
+  <simpara>
    Normally PHP would search the current directory for <literal>file2.txt</literal>,
    which would translate as the directory of file.php, or the current directory of
    a command-line user.  <function>Phar::interceptFileFuncs</function> instructs
    PHP to consider the current directory to be <literal>phar:///path/to/myphar.phar/</literal>
    and so opens <literal>phar:///path/to/myphar.phar/file2.txt</literal> in the above
    example code.
-  </para>
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/reference/phar/Phar/isBuffering.xml
+++ b/reference/phar/Phar/isBuffering.xml
@@ -12,16 +12,16 @@
    <void/>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    This method can be used to determine whether a Phar will save changes
    to disk immediately, or whether a call to <function>Phar::stopBuffering</function>
    is needed to enable saving changes.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Phar write buffering is per-archive, buffering active for the
    <literal>foo.phar</literal> Phar archive does not affect changes
    to the <literal>bar.phar</literal> Phar archive.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -32,9 +32,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns &true; if the write operations are being buffer, &false; otherwise.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -42,8 +42,8 @@
   <para>
    <example>
     <title>A <function>Phar::isBuffering</function> example</title>
-    <para>
-    </para>
+    <simpara>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/Phar/isCompressed.xml
+++ b/reference/phar/Phar/isCompressed.xml
@@ -14,25 +14,25 @@
   </methodsynopsis>
 &phar.write;
  
-  <para>
+  <simpara>
    Returns Phar::GZ or PHAR::BZ2 if the entire phar archive is compressed
    (.tar.gz/tar.bz and so on).  Zip-based phar archives cannot be compressed as a
    file, and so this method will always return &false; if a zip-based phar archive is queried.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
+  <simpara>
    No parameters.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    <literal>Phar::GZ</literal>, <literal>Phar::BZ2</literal> or &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/Phar/isFileFormat.xml
+++ b/reference/phar/Phar/isFileFormat.xml
@@ -12,8 +12,8 @@
    <modifier>public</modifier> <type>bool</type><methodname>Phar::isFileFormat</methodname>
    <methodparam><type>int</type><parameter>format</parameter></methodparam>
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -23,10 +23,10 @@
     <varlistentry>
      <term><parameter>format</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Either <literal>Phar::PHAR</literal>, <literal>Phar::TAR</literal>, or
        <literal>Phar::ZIP</literal> to test for the format of the archive.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -36,17 +36,17 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns &true; if the phar archive matches the file format requested by the parameter
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    <classname>PharException</classname> is thrown if the parameter is an unknown file
    format specifier.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/phar/Phar/isValidPharFilename.xml
+++ b/reference/phar/Phar/isValidPharFilename.xml
@@ -14,12 +14,12 @@
    <methodparam choice="opt"><type>bool</type><parameter>executable</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Returns whether the given filename is a valid phar filename that will be recognized
    as a phar archive by the phar extension.  This can be used to test a name without
    having to instantiate a phar archive and catch the inevitable Exception that will be
    thrown if an invalid name is specified.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,18 +29,18 @@
     <varlistentry>
      <term><parameter>filename</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The name or full path to a phar archive not yet created
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>executable</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        This parameter determines whether the filename should be treated as
        a phar executable archive, or a data non-executable archive
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -49,9 +49,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns &true; if the filename is valid, &false; if not.
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/phar/Phar/isWritable.xml
+++ b/reference/phar/Phar/isWritable.xml
@@ -12,24 +12,24 @@
    <modifier>public</modifier> <type>bool</type><methodname>Phar::isWritable</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    This method returns &true; if <literal>phar.readonly</literal> is <literal>0</literal>,
    and the actual phar archive on disk is not read-only.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
+  <simpara>
    No parameters.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns &true; if the phar archive can be modified
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/phar/Phar/loadPhar.xml
+++ b/reference/phar/Phar/loadPhar.xml
@@ -13,12 +13,12 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>alias</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    This can be used to read the contents of an external Phar archive.  This
    is most useful for assigning an alias to a phar so that subsequent references
    to the phar can use the shorter alias, or for loading Phar archives that
    only contain data and are not intended for execution/inclusion in PHP scripts.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
@@ -28,20 +28,20 @@
     <varlistentry>
      <term><parameter>filename</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        the full or relative path to the phar archive to open
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>alias</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The alias that may be used to refer to the phar archive.  Note
        that many phar archives specify an explicit alias inside the
        phar archive, and a <classname>PharException</classname> will be thrown if
        a new alias is specified in this case.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -49,17 +49,17 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    <classname>PharException</classname> is thrown if an alias is passed in and the phar archive
    already has an explicit alias
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -67,10 +67,10 @@
   <para>
    <example>
     <title>A <function>Phar::loadPhar</function> example</title>
-    <para>
+    <simpara>
      Phar::loadPhar can be used anywhere to load an external Phar archive, whereas
      Phar::mapPhar should be used in a loader stub for a Phar.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/Phar/mapPhar.xml
+++ b/reference/phar/Phar/mapPhar.xml
@@ -13,11 +13,11 @@
    <methodparam choice="opt"><type>int</type><parameter>offset</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    This static method can only be used inside a Phar archive's loader stub
    in order to initialize the phar when it is directly executed, or when
    it is included in another script.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
@@ -27,18 +27,18 @@
     <varlistentry>
      <term><parameter>alias</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The alias that can be used in <literal>phar://</literal> URLs to
        refer to this archive, rather than its full path.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>offset</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Unused variable, here for compatibility with PEAR's PHP_Archive.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -46,18 +46,18 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    <classname>PharException</classname> is thrown if not called directly within PHP execution,
    if no __HALT_COMPILER(); token is found in the current source file, or if
    the file cannot be opened for reading.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -65,13 +65,13 @@
   <para>
    <example>
     <title>A <function>Phar::mapPhar</function> example</title>
-    <para>
+    <simpara>
      mapPhar should be used only inside a phar's loader stub.  Use
      loadPhar to load an external phar into memory.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
      Here is a sample Phar loader stub that uses mapPhar.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/Phar/mount.xml
+++ b/reference/phar/Phar/mount.xml
@@ -13,13 +13,13 @@
    <methodparam><type>string</type><parameter>pharPath</parameter></methodparam>
    <methodparam><type>string</type><parameter>externalPath</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Much like the unix file system concept of mounting external devices to paths within the
    directory tree, <function>Phar::mount</function> allows referring to external files
    and directories as if they were inside of an archive.  This allows powerful
    abstraction such as referring to external configuration files as if they were
    inside the archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,18 +29,18 @@
     <varlistentry>
      <term><parameter>pharPath</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The internal path within the phar archive to use as the mounted path location.
        This must be a relative path within the phar archive, and must not already exist.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>externalPath</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        A path or URL to an external file or directory to mount within the phar archive
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -49,16 +49,16 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    No return.  <classname>PharException</classname> is thrown on failure.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>PharException</classname> if any problems occur mounting the path.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -66,13 +66,13 @@
   <para>
    <example>
     <title>A <function>Phar::mount</function> example</title>
-    <para>
+    <simpara>
      The following example shows accessing an external configuration file as if it were
      a path within a phar archive.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
      First, the code inside of a phar archive:
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -81,9 +81,9 @@ $configuration = simplexml_load_string(file_get_contents(
 ?>
 ]]>
     </programlisting>
-    <para>
+    <simpara>
      Next the external code used to mount the configuration file:
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -95,11 +95,11 @@ include '/path/to/archive.phar';
 ?>
 ]]>
     </programlisting>
-    <para>
+    <simpara>
      Another method is to put the mounting code inside the stub of the phar archive.
      Here is an example of setting up a default
      configuration file if no user configuration is specified:
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -120,9 +120,9 @@ __HALT_COMPILER();
 ?>
 ]]>
     </programlisting>
-    <para>
+    <simpara>
      ...and the code externally to load this phar archive:
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/Phar/mungServer.xml
+++ b/reference/phar/Phar/mungServer.xml
@@ -12,29 +12,29 @@
    <modifier>final</modifier> <modifier>public</modifier> <modifier>static</modifier> <type>void</type><methodname>Phar::mungServer</methodname>
    <methodparam><type>array</type><parameter>variables</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>Phar::mungServer</function> should only be called within the
    stub of a phar archive.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Defines a list of up to 4 <varname>$_SERVER</varname> variables that should be
    modified for execution.
    Variables that can be modified to remove traces of phar execution are
    <literal>REQUEST_URI</literal>, <literal>PHP_SELF</literal>,
    <literal>SCRIPT_NAME</literal> and <literal>SCRIPT_FILENAME</literal>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    On its own, this method does nothing.  Only when combined with
    <function>Phar::webPhar</function> does it take effect, and only when the requested
    file is a PHP file to be parsed.  Note that the
    <literal>PATH_INFO</literal> and <literal>PATH_TRANSLATED</literal> variables
    are always modified.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    The original values of variables that are modified are stored in the SERVER
    array with <literal>PHAR_</literal> prepended, so for instance
    <literal>SCRIPT_NAME</literal> would be saved as <literal>PHAR_SCRIPT_NAME</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -44,13 +44,13 @@
     <varlistentry>
      <term><parameter>variables</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        An array of any of the strings
        <literal>REQUEST_URI</literal>, <literal>PHP_SELF</literal>,
        <literal>SCRIPT_NAME</literal> and <literal>SCRIPT_FILENAME</literal>.
        Other values trigger an exception, and <function>Phar::mungServer</function>
        is case-sensitive.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -59,17 +59,17 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    No return.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>UnexpectedValueException</classname> if any problems are
    found with the passed in data.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/Phar/offsetExists.xml
+++ b/reference/phar/Phar/offsetExists.xml
@@ -11,14 +11,14 @@
    <modifier>public</modifier> <type>bool</type><methodname>Phar::offsetExists</methodname>
    <methodparam><type>string</type><parameter>localName</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    This is an implementation of the <interfacename>ArrayAccess</interfacename> interface allowing
    direct manipulation of the contents of a Phar archive using
    array access brackets.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    offsetExists() is called whenever <function>isset</function> is called.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
     <varlistentry>
      <term><parameter>localName</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The filename (relative path) to look for in a Phar.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -38,9 +38,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns &true; if the file exists within the phar, or &false; if not.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/Phar/offsetGet.xml
+++ b/reference/phar/Phar/offsetGet.xml
@@ -12,12 +12,12 @@
    <methodparam><type>string</type><parameter>localName</parameter></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    This is an implementation of the <interfacename>ArrayAccess</interfacename>
    interface allowing direct manipulation of the contents of a Phar archive using
    array access brackets. <methodname>Phar::offsetGet</methodname> is used 
    for retrieving files from a Phar archive.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
     <varlistentry>
      <term><parameter>localName</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The filename (relative path) to look for in a Phar.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -37,18 +37,18 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    A <classname>PharFileInfo</classname> object is returned that can be used to
    iterate over a file's contents or to retrieve information about the current file.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    This method throws <classname>BadMethodCallException</classname> if the file
    does not exist in the Phar archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -56,11 +56,11 @@
   <para>
    <example>
     <title><function>Phar::offsetGet</function> example</title>
-    <para>
+    <simpara>
      As with all classes that implement the <classname>ArrayAccess</classname>
      interface, <methodname>Phar::offsetGet</methodname> is automatically
      called when using the <literal>[]</literal> angle bracket operator.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/Phar/offsetSet.xml
+++ b/reference/phar/Phar/offsetSet.xml
@@ -15,12 +15,12 @@
   &phar.write;
 
 
-  <para>
+  <simpara>
    This is an implementation of the <interfacename>ArrayAccess</interfacename> interface allowing
    direct manipulation of the contents of a Phar archive using
    array access brackets.  offsetSet is used for modifying an
    existing file, or adding a new file to a Phar archive.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
@@ -30,17 +30,17 @@
     <varlistentry>
      <term><parameter>localName</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The filename (relative path) to modify in a Phar.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>value</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Content of the file.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -48,20 +48,20 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    No return values.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    if <link linkend="ini.phar.readonly">phar.readonly</link> is <literal>1</literal>,
    <classname>BadMethodCallException</classname> is thrown, as modifying a Phar
    is only allowed when phar.readonly is set to <literal>0</literal>. Throws
    <classname>PharException</classname> if there are any problems flushing
    changes made to the Phar archive to disk.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -69,10 +69,10 @@
   <para>
    <example>
     <title>A <function>Phar::offsetSet</function> example</title>
-    <para>
+    <simpara>
      offsetSet should not be accessed directly, but instead used
      via array access with the <literal>[]</literal> operator.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/Phar/offsetUnset.xml
+++ b/reference/phar/Phar/offsetUnset.xml
@@ -14,13 +14,13 @@
   &phar.write;
 
 
-  <para>
+  <simpara>
    This is an implementation of the <interfacename>ArrayAccess</interfacename> interface allowing
    direct manipulation of the contents of a Phar archive using
    array access brackets.  offsetUnset is used for deleting an
    existing file, and is called by the <function>unset</function>
    language construct.
-  </para>
+  </simpara>
 
  </refsect1>
  
@@ -31,9 +31,9 @@
     <varlistentry>
      <term><parameter>localName</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The filename (relative path) to modify in a Phar.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,20 +42,20 @@
  
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    if <link linkend="ini.phar.readonly">phar.readonly</link> is <literal>1</literal>,
    <classname>BadMethodCallException</classname> is thrown, as modifying a Phar
    is only allowed when phar.readonly is set to <literal>0</literal>. Throws
    <classname>PharException</classname> if there are any problems flushing
    changes made to the Phar archive to disk.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/Phar/running.xml
+++ b/reference/phar/Phar/running.xml
@@ -13,16 +13,16 @@
    <methodparam choice="opt"><type>bool</type><parameter>returnPhar</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Returns the full path to the running phar archive.  This is intended for use much
    like the <literal>__FILE__</literal> magic constant, and only has effect inside
    an executing phar archive.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Inside the stub of an archive, <function>Phar::running</function> returns
    <literal>&quot;&quot;</literal>.  Simply use <constant>__FILE__</constant>
    to access the current running phar inside a stub.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,10 +32,10 @@
     <varlistentry>
      <term><parameter>returnPhar</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        If &false;, the full path on disk to the phar
        archive is returned.  If &true;, a full phar URL is returned.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -45,9 +45,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the filename if valid, empty string otherwise.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -55,10 +55,10 @@
   <para>
    <example>
     <title>A <function>Phar::running</function> example</title>
-    <para>
+    <simpara>
      For the following example, assume the phar archive is located
      at <literal>/path/to/phar/my.phar</literal>.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/Phar/setAlias.xml
+++ b/reference/phar/Phar/setAlias.xml
@@ -14,7 +14,7 @@
   </methodsynopsis>
   &phar.write;
 
-  <para>
+  <simpara>
    Set the alias for the Phar archive, and write it as the permanent alias
    for this phar archive.  An alias can be used internally to a phar archive to
    ensure that use of the <literal>phar</literal> stream wrapper to access internal
@@ -22,7 +22,7 @@
    filesystem.  Another alternative is to rely upon Phar's interception of
    <function>include</function> or to use <function>Phar::interceptFileFuncs</function>
    and use relative paths.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,10 +32,10 @@
     <varlistentry>
      <term><parameter>alias</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        A shorthand string that this archive can be referred to in <literal>phar</literal>
        stream wrapper access.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -51,11 +51,11 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>UnexpectedValueException</classname> when write access
    is disabled, and <classname>PharException</classname> if the alias is
    already in use or any problems were encountered flushing changes to disk.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/phar/Phar/setDefaultStub.xml
+++ b/reference/phar/Phar/setDefaultStub.xml
@@ -13,10 +13,10 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>webIndex</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   &phar.write;
-  <para>
+  <simpara>
    This method is a convenience method that combines the functionality of
    <function>Phar::createDefaultStub</function> and <function>Phar::setStub</function>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,17 +26,17 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Relative path within the phar archive to run if accessed on the command-line
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>webIndex</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Relative path within the phar archive to run if accessed through a web browser
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -52,13 +52,13 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    <classname>UnexpectedValueException</classname> is thrown if
    <link linkend="ini.phar.readonly">phar.readonly</link> is enabled
    in php.ini.
    <classname>PharException</classname> is thrown if any problems are encountered
    flushing changes to disk.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -95,8 +95,8 @@
   <para>
    <example>
     <title>A <function>Phar::setDefaultStub</function> example</title>
-    <para>
-    </para>
+    <simpara>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/Phar/setMetadata.xml
+++ b/reference/phar/Phar/setMetadata.xml
@@ -15,18 +15,18 @@
   </methodsynopsis>
  &phar.write;
 
-  <para>
+  <simpara>
    <function>Phar::setMetadata</function> should be used to store customized data
    that describes something about the phar archive as a complete entity.
    <function>PharFileInfo::setMetadata</function> should be used for file-specific meta-data.
    Meta-data can slow down the performance of loading a phar archive if the data is large. 
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Some possible uses for meta-data include specifying which file within the archive
    should be used to bootstrap the archive, or the location of a file manifest
    like <link xlink:href="&url.pear;">PEAR</link>'s package.xml file.
    However, any useful data that describes the phar archive may be stored.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -37,9 +37,9 @@
     <varlistentry>
      <term><parameter>metadata</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Any PHP variable containing information to store that describes the phar archive
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -48,9 +48,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -58,8 +58,8 @@
   <para>
    <example>
     <title>A <function>Phar::setMetadata</function> example</title>
-    <para>
-    </para>
+    <simpara>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/Phar/setSignatureAlgorithm.xml
+++ b/reference/phar/Phar/setSignatureAlgorithm.xml
@@ -15,19 +15,19 @@
   </methodsynopsis>
   &phar.write;
 
-  <para>
+  <simpara>
    set the signature algorithm for a phar and apply it.  The
    signature algorithm must be one of <literal>Phar::MD5</literal>,
    <literal>Phar::SHA1</literal>, <literal>Phar::SHA256</literal>,
    <literal>Phar::SHA512</literal>, or <literal>Phar::OPENSSL</literal>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Note that all executable phar archives have a signature created
    automatically, <literal>SHA1</literal> by default.  data tar- or zip-based archives
    (archives created with the <classname>PharData</classname> class) must have
    their signature created and set explicitly via
    <function>Phar::setSignatureAlgorithm</function>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -37,11 +37,11 @@
     <varlistentry>
      <term><parameter>algo</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        One of <literal>Phar::MD5</literal>,
    <literal>Phar::SHA1</literal>, <literal>Phar::SHA256</literal>,
    <literal>Phar::SHA512</literal>, or <literal>Phar::OPENSSL</literal>
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -72,18 +72,18 @@ $p->setSignatureAlgorithm(Phar::OPENSSL, $pkey);
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>UnexpectedValueException</classname> for many errors,
    and a <classname>PharException</classname>
    if any problems occur flushing changes to disk.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/phar/Phar/setStub.xml
+++ b/reference/phar/Phar/setStub.xml
@@ -15,14 +15,14 @@
   &phar.write;
 
 
-  <para>
+  <simpara>
    This method is used to add a PHP bootstrap loader stub to a new Phar archive, or
    to replace the loader stub in an existing Phar archive.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    The loader stub for a Phar archive is used whenever an archive is included directly
    as in this example:
-  </para>
+  </simpara>
   <programlisting role="php">
    <![CDATA[
 <?php
@@ -30,10 +30,10 @@ include 'myphar.phar';
 ?>
    ]]>
   </programlisting>
-  <para>
+  <simpara>
    The loader is not accessed when including a file through the <literal>phar</literal>
    stream wrapper like so:
-  </para>
+  </simpara>
   <programlisting role="php">
    <![CDATA[
 <?php
@@ -51,18 +51,18 @@ include 'phar://myphar.phar/somefile.php';
     <varlistentry>
      <term><parameter>stub</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        A string or an open stream handle to use as the executable stub for this
        phar archive.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>length</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -71,20 +71,20 @@ include 'phar://myphar.phar/somefile.php';
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    <classname>UnexpectedValueException</classname> is thrown if
    <link linkend="ini.phar.readonly">phar.readonly</link> is enabled
    in php.ini.
    <classname>PharException</classname> is thrown if any problems are encountered
    flushing changes to disk.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -117,8 +117,8 @@ include 'phar://myphar.phar/somefile.php';
   <para>
    <example>
     <title>A <function>Phar::setStub</function> example</title>
-    <para>
-    </para>
+    <simpara>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/Phar/startBuffering.xml
+++ b/reference/phar/Phar/startBuffering.xml
@@ -12,15 +12,15 @@
    <void/>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Although technically unnecessary, the <function>Phar::startBuffering</function> method
    can provide a significant performance boost when creating or modifying a
    Phar archive with a large number of files.  Ordinarily, every time a file
    within a Phar archive is created or modified in any way, the entire Phar
    archive will be recreated with the changes.  In this way, the archive will
    be up-to-date with the activity performed on it.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    However, this can be unnecessary when simply creating a new Phar archive,
    when it would make more sense to write the entire archive out at once.
    Similarly, it is often necessary to make a series of changes and to ensure
@@ -28,12 +28,12 @@
    relational database concept of transactions.  the
    <function>Phar::startBuffering</function>/<function>Phar::stopBuffering</function> pair
    of methods is provided for this purpose.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Phar write buffering is per-archive, buffering active for the
    <literal>foo.phar</literal> Phar archive does not affect changes
    to the <literal>bar.phar</literal> Phar archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -43,9 +43,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -53,8 +53,8 @@
   <para>
    <example>
     <title>A <function>Phar::startBuffering</function> example</title>
-    <para>
-    </para>
+    <simpara>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/Phar/stopBuffering.xml
+++ b/reference/phar/Phar/stopBuffering.xml
@@ -12,7 +12,7 @@
    <void/>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    <function>Phar::stopBuffering</function> is used in conjunction with the
    <function>Phar::startBuffering</function> method.  <function>Phar::startBuffering</function>
    can provide a significant performance boost when creating or modifying a
@@ -20,8 +20,8 @@
    within a Phar archive is created or modified in any way, the entire Phar
    archive will be recreated with the changes.  In this way, the archive will
    be up-to-date with the activity performed on it.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    However, this can be unnecessary when simply creating a new Phar archive,
    when it would make more sense to write the entire archive out at once.
    Similarly, it is often necessary to make a series of changes and to ensure
@@ -29,12 +29,12 @@
    relational database concept of transactions.  The
    <function>Phar::startBuffering</function>/<function>Phar::stopBuffering</function> pair
    of methods is provided for this purpose.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Phar write buffering is per-archive, buffering active for the
    <literal>foo.phar</literal> Phar archive does not affect changes
    to the <literal>bar.phar</literal> Phar archive.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -45,17 +45,17 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    <classname>PharException</classname> is thrown if any problems are encountered
    flushing changes to disk.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -63,8 +63,8 @@
   <para>
    <example>
     <title>A <function>Phar::stopBuffering</function> example</title>
-    <para>
-    </para>
+    <simpara>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/Phar/unlinkArchive.xml
+++ b/reference/phar/Phar/unlinkArchive.xml
@@ -12,9 +12,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <modifier>static</modifier> <type>true</type><methodname>Phar::unlinkArchive</methodname>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Removes a phar archive from disk and memory.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +24,9 @@
     <varlistentry>
      <term><parameter>filename</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The path on disk to the phar archive.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -36,18 +36,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.true.always;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    <classname>PharException</classname> is thrown if there are any open file pointers to
    the phar archive, or any existing <classname>Phar</classname>, <classname>PharData</classname>,
    or <classname>PharFileInfo</classname> objects referring to the phar archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/Phar/webPhar.xml
+++ b/reference/phar/Phar/webPhar.xml
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>array</type><parameter>mimeTypes</parameter><initializer>[]</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>callable</type><type>null</type></type><parameter>rewrite</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>Phar::webPhar</function> serves as <function>Phar::mapPhar</function> for 
    web-based phars.  This method parses <varname>$_SERVER['REQUEST_URI']</varname> and 
    routes a request from a web browser to an internal file within the phar archive.  
@@ -24,12 +24,12 @@
    headers and parsing PHP files as needed.  Combined with <function>Phar::mungServer</function> 
    and <function>Phar::interceptFileFuncs</function>, any web application can be used 
    unmodified from a phar archive.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    <function>Phar::webPhar</function> should only be
    called from the stub of a phar archive (see <link linkend="phar.fileformat.stub">here</link>
    for more information on what a stub is).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -39,27 +39,27 @@
     <varlistentry>
      <term><parameter>alias</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The alias that can be used in <literal>phar://</literal> URLs to
        refer to this archive, rather than its full path.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The location within the phar of the directory index.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>fileNotFoundScript</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The location of the script to run when a file is not found.  This
        script should output the proper HTTP 404 headers.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -123,18 +123,18 @@ $mimes = array(
     <varlistentry>
      <term><parameter>rewrite</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The rewrites function is passed a string as its only parameter and must return a <type>string</type> or &false;.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        If you are using fast-cgi or cgi then the parameter passed to the function is the value of the 
        <varname>$_SERVER['PATH_INFO']</varname> variable. Otherwise, the parameter passed to the function is the value
        of the <varname>$_SERVER['REQUEST_URI']</varname> variable.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        If a string is returned it is used as the internal file path. If &false; is returned then webPhar() will
        send a HTTP 403 Denied Code.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -143,20 +143,20 @@ $mimes = array(
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>PharException</classname> when unable to open the internal
    file to output, or if
    called from a non-stub.  If an invalid array value is passed into
    <parameter>mimeTypes</parameter> or an invalid callback is passed into <parameter>rewrite</parameter>, then
    <classname>UnexpectedValueException</classname> is thrown.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -186,12 +186,12 @@ $mimes = array(
   <para>
    <example>
     <title>A <function>Phar::webPhar</function> example</title>
-    <para>
+    <simpara>
      With the example below, the created phar will display <literal>Hello World</literal>
      if one browses to <literal>/myphar.phar/index.php</literal> or to
      <literal>/myphar.phar</literal>, and will display the source of
      <literal>index.phps</literal> if one browses to <literal>/myphar.phar/index.phps</literal>.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/PharData.xml
+++ b/reference/phar/PharData.xml
@@ -9,13 +9,13 @@
 <!-- {{{ Phar intro -->
   <section xml:id="phardata.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     The PharData class provides a high-level interface to accessing and creating
     non-executable tar and zip archives.  Because these archives do not contain
     a stub and cannot be executed by the phar extension, it is possible to create
     and manipulate regular zip and tar files using the PharData class even if
     <literal>phar.readonly</literal> php.ini setting is <literal>1</literal>.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
  

--- a/reference/phar/PharData/addEmptyDir.xml
+++ b/reference/phar/PharData/addEmptyDir.xml
@@ -12,10 +12,10 @@
    <methodparam><type>string</type><parameter>directory</parameter></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    With this method, an empty directory is created with path <literal>dirname</literal>.
    This method is similar to <function>ZipArchive::addEmptyDir</function>.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
     <varlistentry>
      <term><parameter>directory</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The name of the empty directory to create in the phar archive
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -36,9 +36,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    no return value, exception is thrown on failure.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/PharData/addFile.xml
+++ b/reference/phar/PharData/addFile.xml
@@ -13,14 +13,14 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>localName</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    With this method, any file or URL can be added to the tar/zip archive.  If
    the optional second parameter <literal>localname</literal> is specified,
    the file will be stored in the archive with that name, otherwise the
    <literal>file</literal> parameter is used as the path to store within
    the archive.  URLs must have a localname or an exception is thrown.
    This method is similar to <function>ZipArchive::addFile</function>.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
@@ -30,18 +30,18 @@
     <varlistentry>
      <term><parameter>filename</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Full or relative path to a file on disk to be added
        to the phar archive.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>localName</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Path that the file will be stored in the archive.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -50,9 +50,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    no return value, exception is thrown on failure.
-  </para>
+  </simpara>
  </refsect1>
  
  <refsect1 role="changelog">

--- a/reference/phar/PharData/addFromString.xml
+++ b/reference/phar/PharData/addFromString.xml
@@ -13,11 +13,11 @@
    <methodparam><type>string</type><parameter>contents</parameter></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    With this method, any string can be added to the tar/zip archive.
    The file will be stored in the archive with <literal>localname</literal> as its
    path.  This method is similar to <function>ZipArchive::addFromString</function>.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
@@ -27,17 +27,17 @@
     <varlistentry>
      <term><parameter>localName</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Path that the file will be stored in the archive.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>contents</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The file contents to store
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -46,9 +46,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    no return value, exception is thrown on failure.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/PharData/buildFromDirectory.xml
+++ b/reference/phar/PharData/buildFromDirectory.xml
@@ -14,12 +14,12 @@
    <methodparam choice="opt"><type>string</type><parameter>pattern</parameter><initializer>""</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Populate a tar/zip archive from directory contents.  The optional second
    parameter is a regular expression (pcre) that is used to exclude files.
    Any filename that matches the regular expression will be included, all others will be
    excluded.  For more fine-grained control, use <function>PharData::buildFromIterator</function>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,20 +29,20 @@
     <varlistentry>
      <term><parameter>directory</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The full or relative path to the directory that contains all files
        to add to the archive.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>pattern</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        An optional pcre regular expression that is used to filter the
        list of files.  Only file paths matching the regular expression
        will be included in the archive.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -51,21 +51,21 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    <function>Phar::buildFromDirectory</function> returns an associative array
    mapping internal path of file to the full path of the file on the
    filesystem, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    This method throws <classname>BadMethodCallException</classname> when unable
    to instantiate the internal directory iterators,
    or a <classname>PharException</classname> if there were errors
    saving the phar archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -94,9 +94,9 @@
   &reftitle.examples;
   <example>
     <title>A <function>PharData::buildFromDirectory</function> example</title>
-  <para>
+  <simpara>
    
-  </para>
+  </simpara>
   <para>
    <programlisting role="php">
     <![CDATA[

--- a/reference/phar/PharData/buildFromIterator.xml
+++ b/reference/phar/PharData/buildFromIterator.xml
@@ -13,13 +13,13 @@
    <methodparam><type>Traversable</type><parameter>iterator</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>baseDirectory</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Populate a tar or zip archive from an iterator.  Two styles of iterators are supported,
    iterators that map the filename within the tar/zip to the name of a file on disk,
    and iterators like DirectoryIterator that return
    SplFileInfo objects.  For iterators that return SplFileInfo objects, the second
    parameter is required.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,19 +29,19 @@
     <varlistentry>
      <term><parameter>iterator</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Any iterator that either associatively maps tar/zip file to location or
        returns SplFileInfo objects
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>baseDirectory</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        For iterators that return SplFileInfo objects, the portion of each
        file's full path to remove when adding to the tar/zip archive
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -50,23 +50,23 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    <function>PharData::buildFromIterator</function> returns an associative array
    mapping internal path of file to the full path of the file on the
    filesystem.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    This method returns <classname>UnexpectedValueException</classname> when the
    iterator returns incorrect values, such as an integer key instead of a
    string, a <classname>BadMethodCallException</classname> when an
    SplFileInfo-based iterator is passed without a <parameter>baseDirectory</parameter>
    parameter, or a <classname>PharException</classname> if there were errors
    saving the phar archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -101,11 +101,11 @@
   &reftitle.examples;
   <example>
    <title>A <function>PharData::buildFromIterator</function> with SplFileInfo</title>
-   <para>
+   <simpara>
     For most tar/zip archives, the archive will reflect an actual directory layout, and
     the second style is the most useful.  For instance, to create a tar/zip archive
     containing the files in this sample directory layout:
-   </para>
+   </simpara>
    <para>
     <screen>
      <![CDATA[
@@ -125,9 +125,9 @@
     ]]>
     </screen>
    </para>
-   <para>
+   <simpara>
     This code could be used to add these files to the &quot;project.tar&quot; tar archive:
-   </para>
+   </simpara>
    <para>
     <programlisting role="php">
      <![CDATA[
@@ -141,16 +141,16 @@ $phar->buildFromIterator(
     ]]>
     </programlisting>
    </para>
-   <para>
+   <simpara>
     The file <literal>project.tar</literal> can then be used immediately.  <function>PharData::buildFromIterator</function> does not
     set values such as compression, metadata, and this can be done after creating the
     tar/zip archive.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     As an interesting note, <function>PharData::buildFromIterator</function> can also be used to
     copy the contents of an existing phar, tar or zip archive, as the PharData object descends
     from <classname>DirectoryIterator</classname>:
-   </para>
+   </simpara>
    <para>
     <programlisting role="php">
      <![CDATA[
@@ -168,10 +168,10 @@ $phar->setStub($phar->createDefaultStub('cli/index.php', 'www/index.php'));
   </example>
   <example>
    <title>A <function>PharData::buildFromIterator</function> with other iterators</title>
-   <para>
+   <simpara>
     The second form of the iterator can be used with any iterator that returns
     a key =&gt; value mapping, such as an <classname>ArrayIterator</classname>:
-   </para>
+   </simpara>
    <para>
     <programlisting role="php">
      <![CDATA[

--- a/reference/phar/PharData/compress.xml
+++ b/reference/phar/PharData/compress.xml
@@ -14,24 +14,24 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>extension</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    For tar archives, this method compresses the entire archive using
    gzip compression or bzip2 compression.  The resulting file can be processed with the
    gunzip command/bunzip command, or accessed directly and transparently with the Phar
    extension.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    For zip archives, this method fails with an exception.
    The <link linkend="ref.zlib">zlib</link> extension must be enabled to compress
    with gzip compression, the <link linkend="ref.bzip2">bzip2</link> extension must be
    enabled in order to compress with bzip2 compression.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    In addition, this method automatically renames the archive, appending <literal>.gz</literal>,
    <literal>.bz2</literal> or removing the extension if passed <literal>Phar::NONE</literal> to
    remove compression.  Alternatively, a file extension may be specified with the second
    parameter.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -41,20 +41,20 @@
     <varlistentry>
      <term><parameter>compression</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Compression must be one of <literal>Phar::GZ</literal>,
        <literal>Phar::BZ2</literal> to add compression, or <literal>Phar::NONE</literal>
        to remove compression.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>extension</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        By default, the extension is <literal>.tar.gz</literal> or <literal>.tar.bz2</literal>
        for compressing a tar, and <literal>.tar</literal> for decompressing.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -64,20 +64,20 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    A <classname>PharData</classname> object is returned on success,
    or &null; on failure.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>BadMethodCallException</classname> if
    the <link linkend="ref.zlib">zlib</link>
    extension is not available, or the <link linkend="ref.bzip2">bzip2</link> extension
    is not enabled.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/phar/PharData/compressFiles.xml
+++ b/reference/phar/PharData/compressFiles.xml
@@ -13,20 +13,20 @@
    <methodparam><type>int</type><parameter>compression</parameter></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    For tar-based archives, this method throws a
    <classname>BadMethodCallException</classname>, as compression of individual
    files within a tar archive is not supported by the file format.  Use
    <function>PharData::compress</function> to compress an entire tar-based archive.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    For Zip-based archives, this method compresses all files in the
    archive using the specified compression.
    The <link linkend="ref.zlib">zlib</link>  or <link linkend="ref.bzip2">bzip2</link>
    extensions must be enabled to take advantage of this feature.  In addition, if any files
    are already compressed using bzip2/zlib compression, the respective extension must be
    enabled in order to decompress the files prior to re-compressing.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -36,11 +36,11 @@
     <varlistentry>
      <term><parameter>compression</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Compression must be one of <literal>Phar::GZ</literal>,
        <literal>Phar::BZ2</literal> to add compression, or <literal>Phar::NONE</literal>
        to remove compression.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -50,21 +50,21 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>BadMethodCallException</classname> if
    the <link linkend="ini.phar.readonly">phar.readonly</link>
    INI variable is on, the <link linkend="ref.zlib">zlib</link>
    extension is not available, or if any files are compressed using
    bzip2 compression and the <link linkend="ref.bzip2">bzip2</link> extension
    is not enabled.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/PharData/construct.xml
+++ b/reference/phar/PharData/construct.xml
@@ -23,37 +23,37 @@
     <varlistentry>
      <term><parameter>filename</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Path to an existing tar/zip archive or to-be-created archive
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Flags to pass to <classname>Phar</classname> parent class
        <classname>RecursiveDirectoryIterator</classname>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>alias</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Alias with which this Phar archive should be referred to in calls to stream
        functionality.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>format</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        One of the
        <link linkend="phar.constants.fileformat">file format constants</link>
        available within the <classname>Phar</classname> class.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -62,11 +62,11 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>BadMethodCallException</classname> if called twice;
    <classname>UnexpectedValueException</classname> if the Phar archive can't
    be opened.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/phar/PharData/convertToData.xml
+++ b/reference/phar/PharData/convertToData.xml
@@ -16,22 +16,22 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>extension</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    This method is used to convert a non-executable tar or zip archive to another
    non-executable format.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    If no changes are specified, this method throws a <classname>BadMethodCallException</classname>.
    This method should be used to convert a tar archive to zip format or vice-versa.  Although
    it is possible to simply change the compression of a tar archive using this method,
    it is better to use the <function>PharData::compress</function> method for logical
    consistency.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    If successful, the method creates a new archive on disk and returns a <classname>PharData</classname>
    object.  The old archive is not removed from disk, and should be done manually after
    the process has finished.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -41,38 +41,38 @@
     <varlistentry>
      <term><parameter>format</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        This should be one of <literal>Phar::TAR</literal>
        or <literal>Phar::ZIP</literal>.  If set to &null;, the existing file format
        will be preserved.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>compression</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        This should be one of <literal>Phar::NONE</literal> for no whole-archive
        compression, <literal>Phar::GZ</literal> for zlib-based compression, and
        <literal>Phar::BZ2</literal> for bzip-based compression.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>extension</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        This parameter is used to override the default file extension for a
        converted archive.  Note that <literal>.phar</literal> cannot be used
        anywhere in the filename for a non-executable tar or zip archive.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        If converting to a tar-based phar archive, the
        default extensions are <literal>.tar</literal>, <literal>.tar.gz</literal>,
        and <literal>.tar.bz2</literal> depending on specified compression.
        For zip-based archives, the
        default extension is <literal>.zip</literal>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -81,22 +81,22 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The method returns a <classname>PharData</classname> object on success,
    or &null; on failure.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    This method throws <classname>BadMethodCallException</classname> when unable
    to compress, an unknown compression method has been specified, the requested
    archive is buffering with <function>Phar::startBuffering</function> and
    has not concluded with <function>Phar::stopBuffering</function>, and a
    <classname>PharException</classname> if any problems are encountered
    during the phar creation process.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -126,9 +126,9 @@
   <para>
    <example>
     <title>A <function>PharData::convertToData</function> example</title>
-    <para>
+    <simpara>
      Using PharData::convertToData():
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/PharData/convertToExecutable.xml
+++ b/reference/phar/PharData/convertToExecutable.xml
@@ -16,19 +16,19 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>extension</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   &phar.write;
-  <para>
+  <simpara>
    This method is used to convert a non-executable tar or zip archive to an
    executable phar archive.  Any of the three executable file formats
    (phar, tar or zip) can be used, and whole-archive compression can also be performed.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    If no changes are specified, this method throws a <classname>BadMethodCallException</classname>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    If successful, the method creates a new archive on disk and returns a <classname>Phar</classname>
    object.  The old archive is not removed from disk, and should be done manually after
    the process has finished.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -38,40 +38,40 @@
     <varlistentry>
      <term><parameter>format</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        This should be one of <literal>Phar::PHAR</literal>, <literal>Phar::TAR</literal>,
        or <literal>Phar::ZIP</literal>.  If set to &null;, the existing file format
        will be preserved.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>compression</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        This should be one of <literal>Phar::NONE</literal> for no whole-archive
        compression, <literal>Phar::GZ</literal> for zlib-based compression, and
        <literal>Phar::BZ2</literal> for bzip-based compression.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>extension</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        This parameter is used to override the default file extension for a
        converted archive.  Note that all zip- and tar-based phar archives must contain
        <literal>.phar</literal> in their file extension in order to be processed as a
        phar archive.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        If converting to a phar-based archive, the default extensions are
        <literal>.phar</literal>, <literal>.phar.gz</literal>, or <literal>.phar.bz2</literal>
        depending on the specified compression.  For tar-based phar archives, the
        default extensions are <literal>.phar.tar</literal>, <literal>.phar.tar.gz</literal>,
        and <literal>.phar.tar.bz2</literal>.  For zip-based phar archives, the
        default extension is <literal>.phar.zip</literal>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -80,15 +80,15 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The method returns a <classname>Phar</classname> object on success,
    or &null; on failure.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    This method throws <classname>BadMethodCallException</classname> when unable
    to compress, an unknown compression method has been specified, the requested
    archive is buffering with <function>Phar::startBuffering</function> and
@@ -96,7 +96,7 @@
    <classname>UnexpectedValueException</classname> if write support is disabled,
    and a <classname>PharException</classname> if any problems are encountered
    during the phar creation process.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -126,9 +126,9 @@
   <para>
    <example>
     <title>A <function>PharData::convertToExecutable</function> example</title>
-    <para>
+    <simpara>
      Using PharData::convertToExecutable():
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/PharData/copy.xml
+++ b/reference/phar/PharData/copy.xml
@@ -14,11 +14,11 @@
    <methodparam><type>string</type><parameter>to</parameter></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Copy a file internal to the tar/zip archive to another new file within the same archive.
    This is an object-oriented alternative to using <function>copy</function> with
    the phar stream wrapper.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,15 +28,15 @@
     <varlistentry>
      <term><parameter>from</parameter></term>
      <listitem>
-      <para>
-      </para>
+      <simpara>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>to</parameter></term>
      <listitem>
-      <para>
-      </para>
+      <simpara>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -45,19 +45,19 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.true.always;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>UnexpectedValueException</classname> if the source file does not
    exist, the destination file already exists, write access is disabled, opening either
    file fails, reading the source file fails, or a <classname>PharException</classname>
    if writing the changes to the phar fails.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -65,12 +65,12 @@
   <para>
    <example>
     <title>A <function>PharData::copy</function> example</title>
-    <para>
+    <simpara>
      This example shows using <function>PharData::copy</function> and the
      equivalent stream wrapper performance of the same thing.  The primary
      difference between the two approaches is error handling.  All PharData methods
      throw exceptions, whereas the stream wrapper uses <function>trigger_error</function>.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/PharData/decompress.xml
+++ b/reference/phar/PharData/decompress.xml
@@ -13,22 +13,22 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>extension</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    For tar-based archives, this method decompresses the entire archive.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    For Zip-based archives, this method fails with an exception.
    The <link linkend="ref.zlib">zlib</link> extension must be enabled to decompress
    an archive compressed with gzip compression, and the
    <link linkend="ref.bzip2">bzip2</link> extension must be
    enabled in order to decompress an archive compressed with bzip2 compression.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    In addition, this method automatically renames the file extension of the archive,
    <literal>.tar</literal> by default.
    Alternatively, a file extension may be specified with the <parameter>extension</parameter>
    parameter.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -38,12 +38,12 @@
     <varlistentry>
      <term><parameter>extension</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        For decompressing, the default file extension
        is <literal>.tar</literal>.
        Use this parameter to specify another file extension. Be aware that only
        executable archives can contain <literal>.phar</literal> in their filename.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -52,20 +52,20 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    A <classname>PharData</classname> object is returned on success,
    or &null; on failure.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>BadMethodCallException</classname> if
    the <link linkend="ref.zlib">zlib</link>
    extension is not available, or the <link linkend="ref.bzip2">bzip2</link> extension
    is not enabled.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/phar/PharData/decompressFiles.xml
+++ b/reference/phar/PharData/decompressFiles.xml
@@ -14,19 +14,19 @@
   </methodsynopsis>
   &phar.write;
 
-  <para>
+  <simpara>
    For tar-based archives, this method throws a
    <classname>BadMethodCallException</classname>, as compression of individual
    files within a tar archive is not supported by the file format.  Use
    <function>PharData::compress</function> to compress an entire tar-based archive.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    For Zip-based archives, this method decompresses all files in the
    archive.
    The <link linkend="ref.zlib">zlib</link>  or <link linkend="ref.bzip2">bzip2</link>
    extensions must be enabled to take advantage of this feature if any files
    are compressed using bzip2/zlib compression.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -36,20 +36,20 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.true.always;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>BadMethodCallException</classname> if
    the <link linkend="ref.zlib">zlib</link>
    extension is not available, or if any files are compressed using
    bzip2 compression and the <link linkend="ref.bzip2">bzip2</link> extension
    is not enabled.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/PharData/delMetadata.xml
+++ b/reference/phar/PharData/delMetadata.xml
@@ -14,30 +14,30 @@
   </methodsynopsis>
   &phar.write;
 
-  <para>
+  <simpara>
    Deletes the global metadata of the zip archive
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-  </para>
+  <simpara>
+  </simpara>
 
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.true.always;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>PharException</classname> if errors occur while flushing
    changes to disk.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/phar/PharData/delete.xml
+++ b/reference/phar/PharData/delete.xml
@@ -13,11 +13,11 @@
    <methodparam><type>string</type><parameter>localName</parameter></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Delete a file within an archive.  This is the functional equivalent of
    calling <function>unlink</function> on the stream wrapper equivalent,
    as shown in the example below.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
     <varlistentry>
      <term><parameter>localName</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Path within an archive to the file to delete.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -38,17 +38,17 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.true.always;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>PharException</classname> if errors occur while flushing
    changes to disk.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/phar/PharData/extractTo.xml
+++ b/reference/phar/PharData/extractTo.xml
@@ -15,7 +15,7 @@
    <methodparam choice="opt"><type>bool</type><parameter>overwrite</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Extract all files within a tar/zip archive to disk.  Extracted files and directories preserve
    permissions as stored in the archive.  The optional parameters allow optional control over
    which files are extracted, and whether existing files on disk can be overwritten.
@@ -24,7 +24,7 @@
    default, this method will not overwrite existing files, the third parameter can be
    set to true to enable overwriting of files.
    This method is similar to <function>ZipArchive::extractTo</function>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -34,25 +34,25 @@
     <varlistentry>
      <term><parameter>directory</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Path to extract the given <literal>files</literal> to
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>files</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The name of a file or directory to extract, or an array of files/directories to extract
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>overwrite</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Set to &true; to enable overwriting existing files
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -61,18 +61,18 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    returns &true; on success, but it is better to check for thrown exception,
    and assume success if none is thrown.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>PharException</classname> if errors occur while flushing
    changes to disk.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/phar/PharData/isWritable.xml
+++ b/reference/phar/PharData/isWritable.xml
@@ -12,25 +12,25 @@
    <modifier>public</modifier> <type>bool</type><methodname>PharData::isWritable</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    This method returns &true; if the tar/zip archive on disk is not read-only.
    Unlike <function>Phar::isWritable</function>, data-only tar/zip archives
    can be modified even if <literal>phar.readonly</literal> is set to <literal>1</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
+  <simpara>
    No parameters.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns &true; if the tar/zip archive can be modified
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/phar/PharData/offsetSet.xml
+++ b/reference/phar/PharData/offsetSet.xml
@@ -14,12 +14,12 @@
   </methodsynopsis>
 
 
-  <para>
+  <simpara>
    This is an implementation of the <interfacename>ArrayAccess</interfacename> interface allowing
    direct manipulation of the contents of a tar/zip archive using
    array access brackets.  offsetSet is used for modifying an
    existing file, or adding a new file to a tar/zip archive.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
@@ -29,17 +29,17 @@
     <varlistentry>
      <term><parameter>localName</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The filename (relative path) to modify in a tar or zip archive.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>value</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Content of the file.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -47,18 +47,18 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    No return values.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws
    <classname>PharException</classname> if there are any problems flushing
    changes made to the tar/zip archive to disk.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -66,10 +66,10 @@
   <para>
    <example>
     <title>A <function>PharData::offsetSet</function> example</title>
-    <para>
+    <simpara>
      offsetSet should not be accessed directly, but instead used
      via array access with the <literal>[]</literal> operator.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/PharData/offsetUnset.xml
+++ b/reference/phar/PharData/offsetUnset.xml
@@ -13,13 +13,13 @@
   </methodsynopsis>
 
 
-  <para>
+  <simpara>
    This is an implementation of the <interfacename>ArrayAccess</interfacename> interface allowing
    direct manipulation of the contents of a tar/zip archive using
    array access brackets.  offsetUnset is used for deleting an
    existing file, and is called by the <function>unset</function>
    language construct.
-  </para>
+  </simpara>
 
  </refsect1>
  
@@ -30,9 +30,9 @@
     <varlistentry>
      <term><parameter>localName</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The filename (relative path) to modify in the tar/zip archive.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -41,18 +41,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws
    <classname>PharException</classname> if there are any problems flushing
    changes made to the tar/zip archive to disk.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/PharData/setAlias.xml
+++ b/reference/phar/PharData/setAlias.xml
@@ -13,10 +13,10 @@
    <methodparam><type>string</type><parameter>alias</parameter></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Non-executable tar/zip archives cannot have an alias, so this method simply
    throws an exception.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,10 +26,10 @@
     <varlistentry>
      <term><parameter>alias</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        A shorthand string that this archive can be referred to in <literal>phar</literal>
        stream wrapper access.  This parameter is ignored.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -38,15 +38,15 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>PharException</classname> on all method calls
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/phar/PharData/setDefaultStub.xml
+++ b/reference/phar/PharData/setDefaultStub.xml
@@ -13,10 +13,10 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>webIndex</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Non-executable tar/zip archives cannot have a stub, so this method simply
    throws an exception.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,17 +26,17 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Relative path within the phar archive to run if accessed on the command-line
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>webIndex</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Relative path within the phar archive to run if accessed through a web browser
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -46,16 +46,16 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>PharException</classname> on all method calls
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/phar/PharData/setMetadata.xml
+++ b/reference/phar/PharData/setMetadata.xml
@@ -15,18 +15,18 @@
   </methodsynopsis>
  &phar.write;
 
-  <para>
+  <simpara>
    <function>Phar::setMetadata</function> should be used to store customized data
    that describes something about the phar archive as a complete entity.
    <function>PharFileInfo::setMetadata</function> should be used for file-specific meta-data.
    Meta-data can slow down the performance of loading a phar archive if the data is large. 
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Some possible uses for meta-data include specifying which file within the archive
    should be used to bootstrap the archive, or the location of a file manifest
    like <link xlink:href="&url.pear;">PEAR</link>'s package.xml file.
    However, any useful data that describes the phar archive may be stored.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -37,9 +37,9 @@
     <varlistentry>
      <term><parameter>metadata</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Any PHP variable containing information to store that describes the phar archive
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -48,9 +48,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -58,8 +58,8 @@
   <para>
    <example>
     <title>A <function>Phar::setMetadata</function> example</title>
-    <para>
-    </para>
+    <simpara>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/PharData/setSignatureAlgorithm.xml
+++ b/reference/phar/PharData/setSignatureAlgorithm.xml
@@ -15,12 +15,12 @@
   </methodsynopsis>
   &phar.write;
 
-  <para>
+  <simpara>
    Set the signature algorithm for a phar and apply it.  The
    signature algorithm must be one of <literal>Phar::MD5</literal>,
    <literal>Phar::SHA1</literal>, <literal>Phar::SHA256</literal>,
    <literal>Phar::SHA512</literal>, or <literal>Phar::OPENSSL</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -30,11 +30,11 @@
     <varlistentry>
      <term><parameter>algo</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        One of <literal>Phar::MD5</literal>,
    <literal>Phar::SHA1</literal>, <literal>Phar::SHA256</literal>,
    <literal>Phar::SHA512</literal>, or <literal>Phar::OPENSSL</literal>
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -44,19 +44,19 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>UnexpectedValueException</classname> for many errors,
    <classname>BadMethodCallException</classname> if called for a zip- or
    a tar-based phar archive, and a <classname>PharException</classname>
    if any problems occur flushing changes to disk.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/phar/PharData/setStub.xml
+++ b/reference/phar/PharData/setStub.xml
@@ -14,10 +14,10 @@
   </methodsynopsis>
 
 
-  <para>
+  <simpara>
    Non-executable tar/zip archives cannot have a stub, so this method simply
    throws an exception.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,18 +27,18 @@
     <varlistentry>
      <term><parameter>stub</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        A string or an open stream handle to use as the executable stub for this
        phar archive.  This parameter is ignored.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>len</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -48,16 +48,16 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>PharException</classname> on all method calls
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/phar/PharException.xml
+++ b/reference/phar/PharException.xml
@@ -9,10 +9,10 @@
 <!-- {{{ Phar intro -->
   <section xml:id="pharexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     The PharException class provides a phar-specific exception class
     for try/catch blocks.
-   </para>
+   </simpara>
   </section>
 <!-- }}} --> 
  

--- a/reference/phar/PharFileInfo.xml
+++ b/reference/phar/PharFileInfo.xml
@@ -9,10 +9,10 @@
 <!-- {{{ Phar intro -->
   <section xml:id="pharfileinfo.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     The PharFileInfo class provides a high-level interface to the contents
     and attributes of a single file within a phar archive.
-   </para>
+   </simpara>
   </section>
 <!-- }}} --> 
  

--- a/reference/phar/PharFileInfo/chmod.xml
+++ b/reference/phar/PharFileInfo/chmod.xml
@@ -12,7 +12,7 @@
    <methodparam><type>int</type><parameter>perms</parameter></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    <function>PharFileInfo::chmod</function> allows setting of the executable
    file permissions bit, as well as read-only bits.  Writeable bits are
    ignored, and set at runtime based on the
@@ -22,7 +22,7 @@
    must be off in order to succeed if the file is within a <classname>Phar</classname>
    archive.  Files within <classname>PharData</classname> archives do not have
    this restriction.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -33,9 +33,9 @@
     <varlistentry>
      <term><parameter>perms</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        permissions (see <function>chmod</function>)
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -44,9 +44,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -54,8 +54,8 @@
   <para>
    <example>
     <title>A <function>PharFileInfo::chmod</function> example</title>
-    <para>
-    </para>
+    <simpara>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/PharFileInfo/compress.xml
+++ b/reference/phar/PharFileInfo/compress.xml
@@ -12,7 +12,7 @@
    <methodparam><type>int</type><parameter>compression</parameter></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    This method compresses the file inside the Phar archive using either bzip2 compression
    or zlib compression.
    The <link linkend="ref.bzip2">bzip2</link> or <link linkend="ref.zlib">zlib</link>
@@ -24,7 +24,7 @@
    must be off in order to succeed if the file is within a <classname>Phar</classname>
    archive.  Files within <classname>PharData</classname> archives do not have
    this restriction.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -34,9 +34,9 @@
     <varlistentry>
      <term><parameter>compression</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Compression must be <constant>Phar::GZ</constant> or <constant>Phar::BZ2</constant>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -45,20 +45,20 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.true.always;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>BadMethodCallException</classname> if
    the <link linkend="ini.phar.readonly">phar.readonly</link>
    INI variable is on, or if the <link linkend="ref.bzip2">bzip2</link>/<link
    linkend="ref.zlib">zlib</link>
    extension is not available.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/PharFileInfo/construct.xml
+++ b/reference/phar/PharFileInfo/construct.xml
@@ -12,11 +12,11 @@
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </constructorsynopsis>
 
-  <para>
+  <simpara>
    This should not be called directly.  Instead, a PharFileInfo object
    is initialized by calling <function>Phar::offsetGet</function>
    through array access.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
@@ -26,11 +26,11 @@
     <varlistentry>
      <term><parameter>filename</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The full url to retrieve a file.  If you wish to retrieve the information
        for the file <literal>my/file.php</literal> from the phar <literal>boo.phar</literal>,
        the entry should be <literal>phar://boo.phar/my/file.php</literal>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -39,13 +39,13 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>BadMethodCallException</classname> if
    <link linkend="object.construct">__construct()</link> is called twice.
    Throws <classname>UnexpectedValueException</classname> if
    the phar URL requested is malformed, the requested
    phar cannot be opened, or the file can't be found within the phar.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -53,8 +53,8 @@
   <para>
    <example>
     <title>A <function>PharFileInfo::__construct</function> example</title>
-    <para>
-    </para>
+    <simpara>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/PharFileInfo/decompress.xml
+++ b/reference/phar/PharFileInfo/decompress.xml
@@ -12,7 +12,7 @@
    <void/>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    This method decompresses the file inside the Phar archive.
    Depending on how the file is compressed, the <link linkend="ref.bzip2">bzip2</link>
    or <link linkend="ref.zlib">zlib</link> extensions must be enabled to take
@@ -21,7 +21,7 @@
    must be off in order to succeed if the file is within a <classname>Phar</classname>
    archive.  Files within <classname>PharData</classname> archives do not have
    this restriction.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -31,19 +31,19 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.true.always;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>BadMethodCallException</classname> if
    the <link linkend="ini.phar.readonly">phar.readonly</link>
    INI variable is on, or if the <link linkend="ref.bzip2">bzip2</link>/<link linkend="ref.zlib">zlib</link>
    extension is not available.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/PharFileInfo/delMetadata.xml
+++ b/reference/phar/PharFileInfo/delMetadata.xml
@@ -12,37 +12,37 @@
    <modifier>public</modifier> <type>true</type><methodname>PharFileInfo::delMetadata</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Deletes the metadata of the entry, if any.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
+  <simpara>
    No parameters.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.true.always;
    As with all functionality that modifies the contents of
    a phar, the <link linkend="ini.phar.readonly">phar.readonly</link> INI variable
    must be off in order to succeed if the file is within a <classname>Phar</classname>
    archive.  Files within <classname>PharData</classname> archives do not have
    this restriction.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>PharException</classname> if errors occurred while flushing
    changes to disk, and <classname>BadMethodCallException</classname> if
    write access is disabled.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/PharFileInfo/getCRC32.xml
+++ b/reference/phar/PharFileInfo/getCRC32.xml
@@ -12,10 +12,10 @@
    <void/>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    This returns the <function>crc32</function> checksum of the file
    within the Phar archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,18 +25,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The <function>crc32</function> checksum of the file within the Phar archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Throws <classname>BadMethodCallException</classname> if the file has not
    yet had its CRC32 verified.  This should be impossible with normal use, as
    the CRC is verified upon opening the file for reading or writing.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -44,8 +44,8 @@
   <para>
    <example>
     <title>A <function>PharFileInfo::getCRC32</function> example</title>
-    <para>
-    </para>
+    <simpara>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/PharFileInfo/getCompressedSize.xml
+++ b/reference/phar/PharFileInfo/getCompressedSize.xml
@@ -12,10 +12,10 @@
    <void/>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    This returns the size of the file within the Phar archive.  Uncompressed files will return
    the same value for getCompressedSize as they will with <function>filesize</function>
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The size in bytes of the file within the Phar archive on disk.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/PharFileInfo/getContent.xml
+++ b/reference/phar/PharFileInfo/getContent.xml
@@ -12,10 +12,10 @@
    <modifier>public</modifier> <type>string</type><methodname>PharFileInfo::getContent</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    This function behaves like <function>file_get_contents</function> but for
    Phar.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the file contents.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/phar/PharFileInfo/getMetadata.xml
+++ b/reference/phar/PharFileInfo/getMetadata.xml
@@ -12,22 +12,22 @@
    <methodparam choice="opt"><type>array</type><parameter>unserializeOptions</parameter><initializer>[]</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Return meta-data that was saved in the Phar archive's manifest for this file.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    any PHP variable that can be serialized and is stored as meta-data for the file,
    or &null; if no meta-data is stored.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -57,8 +57,8 @@
   <para>
    <example>
     <title>A <function>PharFileInfo::getMetadata</function> example</title>
-    <para>
-    </para>
+    <simpara>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/PharFileInfo/getPharFlags.xml
+++ b/reference/phar/PharFileInfo/getPharFlags.xml
@@ -11,10 +11,10 @@
    <modifier>public</modifier> <type>int</type><methodname>PharFileInfo::getPharFlags</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    This returns the flags set in the manifest for a Phar.  This will always
    return <literal>0</literal> in the current implementation.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +24,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The Phar flags (always <literal>0</literal> in the current implementation)
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/PharFileInfo/hasMetadata.xml
+++ b/reference/phar/PharFileInfo/hasMetadata.xml
@@ -12,23 +12,23 @@
    <modifier>public</modifier> <type>bool</type><methodname>PharFileInfo::hasMetadata</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Returns the metadata of a file within a phar archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
+  <simpara>
    No parameters.
-  </para>
+  </simpara>
 
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns &false; if no metadata is set or is &null;, &true; if metadata is not &null;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/phar/PharFileInfo/isCRCChecked.xml
+++ b/reference/phar/PharFileInfo/isCRCChecked.xml
@@ -12,10 +12,10 @@
    <void/>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    This returns whether a file within a Phar archive
    has had its CRC verified.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &true; if the file has had its CRC verified, &false; if not.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/PharFileInfo/isCompressed.xml
+++ b/reference/phar/PharFileInfo/isCompressed.xml
@@ -12,10 +12,10 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>compression</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    This returns whether a file is compressed within a Phar archive
    with either Gzip or Bzip2 compression.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,10 +25,10 @@
     <varlistentry>
      <term><parameter>compression</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        One of <constant>Phar::GZ</constant> or <constant>Phar::BZ2</constant>,
        defaults to any compression.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -37,9 +37,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &true; if the file is compressed within the Phar archive, &false; if not.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/phar/PharFileInfo/setMetadata.xml
+++ b/reference/phar/PharFileInfo/setMetadata.xml
@@ -12,7 +12,7 @@
    <methodparam><type>mixed</type><parameter>metadata</parameter></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    <function>PharFileInfo::setMetadata</function> should only be used to store customized data in a file
    that cannot be represented with existing information stored with a file.
    Meta-data can significantly slow down the performance of loading a phar
@@ -24,13 +24,13 @@
    must be off in order to succeed if the file is within a <classname>Phar</classname>
    archive.  Files within <classname>PharData</classname> archives do not have
    this restriction.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Some possible uses for meta-data include passing a user/group that should be set
    when a file is extracted from the phar to disk.  Other uses could include
    explicitly specifying a MIME type to return.  However, any useful data that
    describes a file, but should not be contained inside of it may be stored.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -41,9 +41,9 @@
     <varlistentry>
      <term><parameter>metadata</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Any PHP variable containing information to store alongside a file
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -52,9 +52,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -62,8 +62,8 @@
   <para>
    <example>
     <title>A <function>PharFileInfo::setMetadata</function> example</title>
-    <para>
-    </para>
+    <simpara>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/book.xml
+++ b/reference/phar/book.xml
@@ -8,7 +8,7 @@
  <!-- {{{ preface -->
  <preface xml:id="intro.phar">
   &reftitle.intro;
-  <para>
+  <simpara>
    The phar extension provides a way to put entire PHP applications into a single file
    called a "phar" (PHP Archive) for easy distribution and installation.
    In addition to providing this service, the phar extension also provides a file-format
@@ -18,20 +18,20 @@
    which cannot convert between different databases, Phar also can convert between tar,
    zip and phar file formats with a single line of code.  see
    <function>Phar::convertToExecutable</function> for one example.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    What is phar?  Phar archives are best characterized as a convenient way to group
    several files into a single file.  As such, a phar archive provides a way to
    distribute a complete PHP application in a single file and run it from that file
    without the need to extract it to disk.  Additionally, phar archives can be
    executed by PHP as easily as any other file, both on the commandline and from
    a web server.  Phar is kind of like a thumb drive for PHP applications.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Phar implements this functionality through a <link linkend="book.stream">Stream
    Wrapper</link>.  Normally, to use an external file within a PHP script, you
    would use <function>include</function>:
-  </para>
+  </simpara>
   <para>
    <example>
     <title>Using an external file</title>
@@ -44,18 +44,18 @@
     </programlisting>
    </example>
   </para>
-  <para>
+  <simpara>
    PHP can be thought of as actually translating
    <literal>/path/to/external/file.php</literal> into a
    stream wrapper as <literal>file:///path/to/external/file.php</literal>, and under
    the hood it does in fact use the plain file stream wrapper stream functions to
    access all local files.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    To use a file named <literal>file.php</literal> contained with a phar archive
    <literal>/path/to/myphar.phar</literal>,
    the syntax is very similar to the <literal>file://</literal> syntax above.
-  </para>
+  </simpara>
   <para>
    <example>
     <title>Using a file within a phar archive</title>
@@ -68,20 +68,20 @@
     </programlisting>
    </example>
   </para>
-  <para>
+  <simpara>
    In fact, one can treat a phar archive exactly as if it were an external disk, using
    any of <function>fopen</function>-related functions, <function>opendir</function> and
    <function>mkdir</function>-related functions to read, change, or create new files
    and directories within the phar archive.  This allows complete PHP applications
    to be distributed in a single file and run directly from that file.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    The most common usage for a phar archive is to distribute a complete application
    in a single file.  For instance, the PEAR Installer that is bundled with PHP
    versions is distributed as a phar archive.  To use a phar archive distributed
    in this way, the archive can be executed on the command-line or via a web server.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Phar archives can be distributed as <literal>tar</literal> archives,
    <literal>zip</literal> archives, or as the custom <literal>phar</literal> file format
    designed specifically for the phar extension.  Each file format has advantages
@@ -92,16 +92,16 @@
    <link xlink:href="&url.pear.package;PHP_Archive">PHP_Archive</link>, but has the
    advantage that applications created in this format will run even if the phar
    extension is not enabled.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    In other words, even with the phar extension disabled, one can execute or include
    a phar-based archive.  Accessing individual files within a phar archive is only
    possible with the phar extension unless the phar archive was created by PHP_Archive.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    The phar extension is also capable of converting a phar archive from tar to zip or
    to phar file format in a single command:
-  </para>
+  </simpara>
   <para>
    <example>
     <title>Converting a phar archive from phar to tar file format</title>
@@ -115,43 +115,43 @@
     </programlisting>
    </example>
   </para>
-  <para>
+  <simpara>
    Phar can compress individual files or an entire archive
    using <link linkend="book.zlib">gzip</link> compression or
    <link linkend="book.bzip2">bzip2</link> compression, and can verify archive
    integrity automatically through the use of MD5, SHA-1, SHA-256 or SHA-512
    signatures.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Lastly, the Phar extension is security-conscious, and disables write access
    to executable phar archives by default, and requires system-level disabling of the
    <literal>phar.readonly</literal> php.ini setting in order to create or
    modify phar archives.  Normal tar and zip archives without an executable stub
    can always be created or modified using the <classname>PharData</classname> class.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    If you are creating applications for distribution, you will want to read
    <link linkend="phar.creating">How to create Phar Archives</link>.  If you want
    more information on the differences between the three file formats that phar supports,
    you should read <link linkend="phar.fileformat">Phar, Tar and Zip</link>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    If you are using phar applications, there are helpful tips in
    <link linkend="phar.using">How to use Phar Archives</link>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    The word <literal>phar</literal> is a portmanteau of <literal>PHP</literal> and
    <literal>Archive</literal> and is based loosely
    on the <literal>jar</literal> (Java Archive) familiar to Java developers.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    The implementation for Phar archives is based on the PEAR package
    <link xlink:href="&url.pear.package;PHP_Archive">PHP_Archive</link>, and
    the implementation details are similar, although the Phar extension
    is much more powerful.  In addition, the Phar extension allows most PHP
    applications to be run unmodified while PHP_Archive-based phar archives
    often require extensive modification in order to work.
-  </para>
+  </simpara>
  </preface>
  <!-- }}} -->
  

--- a/reference/phar/creating.xml
+++ b/reference/phar/creating.xml
@@ -5,11 +5,11 @@
 
  <section xml:id="phar.creating.intro" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Creating Phar Archives: Introduction</title>
- <para>
+ <simpara>
   To be written fully in the near future.  Before reading this, be sure to read
   <link linkend="phar.using">How to use Phar Archives</link>.
- </para>
- <para>
+ </simpara>
+ <simpara>
   A great place to start is by reading about <function>Phar::buildFromIterator</function>,
   and the specifics of the <link linkend="phar.fileformat">file format</link> choices
   available for archives.  A healthy understanding of what a stub is and does is crucial
@@ -19,7 +19,7 @@
   <function>Phar::webPhar</function> and related method
   <function>Phar::mungServer</function>.  Any application that accesses
   its own files should also consider using <function>Phar::interceptFileFuncs</function>.
- </para>
+ </simpara>
 </section>
 </chapter>
 

--- a/reference/phar/fileformat.xml
+++ b/reference/phar/fileformat.xml
@@ -8,35 +8,35 @@
    All Phar archives contain three to four sections:
    <orderedlist>
     <listitem>
-     <para>a stub</para>
+     <simpara>a stub</simpara>
     </listitem>
     <listitem>
-     <para>a manifest describing the contents</para>
+     <simpara>a manifest describing the contents</simpara>
     </listitem>
     <listitem>
-     <para>the file contents</para>
+     <simpara>the file contents</simpara>
     </listitem>
     <listitem>
-     <para>[optional] a signature for verifying Phar integrity (phar file format only)</para>
+     <simpara>[optional] a signature for verifying Phar integrity (phar file format only)</simpara>
     </listitem>
    </orderedlist>
   </para>
  </section>
 <section xml:id="phar.fileformat.stub" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Phar file stub</title>
- <para>
+ <simpara>
   A Phar's stub is a simple PHP file.  The smallest possible stub follows:
- </para>
+ </simpara>
  <para>
   <programlisting role="php">
    <![CDATA[<?php __HALT_COMPILER();]]>
   </programlisting>
  </para>
- <para>
+ <simpara>
   A stub must contain as a minimum, the <literal>__HALT_COMPILER();</literal> token
   at its conclusion.  Typically, a stub will contain loader functionality
   like so:
- </para>
+ </simpara>
  <para>
   <programlisting role="php">
    <![CDATA[
@@ -47,25 +47,25 @@ __HALT_COMPILER();
    ]]>
   </programlisting>
  </para>
- <para>
+ <simpara>
   There are no restrictions on the contents of a Phar stub, except for the requirement
   that it conclude with <literal>__HALT_COMPILER();</literal>.  The closing PHP tag
   <literal><![CDATA[?>]]></literal> may be included or omitted, but there can be
   no more than 1 space between the <literal>;</literal> and the close tag
   <literal><![CDATA[?>]]></literal> or the phar extension will be unable
   to process the Phar archive's manifest.
- </para>
- <para>
+ </simpara>
+ <simpara>
   In a tar or zip-based phar archive, the stub is stored in the
   <literal>.phar/stub.php</literal> file.  The default stub for phar-based
   Phar archives contains approximately 7k of code to extract the contents
   of the phar and execute them.  See <function>Phar::createDefaultStub</function>
   for more detail.
- </para>
- <para>
+ </simpara>
+ <simpara>
   The phar alias is stored in a tar or zip-based phar archive in the
   <literal>.phar/alias.txt</literal> file as plain text.
- </para>
+ </simpara>
  </section>
  <section xml:id="phar.fileformat.comparison" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Head-to-head comparison of Phar, Tar and Zip</title>
@@ -162,37 +162,37 @@ __HALT_COMPILER();
   </para>
   <para xml:id="phar.fileformat.phartip">
    <tip>
-    <para>
+    <simpara>
     [1] PHP can only directly access the contents of a Phar archive
     without the Phar extension if it is using a <literal>stub</literal>
     that extracts the contents of the phar archive.  The stub
     created by <function>Phar::createDefaultStub</function> extracts
     the phar archive and runs its contents from a temporary directory
     if no phar extension is found.
-    </para>
+    </simpara>
    </tip>
   </para>
   <para xml:id="phar.fileformat.phartip2">
    <tip>
-    <para>
+    <simpara>
     [2] All write access requires <literal>phar.readonly</literal> to
     be disabled in php.ini or on the command-line directly.
-    </para>
+    </simpara>
    </tip>
   </para>
   <para xml:id="phar.fileformat.phartip3">
    <tip>
-    <para>
+    <simpara>
     [3] Only tar and zip archives without <literal>.phar</literal> in their
     filename and without an executable stub <literal>.phar/stub.php</literal>
     can be created if phar.readonly=1.
-    </para>
+    </simpara>
    </tip>
   </para>
  </section>
  <section xml:id="phar.fileformat.tar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Tar-based phars</title>
-  <para>
+  <simpara>
    Archives based on the tar file format follow the more modern USTAR
    file format.  The design of the tar file header makes them more efficient
    to access than the zip file format, and almost as efficient as the phar
@@ -200,22 +200,22 @@ __HALT_COMPILER();
    full path within the phar archive.  There is no limit on the number of files
    within a tar-based phar archive.  These archives can fully compressed in
    gzip or bzip2 format and still be executed by the Phar extension.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    There is limited support for reading tarballs in pax interchange format,
    but all recognized pax headers (currently, typeflag <literal>x</literal> and
    <literal>g</literal>) are silently ignored.
    There is also limited support for GNU Tar Archives;
    currently, <literal>././@LongLink</literal> headers are resolved.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    To compress an entire archive, use <function>Phar::compress</function>.
    To decompress an entire archive, use <function>Phar::decompress</function>.
-  </para>
+  </simpara>
  </section>
  <section xml:id="phar.fileformat.zip" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Zip-based phars</title>
-  <para>
+  <simpara>
    Archives based on the zip file format support several features built into
    the zip file format.  Per-file and whole-archive metadata is stored in
    the zip file comment and zip archive comment as a serialized string.  Pre-existing
@@ -224,30 +224,30 @@ __HALT_COMPILER();
    with bzip2 compression.  There is no limit on the number of files
    within a zip-based phar archive.  Empty directories are stored in the zip archive
    as files with a trailing slash like <literal>my/directory/</literal>
-  </para>
+  </simpara>
  </section>
  <section xml:id="phar.fileformat.phar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Phar File Format</title>
- <para>
+ <simpara>
   The phar file format is literally laid out as stub/manifest/contents/signature, and
   stores the crucial information of what is included in the phar archive in its
   <literal>manifest</literal>.
- </para>
- <para>
+ </simpara>
+ <simpara>
   The Phar manifest is a highly optimized format that allows per-file
   specification of file compression, file permissions, and even user-defined
   meta-data such as file user or group.  All values greater than 1 byte are stored
   in little-endian byte order, with the exception of the API version, which
   for historical reasons is stored as 3 nibbles in big-endian order.
- </para>
- <para>
+ </simpara>
+ <simpara>
   All unused flags are reserved for future use, and must not be used
   to store custom information.  Use the per-file meta-data facility
   to store customized information about particular files.
- </para>
- <para>
+ </simpara>
+ <simpara>
   The basic file format of a Phar archive manifest is as follows:
- </para>
+ </simpara>
  <para>
  <table>
   <title>Global Phar manifest format</title>
@@ -302,10 +302,10 @@ __HALT_COMPILER();
 </section>
 <section xml:id="phar.fileformat.flags" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Global Phar bitmapped flags</title>
- <para>
+ <simpara>
   Here are the bitmapped flags currently recognized by the Phar extension
   for the global Phar flat bitmap:
- </para>
+ </simpara>
  <para>
   <table>
    <title>Bitmap values recognized</title>
@@ -342,9 +342,9 @@ __HALT_COMPILER();
 </section>
 <section xml:id="phar.fileformat.manifestfile" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Phar manifest file entry definition</title>
- <para>
+ <simpara>
   Each file in the manifest contains the following information:
- </para>
+ </simpara>
  <para>
   <table>
    <title>Phar Manifest file entry</title>
@@ -396,13 +396,13 @@ __HALT_COMPILER();
    </tgroup>
   </table>
  </para>
- <para>
+ <simpara>
   Note that as of API version 1.1.1, empty directories are stored as filenames
   with a trailing slash like <literal>my/directory/</literal>
- </para>
- <para>
+ </simpara>
+ <simpara>
   The File-specific bitmap values recognized are:
- </para>
+ </simpara>
  <para>
   <table>
    <title>Bitmap values recognized</title>
@@ -441,12 +441,12 @@ __HALT_COMPILER();
 </section>
 <section xml:id="phar.fileformat.signature" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Phar Signature format</title>
- <para>
+ <simpara>
   Phars containing a signature always have the signature appended to the
   end of the Phar archive after the loader, manifest, and file contents.
   The signature formats supported at this time are MD5, SHA1, SHA256, SHA512,
   and OPENSSL.
- </para>
+ </simpara>
  <para>
   <table>
    <title>Signature format</title>

--- a/reference/phar/ini.xml
+++ b/reference/phar/ini.xml
@@ -49,23 +49,23 @@
      <type>bool</type>
     </term>
     <listitem>
-     <para>
+     <simpara>
       This option disables creation or modification of Phar archives
       using the <literal>phar</literal> stream or <classname>Phar</classname>
       object's write support.  This setting should always be enabled on
       production machines, as the phar extension's convenient write support
       could allow straightforward creation of a php-based virus when coupled
       with other common security vulnerabilities.
-     </para>
+     </simpara>
      <note>
-      <para>
+      <simpara>
        This setting can only be unset in php.ini due to security reasons.
        If <literal>phar.readonly</literal> is disabled in php.ini, the
        user may enable <literal>phar.readonly</literal> in a script
        or disable it later.  If <literal>phar.readonly</literal> is
        enabled in php.ini, a script may harmlessly &quot;re-enable&quot;
        the INI variable, but may not disable it.
-      </para>
+      </simpara>
      </note>
     </listitem>
    </varlistentry>
@@ -76,24 +76,24 @@
      <type>bool</type>
     </term>
     <listitem>
-     <para>
+     <simpara>
       This option will force all opened Phar archives to contain some
       kind of signature (currently MD5, SHA1, SHA256, SHA512 and OpenSSL are supported), and will
       refuse to process any Phar archive that does not contain a signature.
-     </para>
+     </simpara>
      <note>
-      <para>
+      <simpara>
        This setting can only be unset in php.ini.
        If <literal>phar.require_hash</literal> is disabled in php.ini, the
        user may enable <literal>phar.require_hash</literal> in a script
        or disable it later.  If <literal>phar.require_hash</literal> is
        enabled in php.ini, a script may harmlessly &quot;re-enable&quot;
        the INI variable, but may not disable it.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        This setting does not affect reading plain tar files with the
        <classname>PharData</classname> class.
-      </para>
+      </simpara>
      </note>
      <caution>
       <simpara>

--- a/reference/phar/installation.xml
+++ b/reference/phar/installation.xml
@@ -2,16 +2,16 @@
 <!-- $Revision$ -->
 <section xml:id="phar.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
- <para>
+ <simpara>
   The Phar extension is bundled with PHP, and enabled by default.
   To disable Phar support, use <option role="configure">--disable-phar</option>.
- </para>
- <para>  
+ </simpara>
+ <simpara>
   Phar may be installed
   via the PECL extension with previous PHP versions, and the
   <link xlink:href="&url.pecl.package;phar">Phar PECL page</link> contains
   further information and history.
- </para>
+ </simpara>
 </section>
 
 <!-- Keep this comment at the end of the file

--- a/reference/phar/setup.xml
+++ b/reference/phar/setup.xml
@@ -7,16 +7,16 @@
  <!-- {{{ Requirements -->
  <section xml:id="phar.requirements">
   &reftitle.required;
-  <para>
+  <simpara>
    You may optionally wish to enable the <link linkend="book.zlib" >zlib</link>
    and <link linkend="book.bzip2" >bzip2</link> extensions to take
    advantage of compressed phar support.  In addition, to take advantage of
    OpenSSL signing, the <link linkend="book.openssl">OpenSSL</link> extension must be
    enabled.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    If <link linkend="ini.zend.multibyte">zend.multibyte</link> is enabled, <link linkend="ini.zend.detect-unicode">zend.detect_unicode</link> must be enabled as well.
-  </para>
+  </simpara>
  </section>
  <!-- }}} -->
 
@@ -31,11 +31,11 @@
  <!-- {{{ Resources -->
  <section xml:id="phar.resources">
   &reftitle.resources;
-   <para>
+   <simpara>
    The Phar extension provides the <literal>phar</literal> stream, which
    allows accessing files contained within a phar transparently. See also the
    <link linkend="phar.fileformat">description of the Phar file format</link>.
-  </para>
+  </simpara>
  </section>
  <!-- }}} -->
 

--- a/reference/phar/using.xml
+++ b/reference/phar/using.xml
@@ -5,20 +5,20 @@
 
  <section xml:id="phar.using.intro" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Using Phar Archives: Introduction</title>
- <para>
+ <simpara>
   Phar archives are similar in concept to Java JAR archives, but are tailored
   to the needs and to the flexibility of PHP applications.  A Phar archive is
   used to distribute a complete PHP application or library in a single file. A
   Phar archive application is used exactly like any other PHP application:
- </para>
+ </simpara>
  <screen>
   <![CDATA[
 php coolapplication.phar
   ]]>
  </screen>
- <para>
+ <simpara>
   Using a Phar archive library is identical to using any other PHP library:
- </para>
+ </simpara>
  <para>
   <informalexample>
    <programlisting role="php">
@@ -30,14 +30,14 @@ include 'coollibrary.phar';
    </programlisting>
   </informalexample>
  </para>
- <para>
+ <simpara>
   The <literal>phar</literal> stream wrapper provides the core of the phar extension, and
   is explained in detail <link linkend="phar.using.stream">here</link>.
   The phar stream wrapper allows accessing the files within a phar archive using
   PHP's standard file functions <function>fopen</function>, <function>opendir</function>, and
   others that work on regular files.  The <literal>phar</literal> stream wrapper supports all
   read/write operations on both files and directories.
- </para>
+ </simpara>
  <para>
   <informalexample>
    <programlisting role="php">
@@ -52,11 +52,11 @@ echo file_get_contents('phar:///fullpath/to/coollibrary.phar/images/wow.jpg');
    </programlisting>
   </informalexample>
  </para>
- <para>
+ <simpara>
   The <classname>Phar</classname> class implements advanced functionality for accessing
   files and for creating phar archives.  The Phar class is explained in detail
   <link linkend="phar.using.object">here</link>.
- </para>
+ </simpara>
  <para>
   <informalexample>
    <programlisting role="php">
@@ -139,7 +139,7 @@ openssl_pkey_export($public, $pkey);
   as <literal>/path/to/my.phar.pubkey</literal>, or phar will be unable to verify
   the OpenSSL signature.
  </para>
- <para>
+ <simpara>
   The <classname>Phar</classname> class also provides 3 static methods, <function>Phar::webPhar</function>,
   <function>Phar::mungServer</function> and <function>Phar::interceptFileFuncs</function> that are crucial
   to packaging up PHP applications designed for usage on regular filesystems and for web-based applications.
@@ -150,12 +150,12 @@ openssl_pkey_export($public, $pkey);
   <function>fopen</function>, <function>file_get_contents</function>, <function>opendir</function>, and
   all of the stat-based functions (<function>file_exists</function>, <function>is_readable</function> and so on) and
   route all relative paths to locations within the phar archive.
- </para>
- <para>
+ </simpara>
+ <simpara>
   As an example, packaging up a release of the popular phpMyAdmin application for use as a phar archive requires
   only this simple script and then <literal>phpMyAdmin.phar.tar.php</literal> can be accessed as a regular file
   from your web server after modifying the user/password:
- </para>
+ </simpara>
  <para>
   <informalexample>
    <programlisting role="php">
@@ -204,17 +204,17 @@ $a->stopBuffering();
 </section>
 <section xml:id="phar.using.stream" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Using Phar Archives: the phar stream wrapper</title>
- <para>
+ <simpara>
   The Phar stream wrapper fully supports <function>fopen</function> for
   read and write (not append), <function>unlink</function>, <function>stat</function>,
   <function>fstat</function>, <function>fseek</function>, <function>rename</function>
   and directory stream operations <function>opendir</function> and <function>rmdir</function>
   and <function>mkdir</function>.
- </para>
- <para>
+ </simpara>
+ <simpara>
   Individual file compression and per-file metadata can also be manipulated
   in a Phar archive using stream contexts:
- </para>
+ </simpara>
  <para>
   <informalexample>
    <programlisting role="php">
@@ -229,45 +229,45 @@ file_put_contents('phar://my.phar/somefile.php', 0, $context);
    </programlisting>
   </informalexample>
  </para>
- <para>
+ <simpara>
   The <literal>phar</literal> stream wrapper does not operate on remote files,
   and cannot operate on remote files, and so is allowed even when the
   <link linkend="ini.allow-url-fopen">allow_url_fopen</link> and
   <link linkend="ini.allow-url-include">allow_url_include</link> INI options
   are disabled.
- </para>
- <para>
+ </simpara>
+ <simpara>
   Although it is possible to create phar archives from scratch just using
   stream operations, it is best to use the functionality built into
   the Phar class.  The stream wrapper is best used for read-only operations.
- </para>
+ </simpara>
 </section>
 <section xml:id="phar.using.object" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Using Phar Archives: the Phar and PharData class</title>
- <para>
+ <simpara>
   The <classname>Phar</classname> class supports reading and manipulation
   of Phar archives, as well as iteration through inherited functionality of
   the <classname>RecursiveDirectoryIterator</classname>
   class.  With support for the <classname>ArrayAccess</classname>
   interface, files inside a Phar archive can be accessed as if they were
   part of an associative array.
- </para>
- <para>
+ </simpara>
+ <simpara>
   The <classname>PharData</classname> class extends the <classname>Phar</classname>, and
   allows creating and modifying non-executable (data) tar and zip archives even if
   <literal>phar.readonly</literal>=1 in php.ini.  As such,
   <function>PharData::setAlias</function> and <function>PharData::setStub</function>
   are both disabled as the concept of alias and stub are unique to executable phar
   archives.
- </para>
- <para>
+ </simpara>
+ <simpara>
   It is important to note that when creating a Phar archive, the full path
   should be passed to the <classname>Phar</classname> object constructor.
   Relative paths will fail to initialize.
- </para>
- <para>
+ </simpara>
+ <simpara>
   Assuming that <literal>$p</literal> is a Phar object initialized as follows:
- </para>
+ </simpara>
  <para>
   <informalexample>
    <programlisting role="php">
@@ -279,12 +279,12 @@ $p = new Phar('/path/to/myphar.phar', 0, 'myphar.phar');
    </programlisting>
   </informalexample>
  </para>
- <para>
+ <simpara>
   An empty Phar archive will be created at <literal>/path/to/myphar.phar</literal>,
   or if <literal>/path/to/myphar.phar</literal> already exists, it will be opened
   again.  The literal <literal>myphar.phar</literal> demonstrates the concept of an alias
   that can be used to reference <literal>/path/to/myphar.phar</literal> in URLs as in:
- </para>
+ </simpara>
  <para>
   <informalexample>
    <programlisting role="php">
@@ -341,7 +341,7 @@ $f = file_get_contents('phar://myphar.phar/whatever.txt');
    </listitem>
   </itemizedlist>
  </para>
- <para>
+ <simpara>
   In addition, the <classname>Phar</classname> object is the only way to access
   Phar-specific metadata, through
   <function>Phar::getMetadata</function>,
@@ -350,17 +350,17 @@ $f = file_get_contents('phar://myphar.phar/whatever.txt');
   <function>Phar::setStub</function>.
   Additionally, compression for the entire Phar archive at once can only be manipulated
   using the <classname>Phar</classname> class.
- </para>
- <para>
+ </simpara>
+ <simpara>
   The full list of <classname>Phar</classname> object functionality is documented
   below.
- </para>
- <para>
+ </simpara>
+ <simpara>
   The <classname>PharFileInfo</classname> class extends the
   <classname>SplFileInfo</classname>
   class, and adds several methods for manipulating Phar-specific details of a file
   contained within a Phar, such as manipulating compression and metadata.
- </para>
+ </simpara>
 </section>
 </chapter>
 


### PR DESCRIPTION
Same conversion as #5536 (zip) and #5522 (language-snippets), now on the `phar` extension. Replaces `<para>` with `<simpara>` everywhere the body is purely inline; the 248 remaining `<para>` are kept because they wrap block children (`<example>`, `<programlisting>`, `<itemizedlist>`, `<note>`, `<variablelist>`, etc.) which `<simpara>` cannot contain. Inner paras nested inside a kept outer para are converted when eligible.

104 files touched, 521 conversions, no semantic change.