### PR TITLE
Add (void) casting syntax for PHP 8.5

### DIFF
--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -317,6 +317,12 @@ var_dump($bar);
    <member><literal>(unset)</literal> - cast to <type>NULL</type></member>
   </simplelist>
 
+  <simpara>
+   The <link linkend="language.types.void.casting"><literal>(void)</literal></link>
+   cast is also available as of PHP 8.5.0, but it is not a value conversion.
+   It is used as a statement to explicitly discard the result of an expression.
+  </simpara>
+
   <warning>
    <para>
     <literal>(integer)</literal> is an alias of the <literal>(int)</literal> cast.
@@ -422,9 +428,16 @@ if ($fst === $str) {
     <member><link linkend="language.types.object.casting">Converting to object</link></member>
     <member><link linkend="language.types.resource.casting">Converting to resource</link></member>
     <member><link linkend="language.types.null.casting">Converting to NULL</link></member>
+    <member><link linkend="language.types.void.casting">Discarding a value with <literal>(void)</literal></link></member>
     <member><link linkend="types.comparisons">The type comparison tables</link></member>
    </simplelist>
   </para>
+
+  <simpara>
+   The <literal>(void)</literal> syntax is also available as of PHP 8.5.0,
+   but it is not a value conversion. It is used as a statement to explicitly
+   discard the result of an expression.
+  </simpara>
 
   <note>
    <simpara>

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -433,12 +433,6 @@ if ($fst === $str) {
    </simplelist>
   </para>
 
-  <simpara>
-   The <literal>(void)</literal> syntax is also available as of PHP 8.5.0,
-   but it is not a value conversion. It is used as a statement to explicitly
-   discard the result of an expression.
-  </simpara>
-
   <note>
    <simpara>
     Because PHP supports indexing into <type>string</type>s via offsets

--- a/language/types/void.xml
+++ b/language/types/void.xml
@@ -24,7 +24,7 @@
    The <literal>(void)</literal> syntax may be used to explicitly discard the
    result of an expression. This is useful to indicate that ignoring a return
    value is intentional, especially when calling a function or method marked
-   with the <link linkend="class.nodiscard"><classname>NoDiscard</classname></link>
+   with the <classname>NoDiscard</classname>
    attribute.
   </simpara>
 

--- a/language/types/void.xml
+++ b/language/types/void.xml
@@ -17,6 +17,39 @@
   </simpara>
  </note>
 
+ <sect2 xml:id="language.types.void.casting">
+  <title>Discarding a value with <literal>(void)</literal></title>
+
+  <simpara>
+   The <literal>(void)</literal> syntax may be used to explicitly discard the
+   result of an expression. This is useful to indicate that ignoring a return
+   value is intentional, especially when calling a function or method marked
+   with the <link linkend="class.nodiscard"><classname>NoDiscard</classname></link>
+   attribute.
+  </simpara>
+
+  <simpara>
+   Unlike other casts, <literal>(void)</literal> does not convert the value to
+   another type and does not produce a value. It is a statement and cannot be
+   used as part of an expression.
+  </simpara>
+
+  <example>
+   <title>Discarding a return value</title>
+   <programlisting role="php" annotations="non-interactive">
+    <![CDATA[
+<?php
+#[\NoDiscard]
+function process(): bool {
+    return true;
+}
+
+(void) process(); // Explicitly discard the return value
+?>
+]]>
+   </programlisting>
+  </example>
+ </sect2>
 </sect1>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Added the (void) cast to indicate that not using a value is intentional. The (void) cast has no effect on the program's execution by itself, but it can be used to suppress warnings emitted by #[\NoDiscard] and possibly also diagnostics emitted by external IDEs or static analysis tools. RFC: https://wiki.php.net/rfc/marking_return_value_as_important

https://github.com/php/doc-en/pull/5038/ depends on this.