### PR TITLE
Fix double anchor tag when classname and link are used together

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1450,7 +1450,7 @@ Stack trace:
    </simpara>
    <simpara>
     Both anonymous functions and arrow functions are implemented using the 
-    <link linkend="class.closure"><classname>Closure</classname></link> class.
+    <classname>Closure</classname> class.
    </simpara>
 
    <simpara>

--- a/reference/intl/collator/asort.xml
+++ b/reference/intl/collator/asort.xml
@@ -144,7 +144,7 @@ array (
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants"><classname>Collator</classname> constants</link></member>
+    <member><link linkend="intl.collator-constants">Collator constants</link></member>
     <member><function>collator_sort</function></member>
     <member><function>collator_sort_with_sort_keys</function></member>
    </simplelist>

--- a/reference/intl/collator/get-attribute.xml
+++ b/reference/intl/collator/get-attribute.xml
@@ -86,7 +86,7 @@ if( $val === false )
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants"><classname>Collator</classname> constants</link></member>
+    <member><link linkend="intl.collator-constants">Collator constants</link></member>
     <member><function>collator_set_attribute</function></member>
     <member><function>collator_get_strength</function></member>
    </simplelist>

--- a/reference/intl/collator/get-strength.xml
+++ b/reference/intl/collator/get-strength.xml
@@ -81,7 +81,7 @@ $strength = collator_get_strength( $coll );
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants"><classname>Collator</classname> constants</link></member>
+    <member><link linkend="intl.collator-constants">Collator constants</link></member>
     <member><function>collator_set_strength</function></member>
     <member><function>collator_get_attribute</function></member>
    </simplelist>

--- a/reference/intl/collator/set-attribute.xml
+++ b/reference/intl/collator/set-attribute.xml
@@ -89,7 +89,7 @@ collator_set_attribute($coll, Collator::NORMALIZATION_MODE, Collator::ON);
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants"><classname>Collator</classname> constants</link></member>
+    <member><link linkend="intl.collator-constants">Collator constants</link></member>
     <member><function>collator_get_attribute</function></member>
     <member><function>collator_set_strength</function></member>
    </simplelist>

--- a/reference/intl/collator/set-strength.xml
+++ b/reference/intl/collator/set-strength.xml
@@ -226,7 +226,7 @@ array (
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants"><classname>Collator</classname> constants</link></member>
+    <member><link linkend="intl.collator-constants">Collator constants</link></member>
     <member><function>collator_get_strength</function></member>
    </simplelist>
   </para>

--- a/reference/intl/collator/sort-with-sort-keys.xml
+++ b/reference/intl/collator/sort-with-sort-keys.xml
@@ -94,7 +94,7 @@ array (
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants"><classname>Collator</classname> constants</link></member>
+    <member><link linkend="intl.collator-constants">Collator constants</link></member>
     <member><function>collator_sort</function></member>
     <member><function>collator_asort</function></member>
    </simplelist>

--- a/reference/intl/collator/sort.xml
+++ b/reference/intl/collator/sort.xml
@@ -136,7 +136,7 @@ array (
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants"><classname>Collator</classname> constants</link></member>
+    <member><link linkend="intl.collator-constants">Collator constants</link></member>
     <member><function>collator_asort</function></member>
     <member><function>collator_sort_with_sort_keys</function></member>
    </simplelist>


### PR DESCRIPTION
Use either `classname` or `link`, not both. It breaks HTML as it renders a double anchor.