### PR TITLE
Improve Docker build process, remove  --disable-segfault-error

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -18,5 +18,13 @@ RUN echo 'memory_limit = 512M' >> /usr/local/etc/php/conf.d/local.ini
 
 ENV FORMAT=xhtml
 
-CMD php doc-base/configure.php --disable-segfault-error && \
-    php phd/render.php --docbook doc-base/.manual.xml --output=/var/www/en/output --package PHP --format ${FORMAT}
+ENV FORMAT=xhtml
+
+CMD ["sh", "-c", "\
+php doc-base/configure.php && \
+exec php phd/render.php \
+  --docbook doc-base/.manual.xml \
+  --output=/var/www/en/output \
+  --package PHP \
+  --format ${FORMAT}\
+"]

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -18,8 +18,6 @@ RUN echo 'memory_limit = 512M' >> /usr/local/etc/php/conf.d/local.ini
 
 ENV FORMAT=xhtml
 
-ENV FORMAT=xhtml
-
 CMD ["sh", "-c", "\
 php doc-base/configure.php && \
 exec php phd/render.php \

--- a/Makefile
+++ b/Makefile
@@ -18,17 +18,22 @@ ifneq ($(wildcard ../phd/LICENSE),)
 	PATHS += -v ${PWD}/../phd:/var/www/phd
 endif
 
-xhtml: .docker/built
+xhtml: docker-build
 	docker run --rm ${PATHS} -w /var/www -u ${CURRENT_UID}:${CURRENT_GID} php/doc-en
 
-php: .docker/built
+php: docker-build
 	docker run --rm ${PATHS} -w /var/www -u ${CURRENT_UID}:${CURRENT_GID} \
 		-e FORMAT=php php/doc-en
 
-build: .docker/built
+build: docker-build
 
-.docker/built:
-	docker build\
-		--build-arg UID=${CURRENT_UID} --build-arg GID=${CURRENT_GID}\
-		.docker -t php/doc-en
-	touch .docker/built
+docker-build:
+	@CURRENT_HASH="$$(sha256sum .docker/Dockerfile | cut -d' ' -f1)"; \
+	if [ ! -f .docker/built ] || [ "$$CURRENT_HASH" != "$$(cat .docker/built)" ]; then \
+		docker build \
+			--build-arg UID=${CURRENT_UID} --build-arg GID=${CURRENT_GID} \
+			.docker -t php/doc-en; \
+		echo "$$CURRENT_HASH" > .docker/built; \
+	else \
+		echo "Docker image is up to date"; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -18,22 +18,17 @@ ifneq ($(wildcard ../phd/LICENSE),)
 	PATHS += -v ${PWD}/../phd:/var/www/phd
 endif
 
-xhtml: docker-build
+xhtml: .docker/built
 	docker run --rm ${PATHS} -w /var/www -u ${CURRENT_UID}:${CURRENT_GID} php/doc-en
 
-php: docker-build
+php: .docker/built
 	docker run --rm ${PATHS} -w /var/www -u ${CURRENT_UID}:${CURRENT_GID} \
 		-e FORMAT=php php/doc-en
 
-build: docker-build
+build: .docker/built
 
-docker-build:
-	@CURRENT_HASH="$$(sha256sum .docker/Dockerfile | cut -d' ' -f1)"; \
-	if [ ! -f .docker/built ] || [ "$$CURRENT_HASH" != "$$(cat .docker/built)" ]; then \
-		docker build \
-			--build-arg UID=${CURRENT_UID} --build-arg GID=${CURRENT_GID} \
-			.docker -t php/doc-en; \
-		echo "$$CURRENT_HASH" > .docker/built; \
-	else \
-		echo "Docker image is up to date"; \
-	fi
+.docker/built: .docker/Dockerfile
+	docker build \
+		--build-arg UID=${CURRENT_UID} --build-arg GID=${CURRENT_GID} \
+		.docker -t php/doc-en
+	touch .docker/built


### PR DESCRIPTION
https://github.com/php/doc-base/pull/285 removed `--disable-segfault-error`. Dockerfile was still passing this argument resulting in a warning. Thus we should remove it as well.

Also altered `Makefile` to write a file hash to .docker/built instead. If we don't this warning will still pop unless we manually remove that file. 