### PR TITLE
Remove SimpleXML from bool false examples

### DIFF
--- a/language/types/boolean.xml
+++ b/language/types/boolean.xml
@@ -113,9 +113,7 @@ if ($show_separators) {
    <listitem>
     <simpara>
      Internal objects that overload their casting behaviour to bool.
-     For example: <link linkend="ref.simplexml">SimpleXML</link> objects
-     created from empty elements without attributes, or
-     <classname>GMP</classname> objects representing the value
+     For example, <classname>GMP</classname> objects representing the value
      <literal>0</literal>.
     </simpara>
    </listitem>


### PR DESCRIPTION
The bool casting page currently says that SimpleXML objects created from empty elements without attributes are false.

That does not match the existing SimpleXML behavior: an existing empty element casts to true, while a missing element casts to false. The php-src discussion for GH-21583 settled on keeping the current behavior and documenting it instead of changing SimpleXML's bool cast.

This keeps the internal-object note, but leaves GMP zero as the example.

Related: php/php-src#21583, php/php-src#21590, php/php-src#22042

Validation:

```
git diff --check
```
